### PR TITLE
Some more static analyser warning fixes

### DIFF
--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -740,20 +740,20 @@ void FlashRoutines::PHSU_D_flash(HelmholtzEOSMixtureBackend &HEOS, parameters ot
                 if (value < y_solid){ throw ValueError(format("Other input [%d:%g] is solid", other, value));}
 
                 // Check if other is above the saturation value.
-                SaturationSolvers::saturation_D_pure_options options;
-                options.omega = 1;
-                options.use_logdelta = false;
+                SaturationSolvers::saturation_D_pure_options optionsD;
+                optionsD.omega = 1;
+                optionsD.use_logdelta = false;
                 if (HEOS._rhomolar > HEOS._crit.rhomolar)
                 {
-                    options.imposed_rho = SaturationSolvers::saturation_D_pure_options::IMPOSED_RHOL;
-                    SaturationSolvers::saturation_D_pure(HEOS, HEOS._rhomolar, options);
+                    optionsD.imposed_rho = SaturationSolvers::saturation_D_pure_options::IMPOSED_RHOL;
+                    SaturationSolvers::saturation_D_pure(HEOS, HEOS._rhomolar, optionsD);
                     // SatL and SatV have the saturation values
                     Sat = HEOS.SatL;
                 }
                 else
                 {
-                    options.imposed_rho = SaturationSolvers::saturation_D_pure_options::IMPOSED_RHOV;
-                    SaturationSolvers::saturation_D_pure(HEOS, HEOS._rhomolar, options);
+                    optionsD.imposed_rho = SaturationSolvers::saturation_D_pure_options::IMPOSED_RHOV;
+                    SaturationSolvers::saturation_D_pure(HEOS, HEOS._rhomolar, optionsD);
                     // SatL and SatV have the saturation values
                     Sat = HEOS.SatV;
                 }
@@ -775,14 +775,14 @@ void FlashRoutines::PHSU_D_flash(HelmholtzEOSMixtureBackend &HEOS, parameters ot
 						// Iterate to find T(p), its just a saturation call
 						
 						// Set some input options
-						SaturationSolvers::saturation_PHSU_pure_options options;
+						SaturationSolvers::saturation_PHSU_pure_options optionsPHSU;
 						// Specified variable is pressure
-						options.specified_variable = SaturationSolvers::saturation_PHSU_pure_options::IMPOSED_PL;
+						optionsPHSU.specified_variable = SaturationSolvers::saturation_PHSU_pure_options::IMPOSED_PL;
 						// Use logarithm of delta as independent variables
-						options.use_logdelta = false;
+						optionsPHSU.use_logdelta = false;
                         
                         // Actually call the solver
-                        SaturationSolvers::saturation_PHSU_pure(HEOS, HEOS._p, options);
+                        SaturationSolvers::saturation_PHSU_pure(HEOS, HEOS._p, optionsPHSU);
 
 						// Load the outputs
 						HEOS._phase = iphase_twophase;
@@ -1335,7 +1335,6 @@ void FlashRoutines::HS_flash(HelmholtzEOSMixtureBackend &HEOS)
             first_maxima_in_saturation_entropy = tripleV.smolar;
         }
         
-        double h1 = HEOS.hmolar(), s1 = HEOS.smolar();
         // Enthalpy at solid line for given entropy
         double hsolid = (tripleV.hmolar-tripleL.hmolar)/(tripleV.smolar-tripleL.smolar)*(HEOS.smolar()-tripleL.smolar) + tripleL.hmolar;
         // Part A - first check if HS is below triple line formed by connecting the triple point states
@@ -1365,7 +1364,6 @@ void FlashRoutines::HS_flash(HelmholtzEOSMixtureBackend &HEOS)
                 
             // Check if above the saturation enthalpy for given entropy
             // If it is, the inputs are definitely single-phase.  We are done here
-            double h1 = HEOS.hmolar(), h2 = HEOS_copy->hmolar();
             if (HEOS.hmolar() > HEOS_copy->hmolar()){
                 solution = single_phase_solution;
             }

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -1646,8 +1646,6 @@ long double HelmholtzEOSMixtureBackend::calc_pressure_nocache(long double T, lon
 }
 long double HelmholtzEOSMixtureBackend::solver_for_rho_given_T_oneof_HSU(long double T, long double value, int other)
 {
-    long double yc, ymin, y;
-
     // Define the residual to be driven to zero
     class solver_resid : public FuncWrapper1D
     {
@@ -1683,6 +1681,7 @@ long double HelmholtzEOSMixtureBackend::solver_for_rho_given_T_oneof_HSU(long do
     // Supercritical temperature
     if (_T > _crit.T)
     {
+        long double yc, ymin, y;
         long double rhoc = components[0]->crit.rhomolar;
         long double rhomin = 1e-10;
 

--- a/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
+++ b/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
@@ -464,7 +464,7 @@ bool PhaseEnvelopeRoutines::is_inside(HelmholtzEOSMixtureBackend &HEOS, paramete
             // Index of minimum distance in the other_values vector
             std::size_t idist = std::distance(d.begin(), std::min_element(d.begin(), d.end()));
             // Index of closest point in the phase envelope
-            std::size_t iclosest = other_indices[idist];
+            iclosest = other_indices[idist];
             
             // Get the state for the point which is closest to the desired value - this
             // can be used as a bounding value in the outer single-phase flash routine

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -281,7 +281,6 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend &HEOS, l
         else if (options.specified_variable == saturation_PHSU_pure_options::IMPOSED_SV)
         {
             CoolPropFluid &component = *(HEOS.get_components()[0]);
-            CoolProp::SimpleState crit = HEOS.get_state("reducing");
             CoolProp::SimpleState hs_anchor = HEOS.get_state("hs_anchor");
             class Residual : public FuncWrapper1D
             {

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -947,7 +947,6 @@ void SaturationSolvers::saturation_T_pure_Maxwell(HelmholtzEOSMixtureBackend &HE
                 rhoV = HEOS.get_components()[0]->ancillaries.rhoV.evaluate(T);
                 p = HEOS.get_components()[0]->ancillaries.pV.evaluate(T);
                 
-                CoolProp::SimpleState &crit = HEOS.get_components()[0]->crit;
                 CoolProp::SimpleState &tripleL = HEOS.get_components()[0]->triple_liquid;
                 CoolProp::SimpleState &tripleV = HEOS.get_components()[0]->triple_vapor;
                 

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -227,8 +227,7 @@ void _PropsSI_initialize(const std::string &backend,
     // Set the fraction for the state
     if (State->using_mole_fractions()){
         // If a predefined mixture or a pure fluid, the fractions will already be set
-        const std::vector<long double> &z = State->get_mole_fractions();
-        if (z.empty()){
+        if (State->get_mole_fractions().empty()){
             State->set_mole_fractions(*fractions_ptr);
         }
     } else if (State->using_mass_fractions()){
@@ -869,19 +868,19 @@ std::string get_fluid_param_string(std::string FluidName, std::string ParamName)
     try{
         std::vector<std::string> comps(1, FluidName);
         shared_ptr<CoolProp::HelmholtzEOSMixtureBackend> HEOS(new CoolProp::HelmholtzEOSMixtureBackend(comps));
-        CoolProp::CoolPropFluid *fluid = HEOS->get_components()[0];
+        CoolProp::CoolPropFluid *cpfluid = HEOS->get_components()[0];
 
         if (!ParamName.compare("aliases")){
-            return strjoin(fluid->aliases, ", ");
+            return strjoin(cpfluid->aliases, ", ");
         }
         else if (!ParamName.compare("CAS") || !ParamName.compare("CAS_number")){
-            return fluid->CAS;
+            return cpfluid->CAS;
         }
         else if (!ParamName.compare("ASHRAE34")){
-            return fluid->environment.ASHRAE34;
+            return cpfluid->environment.ASHRAE34;
         }
         else if (!ParamName.compare("REFPROPName") || !ParamName.compare("REFPROP_name") || !ParamName.compare("REFPROPname")){
-            return fluid->REFPROPname;
+            return cpfluid->REFPROPname;
         }
         else if (ParamName.find("BibTeX") == 0) // Starts with "BibTeX"
         {

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -220,20 +220,20 @@ void _PropsSI_initialize(const std::string &backend,
             State.reset(AbstractState::factory(backend, fluid_names));
         }
     }
+    else { // The only path where fractions_ptr stays NULL
+      throw ValueError("fractions_ptr is NULL");
+    }
 
     // Set the fraction for the state
     if (State->using_mole_fractions()){
         // If a predefined mixture or a pure fluid, the fractions will already be set
         const std::vector<long double> &z = State->get_mole_fractions();
         if (z.empty()){
-			if (fractions_ptr == NULL){ throw ValueError("fractions_ptr is NULL"); }
             State->set_mole_fractions(*fractions_ptr);
         }
     } else if (State->using_mass_fractions()){
-        if (fractions_ptr == NULL){ throw ValueError("fractions_ptr is NULL");}
         State->set_mass_fractions(*fractions_ptr);
     } else if (State->using_volu_fractions()){
-        if (fractions_ptr == NULL){ throw ValueError("fractions_ptr is NULL");}
         State->set_volu_fractions(*fractions_ptr);
     } else {
         if (get_debug_level()>50) std::cout << format("%s:%d: _PropsSI, could not set composition to %s, defaulting to mole fraction.\n",__FILE__,__LINE__, vec_to_string(z).c_str()).c_str();

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -848,10 +848,10 @@ TEST_CASE("Check inputs to get_global_param_string","[get_global_param_string]")
 
 std::string get_fluid_param_string(std::string FluidName, std::string ParamName)
 {
-    std::string backend, fluid;
-    extract_backend(FluidName, backend, fluid);
-    if (backend == "INCOMP"){
-        try{
+    try {
+        std::string backend, fluid;
+        extract_backend(FluidName, backend, fluid);
+        if (backend == "INCOMP"){
             shared_ptr<CoolProp::IncompressibleBackend> INCOMP(new CoolProp::IncompressibleBackend(fluid));
 
             if (!ParamName.compare("long_name")){
@@ -861,11 +861,7 @@ std::string get_fluid_param_string(std::string FluidName, std::string ParamName)
                 throw ValueError(format("Input value [%s] is invalid for Fluid [%s]",ParamName.c_str(),FluidName.c_str()));
             }
         }
-        catch(std::exception &e){ throw ValueError(format("CoolProp error: %s", e.what())); }
-        catch(...){ throw ValueError("CoolProp error: Indeterminate error"); }
-    }
 
-    try{
         std::vector<std::string> comps(1, FluidName);
         shared_ptr<CoolProp::HelmholtzEOSMixtureBackend> HEOS(new CoolProp::HelmholtzEOSMixtureBackend(comps));
         CoolProp::CoolPropFluid *cpfluid = HEOS->get_components()[0];

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -104,7 +104,7 @@ double convert_from_SI_to_kSI(long iInput, double value)
 EXPORT_CODE long CONVENTION redirect_stdout(const char* file){
     FILE *fp = freopen(file, "a+", stdout);
     reset_fpu();
-    return 0;
+    return (fp) ? 1 : 0; // 0 = failure if redirection could not be done; original stdout is already closed
 }
 EXPORT_CODE int CONVENTION set_reference_stateS(const char *Ref, const char *reference_state)
 {

--- a/src/Helmholtz.cpp
+++ b/src/Helmholtz.cpp
@@ -256,15 +256,15 @@ void ResidualHelmholtzNonAnalytic::to_json(rapidjson::Value &el, rapidjson::Docu
                      _C(rapidjson::kArrayType), _D(rapidjson::kArrayType);
     for (unsigned int i=0; i<=N; ++i)
     {
-        ResidualHelmholtzNonAnalyticElement &el = elements[i];
-        _n.PushBack((double)el.n, doc.GetAllocator());
-        _a.PushBack((double)el.a, doc.GetAllocator());
-        _b.PushBack((double)el.b, doc.GetAllocator());
-        _beta.PushBack((double)el.beta, doc.GetAllocator());
-        _A.PushBack((double)el.A, doc.GetAllocator());
-        _B.PushBack((double)el.B, doc.GetAllocator());
-        _C.PushBack((double)el.C, doc.GetAllocator());
-        _D.PushBack((double)el.D, doc.GetAllocator());
+        ResidualHelmholtzNonAnalyticElement &elem = elements[i];
+        _n.PushBack((double)elem.n, doc.GetAllocator());
+        _a.PushBack((double)elem.a, doc.GetAllocator());
+        _b.PushBack((double)elem.b, doc.GetAllocator());
+        _beta.PushBack((double)elem.beta, doc.GetAllocator());
+        _A.PushBack((double)elem.A, doc.GetAllocator());
+        _B.PushBack((double)elem.B, doc.GetAllocator());
+        _C.PushBack((double)elem.C, doc.GetAllocator());
+        _D.PushBack((double)elem.D, doc.GetAllocator());
     }
     el.AddMember("n",_n,doc.GetAllocator());
     el.AddMember("a",_a,doc.GetAllocator());


### PR DESCRIPTION
Here are some fixes:
1. restructuring the fix in CoolProp.cpp for #483;
2. return result of redirect_stdout DLL function (allowing for error handling);
3. fixes for "Local declaration hides local" warnings - there seem to be a number of unnecessary variables, and even one variable declaration that masks return value (iclosest in PhaseEnvelopeRoutines::is_inside())
4. restructuring get_fluid_param_string() exception handling to simplify and unify it; removes two identical code runs.