### PR TITLE
Matlab hide enums

### DIFF
--- a/src/CoolProp.i
+++ b/src/CoolProp.i
@@ -4,11 +4,14 @@
 %ignore CoolProp::AbstractState::set_mass_fractions(const std::vector< long double> &);
 %ignore CoolProp::set_config_json(rapidjson::Document &);
 %ignore CoolProp::get_config_as_json(rapidjson::Document &);
+
+#ifdef SWIGMATLAB
 %ignore configuration_keys;
 %ignore CoolProp::ConfigurationItem::ConfigurationDataTypes;
 %ignore CoolProp::SsatSimpleState::SsatSimpleStateEnum;
 %ignore CoolProp::composition_types;
 %ignore CoolProp::fluid_types;
+#endif
 
 %include "std_string.i" // This %include allows the use of std::string natively
 %include "std_vector.i" // This allows for the use of STL vectors natively(ish)


### PR DESCRIPTION
The number of constants exported through swig was greater than the nesting level allowed by MSVC, which was causing compilation errors

See #355
