### PR TITLE
Refprop wrapper cleanup

### DIFF
--- a/include/CoolPropTools.h
+++ b/include/CoolPropTools.h
@@ -127,6 +127,13 @@
         std::transform(str.begin(), str.end(), str.begin(), ::toupper);
         return str;
     }
+	
+	inline std::string lower(const std::string str_)
+    {
+        std::string str = str_;
+        std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+        return str;
+    }
 
     std::string strjoin(std::vector<std::string> strings, std::string delim);
 

--- a/src/Backends/REFPROP/REFPROP_lib.h
+++ b/src/Backends/REFPROP/REFPROP_lib.h
@@ -7,7 +7,7 @@
  * This will be used to generate function names, pointers, etc. below
  */
 #define LIST_OF_REFPROP_FUNCTION_NAMES \
-	X(RPVersion) \	
+	X(RPVersion) \
 	X(SETPATHdll) \
 	X(ABFL1dll) \
 	X(ABFL2dll) \
@@ -60,7 +60,7 @@
 	X(MELTTdll) \
 	X(MLTH2Odll) \
 	X(NAMEdll) \
-	X(PASSCMN) \
+	X(PASSCMNdll) \
 	X(PDFL1dll) \
 	X(PDFLSHdll) \
 	X(PEFLSHdll) \


### PR DESCRIPTION
Removed more than 1000 lines of code.  Xmacros to the rescue.

Closes #332 
