### PR TITLE
CoolPropDbl

### DIFF
--- a/Web/coolprop/snippets/mixture_derivative_table.cxx
+++ b/Web/coolprop/snippets/mixture_derivative_table.cxx
@@ -6,7 +6,7 @@ int main()
 {
     // Ethane/Propane mixture, 25/75 molar
     std::vector<std::string> components(2,"Ethane"); components[1] = "Propane";
-    std::vector<long double> z(2,0.25); z[1] = 0.75;
+    std::vector<CoolPropDbl> z(2,0.25); z[1] = 0.75;
     
     shared_ptr<HelmholtzEOSMixtureBackend> HEOS(new HelmholtzEOSMixtureBackend(components));
 	HelmholtzEOSMixtureBackend &rHEOS = *(HEOS.get());

--- a/include/AbstractState.h
+++ b/include/AbstractState.h
@@ -99,173 +99,173 @@ protected:
     // for properties that are not always calculated
     // ----------------------------------------
     /// Using this backend, calculate the molar enthalpy in J/mol
-    virtual long double calc_hmolar(void){throw NotImplementedError("calc_hmolar is not implemented for this backend");};
+    virtual CoolPropDbl calc_hmolar(void){throw NotImplementedError("calc_hmolar is not implemented for this backend");};
     /// Using this backend, calculate the molar entropy in J/mol/K
-    virtual long double calc_smolar(void){throw NotImplementedError("calc_smolar is not implemented for this backend");};
+    virtual CoolPropDbl calc_smolar(void){throw NotImplementedError("calc_smolar is not implemented for this backend");};
     /// Using this backend, calculate the molar internal energy in J/mol
-    virtual long double calc_umolar(void){throw NotImplementedError("calc_umolar is not implemented for this backend");};
+    virtual CoolPropDbl calc_umolar(void){throw NotImplementedError("calc_umolar is not implemented for this backend");};
     /// Using this backend, calculate the molar constant-pressure specific heat in J/mol/K
-    virtual long double calc_cpmolar(void){throw NotImplementedError("calc_cpmolar is not implemented for this backend");};
+    virtual CoolPropDbl calc_cpmolar(void){throw NotImplementedError("calc_cpmolar is not implemented for this backend");};
     /// Using this backend, calculate the ideal gas molar constant-pressure specific heat in J/mol/K
-    virtual long double calc_cpmolar_idealgas(void){throw NotImplementedError("calc_cpmolar_idealgas is not implemented for this backend");};
+    virtual CoolPropDbl calc_cpmolar_idealgas(void){throw NotImplementedError("calc_cpmolar_idealgas is not implemented for this backend");};
     /// Using this backend, calculate the molar constant-volume specific heat in J/mol/K
-    virtual long double calc_cvmolar(void){throw NotImplementedError("calc_cvmolar is not implemented for this backend");};
+    virtual CoolPropDbl calc_cvmolar(void){throw NotImplementedError("calc_cvmolar is not implemented for this backend");};
     /// Using this backend, calculate the molar Gibbs function in J/mol
-    virtual long double calc_gibbsmolar(void){throw NotImplementedError("calc_gibbsmolar is not implemented for this backend");};
+    virtual CoolPropDbl calc_gibbsmolar(void){throw NotImplementedError("calc_gibbsmolar is not implemented for this backend");};
     /// Using this backend, calculate the speed of sound in m/s
-    virtual long double calc_speed_sound(void){throw NotImplementedError("calc_speed_sound is not implemented for this backend");};
+    virtual CoolPropDbl calc_speed_sound(void){throw NotImplementedError("calc_speed_sound is not implemented for this backend");};
     /// Using this backend, calculate the isothermal compressibility \f$ \kappa = -\frac{1}{v}\left.\frac{\partial v}{\partial p}\right|_T=\frac{1}{\rho}\left.\frac{\partial \rho}{\partial p}\right|_T\f$  in 1/Pa
-    virtual long double calc_isothermal_compressibility(void){throw NotImplementedError("calc_isothermal_compressibility is not implemented for this backend");};
+    virtual CoolPropDbl calc_isothermal_compressibility(void){throw NotImplementedError("calc_isothermal_compressibility is not implemented for this backend");};
     /// Using this backend, calculate the isobaric expansion coefficient \f$ \beta = \frac{1}{v}\left.\frac{\partial v}{\partial T}\right|_p = -\frac{1}{\rho}\left.\frac{\partial \rho}{\partial T}\right|_p\f$  in 1/K
-    virtual long double calc_isobaric_expansion_coefficient(void){throw NotImplementedError("calc_isobaric_expansion_coefficient is not implemented for this backend");};
+    virtual CoolPropDbl calc_isobaric_expansion_coefficient(void){throw NotImplementedError("calc_isobaric_expansion_coefficient is not implemented for this backend");};
     /// Using this backend, calculate the viscosity in Pa-s
-    virtual long double calc_viscosity(void){throw NotImplementedError("calc_viscosity is not implemented for this backend");};
+    virtual CoolPropDbl calc_viscosity(void){throw NotImplementedError("calc_viscosity is not implemented for this backend");};
     /// Using this backend, calculate the thermal conductivity in W/m/K
-    virtual long double calc_conductivity(void){throw NotImplementedError("calc_conductivity is not implemented for this backend");};
+    virtual CoolPropDbl calc_conductivity(void){throw NotImplementedError("calc_conductivity is not implemented for this backend");};
     /// Using this backend, calculate the surface tension in N/m
-    virtual long double calc_surface_tension(void){throw NotImplementedError("calc_surface_tension is not implemented for this backend");};
+    virtual CoolPropDbl calc_surface_tension(void){throw NotImplementedError("calc_surface_tension is not implemented for this backend");};
     /// Using this backend, calculate the molar mass in kg/mol
-    virtual long double calc_molar_mass(void){throw NotImplementedError("calc_molar_mass is not implemented for this backend");};
+    virtual CoolPropDbl calc_molar_mass(void){throw NotImplementedError("calc_molar_mass is not implemented for this backend");};
     /// Using this backend, calculate the acentric factor
-    virtual long double calc_acentric_factor(void){throw NotImplementedError("calc_acentric_factor is not implemented for this backend");};   
+    virtual CoolPropDbl calc_acentric_factor(void){throw NotImplementedError("calc_acentric_factor is not implemented for this backend");};   
     /// Using this backend, calculate the pressure in Pa
-    virtual long double calc_pressure(void){throw NotImplementedError("calc_pressure is not implemented for this backend");};
+    virtual CoolPropDbl calc_pressure(void){throw NotImplementedError("calc_pressure is not implemented for this backend");};
     /// Using this backend, calculate the universal gas constant \f$R_u\f$ in J/mol/K
-    virtual long double calc_gas_constant(void){throw NotImplementedError("calc_gas_constant is not implemented for this backend");};
+    virtual CoolPropDbl calc_gas_constant(void){throw NotImplementedError("calc_gas_constant is not implemented for this backend");};
     /// Using this backend, calculate the fugacity coefficient (dimensionless)
-    virtual long double calc_fugacity_coefficient(int i){throw NotImplementedError("calc_fugacity_coefficient is not implemented for this backend");};
+    virtual CoolPropDbl calc_fugacity_coefficient(int i){throw NotImplementedError("calc_fugacity_coefficient is not implemented for this backend");};
 
 
     // Derivatives of residual helmholtz energy
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r\f$ (dimensionless)
-    virtual long double calc_alphar(void){throw NotImplementedError("calc_alphar is not implemented for this backend");};
+    virtual CoolPropDbl calc_alphar(void){throw NotImplementedError("calc_alphar is not implemented for this backend");};
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta}\f$ (dimensionless)
-    virtual long double calc_dalphar_dDelta(void){throw NotImplementedError("calc_dalphar_dDelta is not implemented for this backend");};
+    virtual CoolPropDbl calc_dalphar_dDelta(void){throw NotImplementedError("calc_dalphar_dDelta is not implemented for this backend");};
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau}\f$ (dimensionless)
-    virtual long double calc_dalphar_dTau(void){throw NotImplementedError("calc_dalphar_dTau is not implemented for this backend");};
+    virtual CoolPropDbl calc_dalphar_dTau(void){throw NotImplementedError("calc_dalphar_dTau is not implemented for this backend");};
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta}\f$ (dimensionless)
-    virtual long double calc_d2alphar_dDelta2(void){throw NotImplementedError("calc_d2alphar_dDelta2 is not implemented for this backend");};
+    virtual CoolPropDbl calc_d2alphar_dDelta2(void){throw NotImplementedError("calc_d2alphar_dDelta2 is not implemented for this backend");};
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau}\f$ (dimensionless)
-    virtual long double calc_d2alphar_dDelta_dTau(void){throw NotImplementedError("calc_d2alphar_dDelta_dTau is not implemented for this backend");};
+    virtual CoolPropDbl calc_d2alphar_dDelta_dTau(void){throw NotImplementedError("calc_d2alphar_dDelta_dTau is not implemented for this backend");};
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau}\f$ (dimensionless)
-    virtual long double calc_d2alphar_dTau2(void){throw NotImplementedError("calc_d2alphar_dTau2 is not implemented for this backend");};
+    virtual CoolPropDbl calc_d2alphar_dTau2(void){throw NotImplementedError("calc_d2alphar_dTau2 is not implemented for this backend");};
 	/// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\delta}\f$ (dimensionless)
-    virtual long double calc_d3alphar_dDelta3(void){throw NotImplementedError("calc_d3alpha0_dDelta3 is not implemented for this backend");};
+    virtual CoolPropDbl calc_d3alphar_dDelta3(void){throw NotImplementedError("calc_d3alpha0_dDelta3 is not implemented for this backend");};
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\tau}\f$ (dimensionless)
-    virtual long double calc_d3alphar_dDelta2_dTau(void){throw NotImplementedError("calc_d3alpha0_dDelta2_dTau is not implemented for this backend");};
+    virtual CoolPropDbl calc_d3alphar_dDelta2_dTau(void){throw NotImplementedError("calc_d3alpha0_dDelta2_dTau is not implemented for this backend");};
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau\tau}\f$ (dimensionless)
-    virtual long double calc_d3alphar_dDelta_dTau2(void){throw NotImplementedError("calc_d3alpha0_dDelta_dTau2 is not implemented for this backend");};
+    virtual CoolPropDbl calc_d3alphar_dDelta_dTau2(void){throw NotImplementedError("calc_d3alpha0_dDelta_dTau2 is not implemented for this backend");};
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau\tau}\f$ (dimensionless)
-    virtual long double calc_d3alphar_dTau3(void){throw NotImplementedError("calc_d3alpha0_dTau3 is not implemented for this backend");};
+    virtual CoolPropDbl calc_d3alphar_dTau3(void){throw NotImplementedError("calc_d3alpha0_dTau3 is not implemented for this backend");};
 	
     // Derivatives of ideal-gas helmholtz energy
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0\f$ (dimensionless)
-    virtual long double calc_alpha0(void){throw NotImplementedError("calc_alpha0 is not implemented for this backend");};
+    virtual CoolPropDbl calc_alpha0(void){throw NotImplementedError("calc_alpha0 is not implemented for this backend");};
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\delta}\f$ (dimensionless)
-    virtual long double calc_dalpha0_dDelta(void){throw NotImplementedError("calc_dalpha0_dDelta is not implemented for this backend");};
+    virtual CoolPropDbl calc_dalpha0_dDelta(void){throw NotImplementedError("calc_dalpha0_dDelta is not implemented for this backend");};
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\tau}\f$ (dimensionless)
-    virtual long double calc_dalpha0_dTau(void){throw NotImplementedError("calc_dalpha0_dTau is not implemented for this backend");};
+    virtual CoolPropDbl calc_dalpha0_dTau(void){throw NotImplementedError("calc_dalpha0_dTau is not implemented for this backend");};
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\delta\delta}\f$ (dimensionless)
-    virtual long double calc_d2alpha0_dDelta_dTau(void){throw NotImplementedError("calc_d2alpha0_dDelta_dTau is not implemented for this backend");};
+    virtual CoolPropDbl calc_d2alpha0_dDelta_dTau(void){throw NotImplementedError("calc_d2alpha0_dDelta_dTau is not implemented for this backend");};
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\delta\tau}\f$ (dimensionless)
-    virtual long double calc_d2alpha0_dDelta2(void){throw NotImplementedError("calc_d2alpha0_dDelta2 is not implemented for this backend");};
+    virtual CoolPropDbl calc_d2alpha0_dDelta2(void){throw NotImplementedError("calc_d2alpha0_dDelta2 is not implemented for this backend");};
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\tau\tau}\f$ (dimensionless)
-    virtual long double calc_d2alpha0_dTau2(void){throw NotImplementedError("calc_d2alpha0_dTau2 is not implemented for this backend");};
+    virtual CoolPropDbl calc_d2alpha0_dTau2(void){throw NotImplementedError("calc_d2alpha0_dTau2 is not implemented for this backend");};
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\delta\delta\delta}\f$ (dimensionless)
-    virtual long double calc_d3alpha0_dDelta3(void){throw NotImplementedError("calc_d3alpha0_dDelta3 is not implemented for this backend");};
+    virtual CoolPropDbl calc_d3alpha0_dDelta3(void){throw NotImplementedError("calc_d3alpha0_dDelta3 is not implemented for this backend");};
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\delta\delta\tau}\f$ (dimensionless)
-    virtual long double calc_d3alpha0_dDelta2_dTau(void){throw NotImplementedError("calc_d3alpha0_dDelta2_dTau is not implemented for this backend");};
+    virtual CoolPropDbl calc_d3alpha0_dDelta2_dTau(void){throw NotImplementedError("calc_d3alpha0_dDelta2_dTau is not implemented for this backend");};
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\delta\tau\tau}\f$ (dimensionless)
-    virtual long double calc_d3alpha0_dDelta_dTau2(void){throw NotImplementedError("calc_d3alpha0_dDelta_dTau2 is not implemented for this backend");};
+    virtual CoolPropDbl calc_d3alpha0_dDelta_dTau2(void){throw NotImplementedError("calc_d3alpha0_dDelta_dTau2 is not implemented for this backend");};
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\tau\tau\tau}\f$ (dimensionless)
-    virtual long double calc_d3alpha0_dTau3(void){throw NotImplementedError("calc_d3alpha0_dTau3 is not implemented for this backend");};
+    virtual CoolPropDbl calc_d3alpha0_dTau3(void){throw NotImplementedError("calc_d3alpha0_dTau3 is not implemented for this backend");};
 
     virtual void calc_reducing_state(void){throw NotImplementedError("calc_reducing_state is not implemented for this backend");};
 
     /// Using this backend, calculate the maximum temperature in K
-    virtual long double calc_Tmax(void){throw NotImplementedError("calc_Tmax is not implemented for this backend");};
+    virtual CoolPropDbl calc_Tmax(void){throw NotImplementedError("calc_Tmax is not implemented for this backend");};
     /// Using this backend, calculate the minimum temperature in K
-    virtual long double calc_Tmin(void){throw NotImplementedError("calc_Tmin is not implemented for this backend");};
+    virtual CoolPropDbl calc_Tmin(void){throw NotImplementedError("calc_Tmin is not implemented for this backend");};
     /// Using this backend, calculate the maximum pressure in Pa
-    virtual long double calc_pmax(void){throw NotImplementedError("calc_pmax is not implemented for this backend");};
+    virtual CoolPropDbl calc_pmax(void){throw NotImplementedError("calc_pmax is not implemented for this backend");};
 
     /// Using this backend, calculate the 20-year global warming potential (GWP)
-    virtual long double calc_GWP20(void){throw NotImplementedError("calc_GWP20 is not implemented for this backend");};
+    virtual CoolPropDbl calc_GWP20(void){throw NotImplementedError("calc_GWP20 is not implemented for this backend");};
     /// Using this backend, calculate the 100-year global warming potential (GWP)
-    virtual long double calc_GWP100(void){throw NotImplementedError("calc_GWP100 is not implemented for this backend");};
+    virtual CoolPropDbl calc_GWP100(void){throw NotImplementedError("calc_GWP100 is not implemented for this backend");};
     /// Using this backend, calculate the 500-year global warming potential (GWP)
-    virtual long double calc_GWP500(void){throw NotImplementedError("calc_GWP500 is not implemented for this backend");};
+    virtual CoolPropDbl calc_GWP500(void){throw NotImplementedError("calc_GWP500 is not implemented for this backend");};
     /// Using this backend, calculate the ozone depletion potential (ODP)
-    virtual long double calc_ODP(void){throw NotImplementedError("calc_ODP is not implemented for this backend");};
+    virtual CoolPropDbl calc_ODP(void){throw NotImplementedError("calc_ODP is not implemented for this backend");};
     /// Using this backend, calculate the flame hazard
-    virtual long double calc_flame_hazard(void){throw NotImplementedError("calc_flame_hazard is not implemented for this backend");};
+    virtual CoolPropDbl calc_flame_hazard(void){throw NotImplementedError("calc_flame_hazard is not implemented for this backend");};
     /// Using this backend, calculate the health hazard
-    virtual long double calc_health_hazard(void){throw NotImplementedError("calc_health_hazard is not implemented for this backend");};
+    virtual CoolPropDbl calc_health_hazard(void){throw NotImplementedError("calc_health_hazard is not implemented for this backend");};
     /// Using this backend, calculate the physical hazard
-    virtual long double calc_physical_hazard(void){throw NotImplementedError("calc_physical_hazard is not implemented for this backend");};
+    virtual CoolPropDbl calc_physical_hazard(void){throw NotImplementedError("calc_physical_hazard is not implemented for this backend");};
 
     /// Calculate the first partial derivative for the desired derivative
-    virtual long double calc_first_partial_deriv(parameters Of, parameters Wrt, parameters Constant);
+    virtual CoolPropDbl calc_first_partial_deriv(parameters Of, parameters Wrt, parameters Constant);
     /// Calculate the second partial derivative using the given backend
-    virtual long double calc_second_partial_deriv(parameters Of1, parameters Wrt1, parameters Constant1, parameters Of2, parameters Constant2);
+    virtual CoolPropDbl calc_second_partial_deriv(parameters Of1, parameters Wrt1, parameters Constant1, parameters Of2, parameters Constant2);
 
     /// Using this backend, calculate the reduced density (rho/rhoc)
-    virtual long double calc_reduced_density(void){throw NotImplementedError("calc_reduced_density is not implemented for this backend");};
+    virtual CoolPropDbl calc_reduced_density(void){throw NotImplementedError("calc_reduced_density is not implemented for this backend");};
     /// Using this backend, calculate the reciprocal reduced temperature (Tc/T)
-    virtual long double calc_reciprocal_reduced_temperature(void){throw NotImplementedError("calc_reciprocal_reduced_temperature is not implemented for this backend");};
+    virtual CoolPropDbl calc_reciprocal_reduced_temperature(void){throw NotImplementedError("calc_reciprocal_reduced_temperature is not implemented for this backend");};
 
     /// Using this backend, calculate the second virial coefficient
-    virtual long double calc_Bvirial(void){throw NotImplementedError("calc_Bvirial is not implemented for this backend");};
+    virtual CoolPropDbl calc_Bvirial(void){throw NotImplementedError("calc_Bvirial is not implemented for this backend");};
     /// Using this backend, calculate the third virial coefficient
-    virtual long double calc_Cvirial(void){throw NotImplementedError("calc_Cvirial is not implemented for this backend");};
+    virtual CoolPropDbl calc_Cvirial(void){throw NotImplementedError("calc_Cvirial is not implemented for this backend");};
     /// Using this backend, calculate the derivative dB/dT
-    virtual long double calc_dBvirial_dT(void){throw NotImplementedError("calc_dBvirial_dT is not implemented for this backend");};
+    virtual CoolPropDbl calc_dBvirial_dT(void){throw NotImplementedError("calc_dBvirial_dT is not implemented for this backend");};
     /// Using this backend, calculate the derivative dC/dT
-    virtual long double calc_dCvirial_dT(void){throw NotImplementedError("calc_dCvirial_dT is not implemented for this backend");};
+    virtual CoolPropDbl calc_dCvirial_dT(void){throw NotImplementedError("calc_dCvirial_dT is not implemented for this backend");};
     /// Using this backend, calculate the compressibility factor Z \f$ Z = p/(\rho R T) \f$
-    virtual long double calc_compressibility_factor(void){throw NotImplementedError("calc_compressibility_factor is not implemented for this backend");};
+    virtual CoolPropDbl calc_compressibility_factor(void){throw NotImplementedError("calc_compressibility_factor is not implemented for this backend");};
 
     /// Using this backend, get the name of the fluid
     virtual std::string calc_name(void){throw NotImplementedError("calc_name is not implemented for this backend");};
 
     /// Using this backend, get the triple point temperature in K
-    virtual long double calc_Ttriple(void){throw NotImplementedError("calc_Ttriple is not implemented for this backend");};
+    virtual CoolPropDbl calc_Ttriple(void){throw NotImplementedError("calc_Ttriple is not implemented for this backend");};
     /// Using this backend, get the triple point pressure in Pa
-    virtual long double calc_p_triple(void){throw NotImplementedError("calc_p_triple is not implemented for this backend");};
+    virtual CoolPropDbl calc_p_triple(void){throw NotImplementedError("calc_p_triple is not implemented for this backend");};
 
     /// Using this backend, get the critical point temperature in K
-    virtual long double calc_T_critical(void){throw NotImplementedError("calc_T_critical is not implemented for this backend");};
+    virtual CoolPropDbl calc_T_critical(void){throw NotImplementedError("calc_T_critical is not implemented for this backend");};
 	/// Using this backend, get the reducing point temperature in K
-    virtual long double calc_T_reducing(void){throw NotImplementedError("calc_T_reducing is not implemented for this backend");};
+    virtual CoolPropDbl calc_T_reducing(void){throw NotImplementedError("calc_T_reducing is not implemented for this backend");};
     /// Using this backend, get the critical point pressure in Pa
-    virtual long double calc_p_critical(void){throw NotImplementedError("calc_p_critical is not implemented for this backend");};
+    virtual CoolPropDbl calc_p_critical(void){throw NotImplementedError("calc_p_critical is not implemented for this backend");};
     /// Using this backend, get the reducing point pressure in Pa
-    virtual long double calc_p_reducing(void){throw NotImplementedError("calc_p_reducing is not implemented for this backend");};
+    virtual CoolPropDbl calc_p_reducing(void){throw NotImplementedError("calc_p_reducing is not implemented for this backend");};
     /// Using this backend, get the critical point molar density in mol/m^3
-    virtual long double calc_rhomolar_critical(void){throw NotImplementedError("calc_rhomolar_critical is not implemented for this backend");};
+    virtual CoolPropDbl calc_rhomolar_critical(void){throw NotImplementedError("calc_rhomolar_critical is not implemented for this backend");};
 	/// Using this backend, get the reducing point molar density in mol/m^3
-    virtual long double calc_rhomolar_reducing(void){throw NotImplementedError("calc_rhomolar_reducing is not implemented for this backend");};
+    virtual CoolPropDbl calc_rhomolar_reducing(void){throw NotImplementedError("calc_rhomolar_reducing is not implemented for this backend");};
     /// Using this backend, construct the phase envelope, the variable type describes the type of phase envelope to be built.
     virtual void calc_phase_envelope(const std::string &type){throw NotImplementedError("calc_phase_envelope is not implemented for this backend");};
     /// 
-    virtual long double calc_rhomass(void){return _rhomolar*molar_mass();}
-    virtual long double calc_hmass(void){return hmolar()/molar_mass();}
-    virtual long double calc_smass(void){return smolar()/molar_mass();}
-    virtual long double calc_cpmass(void){return cpmolar()/molar_mass();}
-    virtual long double calc_cp0mass(void){return cp0molar()/molar_mass();}
-    virtual long double calc_cvmass(void){return cvmolar()/molar_mass();}
-    virtual long double calc_umass(void){return umolar()/molar_mass();}
+    virtual CoolPropDbl calc_rhomass(void){return _rhomolar*molar_mass();}
+    virtual CoolPropDbl calc_hmass(void){return hmolar()/molar_mass();}
+    virtual CoolPropDbl calc_smass(void){return smolar()/molar_mass();}
+    virtual CoolPropDbl calc_cpmass(void){return cpmolar()/molar_mass();}
+    virtual CoolPropDbl calc_cp0mass(void){return cp0molar()/molar_mass();}
+    virtual CoolPropDbl calc_cvmass(void){return cvmolar()/molar_mass();}
+    virtual CoolPropDbl calc_umass(void){return umolar()/molar_mass();}
     
     /// Update the states after having changed the reference state for enthalpy and entropy
     virtual void update_states(void){throw NotImplementedError("This backend does not implement update_states function");};
     
-    virtual long double calc_melting_line(int param, int given, long double value){throw NotImplementedError("This backend does not implement calc_melting_line function");};
+    virtual CoolPropDbl calc_melting_line(int param, int given, CoolPropDbl value){throw NotImplementedError("This backend does not implement calc_melting_line function");};
     
     /// @param param The key for the parameter to be returned
     /// @param Q The quality for the parameter that is given (0 = saturated liquid, 1 = saturated vapor)
     /// @param given The key for the parameter that is given
     /// @param value The value for the parameter that is given
-    virtual long double calc_saturation_ancillary(parameters param, int Q, parameters given, double value){throw NotImplementedError("This backend does not implement calc_saturation_ancillary");};
+    virtual CoolPropDbl calc_saturation_ancillary(parameters param, int Q, parameters given, double value){throw NotImplementedError("This backend does not implement calc_saturation_ancillary");};
     
     /// Using this backend, calculate the phase
     virtual phases calc_phase(void){throw NotImplementedError("This backend does not implement calc_phase function");};
@@ -281,23 +281,23 @@ protected:
     
     virtual const CoolProp::PhaseEnvelopeData & calc_phase_envelope_data(void){throw NotImplementedError("calc_phase_envelope_data is not implemented for this backend");};
     
-    virtual std::vector<long double> calc_mole_fractions_liquid(void){throw NotImplementedError("calc_mole_fractions_liquid is not implemented for this backend");};
-    virtual std::vector<long double> calc_mole_fractions_vapor(void){throw NotImplementedError("calc_mole_fractions_vapor is not implemented for this backend");};
+    virtual std::vector<CoolPropDbl> calc_mole_fractions_liquid(void){throw NotImplementedError("calc_mole_fractions_liquid is not implemented for this backend");};
+    virtual std::vector<CoolPropDbl> calc_mole_fractions_vapor(void){throw NotImplementedError("calc_mole_fractions_vapor is not implemented for this backend");};
 
     /// Get the minimum fraction (mole, mass, volume) for incompressible fluid
-    virtual long double calc_fraction_min(void){throw NotImplementedError("calc_fraction_min is not implemented for this backend");};
+    virtual CoolPropDbl calc_fraction_min(void){throw NotImplementedError("calc_fraction_min is not implemented for this backend");};
     /// Get the maximum fraction (mole, mass, volume) for incompressible fluid
-    virtual long double calc_fraction_max(void){throw NotImplementedError("calc_fraction_max is not implemented for this backend");};
-    virtual long double calc_T_freeze(void){throw NotImplementedError("calc_T_freeze is not implemented for this backend");};
+    virtual CoolPropDbl calc_fraction_max(void){throw NotImplementedError("calc_fraction_max is not implemented for this backend");};
+    virtual CoolPropDbl calc_T_freeze(void){throw NotImplementedError("calc_T_freeze is not implemented for this backend");};
 	
-	virtual long double calc_first_saturation_deriv(parameters Of1, parameters Wrt1){throw NotImplementedError("calc_first_saturation_deriv is not implemented for this backend");};
-	virtual long double calc_second_saturation_deriv(parameters Of1, parameters Wrt1, parameters Of2, parameters Wrt2){throw NotImplementedError("calc_second_saturation_deriv is not implemented for this backend");};
-    virtual long double calc_first_two_phase_deriv(parameters Of, parameters Wrt, parameters Constant){throw NotImplementedError("calc_first_two_phase_deriv is not implemented for this backend");};
-    virtual long double calc_second_two_phase_deriv(parameters Of, parameters Wrt, parameters Constant, parameters Wrt2, parameters Constant2){throw NotImplementedError("calc_second_two_phase_deriv is not implemented for this backend");};
-    virtual long double calc_first_two_phase_deriv_splined(parameters Of, parameters Wrt, parameters Constant, long double x_end){throw NotImplementedError("calc_first_two_phase_deriv_splined is not implemented for this backend");};
+	virtual CoolPropDbl calc_first_saturation_deriv(parameters Of1, parameters Wrt1){throw NotImplementedError("calc_first_saturation_deriv is not implemented for this backend");};
+	virtual CoolPropDbl calc_second_saturation_deriv(parameters Of1, parameters Wrt1, parameters Of2, parameters Wrt2){throw NotImplementedError("calc_second_saturation_deriv is not implemented for this backend");};
+    virtual CoolPropDbl calc_first_two_phase_deriv(parameters Of, parameters Wrt, parameters Constant){throw NotImplementedError("calc_first_two_phase_deriv is not implemented for this backend");};
+    virtual CoolPropDbl calc_second_two_phase_deriv(parameters Of, parameters Wrt, parameters Constant, parameters Wrt2, parameters Constant2){throw NotImplementedError("calc_second_two_phase_deriv is not implemented for this backend");};
+    virtual CoolPropDbl calc_first_two_phase_deriv_splined(parameters Of, parameters Wrt, parameters Constant, CoolPropDbl x_end){throw NotImplementedError("calc_first_two_phase_deriv_splined is not implemented for this backend");};
     
-    virtual long double calc_saturated_liquid_keyed_output(parameters key){throw NotImplementedError("calc_saturated_liquid_keyed_output is not implemented for this backend");};
-    virtual long double calc_saturated_vapor_keyed_output(parameters key){throw NotImplementedError("calc_saturated_vapor_keyed_output is not implemented for this backend");};
+    virtual CoolPropDbl calc_saturated_liquid_keyed_output(parameters key){throw NotImplementedError("calc_saturated_liquid_keyed_output is not implemented for this backend");};
+    virtual CoolPropDbl calc_saturated_vapor_keyed_output(parameters key){throw NotImplementedError("calc_saturated_vapor_keyed_output is not implemented for this backend");};
 
 public:
 
@@ -347,20 +347,20 @@ public:
     virtual bool using_volu_fractions(void) = 0;
 
     virtual void update(CoolProp::input_pairs input_pair, double Value1, double Value2) = 0;
-    virtual void set_mole_fractions(const std::vector<long double> &mole_fractions) = 0;
-    virtual void set_mass_fractions(const std::vector<long double> &mass_fractions) = 0;
-    virtual void set_volu_fractions(const std::vector<long double> &mass_fractions){throw NotImplementedError("Volume composition has not been implemented.");}
+    virtual void set_mole_fractions(const std::vector<CoolPropDbl> &mole_fractions) = 0;
+    virtual void set_mass_fractions(const std::vector<CoolPropDbl> &mass_fractions) = 0;
+    virtual void set_volu_fractions(const std::vector<CoolPropDbl> &mass_fractions){throw NotImplementedError("Volume composition has not been implemented.");}
     /// Get the mole fractions of the components
-    virtual const std::vector<long double> & get_mole_fractions(void) = 0;
+    virtual const std::vector<CoolPropDbl> & get_mole_fractions(void) = 0;
     
 	std::vector<std::string> fluid_names(void);
     
     /// Clear all the cached values
     bool clear();
 
-    void set_mole_fractions(const std::vector<double> &mole_fractions){set_mole_fractions(std::vector<long double>(mole_fractions.begin(), mole_fractions.end()));};
-    void set_mass_fractions(const std::vector<double> &mass_fractions){set_mass_fractions(std::vector<long double>(mass_fractions.begin(), mass_fractions.end()));};
-    void set_volu_fractions(const std::vector<double> &volu_fractions){set_volu_fractions(std::vector<long double>(volu_fractions.begin(), volu_fractions.end()));};
+    void set_mole_fractions(const std::vector<double> &mole_fractions){set_mole_fractions(std::vector<CoolPropDbl>(mole_fractions.begin(), mole_fractions.end()));};
+    void set_mass_fractions(const std::vector<double> &mass_fractions){set_mass_fractions(std::vector<CoolPropDbl>(mass_fractions.begin(), mass_fractions.end()));};
+    void set_volu_fractions(const std::vector<double> &volu_fractions){set_volu_fractions(std::vector<CoolPropDbl>(volu_fractions.begin(), volu_fractions.end()));};
 
     virtual const CoolProp::SimpleState & get_reducing_state(){return _reducing;};
     const CoolProp::SimpleState & get_state(const std::string &state){return calc_state(state);};
@@ -497,8 +497,8 @@ public:
     double fugacity_coefficient(int i);
     //double fundamental_derivative_of_gas_dynamics(void);
     
-    std::vector<long double> mole_fractions_liquid(void){return calc_mole_fractions_liquid();};
-    std::vector<long double> mole_fractions_vapor(void){return calc_mole_fractions_vapor();};
+    std::vector<CoolPropDbl> mole_fractions_liquid(void){return calc_mole_fractions_liquid();};
+    std::vector<CoolPropDbl> mole_fractions_vapor(void){return calc_mole_fractions_vapor();};
     
     // ----------------------------------------
     //    Partial derivatives
@@ -508,7 +508,7 @@ public:
      * 
      * \f[ \left(\frac{\partial A}{\partial B}\right)_C = \frac{\left(\frac{\partial A}{\partial \tau}\right)_\delta\left(\frac{\partial C}{\partial \delta}\right)_\tau-\left(\frac{\partial A}{\partial \delta}\right)_\tau\left(\frac{\partial C}{\partial \tau}\right)_\delta}{\left(\frac{\partial B}{\partial \tau}\right)_\delta\left(\frac{\partial C}{\partial \delta}\right)_\tau-\left(\frac{\partial B}{\partial \delta}\right)_\tau\left(\frac{\partial C}{\partial \tau}\right)_\delta} = \frac{N}{D}\f]
      */
-    long double first_partial_deriv(parameters Of, parameters Wrt, parameters Constant){return calc_first_partial_deriv(Of, Wrt, Constant);};
+    CoolPropDbl first_partial_deriv(parameters Of, parameters Wrt, parameters Constant){return calc_first_partial_deriv(Of, Wrt, Constant);};
     
     /** \brief The second partial derivative in homogeneous phases
      * 
@@ -533,7 +533,7 @@ public:
      * 
      * The terms \f$ N \f$ and \f$ D \f$ are the numerator and denominator from \ref CoolProp::AbstractState::first_partial_deriv respectively
      */
-    long double second_partial_deriv(parameters Of1, parameters Wrt1, parameters Constant1, parameters Of2, parameters Constant2){return calc_second_partial_deriv(Of1,Wrt1,Constant1,Of2,Constant2);};
+    CoolPropDbl second_partial_deriv(parameters Of1, parameters Wrt1, parameters Constant1, parameters Of2, parameters Constant2){return calc_second_partial_deriv(Of1,Wrt1,Constant1,Of2,Constant2);};
     
 	/** \brief The first partial derivative along the saturation curve
 	 * 
@@ -556,7 +556,7 @@ public:
 	 * @param Of1 The parameter that the derivative is taken of
 	 * @param Wrt1 The parameter that the derivative is taken with respect to
 	 */
-	long double first_saturation_deriv(parameters Of1, parameters Wrt1){return calc_first_saturation_deriv(Of1,Wrt1);};
+	CoolPropDbl first_saturation_deriv(parameters Of1, parameters Wrt1){return calc_first_saturation_deriv(Of1,Wrt1);};
 	
 	/** \brief The second partial derivative along the saturation curve
 	 * 
@@ -576,7 +576,7 @@ public:
 	 * @param Of2 The parameter that the second derivative is taken of
 	 * @param Wrt2 The parameter that the second derivative is taken with respect to
 	 * */
-	long double second_saturation_deriv(parameters Of1, parameters Wrt1, parameters Of2, parameters Wrt2){return calc_second_saturation_deriv(Of1,Wrt1,Of2,Wrt2);};
+	CoolPropDbl second_saturation_deriv(parameters Of1, parameters Wrt1, parameters Of2, parameters Wrt2){return calc_second_saturation_deriv(Of1,Wrt1,Of2,Wrt2);};
     
     /**
      * @brief Calculate the first "two-phase" derivative as described by Thorade and Sadaat, EAS, 2013
@@ -651,84 +651,84 @@ public:
     // Helmholtz energy and derivatives
     // ----------------------------------------
     /// Return the term \f$ \alpha^0 \f$
-    long double alpha0(void){
+    CoolPropDbl alpha0(void){
         if (!_alpha0) _alpha0 = calc_alpha0();
         return _alpha0;
     };
-    long double dalpha0_dDelta(void){
+    CoolPropDbl dalpha0_dDelta(void){
         if (!_dalpha0_dDelta) _dalpha0_dDelta = calc_dalpha0_dDelta();
         return _dalpha0_dDelta;
     };
-    long double dalpha0_dTau(void){
+    CoolPropDbl dalpha0_dTau(void){
         if (!_dalpha0_dTau) _dalpha0_dTau = calc_dalpha0_dTau();
         return _dalpha0_dTau;
     };
-    long double d2alpha0_dDelta2(void){
+    CoolPropDbl d2alpha0_dDelta2(void){
         if (!_d2alpha0_dDelta2) _d2alpha0_dDelta2 = calc_d2alpha0_dDelta2();
         return _d2alpha0_dDelta2;
     };
-    long double d2alpha0_dDelta_dTau(void){
+    CoolPropDbl d2alpha0_dDelta_dTau(void){
         if (!_d2alpha0_dDelta_dTau) _d2alpha0_dDelta_dTau = calc_d2alpha0_dDelta_dTau();
         return _d2alpha0_dDelta_dTau;
     };
-    long double d2alpha0_dTau2(void){
+    CoolPropDbl d2alpha0_dTau2(void){
         if (!_d2alpha0_dTau2) _d2alpha0_dTau2 = calc_d2alpha0_dTau2();
         return _d2alpha0_dTau2;
     };
-    long double d3alpha0_dTau3(void){
+    CoolPropDbl d3alpha0_dTau3(void){
         if (!_d3alpha0_dTau3) _d3alpha0_dTau3 = calc_d3alpha0_dTau3();
         return _d3alpha0_dTau3;
     };
-    long double d3alpha0_dDelta_dTau2(void){
+    CoolPropDbl d3alpha0_dDelta_dTau2(void){
         if (!_d3alpha0_dDelta_dTau2) _d3alpha0_dDelta_dTau2 = calc_d3alpha0_dDelta_dTau2();
         return _d3alpha0_dDelta_dTau2;
     };
-    long double d3alpha0_dDelta2_dTau(void){
+    CoolPropDbl d3alpha0_dDelta2_dTau(void){
         if (!_d3alpha0_dDelta2_dTau) _d3alpha0_dDelta2_dTau = calc_d3alpha0_dDelta2_dTau();
         return _d3alpha0_dDelta2_dTau;
     };
-    long double d3alpha0_dDelta3(void){
+    CoolPropDbl d3alpha0_dDelta3(void){
         if (!_d3alpha0_dDelta3) _d3alpha0_dDelta3 = calc_d3alpha0_dDelta3();
         return _d3alpha0_dDelta3;
     };
 
-    long double alphar(void){
+    CoolPropDbl alphar(void){
         if (!_alphar) _alphar = calc_alphar();
         return _alphar;
     };
-    long double dalphar_dDelta(void){
+    CoolPropDbl dalphar_dDelta(void){
         if (!_dalphar_dDelta) _dalphar_dDelta = calc_dalphar_dDelta();
         return _dalphar_dDelta;
     };
-    long double dalphar_dTau(void){
+    CoolPropDbl dalphar_dTau(void){
         if (!_dalphar_dTau) _dalphar_dTau = calc_dalphar_dTau();
         return _dalphar_dTau;
     };
-    long double d2alphar_dDelta2(void){
+    CoolPropDbl d2alphar_dDelta2(void){
         if (!_d2alphar_dDelta2) _d2alphar_dDelta2 = calc_d2alphar_dDelta2();
         return _d2alphar_dDelta2;
     };
-    long double d2alphar_dDelta_dTau(void){
+    CoolPropDbl d2alphar_dDelta_dTau(void){
         if (!_d2alphar_dDelta_dTau) _d2alphar_dDelta_dTau = calc_d2alphar_dDelta_dTau();
         return _d2alphar_dDelta_dTau;
     };
-    long double d2alphar_dTau2(void){
+    CoolPropDbl d2alphar_dTau2(void){
         if (!_d2alphar_dTau2) _d2alphar_dTau2 = calc_d2alphar_dTau2();
         return _d2alphar_dTau2;
     };
-	long double d3alphar_dDelta3(void){
+	CoolPropDbl d3alphar_dDelta3(void){
         if (!_d3alphar_dDelta3) _d3alphar_dDelta3 = calc_d3alphar_dDelta3();
         return _d3alphar_dDelta3;
     };
-	long double d3alphar_dDelta2_dTau(void){
+	CoolPropDbl d3alphar_dDelta2_dTau(void){
         if (!_d3alphar_dDelta2_dTau) _d3alphar_dDelta2_dTau = calc_d3alphar_dDelta2_dTau();
         return _d3alphar_dDelta2_dTau;
     };
-	long double d3alphar_dDelta_dTau2(void){
+	CoolPropDbl d3alphar_dDelta_dTau2(void){
         if (!_d3alphar_dDelta_dTau2) _d3alphar_dDelta_dTau2 = d3alphar_dDelta_dTau2();
         return _d3alphar_dDelta_dTau2;
     };
-	long double d3alphar_dTau3(void){
+	CoolPropDbl d3alphar_dTau3(void){
         if (!_d3alphar_dTau3) _d3alphar_dTau3 = calc_d3alphar_dTau3();
         return _d3alphar_dTau3;
     };

--- a/include/Ancillaries.h
+++ b/include/Ancillaries.h
@@ -24,8 +24,8 @@ surface tension is in N/m
 class SurfaceTensionCorrelation
 {
 public:
-    std::vector<long double> a, n, s;
-    long double Tc;
+    std::vector<CoolPropDbl> a, n, s;
+    CoolPropDbl Tc;
 
     std::size_t N;
 
@@ -42,10 +42,10 @@ public:
         this->N = n.size();
         s = n;
     };
-    long double evaluate(long double T)
+    CoolPropDbl evaluate(CoolPropDbl T)
     {
         if (a.empty()){ throw NotImplementedError(format("surface tension curve not provided"));}
-        long double THETA = 1-T/Tc;
+        CoolPropDbl THETA = 1-T/Tc;
         for (std::size_t i = 0; i < N; ++i)
         {
             s[i] = a[i]*pow(THETA, n[i]);
@@ -84,7 +84,7 @@ private:
                     den_coeffs; ///< Coefficients for denominator in rational polynomial
     std::vector<double> n, t, s;
     bool using_tau_r;
-    long double Tmax, Tmin, reducing_value, T_r, max_abs_error;
+    CoolPropDbl Tmax, Tmin, reducing_value, T_r, max_abs_error;
     enum ancillaryfunctiontypes{TYPE_NOT_SET = 0, 
                                 TYPE_NOT_EXPONENTIAL, 
                                 TYPE_EXPONENTIAL, 
@@ -101,7 +101,7 @@ public:
     
     /// Get the maximum absolute error for this fit
     /// @returns max_abs_error the maximum absolute error for ancillaries that are characterized by maximum absolute error
-    long double get_max_abs_error(){return max_abs_error;};
+    CoolPropDbl get_max_abs_error(){return max_abs_error;};
     
     /// Evaluate this ancillary function, yielding for instance the saturated liquid density
     /// @param T The temperature in K
@@ -127,7 +127,7 @@ public:
 
 struct MeltingLinePiecewiseSimonSegment
 {
-    long double T_0, a, c, p_0, T_max, T_min, p_min, p_max;
+    CoolPropDbl T_0, a, c, p_0, T_max, T_min, p_min, p_max;
 };
 struct MeltingLinePiecewiseSimonData
 {
@@ -136,11 +136,11 @@ struct MeltingLinePiecewiseSimonData
 class MeltingLinePiecewisePolynomialInTrSegment
 {
 public:
-    std::vector<long double> a, t;
-    long double T_0, p_0, T_max, T_min, p_min, p_max;
-    long double evaluate(long double T)
+    std::vector<CoolPropDbl> a, t;
+    CoolPropDbl T_0, p_0, T_max, T_min, p_min, p_max;
+    CoolPropDbl evaluate(CoolPropDbl T)
     {
-        long double summer = 0;
+        CoolPropDbl summer = 0;
         for (std::size_t i =0; i < a.size(); ++i){
             summer += a[i]*(pow(T/T_0,t[i])-1);
         }
@@ -154,12 +154,12 @@ struct MeltingLinePiecewisePolynomialInTrData
 class MeltingLinePiecewisePolynomialInThetaSegment
 {
 public:
-    std::vector<long double> a, t;
-    long double T_0, p_0, T_max, T_min, p_min, p_max;
+    std::vector<CoolPropDbl> a, t;
+    CoolPropDbl T_0, p_0, T_max, T_min, p_min, p_max;
     
-    long double evaluate(long double T)
+    CoolPropDbl evaluate(CoolPropDbl T)
     {
-        long double summer = 0;
+        CoolPropDbl summer = 0;
         for (std::size_t i =0; i < a.size(); ++i){
             summer += a[i]*pow(T/T_0-1,t[i]);
         }
@@ -179,16 +179,16 @@ public:
         MELTING_LINE_POLYNOMIAL_IN_THETA_TYPE,
         MELTING_LINE_NOT_SET
     };
-    long double Tmin, Tmax, pmin, pmax;
+    CoolPropDbl Tmin, Tmax, pmin, pmax;
     
-    long double evaluate(int OF, int GIVEN, long double value);
+    CoolPropDbl evaluate(int OF, int GIVEN, CoolPropDbl value);
     
     /// Evaluate the melting line to calculate the limits of the curve (Tmin/Tmax and pmin/pmax)
     void set_limits();
     
     bool enabled(){return type != MELTING_LINE_NOT_SET;};
     std::string BibTeX;
-    long double T_m; ///< Melting temperature at 1 atmosphere
+    CoolPropDbl T_m; ///< Melting temperature at 1 atmosphere
     MeltingLinePiecewiseSimonData simon;
     MeltingLinePiecewisePolynomialInTrData polynomial_in_Tr;
     MeltingLinePiecewisePolynomialInThetaData polynomial_in_Theta;

--- a/include/CachedElement.h
+++ b/include/CachedElement.h
@@ -33,7 +33,7 @@ class CachedElement {
 
 private:
     bool is_cached;
-    long double value;
+    CoolPropDbl value;
 public:
     /// Default constructor
     CachedElement() {
@@ -62,7 +62,7 @@ public:
             throw std::exception();
         }
     }
-    operator long double() {
+    operator CoolPropDbl() {
         if (is_cached) {return value; }
         else {
             throw std::exception();
@@ -73,7 +73,7 @@ public:
         is_cached = false;
         this->value = _HUGE;
     };
-    long double &pt(){
+    CoolPropDbl &pt(){
         return this->value;
     }
 };

--- a/include/CoolPropFluid.h
+++ b/include/CoolPropFluid.h
@@ -91,17 +91,17 @@ struct EOSLimits
 
 struct ConductivityECSVariables{
     std::string reference_fluid;
-    long double psi_rhomolar_reducing, f_int_T_reducing;
-    std::vector<long double> psi_a, psi_t, f_int_a, f_int_t;
+    CoolPropDbl psi_rhomolar_reducing, f_int_T_reducing;
+    std::vector<CoolPropDbl> psi_a, psi_t, f_int_a, f_int_t;
 };
 
 struct ConductivityDiluteEta0AndPolyData{
-    std::vector<long double> A, t;
+    std::vector<CoolPropDbl> A, t;
 };
 
 struct ConductivityDiluteRatioPolynomialsData{
-    long double T_reducing, p_reducing;
-    std::vector<long double> A, B, n, m;
+    CoolPropDbl T_reducing, p_reducing;
+    std::vector<CoolPropDbl> A, B, n, m;
 };
 struct ConductivityDiluteVariables
 {
@@ -120,13 +120,13 @@ struct ConductivityDiluteVariables
 };
 
 struct ConductivityResidualPolynomialAndExponentialData{
-    long double T_reducing, rhomass_reducing;
-    std::vector<long double> A, t, d, gamma, l;
+    CoolPropDbl T_reducing, rhomass_reducing;
+    std::vector<CoolPropDbl> A, t, d, gamma, l;
 };
 
 struct ConductivityResidualPolynomialData{
-    long double T_reducing, rhomass_reducing;
-    std::vector<long double> B, t, d;
+    CoolPropDbl T_reducing, rhomass_reducing;
+    std::vector<CoolPropDbl> B, t, d;
 };
 struct ConductivityResidualVariables
 {
@@ -144,7 +144,7 @@ struct ConductivityResidualVariables
 };
 
 struct ConductivityCriticalSimplifiedOlchowySengersData{
-    long double T_reducing, p_reducing, k, R0, gamma, nu, qD, zeta0, GAMMA, T_ref;
+    CoolPropDbl T_reducing, p_reducing, k, R0, gamma, nu, qD, zeta0, GAMMA, T_ref;
     ConductivityCriticalSimplifiedOlchowySengersData(){
         // Universal constants - can still be adjusted if need be
         k = 1.3806488e-23; //[J/K]
@@ -179,18 +179,18 @@ struct ConductivityCriticalVariables
 /// Variables for the dilute gas part
 struct ViscosityDiluteGasCollisionIntegralData
 {
-    long double molar_mass, C;
-    std::vector<long double> a, t;
+    CoolPropDbl molar_mass, C;
+    std::vector<CoolPropDbl> a, t;
 };
 struct ViscosityDiluteCollisionIntegralPowersOfTstarData
 {
-    long double T_reducing, ///< Reducing temperature [K[
+    CoolPropDbl T_reducing, ///< Reducing temperature [K[
                 C;          ///< Leading constant
-    std::vector<long double> a, t;
+    std::vector<CoolPropDbl> a, t;
 };
 struct ViscosityDiluteGasPowersOfT
 {
-    std::vector<long double> a, t;
+    std::vector<CoolPropDbl> a, t;
 };
 struct ViscosityDiluteVariables
 {
@@ -211,12 +211,12 @@ struct ViscosityDiluteVariables
 
 struct ViscosityRainWaterFriendData
 {
-    std::vector<long double> b, t;
+    std::vector<CoolPropDbl> b, t;
 };
 struct ViscosityInitialDensityEmpiricalData
 {
-    std::vector<long double> n, d, t;
-    long double T_reducing, rhomolar_reducing;
+    std::vector<CoolPropDbl> n, d, t;
+    CoolPropDbl T_reducing, rhomolar_reducing;
 };
 
 struct ViscosityInitialDensityVariables
@@ -233,14 +233,14 @@ struct ViscosityInitialDensityVariables
 
 struct ViscosityModifiedBatschinskiHildebrandData
 {
-    std::vector<long double> a,d1,d2,t1,t2,f,g,h,p,q,gamma, l;
-    long double T_reduce, rhomolar_reduce;
+    std::vector<CoolPropDbl> a,d1,d2,t1,t2,f,g,h,p,q,gamma, l;
+    CoolPropDbl T_reduce, rhomolar_reduce;
 };
 struct ViscosityFrictionTheoryData
 {
-    std::vector<long double> Aa, Aaa, Aaaa, Ar, Arr, Adrdr, Arrr, Ai, Aii, AdrAdr;
+    std::vector<CoolPropDbl> Aa, Aaa, Aaaa, Ar, Arr, Adrdr, Arrr, Ai, Aii, AdrAdr;
     int Na, Naa, Naaa, Nr, Nrr, Nrrr, Nii;
-    long double c1, c2, T_reduce, rhomolar_reduce;
+    CoolPropDbl c1, c2, T_reduce, rhomolar_reduce;
 };
 struct ViscosityHigherOrderVariables
 {
@@ -261,8 +261,8 @@ struct ViscosityHigherOrderVariables
 
 struct ViscosityECSVariables{
     std::string reference_fluid;
-    long double psi_rhomolar_reducing;
-    std::vector<long double> psi_a, psi_t;
+    CoolPropDbl psi_rhomolar_reducing;
+    std::vector<CoolPropDbl> psi_a, psi_t;
 };
 
 class TransportPropertyData
@@ -295,7 +295,7 @@ public:
     bool conductivity_using_ECS; ///< A flag for whether to use extended corresponding states for conductivity.  False for no
 	bool conductivity_model_provided; ///< A flag for whether thermal conductivity model is provided.  False for no
 	bool viscosity_model_provided; ///< A flag for whether viscosity model is provided.  False for no
-    long double sigma_eta, ///< The Lennard-Jones 12-6 \f$ \sigma \f$ parameter
+    CoolPropDbl sigma_eta, ///< The Lennard-Jones 12-6 \f$ \sigma \f$ parameter
                 epsilon_over_k; ///< The Lennard-Jones 12-6 \f$ \varepsilon/k \f$ parameter
     ViscosityHardcodedEnum hardcoded_viscosity; ///< Hardcoded flags for the viscosity
     ConductivityHardcodedEnum hardcoded_conductivity; ///< Hardcoded flags for the conductivity
@@ -352,90 +352,90 @@ public:
         assert(R_u < 9 && R_u > 8);
         assert(molar_mass > 0.001 && molar_mass < 1);
     };
-    long double baser(const long double &tau, const long double &delta) throw()
+    CoolPropDbl baser(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alphar.base(tau, delta);
     };
     // First partials
-    long double dalphar_dDelta(const long double &tau, const long double &delta) throw()
+    CoolPropDbl dalphar_dDelta(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alphar.dDelta(tau, delta);
     };
-    long double dalphar_dTau(const long double &tau, const long double &delta) throw()
+    CoolPropDbl dalphar_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alphar.dTau(tau, delta);
     };
     // Second partials
-    long double d2alphar_dDelta2(const long double &tau, const long double &delta) throw()
+    CoolPropDbl d2alphar_dDelta2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alphar.dDelta2(tau, delta);
     };
-    long double d2alphar_dDelta_dTau(const long double &tau, const long double &delta) throw()
+    CoolPropDbl d2alphar_dDelta_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alphar.dDelta_dTau(tau, delta);
     };
-    long double d2alphar_dTau2(const long double &tau, const long double &delta) throw()
+    CoolPropDbl d2alphar_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alphar.dTau2(tau, delta);
     };
     // Third partials
-    long double d3alphar_dDelta3(const long double &tau, const long double &delta) throw()
+    CoolPropDbl d3alphar_dDelta3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alphar.dDelta3(tau, delta);
     };
-    long double d3alphar_dDelta2_dTau(const long double &tau, const long double &delta) throw()
+    CoolPropDbl d3alphar_dDelta2_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alphar.dDelta2_dTau(tau, delta);
     };
-    long double d3alphar_dDelta_dTau2(const long double &tau, const long double &delta) throw()
+    CoolPropDbl d3alphar_dDelta_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alphar.dDelta_dTau2(tau, delta);
     };
-    long double d3alphar_dTau3(const long double &tau, const long double &delta) throw()
+    CoolPropDbl d3alphar_dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alphar.dTau3(tau, delta);
     };
 
-    long double base0(const long double &tau, const long double &delta) throw()
+    CoolPropDbl base0(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alpha0.base(tau, delta);
     };
     // First partials
-    long double dalpha0_dDelta(const long double &tau, const long double &delta) throw()
+    CoolPropDbl dalpha0_dDelta(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alpha0.dDelta(tau, delta);
     };
-    long double dalpha0_dTau(const long double &tau, const long double &delta) throw()
+    CoolPropDbl dalpha0_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alpha0.dTau(tau, delta);
     };
     // Second partials
-    long double d2alpha0_dDelta2(const long double &tau, const long double &delta) throw()
+    CoolPropDbl d2alpha0_dDelta2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alpha0.dDelta2(tau, delta);
     };
-    long double d2alpha0_dDelta_dTau(const long double &tau, const long double &delta) throw()
+    CoolPropDbl d2alpha0_dDelta_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alpha0.dDelta_dTau(tau, delta);
     };
-    long double d2alpha0_dTau2(const long double &tau, const long double &delta) throw()
+    CoolPropDbl d2alpha0_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alpha0.dTau2(tau, delta);
     };
     // Third partials
-    long double d3alpha0_dDelta3(const long double &tau, const long double &delta) throw()
+    CoolPropDbl d3alpha0_dDelta3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alpha0.dDelta3(tau, delta);
     };
-    long double d3alpha0_dDelta2_dTau(const long double &tau, const long double &delta) throw()
+    CoolPropDbl d3alpha0_dDelta2_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alpha0.dDelta2_dTau(tau, delta);
     };
-    long double d3alpha0_dDelta_dTau2(const long double &tau, const long double &delta) throw()
+    CoolPropDbl d3alpha0_dDelta_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alpha0.dDelta_dTau2(tau, delta);
     };
-    long double d3alpha0_dTau3(const long double &tau, const long double &delta) throw()
+    CoolPropDbl d3alpha0_dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
     {
         return alpha0.dTau3(tau, delta);
     };

--- a/include/CoolPropTools.h
+++ b/include/CoolPropTools.h
@@ -11,6 +11,8 @@
     #include <cmath>
     #include "float.h"
 
+    typedef long double CoolPropDbl;
+
     #ifndef M_PI
     #  define M_PI 3.14159265358979323846
     #endif

--- a/include/DataStructures.h
+++ b/include/DataStructures.h
@@ -175,7 +175,7 @@ std::string get_csv_parameter_list();
 /// These are constants for the compositions
 enum composition_types{IFRAC_MASS, IFRAC_MOLE, IFRAC_VOLUME, IFRAC_UNDEFINED, IFRAC_PURE};
 
-const long double R_u_CODATA = 8.3144621; ///< The value for the ideal gas constant in J/mol/K according to CODATA 2010.  This value is used to harmonize all the ideal gas constants.  This is especially important in the critical region.
+const CoolPropDbl R_u_CODATA = 8.3144621; ///< The value for the ideal gas constant in J/mol/K according to CODATA 2010.  This value is used to harmonize all the ideal gas constants.  This is especially important in the critical region.
 
 /// These are unit types for the fluid
 enum fluid_types{FLUID_TYPE_PURE, FLUID_TYPE_PSEUDOPURE, FLUID_TYPE_REFPROP, FLUID_TYPE_INCOMPRESSIBLE_LIQUID, FLUID_TYPE_INCOMPRESSIBLE_SOLUTION, FLUID_TYPE_UNDEFINED};

--- a/include/Helmholtz.h
+++ b/include/Helmholtz.h
@@ -44,52 +44,52 @@ public:
     /** @param tau Reciprocal reduced temperature where \f$\tau=T_c / T\f$
      *  @param delta Reduced density where \f$\delta = \rho / \rho_c \f$
      */
-    virtual long double base(const long double &tau, const long double &delta) throw() = 0;
+    virtual CoolPropDbl base(const CoolPropDbl &tau, const CoolPropDbl &delta) throw() = 0;
     /// Returns the first partial derivative of Helmholtz energy term with respect to tau [-]
     /** @param tau Reciprocal reduced temperature where \f$\tau=T_c / T\f$
      *  @param delta Reduced density where \f$\delta = \rho / \rho_c \f$
      */
-    virtual long double dTau(const long double &tau, const long double &delta) throw() = 0;
+    virtual CoolPropDbl dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw() = 0;
     /// Returns the second partial derivative of Helmholtz energy term with respect to tau [-]
     /** @param tau Reciprocal reduced temperature where \f$\tau=T_c / T\f$
      *  @param delta Reduced density where \f$\delta = \rho / \rho_c \f$
      */ 
-    virtual long double dTau2(const long double &tau, const long double &delta) throw() = 0;
+    virtual CoolPropDbl dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw() = 0;
     /// Returns the second mixed partial derivative (delta1,dtau1) of Helmholtz energy term with respect to delta and tau [-]
     /** @param tau Reciprocal reduced temperature where \f$\tau=T_c / T\f$
      *  @param delta Reduced density where \f$\delta = \rho / \rho_c \f$
      */
-    virtual long double dDelta_dTau(const long double &tau, const long double &delta) throw() = 0;
+    virtual CoolPropDbl dDelta_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw() = 0;
     /// Returns the first partial derivative of Helmholtz energy term with respect to delta [-]
     /** @param tau Reciprocal reduced temperature where \f$\tau=T_c / T\f$
      *  @param delta Reduced density where \f$\delta = \rho / \rho_c \f$
      */
-    virtual long double dDelta(const long double &tau, const long double &delta) throw() = 0;
+    virtual CoolPropDbl dDelta(const CoolPropDbl &tau, const CoolPropDbl &delta) throw() = 0;
     /// Returns the second partial derivative of Helmholtz energy term with respect to delta [-]
     /** @param tau Reciprocal reduced temperature where \f$\tau=T_c / T\f$
      *  @param delta Reduced density where \f$\delta = \rho / \rho_c \f$
      */
-    virtual long double dDelta2(const long double &tau, const long double &delta) throw() = 0;
+    virtual CoolPropDbl dDelta2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw() = 0;
     /// Returns the third mixed partial derivative (delta2,dtau1) of Helmholtz energy term with respect to delta and tau [-]
     /** @param tau Reciprocal reduced temperature where \f$\tau=T_c / T\f$
      *  @param delta Reduced density where \f$\delta = \rho / \rho_c \f$
      */
-    virtual long double dDelta2_dTau(const long double &tau, const long double &delta) throw() = 0;
+    virtual CoolPropDbl dDelta2_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw() = 0;
     /// Returns the third mixed partial derivative (delta1,dtau2) of Helmholtz energy term with respect to delta and tau [-]
     /** @param tau Reciprocal reduced temperature where \f$\tau=T_c / T\f$
      *  @param delta Reduced density where \f$\delta = \rho / \rho_c \f$
      */
-    virtual long double dDelta_dTau2(const long double &tau, const long double &delta) throw() = 0;
+    virtual CoolPropDbl dDelta_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw() = 0;
     /// Returns the third partial derivative of Helmholtz energy term with respect to tau [-]
     /** @param tau Reciprocal reduced temperature where \f$\tau=T_c / T\f$
      *  @param delta Reduced density where \f$\delta = \rho / \rho_c \f$
      */
-    virtual long double dTau3(const long double &tau, const long double &delta) throw() = 0;
+    virtual CoolPropDbl dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw() = 0;
     /// Returns the third partial derivative of Helmholtz energy term with respect to delta [-]
     /** @param tau Reciprocal reduced temperature where \f$\tau=T_c / T\f$
      *  @param delta Reduced density where \f$\delta = \rho / \rho_c \f$
      */
-    virtual long double dDelta3(const long double &tau, const long double &delta) throw() = 0;
+    virtual CoolPropDbl dDelta3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw() = 0;
     
 };
 
@@ -114,10 +114,10 @@ struct HelmholtzDerivatives
 struct ResidualHelmholtzGeneralizedExponentialElement
 {
     /// These variables are for the n*delta^d_i*tau^t_i part
-    long double n,d,t;
+    CoolPropDbl n,d,t;
     /// These variables are for the exp(u) part
     /// u is given by -c*delta^l_i-omega*tau^m_i-eta1*(delta-epsilon1)-eta2*(delta-epsilon2)^2-beta1*(tau-gamma1)-beta2*(tau-gamma2)^2
-    long double c, l_double, omega, m_double, eta1, epsilon1, eta2, epsilon2, beta1, gamma1, beta2, gamma2;
+    CoolPropDbl c, l_double, omega, m_double, eta1, epsilon1, eta2, epsilon2, beta1, gamma1, beta2, gamma2;
     /// If l_i or m_i are integers, we will store them as integers in order to call pow(double, int) rather than pow(double, double)
     int l_int, m_int;
     
@@ -142,7 +142,7 @@ class ResidualHelmholtzGeneralizedExponential : public BaseHelmholtzTerm{
     
 public:
     bool delta_li_in_u, tau_mi_in_u, eta1_in_u, eta2_in_u, beta1_in_u, beta2_in_u, finished;
-    std::vector<long double> s;
+    std::vector<CoolPropDbl> s;
     std::size_t N;
     
     // These variables are for the exp(u) part
@@ -169,8 +169,8 @@ public:
 	 * Term of the format
 	 * \f$ \alpha^r=\left\lbrace\begin{array}{cc}\displaystyle\sum_i n_i \delta^{d_i} \tau^{t_i} & l_i=0\\ \displaystyle\sum_i n_i \delta^{d_i} \tau^{t_i} \exp(-\delta^{l_i}) & l_i\neq 0\end{array}\right.\f$
 	 */
-    void add_Power(const std::vector<long double> &n, const std::vector<long double> &d, 
-                   const std::vector<long double> &t, const std::vector<long double> &l)
+    void add_Power(const std::vector<CoolPropDbl> &n, const std::vector<CoolPropDbl> &d, 
+                   const std::vector<CoolPropDbl> &t, const std::vector<CoolPropDbl> &l)
     {
         for (std::size_t i = 0; i < n.size(); ++i)
         {
@@ -193,9 +193,9 @@ public:
 	 * Term of the format 
 	 * \f$ \alpha^r=\displaystyle\sum_i n_i \delta^{d_i} \tau^{t_i} \exp(-g_i\delta^{l_i}) \f$
 	 */
-    void add_Exponential(const std::vector<long double> &n, const std::vector<long double> &d, 
-                         const std::vector<long double> &t, const std::vector<long double> &g, 
-                         const std::vector<long double> &l)
+    void add_Exponential(const std::vector<CoolPropDbl> &n, const std::vector<CoolPropDbl> &d, 
+                         const std::vector<CoolPropDbl> &t, const std::vector<CoolPropDbl> &g, 
+                         const std::vector<CoolPropDbl> &l)
     {
         for (std::size_t i = 0; i < n.size(); ++i)
         {
@@ -215,13 +215,13 @@ public:
 	 * Term of the format
 	 * \f$ \alpha^r=\displaystyle\sum_i n_i \delta^{d_i} \tau^{t_i} \exp(-\eta_i(\delta-\epsilon_i)^2-\beta_i(\tau-\gamma_i)^2)\f$
 	 */
-    void add_Gaussian(const std::vector<long double> &n, 
-                      const std::vector<long double> &d, 
-                      const std::vector<long double> &t, 
-                      const std::vector<long double> &eta, 
-                      const std::vector<long double> &epsilon,
-                      const std::vector<long double> &beta,
-                      const std::vector<long double> &gamma
+    void add_Gaussian(const std::vector<CoolPropDbl> &n, 
+                      const std::vector<CoolPropDbl> &d, 
+                      const std::vector<CoolPropDbl> &t, 
+                      const std::vector<CoolPropDbl> &eta, 
+                      const std::vector<CoolPropDbl> &epsilon,
+                      const std::vector<CoolPropDbl> &beta,
+                      const std::vector<CoolPropDbl> &gamma
                       )
     { 
         for (std::size_t i = 0; i < n.size(); ++i)
@@ -244,13 +244,13 @@ public:
 	 * Term of the format
 	 * \f$ \alpha^r=\displaystyle\sum_i n_i \delta^{d_i} \tau^{t_i} \exp(-\eta_i(\delta-\epsilon_i)^2-\beta_i(\delta-\gamma_i))\f$
 	 */
-    void add_GERG2008Gaussian(const std::vector<long double> &n, 
-                              const std::vector<long double> &d, 
-                              const std::vector<long double> &t, 
-                              const std::vector<long double> &eta, 
-                              const std::vector<long double> &epsilon,
-                              const std::vector<long double> &beta,
-                              const std::vector<long double> &gamma)
+    void add_GERG2008Gaussian(const std::vector<CoolPropDbl> &n, 
+                              const std::vector<CoolPropDbl> &d, 
+                              const std::vector<CoolPropDbl> &t, 
+                              const std::vector<CoolPropDbl> &eta, 
+                              const std::vector<CoolPropDbl> &epsilon,
+                              const std::vector<CoolPropDbl> &beta,
+                              const std::vector<CoolPropDbl> &gamma)
     { 
         for (std::size_t i = 0; i < n.size(); ++i)
         {
@@ -272,11 +272,11 @@ public:
 	 * Term of the format
 	 * \f$ \alpha^r=\displaystyle\sum_i n_i \delta^{d_i} \tau^{t_i} \exp(-\delta^{l_i}-\tau^{m_i})\f$
 	 */
-    void add_Lemmon2005(const std::vector<long double> &n, 
-                        const std::vector<long double> &d, 
-                        const std::vector<long double> &t, 
-                        const std::vector<long double> &l, 
-                        const std::vector<long double> &m)
+    void add_Lemmon2005(const std::vector<CoolPropDbl> &n, 
+                        const std::vector<CoolPropDbl> &d, 
+                        const std::vector<CoolPropDbl> &t, 
+                        const std::vector<CoolPropDbl> &l, 
+                        const std::vector<CoolPropDbl> &m)
     {
         for (std::size_t i = 0; i < n.size(); ++i)
         {
@@ -331,44 +331,44 @@ public:
 
     void to_json(rapidjson::Value &el, rapidjson::Document &doc);
     
-    long double base(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.alphar;};
-    long double dDelta(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.dalphar_ddelta;};
-    long double dTau(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.dalphar_dtau;};
-    long double dDelta2(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d2alphar_ddelta2;};
-    long double dDelta_dTau(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d2alphar_ddelta_dtau;};
-    long double dTau2(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d2alphar_dtau2;};
-    long double dDelta3(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d3alphar_ddelta3;};
-    long double dDelta2_dTau(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d3alphar_ddelta2_dtau;};
-    long double dDelta_dTau2(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d3alphar_ddelta_dtau2;};
-    long double dTau3(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d3alphar_dtau3;};
+    CoolPropDbl base(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.alphar;};
+    CoolPropDbl dDelta(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.dalphar_ddelta;};
+    CoolPropDbl dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.dalphar_dtau;};
+    CoolPropDbl dDelta2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d2alphar_ddelta2;};
+    CoolPropDbl dDelta_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d2alphar_ddelta_dtau;};
+    CoolPropDbl dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d2alphar_dtau2;};
+    CoolPropDbl dDelta3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d3alphar_ddelta3;};
+    CoolPropDbl dDelta2_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d3alphar_ddelta2_dtau;};
+    CoolPropDbl dDelta_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d3alphar_ddelta_dtau2;};
+    CoolPropDbl dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d3alphar_dtau3;};
     
-    void all(const long double &tau, const long double &delta, HelmholtzDerivatives &derivs) throw();
-    //void allEigen(const long double &tau, const long double &delta, HelmholtzDerivatives &derivs) throw();
+    void all(const CoolPropDbl &tau, const CoolPropDbl &delta, HelmholtzDerivatives &derivs) throw();
+    //void allEigen(const CoolPropDbl &tau, const CoolPropDbl &delta, HelmholtzDerivatives &derivs) throw();
 };
 
 struct ResidualHelmholtzNonAnalyticElement
 {
-    long double n, a, b, beta, A, B, C, D;
+    CoolPropDbl n, a, b, beta, A, B, C, D;
 };
 class ResidualHelmholtzNonAnalytic : public BaseHelmholtzTerm{
 
 public:
     std::size_t N;
-    std::vector<long double> s;
+    std::vector<CoolPropDbl> s;
     std::vector<ResidualHelmholtzNonAnalyticElement> elements;
     /// Default Constructor
     ResidualHelmholtzNonAnalytic(){N = 0;};
     /// Destructor. No implementation
     ~ResidualHelmholtzNonAnalytic(){};
     /// Constructor
-    ResidualHelmholtzNonAnalytic(const std::vector<long double> &n, 
-                                 const std::vector<long double> &a, 
-                                 const std::vector<long double> &b, 
-                                 const std::vector<long double> &beta, 
-                                 const std::vector<long double> &A,
-                                 const std::vector<long double> &B,
-                                 const std::vector<long double> &C,
-                                 const std::vector<long double> &D
+    ResidualHelmholtzNonAnalytic(const std::vector<CoolPropDbl> &n, 
+                                 const std::vector<CoolPropDbl> &a, 
+                                 const std::vector<CoolPropDbl> &b, 
+                                 const std::vector<CoolPropDbl> &beta, 
+                                 const std::vector<CoolPropDbl> &A,
+                                 const std::vector<CoolPropDbl> &B,
+                                 const std::vector<CoolPropDbl> &C,
+                                 const std::vector<CoolPropDbl> &D
                                  )
     {
         N = n.size(); 
@@ -390,18 +390,18 @@ public:
 
     void to_json(rapidjson::Value &el, rapidjson::Document &doc);
 
-    long double base(const long double &tau, const long double &delta) throw();
-    long double dDelta(const long double &tau, const long double &delta) throw();
-    long double dTau(const long double &tau, const long double &delta) throw();
-    long double dDelta2(const long double &tau, const long double &delta) throw();
-    long double dDelta_dTau(const long double &tau, const long double &delta) throw();
-    long double dTau2(const long double &tau, const long double &delta) throw();
-    long double dDelta3(const long double &tau, const long double &delta) throw();
-    long double dDelta2_dTau(const long double &tau, const long double &delta) throw();
-    long double dDelta_dTau2(const long double &tau, const long double &delta) throw();
-    long double dTau3(const long double &tau, const long double &delta) throw();
+    CoolPropDbl base(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
+    CoolPropDbl dDelta(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
+    CoolPropDbl dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
+    CoolPropDbl dDelta2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
+    CoolPropDbl dDelta_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
+    CoolPropDbl dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
+    CoolPropDbl dDelta3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
+    CoolPropDbl dDelta2_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
+    CoolPropDbl dDelta_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
+    CoolPropDbl dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
     
-    void all(const long double &tau, const long double &delta, HelmholtzDerivatives &derivs) throw();
+    void all(const CoolPropDbl &tau, const CoolPropDbl &delta, HelmholtzDerivatives &derivs) throw();
 };
 
 class ResidualHelmholtzSAFTAssociating : public BaseHelmholtzTerm{
@@ -409,36 +409,36 @@ class ResidualHelmholtzSAFTAssociating : public BaseHelmholtzTerm{
 protected:
     double a, m,epsilonbar, vbarn, kappabar;
 
-    long double Deltabar(const long double &tau, const long double &delta);
-    long double dDeltabar_ddelta__consttau(const long double &tau, const long double &delta);
-    long double d2Deltabar_ddelta2__consttau(const long double &tau, const long double &delta);
-    long double dDeltabar_dtau__constdelta(const long double &tau, const long double &delta);
-    long double d2Deltabar_dtau2__constdelta(const long double &tau, const long double &delta);
-    long double d2Deltabar_ddelta_dtau(const long double &tau, const long double &delta);
-    long double d3Deltabar_dtau3__constdelta(const long double &tau, const long double &delta);
-    long double d3Deltabar_ddelta_dtau2(const long double &tau, const long double &delta);
-    long double d3Deltabar_ddelta3__consttau(const long double &tau, const long double &delta);
-    long double d3Deltabar_ddelta2_dtau(const long double &tau, const long double &delta);
+    CoolPropDbl Deltabar(const CoolPropDbl &tau, const CoolPropDbl &delta);
+    CoolPropDbl dDeltabar_ddelta__consttau(const CoolPropDbl &tau, const CoolPropDbl &delta);
+    CoolPropDbl d2Deltabar_ddelta2__consttau(const CoolPropDbl &tau, const CoolPropDbl &delta);
+    CoolPropDbl dDeltabar_dtau__constdelta(const CoolPropDbl &tau, const CoolPropDbl &delta);
+    CoolPropDbl d2Deltabar_dtau2__constdelta(const CoolPropDbl &tau, const CoolPropDbl &delta);
+    CoolPropDbl d2Deltabar_ddelta_dtau(const CoolPropDbl &tau, const CoolPropDbl &delta);
+    CoolPropDbl d3Deltabar_dtau3__constdelta(const CoolPropDbl &tau, const CoolPropDbl &delta);
+    CoolPropDbl d3Deltabar_ddelta_dtau2(const CoolPropDbl &tau, const CoolPropDbl &delta);
+    CoolPropDbl d3Deltabar_ddelta3__consttau(const CoolPropDbl &tau, const CoolPropDbl &delta);
+    CoolPropDbl d3Deltabar_ddelta2_dtau(const CoolPropDbl &tau, const CoolPropDbl &delta);
 
-    long double X(const long double &delta, const long double &Deltabar);
-    long double dX_dDeltabar__constdelta(const long double &delta, const long double &Deltabar);
-    long double dX_ddelta__constDeltabar(const long double &delta, const long double &Deltabar);
-    long double dX_dtau(const long double &tau, const long double &delta);
-    long double dX_ddelta(const long double &tau, const long double &delta);
-    long double d2X_dtau2(const long double &tau, const long double &delta);
-    long double d2X_ddeltadtau(const long double &tau, const long double &delta);
-    long double d2X_ddelta2(const long double &tau, const long double &delta);
+    CoolPropDbl X(const CoolPropDbl &delta, const CoolPropDbl &Deltabar);
+    CoolPropDbl dX_dDeltabar__constdelta(const CoolPropDbl &delta, const CoolPropDbl &Deltabar);
+    CoolPropDbl dX_ddelta__constDeltabar(const CoolPropDbl &delta, const CoolPropDbl &Deltabar);
+    CoolPropDbl dX_dtau(const CoolPropDbl &tau, const CoolPropDbl &delta);
+    CoolPropDbl dX_ddelta(const CoolPropDbl &tau, const CoolPropDbl &delta);
+    CoolPropDbl d2X_dtau2(const CoolPropDbl &tau, const CoolPropDbl &delta);
+    CoolPropDbl d2X_ddeltadtau(const CoolPropDbl &tau, const CoolPropDbl &delta);
+    CoolPropDbl d2X_ddelta2(const CoolPropDbl &tau, const CoolPropDbl &delta);
 
-    long double d3X_dtau3(const long double &tau, const long double &delta);
-    long double d3X_ddelta3(const long double &tau, const long double &delta);
-    long double d3X_ddeltadtau2(const long double &tau, const long double &delta);
-    long double d3X_ddelta2dtau(const long double &tau, const long double &delta);
+    CoolPropDbl d3X_dtau3(const CoolPropDbl &tau, const CoolPropDbl &delta);
+    CoolPropDbl d3X_ddelta3(const CoolPropDbl &tau, const CoolPropDbl &delta);
+    CoolPropDbl d3X_ddeltadtau2(const CoolPropDbl &tau, const CoolPropDbl &delta);
+    CoolPropDbl d3X_ddelta2dtau(const CoolPropDbl &tau, const CoolPropDbl &delta);
 
-    long double g(const long double &eta);
-    long double dg_deta(const long double &eta);
-    long double d2g_deta2(const long double &eta);
-    long double d3g_deta3(const long double &eta);
-    long double eta(const long double &delta);
+    CoolPropDbl g(const CoolPropDbl &eta);
+    CoolPropDbl dg_deta(const CoolPropDbl &eta);
+    CoolPropDbl d2g_deta2(const CoolPropDbl &eta);
+    CoolPropDbl d3g_deta3(const CoolPropDbl &eta);
+    CoolPropDbl eta(const CoolPropDbl &delta);
 
 public:
     /// Default constructor
@@ -457,18 +457,18 @@ public:
 
     void to_json(rapidjson::Value &el, rapidjson::Document &doc);
 
-    long double base(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.alphar;};
-    long double dDelta(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.dalphar_ddelta;};
-    long double dTau(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.dalphar_dtau;};
-    long double dDelta2(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d2alphar_ddelta2;};
-    long double dDelta_dTau(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d2alphar_ddelta_dtau;};
-    long double dTau2(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d2alphar_dtau2;};
-    long double dDelta3(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d3alphar_ddelta3;};
-    long double dDelta2_dTau(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d3alphar_ddelta2_dtau;};
-    long double dDelta_dTau2(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d3alphar_ddelta_dtau2;};
-    long double dTau3(const long double &tau, const long double &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d3alphar_dtau3;};
+    CoolPropDbl base(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.alphar;};
+    CoolPropDbl dDelta(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.dalphar_ddelta;};
+    CoolPropDbl dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.dalphar_dtau;};
+    CoolPropDbl dDelta2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d2alphar_ddelta2;};
+    CoolPropDbl dDelta_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d2alphar_ddelta_dtau;};
+    CoolPropDbl dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d2alphar_dtau2;};
+    CoolPropDbl dDelta3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d3alphar_ddelta3;};
+    CoolPropDbl dDelta2_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d3alphar_ddelta2_dtau;};
+    CoolPropDbl dDelta_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d3alphar_ddelta_dtau2;};
+    CoolPropDbl dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){HelmholtzDerivatives deriv; all(tau,delta,deriv); return deriv.d3alphar_dtau3;};
     
-    void all(const long double &tau, const long double &delta, HelmholtzDerivatives &deriv) throw();
+    void all(const CoolPropDbl &tau, const CoolPropDbl &delta, HelmholtzDerivatives &deriv) throw();
 };
 
 class ResidualHelmholtzContainer
@@ -479,7 +479,7 @@ public:
     ResidualHelmholtzSAFTAssociating SAFT;
     ResidualHelmholtzGeneralizedExponential GenExp; 
 
-    HelmholtzDerivatives all(const long double tau, const long double delta)
+    HelmholtzDerivatives all(const CoolPropDbl tau, const CoolPropDbl delta)
     {
         HelmholtzDerivatives derivs; // zeros out the elements
         GenExp.all(tau, delta, derivs);
@@ -487,16 +487,16 @@ public:
         SAFT.all(tau, delta, derivs);
         return derivs;
     };
-    long double base(long double tau, long double delta) { return all(tau,delta).alphar; };
-    long double dDelta(long double tau, long double delta) { return all(tau,delta).dalphar_ddelta; };
-    long double dTau(long double tau, long double delta) { return all(tau, delta).dalphar_dtau; };
-    long double dDelta2(long double tau, long double delta) {  return all(tau, delta).d2alphar_ddelta2; };
-    long double dDelta_dTau(long double tau, long double delta) { return all(tau, delta).d2alphar_ddelta_dtau; };
-    long double dTau2(long double tau, long double delta) { return all(tau, delta).d2alphar_dtau2; };
-    long double dDelta3(long double tau, long double delta) { return all(tau, delta).d3alphar_ddelta3; };
-    long double dDelta2_dTau(long double tau, long double delta) { return all(tau, delta).d3alphar_ddelta2_dtau; };
-    long double dDelta_dTau2(long double tau, long double delta) { return all(tau, delta).d3alphar_ddelta_dtau2; };
-    long double dTau3(long double tau, long double delta) { return all(tau, delta).d3alphar_dtau3; };
+    CoolPropDbl base(CoolPropDbl tau, CoolPropDbl delta) { return all(tau,delta).alphar; };
+    CoolPropDbl dDelta(CoolPropDbl tau, CoolPropDbl delta) { return all(tau,delta).dalphar_ddelta; };
+    CoolPropDbl dTau(CoolPropDbl tau, CoolPropDbl delta) { return all(tau, delta).dalphar_dtau; };
+    CoolPropDbl dDelta2(CoolPropDbl tau, CoolPropDbl delta) {  return all(tau, delta).d2alphar_ddelta2; };
+    CoolPropDbl dDelta_dTau(CoolPropDbl tau, CoolPropDbl delta) { return all(tau, delta).d2alphar_ddelta_dtau; };
+    CoolPropDbl dTau2(CoolPropDbl tau, CoolPropDbl delta) { return all(tau, delta).d2alphar_dtau2; };
+    CoolPropDbl dDelta3(CoolPropDbl tau, CoolPropDbl delta) { return all(tau, delta).d3alphar_ddelta3; };
+    CoolPropDbl dDelta2_dTau(CoolPropDbl tau, CoolPropDbl delta) { return all(tau, delta).d3alphar_ddelta2_dtau; };
+    CoolPropDbl dDelta_dTau2(CoolPropDbl tau, CoolPropDbl delta) { return all(tau, delta).d3alphar_ddelta_dtau2; };
+    CoolPropDbl dTau3(CoolPropDbl tau, CoolPropDbl delta) { return all(tau, delta).d3alphar_dtau3; };
 };
 
 // #############################################################################
@@ -516,14 +516,14 @@ public:
 class IdealHelmholtzLead : public BaseHelmholtzTerm{
 
 private:
-    long double a1, a2;
+    CoolPropDbl a1, a2;
     bool enabled;
 public:
     // Default constructor
     IdealHelmholtzLead(){enabled = false;};
 
     // Constructor
-    IdealHelmholtzLead(const long double a1, const long double a2)
+    IdealHelmholtzLead(const CoolPropDbl a1, const CoolPropDbl a2)
     :a1(a1), a2(a2)
     {enabled = true;};
 
@@ -539,31 +539,31 @@ public:
     };
 
     // Term and its derivatives
-    long double base(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl base(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
         return log(delta)+a1+a2*tau;
     };
-    long double dDelta(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl dDelta(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
         return 1.0/delta;
     };
-    long double dTau(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
         return a2;
     };
-    long double dDelta2(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl dDelta2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
         return -1.0/delta/delta;
     };
-    long double dDelta_dTau(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dTau2(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta3(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl dDelta_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
         return 2/delta/delta/delta;
     };
-    long double dDelta2_dTau(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta_dTau2(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dTau3(const long double &tau, const long double &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta2_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
 };
 
 /// The term in the EOS used to shift the reference state of the fluid
@@ -574,17 +574,17 @@ public:
 */
 class IdealHelmholtzEnthalpyEntropyOffset : public BaseHelmholtzTerm{
 private:
-    long double a1,a2; // Use these variables internally
+    CoolPropDbl a1,a2; // Use these variables internally
     bool enabled;
     std::string reference;
 public:
     IdealHelmholtzEnthalpyEntropyOffset(){enabled = false;};
 
     // Constructor
-    IdealHelmholtzEnthalpyEntropyOffset(long double a1, long double a2, std::string reference):a1(a1), a2(a2){this->reference = reference; enabled = true;};
+    IdealHelmholtzEnthalpyEntropyOffset(CoolPropDbl a1, CoolPropDbl a2, std::string reference):a1(a1), a2(a2){this->reference = reference; enabled = true;};
 
     // Set the values in the class
-    void set(long double a1, long double a2, std::string reference){this->a1 = a1; this->a2 = a2; this->reference = reference; enabled = true;}
+    void set(CoolPropDbl a1, CoolPropDbl a2, std::string reference){this->a1 = a1; this->a2 = a2; this->reference = reference; enabled = true;}
 
     //Destructor
     ~IdealHelmholtzEnthalpyEntropyOffset(){};
@@ -598,22 +598,22 @@ public:
     };
 
     // Term and its derivatives
-    long double base(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl base(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
         return a1+a2*tau;
     };
-    long double dDelta(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dTau(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl dDelta(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
         return a2;
     };
-    long double dDelta2(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta_dTau(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dTau2(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta3(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta2_dTau(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta_dTau2(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dTau3(const long double &tau, const long double &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta2_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
 };
 
 
@@ -625,7 +625,7 @@ public:
 class IdealHelmholtzLogTau : public BaseHelmholtzTerm
 {
 private:
-    long double a1;
+    CoolPropDbl a1;
     bool enabled;
 public:
 
@@ -633,7 +633,7 @@ public:
     IdealHelmholtzLogTau(){enabled = false;};
 
     // Constructor
-    IdealHelmholtzLogTau(long double a1){this->a1=a1; enabled = true;};
+    IdealHelmholtzLogTau(CoolPropDbl a1){this->a1=a1; enabled = true;};
 
     bool is_enabled(){return enabled;};
 
@@ -646,28 +646,28 @@ public:
     };
 
     // Term and its derivatives
-    long double base(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl base(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
         return a1*log(tau);
     };
-    long double dTau(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
         return a1/tau;
     };
-    long double dTau2(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
         return -a1/tau/tau;
     };
-    long double dTau3(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
         return 2*a1/tau/tau/tau;
     };
-    long double dDelta(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta2(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta2_dTau(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta_dTau(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta_dTau2(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta3(const long double &tau, const long double &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta2_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
 };
 
 /**
@@ -678,13 +678,13 @@ public:
 class IdealHelmholtzPower : public BaseHelmholtzTerm{
     
 private:
-    std::vector<long double> n, t; // Use these variables internally
+    std::vector<CoolPropDbl> n, t; // Use these variables internally
     std::size_t N;
     bool enabled;
 public:
     IdealHelmholtzPower(){enabled = false;};
     // Constructor
-    IdealHelmholtzPower(const std::vector<long double> &n, const std::vector<long double> &t)
+    IdealHelmholtzPower(const std::vector<CoolPropDbl> &n, const std::vector<CoolPropDbl> &t)
     :n(n), t(t)
     {
         this->N = n.size();
@@ -704,28 +704,28 @@ public:
     };
 
     // Term and its derivatives
-    long double base(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl base(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
-        long double s=0; for (std::size_t i = 0; i<N; ++i){s += n[i]*pow(tau, t[i]);} return s;
+        CoolPropDbl s=0; for (std::size_t i = 0; i<N; ++i){s += n[i]*pow(tau, t[i]);} return s;
     };
-    long double dTau(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
-        long double s=0; for (std::size_t i = 0; i<N; ++i){s += n[i]*t[i]*pow(tau, t[i]-1);} return s;
+        CoolPropDbl s=0; for (std::size_t i = 0; i<N; ++i){s += n[i]*t[i]*pow(tau, t[i]-1);} return s;
     };
-    long double dTau2(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
-        long double s=0; for (std::size_t i = 0; i<N; ++i){s += n[i]*t[i]*(t[i]-1)*pow(tau, t[i]-2);} return s;
+        CoolPropDbl s=0; for (std::size_t i = 0; i<N; ++i){s += n[i]*t[i]*(t[i]-1)*pow(tau, t[i]-2);} return s;
     };
-    long double dTau3(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
-        long double s=0; for (std::size_t i = 0; i<N; ++i){s += n[i]*t[i]*(t[i]-1)*(t[i]-2)*pow(tau, t[i]-3);} return s;
+        CoolPropDbl s=0; for (std::size_t i = 0; i<N; ++i){s += n[i]*t[i]*(t[i]-1)*(t[i]-2)*pow(tau, t[i]-3);} return s;
     };
-    long double dDelta(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta2(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta2_dTau(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta_dTau(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta_dTau2(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta3(const long double &tau, const long double &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta2_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
 };
 
 /**
@@ -777,13 +777,13 @@ where
 class IdealHelmholtzPlanckEinsteinGeneralized : public BaseHelmholtzTerm{
     
 private:
-    std::vector<long double> n,theta,c,d; // Use these variables internally
+    std::vector<CoolPropDbl> n,theta,c,d; // Use these variables internally
     std::size_t N;
     bool enabled;
 public:
     IdealHelmholtzPlanckEinsteinGeneralized(){N = 0; enabled = false;}
     // Constructor with std::vector instances
-    IdealHelmholtzPlanckEinsteinGeneralized(std::vector<long double> n, std::vector<long double> theta, std::vector<long double> c, std::vector<long double> d)
+    IdealHelmholtzPlanckEinsteinGeneralized(std::vector<CoolPropDbl> n, std::vector<CoolPropDbl> theta, std::vector<CoolPropDbl> c, std::vector<CoolPropDbl> d)
     :n(n), theta(theta), c(c), d(d)
     {
         N = n.size();
@@ -794,7 +794,7 @@ public:
     ~IdealHelmholtzPlanckEinsteinGeneralized(){};
 
     // Extend the vectors to allow for multiple instances feeding values to this function
-    void extend(std::vector<long double> n, std::vector<long double> theta, std::vector<long double> c, std::vector<long double> d)
+    void extend(std::vector<CoolPropDbl> n, std::vector<CoolPropDbl> theta, std::vector<CoolPropDbl> c, std::vector<CoolPropDbl> d)
     {
         this->n.insert(this->n.end(), n.begin(), n.end());
         this->theta.insert(this->theta.end(), theta.begin(), theta.end());
@@ -813,32 +813,32 @@ public:
     };
 
     // Term and its derivatives
-    long double base(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl base(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
-        long double s=0; for (std::size_t i=0; i < N; ++i){
+        CoolPropDbl s=0; for (std::size_t i=0; i < N; ++i){
             s += n[i]*log(c[i]+d[i]*exp(theta[i]*tau));
         } 
         return s;
     };
-    long double dTau(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
-        long double s=0; for (std::size_t i=0; i < N; ++i){s += n[i]*theta[i]*d[i]*exp(theta[i]*tau)/(c[i]+d[i]*exp(theta[i]*tau));} 
+        CoolPropDbl s=0; for (std::size_t i=0; i < N; ++i){s += n[i]*theta[i]*d[i]*exp(theta[i]*tau)/(c[i]+d[i]*exp(theta[i]*tau));} 
         return s;
     };
-    long double dTau2(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
-        long double s=0; for (std::size_t i=0; i < N; ++i){s += n[i]*pow(theta[i],2)*c[i]*d[i]*exp(theta[i]*tau)/pow(c[i]+d[i]*exp(theta[i]*tau),2);} return s;
+        CoolPropDbl s=0; for (std::size_t i=0; i < N; ++i){s += n[i]*pow(theta[i],2)*c[i]*d[i]*exp(theta[i]*tau)/pow(c[i]+d[i]*exp(theta[i]*tau),2);} return s;
     };
-    long double dTau3(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
-        long double s=0; for (std::size_t i=0; i < N; ++i){s += n[i]*pow(theta[i],3)*c[i]*d[i]*(c[i]-d[i]*exp(theta[i]*tau))*exp(theta[i]*tau)/pow(c[i]+d[i]*exp(theta[i]*tau),3);} return s;
+        CoolPropDbl s=0; for (std::size_t i=0; i < N; ++i){s += n[i]*pow(theta[i],3)*c[i]*d[i]*(c[i]-d[i]*exp(theta[i]*tau))*exp(theta[i]*tau)/pow(c[i]+d[i]*exp(theta[i]*tau),3);} return s;
     };
-    long double dDelta(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta2(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta2_dTau(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta_dTau(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta_dTau2(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta3(const long double &tau, const long double &delta) throw(){return 0;};
+    CoolPropDbl dDelta(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta2_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0;};
 };
 
 class IdealHelmholtzCP0Constant : public BaseHelmholtzTerm{
@@ -851,7 +851,7 @@ public:
     IdealHelmholtzCP0Constant(){enabled = false;};
 
     /// Constructor with just a single double value
-    IdealHelmholtzCP0Constant(long double cp_over_R, long double Tc, long double T0) 
+    IdealHelmholtzCP0Constant(CoolPropDbl cp_over_R, CoolPropDbl Tc, CoolPropDbl T0) 
     : cp_over_R(cp_over_R), Tc(Tc), T0(T0)
     { 
         enabled = true; tau0 = Tc/T0;
@@ -871,34 +871,34 @@ public:
     };
 
     // Term and its derivatives
-    long double base(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl base(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
         return cp_over_R-cp_over_R*tau/tau0+cp_over_R*log(tau/tau0);
     };
-    long double dTau(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
         return cp_over_R/tau-cp_over_R/tau0;
     };
-    long double dTau2(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
         return -cp_over_R/(tau*tau);
     };
-    long double dTau3(const long double &tau, const long double &delta) throw(){
+    CoolPropDbl dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){
         if (!enabled){return 0.0;}
         return 2*cp_over_R/(tau*tau*tau);
     };
-    long double dDelta(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta2(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta2_dTau(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta_dTau(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta_dTau2(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta3(const long double &tau, const long double &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta2_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
 };
 
 class IdealHelmholtzCP0PolyT : public BaseHelmholtzTerm{
 private:
-    std::vector<long double> c, t;
-    long double Tc, T0, tau0; // Use these variables internally
+    std::vector<CoolPropDbl> c, t;
+    CoolPropDbl Tc, T0, tau0; // Use these variables internally
     std::size_t N;
     bool enabled;
 public:
@@ -906,7 +906,7 @@ public:
     IdealHelmholtzCP0PolyT(){N = 0; enabled = false;};
 
     /// Constructor with std::vectors
-    IdealHelmholtzCP0PolyT(const std::vector<long double> &c, const std::vector<long double> &t, double Tc, double T0) 
+    IdealHelmholtzCP0PolyT(const std::vector<CoolPropDbl> &c, const std::vector<CoolPropDbl> &t, double Tc, double T0) 
     : c(c), t(t), Tc(Tc), T0(T0)
     { 
         assert(c.size() == t.size());
@@ -915,7 +915,7 @@ public:
         N = c.size();
     };
 
-    void extend(const std::vector<long double> &c, const std::vector<long double> &t)
+    void extend(const std::vector<CoolPropDbl> &c, const std::vector<CoolPropDbl> &t)
     {
         this->c.insert(this->c.end(), c.begin(), c.end());
         this->t.insert(this->t.end(), t.begin(), t.end());
@@ -930,16 +930,16 @@ public:
     void to_json(rapidjson::Value &el, rapidjson::Document &doc);
 
     // Term and its derivatives
-    long double base(const long double &tau, const long double &delta) throw();
-    long double dDelta(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dTau(const long double &tau, const long double &delta) throw();
-    long double dDelta2(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta_dTau(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dTau2(const long double &tau, const long double &delta) throw();
-    long double dDelta3(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta2_dTau(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta_dTau2(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dTau3(const long double &tau, const long double &delta) throw();
+    CoolPropDbl base(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
+    CoolPropDbl dDelta(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
+    CoolPropDbl dDelta2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
+    CoolPropDbl dDelta3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta2_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
     
 };
 
@@ -985,14 +985,14 @@ see also Jaeschke and Schley, 1995, (http://link.springer.com/article/10.1007%2F
 */
 class IdealHelmholtzCP0AlyLee : public BaseHelmholtzTerm{
 private:
-    std::vector<long double> c;
-    long double Tc, tau0, T0; // Use these variables internally
+    std::vector<CoolPropDbl> c;
+    CoolPropDbl Tc, tau0, T0; // Use these variables internally
     bool enabled;
 public:
     IdealHelmholtzCP0AlyLee(){enabled = false;};
 
     /// Constructor with std::vectors
-    IdealHelmholtzCP0AlyLee(std::vector<long double> c, double Tc, double T0)
+    IdealHelmholtzCP0AlyLee(std::vector<CoolPropDbl> c, double Tc, double T0)
     :c(c), Tc(Tc), T0(T0)
     {
         tau0=Tc/T0;
@@ -1024,7 +1024,7 @@ public:
     \displaystyle\int \frac{1}{\tau^2}\frac{c_p^0}{R_u}d\tau = -\frac{a_0}{\tau}+\frac{2a_1a_2}{T_c\left[\exp\left(-\frac{2a_2\tau}{T_c}\right)-1\right]}+\frac{2a_3a_4}{T_c\left[\exp\left(-\frac{2a_4\tau}{T_c}\right)+1\right]}
     \f]
     */
-    long double anti_deriv_cp0_tau2(const long double &tau);
+    CoolPropDbl anti_deriv_cp0_tau2(const CoolPropDbl &tau);
 
     /// The antiderivative given by \f$ \displaystyle\int \frac{1}{\tau}\frac{c_p^0}{R_u}d\tau \f$
     /**
@@ -1059,18 +1059,18 @@ public:
     \displaystyle\int \frac{a_1a_2^2}{T_c^2}\frac{\tau}{\cosh\left(\displaystyle\frac{a_2\tau}{T_c}\right)^2} d\tau = - \frac{a_{3}}{Tc \left(e^{\frac{2 a_{4}}{Tc} \tau} + 1\right)} \left(Tc e^{\frac{2 a_{4}}{Tc} \tau} \log{\left (e^{\frac{2 a_{4}}{Tc} \tau} + 1 \right )} + Tc \log{\left (e^{\frac{2 a_{4}}{Tc} \tau} + 1 \right )} - 2 a_{4} \tau e^{\frac{2 a_{4}}{Tc} \tau}\right)
     \f]
     */
-    long double anti_deriv_cp0_tau(const long double &tau);
+    CoolPropDbl anti_deriv_cp0_tau(const CoolPropDbl &tau);
 
-    long double base(const long double &tau, const long double &delta) throw();
-    long double dDelta(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dTau(const long double &tau, const long double &delta) throw();
-    long double dDelta2(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta_dTau(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dTau2(const long double &tau, const long double &delta) throw();
-    long double dDelta3(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta2_dTau(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dDelta_dTau2(const long double &tau, const long double &delta) throw(){return 0.0;};
-    long double dTau3(const long double &tau, const long double &delta) throw();
+    CoolPropDbl base(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
+    CoolPropDbl dDelta(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
+    CoolPropDbl dDelta2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
+    CoolPropDbl dDelta3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta2_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dDelta_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw(){return 0.0;};
+    CoolPropDbl dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw();
     
 };
 
@@ -1088,7 +1088,7 @@ public:
     IdealHelmholtzCP0Constant CP0Constant;
     IdealHelmholtzCP0PolyT CP0PolyT;
 
-    long double base(const long double &tau, const long double &delta)
+    CoolPropDbl base(const CoolPropDbl &tau, const CoolPropDbl &delta)
     {
         return (Lead.base(tau, delta) + EnthalpyEntropyOffset.base(tau, delta)
                 + EnthalpyEntropyOffsetCore.base(tau, delta)
@@ -1097,7 +1097,7 @@ public:
                 + CP0Constant.base(tau, delta) + CP0PolyT.base(tau, delta)
                 );
     };
-    long double dDelta(const long double &tau, const long double &delta)
+    CoolPropDbl dDelta(const CoolPropDbl &tau, const CoolPropDbl &delta)
     {
         return (Lead.dDelta(tau, delta) + EnthalpyEntropyOffset.dDelta(tau, delta)
                 + EnthalpyEntropyOffsetCore.dDelta(tau, delta)
@@ -1106,7 +1106,7 @@ public:
                 + CP0Constant.dDelta(tau, delta) + CP0PolyT.dDelta(tau, delta)
                 );
     };
-    long double dTau(const long double &tau, const long double &delta)
+    CoolPropDbl dTau(const CoolPropDbl &tau, const CoolPropDbl &delta)
     {
         return (Lead.dTau(tau, delta) + EnthalpyEntropyOffset.dTau(tau, delta)
                 + EnthalpyEntropyOffsetCore.dTau(tau, delta)
@@ -1115,7 +1115,7 @@ public:
                 + CP0Constant.dTau(tau, delta) + CP0PolyT.dTau(tau, delta)
                 );
     };
-    long double dDelta2(const long double &tau, const long double &delta)
+    CoolPropDbl dDelta2(const CoolPropDbl &tau, const CoolPropDbl &delta)
     {
         return (Lead.dDelta2(tau, delta) + EnthalpyEntropyOffset.dDelta2(tau, delta)
                 + EnthalpyEntropyOffsetCore.dDelta2(tau, delta)
@@ -1124,7 +1124,7 @@ public:
                 + CP0Constant.dDelta2(tau, delta) + CP0PolyT.dDelta2(tau, delta)
                 );
     };
-    long double dDelta_dTau(const long double &tau, const long double &delta)
+    CoolPropDbl dDelta_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta)
     {
         return (Lead.dDelta_dTau(tau, delta) + EnthalpyEntropyOffset.dDelta_dTau(tau, delta)
                 + EnthalpyEntropyOffsetCore.dDelta_dTau(tau, delta)
@@ -1133,7 +1133,7 @@ public:
                 + CP0Constant.dDelta_dTau(tau, delta) + CP0PolyT.dDelta_dTau(tau, delta)
                 );
     };
-    long double dTau2(const long double &tau, const long double &delta)
+    CoolPropDbl dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta)
     {
         return (Lead.dTau2(tau, delta) + EnthalpyEntropyOffset.dTau2(tau, delta)
                 + EnthalpyEntropyOffsetCore.dTau2(tau, delta)
@@ -1142,7 +1142,7 @@ public:
                 + CP0Constant.dTau2(tau, delta) + CP0PolyT.dTau2(tau, delta)
                 );
     };
-    long double dDelta3(const long double &tau, const long double &delta) 
+    CoolPropDbl dDelta3(const CoolPropDbl &tau, const CoolPropDbl &delta) 
     {
         return (Lead.dDelta3(tau, delta) + EnthalpyEntropyOffset.dDelta3(tau, delta)
                 + EnthalpyEntropyOffsetCore.dDelta3(tau, delta)
@@ -1151,7 +1151,7 @@ public:
                 + CP0Constant.dDelta3(tau, delta) + CP0PolyT.dDelta3(tau, delta)
                 );
     };
-    long double dDelta2_dTau(const long double &tau, const long double &delta)
+    CoolPropDbl dDelta2_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta)
     {
         return (Lead.dDelta2_dTau(tau, delta) + EnthalpyEntropyOffset.dDelta2_dTau(tau, delta)
                 + EnthalpyEntropyOffsetCore.dDelta2_dTau(tau, delta)
@@ -1160,7 +1160,7 @@ public:
                 + CP0Constant.dDelta2_dTau(tau, delta) + CP0PolyT.dDelta2_dTau(tau, delta)
                 );
     };
-    long double dDelta_dTau2(const long double &tau, const long double &delta)
+    CoolPropDbl dDelta_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta)
     {
         return (Lead.dDelta_dTau2(tau, delta) + EnthalpyEntropyOffset.dDelta_dTau2(tau, delta)
                 + EnthalpyEntropyOffsetCore.dDelta_dTau2(tau, delta)
@@ -1169,7 +1169,7 @@ public:
                 + CP0Constant.dDelta_dTau2(tau, delta) + CP0PolyT.dDelta_dTau2(tau, delta)
                 );
     };
-    long double dTau3(const long double &tau, const long double &delta)
+    CoolPropDbl dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta)
     {
         return (Lead.dTau3(tau, delta) + EnthalpyEntropyOffset.dTau3(tau, delta)
                 + EnthalpyEntropyOffsetCore.dTau3(tau, delta)

--- a/include/PhaseEnvelope.h
+++ b/include/PhaseEnvelope.h
@@ -17,8 +17,8 @@ public:
                 ipsat_max, ///< The index of the point corresponding to the maximum pressure for Type-I mixtures
                 icrit; ///< The index of the point corresponding to the critical point
                 
-    std::vector< std::vector<long double> > K, lnK, x, y;
-    std::vector<long double> T, p, lnT, lnp, rhomolar_liq, rhomolar_vap, lnrhomolar_liq, lnrhomolar_vap, hmolar_liq, hmolar_vap, smolar_liq, smolar_vap, Q;
+    std::vector< std::vector<CoolPropDbl> > K, lnK, x, y;
+    std::vector<CoolPropDbl> T, p, lnT, lnp, rhomolar_liq, rhomolar_vap, lnrhomolar_liq, lnrhomolar_vap, hmolar_liq, hmolar_vap, smolar_liq, smolar_vap, Q;
     
     PhaseEnvelopeData(){ built = false; TypeI = false; };
     
@@ -34,16 +34,16 @@ public:
         lnrhomolar_liq.clear(); lnrhomolar_vap.clear(); hmolar_liq.clear(); hmolar_vap.clear(); smolar_liq.clear(); smolar_vap.clear();
         K.clear(); lnK.clear(); x.clear(); y.clear(); Q.clear();
     }
-    void insert_variables(const long double T, 
-                          const long double p, 
-                          const long double rhomolar_liq, 
-                          const long double rhomolar_vap,
-                          const long double hmolar_liq, 
-                          const long double hmolar_vap,
-                          const long double smolar_liq, 
-                          const long double smolar_vap,
-                          const std::vector<long double> & x, 
-                          const std::vector<long double> & y,
+    void insert_variables(const CoolPropDbl T, 
+                          const CoolPropDbl p, 
+                          const CoolPropDbl rhomolar_liq, 
+                          const CoolPropDbl rhomolar_vap,
+                          const CoolPropDbl hmolar_liq, 
+                          const CoolPropDbl hmolar_vap,
+                          const CoolPropDbl smolar_liq, 
+                          const CoolPropDbl smolar_vap,
+                          const std::vector<CoolPropDbl> & x, 
+                          const std::vector<CoolPropDbl> & y,
                           std::size_t i)
     {
         std::size_t N = K.size();
@@ -74,16 +74,16 @@ public:
             this->Q.insert(this->Q.begin(), 0);
         }
     };
-    void store_variables(const long double T, 
-                         const long double p, 
-                         const long double rhomolar_liq, 
-                         const long double rhomolar_vap,
-                         const long double hmolar_liq, 
-                         const long double hmolar_vap,
-                         const long double smolar_liq, 
-                         const long double smolar_vap,
-                         const std::vector<long double> & x, 
-                         const std::vector<long double> & y)
+    void store_variables(const CoolPropDbl T, 
+                         const CoolPropDbl p, 
+                         const CoolPropDbl rhomolar_liq, 
+                         const CoolPropDbl rhomolar_vap,
+                         const CoolPropDbl hmolar_liq, 
+                         const CoolPropDbl hmolar_vap,
+                         const CoolPropDbl smolar_liq, 
+                         const CoolPropDbl smolar_vap,
+                         const std::vector<CoolPropDbl> & x, 
+                         const std::vector<CoolPropDbl> & y)
     {
         std::size_t N = K.size();
         if (N==0){throw CoolProp::ValueError("Cannot store variables in phase envelope since resize() function has not been called");}

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -421,9 +421,9 @@ double AbstractState::dCvirial_dT(void){ return calc_dCvirial_dT(); }
 double AbstractState::compressibility_factor(void){ return calc_compressibility_factor(); }
 
 // Get the derivatives of the parameters in the partial derivative with respect to T and rho
-void get_dT_drho(AbstractState &AS, parameters index, long double &dT, long double &drho)
+void get_dT_drho(AbstractState &AS, parameters index, CoolPropDbl &dT, CoolPropDbl &drho)
 {
-    long double T = AS.T(),
+    CoolPropDbl T = AS.T(),
                 rho = AS.rhomolar(),
                 rhor = AS.rhomolar_reducing(),
                 Tr = AS.T_reducing(),
@@ -498,9 +498,9 @@ void get_dT_drho(AbstractState &AS, parameters index, long double &dT, long doub
         throw ValueError(format("input to get_dT_drho[%s] is invalid",get_parameter_information(index,"short").c_str()));
     }
 }
-void get_dT_drho_second_derivatives(AbstractState &AS, int index, long double &dT2, long double &drho_dT, long double &drho2)
+void get_dT_drho_second_derivatives(AbstractState &AS, int index, CoolPropDbl &dT2, CoolPropDbl &drho_dT, CoolPropDbl &drho2)
 {
-	long double T = AS.T(),
+	CoolPropDbl T = AS.T(),
                 rho = AS.rhomolar(),
                 rhor = AS.rhomolar_reducing(),
                 Tr = AS.T_reducing(),
@@ -584,9 +584,9 @@ void get_dT_drho_second_derivatives(AbstractState &AS, int index, long double &d
         throw ValueError(format("input to get_dT_drho_second_derivatives[%s] is invalid", get_parameter_information(index,"short").c_str()));
     }
 }
-long double AbstractState::calc_first_partial_deriv(parameters Of, parameters Wrt, parameters Constant)
+CoolPropDbl AbstractState::calc_first_partial_deriv(parameters Of, parameters Wrt, parameters Constant)
 {
-	long double dOf_dT, dOf_drho, dWrt_dT, dWrt_drho, dConstant_dT, dConstant_drho;
+	CoolPropDbl dOf_dT, dOf_drho, dWrt_dT, dWrt_drho, dConstant_dT, dConstant_drho;
 
     get_dT_drho(*this, Of, dOf_dT, dOf_drho);
     get_dT_drho(*this, Wrt, dWrt_dT, dWrt_drho);
@@ -594,9 +594,9 @@ long double AbstractState::calc_first_partial_deriv(parameters Of, parameters Wr
 
     return (dOf_dT*dConstant_drho-dOf_drho*dConstant_dT)/(dWrt_dT*dConstant_drho-dWrt_drho*dConstant_dT);
 }
-long double AbstractState::calc_second_partial_deriv(parameters Of1, parameters Wrt1, parameters Constant1, parameters Wrt2, parameters Constant2)
+CoolPropDbl AbstractState::calc_second_partial_deriv(parameters Of1, parameters Wrt1, parameters Constant1, parameters Wrt2, parameters Constant2)
 {
-    long double dOf1_dT, dOf1_drho, dWrt1_dT, dWrt1_drho, dConstant1_dT, dConstant1_drho, d2Of1_dT2, d2Of1_drhodT,
+    CoolPropDbl dOf1_dT, dOf1_drho, dWrt1_dT, dWrt1_drho, dConstant1_dT, dConstant1_drho, d2Of1_dT2, d2Of1_drhodT,
                 d2Of1_drho2, d2Wrt1_dT2, d2Wrt1_drhodT, d2Wrt1_drho2, d2Constant1_dT2, d2Constant1_drhodT, d2Constant1_drho2,
                 dWrt2_dT, dWrt2_drho, dConstant2_dT, dConstant2_drho, N, D, dNdrho__T, dDdrho__T, dNdT__rho, dDdT__rho,
                 dderiv1_drho, dderiv1_dT, second;

--- a/src/Backends/Helmholtz/ExcessHEFunction.h
+++ b/src/Backends/Helmholtz/ExcessHEFunction.h
@@ -8,7 +8,7 @@
 
 namespace CoolProp{
 
-typedef std::vector<std::vector<long double> > STLMatrix;
+typedef std::vector<std::vector<CoolPropDbl> > STLMatrix;
 
 /** \brief The abstract base class for departure functions used in the excess part of the Helmholtz energy
  * 
@@ -52,10 +52,10 @@ public:
     {
         /// Break up into power and gaussian terms
         {
-            std::vector<long double> _n(n.begin(), n.begin()+Npower);
-            std::vector<long double> _d(d.begin(), d.begin()+Npower);
-            std::vector<long double> _t(t.begin(), t.begin()+Npower);
-            std::vector<long double> _l(Npower, 0.0);
+            std::vector<CoolPropDbl> _n(n.begin(), n.begin()+Npower);
+            std::vector<CoolPropDbl> _d(d.begin(), d.begin()+Npower);
+            std::vector<CoolPropDbl> _t(t.begin(), t.begin()+Npower);
+            std::vector<CoolPropDbl> _l(Npower, 0.0);
             phi.add_Power(_n, _d, _t, _l);
         }
         if (n.size() == Npower)
@@ -65,13 +65,13 @@ public:
         else
         {
             using_gaussian = true;
-            std::vector<long double> _n(n.begin()+Npower,                   n.end());
-            std::vector<long double> _d(d.begin()+Npower,                   d.end());
-            std::vector<long double> _t(t.begin()+Npower,                   t.end());
-            std::vector<long double> _eta(eta.begin()+Npower,             eta.end());
-            std::vector<long double> _epsilon(epsilon.begin()+Npower, epsilon.end());
-            std::vector<long double> _beta(beta.begin()+Npower,          beta.end());
-            std::vector<long double> _gamma(gamma.begin()+Npower,       gamma.end());
+            std::vector<CoolPropDbl> _n(n.begin()+Npower,                   n.end());
+            std::vector<CoolPropDbl> _d(d.begin()+Npower,                   d.end());
+            std::vector<CoolPropDbl> _t(t.begin()+Npower,                   t.end());
+            std::vector<CoolPropDbl> _eta(eta.begin()+Npower,             eta.end());
+            std::vector<CoolPropDbl> _epsilon(epsilon.begin()+Npower, epsilon.end());
+            std::vector<CoolPropDbl> _beta(beta.begin()+Npower,          beta.end());
+            std::vector<CoolPropDbl> _gamma(gamma.begin()+Npower,       gamma.end());
             phi.add_GERG2008Gaussian(_n, _d, _t, _eta, _epsilon, _beta, _gamma);
         }
     };
@@ -102,10 +102,10 @@ public:
     ExponentialDepartureFunction(const std::vector<double> &n, const std::vector<double> &d,
                                  const std::vector<double> &t, const std::vector<double> &l)
                                  {
-                                     std::vector<long double> _n(n.begin(), n.begin()+n.size());
-                                     std::vector<long double> _d(d.begin(), d.begin()+d.size());
-                                     std::vector<long double> _t(t.begin(), t.begin()+t.size());
-                                     std::vector<long double> _l(l.begin(), l.begin()+l.size());
+                                     std::vector<CoolPropDbl> _n(n.begin(), n.begin()+n.size());
+                                     std::vector<CoolPropDbl> _d(d.begin(), d.begin()+d.size());
+                                     std::vector<CoolPropDbl> _t(t.begin(), t.begin()+t.size());
+                                     std::vector<CoolPropDbl> _l(l.begin(), l.begin()+l.size());
                                      phi.add_Power(_n, _d, _t, _l);
                                  };
     ~ExponentialDepartureFunction(){};
@@ -125,7 +125,7 @@ class ExcessTerm
 public:
     std::size_t N;
     std::vector<std::vector<DepartureFunctionPointer> > DepartureFunctionMatrix;
-    std::vector<std::vector<long double> > F;
+    std::vector<std::vector<CoolPropDbl> > F;
 
     ExcessTerm(){};
     ~ExcessTerm(){};
@@ -133,14 +133,14 @@ public:
     /// Resize the parts of this term
     void resize(std::size_t N){
         this->N = N;
-        F.resize(N, std::vector<long double>(N, 0));
+        F.resize(N, std::vector<CoolPropDbl>(N, 0));
         DepartureFunctionMatrix.resize(N);
         for (std::size_t i = 0; i < N; ++i){
             DepartureFunctionMatrix[i].resize(N);
         }
     };
 
-    double alphar(double tau, double delta, const std::vector<long double> &x)
+    double alphar(double tau, double delta, const std::vector<CoolPropDbl> &x)
     {
         double summer = 0;
         for (std::size_t i = 0; i < N-1; i++)
@@ -152,7 +152,7 @@ public:
         }
         return summer;
     }
-    double dalphar_dDelta(double tau, double delta, const std::vector<long double> &x)
+    double dalphar_dDelta(double tau, double delta, const std::vector<CoolPropDbl> &x)
     {
         double summer = 0;
         for (std::size_t i = 0; i < N-1; i++)
@@ -164,7 +164,7 @@ public:
         }
         return summer;
     }
-    double d2alphar_dDelta2(double tau, double delta, const std::vector<long double> &x)
+    double d2alphar_dDelta2(double tau, double delta, const std::vector<CoolPropDbl> &x)
     {
         double summer = 0;
         for (std::size_t i = 0; i < N-1; i++)
@@ -176,7 +176,7 @@ public:
         }
         return summer;
     };
-    double d2alphar_dDelta_dTau(double tau, double delta, const std::vector<long double> &x)
+    double d2alphar_dDelta_dTau(double tau, double delta, const std::vector<CoolPropDbl> &x)
     {
         double summer = 0;
         for (std::size_t i = 0; i < N-1; i++)
@@ -188,7 +188,7 @@ public:
         }
         return summer;
     }
-    double dalphar_dTau(double tau, double delta, const std::vector<long double> &x)
+    double dalphar_dTau(double tau, double delta, const std::vector<CoolPropDbl> &x)
     {
         double summer = 0;
         for (std::size_t i = 0; i < N-1; i++)
@@ -200,7 +200,7 @@ public:
         }
         return summer;
     };
-    double d2alphar_dTau2(double tau, double delta, const std::vector<long double> &x)
+    double d2alphar_dTau2(double tau, double delta, const std::vector<CoolPropDbl> &x)
     {
         double summer = 0;
         for (std::size_t i = 0; i < N-1; i++)
@@ -212,7 +212,7 @@ public:
         }
         return summer;
     };
-    double dalphar_dxi(double tau, double delta, const std::vector<long double> &x, std::size_t i)
+    double dalphar_dxi(double tau, double delta, const std::vector<CoolPropDbl> &x, std::size_t i)
     {
         double summer = 0;
         for (std::size_t k = 0; k < N; k++)
@@ -224,7 +224,7 @@ public:
         }
         return summer;
     };
-    double d2alphardxidxj(double tau, double delta, const std::vector<long double> &x, std::size_t i, std::size_t j)
+    double d2alphardxidxj(double tau, double delta, const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j)
     {
         if (i != j)
         {
@@ -235,7 +235,7 @@ public:
             return 0;
         }
     };
-    double d2alphar_dxi_dTau(double tau, double delta, const std::vector<long double> &x, std::size_t i)
+    double d2alphar_dxi_dTau(double tau, double delta, const std::vector<CoolPropDbl> &x, std::size_t i)
     {
         double summer = 0;
         for (std::size_t k = 0; k < N; k++)
@@ -247,7 +247,7 @@ public:
         }
         return summer;
     };
-    double d2alphar_dxi_dDelta(double tau, double delta, const std::vector<long double> &x, std::size_t i)
+    double d2alphar_dxi_dDelta(double tau, double delta, const std::vector<CoolPropDbl> &x, std::size_t i)
     {
         double summer = 0;
         for (std::size_t k = 0; k < N; k++)

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -46,25 +46,25 @@ void FlashRoutines::PT_flash_mixtures(HelmholtzEOSMixtureBackend &HEOS)
             // Gas solution - bounded between phase envelope temperature and very high temperature
             //
             // Start with a guess value from SRK
-            long double rhomolar_guess = HEOS.solver_rho_Tp_SRK(HEOS._T, HEOS._p, iphase_gas);
+            CoolPropDbl rhomolar_guess = HEOS.solver_rho_Tp_SRK(HEOS._T, HEOS._p, iphase_gas);
             
             solver_TP_resid resid(HEOS, HEOS._T, HEOS._p);
             std::string errstr;
             HEOS.specify_phase(iphase_gas);
             try{
                 // Try using Newton's method
-                long double rhomolar = Newton(resid, rhomolar_guess, 1e-10, 100, errstr);
+                CoolPropDbl rhomolar = Newton(resid, rhomolar_guess, 1e-10, 100, errstr);
                 // Make sure the solution is within the bounds
-                if (!is_in_closed_range(static_cast<long double>(closest_state.rhomolar), 0.0L, rhomolar)){
+                if (!is_in_closed_range(static_cast<CoolPropDbl>(closest_state.rhomolar), 0.0L, rhomolar)){
                     throw ValueError("out of range");
                 }
                 HEOS.update_DmolarT_direct(rhomolar, HEOS._T);
             }
             catch(std::exception &){
                 // If that fails, try a bounded solver
-                long double rhomolar = Brent(resid, closest_state.rhomolar, 1e-10, DBL_EPSILON, 1e-10, 100, errstr);
+                CoolPropDbl rhomolar = Brent(resid, closest_state.rhomolar, 1e-10, DBL_EPSILON, 1e-10, 100, errstr);
                 // Make sure the solution is within the bounds
-                if (!is_in_closed_range(static_cast<long double>(closest_state.rhomolar), 0.0L, rhomolar)){
+                if (!is_in_closed_range(static_cast<CoolPropDbl>(closest_state.rhomolar), 0.0L, rhomolar)){
                     throw ValueError("out of range");
                 }
             }
@@ -79,26 +79,26 @@ void FlashRoutines::PT_flash_mixtures(HelmholtzEOSMixtureBackend &HEOS)
         // Following the strategy of Gernert, 2014
         
         // Step 1 a) Get lnK factors using Wilson
-        std::vector<long double> lnK(HEOS.get_mole_fractions().size());
+        std::vector<CoolPropDbl> lnK(HEOS.get_mole_fractions().size());
         for (std::size_t i = 0; i < lnK.size(); ++i){
             lnK[i] = SaturationSolvers::Wilson_lnK_factor(HEOS, HEOS._T, HEOS._p, i);
         }
         
         // Use Rachford-Rice to check whether you are in a homogeneous phase
-        long double g_RR_0 = g_RachfordRice(HEOS.get_mole_fractions(), lnK, 0.0L);
+        CoolPropDbl g_RR_0 = g_RachfordRice(HEOS.get_mole_fractions(), lnK, 0.0L);
         if (g_RR_0 < 0){
             // Subcooled liquid - done
-            long double rhomolar_guess = HEOS.solver_rho_Tp_SRK(HEOS._T, HEOS._p, iphase_liquid);
+            CoolPropDbl rhomolar_guess = HEOS.solver_rho_Tp_SRK(HEOS._T, HEOS._p, iphase_liquid);
             HEOS.specify_phase(iphase_liquid);
             HEOS.update_TP_guessrho(HEOS._T, HEOS._p, rhomolar_guess);
             HEOS.unspecify_phase();
             return;
         }
         else{
-            long double g_RR_1 = g_RachfordRice(HEOS.get_mole_fractions(), lnK, 1.0L);
+            CoolPropDbl g_RR_1 = g_RachfordRice(HEOS.get_mole_fractions(), lnK, 1.0L);
             if (g_RR_1 > 0){
                 // Superheated vapor - done
-                long double rhomolar_guess = HEOS.solver_rho_Tp_SRK(HEOS._T, HEOS._p, iphase_gas);
+                CoolPropDbl rhomolar_guess = HEOS.solver_rho_Tp_SRK(HEOS._T, HEOS._p, iphase_gas);
                 HEOS.specify_phase(iphase_gas);
                 HEOS.update_TP_guessrho(HEOS._T, HEOS._p, rhomolar_guess);
                 HEOS.unspecify_phase();
@@ -141,7 +141,7 @@ void FlashRoutines::PT_flash(HelmholtzEOSMixtureBackend &HEOS)
     HEOS._rhomolar = HEOS.solver_rho_Tp(HEOS._T, HEOS._p);
     HEOS._Q = -1;
 }
-void FlashRoutines::HQ_flash(HelmholtzEOSMixtureBackend &HEOS, long double Tguess)
+void FlashRoutines::HQ_flash(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl Tguess)
 {
     SaturationSolvers::saturation_PHSU_pure_options options;
     options.use_logdelta = false;
@@ -214,15 +214,15 @@ void FlashRoutines::QS_flash(HelmholtzEOSMixtureBackend &HEOS)
 }
 void FlashRoutines::QT_flash(HelmholtzEOSMixtureBackend &HEOS)
 {
-    long double T = HEOS._T;
+    CoolPropDbl T = HEOS._T;
     if (HEOS.is_pure_or_pseudopure)
     {
         // The maximum possible saturation temperature
         // Critical point for pure fluids, slightly different for pseudo-pure, very different for mixtures
-        long double Tmax_sat = HEOS.calc_Tmax_sat() + 1e-13;
+        CoolPropDbl Tmax_sat = HEOS.calc_Tmax_sat() + 1e-13;
         
         // Check what the minimum limits for the equation of state are
-        long double Tmin_satL, Tmin_satV, Tmin_sat;
+        CoolPropDbl Tmin_satL, Tmin_satV, Tmin_sat;
         HEOS.calc_Tmin_sat(Tmin_satL, Tmin_satV);
         Tmin_sat = std::max(Tmin_satL, Tmin_satV) - 1e-13;
         
@@ -262,9 +262,9 @@ void FlashRoutines::QT_flash(HelmholtzEOSMixtureBackend &HEOS)
         }
         else{
             // Pseudo-pure fluid
-            long double rhoLanc = _HUGE, rhoVanc = _HUGE, rhoLsat = _HUGE, rhoVsat = _HUGE;
-            long double psatLanc = HEOS.components[0]->ancillaries.pL.evaluate(HEOS._T); // These ancillaries are used explicitly
-            long double psatVanc = HEOS.components[0]->ancillaries.pV.evaluate(HEOS._T); // These ancillaries are used explicitly
+            CoolPropDbl rhoLanc = _HUGE, rhoVanc = _HUGE, rhoLsat = _HUGE, rhoVsat = _HUGE;
+            CoolPropDbl psatLanc = HEOS.components[0]->ancillaries.pL.evaluate(HEOS._T); // These ancillaries are used explicitly
+            CoolPropDbl psatVanc = HEOS.components[0]->ancillaries.pV.evaluate(HEOS._T); // These ancillaries are used explicitly
             try{
                 rhoLanc = HEOS.components[0]->ancillaries.rhoL.evaluate(HEOS._T);
                 rhoVanc = HEOS.components[0]->ancillaries.rhoV.evaluate(HEOS._T);
@@ -307,7 +307,7 @@ void FlashRoutines::QT_flash(HelmholtzEOSMixtureBackend &HEOS)
             options.Nstep_max = 20;
 
             // Get an extremely rough guess by interpolation of ln(p) v. T curve where the limits are mole-fraction-weighted
-            long double pguess = SaturationSolvers::saturation_preconditioner(HEOS, HEOS._T, SaturationSolvers::imposed_T, HEOS.mole_fractions);
+            CoolPropDbl pguess = SaturationSolvers::saturation_preconditioner(HEOS, HEOS._T, SaturationSolvers::imposed_T, HEOS.mole_fractions);
 
             // Use Wilson iteration to obtain updated guess for pressure
             pguess = SaturationSolvers::saturation_Wilson(HEOS, HEOS._Q, HEOS._T, SaturationSolvers::imposed_T, HEOS.mole_fractions, pguess);
@@ -335,8 +335,8 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend &HEOS)
             HEOS._TLanc = HEOS.components[0]->ancillaries.pL.invert(HEOS._p);
             HEOS._TVanc = HEOS.components[0]->ancillaries.pV.invert(HEOS._p);
             // Get guesses for the ancillaries for density
-            long double rhoL = HEOS.components[0]->ancillaries.rhoL.evaluate(HEOS._TLanc);
-            long double rhoV = HEOS.components[0]->ancillaries.rhoV.evaluate(HEOS._TVanc);
+            CoolPropDbl rhoL = HEOS.components[0]->ancillaries.rhoL.evaluate(HEOS._TLanc);
+            CoolPropDbl rhoV = HEOS.components[0]->ancillaries.rhoV.evaluate(HEOS._TVanc);
             // Solve for the density
             HEOS.SatL->update_TP_guessrho(HEOS._TLanc, HEOS._p, rhoL);
             HEOS.SatV->update_TP_guessrho(HEOS._TVanc, HEOS._p, rhoV);
@@ -349,15 +349,15 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend &HEOS)
         }
         else{
             // Critical point for pure fluids, slightly different for pseudo-pure, very different for mixtures
-            long double pmax_sat = HEOS.calc_pmax_sat();
+            CoolPropDbl pmax_sat = HEOS.calc_pmax_sat();
             
             // Check what the minimum limits for the equation of state are
-            long double pmin_satL, pmin_satV, pmin_sat;
+            CoolPropDbl pmin_satL, pmin_satV, pmin_sat;
             HEOS.calc_pmin_sat(pmin_satL, pmin_satV);
             pmin_sat = std::max(pmin_satL, pmin_satV);
             
             // Check for being AT the critical point
-            if (is_in_closed_range(pmax_sat*(1-1e-10), pmax_sat*(1+1e-10), static_cast<long double>(HEOS._p))){
+            if (is_in_closed_range(pmax_sat*(1-1e-10), pmax_sat*(1+1e-10), static_cast<CoolPropDbl>(HEOS._p))){
                 // Load the outputs
                 HEOS._phase = iphase_critical_point;
                 HEOS._p = HEOS.p_critical();
@@ -367,7 +367,7 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend &HEOS)
             }
             
             // Check limits
-            if (!is_in_closed_range(pmin_sat*0.999999, pmax_sat*1.000001, static_cast<long double>(HEOS._p))){
+            if (!is_in_closed_range(pmin_sat*0.999999, pmax_sat*1.000001, static_cast<CoolPropDbl>(HEOS._p))){
                 throw ValueError(format("Pressure to PQ_flash [%6g Pa] must be in range [%8Lg Pa, %8Lg Pa]",HEOS._p, pmin_sat, pmax_sat));
             }
             // ------------------
@@ -426,7 +426,7 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend &HEOS)
             io.Nstep_max = 10;
 
             // Get an extremely rough guess by interpolation of ln(p) v. T curve where the limits are mole-fraction-weighted
-            long double Tguess = SaturationSolvers::saturation_preconditioner(HEOS, HEOS._p, SaturationSolvers::imposed_p, HEOS.mole_fractions);
+            CoolPropDbl Tguess = SaturationSolvers::saturation_preconditioner(HEOS, HEOS._p, SaturationSolvers::imposed_p, HEOS.mole_fractions);
 
             // Use Wilson iteration to obtain updated guess for temperature
             Tguess = SaturationSolvers::saturation_Wilson(HEOS, HEOS._Q, HEOS._p, SaturationSolvers::imposed_p, HEOS.mole_fractions, Tguess);
@@ -443,7 +443,7 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend &HEOS)
     }
 }
 
-void FlashRoutines::PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend &HEOS, parameters other, long double value)
+void FlashRoutines::PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend &HEOS, parameters other, CoolPropDbl value)
 {
     
     // Find the intersections in the phase envelope
@@ -494,14 +494,14 @@ void FlashRoutines::PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend &HEOS, parame
                 IO.p = HEOS._p;
                 IO.imposed_variable = SaturationSolvers::newton_raphson_saturation_options::P_IMPOSED;
                 // p -> rhomolar_vap
-                IO.rhomolar_vap = CubicInterp(env.p, env.rhomolar_vap, imax-1, imax, imax+1, imax+2, static_cast<long double>(IO.p));
+                IO.rhomolar_vap = CubicInterp(env.p, env.rhomolar_vap, imax-1, imax, imax+1, imax+2, static_cast<CoolPropDbl>(IO.p));
                 IO.T = CubicInterp(env.rhomolar_vap, env.T, imax-1, imax, imax+1, imax+2, IO.rhomolar_vap);
             }
             else if (other == iT){
                 IO.T = HEOS._T;
                 IO.imposed_variable = SaturationSolvers::newton_raphson_saturation_options::T_IMPOSED;
                 // T -> rhomolar_vap
-                IO.rhomolar_vap = CubicInterp(env.T, env.rhomolar_vap, imax-1, imax, imax+1, imax+2, static_cast<long double>(IO.T));
+                IO.rhomolar_vap = CubicInterp(env.T, env.rhomolar_vap, imax-1, imax, imax+1, imax+2, static_cast<CoolPropDbl>(IO.T));
                 IO.p = CubicInterp(env.rhomolar_vap, env.p, imax-1, imax, imax+1, imax+2, IO.rhomolar_vap);
             }
             IO.rhomolar_liq = CubicInterp(env.rhomolar_vap, env.rhomolar_liq, imax-1, imax, imax+1, imax+2, IO.rhomolar_vap);
@@ -565,7 +565,7 @@ void FlashRoutines::PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend &HEOS, parame
         SaturationSolvers::newton_raphson_twophase_options IO;
         IO.beta = HEOS._Q;
         
-        long double rhomolar_vap_sat_vap, T_sat_vap, rhomolar_liq_sat_vap, rhomolar_liq_sat_liq, T_sat_liq, rhomolar_vap_sat_liq, p_sat_liq, p_sat_vap;
+        CoolPropDbl rhomolar_vap_sat_vap, T_sat_vap, rhomolar_liq_sat_vap, rhomolar_liq_sat_liq, T_sat_liq, rhomolar_vap_sat_liq, p_sat_liq, p_sat_vap;
 
         if (other == iP){
             IO.p = HEOS._p;
@@ -573,12 +573,12 @@ void FlashRoutines::PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend &HEOS, parame
             IO.imposed_variable = SaturationSolvers::newton_raphson_twophase_options::P_IMPOSED;
             
             // Calculate the interpolated values for beta = 0 and beta = 1
-            rhomolar_vap_sat_vap = CubicInterp(env.p, env.rhomolar_vap, ivap-1, ivap, ivap+1, ivap+2, static_cast<long double>(IO.p));
+            rhomolar_vap_sat_vap = CubicInterp(env.p, env.rhomolar_vap, ivap-1, ivap, ivap+1, ivap+2, static_cast<CoolPropDbl>(IO.p));
             T_sat_vap = CubicInterp(env.rhomolar_vap, env.T, ivap-1, ivap, ivap+1, ivap+2, rhomolar_vap_sat_vap);
             rhomolar_liq_sat_vap = CubicInterp(env.rhomolar_vap, env.rhomolar_liq, ivap-1, ivap, ivap+1, ivap+2, rhomolar_vap_sat_vap);
             
             // Phase inversion for liquid solution (liquid is vapor and vice versa)
-            rhomolar_liq_sat_liq = CubicInterp(env.p, env.rhomolar_vap, iliq-1, iliq, iliq+1, iliq+2, static_cast<long double>(IO.p)); 
+            rhomolar_liq_sat_liq = CubicInterp(env.p, env.rhomolar_vap, iliq-1, iliq, iliq+1, iliq+2, static_cast<CoolPropDbl>(IO.p)); 
             T_sat_liq = CubicInterp(env.rhomolar_vap, env.T, iliq-1, iliq, iliq+1, iliq+2, rhomolar_liq_sat_liq);
             rhomolar_vap_sat_liq = CubicInterp(env.rhomolar_vap, env.rhomolar_liq, iliq-1, iliq, iliq+1, iliq+2, rhomolar_liq_sat_liq);
         }
@@ -588,12 +588,12 @@ void FlashRoutines::PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend &HEOS, parame
             IO.imposed_variable = SaturationSolvers::newton_raphson_twophase_options::T_IMPOSED;
             
             // Calculate the interpolated values for beta = 0 and beta = 1
-            rhomolar_vap_sat_vap = CubicInterp(env.T, env.rhomolar_vap, ivap-1, ivap, ivap+1, ivap+2, static_cast<long double>(IO.T));
+            rhomolar_vap_sat_vap = CubicInterp(env.T, env.rhomolar_vap, ivap-1, ivap, ivap+1, ivap+2, static_cast<CoolPropDbl>(IO.T));
             p_sat_vap = CubicInterp(env.rhomolar_vap, env.p, ivap-1, ivap, ivap+1, ivap+2, rhomolar_vap_sat_vap);
             rhomolar_liq_sat_vap = CubicInterp(env.rhomolar_vap, env.rhomolar_liq, ivap-1, ivap, ivap+1, ivap+2, rhomolar_vap_sat_vap);
             
             // Phase inversion for liquid solution (liquid is vapor and vice versa)
-            rhomolar_liq_sat_liq = CubicInterp(env.T, env.rhomolar_vap, iliq-1, iliq, iliq+1, iliq+2, static_cast<long double>(IO.T)); 
+            rhomolar_liq_sat_liq = CubicInterp(env.T, env.rhomolar_vap, iliq-1, iliq, iliq+1, iliq+2, static_cast<CoolPropDbl>(IO.T)); 
             p_sat_liq = CubicInterp(env.rhomolar_vap, env.p, iliq-1, iliq, iliq+1, iliq+2, rhomolar_liq_sat_liq);
             rhomolar_vap_sat_liq = CubicInterp(env.rhomolar_vap, env.rhomolar_liq, iliq-1, iliq, iliq+1, iliq+2, rhomolar_liq_sat_liq);
         }
@@ -613,33 +613,33 @@ void FlashRoutines::PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend &HEOS, parame
         
         for (std::size_t i = 0; i < IO.x.size()-1; ++i) // First N-1 elements
         {
-            long double x_sat_vap = CubicInterp(env.rhomolar_vap, env.x[i], ivap-1, ivap, ivap+1, ivap+2, rhomolar_vap_sat_vap);
-            long double y_sat_vap = CubicInterp(env.rhomolar_vap, env.y[i], ivap-1, ivap, ivap+1, ivap+2, rhomolar_vap_sat_vap);
+            CoolPropDbl x_sat_vap = CubicInterp(env.rhomolar_vap, env.x[i], ivap-1, ivap, ivap+1, ivap+2, rhomolar_vap_sat_vap);
+            CoolPropDbl y_sat_vap = CubicInterp(env.rhomolar_vap, env.y[i], ivap-1, ivap, ivap+1, ivap+2, rhomolar_vap_sat_vap);
             
-            long double x_sat_liq = CubicInterp(env.rhomolar_vap, env.y[i], iliq-1, iliq, iliq+1, iliq+2, rhomolar_liq_sat_liq);
-            long double y_sat_liq = CubicInterp(env.rhomolar_vap, env.x[i], iliq-1, iliq, iliq+1, iliq+2, rhomolar_liq_sat_liq);
+            CoolPropDbl x_sat_liq = CubicInterp(env.rhomolar_vap, env.y[i], iliq-1, iliq, iliq+1, iliq+2, rhomolar_liq_sat_liq);
+            CoolPropDbl y_sat_liq = CubicInterp(env.rhomolar_vap, env.x[i], iliq-1, iliq, iliq+1, iliq+2, rhomolar_liq_sat_liq);
             
             IO.x[i] = IO.beta*x_sat_vap + (1-IO.beta)*x_sat_liq;
             IO.y[i] = IO.beta*y_sat_vap + (1-IO.beta)*y_sat_liq;
         }
         IO.x[IO.x.size()-1] = 1 - std::accumulate(IO.x.begin(), IO.x.end()-1, 0.0);
         IO.y[IO.y.size()-1] = 1 - std::accumulate(IO.y.begin(), IO.y.end()-1, 0.0);
-        std::vector<long double> &XX = IO.x;
-        std::vector<long double> &YY = IO.y;
+        std::vector<CoolPropDbl> &XX = IO.x;
+        std::vector<CoolPropDbl> &YY = IO.y;
         NR.call(HEOS, IO);
     }
 }
-void FlashRoutines::HSU_D_flash_twophase(HelmholtzEOSMixtureBackend &HEOS, long double rhomolar_spec, parameters other, long double value)
+void FlashRoutines::HSU_D_flash_twophase(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl rhomolar_spec, parameters other, CoolPropDbl value)
 {
     class Residual : public FuncWrapper1D
     {
         
     public:
         HelmholtzEOSMixtureBackend &HEOS;
-        long double rhomolar_spec, Qd, Qo;
+        CoolPropDbl rhomolar_spec, Qd, Qo;
 		parameters other;
-		long double value;
-        Residual(HelmholtzEOSMixtureBackend &HEOS, long double rhomolar_spec, parameters other, long double value) : HEOS(HEOS), rhomolar_spec(rhomolar_spec), other(other), value(value){};
+		CoolPropDbl value;
+        Residual(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl rhomolar_spec, parameters other, CoolPropDbl value) : HEOS(HEOS), rhomolar_spec(rhomolar_spec), other(other), value(value){};
         double call(double T){
             HEOS.update(QT_INPUTS, 0, T);
             HelmholtzEOSMixtureBackend &SatL = HEOS.get_SatL(),
@@ -655,10 +655,10 @@ void FlashRoutines::HSU_D_flash_twophase(HelmholtzEOSMixtureBackend &HEOS, long 
     
     std::string errstr;
     // Critical point for pure fluids, slightly different for pseudo-pure, very different for mixtures
-    long double Tmax_sat = HEOS.calc_Tmax_sat() - 1e-13;
+    CoolPropDbl Tmax_sat = HEOS.calc_Tmax_sat() - 1e-13;
     
     // Check what the minimum limits for the equation of state are
-    long double Tmin_satL, Tmin_satV, Tmin_sat;
+    CoolPropDbl Tmin_satL, Tmin_satV, Tmin_sat;
     HEOS.calc_Tmin_sat(Tmin_satL, Tmin_satV);
     Tmin_sat = std::max(Tmin_satL, Tmin_satV) - 1e-13;
         
@@ -673,10 +673,10 @@ void FlashRoutines::PHSU_D_flash(HelmholtzEOSMixtureBackend &HEOS, parameters ot
     public:
 
         HelmholtzEOSMixtureBackend *HEOS;
-        long double r, eos, rhomolar, value, T;
+        CoolPropDbl r, eos, rhomolar, value, T;
         int other;
 
-        solver_resid(HelmholtzEOSMixtureBackend *HEOS, long double rhomolar, long double value, int other) : HEOS(HEOS), rhomolar(rhomolar), value(value), other(other){};
+        solver_resid(HelmholtzEOSMixtureBackend *HEOS, CoolPropDbl rhomolar, CoolPropDbl value, int other) : HEOS(HEOS), rhomolar(rhomolar), value(value), other(other){};
         double call(double T){
             this->T = T;
             switch(other)
@@ -712,14 +712,14 @@ void FlashRoutines::PHSU_D_flash(HelmholtzEOSMixtureBackend &HEOS, parameters ot
             CoolPropFluid * component = HEOS.components[0];
 
             shared_ptr<HelmholtzEOSMixtureBackend> Sat;
-            long double rhoLtriple = component->triple_liquid.rhomolar;
-            long double rhoVtriple = component->triple_vapor.rhomolar;
+            CoolPropDbl rhoLtriple = component->triple_liquid.rhomolar;
+            CoolPropDbl rhoVtriple = component->triple_vapor.rhomolar;
             // Check if in the "normal" region
             if (HEOS._rhomolar >= rhoVtriple && HEOS._rhomolar <= rhoLtriple)
             {
-                long double yL, yV, value, y_solid;
-                long double TLtriple = component->triple_liquid.T; ///TODO: separate TL and TV for ppure
-                long double TVtriple = component->triple_vapor.T;
+                CoolPropDbl yL, yV, value, y_solid;
+                CoolPropDbl TLtriple = component->triple_liquid.T; ///TODO: separate TL and TV for ppure
+                CoolPropDbl TVtriple = component->triple_vapor.T;
 
                 // First check if solid (below the line connecting the triple point values) - this is an error for now
                 switch (other)
@@ -799,8 +799,8 @@ void FlashRoutines::PHSU_D_flash(HelmholtzEOSMixtureBackend &HEOS, parameters ot
             // Check if vapor/solid region below triple point vapor density
             else if (HEOS._rhomolar < component->triple_vapor.rhomolar)
             {
-                long double y, value;
-                long double TVtriple = component->triple_vapor.T; //TODO: separate TL and TV for ppure
+                CoolPropDbl y, value;
+                CoolPropDbl TVtriple = component->triple_vapor.T; //TODO: separate TL and TV for ppure
 
                 // If value is above the value calculated from X(Ttriple, _rhomolar), it is vapor
                 switch (other)
@@ -833,8 +833,8 @@ void FlashRoutines::PHSU_D_flash(HelmholtzEOSMixtureBackend &HEOS, parameters ot
             // Check in the liquid/solid region above the triple point density
             else
             {
-                long double y, value;
-                long double TLtriple = component->pEOS->Ttriple;
+                CoolPropDbl y, value;
+                CoolPropDbl TLtriple = component->pEOS->Ttriple;
 
                 // If value is above the value calculated from X(Ttriple, _rhomolar), it is vapor
                 switch (other)
@@ -869,16 +869,16 @@ void FlashRoutines::PHSU_D_flash(HelmholtzEOSMixtureBackend &HEOS, parameters ot
     }
 }
 
-void FlashRoutines::HSU_P_flash_singlephase_Newton(HelmholtzEOSMixtureBackend &HEOS, parameters other, long double T0, long double rhomolar0)
+void FlashRoutines::HSU_P_flash_singlephase_Newton(HelmholtzEOSMixtureBackend &HEOS, parameters other, CoolPropDbl T0, CoolPropDbl rhomolar0)
 {
     double A[2][2], B[2][2];
-    long double y = _HUGE;
+    CoolPropDbl y = _HUGE;
     HelmholtzEOSMixtureBackend _HEOS(HEOS.get_components());
     _HEOS.update(DmolarT_INPUTS, rhomolar0, T0);
-    long double Tc = HEOS.calc_T_critical();
-    long double rhoc = HEOS.calc_rhomolar_critical();
-    long double R = HEOS.gas_constant();
-    long double p = HEOS.p();
+    CoolPropDbl Tc = HEOS.calc_T_critical();
+    CoolPropDbl rhoc = HEOS.calc_rhomolar_critical();
+    CoolPropDbl R = HEOS.gas_constant();
+    CoolPropDbl p = HEOS.p();
     switch (other)
     {
         case iHmolar: y = HEOS.hmolar(); break;
@@ -886,31 +886,31 @@ void FlashRoutines::HSU_P_flash_singlephase_Newton(HelmholtzEOSMixtureBackend &H
         default: throw ValueError("other is invalid in HSU_P_flash_singlephase_Newton");
     }
     
-    long double worst_error = 999;
+    CoolPropDbl worst_error = 999;
     int iter = 0;
     bool failed = false;
-    long double omega = 1.0, f2, df2_dtau, df2_ddelta;
-    long double tau = _HEOS.tau(), delta = _HEOS.delta();
+    CoolPropDbl omega = 1.0, f2, df2_dtau, df2_ddelta;
+    CoolPropDbl tau = _HEOS.tau(), delta = _HEOS.delta();
     while (worst_error>1e-6 && failed == false)
     {
         
         // All the required partial derivatives
-        long double a0 = _HEOS.calc_alpha0_deriv_nocache(0,0,HEOS.mole_fractions, tau, delta,Tc,rhoc);
-        long double da0_ddelta = _HEOS.calc_alpha0_deriv_nocache(0,1,HEOS.mole_fractions, tau, delta,Tc,rhoc);
-        long double da0_dtau = _HEOS.calc_alpha0_deriv_nocache(1,0,HEOS.mole_fractions, tau, delta,Tc,rhoc);
-        long double d2a0_dtau2 = _HEOS.calc_alpha0_deriv_nocache(2,0,HEOS.mole_fractions, tau, delta,Tc,rhoc);
-        long double d2a0_ddelta_dtau = 0.0;
+        CoolPropDbl a0 = _HEOS.calc_alpha0_deriv_nocache(0,0,HEOS.mole_fractions, tau, delta,Tc,rhoc);
+        CoolPropDbl da0_ddelta = _HEOS.calc_alpha0_deriv_nocache(0,1,HEOS.mole_fractions, tau, delta,Tc,rhoc);
+        CoolPropDbl da0_dtau = _HEOS.calc_alpha0_deriv_nocache(1,0,HEOS.mole_fractions, tau, delta,Tc,rhoc);
+        CoolPropDbl d2a0_dtau2 = _HEOS.calc_alpha0_deriv_nocache(2,0,HEOS.mole_fractions, tau, delta,Tc,rhoc);
+        CoolPropDbl d2a0_ddelta_dtau = 0.0;
         
-        long double ar = _HEOS.calc_alphar_deriv_nocache(0,0,HEOS.mole_fractions, tau, delta);
-        long double dar_dtau = _HEOS.calc_alphar_deriv_nocache(1,0,HEOS.mole_fractions, tau, delta);
-        long double dar_ddelta = _HEOS.calc_alphar_deriv_nocache(0,1,HEOS.mole_fractions, tau, delta);
-        long double d2ar_ddelta_dtau = _HEOS.calc_alphar_deriv_nocache(1,1,HEOS.mole_fractions, tau, delta);
-        long double d2ar_ddelta2 = _HEOS.calc_alphar_deriv_nocache(0,2,HEOS.mole_fractions, tau, delta);
-        long double d2ar_dtau2 = _HEOS.calc_alphar_deriv_nocache(2,0,HEOS.mole_fractions, tau, delta);
+        CoolPropDbl ar = _HEOS.calc_alphar_deriv_nocache(0,0,HEOS.mole_fractions, tau, delta);
+        CoolPropDbl dar_dtau = _HEOS.calc_alphar_deriv_nocache(1,0,HEOS.mole_fractions, tau, delta);
+        CoolPropDbl dar_ddelta = _HEOS.calc_alphar_deriv_nocache(0,1,HEOS.mole_fractions, tau, delta);
+        CoolPropDbl d2ar_ddelta_dtau = _HEOS.calc_alphar_deriv_nocache(1,1,HEOS.mole_fractions, tau, delta);
+        CoolPropDbl d2ar_ddelta2 = _HEOS.calc_alphar_deriv_nocache(0,2,HEOS.mole_fractions, tau, delta);
+        CoolPropDbl d2ar_dtau2 = _HEOS.calc_alphar_deriv_nocache(2,0,HEOS.mole_fractions, tau, delta);
 
-        long double f1 = delta/tau*(1+delta*dar_ddelta)-p/(rhoc*R*Tc);
-        long double df1_dtau = (1+delta*dar_ddelta)*(-delta/tau/tau)+delta/tau*(delta*d2ar_ddelta_dtau);
-        long double df1_ddelta = (1.0/tau)*(1+2.0*delta*dar_ddelta+delta*delta*d2ar_ddelta2);
+        CoolPropDbl f1 = delta/tau*(1+delta*dar_ddelta)-p/(rhoc*R*Tc);
+        CoolPropDbl df1_dtau = (1+delta*dar_ddelta)*(-delta/tau/tau)+delta/tau*(delta*d2ar_ddelta_dtau);
+        CoolPropDbl df1_ddelta = (1.0/tau)*(1+2.0*delta*dar_ddelta+delta*delta*d2ar_ddelta2);
         switch (other)
         {
             case iHmolar:
@@ -962,7 +962,7 @@ void FlashRoutines::HSU_P_flash_singlephase_Newton(HelmholtzEOSMixtureBackend &H
     
     HEOS.update(DmolarT_INPUTS, rhoc*delta, Tc/tau);
 }
-void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend &HEOS, parameters other, long double value, long double Tmin, long double Tmax)
+void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend &HEOS, parameters other, CoolPropDbl value, CoolPropDbl Tmin, CoolPropDbl Tmax)
 {
     if (!ValidNumber(HEOS._p)){throw ValueError("value for p in HSU_P_flash_singlephase_Brent is invalid");};
     if (!ValidNumber(value)){throw ValueError("value for other in HSU_P_flash_singlephase_Brent is invalid");};
@@ -971,11 +971,11 @@ void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend &HE
     public:
 
         HelmholtzEOSMixtureBackend *HEOS;
-        long double r, eos, p, value, T, rhomolar;
+        CoolPropDbl r, eos, p, value, T, rhomolar;
         int other;
         int iter;
-        long double r0, r1, T1, T0, eos0, eos1, pp;
-        solver_resid(HelmholtzEOSMixtureBackend *HEOS, long double p, long double value, int other) : 
+        CoolPropDbl r0, r1, T1, T0, eos0, eos1, pp;
+        solver_resid(HelmholtzEOSMixtureBackend *HEOS, CoolPropDbl p, CoolPropDbl value, int other) : 
                 HEOS(HEOS), p(p), value(value), other(other)
                 {
                     iter = 0;
@@ -1030,7 +1030,7 @@ void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend &HE
         
         // Determine why you were out of range if you can
         // 
-        long double eos0 = resid.eos0, eos1 = resid.eos1;
+        CoolPropDbl eos0 = resid.eos0, eos1 = resid.eos1;
         std::string name = get_parameter_information(other,"short");
         std::string units = get_parameter_information(other,"units");
         if (eos1 > eos0 && value > eos1){
@@ -1047,7 +1047,7 @@ void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend &HE
 void FlashRoutines::HSU_P_flash(HelmholtzEOSMixtureBackend &HEOS, parameters other)
 {
     bool saturation_called = false;
-    long double value;
+    CoolPropDbl value;
     if (HEOS.imposed_phase_index != iphase_not_imposed)
     {
         // Use the phase defined by the imposed phase
@@ -1077,7 +1077,7 @@ void FlashRoutines::HSU_P_flash(HelmholtzEOSMixtureBackend &HEOS, parameters oth
             {
                 // Now we use the single-phase solver to find T,rho given P,Y using a 
                 // bounded 1D solver by adjusting T and using given value of p
-                long double Tmin, Tmax;
+                CoolPropDbl Tmin, Tmax;
                 switch(HEOS._phase)
                 {
                     case iphase_gas:
@@ -1140,7 +1140,7 @@ void FlashRoutines::HSU_P_flash(HelmholtzEOSMixtureBackend &HEOS, parameters oth
                 if (!twophase){
                     PY_singlephase_flash_resid resid(HEOS, HEOS._p, other, value);
                     // If that fails, try a bounded solver
-                    long double rhomolar = Brent(resid, closest_state.T+10, 1000, DBL_EPSILON, 1e-10, 100, errstr);
+                    CoolPropDbl rhomolar = Brent(resid, closest_state.T+10, 1000, DBL_EPSILON, 1e-10, 100, errstr);
                     HEOS.unspecify_phase();
                 }
                 else{
@@ -1209,15 +1209,15 @@ void FlashRoutines::DHSU_T_flash(HelmholtzEOSMixtureBackend &HEOS, parameters ot
     // Update the state for conditions where the state was guessed
     
 }
-void FlashRoutines::HS_flash_twophase(HelmholtzEOSMixtureBackend &HEOS, long double hmolar_spec, long double smolar_spec, HS_flash_twophaseOptions &options)
+void FlashRoutines::HS_flash_twophase(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl hmolar_spec, CoolPropDbl smolar_spec, HS_flash_twophaseOptions &options)
 {
     class Residual : public FuncWrapper1D
     {
         
     public:
         HelmholtzEOSMixtureBackend &HEOS;
-        long double hmolar, smolar, Qs, Qh;
-        Residual(HelmholtzEOSMixtureBackend &HEOS, long double hmolar_spec, long double smolar_spec) : HEOS(HEOS), hmolar(hmolar_spec), smolar(smolar_spec){};
+        CoolPropDbl hmolar, smolar, Qs, Qh;
+        Residual(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl hmolar_spec, CoolPropDbl smolar_spec) : HEOS(HEOS), hmolar(hmolar_spec), smolar(smolar_spec){};
         double call(double T){
             HEOS.update(QT_INPUTS, 0, T);
             HelmholtzEOSMixtureBackend &SatL = HEOS.get_SatL(),
@@ -1233,16 +1233,16 @@ void FlashRoutines::HS_flash_twophase(HelmholtzEOSMixtureBackend &HEOS, long dou
     
     std::string errstr;
     // Critical point for pure fluids, slightly different for pseudo-pure, very different for mixtures
-    long double Tmax_sat = HEOS.calc_Tmax_sat() - 1e-13;
+    CoolPropDbl Tmax_sat = HEOS.calc_Tmax_sat() - 1e-13;
     
     // Check what the minimum limits for the equation of state are
-    long double Tmin_satL, Tmin_satV, Tmin_sat;
+    CoolPropDbl Tmin_satL, Tmin_satV, Tmin_sat;
     HEOS.calc_Tmin_sat(Tmin_satL, Tmin_satV);
     Tmin_sat = std::max(Tmin_satL, Tmin_satV) - 1e-13;
         
     Brent(resid, Tmin_sat, Tmax_sat-0.01, DBL_EPSILON, 1e-12, 20, errstr);
 }
-void FlashRoutines::HS_flash_singlephase(HelmholtzEOSMixtureBackend &HEOS, long double hmolar_spec, long double smolar_spec, HS_flash_singlephaseOptions &options)
+void FlashRoutines::HS_flash_singlephase(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl hmolar_spec, CoolPropDbl smolar_spec, HS_flash_singlephaseOptions &options)
 {
     int iter = 0;
     double resid = 9e30, resid_old = 9e30;

--- a/src/Backends/Helmholtz/FlashRoutines.h
+++ b/src/Backends/Helmholtz/FlashRoutines.h
@@ -43,13 +43,13 @@ public:
     /// Flash for given molar enthalpy and (molar) quality
     /// @param HEOS The HelmholtzEOSMixtureBackend to be used
     /// @param Tguess (optional) The guess temperature in K to start from, ignored if < 0
-    static void HQ_flash(HelmholtzEOSMixtureBackend &HEOS, long double Tguess = -1);
+    static void HQ_flash(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl Tguess = -1);
     
     /// Flash for mixture given temperature or pressure and (molar) quality
     /// @param HEOS The HelmholtzEOSMixtureBackend to be used
     /// @param other The parameter that is imposed, either iT or iP
     /// @param value The value for the imposed parameter
-    static void PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend &HEOS, parameters other, long double value);
+    static void PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend &HEOS, parameters other, CoolPropDbl value);
     
     /// Flash for given pressure and temperature
     /// @param HEOS The HelmholtzEOSMixtureBackend to be used
@@ -74,7 +74,7 @@ public:
     /// @param other The index for the other input from CoolProp::parameters; allowed values are iHmolar, iSmolar, iUmolar
     /// @param T0 The initial guess value for the temperature [K]
     /// @param rhomolar0 The initial guess value for the density [mol/m^3]
-    static void HSU_P_flash_singlephase_Newton(HelmholtzEOSMixtureBackend &HEOS, parameters other, long double T0, long double rhomolar0);
+    static void HSU_P_flash_singlephase_Newton(HelmholtzEOSMixtureBackend &HEOS, parameters other, CoolPropDbl T0, CoolPropDbl rhomolar0);
     
     /// The single-phase flash routine for the pairs (P,H), (P,S), and (P,U).  Similar analysis is needed
     /// @param HEOS The HelmholtzEOSMixtureBackend to be used
@@ -82,12 +82,12 @@ public:
     /// @param value The value of the other input
     /// @param Tmin The lower temperature limit [K]
     /// @param Tmax The higher temperature limit [K]
-    static void HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend &HEOS, parameters other, long double value, long double Tmin, long double Tmax);
+    static void HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend &HEOS, parameters other, CoolPropDbl value, CoolPropDbl Tmin, CoolPropDbl Tmax);
     
 	/// A generic flash routine for the pairs (D,H), (D,S), and (D,U) for twophase state.  Similar analysis is needed
     /// @param HEOS The HelmholtzEOSMixtureBackend to be used
     /// @param other The index for the other input from CoolProp::parameters; allowed values are iP, iHmolar, iSmolar, iUmolar
-	static void HSU_D_flash_twophase(HelmholtzEOSMixtureBackend &HEOS, long double rhomolar_spec, parameters other, long double value);
+	static void HSU_D_flash_twophase(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl rhomolar_spec, parameters other, CoolPropDbl value);
 	
     /// A generic flash routine for the pairs (D,P), (D,H), (D,S), and (D,U).  Similar analysis is needed
     /// @param HEOS The HelmholtzEOSMixtureBackend to be used
@@ -109,14 +109,14 @@ public:
         double omega;
         HS_flash_singlephaseOptions(){omega = 1.0;}
     };
-    static void HS_flash_singlephase(HelmholtzEOSMixtureBackend &HEOS, long double hmolar_spec, long double smolar_spec, HS_flash_singlephaseOptions &options);
+    static void HS_flash_singlephase(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl hmolar_spec, CoolPropDbl smolar_spec, HS_flash_singlephaseOptions &options);
     
     struct HS_flash_twophaseOptions
     {
         double omega;
         HS_flash_twophaseOptions(){omega = 1.0;}
     };
-    static void HS_flash_twophase(HelmholtzEOSMixtureBackend &HEOS, long double hmolar_spec, long double smolar_spec, HS_flash_twophaseOptions &options);
+    static void HS_flash_twophase(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl hmolar_spec, CoolPropDbl smolar_spec, HS_flash_twophaseOptions &options);
 };
 
 
@@ -125,10 +125,10 @@ public:
 class solver_TP_resid : public FuncWrapper1D
 {
 public:
-    long double T, p, r, peos, rhomolar, rhor, tau, R_u, delta, dalphar_dDelta;
+    CoolPropDbl T, p, r, peos, rhomolar, rhor, tau, R_u, delta, dalphar_dDelta;
     HelmholtzEOSMixtureBackend *HEOS;
 
-    solver_TP_resid(HelmholtzEOSMixtureBackend &HEOS, long double T, long double p){
+    solver_TP_resid(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl T, CoolPropDbl p){
         this->HEOS = &HEOS; this->T = T; this->p = p; this->rhor = HEOS.get_reducing_state().rhomolar;
         this->tau = HEOS.get_reducing_state().T/T; this->R_u = HEOS.gas_constant();
     };
@@ -153,13 +153,13 @@ class PY_singlephase_flash_resid : public FuncWrapper1D
 public:
 
     HelmholtzEOSMixtureBackend *HEOS;
-    long double p;
+    CoolPropDbl p;
     parameters other;
-    long double r, eos, value, T, rhomolar;
+    CoolPropDbl r, eos, value, T, rhomolar;
     
     int iter;
-    long double r0, r1, T1, T0, eos0, eos1, pp;
-    PY_singlephase_flash_resid(HelmholtzEOSMixtureBackend &HEOS, long double p, parameters other, long double value) : 
+    CoolPropDbl r0, r1, T1, T0, eos0, eos1, pp;
+    PY_singlephase_flash_resid(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl p, parameters other, CoolPropDbl value) : 
             HEOS(&HEOS), p(p), other(other), value(value)
             {
                 iter = 0;

--- a/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
+++ b/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
@@ -94,9 +94,9 @@ double SaturationAncillaryFunction::invert(double value, double min_bound, doubl
     public:
         int other;
         SaturationAncillaryFunction *anc;
-        long double T, value, r, current_value;
+        CoolPropDbl T, value, r, current_value;
 
-        solver_resid(SaturationAncillaryFunction *anc, long double value) : anc(anc), value(value){};
+        solver_resid(SaturationAncillaryFunction *anc, CoolPropDbl value) : anc(anc), value(value){};
 
         double call(double T){
             this->T = T;
@@ -164,7 +164,7 @@ void MeltingLineVariables::set_limits(void)
     }
 }
 
-long double MeltingLineVariables::evaluate(int OF, int GIVEN, long double value)
+CoolPropDbl MeltingLineVariables::evaluate(int OF, int GIVEN, CoolPropDbl value)
 {
     if (type == MELTING_LINE_NOT_SET){throw ValueError("Melting line curve not set");}
     if (OF == iP_max){ return pmax;}
@@ -172,7 +172,7 @@ long double MeltingLineVariables::evaluate(int OF, int GIVEN, long double value)
     else if (OF == iT_max){ return Tmax;}
     else if (OF == iT_min){ return Tmin;}
     else if (OF == iP && GIVEN == iT){
-        long double T = value;
+        CoolPropDbl T = value;
         if (type == MELTING_LINE_SIMON_TYPE){
             // Need to find the right segment
             for (std::size_t i = 0; i < simon.parts.size(); ++i){
@@ -213,7 +213,7 @@ long double MeltingLineVariables::evaluate(int OF, int GIVEN, long double value)
             for (std::size_t i = 0; i < simon.parts.size(); ++i){
                 MeltingLinePiecewiseSimonSegment &part = simon.parts[i];
                 //  p = part.p_0 + part.a*(pow(T/part.T_0,part.c)-1);
-                long double T = pow((value-part.p_0)/part.a+1,1/part.c)*part.T_0;
+                CoolPropDbl T = pow((value-part.p_0)/part.a+1,1/part.c)*part.T_0;
                 if (T >= part.T_0 && T <= part.T_max){
                     return T;
                 }
@@ -226,8 +226,8 @@ long double MeltingLineVariables::evaluate(int OF, int GIVEN, long double value)
             {
             public:
                 MeltingLinePiecewisePolynomialInTrSegment *part;
-                long double r, given_p, calc_p, T;
-                solver_resid(MeltingLinePiecewisePolynomialInTrSegment *part, long double p) : part(part), given_p(p){};
+                CoolPropDbl r, given_p, calc_p, T;
+                solver_resid(MeltingLinePiecewisePolynomialInTrSegment *part, CoolPropDbl p) : part(part), given_p(p){};
                 double call(double T){
 
                     this->T = T;
@@ -260,8 +260,8 @@ long double MeltingLineVariables::evaluate(int OF, int GIVEN, long double value)
             {
             public:
                 MeltingLinePiecewisePolynomialInThetaSegment *part;
-                long double r, given_p, calc_p, T;
-                solver_resid(MeltingLinePiecewisePolynomialInThetaSegment *part, long double p) : part(part), given_p(p){};
+                CoolPropDbl r, given_p, calc_p, T;
+                solver_resid(MeltingLinePiecewisePolynomialInThetaSegment *part, CoolPropDbl p) : part(part), given_p(p){};
                 double call(double T){
 
                     this->T = T;

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.h
@@ -43,10 +43,10 @@ protected:
 
             if (!type.compare("ResidualHelmholtzPower"))
             {
-                std::vector<long double> n = cpjson::get_long_double_array(contribution["n"]);
-                std::vector<long double> d = cpjson::get_long_double_array(contribution["d"]);
-                std::vector<long double> t = cpjson::get_long_double_array(contribution["t"]);
-                std::vector<long double> l = cpjson::get_long_double_array(contribution["l"]);
+                std::vector<CoolPropDbl> n = cpjson::get_long_double_array(contribution["n"]);
+                std::vector<CoolPropDbl> d = cpjson::get_long_double_array(contribution["d"]);
+                std::vector<CoolPropDbl> t = cpjson::get_long_double_array(contribution["t"]);
+                std::vector<CoolPropDbl> l = cpjson::get_long_double_array(contribution["l"]);
                 assert(n.size() == d.size());
                 assert(n.size() == t.size());
                 assert(n.size() == l.size());
@@ -55,13 +55,13 @@ protected:
             }
             else if (!type.compare("ResidualHelmholtzGaussian"))
             {
-                std::vector<long double> n = cpjson::get_long_double_array(contribution["n"]);
-                std::vector<long double> d = cpjson::get_long_double_array(contribution["d"]);
-                std::vector<long double> t = cpjson::get_long_double_array(contribution["t"]);
-                std::vector<long double> eta = cpjson::get_long_double_array(contribution["eta"]);
-                std::vector<long double> epsilon = cpjson::get_long_double_array(contribution["epsilon"]);
-                std::vector<long double> beta = cpjson::get_long_double_array(contribution["beta"]);
-                std::vector<long double> gamma = cpjson::get_long_double_array(contribution["gamma"]);
+                std::vector<CoolPropDbl> n = cpjson::get_long_double_array(contribution["n"]);
+                std::vector<CoolPropDbl> d = cpjson::get_long_double_array(contribution["d"]);
+                std::vector<CoolPropDbl> t = cpjson::get_long_double_array(contribution["t"]);
+                std::vector<CoolPropDbl> eta = cpjson::get_long_double_array(contribution["eta"]);
+                std::vector<CoolPropDbl> epsilon = cpjson::get_long_double_array(contribution["epsilon"]);
+                std::vector<CoolPropDbl> beta = cpjson::get_long_double_array(contribution["beta"]);
+                std::vector<CoolPropDbl> gamma = cpjson::get_long_double_array(contribution["gamma"]);
                 assert(n.size() == d.size());
                 assert(n.size() == t.size());
                 assert(n.size() == eta.size());
@@ -73,14 +73,14 @@ protected:
             else if (!type.compare("ResidualHelmholtzNonAnalytic"))
             {
                 if (EOS.alphar.NonAnalytic.N > 0){throw ValueError("Cannot add ");}
-                std::vector<long double> n = cpjson::get_long_double_array(contribution["n"]);
-                std::vector<long double> a = cpjson::get_long_double_array(contribution["a"]);
-                std::vector<long double> b = cpjson::get_long_double_array(contribution["b"]);
-                std::vector<long double> beta = cpjson::get_long_double_array(contribution["beta"]);
-                std::vector<long double> A = cpjson::get_long_double_array(contribution["A"]);
-                std::vector<long double> B = cpjson::get_long_double_array(contribution["B"]);
-                std::vector<long double> C = cpjson::get_long_double_array(contribution["C"]);
-                std::vector<long double> D = cpjson::get_long_double_array(contribution["D"]);
+                std::vector<CoolPropDbl> n = cpjson::get_long_double_array(contribution["n"]);
+                std::vector<CoolPropDbl> a = cpjson::get_long_double_array(contribution["a"]);
+                std::vector<CoolPropDbl> b = cpjson::get_long_double_array(contribution["b"]);
+                std::vector<CoolPropDbl> beta = cpjson::get_long_double_array(contribution["beta"]);
+                std::vector<CoolPropDbl> A = cpjson::get_long_double_array(contribution["A"]);
+                std::vector<CoolPropDbl> B = cpjson::get_long_double_array(contribution["B"]);
+                std::vector<CoolPropDbl> C = cpjson::get_long_double_array(contribution["C"]);
+                std::vector<CoolPropDbl> D = cpjson::get_long_double_array(contribution["D"]);
                 assert(n.size() == a.size());
                 assert(n.size() == b.size());
                 assert(n.size() == beta.size());
@@ -92,11 +92,11 @@ protected:
             }
             else if (!type.compare("ResidualHelmholtzLemmon2005"))
             {
-                std::vector<long double> n = cpjson::get_long_double_array(contribution["n"]);
-                std::vector<long double> d = cpjson::get_long_double_array(contribution["d"]);
-                std::vector<long double> t = cpjson::get_long_double_array(contribution["t"]);
-                std::vector<long double> l = cpjson::get_long_double_array(contribution["l"]);
-                std::vector<long double> m = cpjson::get_long_double_array(contribution["m"]);
+                std::vector<CoolPropDbl> n = cpjson::get_long_double_array(contribution["n"]);
+                std::vector<CoolPropDbl> d = cpjson::get_long_double_array(contribution["d"]);
+                std::vector<CoolPropDbl> t = cpjson::get_long_double_array(contribution["t"]);
+                std::vector<CoolPropDbl> l = cpjson::get_long_double_array(contribution["l"]);
+                std::vector<CoolPropDbl> m = cpjson::get_long_double_array(contribution["m"]);
                 assert(n.size() == d.size());
                 assert(n.size() == t.size());
                 assert(n.size() == l.size());
@@ -105,11 +105,11 @@ protected:
             }
             else if (!type.compare("ResidualHelmholtzExponential"))
             {
-                std::vector<long double> n = cpjson::get_long_double_array(contribution["n"]);
-                std::vector<long double> d = cpjson::get_long_double_array(contribution["d"]);
-                std::vector<long double> t = cpjson::get_long_double_array(contribution["t"]);
-                std::vector<long double> g = cpjson::get_long_double_array(contribution["g"]);
-                std::vector<long double> l = cpjson::get_long_double_array(contribution["l"]);
+                std::vector<CoolPropDbl> n = cpjson::get_long_double_array(contribution["n"]);
+                std::vector<CoolPropDbl> d = cpjson::get_long_double_array(contribution["d"]);
+                std::vector<CoolPropDbl> t = cpjson::get_long_double_array(contribution["t"]);
+                std::vector<CoolPropDbl> g = cpjson::get_long_double_array(contribution["g"]);
+                std::vector<CoolPropDbl> l = cpjson::get_long_double_array(contribution["l"]);
                 assert(n.size() == d.size());
                 assert(n.size() == t.size());
                 assert(n.size() == g.size());
@@ -119,11 +119,11 @@ protected:
             else if (!type.compare("ResidualHelmholtzAssociating"))
             {
                 if (EOS.alphar.SAFT.disabled == false){throw ValueError("Cannot add ");}
-                long double a = cpjson::get_double(contribution,"a");
-                long double m = cpjson::get_double(contribution,"m");
-                long double epsilonbar = cpjson::get_double(contribution,"epsilonbar");
-                long double vbarn = cpjson::get_double(contribution,"vbarn");
-                long double kappabar = cpjson::get_double(contribution,"kappabar");
+                CoolPropDbl a = cpjson::get_double(contribution,"a");
+                CoolPropDbl m = cpjson::get_double(contribution,"m");
+                CoolPropDbl epsilonbar = cpjson::get_double(contribution,"epsilonbar");
+                CoolPropDbl vbarn = cpjson::get_double(contribution,"vbarn");
+                CoolPropDbl kappabar = cpjson::get_double(contribution,"kappabar");
                 EOS.alphar.SAFT = ResidualHelmholtzSAFTAssociating(a,m,epsilonbar,vbarn,kappabar);
             }
             else
@@ -151,34 +151,34 @@ protected:
             if (!type.compare("IdealGasHelmholtzLead"))
             {
                 if (EOS.alpha0.Lead.is_enabled() == true){throw ValueError("Cannot add ");}
-                long double a1 = cpjson::get_double(contribution,"a1");
-                long double a2 = cpjson::get_double(contribution,"a2");
+                CoolPropDbl a1 = cpjson::get_double(contribution,"a1");
+                CoolPropDbl a2 = cpjson::get_double(contribution,"a2");
                 
                 EOS.alpha0.Lead = IdealHelmholtzLead(a1, a2);
             }
             else if (!type.compare("IdealGasHelmholtzPower"))
             {
                 if (EOS.alpha0.Power.is_enabled() == true){throw ValueError("Cannot add ");}
-                std::vector<long double> n = cpjson::get_long_double_array(contribution["n"]);
-                std::vector<long double> t = cpjson::get_long_double_array(contribution["t"]);
+                std::vector<CoolPropDbl> n = cpjson::get_long_double_array(contribution["n"]);
+                std::vector<CoolPropDbl> t = cpjson::get_long_double_array(contribution["t"]);
                 
                 EOS.alpha0.Power = IdealHelmholtzPower(n, t);
             }
             else if (!type.compare("IdealGasHelmholtzLogTau"))
             {
                 if (EOS.alpha0.LogTau.is_enabled() == true){throw ValueError("Cannot add ");}
-                long double a = cpjson::get_double(contribution,"a");
+                CoolPropDbl a = cpjson::get_double(contribution,"a");
                 
                 EOS.alpha0.LogTau = IdealHelmholtzLogTau(a);
             }
             else if (!type.compare("IdealGasHelmholtzPlanckEinsteinGeneralized"))
             {
                 // Retrieve the values
-                std::vector<long double> n = cpjson::get_long_double_array(contribution["n"]);
-                std::vector<long double> t = cpjson::get_long_double_array(contribution["t"]);
+                std::vector<CoolPropDbl> n = cpjson::get_long_double_array(contribution["n"]);
+                std::vector<CoolPropDbl> t = cpjson::get_long_double_array(contribution["t"]);
 
-                std::vector<long double> c = cpjson::get_long_double_array(contribution["c"]);
-                std::vector<long double> d = cpjson::get_long_double_array(contribution["d"]);
+                std::vector<CoolPropDbl> c = cpjson::get_long_double_array(contribution["c"]);
+                std::vector<CoolPropDbl> d = cpjson::get_long_double_array(contribution["d"]);
                 
                 if (EOS.alpha0.PlanckEinstein.is_enabled() == true){
                     EOS.alpha0.PlanckEinstein.extend(n, t, c, d);
@@ -190,12 +190,12 @@ protected:
             else if (!type.compare("IdealGasHelmholtzPlanckEinstein"))
             {
                 // Retrieve the values
-                std::vector<long double> n = cpjson::get_long_double_array(contribution["n"]);
-                std::vector<long double> t = cpjson::get_long_double_array(contribution["t"]);
+                std::vector<CoolPropDbl> n = cpjson::get_long_double_array(contribution["n"]);
+                std::vector<CoolPropDbl> t = cpjson::get_long_double_array(contribution["t"]);
                 // Flip the sign of theta
                 for (std::size_t i = 0; i < t.size(); ++i){ t[i] *= -1;}
-                std::vector<long double> c(n.size(), 1);
-                std::vector<long double> d(c.size(), -1);
+                std::vector<CoolPropDbl> c(n.size(), 1);
+                std::vector<CoolPropDbl> d(c.size(), -1);
                 
                 if (EOS.alpha0.PlanckEinstein.is_enabled() == true){
                     EOS.alpha0.PlanckEinstein.extend(n, t, c, d);
@@ -207,30 +207,30 @@ protected:
             else if (!type.compare("IdealGasHelmholtzCP0Constant"))
             {
                 if (EOS.alpha0.CP0Constant.is_enabled() == true){throw ValueError("Cannot add ");}
-                long double cp_over_R = cpjson::get_double(contribution, "cp_over_R");
-                long double Tc = cpjson::get_double(contribution, "Tc");
-                long double T0 = cpjson::get_double(contribution, "T0");
+                CoolPropDbl cp_over_R = cpjson::get_double(contribution, "cp_over_R");
+                CoolPropDbl Tc = cpjson::get_double(contribution, "Tc");
+                CoolPropDbl T0 = cpjson::get_double(contribution, "T0");
                 EOS.alpha0.CP0Constant = IdealHelmholtzCP0Constant(cp_over_R, Tc, T0);
             }
             else if (!type.compare("IdealGasHelmholtzCP0PolyT"))
             {
                 if (EOS.alpha0.CP0PolyT.is_enabled() == true){throw ValueError("Cannot add ");}
-                std::vector<long double> c = cpjson::get_long_double_array(contribution["c"]);
-                std::vector<long double> t = cpjson::get_long_double_array(contribution["t"]);
-                long double Tc = cpjson::get_double(contribution, "Tc");
-                long double T0 = cpjson::get_double(contribution, "T0");
+                std::vector<CoolPropDbl> c = cpjson::get_long_double_array(contribution["c"]);
+                std::vector<CoolPropDbl> t = cpjson::get_long_double_array(contribution["t"]);
+                CoolPropDbl Tc = cpjson::get_double(contribution, "Tc");
+                CoolPropDbl T0 = cpjson::get_double(contribution, "T0");
                 EOS.alpha0.CP0PolyT = IdealHelmholtzCP0PolyT(c, t, Tc, T0);
             }
             else if (!type.compare("IdealGasHelmholtzCP0AlyLee"))
             {
 
-                std::vector<long double> constants = cpjson::get_long_double_array(contribution["c"]);
-                long double Tc = cpjson::get_double(contribution, "Tc");
-                long double T0 = cpjson::get_double(contribution, "T0");
+                std::vector<CoolPropDbl> constants = cpjson::get_long_double_array(contribution["c"]);
+                CoolPropDbl Tc = cpjson::get_double(contribution, "Tc");
+                CoolPropDbl T0 = cpjson::get_double(contribution, "T0");
 
                 // Take the constant term if nonzero and set it as a polyT term
                 if (std::abs(constants[0]) > 1e-14){
-                    std::vector<long double> c(1,constants[0]), t(1,0);
+                    std::vector<CoolPropDbl> c(1,constants[0]), t(1,0);
                     if (EOS.alpha0.CP0PolyT.is_enabled() == true){
                         EOS.alpha0.CP0PolyT.extend(c,t);
                     }
@@ -238,7 +238,7 @@ protected:
                         EOS.alpha0.CP0PolyT = IdealHelmholtzCP0PolyT(c, t, Tc, T0);
                     }
                 }
-                std::vector<long double> n, c, d, t;
+                std::vector<CoolPropDbl> n, c, d, t;
                 if (std::abs(constants[1]) > 1e-14){
                     // sinh term can be converted by setting  a_k = C, b_k = 2*D, c_k = -1, d_k = 1
                     n.push_back(constants[1]);
@@ -262,8 +262,8 @@ protected:
             }
             else if (!type.compare("IdealGasHelmholtzEnthalpyEntropyOffset"))
             {
-                long double a1 = cpjson::get_double(contribution, "a1");
-                long double a2 = cpjson::get_double(contribution, "a2");
+                CoolPropDbl a1 = cpjson::get_double(contribution, "a1");
+                CoolPropDbl a2 = cpjson::get_double(contribution, "a2");
                 std::string reference = cpjson::get_string(contribution, "reference");
                 EOS.alpha0.EnthalpyEntropyOffsetCore = IdealHelmholtzEnthalpyEntropyOffset(a1, a2, reference);
             }
@@ -871,9 +871,9 @@ protected:
         // Use the method of Chung to approximate the values for epsilon_over_k and sigma_eta
         // Chung, T.-H.; Ajlan, M.; Lee, L. L.; Starling, K. E. Generalized Multiparameter Correlation for Nonpolar and Polar Fluid Transport Properties. Ind. Eng. Chem. Res. 1988, 27, 671-679.
         // rhoc needs to be in mol/L to yield a sigma in nm,
-        long double rho_crit_molar = fluid.pEOS->reduce.rhomolar/1000.0;// [mol/m3 to mol/L]
-        long double Tc = fluid.pEOS->reduce.T;
-        fluid.transport.sigma_eta = 0.809/pow(rho_crit_molar, static_cast<long double>(1.0/3.0))/1e9; // 1e9 is to convert from nm to m
+        CoolPropDbl rho_crit_molar = fluid.pEOS->reduce.rhomolar/1000.0;// [mol/m3 to mol/L]
+        CoolPropDbl Tc = fluid.pEOS->reduce.T;
+        fluid.transport.sigma_eta = 0.809/pow(rho_crit_molar, static_cast<CoolPropDbl>(1.0/3.0))/1e9; // 1e9 is to convert from nm to m
         fluid.transport.epsilon_over_k = Tc/1.3593; // [K]
     }
 

--- a/src/Backends/Helmholtz/HelmholtzEOSBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSBackend.h
@@ -39,7 +39,7 @@ public:
         // Set the components
         set_components(components);
         // Set the mole fractions
-        set_mole_fractions(std::vector<long double>(mole_fractions.begin(), mole_fractions.end()));
+        set_mole_fractions(std::vector<CoolPropDbl>(mole_fractions.begin(), mole_fractions.end()));
     };
     virtual ~HelmholtzEOSBackend(){};
 };

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -67,7 +67,7 @@ void HelmholtzEOSMixtureBackend::set_components(const std::vector<CoolPropFluid*
 
     if (components.size() == 1){
         is_pure_or_pseudopure = true;
-        mole_fractions = std::vector<long double>(1, 1);
+        mole_fractions = std::vector<CoolPropDbl>(1, 1);
     }
     else{
         is_pure_or_pseudopure = false;
@@ -92,7 +92,7 @@ void HelmholtzEOSMixtureBackend::set_components(const std::vector<CoolPropFluid*
         SatV->specify_phase(iphase_gas);
     }
 }
-void HelmholtzEOSMixtureBackend::set_mole_fractions(const std::vector<long double> &mole_fractions)
+void HelmholtzEOSMixtureBackend::set_mole_fractions(const std::vector<CoolPropDbl> &mole_fractions)
 {
     if (mole_fractions.size() != N)
     {
@@ -199,7 +199,7 @@ const CoolProp::SimpleState & HelmholtzEOSMixtureBackend::calc_state(const std::
         throw ValueError(format("calc_state not supported for mixtures"));
     }
 };
-long double HelmholtzEOSMixtureBackend::calc_acentric_factor(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_acentric_factor(void)
 {
     if (is_pure_or_pseudopure){
         return components[0]->EOSVector[0].acentric;
@@ -208,7 +208,7 @@ long double HelmholtzEOSMixtureBackend::calc_acentric_factor(void)
         throw ValueError("acentric factor cannot be calculated for mixtures");
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_gas_constant(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_gas_constant(void)
 {
     if (is_pure_or_pseudopure){
         return components[0]->gas_constant();
@@ -228,7 +228,7 @@ long double HelmholtzEOSMixtureBackend::calc_gas_constant(void)
         }
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_molar_mass(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_molar_mass(void)
 {
     double summer = 0;
     for (unsigned int i = 0; i < components.size(); ++i)
@@ -237,7 +237,7 @@ long double HelmholtzEOSMixtureBackend::calc_molar_mass(void)
     }
     return summer;
 }
-long double HelmholtzEOSMixtureBackend::calc_saturation_ancillary(parameters param, int Q, parameters given, double value)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_saturation_ancillary(parameters param, int Q, parameters given, double value)
 {
     if (is_pure_or_pseudopure)
     {
@@ -298,7 +298,7 @@ long double HelmholtzEOSMixtureBackend::calc_saturation_ancillary(parameters par
     }
 }
 
-long double HelmholtzEOSMixtureBackend::calc_melting_line(int param, int given, long double value)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_melting_line(int param, int given, CoolPropDbl value)
 {
     if (is_pure_or_pseudopure)
     {
@@ -309,7 +309,7 @@ long double HelmholtzEOSMixtureBackend::calc_melting_line(int param, int given, 
         throw NotImplementedError(format("calc_melting_line not implemented for mixtures"));
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_surface_tension(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_surface_tension(void)
 {
     if (is_pure_or_pseudopure){
 		return components[0]->ancillaries.surface_tension.evaluate(T());
@@ -318,11 +318,11 @@ long double HelmholtzEOSMixtureBackend::calc_surface_tension(void)
         throw NotImplementedError(format("surface tension not implemented for mixtures"));
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_viscosity_dilute(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity_dilute(void)
 {
     if (is_pure_or_pseudopure)
     {
-        long double eta_dilute;
+        CoolPropDbl eta_dilute;
         switch(components[0]->transport.viscosity_dilute.type)
         {
         case ViscosityDiluteVariables::VISCOSITY_DILUTE_KINETIC_THEORY:
@@ -348,20 +348,20 @@ long double HelmholtzEOSMixtureBackend::calc_viscosity_dilute(void)
     }
 
 }
-long double HelmholtzEOSMixtureBackend::calc_viscosity_background()
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity_background()
 {
-    long double eta_dilute = calc_viscosity_dilute();
+    CoolPropDbl eta_dilute = calc_viscosity_dilute();
     return calc_viscosity_background(eta_dilute);
 }
-long double HelmholtzEOSMixtureBackend::calc_viscosity_background(long double eta_dilute)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity_background(CoolPropDbl eta_dilute)
 {
-    long double initial_part = 0.0;
+    CoolPropDbl initial_part = 0.0;
     
     switch(components[0]->transport.viscosity_initial.type){        
         case ViscosityInitialDensityVariables::VISCOSITY_INITIAL_DENSITY_RAINWATER_FRIEND:
         {
-            long double B_eta_initial = TransportRoutines::viscosity_initial_density_dependence_Rainwater_Friend(*this);
-            long double rho = rhomolar();
+            CoolPropDbl B_eta_initial = TransportRoutines::viscosity_initial_density_dependence_Rainwater_Friend(*this);
+            CoolPropDbl rho = rhomolar();
             initial_part = eta_dilute*B_eta_initial*rho;
             break;
         }
@@ -377,7 +377,7 @@ long double HelmholtzEOSMixtureBackend::calc_viscosity_background(long double et
     }
 
     // Higher order terms
-    long double delta_eta_h = 0.0;
+    CoolPropDbl delta_eta_h = 0.0;
     switch(components[0]->transport.viscosity_higher_order.type)
     {
     case ViscosityHigherOrderVariables::VISCOSITY_HIGHER_ORDER_BATSCHINKI_HILDEBRAND:
@@ -398,12 +398,12 @@ long double HelmholtzEOSMixtureBackend::calc_viscosity_background(long double et
         throw ValueError(format("higher order viscosity type [%d] is invalid for fluid %s", components[0]->transport.viscosity_dilute.type, name().c_str()));
     }
 
-    long double eta_residual = initial_part + delta_eta_h;
+    CoolPropDbl eta_residual = initial_part + delta_eta_h;
 
     return eta_residual;
 }
 
-long double HelmholtzEOSMixtureBackend::calc_viscosity(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity(void)
 {
     if (is_pure_or_pseudopure)
     {
@@ -443,20 +443,20 @@ long double HelmholtzEOSMixtureBackend::calc_viscosity(void)
             }
         }
         // Dilute part
-        long double eta_dilute = calc_viscosity_dilute();
+        CoolPropDbl eta_dilute = calc_viscosity_dilute();
 
         // Background viscosity given by the sum of the initial density dependence and higher order terms
-        long double eta_back = calc_viscosity_background(eta_dilute);
+        CoolPropDbl eta_back = calc_viscosity_background(eta_dilute);
 
         // Critical part (no fluids have critical enhancement for viscosity currently)
-        long double eta_critical = 0;
+        CoolPropDbl eta_critical = 0;
 
         return eta_dilute + eta_back + eta_critical;
     }
     else
     {
         set_warning_string("Mixture model for viscosity is highly approximate");
-        long double summer = 0;
+        CoolPropDbl summer = 0;
         for (std::size_t i = 0; i < mole_fractions.size(); ++i){
             shared_ptr<HelmholtzEOSBackend> HEOS(new HelmholtzEOSBackend(components[i]));
             HEOS->update(DmolarT_INPUTS, _rhomolar, _T);
@@ -465,10 +465,10 @@ long double HelmholtzEOSMixtureBackend::calc_viscosity(void)
         return exp(summer);
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_conductivity_background(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_conductivity_background(void)
 {
     // Residual part
-    long double lambda_residual = _HUGE;
+    CoolPropDbl lambda_residual = _HUGE;
     switch(components[0]->transport.conductivity_residual.type)
     {
     case ConductivityResidualVariables::CONDUCTIVITY_RESIDUAL_POLYNOMIAL:
@@ -480,7 +480,7 @@ long double HelmholtzEOSMixtureBackend::calc_conductivity_background(void)
     }
     return lambda_residual;
 }
-long double HelmholtzEOSMixtureBackend::calc_conductivity(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_conductivity(void)
 {
     if (is_pure_or_pseudopure)
     {
@@ -519,7 +519,7 @@ long double HelmholtzEOSMixtureBackend::calc_conductivity(void)
         }
 
         // Dilute part
-        long double lambda_dilute = _HUGE;
+        CoolPropDbl lambda_dilute = _HUGE;
         switch(component.transport.conductivity_dilute.type)
         {
         case ConductivityDiluteVariables::CONDUCTIVITY_DILUTE_RATIO_POLYNOMIALS:
@@ -536,10 +536,10 @@ long double HelmholtzEOSMixtureBackend::calc_conductivity(void)
             throw ValueError(format("dilute conductivity type [%d] is invalid for fluid %s", components[0]->transport.conductivity_dilute.type, name().c_str()));
         }
 
-        long double lambda_residual = calc_conductivity_background();
+        CoolPropDbl lambda_residual = calc_conductivity_background();
 
         // Critical part
-        long double lambda_critical = _HUGE;
+        CoolPropDbl lambda_critical = _HUGE;
         switch(component.transport.conductivity_critical.type)
         {
         case ConductivityCriticalVariables::CONDUCTIVITY_CRITICAL_SIMPLIFIED_OLCHOWY_SENGERS:
@@ -561,7 +561,7 @@ long double HelmholtzEOSMixtureBackend::calc_conductivity(void)
     else
     {
         set_warning_string("Mixture model for conductivity is highly approximate");
-        long double summer = 0;
+        CoolPropDbl summer = 0;
         for (std::size_t i = 0; i < mole_fractions.size(); ++i){
             shared_ptr<HelmholtzEOSBackend> HEOS(new HelmholtzEOSBackend(components[i]));
             HEOS->update(DmolarT_INPUTS, _rhomolar, _T);
@@ -570,7 +570,7 @@ long double HelmholtzEOSMixtureBackend::calc_conductivity(void)
         return summer;
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_Ttriple(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_Ttriple(void)
 {
     double summer = 0;
     for (unsigned int i = 0; i < components.size(); ++i){
@@ -578,7 +578,7 @@ long double HelmholtzEOSMixtureBackend::calc_Ttriple(void)
     }
     return summer;
 }
-long double HelmholtzEOSMixtureBackend::calc_p_triple(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_p_triple(void)
 {
     double summer = 0;
     for (unsigned int i = 0; i < components.size(); ++i){
@@ -604,52 +604,52 @@ std::vector<std::string> HelmholtzEOSMixtureBackend::calc_fluid_names(void)
     }
 	return out;
 }
-long double HelmholtzEOSMixtureBackend::calc_ODP(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_ODP(void)
 {
     if (components.size() != 1){
         throw ValueError(format("For now, calc_ODP is only valid for pure and pseudo-pure fluids, %d components", components.size()));
     }
     else{
-        long double v = components[0]->environment.ODP;
+        CoolPropDbl v = components[0]->environment.ODP;
         if (!ValidNumber(v) || v < 0){ throw ValueError(format("ODP value is not specified or invalid")); }
         return v;
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_GWP20(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_GWP20(void)
 {
     if (components.size() != 1){
         throw ValueError(format("For now, calc_GWP20 is only valid for pure and pseudo-pure fluids, %d components", components.size()));
     }
     else{
-        long double v = components[0]->environment.GWP20;
+        CoolPropDbl v = components[0]->environment.GWP20;
         if (!ValidNumber(v) || v < 0){ throw ValueError(format("GWP20 value is not specified or invalid"));}
         return v;
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_GWP100(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_GWP100(void)
 {
     if (components.size() != 1){
         throw ValueError(format("For now, calc_GWP100 is only valid for pure and pseudo-pure fluids, %d components", components.size()));
     }
     else{
-        long double v = components[0]->environment.GWP100;
+        CoolPropDbl v = components[0]->environment.GWP100;
         if (!ValidNumber(v) || v < 0){ throw ValueError(format("GWP100 value is not specified or invalid")); }
         return v;
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_GWP500(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_GWP500(void)
 {
     if (components.size() != 1){
         throw ValueError(format("For now, calc_GWP500 is only valid for pure and pseudo-pure fluids, %d components", components.size()));
     }
     else{
-        long double v = components[0]->environment.GWP500;
+        CoolPropDbl v = components[0]->environment.GWP500;
         if (!ValidNumber(v) || v < 0){ throw ValueError(format("GWP500 value is not specified or invalid")); }
         return v;
     }
 }
 
-long double HelmholtzEOSMixtureBackend::calc_T_critical(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_T_critical(void)
 {
     if (components.size() != 1){
         throw ValueError(format("For now, calc_T_critical is only valid for pure and pseudo-pure fluids, %d components", components.size()));
@@ -658,7 +658,7 @@ long double HelmholtzEOSMixtureBackend::calc_T_critical(void)
         return components[0]->crit.T;
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_p_critical(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_p_critical(void)
 {
     if (components.size() != 1){
         throw ValueError(format("For now, calc_p_critical is only valid for pure and pseudo-pure fluids, %d components", components.size()));
@@ -667,7 +667,7 @@ long double HelmholtzEOSMixtureBackend::calc_p_critical(void)
         return components[0]->crit.p;
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_rhomolar_critical(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_rhomolar_critical(void)
 {
     if (components.size() != 1){
         throw ValueError(format("For now, calc_rhomolar_critical is only valid for pure and pseudo-pure fluids, %d components", components.size()));
@@ -676,7 +676,7 @@ long double HelmholtzEOSMixtureBackend::calc_rhomolar_critical(void)
         return components[0]->crit.rhomolar;
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_pmax_sat(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_pmax_sat(void)
 {
     if (is_pure_or_pseudopure)
     {
@@ -692,7 +692,7 @@ long double HelmholtzEOSMixtureBackend::calc_pmax_sat(void)
         throw ValueError("calc_pmax_sat not yet defined for mixtures");
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_Tmax_sat(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_Tmax_sat(void)
 {
     if (is_pure_or_pseudopure)
     {
@@ -709,7 +709,7 @@ long double HelmholtzEOSMixtureBackend::calc_Tmax_sat(void)
     }
 }
 
-void HelmholtzEOSMixtureBackend::calc_Tmin_sat(long double &Tmin_satL, long double &Tmin_satV)
+void HelmholtzEOSMixtureBackend::calc_Tmin_sat(CoolPropDbl &Tmin_satL, CoolPropDbl &Tmin_satV)
 {
     if (is_pure_or_pseudopure)
     {
@@ -722,7 +722,7 @@ void HelmholtzEOSMixtureBackend::calc_Tmin_sat(long double &Tmin_satL, long doub
     }
 }
 
-void HelmholtzEOSMixtureBackend::calc_pmin_sat(long double &pmin_satL, long double &pmin_satV)
+void HelmholtzEOSMixtureBackend::calc_pmin_sat(CoolPropDbl &pmin_satL, CoolPropDbl &pmin_satV)
 {
     if (is_pure_or_pseudopure)
     {
@@ -738,7 +738,7 @@ void HelmholtzEOSMixtureBackend::calc_pmin_sat(long double &pmin_satL, long doub
 // Minimum allowed saturation temperature the maximum of the saturation temperatures of liquid and vapor
         // For pure fluids, both values are the same, for pseudo-pure they are probably the same, for mixtures they are definitely not the same
 
-long double HelmholtzEOSMixtureBackend::calc_Tmax(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_Tmax(void)
 {
     double summer = 0;
     for (unsigned int i = 0; i < components.size(); ++i)
@@ -747,7 +747,7 @@ long double HelmholtzEOSMixtureBackend::calc_Tmax(void)
     }
     return summer;
 }
-long double HelmholtzEOSMixtureBackend::calc_Tmin(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_Tmin(void)
 {
     double summer = 0;
     for (unsigned int i = 0; i < components.size(); ++i)
@@ -756,7 +756,7 @@ long double HelmholtzEOSMixtureBackend::calc_Tmin(void)
     }
     return summer;
 }
-long double HelmholtzEOSMixtureBackend::calc_pmax(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_pmax(void)
 {
     double summer = 0;
     for (unsigned int i = 0; i < components.size(); ++i)
@@ -766,14 +766,14 @@ long double HelmholtzEOSMixtureBackend::calc_pmax(void)
     return summer;
 }
 
-void HelmholtzEOSMixtureBackend::update_DmolarT_direct(long double rhomolar, long double T)
+void HelmholtzEOSMixtureBackend::update_DmolarT_direct(CoolPropDbl rhomolar, CoolPropDbl T)
 {
     CoolProp::input_pairs pair = DmolarT_INPUTS;
     // Set up the state
     pre_update(pair, rhomolar, T);
     
     // Save the current value of vapor quality
-    long double Q_old = _Q;
+    CoolPropDbl Q_old = _Q;
     
     _rhomolar = rhomolar;
     _T = T;
@@ -787,7 +787,7 @@ void HelmholtzEOSMixtureBackend::update_DmolarT_direct(long double rhomolar, lon
     _Q = Q_old;
 }
 
-void HelmholtzEOSMixtureBackend::update_HmolarQ_with_guessT(long double hmolar, long double Q, long double Tguess)
+void HelmholtzEOSMixtureBackend::update_HmolarQ_with_guessT(CoolPropDbl hmolar, CoolPropDbl Q, CoolPropDbl Tguess)
 {
     CoolProp::input_pairs pair = CoolProp::HmolarQ_INPUTS;
     // Set up the state
@@ -813,14 +813,14 @@ void HelmholtzEOSMixtureBackend::update_internal(HelmholtzEOSMixtureBackend &HEO
     
     // Copy the derivatives as well
 }
-void HelmholtzEOSMixtureBackend::update_TP_guessrho(long double T, long double p, long double rhomolar_guess)
+void HelmholtzEOSMixtureBackend::update_TP_guessrho(CoolPropDbl T, CoolPropDbl p, CoolPropDbl rhomolar_guess)
 {
     CoolProp::input_pairs pair = PT_INPUTS;
     // Set up the state
     pre_update(pair, p, T);
     
     // Do the flash call
-    long double rhomolar = solver_rho_Tp(T, p, rhomolar_guess);
+    CoolPropDbl rhomolar = solver_rho_Tp(T, p, rhomolar_guess);
     
     // Update the class with the new calculated density
     update(DmolarT_INPUTS, rhomolar, T);
@@ -829,7 +829,7 @@ void HelmholtzEOSMixtureBackend::update_TP_guessrho(long double T, long double p
     post_update();
 }
 
-void HelmholtzEOSMixtureBackend::mass_to_molar_inputs(CoolProp::input_pairs &input_pair, long double &value1, long double &value2)
+void HelmholtzEOSMixtureBackend::mass_to_molar_inputs(CoolProp::input_pairs &input_pair, CoolPropDbl &value1, CoolPropDbl &value2)
 {
     // Check if a mass based input, convert it to molar units
 
@@ -853,7 +853,7 @@ void HelmholtzEOSMixtureBackend::mass_to_molar_inputs(CoolProp::input_pairs &inp
             molar_mass();
 
             // Molar mass (just for compactness of the following switch)
-            long double mm = static_cast<long double>(_molar_mass);
+            CoolPropDbl mm = static_cast<CoolPropDbl>(_molar_mass);
 
             switch(input_pair)
             {
@@ -879,7 +879,7 @@ void HelmholtzEOSMixtureBackend::mass_to_molar_inputs(CoolProp::input_pairs &inp
     }
 }
 
-void HelmholtzEOSMixtureBackend::pre_update(CoolProp::input_pairs &input_pair, long double &value1, long double &value2 )
+void HelmholtzEOSMixtureBackend::pre_update(CoolProp::input_pairs &input_pair, CoolPropDbl &value1, CoolPropDbl &value2 )
 {
     // Clear the state
     clear();
@@ -903,7 +903,7 @@ void HelmholtzEOSMixtureBackend::update(CoolProp::input_pairs input_pair, double
 {
     if (get_debug_level() > 10){std::cout << format("%s (%d): update called with (%d: (%s), %g, %g)",__FILE__,__LINE__, input_pair, get_input_pair_short_desc(input_pair).c_str(), value1, value2) << std::endl;}
     
-    long double ld_value1 = value1, ld_value2 = value2;
+    CoolPropDbl ld_value1 = value1, ld_value2 = value2;
     pre_update(input_pair, ld_value1, ld_value2);
     value1 = ld_value1; value2 = ld_value2;
 
@@ -971,25 +971,25 @@ void HelmholtzEOSMixtureBackend::post_update()
     _delta = _rhomolar/_reducing.rhomolar;
 }
 
-long double HelmholtzEOSMixtureBackend::calc_Bvirial()
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_Bvirial()
 {
     return 1/get_reducing_state().rhomolar*calc_alphar_deriv_nocache(0,1,mole_fractions,_tau,1e-12);
 }
-long double HelmholtzEOSMixtureBackend::calc_dBvirial_dT()
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_dBvirial_dT()
 {
-    long double dtau_dT =-get_reducing_state().T/pow(_T,2);
+    CoolPropDbl dtau_dT =-get_reducing_state().T/pow(_T,2);
     return 1/get_reducing_state().rhomolar*calc_alphar_deriv_nocache(1,1,mole_fractions,_tau,1e-12)*dtau_dT;
 }
-long double HelmholtzEOSMixtureBackend::calc_Cvirial()
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_Cvirial()
 {
     return 1/pow(get_reducing_state().rhomolar,2)*calc_alphar_deriv_nocache(0,2,mole_fractions,_tau,1e-12);
 }
-long double HelmholtzEOSMixtureBackend::calc_dCvirial_dT()
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_dCvirial_dT()
 {
-    long double dtau_dT =-get_reducing_state().T/pow(_T,2);
+    CoolPropDbl dtau_dT =-get_reducing_state().T/pow(_T,2);
     return 1/pow(get_reducing_state().rhomolar,2)*calc_alphar_deriv_nocache(1,2,mole_fractions,_tau,1e-12)*dtau_dT;
 }
-void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int other, long double value, bool &saturation_called)
+void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int other, CoolPropDbl value, bool &saturation_called)
 {
     /*
     Determine the phase given p and one other state variable
@@ -1072,8 +1072,8 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
         {
             case iT:
             {
-                long double T_vap =  0.1 + static_cast<double>(_TVanc);
-                long double T_liq = -0.1 + static_cast<double>(_TLanc);
+                CoolPropDbl T_vap =  0.1 + static_cast<double>(_TVanc);
+                CoolPropDbl T_liq = -0.1 + static_cast<double>(_TLanc);
 
                 if (value > T_vap){
                     this->_phase = iphase_gas; _Q = -1000; return;
@@ -1087,10 +1087,10 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
             {
                 if (!component.ancillaries.hL.enabled()){break;}
                 // Ancillaries are h-h_anchor, so add back h_anchor
-                long double h_liq = component.ancillaries.hL.evaluate(_TLanc) + component.pEOS->hs_anchor.hmolar;
-                long double h_liq_error_band = component.ancillaries.hL.get_max_abs_error();
-                long double h_vap = h_liq + component.ancillaries.hLV.evaluate(_TLanc);
-                long double h_vap_error_band = h_liq_error_band + component.ancillaries.hLV.get_max_abs_error();
+                CoolPropDbl h_liq = component.ancillaries.hL.evaluate(_TLanc) + component.pEOS->hs_anchor.hmolar;
+                CoolPropDbl h_liq_error_band = component.ancillaries.hL.get_max_abs_error();
+                CoolPropDbl h_vap = h_liq + component.ancillaries.hLV.evaluate(_TLanc);
+                CoolPropDbl h_vap_error_band = h_liq_error_band + component.ancillaries.hLV.get_max_abs_error();
                                 
 //                HelmholtzEOSMixtureBackend HEOS(components);
 //                HEOS.update(QT_INPUTS, 1, _TLanc);
@@ -1112,11 +1112,11 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
             {
                 if (!component.ancillaries.sL.enabled()){break;}
                 // Ancillaries are s-s_anchor, so add back s_anchor
-                long double s_anchor = component.EOSVector[0].hs_anchor.smolar;
-                long double s_liq = component.ancillaries.sL.evaluate(_TLanc) + s_anchor;
-                long double s_liq_error_band = component.ancillaries.sL.get_max_abs_error();
-                long double s_vap = s_liq + component.ancillaries.sLV.evaluate(_TVanc);
-                long double s_vap_error_band = s_liq_error_band + component.ancillaries.sLV.get_max_abs_error();
+                CoolPropDbl s_anchor = component.EOSVector[0].hs_anchor.smolar;
+                CoolPropDbl s_liq = component.ancillaries.sL.evaluate(_TLanc) + s_anchor;
+                CoolPropDbl s_liq_error_band = component.ancillaries.sL.get_max_abs_error();
+                CoolPropDbl s_vap = s_liq + component.ancillaries.sLV.evaluate(_TVanc);
+                CoolPropDbl s_vap_error_band = s_liq_error_band + component.ancillaries.sLV.get_max_abs_error();
                 
                 // Check if in range given the accuracy of the fit
                 if (value > s_vap + s_vap_error_band){
@@ -1134,16 +1134,16 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
                 // u = h-p/rho
                 
                 // Ancillaries are h-h_anchor, so add back h_anchor
-                long double h_liq = component.ancillaries.hL.evaluate(_TLanc) + component.EOSVector[0].hs_anchor.hmolar;
-                long double h_liq_error_band = component.ancillaries.hL.get_max_abs_error();
-                long double h_vap = h_liq + component.ancillaries.hLV.evaluate(_TLanc);
-                long double h_vap_error_band = h_liq_error_band + component.ancillaries.hLV.get_max_abs_error();
-                long double rho_vap = component.ancillaries.rhoV.evaluate(_TVanc);
-                long double rho_liq = component.ancillaries.rhoL.evaluate(_TLanc);
-                long double u_liq = h_liq-_p/rho_liq;
-                long double u_vap = h_vap-_p/rho_vap;
-                long double u_liq_error_band = 1.5*h_liq_error_band; // Most of error is in enthalpy
-                long double u_vap_error_band = 1.5*h_vap_error_band; // Most of error is in enthalpy
+                CoolPropDbl h_liq = component.ancillaries.hL.evaluate(_TLanc) + component.EOSVector[0].hs_anchor.hmolar;
+                CoolPropDbl h_liq_error_band = component.ancillaries.hL.get_max_abs_error();
+                CoolPropDbl h_vap = h_liq + component.ancillaries.hLV.evaluate(_TLanc);
+                CoolPropDbl h_vap_error_band = h_liq_error_band + component.ancillaries.hLV.get_max_abs_error();
+                CoolPropDbl rho_vap = component.ancillaries.rhoV.evaluate(_TVanc);
+                CoolPropDbl rho_liq = component.ancillaries.rhoL.evaluate(_TLanc);
+                CoolPropDbl u_liq = h_liq-_p/rho_liq;
+                CoolPropDbl u_vap = h_vap-_p/rho_vap;
+                CoolPropDbl u_liq_error_band = 1.5*h_liq_error_band; // Most of error is in enthalpy
+                CoolPropDbl u_vap_error_band = 1.5*h_vap_error_band; // Most of error is in enthalpy
                 
                 // Check if in range given the accuracy of the fit
                 if (value > u_vap + u_vap_error_band){
@@ -1167,8 +1167,8 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
         {
             _rhoVanc = component.ancillaries.rhoV.evaluate(_TVanc);
             _rhoLanc = component.ancillaries.rhoL.evaluate(_TLanc);
-            long double rho_vap = 0.95*static_cast<double>(_rhoVanc);
-            long double rho_liq = 1.05*static_cast<double>(_rhoLanc);
+            CoolPropDbl rho_vap = 0.95*static_cast<double>(_rhoVanc);
+            CoolPropDbl rho_liq = 1.05*static_cast<double>(_rhoLanc);
             switch (other)
             {
                 case iDmolar:
@@ -1199,7 +1199,7 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
         // the other solvers
         saturation_called = true;
         
-        long double Q;
+        CoolPropDbl Q;
 
         if (other == iT){
             if (value < HEOS.SatL->T()-100*DBL_EPSILON){
@@ -1318,7 +1318,7 @@ void HelmholtzEOSMixtureBackend::calc_hsat_max(void)
         hsat_max.smolar = residhmax.HEOS->smolar();
     }
 }
-void HelmholtzEOSMixtureBackend::T_phase_determination_pure_or_pseudopure(int other, long double value)
+void HelmholtzEOSMixtureBackend::T_phase_determination_pure_or_pseudopure(int other, CoolPropDbl value)
 {
     if (!ValidNumber(value)){
         throw ValueError(format("value to T_phase_determination_pure_or_pseudopure is invalid"));};
@@ -1356,8 +1356,8 @@ void HelmholtzEOSMixtureBackend::T_phase_determination_pure_or_pseudopure(int ot
             {
                 _pLanc = components[0]->ancillaries.pL.evaluate(_T);
                 _pVanc = components[0]->ancillaries.pV.evaluate(_T);
-                long double p_vap = 0.98*static_cast<double>(_pVanc);
-                long double p_liq = 1.02*static_cast<double>(_pLanc);
+                CoolPropDbl p_vap = 0.98*static_cast<double>(_pVanc);
+                CoolPropDbl p_liq = 1.02*static_cast<double>(_pLanc);
 
                 if (value < p_vap){
                     this->_phase = iphase_gas; _Q = -1000; return;
@@ -1365,7 +1365,7 @@ void HelmholtzEOSMixtureBackend::T_phase_determination_pure_or_pseudopure(int ot
                 else if (value > p_liq){
                     this->_phase = iphase_liquid; _Q = 1000; return;
                 }
-                else if (!is_pure() && value < static_cast<long double>(_pLanc) && value > static_cast<long double>(_pVanc)){
+                else if (!is_pure() && value < static_cast<CoolPropDbl>(_pLanc) && value > static_cast<CoolPropDbl>(_pVanc)){
                     throw ValueError("Two-phase inputs not supported for pseudo-pure for now");
                 }
                 break;
@@ -1375,8 +1375,8 @@ void HelmholtzEOSMixtureBackend::T_phase_determination_pure_or_pseudopure(int ot
                 // Always calculate the densities using the ancillaries
                 _rhoVanc = components[0]->ancillaries.rhoV.evaluate(_T);
                 _rhoLanc = components[0]->ancillaries.rhoL.evaluate(_T);
-                long double rho_vap = 0.95*static_cast<double>(_rhoVanc);
-                long double rho_liq = 1.05*static_cast<double>(_rhoLanc);
+                CoolPropDbl rho_vap = 0.95*static_cast<double>(_rhoVanc);
+                CoolPropDbl rho_liq = 1.05*static_cast<double>(_rhoLanc);
                 switch (other)
                 {
                     case iDmolar:
@@ -1444,7 +1444,7 @@ void HelmholtzEOSMixtureBackend::T_phase_determination_pure_or_pseudopure(int ot
         SaturationSolvers::saturation_T_pure_options options;
         SaturationSolvers::saturation_T_pure(HEOS, _T, options);
 
-        long double Q;
+        CoolPropDbl Q;
 
         if (other == iP)
         {
@@ -1553,9 +1553,9 @@ void HelmholtzEOSMixtureBackend::T_phase_determination_pure_or_pseudopure(int ot
         throw ValueError(format("For now, we don't support T [%g K] below Ttriple [%g K]", _T, components[0]->pEOS->Ttriple));
     }
 }
-void get_dT_drho(HelmholtzEOSMixtureBackend *HEOS, parameters index, long double &dT, long double &drho)
+void get_dT_drho(HelmholtzEOSMixtureBackend *HEOS, parameters index, CoolPropDbl &dT, CoolPropDbl &drho)
 {
-    long double T = HEOS->T(),
+    CoolPropDbl T = HEOS->T(),
                 rho = HEOS->rhomolar(),
                 rhor = HEOS->get_reducing_state().rhomolar,
                 Tr = HEOS->get_reducing_state().T,
@@ -1631,30 +1631,30 @@ void get_dT_drho(HelmholtzEOSMixtureBackend *HEOS, parameters index, long double
     }
 }
 
-long double HelmholtzEOSMixtureBackend::calc_pressure_nocache(long double T, long double rhomolar)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_pressure_nocache(CoolPropDbl T, CoolPropDbl rhomolar)
 {
     SimpleState reducing = calc_reducing_state_nocache(mole_fractions);
-    long double delta = rhomolar/reducing.rhomolar;
-    long double tau = reducing.T/T;
+    CoolPropDbl delta = rhomolar/reducing.rhomolar;
+    CoolPropDbl tau = reducing.T/T;
 
     // Calculate derivative if needed
     int nTau = 0, nDelta = 1;
-    long double dalphar_dDelta = calc_alphar_deriv_nocache(nTau, nDelta, mole_fractions, tau, delta);
+    CoolPropDbl dalphar_dDelta = calc_alphar_deriv_nocache(nTau, nDelta, mole_fractions, tau, delta);
 
     // Get pressure
     return rhomolar*gas_constant()*T*(1+delta*dalphar_dDelta);
 }
-long double HelmholtzEOSMixtureBackend::solver_for_rho_given_T_oneof_HSU(long double T, long double value, int other)
+CoolPropDbl HelmholtzEOSMixtureBackend::solver_for_rho_given_T_oneof_HSU(CoolPropDbl T, CoolPropDbl value, int other)
 {
     // Define the residual to be driven to zero
     class solver_resid : public FuncWrapper1D
     {
     public:
         int other;
-        long double T, value, r, eos, rhomolar;
+        CoolPropDbl T, value, r, eos, rhomolar;
         HelmholtzEOSMixtureBackend *HEOS;
 
-        solver_resid(HelmholtzEOSMixtureBackend *HEOS, long double T, long double value, int other){
+        solver_resid(HelmholtzEOSMixtureBackend *HEOS, CoolPropDbl T, CoolPropDbl value, int other){
             this->HEOS = HEOS; this->T = T; this->value = value; this->other = other;
         };
         double call(double rhomolar){
@@ -1681,9 +1681,9 @@ long double HelmholtzEOSMixtureBackend::solver_for_rho_given_T_oneof_HSU(long do
     // Supercritical temperature
     if (_T > _crit.T)
     {
-        long double yc, ymin, y;
-        long double rhoc = components[0]->crit.rhomolar;
-        long double rhomin = 1e-10;
+        CoolPropDbl yc, ymin, y;
+        CoolPropDbl rhoc = components[0]->crit.rhomolar;
+        CoolPropDbl rhomin = 1e-10;
 
         switch(other)
         {
@@ -1714,7 +1714,7 @@ long double HelmholtzEOSMixtureBackend::solver_for_rho_given_T_oneof_HSU(long do
 
         if (is_in_closed_range(yc, ymin, y))
         {
-            long double rhomolar = Brent(resid, rhoc, rhomin, LDBL_EPSILON, 1e-12, 100, errstring);
+            CoolPropDbl rhomolar = Brent(resid, rhoc, rhomin, LDBL_EPSILON, 1e-12, 100, errstring);
             return rhomolar;
         }
         else if (y < yc){
@@ -1735,7 +1735,7 @@ long double HelmholtzEOSMixtureBackend::solver_for_rho_given_T_oneof_HSU(long do
                 }
                 step_count++;
             }
-            long double rhomolar = Brent(resid, rhomin, rhoc, LDBL_EPSILON, 1e-12, 100, errstring);
+            CoolPropDbl rhomolar = Brent(resid, rhomin, rhoc, LDBL_EPSILON, 1e-12, 100, errstring);
             return rhomolar;
         }
         else
@@ -1753,9 +1753,9 @@ long double HelmholtzEOSMixtureBackend::solver_for_rho_given_T_oneof_HSU(long do
     // Subcritical temperature liquid
     else if (_phase == iphase_liquid)
     {
-        long double ymelt, yL, y;
-        long double rhomelt = components[0]->triple_liquid.rhomolar;
-        long double rhoL = static_cast<double>(_rhoLanc);
+        CoolPropDbl ymelt, yL, y;
+        CoolPropDbl rhomelt = components[0]->triple_liquid.rhomolar;
+        CoolPropDbl rhoL = static_cast<double>(_rhoLanc);
 
         switch(other)
         {
@@ -1775,20 +1775,20 @@ long double HelmholtzEOSMixtureBackend::solver_for_rho_given_T_oneof_HSU(long do
                 throw ValueError();
         }
 
-        long double rhomolar_guess = (rhomelt-rhoL)/(ymelt-yL)*(y-yL) + rhoL;
+        CoolPropDbl rhomolar_guess = (rhomelt-rhoL)/(ymelt-yL)*(y-yL) + rhoL;
 
-        long double rhomolar = Secant(resid, rhomolar_guess, 0.0001*rhomolar_guess, 1e-12, 100, errstring);
+        CoolPropDbl rhomolar = Secant(resid, rhomolar_guess, 0.0001*rhomolar_guess, 1e-12, 100, errstring);
         return rhomolar;
     }
     // Subcritical temperature gas
     else if (_phase == iphase_gas)
     {
-        long double rhomin = 1e-14;
-        long double rhoV = static_cast<double>(_rhoVanc);
+        CoolPropDbl rhomin = 1e-14;
+        CoolPropDbl rhoV = static_cast<double>(_rhoVanc);
 
         try
         {
-            long double rhomolar = Brent(resid, rhomin, rhoV, LDBL_EPSILON, 1e-12, 100, errstring);
+            CoolPropDbl rhomolar = Brent(resid, rhomin, rhoV, LDBL_EPSILON, 1e-12, 100, errstring);
             return rhomolar;
         }
         catch(std::exception &)
@@ -1800,7 +1800,7 @@ long double HelmholtzEOSMixtureBackend::solver_for_rho_given_T_oneof_HSU(long do
         throw ValueError(format("phase to solver_for_rho_given_T_oneof_HSU is invalid"));
     }
 }
-long double HelmholtzEOSMixtureBackend::solver_rho_Tp(long double T, long double p, long double rhomolar_guess)
+CoolPropDbl HelmholtzEOSMixtureBackend::solver_rho_Tp(CoolPropDbl T, CoolPropDbl p, CoolPropDbl rhomolar_guess)
 {
     phases phase;
 
@@ -1808,10 +1808,10 @@ long double HelmholtzEOSMixtureBackend::solver_rho_Tp(long double T, long double
     class solver_TP_resid : public FuncWrapper1D
     {
     public:
-        long double T, p, r, peos, rhomolar, rhor, tau, R_u, delta, dalphar_dDelta;
+        CoolPropDbl T, p, r, peos, rhomolar, rhor, tau, R_u, delta, dalphar_dDelta;
         HelmholtzEOSMixtureBackend *HEOS;
 
-        solver_TP_resid(HelmholtzEOSMixtureBackend *HEOS, long double T, long double p){
+        solver_TP_resid(HelmholtzEOSMixtureBackend *HEOS, CoolPropDbl T, CoolPropDbl p){
             this->HEOS = HEOS; this->T = T; this->p = p; this->rhor = HEOS->get_reducing_state().rhomolar;
             this->tau = HEOS->get_reducing_state().T/T; this->R_u = HEOS->gas_constant();
         };
@@ -1855,7 +1855,7 @@ long double HelmholtzEOSMixtureBackend::solver_rho_Tp(long double T, long double
         // It's liquid at subcritical pressure, we can use ancillaries as a backup
         else if (phase == iphase_liquid)
         {
-            long double _rhoLancval = static_cast<long double>(components[0]->ancillaries.rhoL.evaluate(T));
+            CoolPropDbl _rhoLancval = static_cast<CoolPropDbl>(components[0]->ancillaries.rhoL.evaluate(T));
             // Next we try with a Brent method bounded solver since the function is 1-1
             double rhomolar = Brent(resid, _rhoLancval*0.9, _rhoLancval*1.3, DBL_EPSILON,1e-8,100,errstring);
             if (!ValidNumber(rhomolar)){throw ValueError();}
@@ -1863,7 +1863,7 @@ long double HelmholtzEOSMixtureBackend::solver_rho_Tp(long double T, long double
         }
         else if (phase == iphase_supercritical_liquid){
             
-            long double rhoLancval = static_cast<long double>(components[0]->ancillaries.rhoL.evaluate(T));
+            CoolPropDbl rhoLancval = static_cast<CoolPropDbl>(components[0]->ancillaries.rhoL.evaluate(T));
             
             // Next we try with a Brent method bounded solver since the function is 1-1
             double rhomolar = Brent(resid, rhoLancval*0.99, rhomolar_critical()*4, DBL_EPSILON,1e-8,100,errstring);
@@ -1912,25 +1912,25 @@ long double HelmholtzEOSMixtureBackend::solver_rho_Tp(long double T, long double
         }
     }
 }
-long double HelmholtzEOSMixtureBackend::solver_rho_Tp_SRK(long double T, long double p, int phase)
+CoolPropDbl HelmholtzEOSMixtureBackend::solver_rho_Tp_SRK(CoolPropDbl T, CoolPropDbl p, int phase)
 {
-    long double rhomolar, R_u = gas_constant(), a = 0, b = 0, k_ij = 0;
+    CoolPropDbl rhomolar, R_u = gas_constant(), a = 0, b = 0, k_ij = 0;
 
     for (std::size_t i = 0; i < components.size(); ++i)
     {
-        long double Tci = components[i]->pEOS->reduce.T, pci = components[i]->pEOS->reduce.p, acentric_i = components[i]->pEOS->acentric;
-        long double m_i = 0.480+1.574*acentric_i-0.176*pow(acentric_i, 2);
-        long double b_i = 0.08664*R_u*Tci/pci;
+        CoolPropDbl Tci = components[i]->pEOS->reduce.T, pci = components[i]->pEOS->reduce.p, acentric_i = components[i]->pEOS->acentric;
+        CoolPropDbl m_i = 0.480+1.574*acentric_i-0.176*pow(acentric_i, 2);
+        CoolPropDbl b_i = 0.08664*R_u*Tci/pci;
         b += mole_fractions[i]*b_i;
 
-        long double a_i = 0.42747*pow(R_u*Tci,2)/pci*pow(1+m_i*(1-sqrt(T/Tci)),2);
+        CoolPropDbl a_i = 0.42747*pow(R_u*Tci,2)/pci*pow(1+m_i*(1-sqrt(T/Tci)),2);
 
         for (std::size_t j = 0; j < components.size(); ++j)
         {
-            long double Tcj = components[j]->pEOS->reduce.T, pcj = components[j]->pEOS->reduce.p, acentric_j = components[j]->pEOS->acentric;
-            long double m_j = 0.480+1.574*acentric_j-0.176*pow(acentric_j, 2);
+            CoolPropDbl Tcj = components[j]->pEOS->reduce.T, pcj = components[j]->pEOS->reduce.p, acentric_j = components[j]->pEOS->acentric;
+            CoolPropDbl m_j = 0.480+1.574*acentric_j-0.176*pow(acentric_j, 2);
 
-            long double a_j = 0.42747*pow(R_u*Tcj,2)/pcj*pow(1+m_j*(1-sqrt(T/Tcj)),2);
+            CoolPropDbl a_j = 0.42747*pow(R_u*Tcj,2)/pcj*pow(1+m_j*(1-sqrt(T/Tcj)),2);
 
             if (i == j){
                 k_ij = 0;
@@ -1943,8 +1943,8 @@ long double HelmholtzEOSMixtureBackend::solver_rho_Tp_SRK(long double T, long do
         }
     }
 
-    long double A = a*p/pow(R_u*T,2);
-    long double B = b*p/(R_u*T);
+    CoolPropDbl A = a*p/pow(R_u*T,2);
+    CoolPropDbl B = b*p/(R_u*T);
 
     //Solve the cubic for solutions for Z = p/(rho*R*T)
     double Z0, Z1, Z2; int Nsolns;
@@ -1955,9 +1955,9 @@ long double HelmholtzEOSMixtureBackend::solver_rho_Tp_SRK(long double T, long do
         rhomolar = p/(Z0*R_u*T);
     }
     else{
-        long double rhomolar0 = p/(Z0*R_u*T);
-        long double rhomolar1 = p/(Z1*R_u*T);
-        long double rhomolar2 = p/(Z2*R_u*T);
+        CoolPropDbl rhomolar0 = p/(Z0*R_u*T);
+        CoolPropDbl rhomolar1 = p/(Z1*R_u*T);
+        CoolPropDbl rhomolar2 = p/(Z2*R_u*T);
 
         // Check if only one solution is positive, return the solution if that is the case
         if (rhomolar0  > 0 && rhomolar1 <= 0 && rhomolar2 <= 0){ return rhomolar0; }
@@ -1978,15 +1978,15 @@ long double HelmholtzEOSMixtureBackend::solver_rho_Tp_SRK(long double T, long do
     return rhomolar;
 }
 
-long double HelmholtzEOSMixtureBackend::calc_pressure(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_pressure(void)
 {
     // Calculate the reducing parameters
     _delta = _rhomolar/_reducing.rhomolar;
     _tau = _reducing.T/_T;
 
     // Calculate derivative if needed
-    long double dar_dDelta = dalphar_dDelta();
-    long double R_u = gas_constant();
+    CoolPropDbl dar_dDelta = dalphar_dDelta();
+    CoolPropDbl R_u = gas_constant();
 
     // Get pressure
     _p = _rhomolar*R_u*_T*(1 + _delta.pt()*dar_dDelta);
@@ -1996,31 +1996,31 @@ long double HelmholtzEOSMixtureBackend::calc_pressure(void)
     //    throw ValueError("Pressure is less than zero");
     //}
 
-    return static_cast<long double>(_p);
+    return static_cast<CoolPropDbl>(_p);
 }
-long double HelmholtzEOSMixtureBackend::calc_hmolar_nocache(long double T, long double rhomolar)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_hmolar_nocache(CoolPropDbl T, CoolPropDbl rhomolar)
 {
     // Calculate the reducing parameters
-    long double delta = rhomolar/_reducing.rhomolar;
-    long double tau = _reducing.T/T;
+    CoolPropDbl delta = rhomolar/_reducing.rhomolar;
+    CoolPropDbl tau = _reducing.T/T;
 
     // Calculate derivatives if needed, or just use cached values
     // Calculate derivative if needed
-    long double dar_dDelta = calc_alphar_deriv_nocache(0, 1, mole_fractions, tau, delta);
-    long double dar_dTau = calc_alphar_deriv_nocache(1, 0, mole_fractions, tau, delta);
-    long double da0_dTau = calc_alpha0_deriv_nocache(1, 0, mole_fractions, tau, delta, _reducing.T, _reducing.rhomolar);
-    long double R_u = gas_constant();
+    CoolPropDbl dar_dDelta = calc_alphar_deriv_nocache(0, 1, mole_fractions, tau, delta);
+    CoolPropDbl dar_dTau = calc_alphar_deriv_nocache(1, 0, mole_fractions, tau, delta);
+    CoolPropDbl da0_dTau = calc_alpha0_deriv_nocache(1, 0, mole_fractions, tau, delta, _reducing.T, _reducing.rhomolar);
+    CoolPropDbl R_u = gas_constant();
 
     // Get molar enthalpy
     return R_u*T*(1 + tau*(da0_dTau+dar_dTau) + delta*dar_dDelta);
 }
-long double HelmholtzEOSMixtureBackend::calc_hmolar(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_hmolar(void)
 {
 	if (get_debug_level()>=50) std::cout << format("HelmholtzEOSMixtureBackend::calc_hmolar: 2phase: %d T: %g rhomomolar: %g", isTwoPhase(), _T, _rhomolar) << std::endl;
     if (isTwoPhase())
     {
         _hmolar = _Q*SatV->hmolar() + (1 - _Q)*SatL->hmolar();
-        return static_cast<long double>(_hmolar);
+        return static_cast<CoolPropDbl>(_hmolar);
     }
     else if (isHomogeneousPhase())
     {
@@ -2029,43 +2029,43 @@ long double HelmholtzEOSMixtureBackend::calc_hmolar(void)
         _tau = _reducing.T/_T;
 
         // Calculate derivatives if needed, or just use cached values
-        long double da0_dTau = dalpha0_dTau();
-        long double dar_dTau = dalphar_dTau();
-        long double dar_dDelta = dalphar_dDelta();
-        long double R_u = gas_constant();
+        CoolPropDbl da0_dTau = dalpha0_dTau();
+        CoolPropDbl dar_dTau = dalphar_dTau();
+        CoolPropDbl dar_dDelta = dalphar_dDelta();
+        CoolPropDbl R_u = gas_constant();
 
         // Get molar enthalpy
         _hmolar = R_u*_T*(1 + _tau.pt()*(da0_dTau+dar_dTau) + _delta.pt()*dar_dDelta);
 
-        return static_cast<long double>(_hmolar);
+        return static_cast<CoolPropDbl>(_hmolar);
     }
     else{
         throw ValueError(format("phase is invalid in calc_hmolar"));
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_smolar_nocache(long double T, long double rhomolar)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_smolar_nocache(CoolPropDbl T, CoolPropDbl rhomolar)
 {
     // Calculate the reducing parameters
-    long double delta = rhomolar/_reducing.rhomolar;
-    long double tau = _reducing.T/T;
+    CoolPropDbl delta = rhomolar/_reducing.rhomolar;
+    CoolPropDbl tau = _reducing.T/T;
 
     // Calculate derivatives if needed, or just use cached values
     // Calculate derivative if needed
-    long double dar_dTau = calc_alphar_deriv_nocache(1, 0, mole_fractions, tau, delta);
-    long double ar = calc_alphar_deriv_nocache(0, 0, mole_fractions, tau, delta);
-    long double da0_dTau = calc_alpha0_deriv_nocache(1, 0, mole_fractions, tau, delta, _reducing.T, _reducing.rhomolar);
-    long double a0 = calc_alpha0_deriv_nocache(0, 0, mole_fractions, tau, delta, _reducing.T, _reducing.rhomolar);
-    long double R_u = gas_constant();
+    CoolPropDbl dar_dTau = calc_alphar_deriv_nocache(1, 0, mole_fractions, tau, delta);
+    CoolPropDbl ar = calc_alphar_deriv_nocache(0, 0, mole_fractions, tau, delta);
+    CoolPropDbl da0_dTau = calc_alpha0_deriv_nocache(1, 0, mole_fractions, tau, delta, _reducing.T, _reducing.rhomolar);
+    CoolPropDbl a0 = calc_alpha0_deriv_nocache(0, 0, mole_fractions, tau, delta, _reducing.T, _reducing.rhomolar);
+    CoolPropDbl R_u = gas_constant();
 
     // Get molar entropy
     return R_u*(tau*(da0_dTau+dar_dTau) - a0 - ar);
 }
-long double HelmholtzEOSMixtureBackend::calc_smolar(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_smolar(void)
 {
     if (isTwoPhase())
     {
         _smolar = _Q*SatV->smolar() + (1 - _Q)*SatL->smolar();
-        return static_cast<long double>(_smolar);
+        return static_cast<CoolPropDbl>(_smolar);
     }
     else if (isHomogeneousPhase())
     {
@@ -2074,41 +2074,41 @@ long double HelmholtzEOSMixtureBackend::calc_smolar(void)
         _tau = _reducing.T/_T;
 
         // Calculate derivatives if needed, or just use cached values
-        long double da0_dTau = dalpha0_dTau();
-        long double ar = alphar();
-        long double a0 = alpha0();
-        long double dar_dTau = dalphar_dTau();
-        long double R_u = gas_constant();
+        CoolPropDbl da0_dTau = dalpha0_dTau();
+        CoolPropDbl ar = alphar();
+        CoolPropDbl a0 = alpha0();
+        CoolPropDbl dar_dTau = dalphar_dTau();
+        CoolPropDbl R_u = gas_constant();
 
         // Get molar entropy
         _smolar = R_u*(_tau.pt()*(da0_dTau+dar_dTau) - a0 - ar);
 
-        return static_cast<long double>(_smolar);
+        return static_cast<CoolPropDbl>(_smolar);
     }
     else{
         throw ValueError(format("phase is invalid in calc_smolar"));
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_umolar_nocache(long double T, long double rhomolar)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_umolar_nocache(CoolPropDbl T, CoolPropDbl rhomolar)
 {
     // Calculate the reducing parameters
-    long double delta = rhomolar/_reducing.rhomolar;
-    long double tau = _reducing.T/T;
+    CoolPropDbl delta = rhomolar/_reducing.rhomolar;
+    CoolPropDbl tau = _reducing.T/T;
 
     // Calculate derivatives
-    long double dar_dTau = calc_alphar_deriv_nocache(1, 0, mole_fractions, tau, delta);
-    long double da0_dTau = calc_alpha0_deriv_nocache(1, 0, mole_fractions, tau, delta, _reducing.T, _reducing.rhomolar);
-    long double R_u = gas_constant();
+    CoolPropDbl dar_dTau = calc_alphar_deriv_nocache(1, 0, mole_fractions, tau, delta);
+    CoolPropDbl da0_dTau = calc_alpha0_deriv_nocache(1, 0, mole_fractions, tau, delta, _reducing.T, _reducing.rhomolar);
+    CoolPropDbl R_u = gas_constant();
 
     // Get molar internal energy
     return R_u*T*tau*(da0_dTau+dar_dTau);
 }
-long double HelmholtzEOSMixtureBackend::calc_umolar(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_umolar(void)
 {
     if (isTwoPhase())
     {
         _umolar = _Q*SatV->umolar() + (1 - _Q)*SatL->umolar();
-        return static_cast<long double>(_umolar);
+        return static_cast<CoolPropDbl>(_umolar);
     }
     else if (isHomogeneousPhase())
     {
@@ -2117,93 +2117,93 @@ long double HelmholtzEOSMixtureBackend::calc_umolar(void)
         _tau = _reducing.T/_T;
 
         // Calculate derivatives if needed, or just use cached values
-        long double da0_dTau = dalpha0_dTau();
-        long double dar_dTau = dalphar_dTau();
-        long double R_u = gas_constant();
+        CoolPropDbl da0_dTau = dalpha0_dTau();
+        CoolPropDbl dar_dTau = dalphar_dTau();
+        CoolPropDbl R_u = gas_constant();
 
         // Get molar internal energy
         _umolar = R_u*_T*_tau.pt()*(da0_dTau+dar_dTau);
 
-        return static_cast<long double>(_umolar);
+        return static_cast<CoolPropDbl>(_umolar);
     }
     else{
         throw ValueError(format("phase is invalid in calc_umolar"));
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_cvmolar(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_cvmolar(void)
 {
     // Calculate the reducing parameters
     _delta = _rhomolar/_reducing.rhomolar;
     _tau = _reducing.T/_T;
 
     // Calculate derivatives if needed, or just use cached values
-    long double d2ar_dTau2 = d2alphar_dTau2();
-    long double d2a0_dTau2 = d2alpha0_dTau2();
-    long double R_u = gas_constant();
+    CoolPropDbl d2ar_dTau2 = d2alphar_dTau2();
+    CoolPropDbl d2a0_dTau2 = d2alpha0_dTau2();
+    CoolPropDbl R_u = gas_constant();
 
     // Get cv
     _cvmolar = -R_u*pow(_tau.pt(),2)*(d2ar_dTau2 + d2a0_dTau2);
 
     return static_cast<double>(_cvmolar);
 }
-long double HelmholtzEOSMixtureBackend::calc_cpmolar(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_cpmolar(void)
 {
     // Calculate the reducing parameters
     _delta = _rhomolar/_reducing.rhomolar;
     _tau = _reducing.T/_T;
 
     // Calculate derivatives if needed, or just use cached values
-    long double d2a0_dTau2 = d2alpha0_dTau2();
-    long double dar_dDelta = dalphar_dDelta();
-    long double d2ar_dDelta2 = d2alphar_dDelta2();
-    long double d2ar_dDelta_dTau = d2alphar_dDelta_dTau();
-    long double d2ar_dTau2 = d2alphar_dTau2();
-    long double R_u = gas_constant();
+    CoolPropDbl d2a0_dTau2 = d2alpha0_dTau2();
+    CoolPropDbl dar_dDelta = dalphar_dDelta();
+    CoolPropDbl d2ar_dDelta2 = d2alphar_dDelta2();
+    CoolPropDbl d2ar_dDelta_dTau = d2alphar_dDelta_dTau();
+    CoolPropDbl d2ar_dTau2 = d2alphar_dTau2();
+    CoolPropDbl R_u = gas_constant();
 
     // Get cp
     _cpmolar = R_u*(-pow(_tau.pt(),2)*(d2ar_dTau2 + d2a0_dTau2)+pow(1+_delta.pt()*dar_dDelta-_delta.pt()*_tau.pt()*d2ar_dDelta_dTau,2)/(1+2*_delta.pt()*dar_dDelta+pow(_delta.pt(),2)*d2ar_dDelta2));
 
     return static_cast<double>(_cpmolar);
 }
-long double HelmholtzEOSMixtureBackend::calc_cpmolar_idealgas(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_cpmolar_idealgas(void)
 {
     // Calculate the reducing parameters
     _delta = _rhomolar/_reducing.rhomolar;
     _tau = _reducing.T/_T;
 
     // Calculate derivatives if needed, or just use cached values
-    long double d2a0_dTau2 = d2alpha0_dTau2();
-    long double R_u = gas_constant();
+    CoolPropDbl d2a0_dTau2 = d2alpha0_dTau2();
+    CoolPropDbl R_u = gas_constant();
 
     // Get cp of the ideal gas
     return R_u*(1+(-pow(_tau.pt(),2))*d2a0_dTau2);
 }
-long double HelmholtzEOSMixtureBackend::calc_speed_sound(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_speed_sound(void)
 {
     // Calculate the reducing parameters
     _delta = _rhomolar/_reducing.rhomolar;
     _tau = _reducing.T/_T;
 
     // Calculate derivatives if needed, or just use cached values
-    long double d2a0_dTau2 = d2alpha0_dTau2();
-    long double dar_dDelta = dalphar_dDelta();
-    long double d2ar_dDelta2 = d2alphar_dDelta2();
-    long double d2ar_dDelta_dTau = d2alphar_dDelta_dTau();
-    long double d2ar_dTau2 = d2alphar_dTau2();
-    long double R_u = gas_constant();
-    long double mm = molar_mass();
+    CoolPropDbl d2a0_dTau2 = d2alpha0_dTau2();
+    CoolPropDbl dar_dDelta = dalphar_dDelta();
+    CoolPropDbl d2ar_dDelta2 = d2alphar_dDelta2();
+    CoolPropDbl d2ar_dDelta_dTau = d2alphar_dDelta_dTau();
+    CoolPropDbl d2ar_dTau2 = d2alphar_dTau2();
+    CoolPropDbl R_u = gas_constant();
+    CoolPropDbl mm = molar_mass();
 
     // Get speed of sound
     _speed_sound = sqrt(R_u*_T/mm*(1+2*_delta.pt()*dar_dDelta+pow(_delta.pt(),2)*d2ar_dDelta2 - pow(1+_delta.pt()*dar_dDelta-_delta.pt()*_tau.pt()*d2ar_dDelta_dTau,2)/(pow(_tau.pt(),2)*(d2ar_dTau2 + d2a0_dTau2))));
 
     return static_cast<double>(_speed_sound);
 }
-long double HelmholtzEOSMixtureBackend::calc_gibbsmolar(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_gibbsmolar(void)
 {
     if (isTwoPhase())
     {
         _gibbsmolar = _Q*SatV->gibbsmolar() + (1 - _Q)*SatL->gibbsmolar();
-        return static_cast<long double>(_gibbsmolar);
+        return static_cast<CoolPropDbl>(_gibbsmolar);
     }
     else if (isHomogeneousPhase())
     {
@@ -2212,31 +2212,31 @@ long double HelmholtzEOSMixtureBackend::calc_gibbsmolar(void)
         _tau = _reducing.T/_T;
 
         // Calculate derivatives if needed, or just use cached values
-        long double ar = alphar();
-        long double a0 = alpha0();
-        long double dar_dDelta = dalphar_dDelta();
-        long double R_u = gas_constant();
+        CoolPropDbl ar = alphar();
+        CoolPropDbl a0 = alpha0();
+        CoolPropDbl dar_dDelta = dalphar_dDelta();
+        CoolPropDbl R_u = gas_constant();
 
         // Get molar gibbs function
         _gibbsmolar = R_u*_T*(1 + a0 + ar +_delta.pt()*dar_dDelta);
 
-        return static_cast<long double>(_gibbsmolar);
+        return static_cast<CoolPropDbl>(_gibbsmolar);
     }
     else{
         throw ValueError(format("phase is invalid in calc_gibbsmolar"));
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_fugacity_coefficient(int i)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_fugacity_coefficient(int i)
 {
     x_N_dependency_flag xN_flag = XN_DEPENDENT;
     return exp(MixtureDerivatives::ln_fugacity_coefficient(*this, i, xN_flag));
 }
-long double HelmholtzEOSMixtureBackend::calc_phase_identification_parameter(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_phase_identification_parameter(void)
 {
     return 2 - rhomolar()*(second_partial_deriv(iP, iDmolar, iT, iT, iDmolar)/first_partial_deriv(iP, iT, iDmolar) -  second_partial_deriv(iP, iDmolar, iT, iDmolar, iT)/first_partial_deriv(iP, iDmolar, iT));
 }
 
-SimpleState HelmholtzEOSMixtureBackend::calc_reducing_state_nocache(const std::vector<long double> & mole_fractions)
+SimpleState HelmholtzEOSMixtureBackend::calc_reducing_state_nocache(const std::vector<CoolPropDbl> & mole_fractions)
 {
     SimpleState reducing;
     if (is_pure_or_pseudopure){
@@ -2255,7 +2255,7 @@ void HelmholtzEOSMixtureBackend::calc_reducing_state(void)
     _reducing = calc_reducing_state_nocache(mole_fractions);
     _crit = _reducing;
 }
-void HelmholtzEOSMixtureBackend::calc_all_alphar_deriv_cache(const std::vector<long double> &mole_fractions, const long double &tau, const long double &delta)
+void HelmholtzEOSMixtureBackend::calc_all_alphar_deriv_cache(const std::vector<CoolPropDbl> &mole_fractions, const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
     deriv_counter++;
     //std::cout << ".";
@@ -2274,11 +2274,11 @@ void HelmholtzEOSMixtureBackend::calc_all_alphar_deriv_cache(const std::vector<l
     }
     else{
         std::size_t N = mole_fractions.size();
-        long double summer_base = 0, summer_dTau = 0, summer_dDelta = 0, 
+        CoolPropDbl summer_base = 0, summer_dTau = 0, summer_dDelta = 0, 
                     summer_dTau2 = 0, summer_dDelta2 = 0, summer_dDelta_dTau = 0;
         for (std::size_t i = 0; i < N; ++i){
             HelmholtzDerivatives derivs = components[i]->pEOS->alphar.all(tau, delta);
-            long double xi = mole_fractions[i];
+            CoolPropDbl xi = mole_fractions[i];
             
             summer_base += xi*derivs.alphar;
             summer_dDelta += xi*derivs.dalphar_ddelta;
@@ -2296,7 +2296,7 @@ void HelmholtzEOSMixtureBackend::calc_all_alphar_deriv_cache(const std::vector<l
     }
 }
 
-long double HelmholtzEOSMixtureBackend::calc_alphar_deriv_nocache(const int nTau, const int nDelta, const std::vector<long double> &mole_fractions, const long double &tau, const long double &delta)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_alphar_deriv_nocache(const int nTau, const int nDelta, const std::vector<CoolPropDbl> &mole_fractions, const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
     if (is_pure_or_pseudopure)
     {
@@ -2338,7 +2338,7 @@ long double HelmholtzEOSMixtureBackend::calc_alphar_deriv_nocache(const int nTau
     else{
 
         std::size_t N = mole_fractions.size();
-        long double summer = 0;
+        CoolPropDbl summer = 0;
         if (nTau == 0 && nDelta == 0){
             for (unsigned int i = 0; i < N; ++i){ summer += mole_fractions[i]*components[i]->pEOS->baser(tau, delta); }
             return summer + Excess.alphar(tau, delta, mole_fractions);
@@ -2385,10 +2385,10 @@ long double HelmholtzEOSMixtureBackend::calc_alphar_deriv_nocache(const int nTau
         }
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_alpha0_deriv_nocache(const int nTau, const int nDelta, const std::vector<long double> &mole_fractions,
-                                                                  const long double &tau, const long double &delta, const long double &Tr, const long double &rhor)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_alpha0_deriv_nocache(const int nTau, const int nDelta, const std::vector<CoolPropDbl> &mole_fractions,
+                                                                  const CoolPropDbl &tau, const CoolPropDbl &delta, const CoolPropDbl &Tr, const CoolPropDbl &rhor)
 {
-    long double val;
+    CoolPropDbl val;
     if (is_pure_or_pseudopure)
     {
         if (nTau == 0 && nDelta == 0){
@@ -2436,8 +2436,8 @@ long double HelmholtzEOSMixtureBackend::calc_alpha0_deriv_nocache(const int nTau
     else{
         // See Table B5, GERG 2008 from Kunz Wagner, JCED, 2012
         std::size_t N = mole_fractions.size();
-        long double summer = 0;
-        long double tau_i, delta_i, rho_ci, T_ci;
+        CoolPropDbl summer = 0;
+        CoolPropDbl tau_i, delta_i, rho_ci, T_ci;
         for (unsigned int i = 0; i < N; ++i){
             rho_ci = components[i]->pEOS->reduce.rhomolar;
             T_ci = components[i]->pEOS->reduce.T;
@@ -2470,110 +2470,110 @@ long double HelmholtzEOSMixtureBackend::calc_alpha0_deriv_nocache(const int nTau
         return summer;
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_alphar(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_alphar(void)
 {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
-    return static_cast<long double>(_alphar);
+    return static_cast<CoolPropDbl>(_alphar);
 }
-long double HelmholtzEOSMixtureBackend::calc_dalphar_dDelta(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_dalphar_dDelta(void)
 {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
-    return static_cast<long double>(_dalphar_dDelta);
+    return static_cast<CoolPropDbl>(_dalphar_dDelta);
 }
-long double HelmholtzEOSMixtureBackend::calc_dalphar_dTau(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_dalphar_dTau(void)
 {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
-    return static_cast<long double>(_dalphar_dTau);
+    return static_cast<CoolPropDbl>(_dalphar_dTau);
 }
-long double HelmholtzEOSMixtureBackend::calc_d2alphar_dTau2(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alphar_dTau2(void)
 {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
-    return static_cast<long double>(_d2alphar_dTau2);
+    return static_cast<CoolPropDbl>(_d2alphar_dTau2);
 }
-long double HelmholtzEOSMixtureBackend::calc_d2alphar_dDelta_dTau(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alphar_dDelta_dTau(void)
 {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
-    return static_cast<long double>(_d2alphar_dDelta_dTau);
+    return static_cast<CoolPropDbl>(_d2alphar_dDelta_dTau);
 }
-long double HelmholtzEOSMixtureBackend::calc_d2alphar_dDelta2(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alphar_dDelta2(void)
 {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
-    return static_cast<long double>(_d2alphar_dDelta2);
+    return static_cast<CoolPropDbl>(_d2alphar_dDelta2);
 }
-long double HelmholtzEOSMixtureBackend::calc_d3alphar_dDelta3(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alphar_dDelta3(void)
 {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
-    return static_cast<long double>(_d3alphar_dDelta3);
+    return static_cast<CoolPropDbl>(_d3alphar_dDelta3);
 }
-long double HelmholtzEOSMixtureBackend::calc_d3alphar_dDelta2_dTau(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alphar_dDelta2_dTau(void)
 {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
-    return static_cast<long double>(_d3alphar_dDelta2_dTau);
+    return static_cast<CoolPropDbl>(_d3alphar_dDelta2_dTau);
 }
-long double HelmholtzEOSMixtureBackend::calc_d3alphar_dDelta_dTau2(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alphar_dDelta_dTau2(void)
 {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
-    return static_cast<long double>(_d3alphar_dDelta_dTau2);
+    return static_cast<CoolPropDbl>(_d3alphar_dDelta_dTau2);
 }
-long double HelmholtzEOSMixtureBackend::calc_d3alphar_dTau3(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alphar_dTau3(void)
 {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
-    return static_cast<long double>(_d3alphar_dTau3);
+    return static_cast<CoolPropDbl>(_d3alphar_dTau3);
 }
-long double HelmholtzEOSMixtureBackend::calc_alpha0(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_alpha0(void)
 {
     const int nTau = 0, nDelta = 0;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-long double HelmholtzEOSMixtureBackend::calc_dalpha0_dDelta(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_dalpha0_dDelta(void)
 {
     const int nTau = 0, nDelta = 1;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-long double HelmholtzEOSMixtureBackend::calc_dalpha0_dTau(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_dalpha0_dTau(void)
 {
     const int nTau = 1, nDelta = 0;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-long double HelmholtzEOSMixtureBackend::calc_d2alpha0_dDelta2(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alpha0_dDelta2(void)
 {
     const int nTau = 0, nDelta = 2;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-long double HelmholtzEOSMixtureBackend::calc_d2alpha0_dDelta_dTau(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alpha0_dDelta_dTau(void)
 {
     const int nTau = 1, nDelta = 1;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-long double HelmholtzEOSMixtureBackend::calc_d2alpha0_dTau2(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alpha0_dTau2(void)
 {
     const int nTau = 2, nDelta = 0;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-long double HelmholtzEOSMixtureBackend::calc_d3alpha0_dDelta3(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alpha0_dDelta3(void)
 {
     const int nTau = 0, nDelta = 3;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-long double HelmholtzEOSMixtureBackend::calc_d3alpha0_dDelta2_dTau(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alpha0_dDelta2_dTau(void)
 {
     const int nTau = 1, nDelta = 2;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-long double HelmholtzEOSMixtureBackend::calc_d3alpha0_dDelta_dTau2(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alpha0_dDelta_dTau2(void)
 {
     const int nTau = 2, nDelta = 1;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-long double HelmholtzEOSMixtureBackend::calc_d3alpha0_dTau3(void)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alpha0_dTau3(void)
 {
     const int nTau = 3, nDelta = 0;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-long double HelmholtzEOSMixtureBackend::calc_first_saturation_deriv(parameters Of1, parameters Wrt1, HelmholtzEOSMixtureBackend &SatL, HelmholtzEOSMixtureBackend &SatV)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_first_saturation_deriv(parameters Of1, parameters Wrt1, HelmholtzEOSMixtureBackend &SatL, HelmholtzEOSMixtureBackend &SatV)
 {
 	// Derivative of temperature w.r.t. pressure ALONG the saturation curve
-	long double dTdP_sat = T()*(1/SatV.rhomolar()-1/SatL.rhomolar())/(SatV.hmolar()-SatL.hmolar());
+	CoolPropDbl dTdP_sat = T()*(1/SatV.rhomolar()-1/SatL.rhomolar())/(SatV.hmolar()-SatL.hmolar());
 	
 	// "Trivial" inputs
 	if (Of1 == iT && Wrt1 == iP){ return dTdP_sat;}
@@ -2590,10 +2590,10 @@ long double HelmholtzEOSMixtureBackend::calc_first_saturation_deriv(parameters O
 		throw ValueError(format("Not possible to take first saturation derivative with respect to %s", get_parameter_information(Wrt1,"short").c_str()));
 	}
 }
-long double HelmholtzEOSMixtureBackend::calc_first_saturation_deriv(parameters Of1, parameters Wrt1)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_first_saturation_deriv(parameters Of1, parameters Wrt1)
 {
 	// Derivative of temperature w.r.t. pressure ALONG the saturation curve
-	long double dTdP_sat = T()*(1/SatV->rhomolar()-1/SatL->rhomolar())/(SatV->hmolar()-SatL->hmolar());
+	CoolPropDbl dTdP_sat = T()*(1/SatV->rhomolar()-1/SatL->rhomolar())/(SatV->hmolar()-SatL->hmolar());
 	
 	// "Trivial" inputs
 	if (Of1 == iT && Wrt1 == iP){ return dTdP_sat;}
@@ -2610,26 +2610,26 @@ long double HelmholtzEOSMixtureBackend::calc_first_saturation_deriv(parameters O
 		throw ValueError(format("Not possible to take first saturation derivative with respect to %s", get_parameter_information(Wrt1,"short").c_str()));
 	}
 }
-long double HelmholtzEOSMixtureBackend::calc_second_saturation_deriv(parameters Of1, parameters Wrt1, parameters Of2, parameters Wrt2)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_second_saturation_deriv(parameters Of1, parameters Wrt1, parameters Of2, parameters Wrt2)
 {
 	if (Wrt1 == iP && Wrt2 == iP){
 		if (Of1 != Of2){ throw ValueError(format("Currently, only possible to take second saturation derivative of y both times (d2ydx2)"));}
-		long double dydT_constp = this->first_partial_deriv(Of1, iT, iP);
-		long double d2ydTdp = this->second_partial_deriv(Of1, iT, iP, iP, iT);
-		long double d2ydp2_constT = this->second_partial_deriv(Of1, iP, iT, iP, iT);
-		long double d2ydT2_constp = this->second_partial_deriv(Of1, iT, iP, iT, iP);
+		CoolPropDbl dydT_constp = this->first_partial_deriv(Of1, iT, iP);
+		CoolPropDbl d2ydTdp = this->second_partial_deriv(Of1, iT, iP, iP, iT);
+		CoolPropDbl d2ydp2_constT = this->second_partial_deriv(Of1, iP, iT, iP, iT);
+		CoolPropDbl d2ydT2_constp = this->second_partial_deriv(Of1, iT, iP, iT, iP);
 		
-		long double dTdp_along_sat = calc_first_saturation_deriv(iT, iP);
-		long double dvdrhoL = -1/POW2(SatL->rhomolar());
-		long double dvdrhoV = -1/POW2(SatV->rhomolar());
-		long double DELTAv = 1/SatV->rhomolar()-1/SatL->rhomolar();
-		long double dDELTAv_dT_constp = dvdrhoV*SatV->first_partial_deriv(iDmolar, iT, iP)-dvdrhoL*SatL->first_partial_deriv(iDmolar, iT, iP);
-		long double dDELTAv_dp_constT = dvdrhoV*SatV->first_partial_deriv(iDmolar, iP, iT)-dvdrhoL*SatL->first_partial_deriv(iDmolar, iP, iT);
-		long double DELTAh = SatV->hmolar()-SatL->hmolar();
-		long double dDELTAh_dT_constp = SatV->first_partial_deriv(iHmolar, iT, iP)-SatL->first_partial_deriv(iHmolar, iT, iP);
-		long double dDELTAh_dp_constT = SatV->first_partial_deriv(iHmolar, iP, iT)-SatL->first_partial_deriv(iHmolar, iP, iT);
-		long double ddT_dTdp_along_sat_constp = (DELTAh*(_T*dDELTAv_dT_constp+DELTAv)-_T*DELTAv*dDELTAh_dT_constp)/POW2(DELTAh);
-		long double ddp_dTdp_along_sat_constT = (DELTAh*(_T*dDELTAv_dp_constT)-_T*DELTAv*dDELTAh_dp_constT)/POW2(DELTAh);
+		CoolPropDbl dTdp_along_sat = calc_first_saturation_deriv(iT, iP);
+		CoolPropDbl dvdrhoL = -1/POW2(SatL->rhomolar());
+		CoolPropDbl dvdrhoV = -1/POW2(SatV->rhomolar());
+		CoolPropDbl DELTAv = 1/SatV->rhomolar()-1/SatL->rhomolar();
+		CoolPropDbl dDELTAv_dT_constp = dvdrhoV*SatV->first_partial_deriv(iDmolar, iT, iP)-dvdrhoL*SatL->first_partial_deriv(iDmolar, iT, iP);
+		CoolPropDbl dDELTAv_dp_constT = dvdrhoV*SatV->first_partial_deriv(iDmolar, iP, iT)-dvdrhoL*SatL->first_partial_deriv(iDmolar, iP, iT);
+		CoolPropDbl DELTAh = SatV->hmolar()-SatL->hmolar();
+		CoolPropDbl dDELTAh_dT_constp = SatV->first_partial_deriv(iHmolar, iT, iP)-SatL->first_partial_deriv(iHmolar, iT, iP);
+		CoolPropDbl dDELTAh_dp_constT = SatV->first_partial_deriv(iHmolar, iP, iT)-SatL->first_partial_deriv(iHmolar, iP, iT);
+		CoolPropDbl ddT_dTdp_along_sat_constp = (DELTAh*(_T*dDELTAv_dT_constp+DELTAv)-_T*DELTAv*dDELTAh_dT_constp)/POW2(DELTAh);
+		CoolPropDbl ddp_dTdp_along_sat_constT = (DELTAh*(_T*dDELTAv_dp_constT)-_T*DELTAv*dDELTAh_dp_constT)/POW2(DELTAh);
 		
 		double ddp_dydpsigma = d2ydp2_constT + dydT_constp*ddp_dTdp_along_sat_constT + d2ydTdp*dTdp_along_sat;
 		double ddT_dydpsigma = d2ydTdp + dydT_constp*ddT_dTdp_along_sat_constp + d2ydT2_constp*dTdp_along_sat;
@@ -2640,50 +2640,50 @@ long double HelmholtzEOSMixtureBackend::calc_second_saturation_deriv(parameters 
 	}
 }
 
-long double HelmholtzEOSMixtureBackend::calc_second_two_phase_deriv(parameters Of, parameters Wrt1, parameters Constant1, parameters Wrt2, parameters Constant2)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_second_two_phase_deriv(parameters Of, parameters Wrt1, parameters Constant1, parameters Wrt2, parameters Constant2)
 {
     if (Of == iDmolar && ((Wrt1 == iHmolar && Constant1 == iP && Wrt2 == iP && Constant2 == iHmolar) || (Wrt2 == iHmolar && Constant2 == iP && Wrt1 == iP && Constant1 == iHmolar))){
         parameters h_key = iHmolar, rho_key = iDmolar, p_key = iP;
         // taking the derivative of (drho/dv)*(dv/dh|p) with respect to p with h constant
-        long double dv_dh_constp = calc_first_two_phase_deriv(rho_key,h_key,p_key)/(-POW2(rhomolar()));
-        long double drhomolar_dp__consth = first_two_phase_deriv(rho_key, p_key, h_key);
+        CoolPropDbl dv_dh_constp = calc_first_two_phase_deriv(rho_key,h_key,p_key)/(-POW2(rhomolar()));
+        CoolPropDbl drhomolar_dp__consth = first_two_phase_deriv(rho_key, p_key, h_key);
         
         // Calculate the derivative of dvdh|p with respect to p at constant h
-        long double dhL_dp_sat =  SatL->calc_first_saturation_deriv(h_key, p_key, *SatL, *SatV);
-        long double dhV_dp_sat =  SatV->calc_first_saturation_deriv(h_key, p_key, *SatL, *SatV);
-        long double drhoL_dp_sat =  SatL->calc_first_saturation_deriv(rho_key, p_key, *SatL, *SatV);
-        long double drhoV_dp_sat =  SatV->calc_first_saturation_deriv(rho_key, p_key, *SatL, *SatV);
-        long double numerator = 1/SatV->keyed_output(rho_key) - 1/SatL->keyed_output(rho_key);
-        long double denominator = SatV->keyed_output(h_key) - SatL->keyed_output(h_key);
-        long double dnumerator = -1/POW2(SatV->keyed_output(rho_key))*drhoV_dp_sat + 1/POW2(SatL->keyed_output(rho_key))*drhoL_dp_sat;
-        long double ddenominator = dhV_dp_sat - dhL_dp_sat;
-        long double d_dvdh_dp__consth = (denominator*dnumerator - numerator*ddenominator)/POW2(denominator);
+        CoolPropDbl dhL_dp_sat =  SatL->calc_first_saturation_deriv(h_key, p_key, *SatL, *SatV);
+        CoolPropDbl dhV_dp_sat =  SatV->calc_first_saturation_deriv(h_key, p_key, *SatL, *SatV);
+        CoolPropDbl drhoL_dp_sat =  SatL->calc_first_saturation_deriv(rho_key, p_key, *SatL, *SatV);
+        CoolPropDbl drhoV_dp_sat =  SatV->calc_first_saturation_deriv(rho_key, p_key, *SatL, *SatV);
+        CoolPropDbl numerator = 1/SatV->keyed_output(rho_key) - 1/SatL->keyed_output(rho_key);
+        CoolPropDbl denominator = SatV->keyed_output(h_key) - SatL->keyed_output(h_key);
+        CoolPropDbl dnumerator = -1/POW2(SatV->keyed_output(rho_key))*drhoV_dp_sat + 1/POW2(SatL->keyed_output(rho_key))*drhoL_dp_sat;
+        CoolPropDbl ddenominator = dhV_dp_sat - dhL_dp_sat;
+        CoolPropDbl d_dvdh_dp__consth = (denominator*dnumerator - numerator*ddenominator)/POW2(denominator);
         return -POW2(rhomolar())*d_dvdh_dp__consth + dv_dh_constp*(-2*rhomolar())*drhomolar_dp__consth;
     }
     else if (Of == iDmass && ((Wrt1 == iHmass && Constant1 == iP && Wrt2 == iP && Constant2 == iHmass) || (Wrt2 == iHmass && Constant2 == iP && Wrt1 == iP && Constant1 == iHmass))){
         parameters h_key = iHmass, rho_key = iDmass, p_key = iP;
-        long double rho = keyed_output(rho_key);
+        CoolPropDbl rho = keyed_output(rho_key);
         // taking the derivative of (drho/dv)*(dv/dh|p) with respect to p with h constant
-        long double dv_dh_constp = calc_first_two_phase_deriv(rho_key,h_key,p_key)/(-POW2(rho));
-        long double drho_dp__consth = first_two_phase_deriv(rho_key, p_key, h_key);
+        CoolPropDbl dv_dh_constp = calc_first_two_phase_deriv(rho_key,h_key,p_key)/(-POW2(rho));
+        CoolPropDbl drho_dp__consth = first_two_phase_deriv(rho_key, p_key, h_key);
         
         // Calculate the derivative of dvdh|p with respect to p at constant h
-        long double dhL_dp_sat =  SatL->calc_first_saturation_deriv(h_key, p_key, *SatL, *SatV);
-        long double dhV_dp_sat =  SatV->calc_first_saturation_deriv(h_key, p_key, *SatL, *SatV);
-        long double drhoL_dp_sat =  SatL->calc_first_saturation_deriv(rho_key, p_key, *SatL, *SatV);
-        long double drhoV_dp_sat =  SatV->calc_first_saturation_deriv(rho_key, p_key, *SatL, *SatV);
-        long double numerator = 1/SatV->keyed_output(rho_key) - 1/SatL->keyed_output(rho_key);
-        long double denominator = SatV->keyed_output(h_key) - SatL->keyed_output(h_key);
-        long double dnumerator = -1/POW2(SatV->keyed_output(rho_key))*drhoV_dp_sat + 1/POW2(SatL->keyed_output(rho_key))*drhoL_dp_sat;
-        long double ddenominator = dhV_dp_sat - dhL_dp_sat;
-        long double d_dvdh_dp__consth = (denominator*dnumerator - numerator*ddenominator)/POW2(denominator);
+        CoolPropDbl dhL_dp_sat =  SatL->calc_first_saturation_deriv(h_key, p_key, *SatL, *SatV);
+        CoolPropDbl dhV_dp_sat =  SatV->calc_first_saturation_deriv(h_key, p_key, *SatL, *SatV);
+        CoolPropDbl drhoL_dp_sat =  SatL->calc_first_saturation_deriv(rho_key, p_key, *SatL, *SatV);
+        CoolPropDbl drhoV_dp_sat =  SatV->calc_first_saturation_deriv(rho_key, p_key, *SatL, *SatV);
+        CoolPropDbl numerator = 1/SatV->keyed_output(rho_key) - 1/SatL->keyed_output(rho_key);
+        CoolPropDbl denominator = SatV->keyed_output(h_key) - SatL->keyed_output(h_key);
+        CoolPropDbl dnumerator = -1/POW2(SatV->keyed_output(rho_key))*drhoV_dp_sat + 1/POW2(SatL->keyed_output(rho_key))*drhoL_dp_sat;
+        CoolPropDbl ddenominator = dhV_dp_sat - dhL_dp_sat;
+        CoolPropDbl d_dvdh_dp__consth = (denominator*dnumerator - numerator*ddenominator)/POW2(denominator);
         return -POW2(rho)*d_dvdh_dp__consth + dv_dh_constp*(-2*rho)*drho_dp__consth;
     }
     else{
         throw ValueError();
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_first_two_phase_deriv(parameters Of, parameters Wrt, parameters Constant)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_first_two_phase_deriv(parameters Of, parameters Wrt, parameters Constant)
 {
     if (Of == iDmolar && Wrt == iHmolar && Constant == iP){
         return -POW2(rhomolar())*(1/SatV->rhomolar() - 1/SatL->rhomolar())/(SatV->hmolar() - SatL->hmolar());
@@ -2693,33 +2693,33 @@ long double HelmholtzEOSMixtureBackend::calc_first_two_phase_deriv(parameters Of
     }
     else if (Of == iDmolar && Wrt == iP && Constant == iHmolar){
         // v = 1/rho; dvdrho = -rho^2; dvdrho = -1/rho^2
-        long double dvdrhoL = -1/POW2(SatL->rhomolar());
-        long double dvdrhoV = -1/POW2(SatV->rhomolar());
-        long double dvL_dp = dvdrhoL*SatL->calc_first_saturation_deriv(iDmolar, iP, *SatL, *SatV);
-        long double dvV_dp = dvdrhoV*SatV->calc_first_saturation_deriv(iDmolar, iP, *SatL, *SatV); 
-        long double dhL_dp = SatL->calc_first_saturation_deriv(iHmolar, iP, *SatL, *SatV);
-        long double dhV_dp = SatV->calc_first_saturation_deriv(iHmolar, iP, *SatL, *SatV);
-        long double dxdp_h = (Q()*dhV_dp + (1 - Q())*dhL_dp)/(SatL->hmolar() - SatV->hmolar());
-        long double dvdp_h = dvL_dp + dxdp_h*(1/SatV->rhomolar() - 1/SatL->rhomolar()) + Q()*(dvV_dp - dvL_dp);
+        CoolPropDbl dvdrhoL = -1/POW2(SatL->rhomolar());
+        CoolPropDbl dvdrhoV = -1/POW2(SatV->rhomolar());
+        CoolPropDbl dvL_dp = dvdrhoL*SatL->calc_first_saturation_deriv(iDmolar, iP, *SatL, *SatV);
+        CoolPropDbl dvV_dp = dvdrhoV*SatV->calc_first_saturation_deriv(iDmolar, iP, *SatL, *SatV); 
+        CoolPropDbl dhL_dp = SatL->calc_first_saturation_deriv(iHmolar, iP, *SatL, *SatV);
+        CoolPropDbl dhV_dp = SatV->calc_first_saturation_deriv(iHmolar, iP, *SatL, *SatV);
+        CoolPropDbl dxdp_h = (Q()*dhV_dp + (1 - Q())*dhL_dp)/(SatL->hmolar() - SatV->hmolar());
+        CoolPropDbl dvdp_h = dvL_dp + dxdp_h*(1/SatV->rhomolar() - 1/SatL->rhomolar()) + Q()*(dvV_dp - dvL_dp);
         return -POW2(rhomolar())*dvdp_h;
     }
     else if (Of == iDmass && Wrt == iP && Constant == iHmass){
         // v = 1/rho; dvdrho = -rho^2; dvdrho = -1/rho^2
-        long double dvdrhoL = -1/POW2(SatL->rhomass());
-        long double dvdrhoV = -1/POW2(SatV->rhomass());
-        long double dvL_dp = dvdrhoL*SatL->calc_first_saturation_deriv(iDmass, iP, *SatL, *SatV);
-        long double dvV_dp = dvdrhoV*SatV->calc_first_saturation_deriv(iDmass, iP, *SatL, *SatV); 
-        long double dhL_dp = SatL->calc_first_saturation_deriv(iHmass, iP, *SatL, *SatV);
-        long double dhV_dp = SatV->calc_first_saturation_deriv(iHmass, iP, *SatL, *SatV);
-        long double dxdp_h = (Q()*dhV_dp + (1 - Q())*dhL_dp)/(SatL->hmass() - SatV->hmass());
-        long double dvdp_h = dvL_dp + dxdp_h*(1/SatV->rhomass() - 1/SatL->rhomass()) + Q()*(dvV_dp - dvL_dp);
+        CoolPropDbl dvdrhoL = -1/POW2(SatL->rhomass());
+        CoolPropDbl dvdrhoV = -1/POW2(SatV->rhomass());
+        CoolPropDbl dvL_dp = dvdrhoL*SatL->calc_first_saturation_deriv(iDmass, iP, *SatL, *SatV);
+        CoolPropDbl dvV_dp = dvdrhoV*SatV->calc_first_saturation_deriv(iDmass, iP, *SatL, *SatV); 
+        CoolPropDbl dhL_dp = SatL->calc_first_saturation_deriv(iHmass, iP, *SatL, *SatV);
+        CoolPropDbl dhV_dp = SatV->calc_first_saturation_deriv(iHmass, iP, *SatL, *SatV);
+        CoolPropDbl dxdp_h = (Q()*dhV_dp + (1 - Q())*dhL_dp)/(SatL->hmass() - SatV->hmass());
+        CoolPropDbl dvdp_h = dvL_dp + dxdp_h*(1/SatV->rhomass() - 1/SatL->rhomass()) + Q()*(dvV_dp - dvL_dp);
         return -POW2(rhomass())*dvdp_h;
     }
     else{
         throw ValueError("These inputs are not supported to calc_first_two_phase_deriv");
     }
 }
-long double HelmholtzEOSMixtureBackend::calc_first_two_phase_deriv_splined(parameters Of, parameters Wrt, parameters Constant, long double x_end)
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_first_two_phase_deriv_splined(parameters Of, parameters Wrt, parameters Constant, CoolPropDbl x_end)
 {
     shared_ptr<HelmholtzEOSMixtureBackend> Liq(new HelmholtzEOSMixtureBackend(this->get_components())), 
                                            End(new HelmholtzEOSMixtureBackend(this->get_components()));
@@ -2739,27 +2739,27 @@ long double HelmholtzEOSMixtureBackend::calc_first_two_phase_deriv_splined(param
             rho_key = iDmolar; h_key = iHmolar; p_key = iP;
         }
         
-        long double Delta = Q()*(SatV->keyed_output(h_key) - SatL->keyed_output(h_key));
-        long double Delta_end = End->keyed_output(h_key) - SatL->keyed_output(h_key);
+        CoolPropDbl Delta = Q()*(SatV->keyed_output(h_key) - SatL->keyed_output(h_key));
+        CoolPropDbl Delta_end = End->keyed_output(h_key) - SatL->keyed_output(h_key);
         
         // At the end of the zone to which spline is applied
-        long double drho_dh_end = End->calc_first_two_phase_deriv(rho_key, h_key, p_key);
-        long double rho_end = End->keyed_output(rho_key);
+        CoolPropDbl drho_dh_end = End->calc_first_two_phase_deriv(rho_key, h_key, p_key);
+        CoolPropDbl rho_end = End->keyed_output(rho_key);
         
         // Faking single-phase
-        long double rho_liq = Liq->keyed_output(rho_key);
-        long double drho_dh_liq__constp = Liq->first_partial_deriv(rho_key, h_key, p_key);
+        CoolPropDbl rho_liq = Liq->keyed_output(rho_key);
+        CoolPropDbl drho_dh_liq__constp = Liq->first_partial_deriv(rho_key, h_key, p_key);
         
         // Spline coordinates a, b, c, d
-        long double Abracket = (2*rho_liq - 2*rho_end + Delta_end * (drho_dh_liq__constp + drho_dh_end));
-        long double a = 1/POW3(Delta_end) * Abracket;
-        long double b = 3/POW2(Delta_end) * (-rho_liq + rho_end) - 1/Delta_end * (drho_dh_end + 2 * drho_dh_liq__constp);
-        long double c = drho_dh_liq__constp;
-        long double d = rho_liq;
+        CoolPropDbl Abracket = (2*rho_liq - 2*rho_end + Delta_end * (drho_dh_liq__constp + drho_dh_end));
+        CoolPropDbl a = 1/POW3(Delta_end) * Abracket;
+        CoolPropDbl b = 3/POW2(Delta_end) * (-rho_liq + rho_end) - 1/Delta_end * (drho_dh_end + 2 * drho_dh_liq__constp);
+        CoolPropDbl c = drho_dh_liq__constp;
+        CoolPropDbl d = rho_liq;
         
         // Either the spline value or drho/dh|p can be directly evaluated now
-        long double rho_spline = a*POW3(Delta) + b*POW2(Delta) + c*Delta + d;
-        long double d_rho_spline_dh__constp = 3*a*POW2(Delta) + 2*b*Delta + c;
+        CoolPropDbl rho_spline = a*POW3(Delta) + b*POW2(Delta) + c*Delta + d;
+        CoolPropDbl d_rho_spline_dh__constp = 3*a*POW2(Delta) + 2*b*Delta + c;
         if ((Wrt == iDmass || Wrt == iDmolar) && (Constant == iDmass || Constant == iDmolar)){
             return rho_spline;
         }
@@ -2771,45 +2771,45 @@ long double HelmholtzEOSMixtureBackend::calc_first_two_phase_deriv_splined(param
         // ... calculate some more things
         
         // At the saturated state
-        long double rhoL =  SatL->keyed_output(rho_key);
-        long double rhoV =  SatV->keyed_output(rho_key);
-        long double hL =  SatL->keyed_output(h_key);
-        long double hV =  SatV->keyed_output(h_key);
+        CoolPropDbl rhoL =  SatL->keyed_output(rho_key);
+        CoolPropDbl rhoV =  SatV->keyed_output(rho_key);
+        CoolPropDbl hL =  SatL->keyed_output(h_key);
+        CoolPropDbl hV =  SatV->keyed_output(h_key);
         
         // Derivatives *along* the saturation curve using the special internal method
-        long double dhL_dp_sat =  SatL->calc_first_saturation_deriv(h_key, p_key, *SatL, *SatV);
-        long double dhV_dp_sat =  SatV->calc_first_saturation_deriv(h_key, p_key, *SatL, *SatV);
-        long double drhoL_dp_sat = SatL->calc_first_saturation_deriv(rho_key, p_key, *SatL, *SatV);
-        long double drhoV_dp_sat = SatV->calc_first_saturation_deriv(rho_key, p_key, *SatL, *SatV);
+        CoolPropDbl dhL_dp_sat =  SatL->calc_first_saturation_deriv(h_key, p_key, *SatL, *SatV);
+        CoolPropDbl dhV_dp_sat =  SatV->calc_first_saturation_deriv(h_key, p_key, *SatL, *SatV);
+        CoolPropDbl drhoL_dp_sat = SatL->calc_first_saturation_deriv(rho_key, p_key, *SatL, *SatV);
+        CoolPropDbl drhoV_dp_sat = SatV->calc_first_saturation_deriv(rho_key, p_key, *SatL, *SatV);
         
-        long double drho_dp_end = POW2(End->keyed_output(rho_key))*(x_end/POW2(rhoV)*drhoV_dp_sat + (1-x_end)/POW2(rhoL)*drhoL_dp_sat);
+        CoolPropDbl drho_dp_end = POW2(End->keyed_output(rho_key))*(x_end/POW2(rhoV)*drhoV_dp_sat + (1-x_end)/POW2(rhoL)*drhoL_dp_sat);
         
         // Faking single-phase
-        long double drho_dp__consth_liq = Liq->first_partial_deriv(rho_key, p_key, h_key);
-        long double d2rhodhdp_liq = Liq->second_partial_deriv(rho_key, h_key, p_key, p_key, h_key); // ?
+        CoolPropDbl drho_dp__consth_liq = Liq->first_partial_deriv(rho_key, p_key, h_key);
+        CoolPropDbl d2rhodhdp_liq = Liq->second_partial_deriv(rho_key, h_key, p_key, p_key, h_key); // ?
         
         // Derivatives at the end point
-        long double drho_dp__consth_end = End->calc_first_two_phase_deriv(rho_key, p_key, h_key);
-        long double d2rhodhdp_end = End->calc_second_two_phase_deriv(rho_key, h_key, p_key, p_key, h_key);
+        CoolPropDbl drho_dp__consth_end = End->calc_first_two_phase_deriv(rho_key, p_key, h_key);
+        CoolPropDbl d2rhodhdp_end = End->calc_second_two_phase_deriv(rho_key, h_key, p_key, p_key, h_key);
         
         // Reminder:
         // Delta = Q()*(hV-hL) = h-hL
         // Delta_end = x_end*(hV-hL);
-        long double d_Delta_dp__consth = -dhL_dp_sat;
-        long double d_Delta_end_dp__consth = x_end*(dhV_dp_sat - dhL_dp_sat);
+        CoolPropDbl d_Delta_dp__consth = -dhL_dp_sat;
+        CoolPropDbl d_Delta_end_dp__consth = x_end*(dhV_dp_sat - dhL_dp_sat);
         
         // First pressure derivative at constant h of the coefficients a,b,c,d
-        // long double Abracket = (2*rho_liq - 2*rho_end + Delta_end * (drho_dh_liq__constp + drho_dh_end));
-        long double d_Abracket_dp_consth = (2*drhoL_dp_sat - 2*drho_dp__consth_end + Delta_end*(d2rhodhdp_liq + d2rhodhdp_end) + d_Delta_dp__consth*(drho_dh_liq__constp + drho_dh_end));
-        long double da_dp = 1/POW3(Delta_end)*d_Abracket_dp_consth + Abracket*(-3/POW4(Delta_end)*d_Delta_end_dp__consth);
-        long double db_dp = - 6/POW3(Delta_end)*d_Delta_end_dp__consth*(rho_end - rho_liq)
+        // CoolPropDbl Abracket = (2*rho_liq - 2*rho_end + Delta_end * (drho_dh_liq__constp + drho_dh_end));
+        CoolPropDbl d_Abracket_dp_consth = (2*drhoL_dp_sat - 2*drho_dp__consth_end + Delta_end*(d2rhodhdp_liq + d2rhodhdp_end) + d_Delta_dp__consth*(drho_dh_liq__constp + drho_dh_end));
+        CoolPropDbl da_dp = 1/POW3(Delta_end)*d_Abracket_dp_consth + Abracket*(-3/POW4(Delta_end)*d_Delta_end_dp__consth);
+        CoolPropDbl db_dp = - 6/POW3(Delta_end)*d_Delta_end_dp__consth*(rho_end - rho_liq)
                             + (3/POW2(Delta_end))*(drho_dp__consth_end - drhoL_dp_sat)
                             + (1/POW2(Delta_end)*d_Delta_end_dp__consth) * (drho_dh_end + 2*drho_dh_liq__constp)
                             - (1/Delta_end) * (d2rhodhdp_end + 2*d2rhodhdp_liq);
-        long double dc_dp = d2rhodhdp_liq;
-        long double dd_dp = drhoL_dp_sat;
+        CoolPropDbl dc_dp = d2rhodhdp_liq;
+        CoolPropDbl dd_dp = drhoL_dp_sat;
         
-        long double d_rho_spline_dp__consth = (3*a*POW2(Delta) + 2*b*Delta + c)*d_Delta_dp__consth + POW3(Delta)*da_dp + POW2(Delta)*db_dp + Delta*dc_dp + dd_dp;
+        CoolPropDbl d_rho_spline_dp__consth = (3*a*POW2(Delta) + 2*b*Delta + c)*d_Delta_dp__consth + POW3(Delta)*da_dp + POW2(Delta)*db_dp + Delta*dc_dp + dd_dp;
     
         return d_rho_spline_dp__consth;
     }

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
@@ -18,14 +18,14 @@ class FlashRoutines;
 class HelmholtzEOSMixtureBackend : public AbstractState {
     
 private:
-    void pre_update(CoolProp::input_pairs &input_pair, long double &value1, long double &value2 );
+    void pre_update(CoolProp::input_pairs &input_pair, CoolPropDbl &value1, CoolPropDbl &value2 );
     void post_update();
 protected:
     std::vector<CoolPropFluid*> components; ///< The components that are in use
 
     bool is_pure_or_pseudopure; ///< A flag for whether the substance is a pure or pseudo-pure fluid (true) or a mixture (false)
-    std::vector<long double> mole_fractions; ///< The bulk mole fractions of the mixture
-    std::vector<long double> K, ///< The K factors for the components
+    std::vector<CoolPropDbl> mole_fractions; ///< The bulk mole fractions of the mixture
+    std::vector<CoolPropDbl> K, ///< The K factors for the components
                              lnK; ///< The natural logarithms of the K factors of the components
 
     SimpleState _crit;
@@ -56,24 +56,24 @@ public:
     bool using_volu_fractions(){return false;}
     bool is_pure(){ return components.size() == 1 && !components[0]->EOSVector[0].pseudo_pure; }
     bool has_melting_line(){ return is_pure_or_pseudopure && components[0]->ancillaries.melting_line.enabled();};
-    long double calc_melting_line(int param, int given, long double value);
+    CoolPropDbl calc_melting_line(int param, int given, CoolPropDbl value);
     phases calc_phase(void){return _phase;};
     void calc_specify_phase(phases phase){ specify_phase(phase); }
     void calc_unspecify_phase(){ unspecify_phase(); }
-    long double calc_saturation_ancillary(parameters param, int Q, parameters given, double value);
+    CoolPropDbl calc_saturation_ancillary(parameters param, int Q, parameters given, double value);
     void calc_ssat_max(void);
     void calc_hsat_max(void);
-    long double calc_GWP20();
-    long double calc_GWP500();
-    long double calc_GWP100();
-    long double calc_ODP();
+    CoolPropDbl calc_GWP20();
+    CoolPropDbl calc_GWP500();
+    CoolPropDbl calc_GWP100();
+    CoolPropDbl calc_ODP();
 	
-	long double calc_first_saturation_deriv(parameters Of1, parameters Wrt1);
-    long double calc_first_saturation_deriv(parameters Of1, parameters Wrt1, HelmholtzEOSMixtureBackend &SatL, HelmholtzEOSMixtureBackend &SatV);
-	long double calc_second_saturation_deriv(parameters Of1, parameters Wrt1, parameters Of2, parameters Wrt2);
-    long double calc_first_two_phase_deriv(parameters Of, parameters Wrt, parameters Constant);
-    long double calc_second_two_phase_deriv(parameters Of, parameters Wrt1, parameters Constant1, parameters Wrt2, parameters Constant2);
-    long double calc_first_two_phase_deriv_splined(parameters Of, parameters Wrt, parameters Constant, long double x_end);
+	CoolPropDbl calc_first_saturation_deriv(parameters Of1, parameters Wrt1);
+    CoolPropDbl calc_first_saturation_deriv(parameters Of1, parameters Wrt1, HelmholtzEOSMixtureBackend &SatL, HelmholtzEOSMixtureBackend &SatV);
+	CoolPropDbl calc_second_saturation_deriv(parameters Of1, parameters Wrt1, parameters Of2, parameters Wrt2);
+    CoolPropDbl calc_first_two_phase_deriv(parameters Of, parameters Wrt, parameters Constant);
+    CoolPropDbl calc_second_two_phase_deriv(parameters Of, parameters Wrt1, parameters Constant1, parameters Wrt2, parameters Constant2);
+    CoolPropDbl calc_first_two_phase_deriv_splined(parameters Of, parameters Wrt, parameters Constant, CoolPropDbl x_end);
     
 	/// Calculate the phase once the state is fully calculated but you aren't sure if it is liquid or gas or ...
 	void recalculate_singlephase_phase();
@@ -81,13 +81,13 @@ public:
     const CoolProp::SimpleState &calc_state(const std::string &state);
 
     const std::vector<CoolPropFluid*> &get_components(){return components;};
-    std::vector<long double> &get_K(){return K;};
-    std::vector<long double> &get_lnK(){return lnK;};
+    std::vector<CoolPropDbl> &get_K(){return K;};
+    std::vector<CoolPropDbl> &get_lnK(){return lnK;};
     HelmholtzEOSMixtureBackend &get_SatL(){return *SatL;};
     HelmholtzEOSMixtureBackend &get_SatV(){return *SatV;};
     
-    std::vector<long double> calc_mole_fractions_liquid(void){return SatL->get_mole_fractions();};
-    std::vector<long double> calc_mole_fractions_vapor(void){return SatV->get_mole_fractions();};
+    std::vector<CoolPropDbl> calc_mole_fractions_liquid(void){return SatL->get_mole_fractions();};
+    std::vector<CoolPropDbl> calc_mole_fractions_vapor(void){return SatV->get_mole_fractions();};
     
     const CoolProp::PhaseEnvelopeData &calc_phase_envelope_data(){return PhaseEnvelope;};
 
@@ -110,9 +110,9 @@ public:
      * @param p Pressure in Pa
      * @param rho_guess Density in mol/m^3 guessed
      */
-    void update_TP_guessrho(long double T, long double p, long double rho_guess);
-    void update_DmolarT_direct(long double rhomolar, long double T);
-    void update_HmolarQ_with_guessT(long double hmolar, long double Q, long double Tguess);
+    void update_TP_guessrho(CoolPropDbl T, CoolPropDbl p, CoolPropDbl rho_guess);
+    void update_DmolarT_direct(CoolPropDbl rhomolar, CoolPropDbl T);
+    void update_HmolarQ_with_guessT(CoolPropDbl hmolar, CoolPropDbl Q, CoolPropDbl Tguess);
 
     /** \brief Set the components of the mixture
      * 
@@ -139,114 +139,114 @@ public:
      * 
      * @param mole_fractions The vector of mole fractions of the components
      */
-    void set_mole_fractions(const std::vector<long double> &mole_fractions);
+    void set_mole_fractions(const std::vector<CoolPropDbl> &mole_fractions);
 
-    const std::vector<long double> &get_mole_fractions(){return mole_fractions;};
-    std::vector<long double> &get_mole_fractions_ref(){return mole_fractions;};
+    const std::vector<CoolPropDbl> &get_mole_fractions(){return mole_fractions;};
+    std::vector<CoolPropDbl> &get_mole_fractions_ref(){return mole_fractions;};
 
     /** \brief Set the mass fractions
      * 
      * @param mass_fractions The vector of mass fractions of the components
      */
-    void set_mass_fractions(const std::vector<long double> &mass_fractions){throw std::exception();};
+    void set_mass_fractions(const std::vector<CoolPropDbl> &mass_fractions){throw std::exception();};
 
-    long double calc_molar_mass(void);
-    long double calc_gas_constant(void);
-    long double calc_acentric_factor(void);
+    CoolPropDbl calc_molar_mass(void);
+    CoolPropDbl calc_gas_constant(void);
+    CoolPropDbl calc_acentric_factor(void);
 
-    long double calc_Bvirial(void);
-    long double calc_Cvirial(void);
-    long double calc_dBvirial_dT(void);
-    long double calc_dCvirial_dT(void);
+    CoolPropDbl calc_Bvirial(void);
+    CoolPropDbl calc_Cvirial(void);
+    CoolPropDbl calc_dBvirial_dT(void);
+    CoolPropDbl calc_dCvirial_dT(void);
 
-    long double calc_pressure(void);
-    long double calc_cvmolar(void);
-    long double calc_cpmolar(void);
-    long double calc_gibbsmolar(void);
-    long double calc_cpmolar_idealgas(void);
-    long double calc_pressure_nocache(long double T, long double rhomolar);
-    long double calc_smolar(void);
-    long double calc_smolar_nocache(long double T, long double rhomolar);
+    CoolPropDbl calc_pressure(void);
+    CoolPropDbl calc_cvmolar(void);
+    CoolPropDbl calc_cpmolar(void);
+    CoolPropDbl calc_gibbsmolar(void);
+    CoolPropDbl calc_cpmolar_idealgas(void);
+    CoolPropDbl calc_pressure_nocache(CoolPropDbl T, CoolPropDbl rhomolar);
+    CoolPropDbl calc_smolar(void);
+    CoolPropDbl calc_smolar_nocache(CoolPropDbl T, CoolPropDbl rhomolar);
     
-    long double calc_hmolar(void);
-    long double calc_hmolar_nocache(long double T, long double rhomolar);
+    CoolPropDbl calc_hmolar(void);
+    CoolPropDbl calc_hmolar_nocache(CoolPropDbl T, CoolPropDbl rhomolar);
     
-    long double calc_umolar_nocache(long double T, long double rhomolar);
-    long double calc_umolar(void);
-    long double calc_speed_sound(void);
+    CoolPropDbl calc_umolar_nocache(CoolPropDbl T, CoolPropDbl rhomolar);
+    CoolPropDbl calc_umolar(void);
+    CoolPropDbl calc_speed_sound(void);
     /** \brief The phase identification parameter of Venkatarathnam et al., FPE, 2011
      * 
      * 
      */
-    long double calc_fugacity_coefficient(int i);
-    long double calc_phase_identification_parameter(void);
+    CoolPropDbl calc_fugacity_coefficient(int i);
+    CoolPropDbl calc_phase_identification_parameter(void);
 
 	/// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r\f$ (dimensionless)
-    long double calc_alphar(void);
+    CoolPropDbl calc_alphar(void);
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta}\f$ (dimensionless)
-	long double calc_dalphar_dDelta(void);
+	CoolPropDbl calc_dalphar_dDelta(void);
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau}\f$ (dimensionless)
-	long double calc_dalphar_dTau(void);
+	CoolPropDbl calc_dalphar_dTau(void);
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta}\f$ (dimensionless)
-	long double calc_d2alphar_dDelta2(void);
+	CoolPropDbl calc_d2alphar_dDelta2(void);
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau}\f$ (dimensionless)
-	long double calc_d2alphar_dDelta_dTau(void);
+	CoolPropDbl calc_d2alphar_dDelta_dTau(void);
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau}\f$ (dimensionless)
-	long double calc_d2alphar_dTau2(void);    
+	CoolPropDbl calc_d2alphar_dTau2(void);    
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\delta}\f$ (dimensionless)
-	long double calc_d3alphar_dDelta3(void);
+	CoolPropDbl calc_d3alphar_dDelta3(void);
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\tau}\f$ (dimensionless)
-	long double calc_d3alphar_dDelta2_dTau(void);
+	CoolPropDbl calc_d3alphar_dDelta2_dTau(void);
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau\tau}\f$ (dimensionless)
-	long double calc_d3alphar_dDelta_dTau2(void);
+	CoolPropDbl calc_d3alphar_dDelta_dTau2(void);
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau\tau}\f$ (dimensionless)
-	long double calc_d3alphar_dTau3(void);
+	CoolPropDbl calc_d3alphar_dTau3(void);
 
-    long double calc_alpha0(void);
-    long double calc_dalpha0_dDelta(void);
-    long double calc_dalpha0_dTau(void);
-    long double calc_d2alpha0_dDelta2(void);
-    long double calc_d2alpha0_dDelta_dTau(void);
-    long double calc_d2alpha0_dTau2(void);
-    long double calc_d3alpha0_dDelta3(void);
-    long double calc_d3alpha0_dDelta2_dTau(void);
-    long double calc_d3alpha0_dDelta_dTau2(void);
-    long double calc_d3alpha0_dTau3(void);
+    CoolPropDbl calc_alpha0(void);
+    CoolPropDbl calc_dalpha0_dDelta(void);
+    CoolPropDbl calc_dalpha0_dTau(void);
+    CoolPropDbl calc_d2alpha0_dDelta2(void);
+    CoolPropDbl calc_d2alpha0_dDelta_dTau(void);
+    CoolPropDbl calc_d2alpha0_dTau2(void);
+    CoolPropDbl calc_d3alpha0_dDelta3(void);
+    CoolPropDbl calc_d3alpha0_dDelta2_dTau(void);
+    CoolPropDbl calc_d3alpha0_dDelta_dTau2(void);
+    CoolPropDbl calc_d3alpha0_dTau3(void);
 
-    long double calc_surface_tension(void);
-    long double calc_viscosity(void);
-    long double calc_viscosity_dilute(void);
-    long double calc_viscosity_background(void);
-    long double calc_viscosity_background(long double eta_dilute);
-    long double calc_conductivity(void);
-    long double calc_conductivity_background(void);
+    CoolPropDbl calc_surface_tension(void);
+    CoolPropDbl calc_viscosity(void);
+    CoolPropDbl calc_viscosity_dilute(void);
+    CoolPropDbl calc_viscosity_background(void);
+    CoolPropDbl calc_viscosity_background(CoolPropDbl eta_dilute);
+    CoolPropDbl calc_conductivity(void);
+    CoolPropDbl calc_conductivity_background(void);
 
-    long double calc_saturated_liquid_keyed_output(parameters key) { return SatL->keyed_output(key); }
-    long double calc_saturated_vapor_keyed_output(parameters key) { return SatV->keyed_output(key); }
+    CoolPropDbl calc_saturated_liquid_keyed_output(parameters key) { return SatL->keyed_output(key); }
+    CoolPropDbl calc_saturated_vapor_keyed_output(parameters key) { return SatV->keyed_output(key); }
 
-    long double calc_Tmin(void);
-    long double calc_Tmax(void);
-    long double calc_pmax(void);
-    long double calc_Ttriple(void);
-    long double calc_p_triple(void);
-    long double calc_pmax_sat(void);
-    long double calc_Tmax_sat(void);
-    void calc_Tmin_sat(long double &Tmin_satL, long double &Tmin_satV);
-    void calc_pmin_sat(long double &pmin_satL, long double &pmin_satV);
+    CoolPropDbl calc_Tmin(void);
+    CoolPropDbl calc_Tmax(void);
+    CoolPropDbl calc_pmax(void);
+    CoolPropDbl calc_Ttriple(void);
+    CoolPropDbl calc_p_triple(void);
+    CoolPropDbl calc_pmax_sat(void);
+    CoolPropDbl calc_Tmax_sat(void);
+    void calc_Tmin_sat(CoolPropDbl &Tmin_satL, CoolPropDbl &Tmin_satV);
+    void calc_pmin_sat(CoolPropDbl &pmin_satL, CoolPropDbl &pmin_satV);
 	
-    long double calc_T_critical(void);
-    long double calc_p_critical(void);
-    long double calc_rhomolar_critical(void);
+    CoolPropDbl calc_T_critical(void);
+    CoolPropDbl calc_p_critical(void);
+    CoolPropDbl calc_rhomolar_critical(void);
 	
-	long double calc_T_reducing(void){return get_reducing_state().T;};
-    long double calc_rhomolar_reducing(void){return get_reducing_state().rhomolar;};
-    long double calc_p_reducing(void){return get_reducing_state().p;};
+	CoolPropDbl calc_T_reducing(void){return get_reducing_state().T;};
+    CoolPropDbl calc_rhomolar_reducing(void){return get_reducing_state().rhomolar;};
+    CoolPropDbl calc_p_reducing(void){return get_reducing_state().p;};
 
     std::string calc_name(void);
 	std::vector<std::string> calc_fluid_names(void);
 
-    void calc_all_alphar_deriv_cache(const std::vector<long double> &mole_fractions, const long double &tau, const long double &delta);
-    long double calc_alphar_deriv_nocache(const int nTau, const int nDelta, const std::vector<long double> & mole_fractions, const long double &tau, const long double &delta);
+    void calc_all_alphar_deriv_cache(const std::vector<CoolPropDbl> &mole_fractions, const CoolPropDbl &tau, const CoolPropDbl &delta);
+    CoolPropDbl calc_alphar_deriv_nocache(const int nTau, const int nDelta, const std::vector<CoolPropDbl> & mole_fractions, const CoolPropDbl &tau, const CoolPropDbl &delta);
 
     /**
     \brief Take derivatives of the ideal-gas part of the Helmholtz energy, don't use any cached values, or store any cached values
@@ -272,28 +272,28 @@ public:
 
     \sa Table B5, GERG 2008 from Kunz Wagner, JCED, 2012
     */
-    long double calc_alpha0_deriv_nocache(const int nTau, const int nDelta, const std::vector<long double> & mole_fractions, const long double &tau, const long double &delta, const long double &Tr, const long double &rhor);
+    CoolPropDbl calc_alpha0_deriv_nocache(const int nTau, const int nDelta, const std::vector<CoolPropDbl> & mole_fractions, const CoolPropDbl &tau, const CoolPropDbl &delta, const CoolPropDbl &Tr, const CoolPropDbl &rhor);
 
     void calc_reducing_state(void);
-    SimpleState calc_reducing_state_nocache(const std::vector<long double> & mole_fractions);
+    SimpleState calc_reducing_state_nocache(const std::vector<CoolPropDbl> & mole_fractions);
 
     const CoolProp::SimpleState & get_reducing_state(){calc_reducing_state(); return _reducing;};
 
     void update_states();
     
-    long double calc_compressibility_factor(void){return 1+delta()*dalphar_dDelta();};
+    CoolPropDbl calc_compressibility_factor(void){return 1+delta()*dalphar_dDelta();};
     
     void calc_phase_envelope(const std::string &type);
     
-    void mass_to_molar_inputs(CoolProp::input_pairs &input_pair, long double &value1, long double &value2);
+    void mass_to_molar_inputs(CoolProp::input_pairs &input_pair, CoolPropDbl &value1, CoolPropDbl &value2);
 
     // ***************************************************************
     // ***************************************************************
     // *************  PHASE DETERMINATION ROUTINES  ******************
     // ***************************************************************
     // ***************************************************************
-    void T_phase_determination_pure_or_pseudopure(int other, long double value);
-    void p_phase_determination_pure_or_pseudopure(int other, long double value, bool &saturation_called);
+    void T_phase_determination_pure_or_pseudopure(int other, CoolPropDbl value);
+    void p_phase_determination_pure_or_pseudopure(int other, CoolPropDbl value, bool &saturation_called);
     void DmolarP_phase_determination();
     
 
@@ -303,9 +303,9 @@ public:
     // ***************************************************************
     // ***************************************************************
 
-    long double solver_rho_Tp(long double T, long double p, long double rho_guess = -1);
-    long double solver_rho_Tp_SRK(long double T, long double p, int phase);
-    long double solver_for_rho_given_T_oneof_HSU(long double T, long double value, int other);
+    CoolPropDbl solver_rho_Tp(CoolPropDbl T, CoolPropDbl p, CoolPropDbl rho_guess = -1);
+    CoolPropDbl solver_rho_Tp_SRK(CoolPropDbl T, CoolPropDbl p, int phase);
+    CoolPropDbl solver_for_rho_given_T_oneof_HSU(CoolPropDbl T, CoolPropDbl value, int other);
 
 };
 

--- a/src/Backends/Helmholtz/MixtureDerivatives.cpp
+++ b/src/Backends/Helmholtz/MixtureDerivatives.cpp
@@ -2,13 +2,13 @@
 
 namespace CoolProp{
     
-long double MixtureDerivatives::dalphar_dxi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::dalphar_dxi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     if (xN_flag == XN_INDEPENDENT){
         return HEOS.components[i]->pEOS->baser(HEOS._tau, HEOS._delta) + HEOS.Excess.dalphar_dxi(HEOS._tau, HEOS._delta, HEOS.mole_fractions, i);
     }
     else if(xN_flag == XN_DEPENDENT){
-        std::vector<long double> &x = HEOS.mole_fractions;
+        std::vector<CoolPropDbl> &x = HEOS.mole_fractions;
         std::size_t N = x.size();
         if (i == N-1) return 0;
         double dar_dxi = HEOS.components[i]->pEOS->baser(HEOS._tau, HEOS._delta) - HEOS.components[N-1]->pEOS->baser(HEOS._tau, HEOS._delta);
@@ -26,13 +26,13 @@ long double MixtureDerivatives::dalphar_dxi(HelmholtzEOSMixtureBackend &HEOS, st
         throw ValueError(format("xN_flag is invalid"));
     }
 }
-long double MixtureDerivatives::d2alphar_dxi_dTau(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::d2alphar_dxi_dTau(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     if (xN_flag == XN_INDEPENDENT){
         return HEOS.components[i]->pEOS->dalphar_dTau(HEOS._tau, HEOS._delta) + HEOS.Excess.d2alphar_dxi_dTau(HEOS._tau, HEOS._delta, HEOS.mole_fractions, i);
     }
     else if(xN_flag == XN_DEPENDENT){
-        std::vector<long double> &x = HEOS.mole_fractions;
+        std::vector<CoolPropDbl> &x = HEOS.mole_fractions;
         std::size_t N = x.size();
         if (i==N-1) return 0;
         double d2ar_dxi_dTau = HEOS.components[i]->pEOS->dalphar_dTau(HEOS._tau, HEOS._delta) - HEOS.components[N-1]->pEOS->dalphar_dTau(HEOS._tau, HEOS._delta);
@@ -51,13 +51,13 @@ long double MixtureDerivatives::d2alphar_dxi_dTau(HelmholtzEOSMixtureBackend &HE
     }
         
 }
-long double MixtureDerivatives::d2alphar_dxi_dDelta(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::d2alphar_dxi_dDelta(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     if (xN_flag == XN_INDEPENDENT){
         return HEOS.components[i]->pEOS->dalphar_dDelta(HEOS._tau, HEOS._delta) + HEOS.Excess.d2alphar_dxi_dDelta(HEOS._tau, HEOS._delta, HEOS.mole_fractions, i);
         }
     else if(xN_flag == XN_DEPENDENT){
-        std::vector<long double> &x = HEOS.mole_fractions;
+        std::vector<CoolPropDbl> &x = HEOS.mole_fractions;
         std::size_t N = x.size();
         if (i==N-1) return 0;
         double d2ar_dxi_dDelta = HEOS.components[i]->pEOS->dalphar_dDelta(HEOS._tau, HEOS._delta) - HEOS.components[N-1]->pEOS->dalphar_dDelta(HEOS._tau, HEOS._delta);
@@ -76,7 +76,7 @@ long double MixtureDerivatives::d2alphar_dxi_dDelta(HelmholtzEOSMixtureBackend &
     }
 }
 
-long double MixtureDerivatives::d2alphardxidxj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::d2alphardxidxj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
 {
     if (xN_flag == XN_INDEPENDENT){
             return 0                           + HEOS.Excess.d2alphardxidxj(HEOS._tau, HEOS._delta, HEOS.mole_fractions, i, j);
@@ -96,71 +96,71 @@ long double MixtureDerivatives::d2alphardxidxj(HelmholtzEOSMixtureBackend &HEOS,
     }
 }
 
-long double MixtureDerivatives::dln_fugacity_i_dT__constp_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::dln_fugacity_i_dT__constp_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     return dln_fugacity_coefficient_dT__constp_n(HEOS, i, xN_flag);
 }
-long double MixtureDerivatives::dln_fugacity_i_dp__constT_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::dln_fugacity_i_dp__constT_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     return dln_fugacity_coefficient_dp__constT_n(HEOS, i, xN_flag) + 1/HEOS.p();
 }
-long double MixtureDerivatives::fugacity_i(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag){
+CoolPropDbl MixtureDerivatives::fugacity_i(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag){
     return HEOS.mole_fractions[i]*HEOS.rhomolar()*HEOS.gas_constant()*HEOS.T()*exp( dnalphar_dni__constT_V_nj(HEOS, i, xN_flag));
 }
-long double MixtureDerivatives::ln_fugacity_coefficient(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::ln_fugacity_coefficient(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     return HEOS.alphar() + ndalphar_dni__constT_V_nj(HEOS, i, xN_flag)-log(1+HEOS._delta.pt()*HEOS.dalphar_dDelta());
 }
-long double MixtureDerivatives::dln_fugacity_i_dT__constrho_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::dln_fugacity_i_dT__constrho_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     return 1/HEOS.T()*(1-HEOS.tau()*HEOS.dalphar_dTau()-HEOS.tau()*d_ndalphardni_dTau(HEOS, i, xN_flag));
 }
-long double MixtureDerivatives::dln_fugacity_i_drho__constT_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::dln_fugacity_i_drho__constT_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     return 1/HEOS.rhomolar()*(1+HEOS.delta()*HEOS.dalphar_dDelta() + HEOS.delta()*d_ndalphardni_dDelta(HEOS, i, xN_flag));
 }
-long double MixtureDerivatives::dnalphar_dni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::dnalphar_dni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     // GERG Equation 7.42
     return HEOS.alphar() + ndalphar_dni__constT_V_nj(HEOS, i, xN_flag);
 }
-long double MixtureDerivatives::d2nalphar_dni_dT(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::d2nalphar_dni_dT(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     return -HEOS._tau.pt()/HEOS._T*(HEOS.dalphar_dTau() + d_ndalphardni_dTau(HEOS, i, xN_flag));
 }
-long double MixtureDerivatives::dln_fugacity_coefficient_dT__constp_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::dln_fugacity_coefficient_dT__constp_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     double T = HEOS._reducing.T/HEOS._tau.pt();
-    long double R_u = HEOS.gas_constant();
+    CoolPropDbl R_u = HEOS.gas_constant();
     return d2nalphar_dni_dT(HEOS, i, xN_flag) + 1/T-partial_molar_volume(HEOS, i, xN_flag)/(R_u*T)*dpdT__constV_n(HEOS);
 }
-long double MixtureDerivatives::partial_molar_volume(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::partial_molar_volume(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     return -ndpdni__constT_V_nj(HEOS, i, xN_flag)/ndpdV__constT_n(HEOS);
 }
 
-long double MixtureDerivatives::dln_fugacity_coefficient_dp__constT_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::dln_fugacity_coefficient_dp__constT_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     // GERG equation 7.30
-    long double R_u = HEOS.gas_constant();
+    CoolPropDbl R_u = HEOS.gas_constant();
     double partial_molar_volumeval = partial_molar_volume(HEOS, i, xN_flag); // [m^3/mol]
     double term1 = partial_molar_volumeval/(R_u*HEOS._T); // m^3/mol/(N*m)*mol = m^2/N = 1/Pa
     double term2 = 1.0/HEOS.p();
     return term1 - term2;
 }
-long double MixtureDerivatives::dln_fugacity_i_dtau__constdelta_x(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::dln_fugacity_i_dtau__constdelta_x(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     return -1/HEOS.tau() + HEOS.dalphar_dTau() + d_ndalphardni_dTau(HEOS, i, xN_flag);
 }
-long double MixtureDerivatives::dln_fugacity_i_ddelta__consttau_x(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::dln_fugacity_i_ddelta__consttau_x(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     return 1 + HEOS.delta()*HEOS.dalphar_dDelta() + HEOS.delta()*d_ndalphardni_dDelta(HEOS, i, xN_flag);
 }
-long double MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
 {
     // This is a term to which some more might be added depending on i and j
-    long double val = dln_fugacity_coefficient_dxj__constT_p_xi(HEOS, i, j, xN_flag);
-    const std::vector<long double> &x = HEOS.get_mole_fractions();
+    CoolPropDbl val = dln_fugacity_coefficient_dxj__constT_p_xi(HEOS, i, j, xN_flag);
+    const std::vector<CoolPropDbl> &x = HEOS.get_mole_fractions();
     std::size_t N = x.size();
     if (i == N-1){
         val += -1/x[N-1];
@@ -170,23 +170,23 @@ long double MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(HelmholtzEOSMixtur
     }
     return val;
 }
-long double MixtureDerivatives::dln_fugacity_dxj__constT_rho_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::dln_fugacity_dxj__constT_rho_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
 {
     if (xN_flag == XN_INDEPENDENT){throw ValueError("dln_fugacity_dxj__constT_rho_xi only valid for xN_DEPENDENT for now");}
-    long double rhor = HEOS.Reducing->rhormolar(HEOS.get_mole_fractions());
-    long double Tr = HEOS.Reducing->Tr(HEOS.get_mole_fractions());
-    long double dTrdxj = HEOS.Reducing->dTrdxi__constxj(HEOS.get_mole_fractions(),j,xN_flag);
-    long double drhordxj = HEOS.Reducing->drhormolardxi__constxj(HEOS.get_mole_fractions(),j,xN_flag);
+    CoolPropDbl rhor = HEOS.Reducing->rhormolar(HEOS.get_mole_fractions());
+    CoolPropDbl Tr = HEOS.Reducing->Tr(HEOS.get_mole_fractions());
+    CoolPropDbl dTrdxj = HEOS.Reducing->dTrdxi__constxj(HEOS.get_mole_fractions(),j,xN_flag);
+    CoolPropDbl drhordxj = HEOS.Reducing->drhormolardxi__constxj(HEOS.get_mole_fractions(),j,xN_flag);
     
     // These lines are all the same
-    long double line1 = dln_fugacity_i_dtau__constdelta_x(HEOS, i, xN_flag)*1/HEOS.T()*dTrdxj;
-    long double line2 = -dln_fugacity_i_ddelta__consttau_x(HEOS, i, xN_flag)*1/rhor*drhordxj;
-    long double line4 = dalphar_dxi(HEOS, j, xN_flag) + d_ndalphardni_dxj__constdelta_tau_xi(HEOS, i, j, xN_flag);
+    CoolPropDbl line1 = dln_fugacity_i_dtau__constdelta_x(HEOS, i, xN_flag)*1/HEOS.T()*dTrdxj;
+    CoolPropDbl line2 = -dln_fugacity_i_ddelta__consttau_x(HEOS, i, xN_flag)*1/rhor*drhordxj;
+    CoolPropDbl line4 = dalphar_dxi(HEOS, j, xN_flag) + d_ndalphardni_dxj__constdelta_tau_xi(HEOS, i, j, xN_flag);
     
-    const std::vector<long double> &x = HEOS.get_mole_fractions();
+    const std::vector<CoolPropDbl> &x = HEOS.get_mole_fractions();
     std::size_t N = x.size();
     
-    long double line3 = 1/rhor*HEOS.Reducing->drhormolardxi__constxj(x, j, xN_flag) + 1/Tr*HEOS.Reducing->dTrdxi__constxj(x, j, xN_flag);;
+    CoolPropDbl line3 = 1/rhor*HEOS.Reducing->drhormolardxi__constxj(x, j, xN_flag) + 1/Tr*HEOS.Reducing->dTrdxi__constxj(x, j, xN_flag);;
     
     // This is a term to which some more might be added depending on i and j
     if (i == N-1){
@@ -200,21 +200,21 @@ long double MixtureDerivatives::dln_fugacity_dxj__constT_rho_xi(HelmholtzEOSMixt
     return line1 + line2 + line3 + line4;
 }
 
-long double MixtureDerivatives::dln_fugacity_coefficient_dxj__constT_p_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::dln_fugacity_coefficient_dxj__constT_p_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
 {
     // Gernert 3.115
-    long double R_u = HEOS.gas_constant();
+    CoolPropDbl R_u = HEOS.gas_constant();
     // partial molar volume is -dpdn/dpdV, so need to flip the sign here
     return d2nalphar_dxj_dni__constT_V(HEOS, j, i, xN_flag) - partial_molar_volume(HEOS, i, xN_flag)/(R_u*HEOS._T)*dpdxj__constT_V_xi(HEOS, j, xN_flag);
 }
-long double MixtureDerivatives::dpdxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::dpdxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag)
 {
     // Gernert 3.130
-    long double R_u = HEOS.gas_constant();
+    CoolPropDbl R_u = HEOS.gas_constant();
     return HEOS._rhomolar*R_u*HEOS._T*(ddelta_dxj__constT_V_xi(HEOS, j, xN_flag)*HEOS.dalphar_dDelta()+HEOS._delta.pt()*d_dalpharddelta_dxj__constT_V_xi(HEOS, j, xN_flag));
 }
 
-long double MixtureDerivatives::d_dalpharddelta_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::d_dalpharddelta_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag)
 {
     // Gernert Equation 3.134 (Catch test provided)
     return HEOS.d2alphar_dDelta2()*ddelta_dxj__constT_V_xi(HEOS, j, xN_flag)
@@ -222,48 +222,48 @@ long double MixtureDerivatives::d_dalpharddelta_dxj__constT_V_xi(HelmholtzEOSMix
          + d2alphar_dxi_dDelta(HEOS, j, xN_flag);
 }
 
-long double MixtureDerivatives::dalphar_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::dalphar_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag)
 {
     //Gernert 3.119 (Catch test provided)
     return HEOS.dalphar_dDelta()*ddelta_dxj__constT_V_xi(HEOS, j, xN_flag)+HEOS.dalphar_dTau()*dtau_dxj__constT_V_xi(HEOS, j, xN_flag)+dalphar_dxi(HEOS, j, xN_flag);
 }
-long double MixtureDerivatives::d_ndalphardni_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::d_ndalphardni_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
 {
     // Gernert 3.118
     return d_ndalphardni_dxj__constdelta_tau_xi(HEOS, i,j, xN_flag)
           + ddelta_dxj__constT_V_xi(HEOS, j, xN_flag)*d_ndalphardni_dDelta(HEOS, i, xN_flag)
           + dtau_dxj__constT_V_xi(HEOS, j, xN_flag)*d_ndalphardni_dTau(HEOS, i, xN_flag);
 }
-long double MixtureDerivatives::ddelta_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::ddelta_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag)
 {
     // Gernert 3.121 (Catch test provided)
     return -HEOS._delta.pt()/HEOS._reducing.rhomolar*HEOS.Reducing->drhormolardxi__constxj(HEOS.mole_fractions,j, xN_flag);
 }
-long double MixtureDerivatives::dtau_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::dtau_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag)
 {
     // Gernert 3.122 (Catch test provided)
     return 1/HEOS._T*HEOS.Reducing->dTrdxi__constxj(HEOS.mole_fractions,j, xN_flag);
 }
 
-long double MixtureDerivatives::dpdT__constV_n(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl MixtureDerivatives::dpdT__constV_n(HelmholtzEOSMixtureBackend &HEOS)
 {
-    long double R_u = HEOS.gas_constant();
+    CoolPropDbl R_u = HEOS.gas_constant();
     return HEOS._rhomolar*R_u*(1+HEOS._delta.pt()*HEOS.dalphar_dDelta()-HEOS._delta.pt()*HEOS._tau.pt()*HEOS.d2alphar_dDelta_dTau());
 }
-long double MixtureDerivatives::dpdrho__constT_n(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl MixtureDerivatives::dpdrho__constT_n(HelmholtzEOSMixtureBackend &HEOS)
 {
-    long double R_u = HEOS.gas_constant();
+    CoolPropDbl R_u = HEOS.gas_constant();
     return R_u*HEOS._T*(1+2*HEOS._delta.pt()*HEOS.dalphar_dDelta()+pow(HEOS._delta.pt(),2)*HEOS.d2alphar_dDelta2());
 }
-long double MixtureDerivatives::ndpdV__constT_n(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl MixtureDerivatives::ndpdV__constT_n(HelmholtzEOSMixtureBackend &HEOS)
 {
-    long double R_u = HEOS.gas_constant();
+    CoolPropDbl R_u = HEOS.gas_constant();
     return -pow(HEOS._rhomolar,2)*R_u*HEOS._T*(1+2*HEOS._delta.pt()*HEOS.dalphar_dDelta()+pow(HEOS._delta.pt(),2)*HEOS.d2alphar_dDelta2());
 }
-long double MixtureDerivatives::ndpdni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::ndpdni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     // Eqn 7.64 and 7.63
-    long double R_u = HEOS.gas_constant();
+    CoolPropDbl R_u = HEOS.gas_constant();
     double ndrhorbar_dni__constnj = HEOS.Reducing->ndrhorbardni__constnj(HEOS.mole_fractions,i, xN_flag);
     double ndTr_dni__constnj = HEOS.Reducing->ndTrdni__constnj(HEOS.mole_fractions,i, xN_flag);
     double summer = 0;
@@ -277,7 +277,7 @@ long double MixtureDerivatives::ndpdni__constT_V_nj(HelmholtzEOSMixtureBackend &
     return HEOS._rhomolar*R_u*HEOS._T*(1+HEOS._delta.pt()*HEOS.dalphar_dDelta()*(2-1/HEOS._reducing.rhomolar*ndrhorbar_dni__constnj)+HEOS._delta.pt()*nd2alphar_dni_dDelta);
 }
 
-long double MixtureDerivatives::ndalphar_dni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::ndalphar_dni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     double term1 = HEOS._delta.pt()*HEOS.dalphar_dDelta()*(1-1/HEOS._reducing.rhomolar*HEOS.Reducing->ndrhorbardni__constnj(HEOS.mole_fractions,i, xN_flag));
     double term2 = HEOS._tau.pt()*HEOS.dalphar_dTau()*(1/HEOS._reducing.T)*HEOS.Reducing->ndTrdni__constnj(HEOS.mole_fractions,i, xN_flag);
@@ -292,20 +292,20 @@ long double MixtureDerivatives::ndalphar_dni__constT_V_nj(HelmholtzEOSMixtureBac
     double term3 = dalphar_dxi(HEOS, i, xN_flag);
     return term1 + term2 + term3 - s;
 }
-long double MixtureDerivatives::ndln_fugacity_coefficient_dnj__constT_p(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::ndln_fugacity_coefficient_dnj__constT_p(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
 {
-    long double R_u = HEOS.gas_constant();
+    CoolPropDbl R_u = HEOS.gas_constant();
     return nd2nalphardnidnj__constT_V(HEOS, j, i, xN_flag) + 1 - partial_molar_volume(HEOS, j, xN_flag)/(R_u*HEOS._T)*ndpdni__constT_V_nj(HEOS, i, xN_flag);
 }
-long double MixtureDerivatives::nddeltadni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::nddeltadni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     return HEOS._delta.pt()-HEOS._delta.pt()/HEOS._reducing.rhomolar*HEOS.Reducing->ndrhorbardni__constnj(HEOS.mole_fractions, i, xN_flag);
 }
-long double MixtureDerivatives::ndtaudni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::ndtaudni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     return HEOS._tau.pt()/HEOS._reducing.T*HEOS.Reducing->ndTrdni__constnj(HEOS.mole_fractions, i, xN_flag);
 }
-long double MixtureDerivatives::d_ndalphardni_dxj__constdelta_tau_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::d_ndalphardni_dxj__constdelta_tau_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
 {
     double line1 = HEOS._delta.pt()*d2alphar_dxi_dDelta(HEOS, j, xN_flag)*(1-1/HEOS._reducing.rhomolar*HEOS.Reducing->ndrhorbardni__constnj(HEOS.mole_fractions, i, xN_flag));
     double line3 = HEOS._tau.pt()*d2alphar_dxi_dTau(HEOS, j, xN_flag)*(1/HEOS._reducing.T)*HEOS.Reducing->ndTrdni__constnj(HEOS.mole_fractions, i, xN_flag);
@@ -322,7 +322,7 @@ long double MixtureDerivatives::d_ndalphardni_dxj__constdelta_tau_xi(HelmholtzEO
     double line5 = d2alphardxidxj(HEOS, i, j, xN_flag)-dalphar_dxi(HEOS, j, xN_flag)-s;
     return line1 + line2 + line3 + line4 + line5;
 }
-long double MixtureDerivatives::nd2nalphardnidnj__constT_V(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::nd2nalphardnidnj__constT_V(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
 {
     double line0 = ndalphar_dni__constT_V_nj(HEOS, j, xN_flag); // First term from 7.46
     double line1 = d_ndalphardni_dDelta(HEOS, i, xN_flag)*nddeltadni__constT_V_nj(HEOS, j, xN_flag);
@@ -337,7 +337,7 @@ long double MixtureDerivatives::nd2nalphardnidnj__constT_V(HelmholtzEOSMixtureBa
     double line3 = d_ndalphardni_dxj__constdelta_tau_xi(HEOS, i, j, xN_flag)-summer;
     return line0 + line1 + line2 + line3;
 }
-long double MixtureDerivatives::d_ndalphardni_dDelta(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::d_ndalphardni_dDelta(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     // The first line
     double term1 = (HEOS._delta.pt()*HEOS.d2alphar_dDelta2()+HEOS.dalphar_dDelta())*(1-1/HEOS._reducing.rhomolar*HEOS.Reducing->ndrhorbardni__constnj(HEOS.mole_fractions, i, xN_flag));
@@ -355,7 +355,7 @@ long double MixtureDerivatives::d_ndalphardni_dDelta(HelmholtzEOSMixtureBackend 
     }
     return term1 + term2 + term3;
 }
-long double MixtureDerivatives::d_ndalphardni_dTau(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl MixtureDerivatives::d_ndalphardni_dTau(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag)
 {
     // The first line
     double term1 = HEOS._delta.pt()*HEOS.d2alphar_dDelta_dTau()*(1-1/HEOS._reducing.rhomolar*HEOS.Reducing->ndrhorbardni__constnj(HEOS.mole_fractions, i, xN_flag));
@@ -405,7 +405,7 @@ TEST_CASE("Mixture derivative checks", "[mixtures],[mixture_derivs]")
                 SECTION(ss000.str(),"")
                 {
                     std::vector<std::string> names;
-                    std::vector<long double> z;
+                    std::vector<CoolPropDbl> z;
                     shared_ptr<HelmholtzEOSMixtureBackend> HEOS, HEOS_plusT_constrho, HEOS_plusrho_constT, HEOS_minusT_constrho, HEOS_minusrho_constT;
                     names.resize(Ncomp);
                     z.resize(Ncomp);
@@ -467,7 +467,7 @@ TEST_CASE("Mixture derivative checks", "[mixtures],[mixture_derivs]")
                         HEOS_pluszi.reset(new HelmholtzEOSMixtureBackend(names));
                         HEOS_pluszi->specify_phase(iphase_gas); 
                         HelmholtzEOSMixtureBackend &rHEOS_pluszi = *(HEOS_pluszi.get());
-                        std::vector<long double> zp = z; /// Copy base composition
+                        std::vector<CoolPropDbl> zp = z; /// Copy base composition
                         zp[i] += dz; 
                         if (xN_flag == XN_DEPENDENT)
                             zp[z.size()-1] -= dz;
@@ -477,7 +477,7 @@ TEST_CASE("Mixture derivative checks", "[mixtures],[mixture_derivs]")
                         HEOS_minuszi.reset(new HelmholtzEOSMixtureBackend(names));
                         HEOS_minuszi->specify_phase(iphase_gas); 
                         HelmholtzEOSMixtureBackend &rHEOS_minuszi = *(HEOS_minuszi.get());
-                        std::vector<long double> zm = z; /// Copy base composition
+                        std::vector<CoolPropDbl> zm = z; /// Copy base composition
                         zm[i] -= dz; 
                         if (xN_flag == XN_DEPENDENT)
                             zm[z.size()-1] += dz;
@@ -752,7 +752,7 @@ TEST_CASE("Mixture derivative checks", "[mixtures],[mixture_derivs]")
                             HEOS_pluszj.reset(new HelmholtzEOSMixtureBackend(names));
                             HEOS_pluszj->specify_phase(iphase_gas); 
                             HelmholtzEOSMixtureBackend &rHEOS_pluszj = *(HEOS_pluszj.get());
-                            std::vector<long double> zp = z; /// Copy base composition
+                            std::vector<CoolPropDbl> zp = z; /// Copy base composition
                             zp[j] += dz; 
                             if (xN_flag == XN_DEPENDENT)
                                 zp[z.size()-1] -= dz;
@@ -762,7 +762,7 @@ TEST_CASE("Mixture derivative checks", "[mixtures],[mixture_derivs]")
                             HEOS_minuszj.reset(new HelmholtzEOSMixtureBackend(names));
                             HEOS_minuszj->specify_phase(iphase_gas); 
                             HelmholtzEOSMixtureBackend &rHEOS_minuszj = *(HEOS_minuszj.get());
-                            std::vector<long double> zm = z; /// Copy base composition
+                            std::vector<CoolPropDbl> zm = z; /// Copy base composition
                             zm[j] -= dz; 
                             if (xN_flag == XN_DEPENDENT)
                                 zm[z.size()-1] += dz;

--- a/src/Backends/Helmholtz/MixtureDerivatives.h
+++ b/src/Backends/Helmholtz/MixtureDerivatives.h
@@ -37,7 +37,7 @@ class MixtureDerivatives{
      * \f]
      * @param HEOS The HelmholtzEOSMixtureBackend to be used
      */
-    static long double ndpdV__constT_n(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl ndpdV__constT_n(HelmholtzEOSMixtureBackend &HEOS);
     
     /** \brief GERG 2004 Monograph equation 7.61
      * 
@@ -47,14 +47,14 @@ class MixtureDerivatives{
      * \f]
      * @param HEOS The HelmholtzEOSMixtureBackend to be used
      */
-    static long double dpdT__constV_n(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl dpdT__constV_n(HelmholtzEOSMixtureBackend &HEOS);
 
-    static long double dpdrho__constT_n(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl dpdrho__constT_n(HelmholtzEOSMixtureBackend &HEOS);
     
-    static long double dalphar_dxi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
-    static long double d2alphar_dxi_dTau(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
-    static long double d2alphar_dxi_dDelta(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
-    static long double d2alphardxidxj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
+    static CoolPropDbl dalphar_dxi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl d2alphar_dxi_dTau(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl d2alphar_dxi_dDelta(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl d2alphardxidxj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
 
     
 
@@ -68,7 +68,7 @@ class MixtureDerivatives{
      * @param i The index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
      */
-    static long double ndpdni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl ndpdni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
 
     /** \brief GERG 2004 monograph Eqn. 7.32
      * 
@@ -80,7 +80,7 @@ class MixtureDerivatives{
      * @param i The index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
      */
-    static long double partial_molar_volume(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl partial_molar_volume(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
 
     /** \brief Fugacity of the i-th component
      * 
@@ -89,7 +89,7 @@ class MixtureDerivatives{
      * f_i(\delta, \tau, \bar x) = x_i\rho R T \exp\left(\frac{\partial n\alpha^r}{\partial n_i}\right)_{T,V,n_{j \neq i}}
      * \f]
      */
-    static long double fugacity_i(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl fugacity_i(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
       
     /** \brief Natural logarithm of the fugacity coefficient
      * 
@@ -97,7 +97,7 @@ class MixtureDerivatives{
      * @param i The index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
      */
-    static long double ln_fugacity_coefficient(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl ln_fugacity_coefficient(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
 
     /** \brief Derivative of the natural logarithm of the fugacity with respect to T
      * 
@@ -109,7 +109,7 @@ class MixtureDerivatives{
      * @param i The index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
      */
-    static long double dln_fugacity_i_dT__constrho_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl dln_fugacity_i_dT__constrho_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
 
     /**    \brief Derivative of the natural logarithm of the fugacity with respect to T
      * 
@@ -121,7 +121,7 @@ class MixtureDerivatives{
      * @param i The index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
      */
-    static long double dln_fugacity_i_drho__constT_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl dln_fugacity_i_drho__constT_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
 
     /** \brief GERG 2004 Monograph Eqn. 7.29
      * 
@@ -134,14 +134,14 @@ class MixtureDerivatives{
      * @param i The index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
      */
-    static long double dln_fugacity_coefficient_dT__constp_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl dln_fugacity_coefficient_dT__constp_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
 
-    static long double dln_fugacity_i_dT__constp_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
-    static long double dln_fugacity_i_dp__constT_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
-    static long double dln_fugacity_dxj__constT_p_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
-    static long double dln_fugacity_i_dtau__constdelta_x(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
-    static long double dln_fugacity_i_ddelta__consttau_x(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
-    static long double dln_fugacity_dxj__constT_rho_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
+    static CoolPropDbl dln_fugacity_i_dT__constp_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl dln_fugacity_i_dp__constT_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl dln_fugacity_dxj__constT_p_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
+    static CoolPropDbl dln_fugacity_i_dtau__constdelta_x(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl dln_fugacity_i_ddelta__consttau_x(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl dln_fugacity_dxj__constT_rho_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
     
     /** \brief Table B4, Kunz, JCED, 2012 for the original term and the subsequent substitutions
      * 
@@ -159,10 +159,10 @@ class MixtureDerivatives{
      * @param i The index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
      */
-    static long double ndalphar_dni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl ndalphar_dni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
 
     /// GERG Equation 7.42
-    static long double dnalphar_dni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl dnalphar_dni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
 
     /** \brief GERG 2004 Monograph Eqn. 7.30
      * 
@@ -174,7 +174,7 @@ class MixtureDerivatives{
      * @param i The index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
     */
-    static long double dln_fugacity_coefficient_dp__constT_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl dln_fugacity_coefficient_dp__constT_n(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
 
     /** \brief GERG 2004 Monograph Equation 7.31
      * 
@@ -191,7 +191,7 @@ class MixtureDerivatives{
      * @param j The second index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
     */
-    static long double ndln_fugacity_coefficient_dnj__constT_p(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
+    static CoolPropDbl ndln_fugacity_coefficient_dnj__constT_p(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
 
     /** \brief Gernert Equation 3.115
      * 
@@ -205,7 +205,7 @@ class MixtureDerivatives{
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
      * 
     */
-    static long double dln_fugacity_coefficient_dxj__constT_p_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
+    static CoolPropDbl dln_fugacity_coefficient_dxj__constT_p_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
 
     /** \brief Gernert Equation 3.130
      * 
@@ -217,7 +217,7 @@ class MixtureDerivatives{
      * @param j The index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
      */
-    static long double dpdxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag);
+    static CoolPropDbl dpdxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag);
 
     /** \brief Gernert Equation 3.117
      * 
@@ -230,27 +230,27 @@ class MixtureDerivatives{
      * @param i The second index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
      */
-    static long double d2nalphar_dxj_dni__constT_V(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, std::size_t i, x_N_dependency_flag xN_flag){ return MixtureDerivatives::d_ndalphardni_dxj__constT_V_xi(HEOS, i, j, xN_flag) + MixtureDerivatives::dalphar_dxj__constT_V_xi(HEOS, j, xN_flag);};
+    static CoolPropDbl d2nalphar_dxj_dni__constT_V(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, std::size_t i, x_N_dependency_flag xN_flag){ return MixtureDerivatives::d_ndalphardni_dxj__constT_V_xi(HEOS, i, j, xN_flag) + MixtureDerivatives::dalphar_dxj__constT_V_xi(HEOS, j, xN_flag);};
 
     /// Gernert Equation 3.119
     /// Catch test provided
-    static long double dalphar_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag);
+    static CoolPropDbl dalphar_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag);
 
     /// Gernert Equation 3.118
     /// Catch test provided
-    static long double d_ndalphardni_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
+    static CoolPropDbl d_ndalphardni_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
 
     /// Gernert Equation 3.134
     /// Catch test provided
-    static long double d_dalpharddelta_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag);
+    static CoolPropDbl d_dalpharddelta_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag);
 
     /// Gernert Equation 3.121
     /// Catch test provided
-    static long double ddelta_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag);
+    static CoolPropDbl ddelta_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag);
 
     /// Gernert Equation 3.122
     /// Catch test provided
-    static long double dtau_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag);
+    static CoolPropDbl dtau_dxj__constT_V_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t j, x_N_dependency_flag xN_flag);
 
     /** \brief GERG 2004 Monograph, equations 7.44 and 7.51
      * 
@@ -265,7 +265,7 @@ class MixtureDerivatives{
      * @param i The second index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
     */
-    static long double d2nalphar_dni_dT(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl d2nalphar_dni_dT(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
 
     /** \brief GERG 2004 Monograph Equation 7.51 and Table B4, Kunz, JCED, 2012
      * 
@@ -279,7 +279,7 @@ class MixtureDerivatives{
      * @param i The index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
      */
-    static long double d_ndalphardni_dTau(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl d_ndalphardni_dTau(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
 
     /** \brief GERG 2004 Monograph Equation 7.50 and Table B4, Kunz, JCED, 2012
      * 
@@ -293,7 +293,7 @@ class MixtureDerivatives{
      * @param i The index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
      */
-    static long double d_ndalphardni_dDelta(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl d_ndalphardni_dDelta(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
 
     /** \brief GERG 2004 Monograph equation 7.41
      * 
@@ -317,7 +317,7 @@ class MixtureDerivatives{
      * @param j The second index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
      */
-    static long double nd2nalphardnidnj__constT_V(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
+    static CoolPropDbl nd2nalphardnidnj__constT_V(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
 
     /** \brief GERG 2004 Monograph equation 7.48
      * 
@@ -329,7 +329,7 @@ class MixtureDerivatives{
      * @param i The index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
      */ 
-    static long double nddeltadni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl nddeltadni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
 
     /** \brief GERG 2004 Monograph equation 7.49
      * 
@@ -341,7 +341,7 @@ class MixtureDerivatives{
      * @param i The index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
      */
-    static long double ndtaudni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
+    static CoolPropDbl ndtaudni__constT_V_nj(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, x_N_dependency_flag xN_flag);
 
     /** \brief GERG 2004 Monograph equation 7.52
      * 
@@ -358,7 +358,7 @@ class MixtureDerivatives{
      * @param j The second index of interest
      * @param xN_flag A flag specifying whether the all mole fractions are independent or only the first N-1
      */
-    static long double d_ndalphardni_dxj__constdelta_tau_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
+    static CoolPropDbl d_ndalphardni_dxj__constdelta_tau_xi(HelmholtzEOSMixtureBackend &HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
 
 }; /* class MixtureDerivatives */
 

--- a/src/Backends/Helmholtz/MixtureParameters.cpp
+++ b/src/Backends/Helmholtz/MixtureParameters.cpp
@@ -285,10 +285,10 @@ void MixtureParameters::set_mixture_parameters(HelmholtzEOSMixtureBackend &HEOS)
     std::size_t N = components.size();
 
     STLMatrix beta_v, gamma_v, beta_T, gamma_T;
-    beta_v.resize(N, std::vector<long double>(N, 0));
-    gamma_v.resize(N, std::vector<long double>(N, 0));
-    beta_T.resize(N, std::vector<long double>(N, 0));
-    gamma_T.resize(N, std::vector<long double>(N, 0));
+    beta_v.resize(N, std::vector<CoolPropDbl>(N, 0));
+    gamma_v.resize(N, std::vector<CoolPropDbl>(N, 0));
+    beta_T.resize(N, std::vector<CoolPropDbl>(N, 0));
+    gamma_T.resize(N, std::vector<CoolPropDbl>(N, 0));
 
     HEOS.Excess.resize(N);
 

--- a/src/Backends/Helmholtz/PhaseEnvelopeRoutines.h
+++ b/src/Backends/Helmholtz/PhaseEnvelopeRoutines.h
@@ -33,7 +33,7 @@ class PhaseEnvelopeRoutines{
      * @param iInput The key for the variable type that is to be checked
      * @param value The value associated with iInput
      */
-    static std::vector<std::pair<std::size_t, std::size_t> > find_intersections(HelmholtzEOSMixtureBackend &HEOS, parameters iInput, long double value);
+    static std::vector<std::pair<std::size_t, std::size_t> > find_intersections(HelmholtzEOSMixtureBackend &HEOS, parameters iInput, CoolPropDbl value);
     
     /** \brief Determine whether a pair of inputs is inside or outside the phase envelope
      * 
@@ -45,7 +45,7 @@ class PhaseEnvelopeRoutines{
      * @param iclosest The index of the phase envelope for the closest point
      * @param closest_state A SimpleState corresponding to the closest point found on the phase envelope
      */
-    static bool is_inside(HelmholtzEOSMixtureBackend &HEOS, parameters iInput1, long double value1, parameters iInput2, long double value2, std::size_t &iclosest, SimpleState &closest_state);
+    static bool is_inside(HelmholtzEOSMixtureBackend &HEOS, parameters iInput1, CoolPropDbl value1, parameters iInput2, CoolPropDbl value2, std::size_t &iclosest, SimpleState &closest_state);
 };
     
 } /* namespace CoolProp */

--- a/src/Backends/Helmholtz/ReducingFunctions.cpp
+++ b/src/Backends/Helmholtz/ReducingFunctions.cpp
@@ -2,10 +2,10 @@
 
 namespace CoolProp{
 
-long double ReducingFunction::d_ndTrdni_dxj__constxi(const std::vector<long double> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl ReducingFunction::d_ndTrdni_dxj__constxi(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
 {
     if (xN_flag == XN_INDEPENDENT){
-        long double s = 0;
+        CoolPropDbl s = 0;
         for (std::size_t k = 0; k < N; k++)
         {
             s += x[k]*d2Trdxidxj(x,j,k, xN_flag);
@@ -14,12 +14,12 @@ long double ReducingFunction::d_ndTrdni_dxj__constxi(const std::vector<long doub
     }
     else if (xN_flag == XN_DEPENDENT){
         if (j == N-1){ return 0;}
-        long double s = 0;
+        CoolPropDbl s = 0;
         for (std::size_t k = 0; k < N-1; k++)
         {
             s += x[k]*d2Trdxidxj(x,k,j, xN_flag);
         }
-        long double val = d2Trdxidxj(x,j,i,xN_flag)-dTrdxi__constxj(x,j, xN_flag)-s;
+        CoolPropDbl val = d2Trdxidxj(x,j,i,xN_flag)-dTrdxi__constxj(x,j, xN_flag)-s;
         return val;
     }
     else{
@@ -27,19 +27,19 @@ long double ReducingFunction::d_ndTrdni_dxj__constxi(const std::vector<long doub
     }
     
 }
-long double ReducingFunction::d_ndrhorbardni_dxj__constxi(const std::vector<long double> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl ReducingFunction::d_ndrhorbardni_dxj__constxi(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
 {
-    long double s = 0;
+    CoolPropDbl s = 0;
     for (std::size_t k = 0; k < N; k++)
     {
         s += x[k]*d2rhormolardxidxj(x,j,k, xN_flag);
     }
     return d2rhormolardxidxj(x,j,i, xN_flag)-drhormolardxi__constxj(x,j, xN_flag)-s;
 }
-long double ReducingFunction::ndrhorbardni__constnj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl ReducingFunction::ndrhorbardni__constnj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag)
 {
     if (xN_flag == XN_INDEPENDENT){
-        long double summer_term1 = 0;
+        CoolPropDbl summer_term1 = 0;
         for (std::size_t j = 0; j < N; j++)
         {
             summer_term1 += x[j]*drhormolardxi__constxj(x,j, xN_flag);
@@ -47,7 +47,7 @@ long double ReducingFunction::ndrhorbardni__constnj(const std::vector<long doubl
         return drhormolardxi__constxj(x,i, xN_flag)-summer_term1;
     }
     else if (xN_flag == XN_DEPENDENT){
-        long double summer_term1 = 0;
+        CoolPropDbl summer_term1 = 0;
         for (std::size_t k = 0; k < N-1; ++k)
         {
             summer_term1 += x[k]*drhormolardxi__constxj(x, k, xN_flag);
@@ -58,11 +58,11 @@ long double ReducingFunction::ndrhorbardni__constnj(const std::vector<long doubl
         throw ValueError(format("xN dependency flag invalid"));
     }
 }
-long double ReducingFunction::ndTrdni__constnj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl ReducingFunction::ndTrdni__constnj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag)
 {
     if (xN_flag == XN_INDEPENDENT){
         // GERG Equation 7.54
-        long double summer_term1 = 0;
+        CoolPropDbl summer_term1 = 0;
         for (std::size_t j = 0; j < N; j++)
         {
             summer_term1 += x[j]*dTrdxi__constxj(x,j, xN_flag);
@@ -70,7 +70,7 @@ long double ReducingFunction::ndTrdni__constnj(const std::vector<long double> &x
         return dTrdxi__constxj(x,i, xN_flag)-summer_term1;
     }
     else if (xN_flag == XN_DEPENDENT){
-        long double summer_term1 = 0;
+        CoolPropDbl summer_term1 = 0;
         for (std::size_t k = 0; k < N-1; ++k)
         {
             summer_term1 += x[k]*dTrdxi__constxj(x, k, xN_flag);
@@ -82,49 +82,49 @@ long double ReducingFunction::ndTrdni__constnj(const std::vector<long double> &x
     }
 }
 
-long double GERG2008ReducingFunction::Tr(const std::vector<long double> &x)
+CoolPropDbl GERG2008ReducingFunction::Tr(const std::vector<CoolPropDbl> &x)
 {
     return Yr(x, beta_T, gamma_T, T_c, Yc_T);
 }
-long double GERG2008ReducingFunction::dTrdxi__constxj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl GERG2008ReducingFunction::dTrdxi__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag)
 {
     return dYrdxi__constxj(x, i, beta_T, gamma_T, T_c, Yc_T, xN_flag);
 }
-long double GERG2008ReducingFunction::d2Trdxi2__constxj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl GERG2008ReducingFunction::d2Trdxi2__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag)
 {
     return d2Yrdxi2__constxj(x, i, beta_T, gamma_T, T_c, Yc_T, xN_flag);
 }
-long double GERG2008ReducingFunction::d2Trdxidxj(const std::vector<long double> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl GERG2008ReducingFunction::d2Trdxidxj(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
 {
     return d2Yrdxidxj(x, i, j, beta_T, gamma_T, T_c, Yc_T, xN_flag);
 }
-long double GERG2008ReducingFunction::rhormolar(const std::vector<long double> &x)
+CoolPropDbl GERG2008ReducingFunction::rhormolar(const std::vector<CoolPropDbl> &x)
 {
     return 1/Yr(x, beta_v, gamma_v, v_c, Yc_v);
 }
-long double GERG2008ReducingFunction::drhormolardxi__constxj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl GERG2008ReducingFunction::drhormolardxi__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag)
 {
     return -pow(rhormolar(x),2)*dvrmolardxi__constxj(x, i, xN_flag);
 }
-long double GERG2008ReducingFunction::dvrmolardxi__constxj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl GERG2008ReducingFunction::dvrmolardxi__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag)
 {
     return dYrdxi__constxj(x, i, beta_v, gamma_v, v_c, Yc_v, xN_flag);
 }
-long double GERG2008ReducingFunction::d2vrmolardxi2__constxj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl GERG2008ReducingFunction::d2vrmolardxi2__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag)
 {
     return d2Yrdxi2__constxj(x, i, beta_v, gamma_v, v_c, Yc_v, xN_flag);
 }
-long double GERG2008ReducingFunction::d2vrmolardxidxj(const std::vector<long double> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl GERG2008ReducingFunction::d2vrmolardxidxj(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
 {
     return d2Yrdxidxj(x, i, j, beta_v, gamma_v, v_c, Yc_v, xN_flag);
 }
-long double GERG2008ReducingFunction::d2rhormolardxi2__constxj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag)
+CoolPropDbl GERG2008ReducingFunction::d2rhormolardxi2__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag)
 {
-    long double rhor = this->rhormolar(x);
-    long double dvrbardxi = this->dvrmolardxi__constxj(x,i, xN_flag);
+    CoolPropDbl rhor = this->rhormolar(x);
+    CoolPropDbl dvrbardxi = this->dvrmolardxi__constxj(x,i, xN_flag);
     return 2*pow(rhor,3)*pow(dvrbardxi,2)-pow(rhor,2)*this->d2vrmolardxi2__constxj(x,i, xN_flag);
 }
-long double GERG2008ReducingFunction::d2rhormolardxidxj(const std::vector<long double> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
+CoolPropDbl GERG2008ReducingFunction::d2rhormolardxidxj(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag)
 {
     double rhor = this->rhormolar(x);
     double dvrbardxi = this->dvrmolardxi__constxj(x,i, xN_flag);
@@ -132,9 +132,9 @@ long double GERG2008ReducingFunction::d2rhormolardxidxj(const std::vector<long d
     return 2*pow(rhor,3)*dvrbardxi*dvrbardxj-pow(rhor,2)*this->d2vrmolardxidxj(x,i,j, xN_flag);
 }
 
-long double GERG2008ReducingFunction::Yr(const std::vector<long double> &x, const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c_ij, const std::vector<long double> &Yc)
+CoolPropDbl GERG2008ReducingFunction::Yr(const std::vector<CoolPropDbl> &x, const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c_ij, const std::vector<CoolPropDbl> &Yc)
 {
-    long double Yr = 0;
+    CoolPropDbl Yr = 0;
     for (std::size_t i = 0; i < N; i++)
     {
         double xi = x[i];
@@ -150,12 +150,12 @@ long double GERG2008ReducingFunction::Yr(const std::vector<long double> &x, cons
     }
     return Yr;
 }
-long double GERG2008ReducingFunction::dYrdxi__constxj(const std::vector<long double> &x, std::size_t i,  const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c_ij, const std::vector<long double> &Yc, x_N_dependency_flag xN_flag)
+CoolPropDbl GERG2008ReducingFunction::dYrdxi__constxj(const std::vector<CoolPropDbl> &x, std::size_t i,  const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c_ij, const std::vector<CoolPropDbl> &Yc, x_N_dependency_flag xN_flag)
 {
     if (xN_flag == XN_INDEPENDENT){
         // See Table B9 from Kunz Wagner 2012 (GERG 2008)
-        long double xi = x[i];
-        long double dYr_dxi = 2*xi*Yc[i];
+        CoolPropDbl xi = x[i];
+        CoolPropDbl dYr_dxi = 2*xi*Yc[i];
         for (std::size_t k = 0; k < i; k++)
         {
             dYr_dxi += c_Y_ij(k,i,beta,gamma,Y_c_ij)*dfYkidxi__constxk(x,k,i,beta);
@@ -169,7 +169,7 @@ long double GERG2008ReducingFunction::dYrdxi__constxj(const std::vector<long dou
     else if (xN_flag == XN_DEPENDENT){
         // Table S1 from Gernert, 2014, supplemental information
         if (i == N-1){return 0.0;}
-        long double dYr_dxi = 2*x[i]*Yc[i] - 2*x[N-1]*Yc[N-1];
+        CoolPropDbl dYr_dxi = 2*x[i]*Yc[i] - 2*x[N-1]*Yc[N-1];
         for (std::size_t k = 0; k < i; k++)
         {
             dYr_dxi += c_Y_ij(k, i, beta, gamma, Y_c_ij)*dfYkidxi__constxk(x,k,i,beta);
@@ -191,11 +191,11 @@ long double GERG2008ReducingFunction::dYrdxi__constxj(const std::vector<long dou
         throw ValueError(format("xN dependency flag invalid"));
     }
 }
-long double GERG2008ReducingFunction::d2Yrdxi2__constxj(const std::vector<long double> &x, std::size_t i,  const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c_ij, const std::vector<long double> &Yc, x_N_dependency_flag xN_flag)
+CoolPropDbl GERG2008ReducingFunction::d2Yrdxi2__constxj(const std::vector<CoolPropDbl> &x, std::size_t i,  const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c_ij, const std::vector<CoolPropDbl> &Yc, x_N_dependency_flag xN_flag)
 {
     if (xN_flag == XN_INDEPENDENT){
         // See Table B9 from Kunz Wagner 2012 (GERG 2008)
-        long double d2Yr_dxi2 = 2*Yc[i];
+        CoolPropDbl d2Yr_dxi2 = 2*Yc[i];
         for (std::size_t k = 0; k < i; k++)
         {
             d2Yr_dxi2 += c_Y_ij(k,i,beta,gamma,Y_c_ij)*d2fYkidxi2__constxk(x,k,i,beta);
@@ -209,7 +209,7 @@ long double GERG2008ReducingFunction::d2Yrdxi2__constxj(const std::vector<long d
     else if (xN_flag == XN_DEPENDENT){
         // Table S1 from Gernert, 2014, supplemental information
         if (i == N-1){return 0.0;}
-        long double d2Yr_dxi2 = 2*Yc[i] + 2*Yc[N-1];
+        CoolPropDbl d2Yr_dxi2 = 2*Yc[i] + 2*Yc[N-1];
         for (std::size_t k = 0; k < i; k++)
         {
             d2Yr_dxi2 += c_Y_ij(k, i, beta, gamma, Y_c_ij)*d2fYkidxi2__constxk(x,k,i,beta);
@@ -232,7 +232,7 @@ long double GERG2008ReducingFunction::d2Yrdxi2__constxj(const std::vector<long d
     }
 }
 
-long double GERG2008ReducingFunction::d2Yrdxidxj(const std::vector<long double> &x, std::size_t i, std::size_t j, const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c_ij, const std::vector<long double> &Yc, x_N_dependency_flag xN_flag)
+CoolPropDbl GERG2008ReducingFunction::d2Yrdxidxj(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j, const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c_ij, const std::vector<CoolPropDbl> &Yc, x_N_dependency_flag xN_flag)
 {
     if (std::abs(x[i]) < 10*DBL_EPSILON && std::abs(x[j]) < 10*DBL_EPSILON){return 0;}
     if (xN_flag == XN_INDEPENDENT){
@@ -250,21 +250,21 @@ long double GERG2008ReducingFunction::d2Yrdxidxj(const std::vector<long double> 
         // Table S1 from Gernert, 2014, supplemental information
         if (j == N-1 || i == N-1){ return 0.0; }
         if (i == j){ return d2Yrdxi2__constxj(x, i, beta, gamma, Y_c_ij, Yc, xN_flag); }
-        long double xN = x[N-1];
-        long double d2Yr_dxidxj = 2*Yc[N-1];
+        CoolPropDbl xN = x[N-1];
+        CoolPropDbl d2Yr_dxidxj = 2*Yc[N-1];
         d2Yr_dxidxj += c_Y_ij(i, j, beta, gamma, Y_c_ij)*d2fYijdxidxj(x,i,j,beta);
         
         for (std::size_t k = 0; k < N-1; k++)
         {
-            long double beta_Y_kN = beta[k][N-1];
+            CoolPropDbl beta_Y_kN = beta[k][N-1];
             d2Yr_dxidxj += 2*c_Y_ij(k, N-1, beta, gamma, Y_c_ij)*x[k]*x[k]*(1-beta_Y_kN*beta_Y_kN)/pow(beta_Y_kN*beta_Y_kN*x[k]+xN,2)*(xN/(beta_Y_kN*beta_Y_kN*x[k]+xN)-1);
         }
         {
-            long double beta_Y_iN = beta[i][N-1];
+            CoolPropDbl beta_Y_iN = beta[i][N-1];
             d2Yr_dxidxj +=  c_Y_ij(i, N-1, beta, gamma, Y_c_ij)*((1-beta_Y_iN*beta_Y_iN)*(2*x[i]*xN*xN/pow(beta_Y_iN*beta_Y_iN*x[i]+xN, 3)-x[i]*xN/pow(beta_Y_iN*beta_Y_iN*x[i]+xN, 2)) - (x[i]+xN)/(beta_Y_iN*beta_Y_iN*x[i]+xN));
         }
         {
-            long double beta_Y_jN = beta[j][N-1];
+            CoolPropDbl beta_Y_jN = beta[j][N-1];
             d2Yr_dxidxj += -c_Y_ij(j, N-1, beta, gamma, Y_c_ij)*((1-beta_Y_jN*beta_Y_jN)*(2*x[j]*x[j]*xN*beta_Y_jN*beta_Y_jN/pow(beta_Y_jN*beta_Y_jN*x[j]+xN, 3)-x[j]*xN/pow(beta_Y_jN*beta_Y_jN*x[j]+xN, 2)) + (x[j]+xN)/(beta_Y_jN*beta_Y_jN*x[j]+xN));
         }
         return d2Yr_dxidxj;
@@ -274,41 +274,41 @@ long double GERG2008ReducingFunction::d2Yrdxidxj(const std::vector<long double> 
     }
 }
 
-long double GERG2008ReducingFunction::dfYkidxi__constxk(const std::vector<long double> &x, std::size_t k, std::size_t i, const STLMatrix &beta)
+CoolPropDbl GERG2008ReducingFunction::dfYkidxi__constxk(const std::vector<CoolPropDbl> &x, std::size_t k, std::size_t i, const STLMatrix &beta)
 {
     double xk = x[k], xi = x[i], beta_Y = beta[k][i];
     if (std::abs(xi) < 10*DBL_EPSILON && std::abs(xk) < 10*DBL_EPSILON){return 0;}
     return xk*(xk+xi)/(beta_Y*beta_Y*xk+xi)+xk*xi/(beta_Y*beta_Y*xk+xi)*(1-(xk+xi)/(beta_Y*beta_Y*xk+xi));
 }
-long double GERG2008ReducingFunction::dfYikdxi__constxk(const std::vector<long double> &x, std::size_t i, std::size_t k, const STLMatrix &beta)
+CoolPropDbl GERG2008ReducingFunction::dfYikdxi__constxk(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t k, const STLMatrix &beta)
 {
     double xk = x[k], xi = x[i], beta_Y = beta[i][k];
     if (std::abs(xi) < 10*DBL_EPSILON && std::abs(xk) < 10*DBL_EPSILON){return 0;}
     return xk*(xi+xk)/(beta_Y*beta_Y*xi+xk)+xi*xk/(beta_Y*beta_Y*xi+xk)*(1-beta_Y*beta_Y*(xi+xk)/(beta_Y*beta_Y*xi+xk));
 }
-long double GERG2008ReducingFunction::c_Y_ij(std::size_t i, std::size_t j, const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c)
+CoolPropDbl GERG2008ReducingFunction::c_Y_ij(std::size_t i, std::size_t j, const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c)
 {
     return 2*beta[i][j]*gamma[i][j]*Y_c[i][j];
 }
-long double GERG2008ReducingFunction::f_Y_ij(const std::vector<long double> &x, std::size_t i, std::size_t j, const STLMatrix &beta)
+CoolPropDbl GERG2008ReducingFunction::f_Y_ij(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j, const STLMatrix &beta)
 {
     double xi = x[i], xj = x[j], beta_Y = beta[i][j];
     if (std::abs(xi) < 10*DBL_EPSILON && std::abs(xj) < 10*DBL_EPSILON){return 0;}
     return xi*xj*(xi+xj)/(beta_Y*beta_Y*xi+xj);
 }
-long double GERG2008ReducingFunction::d2fYikdxi2__constxk(const std::vector<long double> &x, std::size_t i, std::size_t k, const STLMatrix &beta)
+CoolPropDbl GERG2008ReducingFunction::d2fYikdxi2__constxk(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t k, const STLMatrix &beta)
 {
     double xi = x[i], xk = x[k], beta_Y = beta[i][k];
     if (std::abs(xi) < 10*DBL_EPSILON && std::abs(xk) < 10*DBL_EPSILON){return 0;}
     return 1/(beta_Y*beta_Y*xi+xk)*(1-beta_Y*beta_Y*(xi+xk)/(beta_Y*beta_Y*xi+xk))*(2*xk-xi*xk*2*beta_Y*beta_Y/(beta_Y*beta_Y*xi+xk));
 }
-long double GERG2008ReducingFunction::d2fYkidxi2__constxk(const std::vector<long double> &x, std::size_t k, std::size_t i, const STLMatrix &beta)
+CoolPropDbl GERG2008ReducingFunction::d2fYkidxi2__constxk(const std::vector<CoolPropDbl> &x, std::size_t k, std::size_t i, const STLMatrix &beta)
 {
     double xi = x[i], xk = x[k], beta_Y = beta[k][i];
     if (std::abs(xi) < 10*DBL_EPSILON && std::abs(xk) < 10*DBL_EPSILON){return 0;}
     return 1/(beta_Y*beta_Y*xk+xi)*(1-(xk+xi)/(beta_Y*beta_Y*xk+xi))*(2*xk-xk*xi*2/(beta_Y*beta_Y*xk+xi));
 }
-long double GERG2008ReducingFunction::d2fYijdxidxj(const std::vector<long double> &x, std::size_t i, std::size_t j, const STLMatrix &beta)
+CoolPropDbl GERG2008ReducingFunction::d2fYijdxidxj(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j, const STLMatrix &beta)
 {
     double xi = x[i], xj = x[j], beta_Y = beta[i][j], beta_Y2 = beta_Y*beta_Y;
     if (std::abs(xi) < 10*DBL_EPSILON && std::abs(xj) < 10*DBL_EPSILON){return 0;}

--- a/src/Backends/Helmholtz/ReducingFunctions.h
+++ b/src/Backends/Helmholtz/ReducingFunctions.h
@@ -13,7 +13,7 @@
 
 namespace CoolProp{
 
-typedef std::vector<std::vector<long double> > STLMatrix;
+typedef std::vector<std::vector<CoolPropDbl> > STLMatrix;
 
 enum x_N_dependency_flag{XN_INDEPENDENT, ///< x_N is an independent variable, and not calculated by \f$ x_N = 1-\sum_i x_i\f$
                          XN_DEPENDENT ///< x_N is an dependent variable, calculated by \f$ x_N = 1-\sum_i x_i\f$
@@ -35,21 +35,21 @@ public:
     virtual ~ReducingFunction(){};
 
     /// A factory function to generate the requiredreducing function
-    static shared_ptr<ReducingFunction> factory(const std::vector<CoolPropFluid*> &components, std::vector< std::vector< long double> > &F);
+    static shared_ptr<ReducingFunction> factory(const std::vector<CoolPropFluid*> &components, std::vector< std::vector< CoolPropDbl> > &F);
 
     /// The reduced temperature
-    virtual long double Tr(const std::vector<long double> &x) = 0;
+    virtual CoolPropDbl Tr(const std::vector<CoolPropDbl> &x) = 0;
     /// The derivative of reduced temperature with respect to component i mole fraction
-    virtual long double dTrdxi__constxj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag) = 0;
+    virtual CoolPropDbl dTrdxi__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag) = 0;
     /// The molar reducing density
-    virtual long double rhormolar(const std::vector<long double> &x) = 0;
+    virtual CoolPropDbl rhormolar(const std::vector<CoolPropDbl> &x) = 0;
     ///Derivative of the molar reducing density with respect to component i mole fraction
-    virtual long double drhormolardxi__constxj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag) = 0;
+    virtual CoolPropDbl drhormolardxi__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag) = 0;
 
-    virtual long double d2rhormolardxi2__constxj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag) = 0;
-    virtual long double d2rhormolardxidxj(const std::vector<long double> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) = 0;
-    virtual long double d2Trdxi2__constxj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag) = 0;
-    virtual long double d2Trdxidxj(const std::vector<long double> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) = 0;
+    virtual CoolPropDbl d2rhormolardxi2__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag) = 0;
+    virtual CoolPropDbl d2rhormolardxidxj(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) = 0;
+    virtual CoolPropDbl d2Trdxi2__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag) = 0;
+    virtual CoolPropDbl d2Trdxidxj(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) = 0;
 
     /** \brief GERG 2004 Monograph equation 7.56:
      * 
@@ -62,7 +62,7 @@ public:
      * \left(\frac{\partial}{\partial x_j}\left(n\left(\frac{\partial T_r}{\partial n_i} \right)_{n_j}\right)\right)_{x_i} = \left(\frac{\partial^2T_r}{\partial x_j \partial x_i}\right)-\left(\frac{\partial T_r}{\partial x_j}\right)_{x_i}-\sum_{k=0}^{N-1}x_k\left(\frac{\partial^2T_r}{\partial x_j \partial x_k}\right)
      * \f]
      */
-    long double d_ndTrdni_dxj__constxi(const std::vector<long double> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
+    CoolPropDbl d_ndTrdni_dxj__constxi(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
     /** \brief 
      * 
      * GERG 2004 Monograph equation 7.55:
@@ -76,10 +76,10 @@ public:
      * \left(\frac{\partial}{\partial x_j}\left(n\left(\frac{\partial \rho_r}{\partial n_i} \right)_{n_j}\right)\right)_{x_i} = \left(\frac{\partial^2\rho_r}{\partial x_j \partial x_i}\right)-\left(\frac{\partial \rho_r}{\partial x_j}\right)_{x_i}-\sum_{k=0}^{N-2}x_k\left(\frac{\partial^2\rho_r}{\partial x_j \partial x_k}\right)
      * \f] 
      */
-    long double d_ndrhorbardni_dxj__constxi(const std::vector<long double> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
+    CoolPropDbl d_ndrhorbardni_dxj__constxi(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
 
-    long double ndrhorbardni__constnj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag);
-    long double ndTrdni__constnj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag);
+    CoolPropDbl ndrhorbardni__constnj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag);
+    CoolPropDbl ndTrdni__constnj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag);
 };
 
 /** \brief The reducing function model of GERG-2008
@@ -98,8 +98,8 @@ protected:
     STLMatrix gamma_v; ///< \f$ \gamma_{v,ij} \f$ from GERG-2008
     STLMatrix beta_T; ///< \f$ \beta_{T,ij} \f$ from GERG-2008
     STLMatrix gamma_T; ///< \f$ \gamma_{T,ij} \f$ from GERG-2008
-    std::vector<long double> Yc_T; ///< Vector of critical temperatures for all components
-    std::vector<long double> Yc_v; ///< Vector of critical molar volumes for all components
+    std::vector<CoolPropDbl> Yc_T; ///< Vector of critical temperatures for all components
+    std::vector<CoolPropDbl> Yc_v; ///< Vector of critical molar volumes for all components
     std::vector<CoolPropFluid *> pFluids; ///< List of pointer to fluids
 
 public:
@@ -111,8 +111,8 @@ public:
         this->beta_T = beta_T;
         this->gamma_T = gamma_T;
         this->N = pFluids.size();
-        T_c.resize(N,std::vector<long double>(N,0));
-        v_c.resize(N,std::vector<long double>(N,0));
+        T_c.resize(N,std::vector<CoolPropDbl>(N,0));
+        v_c.resize(N,std::vector<CoolPropDbl>(N,0));
         Yc_T.resize(N);
         Yc_v.resize(N);
         for (std::size_t i = 0; i < N; ++i)
@@ -132,43 +132,43 @@ public:
     /** \brief The reducing temperature
      * Calculated from \ref Yr with \f$T = Y\f$
      */
-    long double Tr(const std::vector<long double> &x);
+    CoolPropDbl Tr(const std::vector<CoolPropDbl> &x);
     /** \brief The derivative of reducing temperature with respect to component i mole fraction
      * 
      * Calculated from \ref dYrdxi__constxj with \f$T = Y\f$
      */
-    long double dTrdxi__constxj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag);
+    CoolPropDbl dTrdxi__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag);
     /** \brief The second derivative of reducing temperature with respect to component i mole fraction
      * 
      * Calculated from \ref d2Yrdxi2__constxj with \f$T = Y\f$
      */
-    long double d2Trdxi2__constxj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag);
+    CoolPropDbl d2Trdxi2__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag);
     /** \brief The second derivative of reducing temperature with respect to component i and j mole fractions
      * 
      * Calculated from \ref d2Yrdxidxj with \f$T = Y\f$
      */
-    long double d2Trdxidxj(const std::vector<long double> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
+    CoolPropDbl d2Trdxidxj(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
     
     /** \brief The derivative of reducing molar volume with respect to component i mole fraction
      * 
      * Calculated from \ref dYrdxi__constxj with \f$v = Y\f$
      */
-    long double dvrmolardxi__constxj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag  xN_fla);
+    CoolPropDbl dvrmolardxi__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag  xN_fla);
     /** \brief The second derivative of reducing molar volume with respect to component i mole fraction
      * 
      * Calculated from \ref d2Yrdxi2__constxj with \f$v = Y\f$
      */
-    long double d2vrmolardxi2__constxj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag);
+    CoolPropDbl d2vrmolardxi2__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag);
     /** \brief The second derivative of reducing molar volume with respect to component i and j mole fractions
      * 
      * Calculated from \ref d2Yrdxidxj with \f$v = Y\f$
      */
-    long double d2vrmolardxidxj(const std::vector<long double> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
+    CoolPropDbl d2vrmolardxidxj(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
     /** \brief The molar reducing density
      * 
      * Given by \f$ \rho_r = 1/v_r \f$
      */
-    long double rhormolar(const std::vector<long double> &x);
+    CoolPropDbl rhormolar(const std::vector<CoolPropDbl> &x);
     /** \brief Derivative of the molar reducing density with respect to component i mole fraction
      * 
      * See also GERG 2004, Eqn. 7.57
@@ -176,7 +176,7 @@ public:
      * \left(\frac{\partial \rho_r}{\partial x_i}\right)_{x_{i\neq j}} = -\rho_r^2\left(\frac{\partial v_r}{\partial x_i}\right)_{x_{i\neq j}}
      * \f]
      */
-    long double drhormolardxi__constxj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag);    
+    CoolPropDbl drhormolardxi__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag);    
     /** \brief Derivative of the molar reducing density with respect to component i mole fraction
      * 
      * See also GERG 2004, Eqn. 7.58
@@ -184,7 +184,7 @@ public:
      * \left(\frac{\partial^2 \rho_r}{\partial x_i^2}\right)_{x_{i\neq j}} = 2\rho_r^3\left(\left(\frac{\partial v_r}{\partial x_i}\right)_{x_{i\neq j}}\right)^2-\rho_r\left(\left(\frac{\partial^2 v_r}{\partial x_i^2}\right)_{x_{i\neq j}}\right)
      * \f]
      */
-    long double d2rhormolardxi2__constxj(const std::vector<long double> &x, std::size_t i, x_N_dependency_flag xN_flag);
+    CoolPropDbl d2rhormolardxi2__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag);
     /** \brief Derivative of the molar reducing density with respect to component i  and j mole fractions
      * 
      * See also GERG 2004, Eqn. 7.59
@@ -192,7 +192,7 @@ public:
      * \left(\frac{\partial^2 \rho_r}{\partial x_i\partial x_j}\right) = 2\rho_r^3\left(\left(\frac{\partial v_r}{\partial x_i}\right)_{x_{i\neq j}}\right)\left(\left(\frac{\partial v_r}{\partial x_j}\right)_{x_{i\neq j}}\right)-\rho_r^2\left(\left(\frac{\partial v_r}{\partial x_i\partial x_j}\right)\right)
      * \f]
      */
-    long double d2rhormolardxidxj(const std::vector<long double> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
+    CoolPropDbl d2rhormolardxidxj(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag);
     
     /** \brief Generalized reducing term \f$Y_r\f$
      * 
@@ -200,7 +200,7 @@ public:
      * Y_r = \sum_{i=1}^{N}x_iY_{c,i}^2+\sum_{i=1}^{N-1}\sum_{j=i+1}^{N} c_{Y,ij}f_{Y,ij}(x_i,x_j)
      * \f]
      */
-    long double Yr(const std::vector<long double> &x, const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c_ij, const std::vector<long double> &Yc);
+    CoolPropDbl Yr(const std::vector<CoolPropDbl> &x, const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c_ij, const std::vector<CoolPropDbl> &Yc);
     /** \brief First composition derivative of \f$Y_r\f$ with \f$x_i\f$
      * 
      * If \f$x_N\f$ is given by \f$ x_N = 1-\sum_{i=1}^{N-1}x_i\f$ (Gernert, FPE, 2014, Table S1):
@@ -216,7 +216,7 @@ public:
      * \f]
      * 
      */
-    long double dYrdxi__constxj(const std::vector<long double> &x, std::size_t i, const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c_ij, const std::vector<long double> &Yc, x_N_dependency_flag xN_flag);
+    CoolPropDbl dYrdxi__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c_ij, const std::vector<CoolPropDbl> &Yc, x_N_dependency_flag xN_flag);
     /** \brief Second composition derivative of \f$Y_r\f$ with \f$x_i\f$
      * 
      * If \f$x_N\f$ is given by \f$ x_N = 1-\sum_{i=1}^{N-1}x_i\f$ (Gernert, FPE, 2014, Table S1):
@@ -231,7 +231,7 @@ public:
      * \left(\frac{\partial^2 Y_r}{\partial x_i^2}\right)_{x_{j\neq i}} = 2Y_{c,i} + \sum_{k=1}^{i-1}c_{Y,ki}\frac{\partial^2 f_{Y,ki}(x_k,x_i)}{\partial x_i^2} + \sum_{k=i+1}^{N}c_{Y,ik}\frac{\partial^2 f_{Y,ik}(x_i,x_k)}{\partial x_i^2}
      * \f]
      */
-    long double d2Yrdxi2__constxj(const std::vector<long double> &x, std::size_t i, const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c_ij, const std::vector<long double> &Yc, x_N_dependency_flag xN_flag);
+    CoolPropDbl d2Yrdxi2__constxj(const std::vector<CoolPropDbl> &x, std::size_t i, const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c_ij, const std::vector<CoolPropDbl> &Yc, x_N_dependency_flag xN_flag);
     /** \brief Second mixed composition derivative of \f$Y_r\f$ with \f$x_i\f$ and  \f$x_j\f$
      * 
      * If \f$x_N\f$ is given by \f$ x_N = 1-\sum_{i=1}^{N-1}x_i\f$ (Gernert, FPE, 2014, Table S1):
@@ -246,53 +246,53 @@ public:
      * \left(\frac{\partial^2 Y_r}{\partial x_i\partial x_j}\right)_{\substack{x_{k\neq j\neq i}}} = c_{Y,ij}\frac{\partial^2f_{Y,ij}(x_i,x_j)}{\partial x_i\partial x_j}
      * \f]
      */
-    long double d2Yrdxidxj(const std::vector<long double> &x, std::size_t i, std::size_t j, const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c_ij, const std::vector<long double> &Yc, x_N_dependency_flag xN_flag);
+    CoolPropDbl d2Yrdxidxj(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j, const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c_ij, const std::vector<CoolPropDbl> &Yc, x_N_dependency_flag xN_flag);
     /** \brief The coefficient \f$ c_{Y,ij} \f$
      * 
      * \f[
      * c_{Y,ij} = 2\beta_{Y,ij}\gamma_{Y,ij}Y_{c,ij}
      * \f]
      */
-    long double c_Y_ij(std::size_t i, std::size_t j, const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c);
+    CoolPropDbl c_Y_ij(std::size_t i, std::size_t j, const STLMatrix &beta, const STLMatrix &gamma, const STLMatrix &Y_c);
     
     /** \brief The function \f$ f_{Y,ij}(x_i,x_j) \f$
      * 
      * \f[ f_{Y,ij}(x_i,x_j) = x_ix_j\frac{x_i+x_j}{\beta_{Y,ij}^2x_i+x_j} \f]
      */
-    long double f_Y_ij(const std::vector<long double> &x, std::size_t i, std::size_t j, const STLMatrix &beta);
+    CoolPropDbl f_Y_ij(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t j, const STLMatrix &beta);
     /**
      * 
      * \f[
      * \left(\frac{\partial f_{Y,ki}(x_k, x_i)}{\partial x_i}\right)_{x_{k\neq i}} = x_k\frac{x_k+x_i}{\beta_{Y,ki}^2x_k+x_i} + \frac{x_kx_i}{\beta_{Y,ki}^2x_k+x_i}\left(1-\frac{x_k+x_i}{\beta_{Y,ki}^2x_k+x_i}\right)
      * \f]
      */
-    long double dfYkidxi__constxk(const std::vector<long double> &x, std::size_t k, std::size_t i, const STLMatrix &beta);
+    CoolPropDbl dfYkidxi__constxk(const std::vector<CoolPropDbl> &x, std::size_t k, std::size_t i, const STLMatrix &beta);
     /**
      * 
      * \f[
      * \left(\frac{\partial f_{Y,ik}(x_i, x_k)}{\partial x_i}\right)_{x_k} = x_k\frac{x_i+x_k}{\beta_{Y,ik}^2x_i+x_k} + \frac{x_ix_k}{\beta_{Y,ik}^2x_i+x_k}\left(1-\beta_{Y,ik}^2\frac{x_i+x_k}{\beta_{Y,ik}^2x_i+x_k}\right)
      * \f]
      */
-    long double dfYikdxi__constxk(const std::vector<long double> &x, std::size_t i, std::size_t k, const STLMatrix &beta);
+    CoolPropDbl dfYikdxi__constxk(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t k, const STLMatrix &beta);
     /**
      * \f[
      * \left(\frac{\partial^2 f_{Y,ki}(x_k, x_i)}{\partial x_i^2}\right)_{x_{k\neq i}} = \frac{1}{\beta_{Y,ki}^2x_k+x_i}\left(1-\frac{x_k+x_i}{\beta_{Y,ki}^2x_k+x_i}\right)\left(2x_k-\frac{2x_kx_i}{\beta_{Y,ki}^2x_k+x_i}\right)
      * \f]
      */
-    long double d2fYkidxi2__constxk(const std::vector<long double> &x, std::size_t k, std::size_t i, const STLMatrix &beta);
+    CoolPropDbl d2fYkidxi2__constxk(const std::vector<CoolPropDbl> &x, std::size_t k, std::size_t i, const STLMatrix &beta);
     /**
      * \f[
      * \left(\frac{\partial^2 f_{Y,ik}(x_i, x_k)}{\partial x_i^2}\right)_{x_{k}} = \frac{1}{\beta_{Y,ik}^2x_i+x_k}\left(1-\beta_{Y,ik}^2\frac{x_i+x_k}{\beta_{Y,ik}^2x_i+x_k}\right)\left(2x_k-\frac{2x_ix_k\beta_{Y,ik}^2}{\beta_{Y,ik}^2x_i+x_k}\right)
      * \f]
      */
-    long double d2fYikdxi2__constxk(const std::vector<long double> &x, std::size_t i, std::size_t k, const STLMatrix &beta);
+    CoolPropDbl d2fYikdxi2__constxk(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t k, const STLMatrix &beta);
     /**
      * \f{eqnarray*}{
      * \left(\frac{\partial^2 f_{Y,ki}(x_k, x_i)}{\partial x_i\partial x_j}\right)_{x_{k\neq j\neq i}} &=& \frac{x_i+x_j}{\beta_{Y,ij}^2x_i+x_j} + \frac{x_j}{\beta_{Y,ij}^2x_i+x_j}\left(1-\frac{x_i+x_j}{\beta_{Y,ij}^2x_i+x_j}\right) \\
      * &+& \frac{x_i}{\beta_{Y,ij}^2x_i+x_j}\left(1-\beta_{Y,ij}^2\frac{x_i+x_j}{\beta_{Y,ij}^2x_i+x_j}\right) - \frac{x_ix_j}{(\beta_{Y,ij}^2x_i+x_j)^2}\left(1+\beta_{Y,ij}^2-2\beta_{Y,ij}^2\frac{x_i+x_j}{\beta_{Y,ij}^2x_i+x_j}\right)
      * \f}
      */
-     long double d2fYijdxidxj(const std::vector<long double> &x, std::size_t i, std::size_t k, const STLMatrix &beta);
+     CoolPropDbl d2fYijdxidxj(const std::vector<CoolPropDbl> &x, std::size_t i, std::size_t k, const STLMatrix &beta);
 };
 
 /** \brief Reducing function converter for dry air and HFC blends
@@ -324,16 +324,16 @@ protected:
     LemmonAirHFCReducingFunction(const LemmonAirHFCReducingFunction &);
 public:
     /// Set the coefficients based on reducing parameters loaded from JSON
-    static void convert_to_GERG(const std::vector<CoolPropFluid*> &pFluids, std::size_t i, std::size_t j, Dictionary d, long double &beta_T, long double &beta_v, long double &gamma_T, long double &gamma_v)
+    static void convert_to_GERG(const std::vector<CoolPropFluid*> &pFluids, std::size_t i, std::size_t j, Dictionary d, CoolPropDbl &beta_T, CoolPropDbl &beta_v, CoolPropDbl &gamma_T, CoolPropDbl &gamma_v)
     {
-        long double xi_ij = d.get_number("xi");
-        long double zeta_ij = d.get_number("zeta");
+        CoolPropDbl xi_ij = d.get_number("xi");
+        CoolPropDbl zeta_ij = d.get_number("zeta");
         beta_T = 1;
         beta_v = 1;
         gamma_T = (pFluids[i]->pEOS->reduce.T + pFluids[j]->pEOS->reduce.T + xi_ij)/(2*sqrt(pFluids[i]->pEOS->reduce.T*pFluids[j]->pEOS->reduce.T));
-        long double v_i = 1/pFluids[i]->pEOS->reduce.rhomolar;
-        long double v_j = 1/pFluids[j]->pEOS->reduce.rhomolar;
-        long double one_third = 1.0/3.0;
+        CoolPropDbl v_i = 1/pFluids[i]->pEOS->reduce.rhomolar;
+        CoolPropDbl v_j = 1/pFluids[j]->pEOS->reduce.rhomolar;
+        CoolPropDbl one_third = 1.0/3.0;
         gamma_v = (v_i + v_j + zeta_ij)/(0.25*pow(pow(v_i, one_third)+pow(v_j, one_third),3));
     };
 };

--- a/src/Backends/Helmholtz/TransportRoutines.cpp
+++ b/src/Backends/Helmholtz/TransportRoutines.cpp
@@ -4,18 +4,18 @@
 
 namespace CoolProp{
 
-long double TransportRoutines::viscosity_dilute_kinetic_theory(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_dilute_kinetic_theory(HelmholtzEOSMixtureBackend &HEOS)
 {
     if (HEOS.is_pure_or_pseudopure)
     {
-        long double Tstar = HEOS.T()/HEOS.components[0]->transport.epsilon_over_k;
-        long double sigma_nm = HEOS.components[0]->transport.sigma_eta*1e9; // 1e9 to convert from m to nm
-        long double molar_mass_kgkmol = HEOS.molar_mass()*1000; // 1000 to convert from kg/mol to kg/kmol
+        CoolPropDbl Tstar = HEOS.T()/HEOS.components[0]->transport.epsilon_over_k;
+        CoolPropDbl sigma_nm = HEOS.components[0]->transport.sigma_eta*1e9; // 1e9 to convert from m to nm
+        CoolPropDbl molar_mass_kgkmol = HEOS.molar_mass()*1000; // 1000 to convert from kg/mol to kg/kmol
 
         // The nondimensional empirical collision integral from Neufeld
         // Neufeld, P. D.; Janzen, A. R.; Aziz, R. A. Empirical Equations to Calculate 16 of the Transport Collision Integrals (l,s)*
         // for the Lennard-Jones (12-6) Potential. J. Chem. Phys. 1972, 57, 1100-1102
-        long double OMEGA22 = 1.16145*pow(Tstar, static_cast<long double>(-0.14874))+0.52487*exp(-0.77320*Tstar)+2.16178*exp(-2.43787*Tstar);
+        CoolPropDbl OMEGA22 = 1.16145*pow(Tstar, static_cast<CoolPropDbl>(-0.14874))+0.52487*exp(-0.77320*Tstar)+2.16178*exp(-2.43787*Tstar);
 
         // The dilute gas component -
         return 26.692e-9*sqrt(molar_mass_kgkmol*HEOS.T())/(pow(sigma_nm, 2)*OMEGA22); // Pa-s
@@ -25,25 +25,25 @@ long double TransportRoutines::viscosity_dilute_kinetic_theory(HelmholtzEOSMixtu
     }
 }
 
-long double TransportRoutines::viscosity_dilute_collision_integral(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_dilute_collision_integral(HelmholtzEOSMixtureBackend &HEOS)
 {
     if (HEOS.is_pure_or_pseudopure)
     {
         // Retrieve values from the state class
         CoolProp::ViscosityDiluteGasCollisionIntegralData &data = HEOS.components[0]->transport.viscosity_dilute.collision_integral;
-        const std::vector<long double> &a = data.a, &t = data.t;
-        const long double C = data.C, molar_mass = data.molar_mass;
+        const std::vector<CoolPropDbl> &a = data.a, &t = data.t;
+        const CoolPropDbl C = data.C, molar_mass = data.molar_mass;
 
-        long double S;
+        CoolPropDbl S;
         // Unit conversions and variable definitions
-        const long double Tstar = HEOS.T()/HEOS.components[0]->transport.epsilon_over_k;
-        const long double sigma_nm = HEOS.components[0]->transport.sigma_eta*1e9; // 1e9 to convert from m to nm
-        const long double molar_mass_kgkmol = molar_mass*1000; // 1000 to convert from kg/mol to kg/kmol
+        const CoolPropDbl Tstar = HEOS.T()/HEOS.components[0]->transport.epsilon_over_k;
+        const CoolPropDbl sigma_nm = HEOS.components[0]->transport.sigma_eta*1e9; // 1e9 to convert from m to nm
+        const CoolPropDbl molar_mass_kgkmol = molar_mass*1000; // 1000 to convert from kg/mol to kg/kmol
 
         /// Both the collision integral \f$\mathfrak{S}^*\f$ and effective cross section \f$\Omega^{(2,2)}\f$ have the same form,
         /// in general we don't care which is used.  The are related through \f$\Omega^{(2,2)} = (5/4)\mathfrak{S}^*\f$
         /// see Vesovic(JPCRD, 1990) for CO\f$_2\f$ for further information
-        long double summer = 0, lnTstar = log(Tstar);
+        CoolPropDbl summer = 0, lnTstar = log(Tstar);
         for (std::size_t i = 0; i < a.size(); ++i)
         {
             summer += a[i]*pow(lnTstar,t[i]);
@@ -58,15 +58,15 @@ long double TransportRoutines::viscosity_dilute_collision_integral(HelmholtzEOSM
     }
 }
 
-long double TransportRoutines::viscosity_dilute_powers_of_T(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_dilute_powers_of_T(HelmholtzEOSMixtureBackend &HEOS)
 {
     if (HEOS.is_pure_or_pseudopure)
     {
         // Retrieve values from the state class
         CoolProp::ViscosityDiluteGasPowersOfT &data = HEOS.components[0]->transport.viscosity_dilute.powers_of_T;
-        const std::vector<long double> &a = data.a, &t = data.t;
+        const std::vector<CoolPropDbl> &a = data.a, &t = data.t;
 
-        long double summer = 0, T = HEOS.T();
+        CoolPropDbl summer = 0, T = HEOS.T();
         for (std::size_t i = 0; i < a.size(); ++i)
         {
             summer += a[i]*pow(T, t[i]);
@@ -78,15 +78,15 @@ long double TransportRoutines::viscosity_dilute_powers_of_T(HelmholtzEOSMixtureB
     }
 }
 
-long double TransportRoutines::viscosity_dilute_collision_integral_powers_of_T(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_dilute_collision_integral_powers_of_T(HelmholtzEOSMixtureBackend &HEOS)
 {
     if (HEOS.is_pure_or_pseudopure)
     {
         // Retrieve values from the state class
         CoolProp::ViscosityDiluteCollisionIntegralPowersOfTstarData &data = HEOS.components[0]->transport.viscosity_dilute.collision_integral_powers_of_Tstar;
-        const std::vector<long double> &a = data.a, &t = data.t;
+        const std::vector<CoolPropDbl> &a = data.a, &t = data.t;
 
-        long double summer = 0, Tstar = HEOS.T()/data.T_reducing;
+        CoolPropDbl summer = 0, Tstar = HEOS.T()/data.T_reducing;
         for (std::size_t i = 0; i < a.size(); ++i)
         {
             summer += a[i]*pow(Tstar, t[i]);
@@ -98,36 +98,36 @@ long double TransportRoutines::viscosity_dilute_collision_integral_powers_of_T(H
     }
 
 }
-long double TransportRoutines::viscosity_higher_order_modified_Batschinski_Hildebrand(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_higher_order_modified_Batschinski_Hildebrand(HelmholtzEOSMixtureBackend &HEOS)
 {
     if (HEOS.is_pure_or_pseudopure)
     {
         CoolProp::ViscosityModifiedBatschinskiHildebrandData &HO = HEOS.components[0]->transport.viscosity_higher_order.modified_Batschinski_Hildebrand;
 
-        long double delta = HEOS.rhomolar()/HO.rhomolar_reduce, tau = HO.T_reduce/HEOS.T();
+        CoolPropDbl delta = HEOS.rhomolar()/HO.rhomolar_reduce, tau = HO.T_reduce/HEOS.T();
 
         // The first term that is formed of powers of tau (Tc/T) and delta (rho/rhoc)
-        long double S = 0;
+        CoolPropDbl S = 0;
         for (unsigned int i = 0; i < HO.a.size(); ++i){
             S += HO.a[i]*pow(delta, HO.d1[i])*pow(tau, HO.t1[i])*exp(HO.gamma[i]*pow(delta, HO.l[i]));
         }
 
         // For the terms that multiplies the bracketed term with delta and delta0
-        long double F = 0;
+        CoolPropDbl F = 0;
         for (unsigned int i = 0; i < HO.f.size(); ++i){
             F += HO.f[i]*pow(delta, HO.d2[i])*pow(tau, HO.t2[i]);
         }
 
         // for delta_0
-        long double summer_numer = 0;
+        CoolPropDbl summer_numer = 0;
         for (unsigned int i = 0; i < HO.g.size(); ++i){
             summer_numer += HO.g[i]*pow(tau, HO.h[i]);
         }
-        long double summer_denom = 0;
+        CoolPropDbl summer_denom = 0;
         for (unsigned int i = 0; i < HO.p.size(); ++i){
             summer_denom += HO.p[i]*pow(tau, HO.q[i]);
         }
-        long double delta0 = summer_numer/summer_denom;
+        CoolPropDbl delta0 = summer_numer/summer_denom;
 
         // The higher-order-term component
         return S + F*(1/(delta0-delta)-1/delta0); // Pa-s
@@ -137,19 +137,19 @@ long double TransportRoutines::viscosity_higher_order_modified_Batschinski_Hilde
     }
 }
 
-long double TransportRoutines::viscosity_initial_density_dependence_Rainwater_Friend(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_initial_density_dependence_Rainwater_Friend(HelmholtzEOSMixtureBackend &HEOS)
 {
     if (HEOS.is_pure_or_pseudopure)
     {
         // Retrieve values from the state class
         CoolProp::ViscosityRainWaterFriendData &data = HEOS.components[0]->transport.viscosity_initial.rainwater_friend;
-        const std::vector<long double> &b = data.b, &t = data.t;
+        const std::vector<CoolPropDbl> &b = data.b, &t = data.t;
 
-        long double B_eta, B_eta_star;
-        long double Tstar = HEOS.T()/HEOS.components[0]->transport.epsilon_over_k; // [no units]
-        long double sigma = HEOS.components[0]->transport.sigma_eta; // [m]
+        CoolPropDbl B_eta, B_eta_star;
+        CoolPropDbl Tstar = HEOS.T()/HEOS.components[0]->transport.epsilon_over_k; // [no units]
+        CoolPropDbl sigma = HEOS.components[0]->transport.sigma_eta; // [m]
 
-        long double summer = 0;
+        CoolPropDbl summer = 0;
         for (unsigned int i = 0; i < b.size(); ++i){
             summer += b[i]*pow(Tstar, t[i]);
         }
@@ -162,19 +162,19 @@ long double TransportRoutines::viscosity_initial_density_dependence_Rainwater_Fr
     }
 }
 
-long double TransportRoutines::viscosity_initial_density_dependence_empirical(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_initial_density_dependence_empirical(HelmholtzEOSMixtureBackend &HEOS)
 {
     // Inspired by the form from Tariq, JPCRD, 2014
     if (HEOS.is_pure_or_pseudopure)
     {
         // Retrieve values from the state class
         CoolProp::ViscosityInitialDensityEmpiricalData &data = HEOS.components[0]->transport.viscosity_initial.empirical;
-        const std::vector<long double> &n = data.n, &d = data.d, &t = data.t;
+        const std::vector<CoolPropDbl> &n = data.n, &d = data.d, &t = data.t;
 
-        long double tau = data.T_reducing/HEOS.T(); // [no units]
-        long double delta = HEOS.rhomolar()/data.rhomolar_reducing; // [no units]
+        CoolPropDbl tau = data.T_reducing/HEOS.T(); // [no units]
+        CoolPropDbl delta = HEOS.rhomolar()/data.rhomolar_reducing; // [no units]
 
-        long double summer = 0;
+        CoolPropDbl summer = 0;
         for (unsigned int i = 0; i < n.size(); ++i){
             summer += n[i]*pow(delta, d[i])*pow(tau, t[i]);
         }
@@ -187,7 +187,7 @@ long double TransportRoutines::viscosity_initial_density_dependence_empirical(He
 
 static void visc_Helper(double Tbar, double rhobar, double *mubar_0, double *mubar_1)
 {
-    std::vector<std::vector<long double> > H(6,std::vector<long double>(7,0));
+    std::vector<std::vector<CoolPropDbl> > H(6,std::vector<CoolPropDbl>(7,0));
     double sum;
     int i,j;
 
@@ -243,7 +243,7 @@ static void visc_Helper(double Tbar, double rhobar, double *mubar_0, double *mub
     }
     *mubar_1=exp(rhobar*sum);
 }
-long double TransportRoutines::viscosity_water_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_water_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
 {
     double x_mu=0.068,qc=1/1.9,qd=1/1.1,nu=0.630,gamma=1.239,zeta_0=0.13,LAMBDA_0=0.06,Tbar_R=1.5, pstar, Tstar, rhostar;
     double delta,tau,mubar_0,mubar_1,mubar_2,drhodp,drhodp_R,DeltaChibar,zeta,w,L,Y,psi_D,Tbar,rhobar;
@@ -295,45 +295,45 @@ long double TransportRoutines::viscosity_water_hardcoded(HelmholtzEOSMixtureBack
 
     return (mubar_0*mubar_1*mubar_2)/1e6;
 }
-long double TransportRoutines::viscosity_hydrogen_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_hydrogen_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
 {
-    long double Tr = HEOS.T()/33.145, rhor = HEOS.keyed_output(CoolProp::iDmass)*0.011;
-    long double c[] = {0, 6.43449673e-6, 4.56334068e-2, 2.32797868e-1, 9.58326120e-1, 1.27941189e-1, 3.63576595e-1};
+    CoolPropDbl Tr = HEOS.T()/33.145, rhor = HEOS.keyed_output(CoolProp::iDmass)*0.011;
+    CoolPropDbl c[] = {0, 6.43449673e-6, 4.56334068e-2, 2.32797868e-1, 9.58326120e-1, 1.27941189e-1, 3.63576595e-1};
     return c[1]*pow(rhor,2)*exp(c[2]*Tr+c[3]/Tr+c[4]*pow(rhor,2)/(c[5]+Tr)+c[6]*pow(rhor,6));
 }
-long double TransportRoutines::viscosity_benzene_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_benzene_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
 {
-    long double Tr = HEOS.T()/562.02, rhor = HEOS.rhomass()/304.792;
-    long double c[] = {-9.98945, 86.06260, 2.74872, 1.11130, -1.0, -134.1330, -352.473, 6.60989, 88.4174};
-    return 1e-6*pow(rhor,static_cast<long double>(2.0/3.0))*sqrt(Tr)*(c[0]*pow(rhor,2) + c[1]*rhor/(c[2]+c[3]*Tr+c[4]*rhor) + (c[5]*rhor+c[6]*pow(rhor,2))/(c[7]+c[8]*pow(rhor,2)));
+    CoolPropDbl Tr = HEOS.T()/562.02, rhor = HEOS.rhomass()/304.792;
+    CoolPropDbl c[] = {-9.98945, 86.06260, 2.74872, 1.11130, -1.0, -134.1330, -352.473, 6.60989, 88.4174};
+    return 1e-6*pow(rhor,static_cast<CoolPropDbl>(2.0/3.0))*sqrt(Tr)*(c[0]*pow(rhor,2) + c[1]*rhor/(c[2]+c[3]*Tr+c[4]*rhor) + (c[5]*rhor+c[6]*pow(rhor,2))/(c[7]+c[8]*pow(rhor,2)));
 }
-long double TransportRoutines::viscosity_hexane_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_hexane_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
 {
 
-    long double Tr = HEOS.T()/507.82, rhor = HEOS.keyed_output(CoolProp::iDmass)/233.182;
+    CoolPropDbl Tr = HEOS.T()/507.82, rhor = HEOS.keyed_output(CoolProp::iDmass)/233.182;
 
     // Output is in Pa-s
     double c[] = {2.53402335/1e6, -9.724061002/1e6, 0.469437316, 158.5571631, 72.42916856/1e6, 10.60751253, 8.628373915, -6.61346441, -2.212724566};
-    return pow(rhor,static_cast<long double>(2.0/3.0))*sqrt(Tr)*(c[0]/Tr+c[1]/(c[2]+Tr+c[3]*rhor*rhor)+c[4]*(1+rhor)/(c[5]+c[6]*Tr+c[7]*rhor+rhor*rhor+c[8]*rhor*Tr));
+    return pow(rhor,static_cast<CoolPropDbl>(2.0/3.0))*sqrt(Tr)*(c[0]/Tr+c[1]/(c[2]+Tr+c[3]*rhor*rhor)+c[4]*(1+rhor)/(c[5]+c[6]*Tr+c[7]*rhor+rhor*rhor+c[8]*rhor*Tr));
 }
 
-long double TransportRoutines::viscosity_heptane_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_heptane_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
 {
     /// From Michailidou-JPCRD-2014-Heptane
-    long double Tr = HEOS.T()/540.13, rhor = HEOS.rhomass()/232;
+    CoolPropDbl Tr = HEOS.T()/540.13, rhor = HEOS.rhomass()/232;
 
     // Output is in Pa-s
     double c[] = {0, 22.15000/1e6, -15.00870/1e6, 3.71791/1e6, 77.72818/1e6, 9.73449, 9.51900, -6.34076, -2.51909};
     return pow(rhor,2.0L/3.0L)*sqrt(Tr)*(c[1]*rhor+c[2]*pow(rhor,2)+c[3]*pow(rhor,3)+c[4]*rhor/(c[5]+c[6]*Tr+c[7]*rhor+rhor*rhor+c[8]*rhor*Tr));
 }
 
-long double TransportRoutines::viscosity_higher_order_friction_theory(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_higher_order_friction_theory(HelmholtzEOSMixtureBackend &HEOS)
 {
     if (HEOS.is_pure_or_pseudopure)
     {
         CoolProp::ViscosityFrictionTheoryData &F = HEOS.components[0]->transport.viscosity_higher_order.friction_theory;
 
-        long double tau = F.T_reduce/HEOS.T(), kii, krrr, kaaa, krr, kdrdr;
+        CoolPropDbl tau = F.T_reduce/HEOS.T(), kii, krrr, kaaa, krr, kdrdr;
 
         double psi1 = exp(tau)-F.c1;
         double psi2 = exp(pow(tau,2))-F.c2;
@@ -378,7 +378,7 @@ long double TransportRoutines::viscosity_higher_order_friction_theory(HelmholtzE
     }
 }
 
-long double TransportRoutines::viscosity_helium_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_helium_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
 {
     double eta_0,eta_0_slash, eta_E_slash, B,C,D,ln_eta,x;
     //
@@ -390,7 +390,7 @@ long double TransportRoutines::viscosity_helium_hardcoded(HelmholtzEOSMixtureBac
     // Report is not clear on viscosity, referring to REFPROP source code for clarity
 
     // Correlation wants density in g/cm^3; kg/m^3 --> g/cm^3, divide by 1000
-    long double rho = HEOS.keyed_output(CoolProp::iDmass)/1000.0, T = HEOS.T();
+    CoolPropDbl rho = HEOS.keyed_output(CoolProp::iDmass)/1000.0, T = HEOS.T();
 
     if (T <= 300){
         x = log(T);
@@ -414,74 +414,74 @@ long double TransportRoutines::viscosity_helium_hardcoded(HelmholtzEOSMixtureBac
     else
     {
         ln_eta = eta_0_slash + eta_E_slash;
-        eta_0 = 196*pow(T,static_cast<long double>(0.71938))*exp(12.451/T-295.67/T/T-4.1249);
+        eta_0 = 196*pow(T,static_cast<CoolPropDbl>(0.71938))*exp(12.451/T-295.67/T/T-4.1249);
         // Correlation yields viscosity in micro g/(cm-s); to get Pa-s, divide by 10 to get micro Pa-s, then another 1e6 to get Pa-s
         return (exp(ln_eta)+eta_0-exp(eta_0_slash))/10.0/1e6;
     }
 }
 
-long double TransportRoutines::viscosity_methanol_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_methanol_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
 {
-    long double B_eta, C_eta,
+    CoolPropDbl B_eta, C_eta,
                 epsilon_over_k = 577.87, /* [K]*/
                 sigma0 = 0.3408e-9, /* [m] */
                 delta = 0.4575, /* NOT the reduced density, that is rhor here*/
                 N_A = 6.02214129e23,
                 M = 32.04216, /* kg/kmol */
                 T = HEOS.T();
-    long double rhomolar = HEOS.rhomolar();
+    CoolPropDbl rhomolar = HEOS.rhomolar();
     
-    long double B_eta_star, C_eta_star;
-    long double Tstar = T/epsilon_over_k; // [no units]
-    long double rhor = HEOS.rhomass()/273;
-    long double Tr = T/512.6;
+    CoolPropDbl B_eta_star, C_eta_star;
+    CoolPropDbl Tstar = T/epsilon_over_k; // [no units]
+    CoolPropDbl rhor = HEOS.rhomass()/273;
+    CoolPropDbl Tr = T/512.6;
 
     // Rainwater-Friend initial density terms
     { // Scoped here so that we can re-use the b variable
-        long double b[9] = {-19.572881, 219.73999, -1015.3226, 2471.01251, -3375.1717, 2491.6597, -787.26086, 14.085455, -0.34664158};
-        long double t[9] = {0, -0.25, -0.5, -0.75, -1.0, -1.25, -1.5, -2.5, -5.5};
-        long double summer = 0;
+        CoolPropDbl b[9] = {-19.572881, 219.73999, -1015.3226, 2471.01251, -3375.1717, 2491.6597, -787.26086, 14.085455, -0.34664158};
+        CoolPropDbl t[9] = {0, -0.25, -0.5, -0.75, -1.0, -1.25, -1.5, -2.5, -5.5};
+        CoolPropDbl summer = 0;
         for (unsigned int i = 0; i < 9; ++i){
             summer += b[i]*pow(Tstar, t[i]);
         }
         B_eta_star = summer; // [no units]
         B_eta = N_A*pow(sigma0, 3)*B_eta_star; // [m^3/mol]
         
-        long double c[2] = {1.86222085e-3, 9.990338};
-        C_eta_star = c[0]*pow(Tstar, 3)*exp(c[1]*pow(Tstar,static_cast<long double>(-0.5))); // [no units]
+        CoolPropDbl c[2] = {1.86222085e-3, 9.990338};
+        C_eta_star = c[0]*pow(Tstar, 3)*exp(c[1]*pow(Tstar,static_cast<CoolPropDbl>(-0.5))); // [no units]
         C_eta = pow(N_A*pow(sigma0, 3), 2)*C_eta_star; // [m^6/mol^2]
     }
     
-    long double eta_g = 1 + B_eta*rhomolar + C_eta*rhomolar*rhomolar;
-    long double a[13] = {1.16145, -0.14874, 0.52487, -0.77320, 2.16178, -2.43787, 0.95976e-3, 0.10225, -0.97346, 0.10657, -0.34528, -0.44557, -2.58055};
-    long double d[7] = {-1.181909, 0.5031030, -0.6268461, 0.5169312, -0.2351349, 5.3980235e-2, -4.9069617e-3};
-    long double e[10] = {0, 4.018368, -4.239180, 2.245110, -0.5750698, 2.3021026e-2, 2.5696775e-2, -6.8372749e-3, 7.2707189e-4, -2.9255711e-5}; 
+    CoolPropDbl eta_g = 1 + B_eta*rhomolar + C_eta*rhomolar*rhomolar;
+    CoolPropDbl a[13] = {1.16145, -0.14874, 0.52487, -0.77320, 2.16178, -2.43787, 0.95976e-3, 0.10225, -0.97346, 0.10657, -0.34528, -0.44557, -2.58055};
+    CoolPropDbl d[7] = {-1.181909, 0.5031030, -0.6268461, 0.5169312, -0.2351349, 5.3980235e-2, -4.9069617e-3};
+    CoolPropDbl e[10] = {0, 4.018368, -4.239180, 2.245110, -0.5750698, 2.3021026e-2, 2.5696775e-2, -6.8372749e-3, 7.2707189e-4, -2.9255711e-5}; 
 
-    long double OMEGA_22_star_LJ = a[0]*pow(Tstar,a[1])+a[2]*exp(a[3]*Tstar)+a[4]*exp(a[5]*Tstar);
-    long double OMEGA_22_star_delta = a[7]*pow(Tstar,a[8]) + a[9]*exp(a[10]*Tstar) + a[11]*exp(a[12]*Tstar);
-    long double OMEGA_22_star_SM = OMEGA_22_star_LJ*(1+pow(delta,2)/(1+a[6]*pow(delta,6))*OMEGA_22_star_delta);
-    long double eta_0 = 2.66957e-26*sqrt(M*T)/(pow(sigma0,2)*OMEGA_22_star_SM);
+    CoolPropDbl OMEGA_22_star_LJ = a[0]*pow(Tstar,a[1])+a[2]*exp(a[3]*Tstar)+a[4]*exp(a[5]*Tstar);
+    CoolPropDbl OMEGA_22_star_delta = a[7]*pow(Tstar,a[8]) + a[9]*exp(a[10]*Tstar) + a[11]*exp(a[12]*Tstar);
+    CoolPropDbl OMEGA_22_star_SM = OMEGA_22_star_LJ*(1+pow(delta,2)/(1+a[6]*pow(delta,6))*OMEGA_22_star_delta);
+    CoolPropDbl eta_0 = 2.66957e-26*sqrt(M*T)/(pow(sigma0,2)*OMEGA_22_star_SM);
     
-    long double summerd = 0;
+    CoolPropDbl summerd = 0;
     for (int i = 0; i < 7; ++i){
         summerd += d[i]/pow(Tr, i);
     }
     for (int j = 1; j < 10; ++j){
         summerd += e[j]*pow(rhor, j);
     }
-    long double sigmac = 0.7193422e-9; // [m]
-    long double sigma_HS = summerd*sigmac; // [m]
-    long double b = 2*M_PI*N_A*pow(sigma_HS,3)/3; // [m^3/mol]
-    long double zeta = b*rhomolar/4; // [-]
-    long double g_sigma_HS = (1 - 0.5*zeta)/pow(1 - zeta, 3); // [-]
-    long double eta_E = 1/g_sigma_HS + 0.8*b*rhomolar + 0.761*g_sigma_HS*pow(b*rhomolar,2); // [-]
+    CoolPropDbl sigmac = 0.7193422e-9; // [m]
+    CoolPropDbl sigma_HS = summerd*sigmac; // [m]
+    CoolPropDbl b = 2*M_PI*N_A*pow(sigma_HS,3)/3; // [m^3/mol]
+    CoolPropDbl zeta = b*rhomolar/4; // [-]
+    CoolPropDbl g_sigma_HS = (1 - 0.5*zeta)/pow(1 - zeta, 3); // [-]
+    CoolPropDbl eta_E = 1/g_sigma_HS + 0.8*b*rhomolar + 0.761*g_sigma_HS*pow(b*rhomolar,2); // [-]
     
-    long double f = 1/(1+exp(5*(rhor-1)));
+    CoolPropDbl f = 1/(1+exp(5*(rhor-1)));
     return eta_0*(f*eta_g + (1-f)*eta_E);
 
 }
 
-long double TransportRoutines::viscosity_R23_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_R23_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
 {
     double C1 = 1.3163, //
            C2 = 0.1832,
@@ -511,7 +511,7 @@ long double TransportRoutines::viscosity_R23_hardcoded(HelmholtzEOSMixtureBacken
     return (pow((rhoL-rhobar)/rhoL,C1)*eta_DG+pow(rhobar/rhoL,C1)*eta_L+DELTAeta_c)/1e6;
 }
 
-long double TransportRoutines::viscosity_dilute_ethane(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_dilute_ethane(HelmholtzEOSMixtureBackend &HEOS)
 {
     double C[] = {0, -3.0328138281, 16.918880086, -37.189364917, 41.288861858, -24.615921140, 8.9488430959, -1.8739245042, 0.20966101390, -9.6570437074e-3};
     double OMEGA_2_2 = 0, e_k = 245, Tstar;
@@ -524,14 +524,14 @@ long double TransportRoutines::viscosity_dilute_ethane(HelmholtzEOSMixtureBacken
 
     return 12.0085*sqrt(Tstar)*OMEGA_2_2/1e6; //[Pa-s]
 }
-long double TransportRoutines::viscosity_dilute_cyclohexane(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_dilute_cyclohexane(HelmholtzEOSMixtureBackend &HEOS)
 {
     // From Tariq, JPCRD, 2014
-    long double T = HEOS.T();
-    long double S_eta = exp(-1.5093 + 364.87/T - 39537/pow(T, 2)); //[nm^2]
+    CoolPropDbl T = HEOS.T();
+    CoolPropDbl S_eta = exp(-1.5093 + 364.87/T - 39537/pow(T, 2)); //[nm^2]
     return 0.19592*sqrt(T)/S_eta/1e6; //[Pa-s]
 }
-long double TransportRoutines::viscosity_ethane_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
+CoolPropDbl TransportRoutines::viscosity_ethane_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS)
 {
     double r[] = {0,1,1,2,2,2,3,3,4,4,1,1};
     double s[] = {0,0,1,0,1,1.5,0,2,0,1,0,1};
@@ -548,13 +548,13 @@ long double TransportRoutines::viscosity_ethane_higher_order_hardcoded(Helmholtz
     return 15.977*sum1/(1+sum2)/1e6;
 }
 
-long double TransportRoutines::conductivity_dilute_ratio_polynomials(HelmholtzEOSMixtureBackend &HEOS){
+CoolPropDbl TransportRoutines::conductivity_dilute_ratio_polynomials(HelmholtzEOSMixtureBackend &HEOS){
     if (HEOS.is_pure_or_pseudopure)
     {
         // Retrieve values from the state class
         CoolProp::ConductivityDiluteRatioPolynomialsData &data = HEOS.components[0]->transport.conductivity_dilute.ratio_polynomials;
 
-        long double summer1 = 0, summer2 = 0, Tr = HEOS.T()/data.T_reducing;
+        CoolPropDbl summer1 = 0, summer2 = 0, Tr = HEOS.T()/data.T_reducing;
         for (std::size_t i = 0; i < data.A.size(); ++i)
         {
             summer1 += data.A[i]*pow(Tr, data.n[i]);
@@ -571,13 +571,13 @@ long double TransportRoutines::conductivity_dilute_ratio_polynomials(HelmholtzEO
     }
 };
 
-long double TransportRoutines::conductivity_residual_polynomial(HelmholtzEOSMixtureBackend &HEOS){
+CoolPropDbl TransportRoutines::conductivity_residual_polynomial(HelmholtzEOSMixtureBackend &HEOS){
     if (HEOS.is_pure_or_pseudopure)
     {
         // Retrieve values from the state class
         CoolProp::ConductivityResidualPolynomialData &data = HEOS.components[0]->transport.conductivity_residual.polynomials;
 
-        long double summer = 0, tau = data.T_reducing/HEOS.T(), delta = HEOS.keyed_output(CoolProp::iDmass)/data.rhomass_reducing;
+        CoolPropDbl summer = 0, tau = data.T_reducing/HEOS.T(), delta = HEOS.keyed_output(CoolProp::iDmass)/data.rhomass_reducing;
         for (std::size_t i = 0; i < data.B.size(); ++i)
         {
             summer += data.B[i]*pow(tau, data.t[i])*pow(delta, data.d[i]);
@@ -589,13 +589,13 @@ long double TransportRoutines::conductivity_residual_polynomial(HelmholtzEOSMixt
     }
 };
 
-long double TransportRoutines::conductivity_residual_polynomial_and_exponential(HelmholtzEOSMixtureBackend &HEOS){
+CoolPropDbl TransportRoutines::conductivity_residual_polynomial_and_exponential(HelmholtzEOSMixtureBackend &HEOS){
     if (HEOS.is_pure_or_pseudopure)
     {
         // Retrieve values from the state class
         CoolProp::ConductivityResidualPolynomialAndExponentialData &data = HEOS.components[0]->transport.conductivity_residual.polynomial_and_exponential;
 
-        long double summer = 0, tau = HEOS.tau(), delta = HEOS.delta();
+        CoolPropDbl summer = 0, tau = HEOS.tau(), delta = HEOS.delta();
         for (std::size_t i = 0; i < data.A.size(); ++i)
         {
             summer += data.A[i]*pow(tau, data.t[i])*pow(delta, data.d[i])*exp(-data.gamma[i]*pow(delta,data.l[i]));
@@ -607,7 +607,7 @@ long double TransportRoutines::conductivity_residual_polynomial_and_exponential(
     }
 };
 
-long double TransportRoutines::conductivity_critical_simplified_Olchowy_Sengers(HelmholtzEOSMixtureBackend &HEOS){
+CoolPropDbl TransportRoutines::conductivity_critical_simplified_Olchowy_Sengers(HelmholtzEOSMixtureBackend &HEOS){
     if (HEOS.is_pure_or_pseudopure)
     {
         // Olchowy and Sengers cross-over term
@@ -666,26 +666,26 @@ long double TransportRoutines::conductivity_critical_simplified_Olchowy_Sengers(
     }
 };
 
-long double TransportRoutines::conductivity_critical_hardcoded_R123(HelmholtzEOSMixtureBackend &HEOS){
+CoolPropDbl TransportRoutines::conductivity_critical_hardcoded_R123(HelmholtzEOSMixtureBackend &HEOS){
     double a13 = 0.486742e-2, a14 = -100, a15 = -7.08535;
     return a13*exp(a14*pow(HEOS.tau()-1,4)+a15*pow(HEOS.delta()-1,2));
 };
 
-long double TransportRoutines::conductivity_critical_hardcoded_CO2_ScalabrinJPCRD2006(HelmholtzEOSMixtureBackend &HEOS){
-    long double nc = 0.775547504e-3*4.81384, Tr = HEOS.T()/304.1282, alpha, rhor = HEOS.keyed_output(iDmass)/467.6;
-    static long double a[] = {0.0, 3.0, 6.70697, 0.94604, 0.30, 0.30, 0.39751, 0.33791, 0.77963, 0.79857, 0.90, 0.02, 0.20};
+CoolPropDbl TransportRoutines::conductivity_critical_hardcoded_CO2_ScalabrinJPCRD2006(HelmholtzEOSMixtureBackend &HEOS){
+    CoolPropDbl nc = 0.775547504e-3*4.81384, Tr = HEOS.T()/304.1282, alpha, rhor = HEOS.keyed_output(iDmass)/467.6;
+    static CoolPropDbl a[] = {0.0, 3.0, 6.70697, 0.94604, 0.30, 0.30, 0.39751, 0.33791, 0.77963, 0.79857, 0.90, 0.02, 0.20};
 
     // Equation 6 from Scalabrin
     alpha = 1-a[10]*acosh(1+a[11]*pow(pow(1-Tr,2),a[12]));
 
     // Equation 5 from Scalabrin
-    long double numer = rhor*exp(-pow(rhor,a[1])/a[1]-pow(a[2]*(Tr-1),2)-pow(a[3]*(rhor-1),2));
-    long double braced = (1-1/Tr)+a[4]*pow(pow(rhor-1,2),0.5/a[5]);
-    long double denom = pow(pow(pow(braced, 2), a[6]) + pow(pow(a[7]*(rhor-alpha), 2), a[8]),a[9]);
+    CoolPropDbl numer = rhor*exp(-pow(rhor,a[1])/a[1]-pow(a[2]*(Tr-1),2)-pow(a[3]*(rhor-1),2));
+    CoolPropDbl braced = (1-1/Tr)+a[4]*pow(pow(rhor-1,2),0.5/a[5]);
+    CoolPropDbl denom = pow(pow(pow(braced, 2), a[6]) + pow(pow(a[7]*(rhor-alpha), 2), a[8]),a[9]);
     return nc*numer/denom;
 }
 
-long double TransportRoutines::conductivity_dilute_hardcoded_CO2(HelmholtzEOSMixtureBackend &HEOS){
+CoolPropDbl TransportRoutines::conductivity_dilute_hardcoded_CO2(HelmholtzEOSMixtureBackend &HEOS){
 
     double e_k = 251.196, Tstar;
     double b[] = {0.4226159, 0.6280115, -0.5387661, 0.6735941, 0, 0, -0.4362677, 0.2255388};
@@ -717,7 +717,7 @@ long double TransportRoutines::conductivity_dilute_hardcoded_CO2(HelmholtzEOSMix
     return lambda_0;
 }
 
-long double TransportRoutines::conductivity_dilute_hardcoded_ethane(HelmholtzEOSMixtureBackend &HEOS){
+CoolPropDbl TransportRoutines::conductivity_dilute_hardcoded_ethane(HelmholtzEOSMixtureBackend &HEOS){
 
     double e_k = 245.0;
     double tau = 305.33/HEOS.T(), Tstar = HEOS.T()/e_k;
@@ -727,7 +727,7 @@ long double TransportRoutines::conductivity_dilute_hardcoded_ethane(HelmholtzEOS
     return lambda_0;
 }
 
-long double TransportRoutines::conductivity_dilute_eta0_and_poly(HelmholtzEOSMixtureBackend &HEOS){
+CoolPropDbl TransportRoutines::conductivity_dilute_eta0_and_poly(HelmholtzEOSMixtureBackend &HEOS){
 
     if (HEOS.is_pure_or_pseudopure)
     {
@@ -736,7 +736,7 @@ long double TransportRoutines::conductivity_dilute_eta0_and_poly(HelmholtzEOSMix
         double eta0_uPas = HEOS.calc_viscosity_dilute()*1e6; // [uPa-s]
         double summer = E.A[0]*eta0_uPas;
         for (std::size_t i=1; i < E.A.size(); ++i)
-            summer += E.A[i]*pow(static_cast<long double>(HEOS.tau()), E.t[i]);
+            summer += E.A[i]*pow(static_cast<CoolPropDbl>(HEOS.tau()), E.t[i]);
         return summer;
     }
     else{
@@ -744,7 +744,7 @@ long double TransportRoutines::conductivity_dilute_eta0_and_poly(HelmholtzEOSMix
     }
 }
 
-long double TransportRoutines::conductivity_hardcoded_water(HelmholtzEOSMixtureBackend &HEOS){
+CoolPropDbl TransportRoutines::conductivity_hardcoded_water(HelmholtzEOSMixtureBackend &HEOS){
 
     double L[5][6] = {{1.60397357,-0.646013523,0.111443906,0.102997357,-0.0504123634,0.00609859258},
                 {2.33771842,-2.78843778,1.53616167,-0.463045512,0.0832827019,-0.00719201245},
@@ -803,7 +803,7 @@ long double TransportRoutines::conductivity_hardcoded_water(HelmholtzEOSMixtureB
     return (lambdabar_0*lambdabar_1+lambdabar_2)*lambdastar;
 }
 
-long double TransportRoutines::conductivity_hardcoded_R23(HelmholtzEOSMixtureBackend &HEOS){
+CoolPropDbl TransportRoutines::conductivity_hardcoded_R23(HelmholtzEOSMixtureBackend &HEOS){
 
     double B1 = -2.5370, // [mW/m/K]
            B2 = 0.05366, // [mW/m/K^2]
@@ -830,7 +830,7 @@ long double TransportRoutines::conductivity_hardcoded_R23(HelmholtzEOSMixtureBac
     return (pow((rhoL-rhobar)/rhoL,C1)*lambda_DG+pow(rhobar/rhoL,C1)*lambda_L+DELTAlambda_c)/1e3;
 }
 
-long double TransportRoutines::conductivity_critical_hardcoded_ammonia(HelmholtzEOSMixtureBackend &HEOS){
+CoolPropDbl TransportRoutines::conductivity_critical_hardcoded_ammonia(HelmholtzEOSMixtureBackend &HEOS){
 
     /*
     From "Thermal Conductivity of Ammonia in a Large
@@ -864,7 +864,7 @@ long double TransportRoutines::conductivity_critical_hardcoded_ammonia(Helmholtz
     return DELTA_lambda;
 }
 
-long double TransportRoutines::conductivity_hardcoded_helium(HelmholtzEOSMixtureBackend &HEOS){
+CoolPropDbl TransportRoutines::conductivity_hardcoded_helium(HelmholtzEOSMixtureBackend &HEOS){
     /*
     What an incredibly annoying formulation!  Implied coefficients?? Not cool.
     */
@@ -932,20 +932,20 @@ long double TransportRoutines::conductivity_hardcoded_helium(HelmholtzEOSMixture
     return lambda_0+lambda_e+lambda_c;
 }
 
-void TransportRoutines::conformal_state_solver(HelmholtzEOSMixtureBackend &HEOS, HelmholtzEOSMixtureBackend &HEOS_Reference, long double &T0, long double &rhomolar0)
+void TransportRoutines::conformal_state_solver(HelmholtzEOSMixtureBackend &HEOS, HelmholtzEOSMixtureBackend &HEOS_Reference, CoolPropDbl &T0, CoolPropDbl &rhomolar0)
 {
     int iter = 0;
     double resid = 9e30, resid_old = 9e30;
-    long double alphar = HEOS.alphar();
-    long double Z = HEOS.keyed_output(iZ);
+    CoolPropDbl alphar = HEOS.alphar();
+    CoolPropDbl Z = HEOS.keyed_output(iZ);
     
     Eigen::Vector2d r;
     Eigen::Matrix2d J;
     // Update the reference fluid with the conformal state
     HEOS_Reference.update_DmolarT_direct(rhomolar0, T0);
     do{
-        long double dtau_dT = -HEOS_Reference.T_critical()/(T0*T0);
-        long double ddelta_drho = 1/HEOS_Reference.rhomolar_critical();
+        CoolPropDbl dtau_dT = -HEOS_Reference.T_critical()/(T0*T0);
+        CoolPropDbl ddelta_drho = 1/HEOS_Reference.rhomolar_critical();
         // Independent variables are T0 and rhomolar0, residuals are matching alphar and Z
         r(0) = HEOS_Reference.alphar() - alphar;
         r(1) = HEOS_Reference.keyed_output(iZ) - Z;
@@ -993,10 +993,10 @@ void TransportRoutines::conformal_state_solver(HelmholtzEOSMixtureBackend &HEOS,
     while(std::abs(resid) > 1e-9);
 }
 
-long double TransportRoutines::viscosity_ECS(HelmholtzEOSMixtureBackend &HEOS, HelmholtzEOSMixtureBackend &HEOS_Reference)
+CoolPropDbl TransportRoutines::viscosity_ECS(HelmholtzEOSMixtureBackend &HEOS, HelmholtzEOSMixtureBackend &HEOS_Reference)
 {
     // Collect some parameters
-    long double M = HEOS.molar_mass(),
+    CoolPropDbl M = HEOS.molar_mass(),
                 M0 = HEOS_Reference.molar_mass(),
                 Tc = HEOS.T_critical(),
                 Tc0 = HEOS_Reference.T_critical(),
@@ -1013,21 +1013,21 @@ long double TransportRoutines::viscosity_ECS(HelmholtzEOSMixtureBackend &HEOS, H
     }
 
     // The dilute gas portion for the fluid of interest [Pa-s]
-    long double eta_dilute = viscosity_dilute_kinetic_theory(HEOS);
+    CoolPropDbl eta_dilute = viscosity_dilute_kinetic_theory(HEOS);
 
     // ************************************
     // Start with a guess for theta and phi
     // ************************************
-    long double theta = 1;
-    long double phi = 1;
+    CoolPropDbl theta = 1;
+    CoolPropDbl phi = 1;
 
     // The equivalent substance reducing ratios
-    long double f = Tc/Tc0*theta;
-    long double h = rhocmolar0/rhocmolar*phi; // Must be the ratio of MOLAR densities!!
+    CoolPropDbl f = Tc/Tc0*theta;
+    CoolPropDbl h = rhocmolar0/rhocmolar*phi; // Must be the ratio of MOLAR densities!!
 
     // To be solved for
-    long double T0 = HEOS.T()/f;
-    long double rhomolar0 = HEOS.rhomolar()*h;
+    CoolPropDbl T0 = HEOS.T()/f;
+    CoolPropDbl rhomolar0 = HEOS.rhomolar()*h;
     
     // **************************
     // Solver for conformal state
@@ -1050,21 +1050,21 @@ long double TransportRoutines::viscosity_ECS(HelmholtzEOSMixtureBackend &HEOS, H
     // **********************
     
     // The reference fluid's contribution to the viscosity [Pa-s]
-    long double eta_resid = HEOS_Reference.calc_viscosity_background();
+    CoolPropDbl eta_resid = HEOS_Reference.calc_viscosity_background();
 
     // The F factor
-    long double F_eta = sqrt(f)*pow(h, -2.0L/3.0L)*sqrt(M/M0);
+    CoolPropDbl F_eta = sqrt(f)*pow(h, -2.0L/3.0L)*sqrt(M/M0);
 
     // The total viscosity considering the contributions of the fluid of interest and the reference fluid [Pa-s]
-    long double eta = eta_dilute + eta_resid*F_eta;
+    CoolPropDbl eta = eta_dilute + eta_resid*F_eta;
 
     return eta;
 }
 
-long double TransportRoutines::conductivity_ECS(HelmholtzEOSMixtureBackend &HEOS, HelmholtzEOSMixtureBackend &HEOS_Reference)
+CoolPropDbl TransportRoutines::conductivity_ECS(HelmholtzEOSMixtureBackend &HEOS, HelmholtzEOSMixtureBackend &HEOS_Reference)
 {
     // Collect some parameters
-    long double M = HEOS.molar_mass(),
+    CoolPropDbl M = HEOS.molar_mass(),
                 M_kmol = M*1000,
                 M0 = HEOS_Reference.molar_mass(),
                 Tc = HEOS.T_critical(),
@@ -1091,31 +1091,31 @@ long double TransportRoutines::conductivity_ECS(HelmholtzEOSMixtureBackend &HEOS
     }
 
     // The dilute gas density for the fluid of interest [uPa-s]
-    long double eta_dilute = viscosity_dilute_kinetic_theory(HEOS)*1e6;
+    CoolPropDbl eta_dilute = viscosity_dilute_kinetic_theory(HEOS)*1e6;
 
     // The mass specific ideal gas constant-pressure specific heat [J/kg/K]
-    long double cp0 = HEOS.calc_cpmolar_idealgas()/HEOS.molar_mass();
+    CoolPropDbl cp0 = HEOS.calc_cpmolar_idealgas()/HEOS.molar_mass();
 
     // The internal contribution to the thermal conductivity [W/m/K]
-    long double lambda_int = fint*eta_dilute*(cp0 - 2.5*R)/1e3;
+    CoolPropDbl lambda_int = fint*eta_dilute*(cp0 - 2.5*R)/1e3;
 
     // The dilute gas contribution to the thermal conductivity [W/m/K]
-    long double lambda_dilute = 15.0e-3/4.0*R_kJkgK*eta_dilute;
+    CoolPropDbl lambda_dilute = 15.0e-3/4.0*R_kJkgK*eta_dilute;
 
     // ************************************
     // Start with a guess for theta and phi
     // ************************************
     
-    long double theta = 1;
-    long double phi = 1;
+    CoolPropDbl theta = 1;
+    CoolPropDbl phi = 1;
 
     // The equivalent substance reducing ratios
-    long double f = Tc/Tc0*theta;
-    long double h = rhocmolar0/rhocmolar*phi; // Must be the ratio of MOLAR densities!!
+    CoolPropDbl f = Tc/Tc0*theta;
+    CoolPropDbl h = rhocmolar0/rhocmolar*phi; // Must be the ratio of MOLAR densities!!
 
     // Initial values for the conformal state
-    long double T0 = HEOS.T()/f;
-    long double rhomolar0 = HEOS.rhomolar()*h;
+    CoolPropDbl T0 = HEOS.T()/f;
+    CoolPropDbl rhomolar0 = HEOS.rhomolar()*h;
     
     // **************************
     // Solver for conformal state
@@ -1136,16 +1136,16 @@ long double TransportRoutines::conductivity_ECS(HelmholtzEOSMixtureBackend &HEOS
     h = rhomolar0/HEOS.rhomolar(); // Must be the ratio of MOLAR densities!!
 
     // The reference fluid's contribution to the conductivity [W/m/K]
-    long double lambda_resid = HEOS_Reference.calc_conductivity_background();
+    CoolPropDbl lambda_resid = HEOS_Reference.calc_conductivity_background();
 
     // The F factor
-    long double F_lambda = sqrt(f)*pow(h, static_cast<long double>(-2.0/3.0))*sqrt(M0/M);
+    CoolPropDbl F_lambda = sqrt(f)*pow(h, static_cast<CoolPropDbl>(-2.0/3.0))*sqrt(M0/M);
 
     // The critical contribution from the fluid of interest [W/m/K]
-    long double lambda_critical = conductivity_critical_simplified_Olchowy_Sengers(HEOS);
+    CoolPropDbl lambda_critical = conductivity_critical_simplified_Olchowy_Sengers(HEOS);
 
     // The total thermal conductivity considering the contributions of the fluid of interest and the reference fluid [Pa-s]
-    long double lambda = lambda_int + lambda_dilute + lambda_resid*F_lambda + lambda_critical;
+    CoolPropDbl lambda = lambda_int + lambda_dilute + lambda_resid*F_lambda + lambda_critical;
 
     return lambda;
 }

--- a/src/Backends/Helmholtz/TransportRoutines.h
+++ b/src/Backends/Helmholtz/TransportRoutines.h
@@ -19,7 +19,7 @@ public:
     \f]
     with \f$T^* = \frac{T}{\varepsilon/k}\f$ and \f$\sigma\f$ in nm, M is in kg/kmol. Yields viscosity in Pa-s.
     */
-    static long double viscosity_dilute_kinetic_theory(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_dilute_kinetic_theory(HelmholtzEOSMixtureBackend &HEOS);
 
     /**
     \brief The dilute gas viscosity term that is based on collision integral or effective cross section
@@ -32,7 +32,7 @@ public:
     \f]
     with \f$T^* = \frac{T}{\varepsilon/k}\f$ and \f$\sigma\f$ in nm, M is in kg/kmol. Yields viscosity in Pa-s.
     */
-    static long double viscosity_dilute_collision_integral(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_dilute_collision_integral(HelmholtzEOSMixtureBackend &HEOS);
 
     /**
     \brief A dilute gas viscosity term formed of summation of power terms
@@ -42,9 +42,9 @@ public:
     \f]
     with T in K, \f$\eta^0\f$ in Pa-s
     */
-    static long double viscosity_dilute_powers_of_T(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_dilute_powers_of_T(HelmholtzEOSMixtureBackend &HEOS);
 
-    static long double viscosity_dilute_collision_integral_powers_of_T(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_dilute_collision_integral_powers_of_T(HelmholtzEOSMixtureBackend &HEOS);
 
     /**
     \brief The initial density dependence term \f$B_{\eta}\f$ from Rainwater-Friend theory
@@ -66,7 +66,7 @@ public:
 
     IMPORTANT: This function returns \f$B_{\eta}\f$, not \f$\eta_{RF}\f$
     */
-    static long double viscosity_initial_density_dependence_Rainwater_Friend(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_initial_density_dependence_Rainwater_Friend(HelmholtzEOSMixtureBackend &HEOS);
     
     /**
      * \brief An empirical form for the initial density dependence 
@@ -77,7 +77,7 @@ public:
      * \f]
      * where the output is in Pa-s
      */
-    static long double viscosity_initial_density_dependence_empirical(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_initial_density_dependence_empirical(HelmholtzEOSMixtureBackend &HEOS);
 
     /**
     \brief The modified Batschinski-Hildebrand contribution to the viscosity
@@ -91,27 +91,27 @@ public:
     \f]
     The more general form of \f$\delta_0(\tau)\f$ is selected in order to be able to handle all the forms in the literature
     */
-    static long double viscosity_higher_order_modified_Batschinski_Hildebrand(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_higher_order_modified_Batschinski_Hildebrand(HelmholtzEOSMixtureBackend &HEOS);
 
-    static long double viscosity_dilute_ethane(HelmholtzEOSMixtureBackend &HEOS);
-    static long double viscosity_dilute_cyclohexane(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_dilute_ethane(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_dilute_cyclohexane(HelmholtzEOSMixtureBackend &HEOS);
 
     /** \brief Viscosity hardcoded for Methanol
      * 
      * From Xiang et al., A New Reference Correlation for the Viscosity of Methanol, J. Phys. Chem. Ref. Data, Vol. 35, No. 4, 2006
      */
-    static long double viscosity_methanol_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_methanol_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
 
-    static long double viscosity_water_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
-    static long double viscosity_helium_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
-    static long double viscosity_R23_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_water_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_helium_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_R23_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
 
-    static long double viscosity_ethane_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
-    static long double viscosity_hydrogen_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
-    static long double viscosity_benzene_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
-    static long double viscosity_hexane_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
-    static long double viscosity_heptane_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
-    static long double viscosity_higher_order_friction_theory(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_ethane_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_hydrogen_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_benzene_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_hexane_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_heptane_higher_order_hardcoded(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl viscosity_higher_order_friction_theory(HelmholtzEOSMixtureBackend &HEOS);
 
     /**
     \brief The general dilute gas conductivity term formed of a ratio of polynomial like terms
@@ -121,7 +121,7 @@ public:
     \f]
     with \f$\lambda^0\f$ in W/m/K, T_r is the reduced temperature \f$T_{r} = T/T_{red}\f$
     */
-    static long double conductivity_dilute_ratio_polynomials(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl conductivity_dilute_ratio_polynomials(HelmholtzEOSMixtureBackend &HEOS);
 
     /**
 
@@ -136,7 +136,7 @@ public:
     \f]
     which can be easily converted by noting that \f$\tau=Tc/T\f$ and \f$\delta=\rho/\rho_c\f$
     */
-    static long double conductivity_residual_polynomial(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl conductivity_residual_polynomial(HelmholtzEOSMixtureBackend &HEOS);
 
     /**
     \brief The simplified critical conductivity term of Olchowy and Sengers
@@ -179,21 +179,21 @@ public:
     Effective cutoff | \f$q_d\f$    | 2 \f$\times\f$ 10\f$^{9}\f$ m
 
     */
-    static long double conductivity_critical_simplified_Olchowy_Sengers(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl conductivity_critical_simplified_Olchowy_Sengers(HelmholtzEOSMixtureBackend &HEOS);
 
-    static long double conductivity_critical_hardcoded_CO2_ScalabrinJPCRD2006(HelmholtzEOSMixtureBackend &HEOS);
-    static long double conductivity_critical_hardcoded_R123(HelmholtzEOSMixtureBackend &HEOS);
-    static long double conductivity_dilute_hardcoded_CO2(HelmholtzEOSMixtureBackend &HEOS);
-    static long double conductivity_dilute_hardcoded_ethane(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl conductivity_critical_hardcoded_CO2_ScalabrinJPCRD2006(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl conductivity_critical_hardcoded_R123(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl conductivity_dilute_hardcoded_CO2(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl conductivity_dilute_hardcoded_ethane(HelmholtzEOSMixtureBackend &HEOS);
 
-    static long double conductivity_dilute_eta0_and_poly(HelmholtzEOSMixtureBackend &HEOS);
-    static long double conductivity_residual_polynomial_and_exponential(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl conductivity_dilute_eta0_and_poly(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl conductivity_residual_polynomial_and_exponential(HelmholtzEOSMixtureBackend &HEOS);
 
-    static long double conductivity_hardcoded_water(HelmholtzEOSMixtureBackend &HEOS);
-    static long double conductivity_hardcoded_R23(HelmholtzEOSMixtureBackend &HEOS);
-    static long double conductivity_hardcoded_helium(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl conductivity_hardcoded_water(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl conductivity_hardcoded_R23(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl conductivity_hardcoded_helium(HelmholtzEOSMixtureBackend &HEOS);
 
-    static long double conductivity_critical_hardcoded_ammonia(HelmholtzEOSMixtureBackend &HEOS);
+    static CoolPropDbl conductivity_critical_hardcoded_ammonia(HelmholtzEOSMixtureBackend &HEOS);
 
     /**
     \brief Calculate the viscosity using the extended corresponding states method
@@ -212,14 +212,14 @@ public:
 
 
     */
-    static long double viscosity_ECS(HelmholtzEOSMixtureBackend &HEOS, HelmholtzEOSMixtureBackend &HEOS_Reference);
+    static CoolPropDbl viscosity_ECS(HelmholtzEOSMixtureBackend &HEOS, HelmholtzEOSMixtureBackend &HEOS_Reference);
 
-    static long double conductivity_ECS(HelmholtzEOSMixtureBackend &HEOS, HelmholtzEOSMixtureBackend &HEOS_Reference);
+    static CoolPropDbl conductivity_ECS(HelmholtzEOSMixtureBackend &HEOS, HelmholtzEOSMixtureBackend &HEOS_Reference);
 
     /* \brief Solver for the conformal state for ECS model
      * 
      */
-    static void conformal_state_solver(HelmholtzEOSMixtureBackend &HEOS, HelmholtzEOSMixtureBackend &HEOS_Reference, long double &T0, long double &rhomolar0);
+    static void conformal_state_solver(HelmholtzEOSMixtureBackend &HEOS, HelmholtzEOSMixtureBackend &HEOS_Reference, CoolPropDbl &T0, CoolPropDbl &rhomolar0);
 
 }; /* class TransportRoutines */
 

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -6,14 +6,14 @@
 
 namespace CoolProp {
     
-void SaturationSolvers::saturation_critical(HelmholtzEOSMixtureBackend &HEOS, parameters ykey, long double y){
+void SaturationSolvers::saturation_critical(HelmholtzEOSMixtureBackend &HEOS, parameters ykey, CoolPropDbl y){
     
     class inner_resid : public FuncWrapper1D{
         public:
         HelmholtzEOSMixtureBackend *HEOS;
-        long double T, desired_p, rhomolar_liq, calc_p, rhomolar_crit;
+        CoolPropDbl T, desired_p, rhomolar_liq, calc_p, rhomolar_crit;
         
-        inner_resid(HelmholtzEOSMixtureBackend *HEOS, long double T, long double desired_p)
+        inner_resid(HelmholtzEOSMixtureBackend *HEOS, CoolPropDbl T, CoolPropDbl desired_p)
             : HEOS(HEOS), T(T), desired_p(desired_p){};
         double call(double rhomolar_liq){
             this->rhomolar_liq = rhomolar_liq;
@@ -32,11 +32,11 @@ void SaturationSolvers::saturation_critical(HelmholtzEOSMixtureBackend &HEOS, pa
 
         HelmholtzEOSMixtureBackend *HEOS;
         parameters ykey;
-        long double y;
-        long double r, T, rhomolar_liq, rhomolar_vap, value, p, gL, gV, rhomolar_crit;
+        CoolPropDbl y;
+        CoolPropDbl r, T, rhomolar_liq, rhomolar_vap, value, p, gL, gV, rhomolar_crit;
         int other;
 
-        outer_resid(HelmholtzEOSMixtureBackend &HEOS, CoolProp::parameters ykey, long double y) 
+        outer_resid(HelmholtzEOSMixtureBackend &HEOS, CoolProp::parameters ykey, CoolPropDbl y) 
             : HEOS(&HEOS), ykey(ykey), y(y){
                 rhomolar_crit = HEOS.rhomolar_critical();
             };
@@ -74,7 +74,7 @@ void SaturationSolvers::saturation_critical(HelmholtzEOSMixtureBackend &HEOS, pa
     Brent(&resid, rhomolar_crit*(1-1e-8), rhomolar_crit*0.5, DBL_EPSILON, 1e-9, 20, errstr);
 }
 
-void SaturationSolvers::saturation_T_pure_1D_P(HelmholtzEOSMixtureBackend &HEOS, long double T, saturation_T_pure_options &options)
+void SaturationSolvers::saturation_T_pure_1D_P(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl T, saturation_T_pure_options &options)
 {
     
     // Define the residual to be driven to zero
@@ -83,10 +83,10 @@ void SaturationSolvers::saturation_T_pure_1D_P(HelmholtzEOSMixtureBackend &HEOS,
     public:
 
         HelmholtzEOSMixtureBackend *HEOS;
-        long double r, T, rhomolar_liq, rhomolar_vap, value, p, gL, gV;
+        CoolPropDbl r, T, rhomolar_liq, rhomolar_vap, value, p, gL, gV;
         int other;
 
-        solver_resid(HelmholtzEOSMixtureBackend &HEOS, long double T, long double rhomolar_liq_guess, long double rhomolar_vap_guess) 
+        solver_resid(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl T, CoolPropDbl rhomolar_liq_guess, CoolPropDbl rhomolar_vap_guess) 
             : HEOS(&HEOS), T(T), rhomolar_liq(rhomolar_liq_guess), rhomolar_vap(rhomolar_vap_guess){};
         double call(double p){
             this->p = p;
@@ -115,13 +115,13 @@ void SaturationSolvers::saturation_T_pure_1D_P(HelmholtzEOSMixtureBackend &HEOS,
         Secant(resid, options.p, options.p*1.1, 1e-10, 100, errstr);
     }
     catch(std::exception &){
-        long double pmax = std::min(options.p*1.03, static_cast<long double>(HEOS.p_critical()+1e-6));
-        long double pmin = std::max(options.p*0.97, static_cast<long double>(HEOS.p_triple()-1e-6));
+        CoolPropDbl pmax = std::min(options.p*1.03, static_cast<CoolPropDbl>(HEOS.p_critical()+1e-6));
+        CoolPropDbl pmin = std::max(options.p*0.97, static_cast<CoolPropDbl>(HEOS.p_triple()-1e-6));
         Brent(resid, pmin, pmax, LDBL_EPSILON, 1e-8, 100, errstr);
     }
 }
 
-void SaturationSolvers::saturation_P_pure_1D_T(HelmholtzEOSMixtureBackend &HEOS, long double p, saturation_PHSU_pure_options &options){
+void SaturationSolvers::saturation_P_pure_1D_T(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl p, saturation_PHSU_pure_options &options){
     
     // Define the residual to be driven to zero
     class solver_resid : public FuncWrapper1D
@@ -129,10 +129,10 @@ void SaturationSolvers::saturation_P_pure_1D_T(HelmholtzEOSMixtureBackend &HEOS,
     public:
 
         HelmholtzEOSMixtureBackend *HEOS;
-        long double r, p, rhomolar_liq, rhomolar_vap, value, T, gL, gV;
+        CoolPropDbl r, p, rhomolar_liq, rhomolar_vap, value, T, gL, gV;
         int other;
 
-        solver_resid(HelmholtzEOSMixtureBackend &HEOS, long double p, long double rhomolar_liq_guess, long double rhomolar_vap_guess) 
+        solver_resid(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl p, CoolPropDbl rhomolar_liq_guess, CoolPropDbl rhomolar_vap_guess) 
             : HEOS(&HEOS), p(p), rhomolar_liq(rhomolar_liq_guess), rhomolar_vap(rhomolar_vap_guess){};
         double call(double T){
             this->T = T;
@@ -157,12 +157,12 @@ void SaturationSolvers::saturation_P_pure_1D_T(HelmholtzEOSMixtureBackend &HEOS,
     if (!ValidNumber(options.rhoV)){throw ValueError("options.rhoV is not valid in saturation_P_pure_1D_T");};
     
     std::string errstr;
-    long double Tmax = std::min(options.T + 2, static_cast<long double>(HEOS.T_critical()-1e-6));
-    long double Tmin = std::max(options.T - 2, static_cast<long double>(HEOS.Ttriple()+1e-6));
+    CoolPropDbl Tmax = std::min(options.T + 2, static_cast<CoolPropDbl>(HEOS.T_critical()-1e-6));
+    CoolPropDbl Tmin = std::max(options.T - 2, static_cast<CoolPropDbl>(HEOS.Ttriple()+1e-6));
     Brent(resid, Tmin, Tmax, LDBL_EPSILON, 1e-11, 100, errstr);
 }
     
-void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend &HEOS, long double specified_value, saturation_PHSU_pure_options &options)
+void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl specified_value, saturation_PHSU_pure_options &options)
 {
     /*
     This function is inspired by the method of Akasaka:
@@ -173,8 +173,8 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend &HEOS, l
 
     Ancillary equations are used to get a sensible starting point
     */
-    std::vector<long double> negativer(3,_HUGE), v;
-    std::vector<std::vector<long double> > J(3, std::vector<long double>(3,_HUGE));
+    std::vector<CoolPropDbl> negativer(3,_HUGE), v;
+    std::vector<std::vector<CoolPropDbl> > J(3, std::vector<CoolPropDbl>(3,_HUGE));
 
     HEOS.calc_reducing_state();
     const SimpleState & reduce = HEOS.get_reducing_state();
@@ -182,8 +182,8 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend &HEOS, l
     shared_ptr<HelmholtzEOSMixtureBackend> SatL = HEOS.SatL,
                                            SatV = HEOS.SatV;
 
-    long double T, rhoL, rhoV, pL, pV, hL, sL, hV, sV;
-    long double deltaL=0, deltaV=0, tau=0, error;
+    CoolPropDbl T, rhoL, rhoV, pL, pV, hL, sL, hV, sV;
+    CoolPropDbl deltaL=0, deltaV=0, tau=0, error;
     int iter=0, specified_parameter;
 
     // Use the density ancillary function as the starting point for the solver
@@ -222,7 +222,7 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend &HEOS, l
                     this->h = h;
                 }
                 double call(double T){
-                    long double h_liq = component->ancillaries.hL.evaluate(T) + component->pEOS->hs_anchor.hmolar;
+                    CoolPropDbl h_liq = component->ancillaries.hL.evaluate(T) + component->pEOS->hs_anchor.hmolar;
                     return h_liq + component->ancillaries.hLV.evaluate(T) - h;
                 };
             };
@@ -230,7 +230,7 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend &HEOS, l
             
             // Ancillary is deltah = h - hs_anchor.h
             std::string errstr;
-            long double Tmin_satL, Tmin_satV;
+            CoolPropDbl Tmin_satL, Tmin_satV;
             HEOS.calc_Tmin_sat(Tmin_satL, Tmin_satV);
             double Tmin = Tmin_satL;
             double Tmax = HEOS.calc_Tmax_sat();
@@ -253,7 +253,7 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend &HEOS, l
                 T = std::max(0.99*crit.T, crit.T-0.1);
             }
             else{
-                long double Tmin, Tmax, Tmin_satV;
+                CoolPropDbl Tmin, Tmax, Tmin_satV;
                 HEOS.calc_Tmin_sat(Tmin, Tmin_satV);
                 Tmax = HEOS.calc_Tmax_sat();
                 // Ancillary is deltas = s - hs_anchor.s
@@ -292,8 +292,8 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend &HEOS, l
                     this->s = s;
                 }
                 double call(double T){
-                    long double s_liq = component->ancillaries.sL.evaluate(T) + component->pEOS->hs_anchor.smolar;
-                    long double resid = s_liq + component->ancillaries.sLV.evaluate(T) - s;
+                    CoolPropDbl s_liq = component->ancillaries.sL.evaluate(T) + component->pEOS->hs_anchor.smolar;
+                    CoolPropDbl resid = s_liq + component->ancillaries.sLV.evaluate(T) - s;
                     
                     return resid;
                 };
@@ -302,7 +302,7 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend &HEOS, l
             
             // Ancillary is deltas = s - hs_anchor.s
             std::string errstr;
-            long double Tmin_satL, Tmin_satV;
+            CoolPropDbl Tmin_satL, Tmin_satV;
             HEOS.calc_Tmin_sat(Tmin_satL, Tmin_satV);
             double Tmin = Tmin_satL;
             double Tmax = HEOS.calc_Tmax_sat();
@@ -310,7 +310,7 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend &HEOS, l
                 T = Brent(resid, Tmin-3, Tmax, DBL_EPSILON, 1e-10, 50, errstr);
             }
             catch(std::exception &){
-                long double vmax = resid.call(Tmax);
+                CoolPropDbl vmax = resid.call(Tmax);
                 // If near the critical point, use a near critical guess value for T
                 if (std::abs(specified_value - hs_anchor.smolar) < std::abs(vmax)){
                     T = std::max(0.99*crit.T, crit.T-0.1);
@@ -329,7 +329,7 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend &HEOS, l
         }
         // If T from the ancillaries is above the critical temp, this will cause failure 
         // in ancillaries for rhoV and rhoL, decrease if needed
-        T = std::min(T, static_cast<long double>(HEOS.T_critical()-0.1));
+        T = std::min(T, static_cast<CoolPropDbl>(HEOS.T_critical()-0.1));
 
         // Evaluate densities from the ancillary equations
         rhoV = HEOS.get_components()[0]->ancillaries.rhoV.evaluate(T);
@@ -372,16 +372,16 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend &HEOS, l
         sV = SatV->smolar();
 
         // These derivatives are needed for both cases
-        long double alpharL = SatL->alphar();
-        long double alpharV = SatV->alphar();
-        long double dalphar_dtauL = SatL->dalphar_dTau();
-        long double dalphar_dtauV = SatV->dalphar_dTau();
-        long double d2alphar_ddelta_dtauL = SatL->d2alphar_dDelta_dTau();
-        long double d2alphar_ddelta_dtauV = SatV->d2alphar_dDelta_dTau();
-        long double dalphar_ddeltaL = SatL->dalphar_dDelta();
-        long double dalphar_ddeltaV = SatV->dalphar_dDelta();
-        long double d2alphar_ddelta2L = SatL->d2alphar_dDelta2();
-        long double d2alphar_ddelta2V = SatV->d2alphar_dDelta2();
+        CoolPropDbl alpharL = SatL->alphar();
+        CoolPropDbl alpharV = SatV->alphar();
+        CoolPropDbl dalphar_dtauL = SatL->dalphar_dTau();
+        CoolPropDbl dalphar_dtauV = SatV->dalphar_dTau();
+        CoolPropDbl d2alphar_ddelta_dtauL = SatL->d2alphar_dDelta_dTau();
+        CoolPropDbl d2alphar_ddelta_dtauV = SatV->d2alphar_dDelta_dTau();
+        CoolPropDbl dalphar_ddeltaL = SatL->dalphar_dDelta();
+        CoolPropDbl dalphar_ddeltaV = SatV->dalphar_dDelta();
+        CoolPropDbl d2alphar_ddelta2L = SatL->d2alphar_dDelta2();
+        CoolPropDbl d2alphar_ddelta2V = SatV->d2alphar_dDelta2();
 
         // -r_1 (equate the pressures)
         negativer[0] = -(deltaV*(1+deltaV*dalphar_ddeltaV)-deltaL*(1+deltaL*dalphar_ddeltaL));
@@ -562,7 +562,7 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend &HEOS, l
     }
     while (error > 1e-9);
 }
-void SaturationSolvers::saturation_D_pure(HelmholtzEOSMixtureBackend &HEOS, long double rhomolar, saturation_D_pure_options &options)
+void SaturationSolvers::saturation_D_pure(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl rhomolar, saturation_D_pure_options &options)
 {
     /*
     This function is inspired by the method of Akasaka:
@@ -573,16 +573,16 @@ void SaturationSolvers::saturation_D_pure(HelmholtzEOSMixtureBackend &HEOS, long
 
     Ancillary equations are used to get a sensible starting point
     */
-    std::vector<long double> r(2,_HUGE), v;
-    std::vector<std::vector<long double> > J(2, std::vector<long double>(2,_HUGE));
+    std::vector<CoolPropDbl> r(2,_HUGE), v;
+    std::vector<std::vector<CoolPropDbl> > J(2, std::vector<CoolPropDbl>(2,_HUGE));
 
     HEOS.calc_reducing_state();
     const SimpleState & reduce = HEOS.get_reducing_state();
     shared_ptr<HelmholtzEOSMixtureBackend> SatL = HEOS.SatL,
                                            SatV = HEOS.SatV;
 
-    long double T, rhoL,rhoV;
-    long double deltaL=0, deltaV=0, tau=0, error, p_error;
+    CoolPropDbl T, rhoL,rhoV;
+    CoolPropDbl deltaL=0, deltaV=0, tau=0, error, p_error;
     int iter=0;
 
     // Use the density ancillary function as the starting point for the solver
@@ -627,18 +627,18 @@ void SaturationSolvers::saturation_D_pure(HelmholtzEOSMixtureBackend &HEOS, long
         SatL->update(DmolarT_INPUTS, rhoL, T);
         SatV->update(DmolarT_INPUTS, rhoV, T);
 
-        long double pL = SatL->p();
-        long double pV = SatV->p();
+        CoolPropDbl pL = SatL->p();
+        CoolPropDbl pV = SatV->p();
 
         // These derivatives are needed for both cases
-        long double dalphar_dtauL = SatL->dalphar_dTau();
-        long double dalphar_dtauV = SatV->dalphar_dTau();
-        long double d2alphar_ddelta_dtauL = SatL->d2alphar_dDelta_dTau();
-        long double d2alphar_ddelta_dtauV = SatV->d2alphar_dDelta_dTau();
-        long double alpharL = SatL->alphar();
-        long double alpharV = SatV->alphar();
-        long double dalphar_ddeltaL = SatL->dalphar_dDelta();
-        long double dalphar_ddeltaV = SatV->dalphar_dDelta();
+        CoolPropDbl dalphar_dtauL = SatL->dalphar_dTau();
+        CoolPropDbl dalphar_dtauV = SatV->dalphar_dTau();
+        CoolPropDbl d2alphar_ddelta_dtauL = SatL->d2alphar_dDelta_dTau();
+        CoolPropDbl d2alphar_ddelta_dtauV = SatV->d2alphar_dDelta_dTau();
+        CoolPropDbl alpharL = SatL->alphar();
+        CoolPropDbl alpharV = SatV->alphar();
+        CoolPropDbl dalphar_ddeltaL = SatL->dalphar_dDelta();
+        CoolPropDbl dalphar_ddeltaV = SatV->dalphar_dDelta();
 
         // -r_1
         r[0] = -(deltaV*(1+deltaV*dalphar_ddeltaV)-deltaL*(1+deltaL*dalphar_ddeltaL));
@@ -652,7 +652,7 @@ void SaturationSolvers::saturation_D_pure(HelmholtzEOSMixtureBackend &HEOS, long
 
         if (options.imposed_rho == saturation_D_pure_options::IMPOSED_RHOL)
         {
-            long double d2alphar_ddelta2V = SatV->d2alphar_dDelta2();
+            CoolPropDbl d2alphar_ddelta2V = SatV->d2alphar_dDelta2();
             if (options.use_logdelta)
             {
                 J[0][1] = deltaV+2*pow(deltaV,2)*dalphar_ddeltaV+pow(deltaV,3)*d2alphar_ddelta2V;
@@ -666,7 +666,7 @@ void SaturationSolvers::saturation_D_pure(HelmholtzEOSMixtureBackend &HEOS, long
         }
         else if (options.imposed_rho == saturation_D_pure_options::IMPOSED_RHOV)
         {
-            long double d2alphar_ddelta2L = SatL->d2alphar_dDelta2();
+            CoolPropDbl d2alphar_ddelta2L = SatL->d2alphar_dDelta2();
             if (options.use_logdelta)
             {
                 J[0][1] = -deltaL-2*pow(deltaL,2)*dalphar_ddeltaL-pow(deltaL,3)*d2alphar_ddelta2L;
@@ -717,12 +717,12 @@ void SaturationSolvers::saturation_D_pure(HelmholtzEOSMixtureBackend &HEOS, long
         }
     }
     while (error > 1e-9);
-    long double p_error_limit = 1e-3;
+    CoolPropDbl p_error_limit = 1e-3;
     if (std::abs(p_error) > p_error_limit){
         throw SolutionError(format("saturation_D_pure solver abs error on p [%Lg] > limit [%Lg]", p_error, p_error_limit));
     }
 }
-void SaturationSolvers::saturation_T_pure(HelmholtzEOSMixtureBackend &HEOS, long double T, saturation_T_pure_options &options)
+void SaturationSolvers::saturation_T_pure(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl T, saturation_T_pure_options &options)
 {
     // Set some imput options
     SaturationSolvers::saturation_T_pure_Akasaka_options _options;
@@ -748,7 +748,7 @@ void SaturationSolvers::saturation_T_pure(HelmholtzEOSMixtureBackend &HEOS, long
         }
     }
 }
-void SaturationSolvers::saturation_T_pure_Akasaka(HelmholtzEOSMixtureBackend &HEOS, long double T, saturation_T_pure_Akasaka_options &options)
+void SaturationSolvers::saturation_T_pure_Akasaka(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl T, saturation_T_pure_Akasaka_options &options)
 {
     // Start with the method of Akasaka
 
@@ -764,12 +764,12 @@ void SaturationSolvers::saturation_T_pure_Akasaka(HelmholtzEOSMixtureBackend &HE
 
     HEOS.calc_reducing_state();
     const SimpleState & reduce = HEOS.get_reducing_state();
-    long double R_u = HEOS.gas_constant();
+    CoolPropDbl R_u = HEOS.gas_constant();
     shared_ptr<HelmholtzEOSMixtureBackend> SatL = HEOS.SatL,
                                            SatV = HEOS.SatV;
 
-    long double rhoL = _HUGE, rhoV = _HUGE,JL,JV,KL,KV,dJL,dJV,dKL,dKV;
-    long double DELTA, deltaL=0, deltaV=0, error, PL, PV, stepL, stepV;
+    CoolPropDbl rhoL = _HUGE, rhoV = _HUGE,JL,JV,KL,KV,dJL,dJV,dKL,dKV;
+    CoolPropDbl DELTA, deltaL=0, deltaV=0, error, PL, PV, stepL, stepV;
     int iter=0;
     
     try
@@ -837,12 +837,12 @@ void SaturationSolvers::saturation_T_pure_Akasaka(HelmholtzEOSMixtureBackend &HE
         // Calculate once to save on calls to EOS
         SatL->update(DmolarT_INPUTS, rhoL, T);
         SatV->update(DmolarT_INPUTS, rhoV, T);
-        long double alpharL = SatL->alphar();
-        long double alpharV = SatV->alphar();
-        long double dalphar_ddeltaL = SatL->dalphar_dDelta();
-        long double dalphar_ddeltaV = SatV->dalphar_dDelta();
-        long double d2alphar_ddelta2L = SatL->d2alphar_dDelta2();
-        long double d2alphar_ddelta2V = SatV->d2alphar_dDelta2();
+        CoolPropDbl alpharL = SatL->alphar();
+        CoolPropDbl alpharV = SatV->alphar();
+        CoolPropDbl dalphar_ddeltaL = SatL->dalphar_dDelta();
+        CoolPropDbl dalphar_ddeltaV = SatV->dalphar_dDelta();
+        CoolPropDbl d2alphar_ddelta2L = SatL->d2alphar_dDelta2();
+        CoolPropDbl d2alphar_ddelta2V = SatV->d2alphar_dDelta2();
 
         JL = deltaL * (1 + deltaL*dalphar_ddeltaL);
         JV = deltaV * (1 + deltaV*dalphar_ddeltaV);
@@ -866,7 +866,7 @@ void SaturationSolvers::saturation_T_pure_Akasaka(HelmholtzEOSMixtureBackend &HE
         stepL = options.omega/DELTA*( (KV-KL)*dJV-(JV-JL)*dKV);
         stepV = options.omega/DELTA*( (KV-KL)*dJL-(JV-JL)*dKL);
 
-        long double deltaL0 = deltaL, deltaV0 = deltaV;
+        CoolPropDbl deltaL0 = deltaL, deltaV0 = deltaV;
         // Conditions for an acceptable step are:
         // a) rhoL > rhoV or deltaL > deltaV
         for (double omega_local = 1.0; omega_local > 0.1; omega_local /= 1.1)
@@ -888,8 +888,8 @@ void SaturationSolvers::saturation_T_pure_Akasaka(HelmholtzEOSMixtureBackend &HE
     }
     while (error > 1e-10 && std::abs(stepL) > 10*DBL_EPSILON*std::abs(stepL) && std::abs(stepV) > 10*DBL_EPSILON*std::abs(stepV));
     
-    long double p_error_limit = 1e-3;
-    long double p_error = (PL - PV)/PL;
+    CoolPropDbl p_error_limit = 1e-3;
+    CoolPropDbl p_error = (PL - PV)/PL;
     if (std::abs(p_error) > p_error_limit){
         options.pL = PL;
         options.pV = PV;
@@ -899,7 +899,7 @@ void SaturationSolvers::saturation_T_pure_Akasaka(HelmholtzEOSMixtureBackend &HE
     }
 }
 
-long double sign(long double x)
+CoolPropDbl sign(CoolPropDbl x)
 {
     if (x > 0){
         return 1;
@@ -909,7 +909,7 @@ long double sign(long double x)
     }
 }
 
-void SaturationSolvers::saturation_T_pure_Maxwell(HelmholtzEOSMixtureBackend &HEOS, long double T, saturation_T_pure_Akasaka_options &options)
+void SaturationSolvers::saturation_T_pure_Maxwell(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl T, saturation_T_pure_Akasaka_options &options)
 {
 
     /*
@@ -922,7 +922,7 @@ void SaturationSolvers::saturation_T_pure_Maxwell(HelmholtzEOSMixtureBackend &HE
     shared_ptr<HelmholtzEOSMixtureBackend> SatL = HEOS.SatL,
                                            SatV = HEOS.SatV;
     CoolProp::SimpleState &crit = HEOS.get_components()[0]->crit;
-    long double rhoL = _HUGE, rhoV = _HUGE, error = 999, DeltavL, DeltavV, pL, pV, p;
+    CoolPropDbl rhoL = _HUGE, rhoV = _HUGE, error = 999, DeltavL, DeltavV, pL, pV, p;
     int iter=0, small_step_count = 0;
     
     try
@@ -975,10 +975,10 @@ void SaturationSolvers::saturation_T_pure_Maxwell(HelmholtzEOSMixtureBackend &HE
                 if (std::abs((SatL->p()-p)/p) > 0.1){
                     for (int iii = 0; iii < 6; ++iii){
                         // Use Halley's method to update the liquid density (http://en.wikipedia.org/wiki/Halley%27s_method)
-                        long double f = SatL->p()-SatV->p();
-                        long double dpdrho = SatL->first_partial_deriv(iP,iDmolar,iT);
-                        long double d2pdrho2 = SatL->second_partial_deriv(iP,iDmolar,iT,iDmolar,iT);
-                        long double deltarhoLHalley = -(2*f*dpdrho)/(2*POW2(dpdrho)-f*d2pdrho2);
+                        CoolPropDbl f = SatL->p()-SatV->p();
+                        CoolPropDbl dpdrho = SatL->first_partial_deriv(iP,iDmolar,iT);
+                        CoolPropDbl d2pdrho2 = SatL->second_partial_deriv(iP,iDmolar,iT,iDmolar,iT);
+                        CoolPropDbl deltarhoLHalley = -(2*f*dpdrho)/(2*POW2(dpdrho)-f*d2pdrho2);
                         rhoL += deltarhoLHalley;
                         if (std::abs(deltarhoLHalley/rhoL) < DBL_EPSILON){
                             break;
@@ -1016,27 +1016,27 @@ void SaturationSolvers::saturation_T_pure_Maxwell(HelmholtzEOSMixtureBackend &HE
     if (get_debug_level() > 0){ std::cout << format("[Maxwell] starting T: %0.16Lg rhoL: %Lg rhoV: %Lg pL: %Lg pV: %g\n", T, rhoL, rhoV, SatL->p(), SatV->p());}
     do{
         pL = SatL->p(); pV = SatV->p();
-        long double vL = 1/SatL->rhomolar(), vV = 1/SatV->rhomolar();
+        CoolPropDbl vL = 1/SatL->rhomolar(), vV = 1/SatV->rhomolar();
         // Get alpha, the pressure derivative with volume at constant T
         // Given by (dp/drho|T)*drhodv
-        long double alphaL = SatL->first_partial_deriv(iP, iDmolar, iT)*(-POW2(SatL->rhomolar()));
-        long double alphaV = SatV->first_partial_deriv(iP, iDmolar, iT)*(-POW2(SatV->rhomolar()));
+        CoolPropDbl alphaL = SatL->first_partial_deriv(iP, iDmolar, iT)*(-POW2(SatL->rhomolar()));
+        CoolPropDbl alphaV = SatV->first_partial_deriv(iP, iDmolar, iT)*(-POW2(SatV->rhomolar()));
         
         // Total helmholtz energy for liquid and vapor
-        long double RT = SatL->gas_constant()*T;
-        long double helmholtzL = (SatL->calc_alpha0() + SatL->calc_alphar())*RT;
-        long double helmholtzV = (SatV->calc_alpha0() + SatV->calc_alphar())*RT;
+        CoolPropDbl RT = SatL->gas_constant()*T;
+        CoolPropDbl helmholtzL = (SatL->calc_alpha0() + SatL->calc_alphar())*RT;
+        CoolPropDbl helmholtzV = (SatV->calc_alpha0() + SatV->calc_alphar())*RT;
         
         // Calculate the mean pressure
-        long double pM = (helmholtzL - helmholtzV)/(vV - vL);
+        CoolPropDbl pM = (helmholtzL - helmholtzV)/(vV - vL);
         
         // Coefficients for the quadratic in the step
-        long double A = 0.5*alphaL*(alphaL - alphaV);
-        long double B = alphaL*(pL - pV - alphaV*(vL - vV));
-        long double C = alphaV*(vL - vV)*(pM - pL) + 0.5*POW2(pL - pV);
+        CoolPropDbl A = 0.5*alphaL*(alphaL - alphaV);
+        CoolPropDbl B = alphaL*(pL - pV - alphaV*(vL - vV));
+        CoolPropDbl C = alphaV*(vL - vV)*(pM - pL) + 0.5*POW2(pL - pV);
         
         // Argument to square root
-        long double sqrt_arg = std::abs(B*B/(4*A*A)-C/A);
+        CoolPropDbl sqrt_arg = std::abs(B*B/(4*A*A)-C/A);
         
         // If the argument to sqrt is very small, we multiply it by a large factor to make it 
         // larger, and then also divide the sqrt by the sqrt of the factor
@@ -1045,7 +1045,7 @@ void SaturationSolvers::saturation_T_pure_Maxwell(HelmholtzEOSMixtureBackend &HE
         }
         else{
             // Scale the argument to sqrt() function to make it about 1.0, and divide by sqrt(factor) to yield a factor of 1
-            long double powerfactor = -log10(sqrt_arg);
+            CoolPropDbl powerfactor = -log10(sqrt_arg);
             DeltavL = -0.5*B/A + sign((alphaL - alphaV)/alphaV)*sqrt(sqrt_arg*powerfactor)/sqrt(powerfactor);
         }
         DeltavV = (pL - pV + alphaL*DeltavL)/alphaV;
@@ -1082,7 +1082,7 @@ void SaturationSolvers::saturation_T_pure_Maxwell(HelmholtzEOSMixtureBackend &HE
     if (get_debug_level() > 0){ std::cout << format("[Maxwell] pL: %g pV: %g\n", SatL->p(), SatV->p());}
 }
 
-void SaturationSolvers::x_and_y_from_K(long double beta, const std::vector<long double> &K, const std::vector<long double> &z, std::vector<long double> &x, std::vector<long double> &y)
+void SaturationSolvers::x_and_y_from_K(CoolPropDbl beta, const std::vector<CoolPropDbl> &K, const std::vector<CoolPropDbl> &z, std::vector<CoolPropDbl> &x, std::vector<CoolPropDbl> &y)
 {
     for (unsigned int i=0; i < K.size(); i++)
     {
@@ -1092,16 +1092,16 @@ void SaturationSolvers::x_and_y_from_K(long double beta, const std::vector<long 
     }
 }
 
-void SaturationSolvers::successive_substitution(HelmholtzEOSMixtureBackend &HEOS, const long double beta, long double T, long double p, const std::vector<long double> &z,
-                                                       std::vector<long double> &K, mixture_VLE_IO &options)
+void SaturationSolvers::successive_substitution(HelmholtzEOSMixtureBackend &HEOS, const CoolPropDbl beta, CoolPropDbl T, CoolPropDbl p, const std::vector<CoolPropDbl> &z,
+                                                       std::vector<CoolPropDbl> &K, mixture_VLE_IO &options)
 {
     int iter = 1;
-    long double change, f, df, deriv_liq, deriv_vap;
+    CoolPropDbl change, f, df, deriv_liq, deriv_vap;
     std::size_t N = z.size();
-    std::vector<long double> ln_phi_liq, ln_phi_vap;
+    std::vector<CoolPropDbl> ln_phi_liq, ln_phi_vap;
     ln_phi_liq.resize(N); ln_phi_vap.resize(N);
 
-    std::vector<long double> &x = HEOS.SatL->get_mole_fractions_ref(), &y = HEOS.SatV->get_mole_fractions_ref();
+    std::vector<CoolPropDbl> &x = HEOS.SatL->get_mole_fractions_ref(), &y = HEOS.SatV->get_mole_fractions_ref();
     x_and_y_from_K(beta, K, z, x, y);
 
     HEOS.SatL->specify_phase(iphase_liquid);
@@ -1114,8 +1114,8 @@ void SaturationSolvers::successive_substitution(HelmholtzEOSMixtureBackend &HEOS
     HEOS.SatV->set_mole_fractions(y);
     HEOS.SatL->calc_reducing_state();
     HEOS.SatV->calc_reducing_state();
-    long double rhomolar_liq = HEOS.SatL->solver_rho_Tp_SRK(T, p, iphase_liquid); // [mol/m^3]
-    long double rhomolar_vap = HEOS.SatV->solver_rho_Tp_SRK(T, p, iphase_gas); // [mol/m^3]
+    CoolPropDbl rhomolar_liq = HEOS.SatL->solver_rho_Tp_SRK(T, p, iphase_liquid); // [mol/m^3]
+    CoolPropDbl rhomolar_vap = HEOS.SatV->solver_rho_Tp_SRK(T, p, iphase_gas); // [mol/m^3]
 
     HEOS.SatL->update_TP_guessrho(T, p, rhomolar_liq*1.5);
     HEOS.SatV->update_TP_guessrho(T, p, rhomolar_vap);
@@ -1203,7 +1203,7 @@ void SaturationSolvers::newton_raphson_saturation::resize(std::size_t N)
     else if (imposed_variable == newton_raphson_saturation_options::P_IMPOSED || imposed_variable == newton_raphson_saturation_options::T_IMPOSED){
         r.resize(N);
         negative_r.resize(N);
-        J.resize(N, std::vector<long double>(N, 0));
+        J.resize(N, std::vector<CoolPropDbl>(N, 0));
         err_rel.resize(N);
     }
     else{
@@ -1219,11 +1219,11 @@ void SaturationSolvers::newton_raphson_saturation::check_Jacobian()
     build_arrays();
 
     // Make copies of the base
-    long double T0 = T;
-    std::vector<long double> r0 = r, x0 = x;
+    CoolPropDbl T0 = T;
+    std::vector<CoolPropDbl> r0 = r, x0 = x;
     STLMatrix J0 = J;
-    long double rhomolar_liq0 = rSatL.rhomolar();
-    long double rhomolar_vap0 = rSatV.rhomolar();
+    CoolPropDbl rhomolar_liq0 = rSatL.rhomolar();
+    CoolPropDbl rhomolar_vap0 = rSatV.rhomolar();
     
     {
         // Derivatives with respect to T
@@ -1232,14 +1232,14 @@ void SaturationSolvers::newton_raphson_saturation::check_Jacobian()
         this->rhomolar_liq = rhomolar_liq0;
         this->rhomolar_vap = rhomolar_vap0;
         build_arrays();
-        std::vector<long double> r1 = r;
+        std::vector<CoolPropDbl> r1 = r;
         this->T = T2;
         this->rhomolar_liq = rhomolar_liq0;
         this->rhomolar_vap = rhomolar_vap0;
         build_arrays();
-        std::vector<long double> r2 = r;
+        std::vector<CoolPropDbl> r2 = r;
         
-        std::vector<long double> diffn(N+1, _HUGE);
+        std::vector<CoolPropDbl> diffn(N+1, _HUGE);
         for (std::size_t i = 0; i < N+1; ++i){
             diffn[i] = (r1[i]-r2[i])/(2*dT);
         }
@@ -1254,14 +1254,14 @@ void SaturationSolvers::newton_raphson_saturation::check_Jacobian()
         this->rhomolar_liq = rhomolar_liq0+drho;
         this->rhomolar_vap = rhomolar_vap0;
         build_arrays();
-        std::vector<long double> rr1 = r;
+        std::vector<CoolPropDbl> rr1 = r;
         this->T = T0;
         this->rhomolar_liq = rhomolar_liq0-drho;
         this->rhomolar_vap = rhomolar_vap0;
         build_arrays();
-        std::vector<long double> rr2 = r;
+        std::vector<CoolPropDbl> rr2 = r;
         
-        std::vector<long double> difffn(N+1, _HUGE);
+        std::vector<CoolPropDbl> difffn(N+1, _HUGE);
         for (std::size_t i = 0; i < N+1; ++i){
             difffn[i] = (rr1[i]-rr2[i])/(2*drho);
         }
@@ -1279,7 +1279,7 @@ void SaturationSolvers::newton_raphson_saturation::check_Jacobian()
         this->rhomolar_liq = rhomolar_liq0;
         this->rhomolar_vap = rhomolar_vap0;
         build_arrays(); 
-        std::vector<long double> r1 = this->r;
+        std::vector<CoolPropDbl> r1 = this->r;
     
         this->x = x0; 
         this->x[i] -= dx; this->x[x.size()-1] += dx;
@@ -1287,9 +1287,9 @@ void SaturationSolvers::newton_raphson_saturation::check_Jacobian()
         this->rhomolar_liq = rhomolar_liq0;
         this->rhomolar_vap = rhomolar_vap0;
         build_arrays(); 
-        std::vector<long double> r2 = this->r;
+        std::vector<CoolPropDbl> r2 = this->r;
     
-        std::vector<long double> diffn(N+1, _HUGE);
+        std::vector<CoolPropDbl> diffn(N+1, _HUGE);
         for (std::size_t j = 0; j < N+1; ++j){
             diffn[j] = (r1[j]-r2[j])/(2*dx);
         }
@@ -1298,7 +1298,7 @@ void SaturationSolvers::newton_raphson_saturation::check_Jacobian()
         std::cout << "analytic: " << vec_to_string(get_col(J0, i), "%0.11Lg") << std::endl;
     }
 }
-void SaturationSolvers::newton_raphson_saturation::call(HelmholtzEOSMixtureBackend &HEOS, const std::vector<long double> &z, std::vector<long double> &z_incipient, newton_raphson_saturation_options &IO)
+void SaturationSolvers::newton_raphson_saturation::call(HelmholtzEOSMixtureBackend &HEOS, const std::vector<CoolPropDbl> &z, std::vector<CoolPropDbl> &z_incipient, newton_raphson_saturation_options &IO)
 {
     int iter = 0;
     
@@ -1339,7 +1339,7 @@ void SaturationSolvers::newton_raphson_saturation::call(HelmholtzEOSMixtureBacke
 
         // Solve for the step; v is the step with the contents
         // [delta(x_0), delta(x_1), ..., delta(x_{N-2}), delta(spec)]
-        std::vector<long double> v = linsolve(J, negative_r);
+        std::vector<CoolPropDbl> v = linsolve(J, negative_r);
         
         if (bubble_point){
             for (unsigned int i = 0; i < N-1; ++i){
@@ -1424,8 +1424,8 @@ void SaturationSolvers::newton_raphson_saturation::build_arrays()
     }
     
     // For diagnostic purposes calculate the pressures (no derivatives are evaluated)
-    long double p_liq = rSatL.p();
-    long double p_vap = rSatV.p();
+    CoolPropDbl p_liq = rSatL.p();
+    CoolPropDbl p_vap = rSatV.p();
     p = 0.5*(p_liq + p_vap);
     
     // Step 2:
@@ -1439,8 +1439,8 @@ void SaturationSolvers::newton_raphson_saturation::build_arrays()
         for (std::size_t i = 0; i < N; ++i)
         {
             // Equate the liquid and vapor fugacities
-            long double ln_f_liq = log(MixtureDerivatives::fugacity_i(rSatL, i, xN_flag));
-            long double ln_f_vap = log(MixtureDerivatives::fugacity_i(rSatV, i, xN_flag));
+            CoolPropDbl ln_f_liq = log(MixtureDerivatives::fugacity_i(rSatL, i, xN_flag));
+            CoolPropDbl ln_f_vap = log(MixtureDerivatives::fugacity_i(rSatV, i, xN_flag));
             r[i] = ln_f_liq - ln_f_vap;
             
             for (std::size_t j = 0; j < N-1; ++j){ // j from 0 to N-2
@@ -1472,8 +1472,8 @@ void SaturationSolvers::newton_raphson_saturation::build_arrays()
         for (std::size_t i = 0; i < N; ++i)
         {
             // Equate the liquid and vapor fugacities
-            long double ln_f_liq = log(MixtureDerivatives::fugacity_i(rSatL, i, xN_flag));
-            long double ln_f_vap = log(MixtureDerivatives::fugacity_i(rSatV, i, xN_flag));
+            CoolPropDbl ln_f_liq = log(MixtureDerivatives::fugacity_i(rSatL, i, xN_flag));
+            CoolPropDbl ln_f_vap = log(MixtureDerivatives::fugacity_i(rSatV, i, xN_flag));
             r[i] = ln_f_liq - ln_f_vap;
             
             for (std::size_t j = 0; j < N-1; ++j){ // j from 0 to N-2
@@ -1494,8 +1494,8 @@ void SaturationSolvers::newton_raphson_saturation::build_arrays()
         for (std::size_t i = 0; i < N; ++i)
         {
             // Equate the liquid and vapor fugacities
-            long double ln_f_liq = log(MixtureDerivatives::fugacity_i(rSatL, i, xN_flag));
-            long double ln_f_vap = log(MixtureDerivatives::fugacity_i(rSatV, i, xN_flag));
+            CoolPropDbl ln_f_liq = log(MixtureDerivatives::fugacity_i(rSatL, i, xN_flag));
+            CoolPropDbl ln_f_vap = log(MixtureDerivatives::fugacity_i(rSatV, i, xN_flag));
             r[i] = ln_f_liq - ln_f_vap;
             
             for (std::size_t j = 0; j < N-1; ++j){ // j from 0 to N-2
@@ -1525,7 +1525,7 @@ void SaturationSolvers::newton_raphson_saturation::build_arrays()
     
     // Calculate derivatives along phase boundary;
     // Gernert thesis 3.96 and 3.97
-    long double dQ_dPsat = 0, dQ_dTsat = 0;
+    CoolPropDbl dQ_dPsat = 0, dQ_dTsat = 0;
     for (std::size_t i = 0; i < N; ++i)
     {
         dQ_dPsat += x[i]*(MixtureDerivatives::dln_fugacity_coefficient_dp__constT_n(rSatL, i, xN_flag) - MixtureDerivatives::dln_fugacity_coefficient_dp__constT_n(rSatV, i, xN_flag));
@@ -1559,7 +1559,7 @@ void SaturationSolvers::newton_raphson_twophase::call(HelmholtzEOSMixtureBackend
     y.resize(N);
     r.resize(2*N-1);
     negative_r.resize(2*N-1);
-    J.resize(2*N-1, std::vector<long double>(2*N-1, 0));
+    J.resize(2*N-1, std::vector<CoolPropDbl>(2*N-1, 0));
     err_rel.resize(2*N-1);
     
     // Hold a pointer to the backend
@@ -1577,7 +1577,7 @@ void SaturationSolvers::newton_raphson_twophase::call(HelmholtzEOSMixtureBackend
         // std::cout << vec_to_string(J, "%0.12Lg") << std::endl;
         // std::cout << vec_to_string(negative_r, "%0.12Lg") << std::endl;
         
-        std::vector<long double> v = linsolve(J, negative_r);
+        std::vector<CoolPropDbl> v = linsolve(J, negative_r);
         for (unsigned int i = 0; i < N-1; ++i){
             err_rel[i] = v[i]/x[i];
             x[i] += v[i];
@@ -1631,15 +1631,15 @@ void SaturationSolvers::newton_raphson_twophase::build_arrays()
     rSatL.set_mole_fractions(x);
     rSatV.set_mole_fractions(y);
 
-    //std::vector<long double> &x = rSatL.get_mole_fractions();
-    //std::vector<long double> &y = rSatV.get_mole_fractions();
+    //std::vector<CoolPropDbl> &x = rSatL.get_mole_fractions();
+    //std::vector<CoolPropDbl> &y = rSatV.get_mole_fractions();
 
     rSatL.update_TP_guessrho(T, p, rhomolar_liq); rhomolar_liq = rSatL.rhomolar();
     rSatV.update_TP_guessrho(T, p, rhomolar_vap); rhomolar_vap = rSatV.rhomolar();
     
     // For diagnostic purposes calculate the pressures (no derivatives are evaluated)
-    long double p_liq = rSatL.p();
-    long double p_vap = rSatV.p();
+    CoolPropDbl p_liq = rSatL.p();
+    CoolPropDbl p_vap = rSatV.p();
     p = 0.5*(p_liq + p_vap);
     
     // Step 2:
@@ -1652,8 +1652,8 @@ void SaturationSolvers::newton_raphson_twophase::build_arrays()
     for (std::size_t i = 0; i < N; ++i)
     {
         // Equate the liquid and vapor fugacities
-        long double ln_f_liq = log(MixtureDerivatives::fugacity_i(rSatL, i, xN_flag));
-        long double ln_f_vap = log(MixtureDerivatives::fugacity_i(rSatV, i, xN_flag));
+        CoolPropDbl ln_f_liq = log(MixtureDerivatives::fugacity_i(rSatL, i, xN_flag));
+        CoolPropDbl ln_f_vap = log(MixtureDerivatives::fugacity_i(rSatV, i, xN_flag));
         r[i] = ln_f_liq - ln_f_vap; // N of these
     
         if (i != N-1){

--- a/src/Backends/Helmholtz/VLERoutines.h
+++ b/src/Backends/Helmholtz/VLERoutines.h
@@ -10,12 +10,12 @@ namespace SaturationSolvers
 {
     struct saturation_T_pure_Akasaka_options{
         bool use_guesses; ///< true to start off at the values specified by rhoL, rhoV
-        long double omega, rhoL, rhoV, pL, pV;
+        CoolPropDbl omega, rhoL, rhoV, pL, pV;
         saturation_T_pure_Akasaka_options(){omega = _HUGE; rhoV = _HUGE; rhoL = _HUGE; pV = _HUGE, pL = _HUGE;}
     };
     struct saturation_T_pure_options{
         bool use_guesses; ///< true to start off at the values specified by rhoL, rhoV
-        long double omega, rhoL, rhoV, pL, pV, p, T;
+        CoolPropDbl omega, rhoL, rhoV, pL, pV, p, T;
         saturation_T_pure_options(){omega = _HUGE; rhoV = _HUGE; rhoL = _HUGE; rhoL = _HUGE; pV = _HUGE, pL = _HUGE; T = _HUGE;}
     };
     
@@ -23,7 +23,7 @@ namespace SaturationSolvers
         enum imposed_rho_options{IMPOSED_RHOL, IMPOSED_RHOV};
         bool use_guesses, ///< True to start off at the values specified by rhoL, rhoV, T
              use_logdelta; ///< True to use partials with respect to log(delta) rather than delta
-        long double omega, rhoL, rhoV, pL, pV;
+        CoolPropDbl omega, rhoL, rhoV, pL, pV;
         int imposed_rho;
         saturation_D_pure_options(){ use_logdelta = true; omega = 1.0;} // Defaults
     };
@@ -32,8 +32,8 @@ namespace SaturationSolvers
     struct mixture_VLE_IO
     {
         int sstype, Nstep_max;
-        long double rhomolar_liq, rhomolar_vap, p, T, beta;
-        std::vector<long double> x, y, K;
+        CoolPropDbl rhomolar_liq, rhomolar_vap, p, T, beta;
+        std::vector<CoolPropDbl> x, y, K;
     };
 
     /*! Returns the natural logarithm of K for component i using the method from Wilson as in
@@ -45,15 +45,15 @@ namespace SaturationSolvers
     @param p Pressure [Pa]
     @param i Index of component [-]
     */
-    static long double Wilson_lnK_factor(HelmholtzEOSMixtureBackend &HEOS, long double T, long double p, std::size_t i){ 
+    static CoolPropDbl Wilson_lnK_factor(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl T, CoolPropDbl p, std::size_t i){ 
         EquationOfState *EOS = (HEOS.get_components())[i]->pEOS; 
         return log(EOS->reduce.p/p)+5.373*(1 + EOS->acentric)*(1-EOS->reduce.T/T);
     };
 
-    void saturation_D_pure(HelmholtzEOSMixtureBackend &HEOS, long double rhomolar, saturation_D_pure_options &options);
-    void saturation_T_pure(HelmholtzEOSMixtureBackend &HEOS, long double T, saturation_T_pure_options &options);
-    void saturation_T_pure_Akasaka(HelmholtzEOSMixtureBackend &HEOS, long double T, saturation_T_pure_Akasaka_options &options);
-    void saturation_T_pure_Maxwell(HelmholtzEOSMixtureBackend &HEOS, long double T, saturation_T_pure_Akasaka_options &options);
+    void saturation_D_pure(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl rhomolar, saturation_D_pure_options &options);
+    void saturation_T_pure(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl T, saturation_T_pure_options &options);
+    void saturation_T_pure_Akasaka(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl T, saturation_T_pure_Akasaka_options &options);
+    void saturation_T_pure_Maxwell(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl T, saturation_T_pure_Akasaka_options &options);
     
     /**
     */
@@ -62,13 +62,13 @@ namespace SaturationSolvers
         bool use_guesses, ///< True to start off at the values specified by rhoL, rhoV, T
              use_logdelta; ///< True to use partials with respect to log(delta) rather than delta
         specified_variable_options specified_variable;
-        long double omega, rhoL, rhoV, pL, pV, T, p;
+        CoolPropDbl omega, rhoL, rhoV, pL, pV, T, p;
         saturation_PHSU_pure_options(){ specified_variable = IMPOSED_INVALID_INPUT; use_guesses = true; omega = 1.0; }
     };
     /**
 
     */
-    void saturation_PHSU_pure(HelmholtzEOSMixtureBackend &HEOS, long double specified_value, saturation_PHSU_pure_options &options);
+    void saturation_PHSU_pure(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl specified_value, saturation_PHSU_pure_options &options);
 
     /* \brief This is a backup saturation_p solver for the case where the Newton solver cannot approach closely enough the solution
      *
@@ -78,7 +78,7 @@ namespace SaturationSolvers
      * @param p Imposed pressure in kPa
      * @param options Options to be passed to the function (at least T, rhoL and rhoV must be provided)
      */
-    void saturation_P_pure_1D_T(HelmholtzEOSMixtureBackend &HEOS, long double p, saturation_PHSU_pure_options &options);
+    void saturation_P_pure_1D_T(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl p, saturation_PHSU_pure_options &options);
     
     /* \brief This is a backup saturation_T solver for the case where the Newton solver cannot approach closely enough the solution
      *
@@ -88,7 +88,7 @@ namespace SaturationSolvers
      * @param T Imposed temperature in K
      * @param options Options to be passed to the function (at least p, rhoL and rhoV must be provided)
      */
-    void saturation_T_pure_1D_P(HelmholtzEOSMixtureBackend &HEOS, long double T, saturation_T_pure_options &options);
+    void saturation_T_pure_1D_P(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl T, saturation_T_pure_options &options);
 
     /* \brief A robust but slow solver in the very-near-critical region
      * 
@@ -103,14 +103,14 @@ namespace SaturationSolvers
      * @param ykey The CoolProp::parameters key to be imposed - one of iT or iP
      * @param y The value for the imposed variable
      */
-    void saturation_critical(HelmholtzEOSMixtureBackend &HEOS, CoolProp::parameters ykey, long double y);
+    void saturation_critical(HelmholtzEOSMixtureBackend &HEOS, CoolProp::parameters ykey, CoolPropDbl y);
         
     void successive_substitution(HelmholtzEOSMixtureBackend &HEOS,
-                                        const long double beta,
-                                        long double T,
-                                        long double p,
-                                        const std::vector<long double> &z,
-                                        std::vector<long double> &K,
+                                        const CoolPropDbl beta,
+                                        CoolPropDbl T,
+                                        CoolPropDbl p,
+                                        const std::vector<CoolPropDbl> &z,
+                                        std::vector<CoolPropDbl> &K,
                                         mixture_VLE_IO &options);
     /** \brief Extract the mole fractions of liquid (x) and vapor (y) given the bulk composition (z), vapor mole fraction and K-factors
      * @param beta Vapor molar fraction [-]
@@ -119,7 +119,7 @@ namespace SaturationSolvers
      * @param x Liquid molar composition [-]
      * @param y Vapor molar composition [-]
      */
-    void x_and_y_from_K(long double beta, const std::vector<long double> &K, const std::vector<long double> &z, std::vector<long double> &x, std::vector<long double> &y);
+    void x_and_y_from_K(CoolPropDbl beta, const std::vector<CoolPropDbl> &K, const std::vector<CoolPropDbl> &z, std::vector<CoolPropDbl> &x, std::vector<CoolPropDbl> &y);
 
     /*! A wrapper function around the residual to find the initial guess for the bubble point temperature
     \f[
@@ -131,11 +131,11 @@ namespace SaturationSolvers
     public:
         int input_type;
         double T, p, beta;
-        const std::vector<long double> *z;
-        std::vector<long double> *K;
+        const std::vector<CoolPropDbl> *z;
+        std::vector<CoolPropDbl> *K;
         HelmholtzEOSMixtureBackend *HEOS;
 
-        WilsonK_resid(HelmholtzEOSMixtureBackend &HEOS, double beta, double imposed_value, int input_type, const std::vector<long double> &z, std::vector<long double> &K){ 
+        WilsonK_resid(HelmholtzEOSMixtureBackend &HEOS, double beta, double imposed_value, int input_type, const std::vector<CoolPropDbl> &z, std::vector<CoolPropDbl> &K){ 
             this->z = &z; this->K = &K; this->HEOS = &HEOS; this->beta = beta; this->input_type = input_type;
             if (input_type == imposed_T){
                 this->T = imposed_value;
@@ -159,7 +159,7 @@ namespace SaturationSolvers
             return summer;
         };
     };
-    inline double saturation_preconditioner(HelmholtzEOSMixtureBackend &HEOS, double input_value, int input_type, const std::vector<long double> &z)
+    inline double saturation_preconditioner(HelmholtzEOSMixtureBackend &HEOS, double input_value, int input_type, const std::vector<CoolPropDbl> &z)
     {
         double ptriple = 0, pcrit = 0, Ttriple = 0, Tcrit = 0;
         
@@ -183,7 +183,7 @@ namespace SaturationSolvers
         }
         else{ throw ValueError();}
     }
-    inline double saturation_Wilson(HelmholtzEOSMixtureBackend &HEOS, double beta, double input_value, int input_type, const std::vector<long double> &z, double guess)
+    inline double saturation_Wilson(HelmholtzEOSMixtureBackend &HEOS, double beta, double input_value, int input_type, const std::vector<CoolPropDbl> &z, double guess)
     {
         double T;
 
@@ -198,16 +198,16 @@ namespace SaturationSolvers
     }
     struct SuccessiveSubstitutionStep
     {
-        long double T,p;
+        CoolPropDbl T,p;
     };
     
     struct newton_raphson_twophase_options{
         enum imposed_variable_options {NO_VARIABLE_IMPOSED = 0, P_IMPOSED, T_IMPOSED};
         int Nstep_max;
         std::size_t Nsteps;
-        long double beta, omega, rhomolar_liq, rhomolar_vap, pL, pV, p, T, hmolar_liq, hmolar_vap, smolar_liq, smolar_vap;
+        CoolPropDbl beta, omega, rhomolar_liq, rhomolar_vap, pL, pV, p, T, hmolar_liq, hmolar_vap, smolar_liq, smolar_vap;
         imposed_variable_options imposed_variable;
-        std::vector<long double> x, y, z;
+        std::vector<CoolPropDbl> x, y, z;
         newton_raphson_twophase_options(){ Nstep_max = 30; Nsteps = 0; beta = -1; omega =1;} // Defaults
     };
 
@@ -245,13 +245,13 @@ namespace SaturationSolvers
     {
         public:
         newton_raphson_twophase_options::imposed_variable_options imposed_variable;
-        long double error_rms, rhomolar_liq, rhomolar_vap, T, p, min_rel_change, beta;
+        CoolPropDbl error_rms, rhomolar_liq, rhomolar_vap, T, p, min_rel_change, beta;
         std::size_t N;
         bool logging;
         int Nsteps;
         STLMatrix J;
         HelmholtzEOSMixtureBackend *HEOS;
-        std::vector<long double> K, x, y, z, r, negative_r, err_rel;
+        std::vector<CoolPropDbl> K, x, y, z, r, negative_r, err_rel;
         std::vector<SuccessiveSubstitutionStep> step_logger;
 
         newton_raphson_twophase(){};
@@ -288,9 +288,9 @@ namespace SaturationSolvers
         int Nstep_max;
         bool bubble_point;
         std::size_t Nsteps;
-        long double omega, rhomolar_liq, rhomolar_vap, pL, pV, p, T, hmolar_liq, hmolar_vap, smolar_liq, smolar_vap;
+        CoolPropDbl omega, rhomolar_liq, rhomolar_vap, pL, pV, p, T, hmolar_liq, hmolar_vap, smolar_liq, smolar_vap;
         imposed_variable_options imposed_variable;
-        std::vector<long double> x, y;
+        std::vector<CoolPropDbl> x, y;
         newton_raphson_saturation_options(){ Nstep_max = 30;  Nsteps = 0;} // Defaults
     };
 
@@ -325,15 +325,15 @@ namespace SaturationSolvers
     {
         public:
         newton_raphson_saturation_options::imposed_variable_options imposed_variable;
-        long double error_rms, rhomolar_liq, rhomolar_vap, T, p, min_rel_change;
+        CoolPropDbl error_rms, rhomolar_liq, rhomolar_vap, T, p, min_rel_change;
         std::size_t N;
         bool logging;
         bool bubble_point;
         int Nsteps;
         STLMatrix J;
         HelmholtzEOSMixtureBackend *HEOS;
-        long double dTsat_dPsat, dPsat_dTsat;
-        std::vector<long double> K, x, y, r, negative_r, err_rel;
+        CoolPropDbl dTsat_dPsat, dPsat_dTsat;
+        std::vector<CoolPropDbl> K, x, y, r, negative_r, err_rel;
         std::vector<SuccessiveSubstitutionStep> step_logger;
 
         newton_raphson_saturation(){};
@@ -359,7 +359,7 @@ namespace SaturationSolvers
          * @param z_incipient Initial guesses for the mole fractions of the incipient phase [-]
          * @param IO The input/output data structure
          */
-        void call(HelmholtzEOSMixtureBackend &HEOS, const std::vector<long double> &z, std::vector<long double> &z_incipient, newton_raphson_saturation_options &IO);
+        void call(HelmholtzEOSMixtureBackend &HEOS, const std::vector<CoolPropDbl> &z, std::vector<CoolPropDbl> &z_incipient, newton_raphson_saturation_options &IO);
 
         /** \brief Build the arrays for the Newton-Raphson solve
          * 

--- a/src/Backends/Incompressible/IncompressibleBackend.cpp
+++ b/src/Backends/Incompressible/IncompressibleBackend.cpp
@@ -28,7 +28,7 @@ IncompressibleBackend::IncompressibleBackend(IncompressibleFluid* fluid) {
     this->fluid = fluid;
     this->set_reference_state();
     if (this->fluid->is_pure()){
-    	this->set_fractions(std::vector<long double>(1,0.0));
+    	this->set_fractions(std::vector<CoolPropDbl>(1,0.0));
     }
 }
 
@@ -36,7 +36,7 @@ IncompressibleBackend::IncompressibleBackend(const std::string &fluid_name) {
     this->fluid = &get_incompressible_fluid(fluid_name);
     this->set_reference_state();
     if (this->fluid->is_pure()){
-    	this->set_fractions(std::vector<long double>(1,0.0));
+    	this->set_fractions(std::vector<CoolPropDbl>(1,0.0));
     }
 }
 
@@ -158,7 +158,7 @@ void IncompressibleBackend::set_reference_state(double T0, double p0, double x0,
 /**
 @param fractions The vector of fractions of the components converted to the correct input
 */
-void IncompressibleBackend::set_fractions(const std::vector<long double> &fractions){
+void IncompressibleBackend::set_fractions(const std::vector<CoolPropDbl> &fractions){
     if (get_debug_level()>=10) std::cout << format("Incompressible backend: Called set_fractions with %s ",vec_to_string(fractions).c_str()) << std::endl;
     if (fractions.size()!=1) throw ValueError(format("The incompressible backend only supports one entry in the fraction vector and not %d.",fractions.size()));
     if ( ( this->_fractions.size()!=1 ) ||
@@ -173,18 +173,18 @@ void IncompressibleBackend::set_fractions(const std::vector<long double> &fracti
 /**
 @param mole_fractions The vector of mole fractions of the components
 */
-void IncompressibleBackend::set_mole_fractions(const std::vector<long double> &mole_fractions){
+void IncompressibleBackend::set_mole_fractions(const std::vector<CoolPropDbl> &mole_fractions){
     if (get_debug_level()>=10) std::cout << format("Incompressible backend: Called set_mole_fractions with %s ",vec_to_string(mole_fractions).c_str()) << std::endl;
     if (mole_fractions.size()!=1) throw ValueError(format("The incompressible backend only supports one entry in the mole fraction vector and not %d.",mole_fractions.size()));
     if ((fluid->getxid()==IFRAC_PURE) && true ){//( this->_fractions[0]!=1.0 )){
-        this->set_fractions(std::vector<long double>(1,1.0));
+        this->set_fractions(std::vector<CoolPropDbl>(1,1.0));
         if (get_debug_level()>=20) std::cout << format("Incompressible backend: Overwriting fractions for pure fluid with %s -> %s",vec_to_string(mole_fractions).c_str(),vec_to_string(this->_fractions).c_str()) << std::endl;
     } else if (fluid->getxid()==IFRAC_MOLE) {
         this->set_fractions(mole_fractions);
     } else {
-        std::vector<long double> tmp_fractions;
+        std::vector<CoolPropDbl> tmp_fractions;
         for (std::size_t i = 0; i < mole_fractions.size(); i++) {
-            tmp_fractions.push_back((long double) fluid->inputFromMole(0.0, mole_fractions[i]));
+            tmp_fractions.push_back((CoolPropDbl) fluid->inputFromMole(0.0, mole_fractions[i]));
         }
         this->set_fractions(tmp_fractions);
     }
@@ -194,18 +194,18 @@ void IncompressibleBackend::set_mole_fractions(const std::vector<long double> &m
 /**
 @param mass_fractions The vector of mass fractions of the components
 */
-void IncompressibleBackend::set_mass_fractions(const std::vector<long double> &mass_fractions){
+void IncompressibleBackend::set_mass_fractions(const std::vector<CoolPropDbl> &mass_fractions){
     if (get_debug_level()>=10) std::cout << format("Incompressible backend: Called set_mass_fractions with %s ",vec_to_string(mass_fractions).c_str()) << std::endl;
     if (mass_fractions.size()!=1) throw ValueError(format("The incompressible backend only supports one entry in the mass fraction vector and not %d.",mass_fractions.size()));
     if ((fluid->getxid()==IFRAC_PURE) && true ){// ( this->_fractions[0]!=1.0 )) {
-        this->set_fractions(std::vector<long double>(1,1.0));
+        this->set_fractions(std::vector<CoolPropDbl>(1,1.0));
         if (get_debug_level()>=20) std::cout << format("Incompressible backend: Overwriting fractions for pure fluid with %s -> %s",vec_to_string(mass_fractions).c_str(),vec_to_string(this->_fractions).c_str()) << std::endl;
     } else if (fluid->getxid()==IFRAC_MASS) {
         this->set_fractions(mass_fractions);
     } else {
-        std::vector<long double> tmp_fractions;
+        std::vector<CoolPropDbl> tmp_fractions;
         for (std::size_t i = 0; i < mass_fractions.size(); i++) {
-            tmp_fractions.push_back((long double) fluid->inputFromMass(0.0, mass_fractions[i]));
+            tmp_fractions.push_back((CoolPropDbl) fluid->inputFromMass(0.0, mass_fractions[i]));
         }
         this->set_fractions(tmp_fractions);
     }
@@ -215,18 +215,18 @@ void IncompressibleBackend::set_mass_fractions(const std::vector<long double> &m
 /**
 @param volu_fractions The vector of volume fractions of the components
 */
-void IncompressibleBackend::set_volu_fractions(const std::vector<long double> &volu_fractions){
+void IncompressibleBackend::set_volu_fractions(const std::vector<CoolPropDbl> &volu_fractions){
     if (get_debug_level()>=10) std::cout << format("Incompressible backend: Called set_volu_fractions with %s ",vec_to_string(volu_fractions).c_str()) << std::endl;
     if (volu_fractions.size()!=1) throw ValueError(format("The incompressible backend only supports one entry in the volume fraction vector and not %d.",volu_fractions.size()));
     if ((fluid->getxid()==IFRAC_PURE) && true ){// ( this->_fractions[0]!=1.0 )) {
-        this->set_fractions(std::vector<long double>(1,1.0));
+        this->set_fractions(std::vector<CoolPropDbl>(1,1.0));
         if (get_debug_level()>=20) std::cout << format("Incompressible backend: Overwriting fractions for pure fluid with %s -> %s",vec_to_string(volu_fractions).c_str(),vec_to_string(this->_fractions).c_str()) << std::endl;
     } else if (fluid->getxid()==IFRAC_VOLUME) {
         this->set_fractions(volu_fractions);
     } else {
-        std::vector<long double> tmp_fractions;
+        std::vector<CoolPropDbl> tmp_fractions;
         for (std::size_t i = 0; i < volu_fractions.size(); i++) {
-            tmp_fractions.push_back((long double) fluid->inputFromVolume(0.0, volu_fractions[i]));
+            tmp_fractions.push_back((CoolPropDbl) fluid->inputFromVolume(0.0, volu_fractions[i]));
         }
         this->set_fractions(tmp_fractions);
     }
@@ -311,7 +311,7 @@ double IncompressibleBackend::smass_ref(void){
 @param p The pressure in Pa
 @returns T The temperature in K
 */
-long double IncompressibleBackend::DmassP_flash(long double rhomass, long double p){
+CoolPropDbl IncompressibleBackend::DmassP_flash(CoolPropDbl rhomass, CoolPropDbl p){
     return fluid->T_rho(rhomass, p, _fractions[0]);
 }
 /// Calculate T given pressure and enthalpy
@@ -320,7 +320,7 @@ long double IncompressibleBackend::DmassP_flash(long double rhomass, long double
 @param p The pressure in Pa
 @returns T The temperature in K
 */
-long double IncompressibleBackend::HmassP_flash(long double hmass, long double p){
+CoolPropDbl IncompressibleBackend::HmassP_flash(CoolPropDbl hmass, CoolPropDbl p){
 
     class HmassP_residual : public FuncWrapper1D {
     protected:
@@ -358,7 +358,7 @@ long double IncompressibleBackend::HmassP_flash(long double hmass, long double p
 @param p The pressure in Pa
 @returns T The temperature in K
 */
-long double IncompressibleBackend::PSmass_flash(long double p, long double smass){
+CoolPropDbl IncompressibleBackend::PSmass_flash(CoolPropDbl p, CoolPropDbl smass){
 
     class PSmass_residual : public FuncWrapper1D {
     protected:
@@ -396,7 +396,7 @@ long double IncompressibleBackend::PSmass_flash(long double p, long double smass
 //@param p The pressure in Pa
 //@returns T The temperature in K
 //*/
-//long double IncompressibleBackend::PUmass_flash(long double p, long double umass){
+//CoolPropDbl IncompressibleBackend::PUmass_flash(CoolPropDbl p, CoolPropDbl umass){
 //
 //	class PUmass_residual : public FuncWrapper1D {
 //	protected:
@@ -429,31 +429,31 @@ long double IncompressibleBackend::PSmass_flash(long double p, long double smass
 //}
 
 /// We start with the functions that do not need a reference state
-long double IncompressibleBackend::calc_melting_line(int param, int given, long double value){
+CoolPropDbl IncompressibleBackend::calc_melting_line(int param, int given, CoolPropDbl value){
 	if (param == iT && given == iP){
 		return fluid->Tfreeze(value, _fractions[0]);
 	} else {
 		throw ValueError("For incompressibles, the only valid inputs to calc_melting_line are T(p)");
 	}
 };
-long double IncompressibleBackend::calc_umass(void){
+CoolPropDbl IncompressibleBackend::calc_umass(void){
 	return hmass()-_p/rhomass();
 };
 
 /// ... and continue with the ones that depend on reference conditions.
-long double IncompressibleBackend::calc_hmass(void){
+CoolPropDbl IncompressibleBackend::calc_hmass(void){
 	return h_ref() + raw_calc_hmass(_T,_p,_fractions[0]) - hmass_ref();
 };
-long double IncompressibleBackend::calc_smass(void){
+CoolPropDbl IncompressibleBackend::calc_smass(void){
 	return s_ref() + raw_calc_smass(_T,_p,_fractions[0]) - smass_ref();
 };
 
 
 /// Functions that can be used with the solver, they miss the reference values!
-long double IncompressibleBackend::raw_calc_hmass(double T, double p, double x){
+CoolPropDbl IncompressibleBackend::raw_calc_hmass(double T, double p, double x){
 	return calc_dhdTatPxdT(T,p,x) + p * calc_dhdpatTx(T,fluid->rho(T, p, x),calc_drhodTatPx(T,p,x));
 };
-long double IncompressibleBackend::raw_calc_smass(double T, double p, double x){
+CoolPropDbl IncompressibleBackend::raw_calc_smass(double T, double p, double x){
 	return calc_dsdTatPxdT(T,p,x) + p * calc_dsdpatTx(  fluid->rho(T, p, x),calc_drhodTatPx(T,p,x));
 };
 
@@ -499,7 +499,7 @@ TEST_CASE("Internal consistency checks and example use cases for the incompressi
 
         //void update(long input_pair, double value1, double value2);
 
-        std::vector<long double> fractions;
+        std::vector<CoolPropDbl> fractions;
         fractions.push_back(0.4);
         CHECK_THROWS( backend.set_mole_fractions(fractions) );
         CHECK_NOTHROW( backend.set_mass_fractions(fractions) );
@@ -514,7 +514,7 @@ TEST_CASE("Internal consistency checks and example use cases for the incompressi
         double T   = 273.15+10;
         double p   = 10e5;
         double x   = 0.25;
-        backend.set_mass_fractions(std::vector<long double>(1,x));
+        backend.set_mass_fractions(std::vector<CoolPropDbl>(1,x));
         double val = 0;
         double res = 0;
 
@@ -668,7 +668,7 @@ TEST_CASE("Internal consistency checks and example use cases for the incompressi
         double pref = 101325*10;
         double xref = x;
         backend.set_reference_state(Tref,pref,xref,0.5,0.5);
-        backend.set_mass_fractions(std::vector<long double>(1,x));
+        backend.set_mass_fractions(std::vector<CoolPropDbl>(1,x));
         backend.update(CoolProp::PT_INPUTS, pref, Tref);
         val = 0.5;
         res = backend.hmass();

--- a/src/Backends/Incompressible/IncompressibleBackend.h
+++ b/src/Backends/Incompressible/IncompressibleBackend.h
@@ -18,7 +18,7 @@ protected:
 
 	/// Bulk values, state variables
 	//double _T, _p; // From AbstractState
-	std::vector<long double> _fractions;
+	std::vector<CoolPropDbl> _fractions;
 
 	/// Reference values, no need to calculate them each time
 	CachedElement _T_ref,_p_ref,_x_ref,_h_ref,_s_ref;
@@ -33,7 +33,7 @@ protected:
     /**
     @param fractions The vector of fractions of the components converted to the correct input
     */
-    void set_fractions(const std::vector<long double> &fractions);
+    void set_fractions(const std::vector<CoolPropDbl> &fractions);
 
 public:
     IncompressibleBackend();
@@ -75,20 +75,20 @@ public:
     /**
     @param mole_fractions The vector of mole fractions of the components
     */
-    void set_mole_fractions(const std::vector<long double> &mole_fractions);
-    const std::vector<long double> & get_mole_fractions(void){throw NotImplementedError("get_mole_fractions not implemented for this backend");};
+    void set_mole_fractions(const std::vector<CoolPropDbl> &mole_fractions);
+    const std::vector<CoolPropDbl> & get_mole_fractions(void){throw NotImplementedError("get_mole_fractions not implemented for this backend");};
 
     /// Set the mass fractions
     /**
     @param mass_fractions The vector of mass fractions of the components
     */
-    void set_mass_fractions(const std::vector<long double> &mass_fractions);
+    void set_mass_fractions(const std::vector<CoolPropDbl> &mass_fractions);
 
     /// Set the volume fractions
     /**
     @param volu_fractions The vector of volume fractions of the components
     */
-    void set_volu_fractions(const std::vector<long double> &volu_fractions);
+    void set_volu_fractions(const std::vector<CoolPropDbl> &volu_fractions);
 
     /// Check if the mole fractions have been set, etc.
     void check_status();
@@ -135,21 +135,21 @@ public:
     @param p The pressure in Pa
     @returns T The temperature in K
     */
-    long double DmassP_flash(long double rhomass, long double p);
+    CoolPropDbl DmassP_flash(CoolPropDbl rhomass, CoolPropDbl p);
     /// Calculate T given pressure and enthalpy
     /**
     @param hmass The mass enthalpy in J/kg
     @param p The pressure in Pa
     @returns T The temperature in K
     */
-    long double HmassP_flash(long double hmass, long double p);
+    CoolPropDbl HmassP_flash(CoolPropDbl hmass, CoolPropDbl p);
     /// Calculate T given pressure and entropy
     /**
     @param smass The mass entropy in J/kg/K
     @param p The pressure in Pa
     @returns T The temperature in K
     */
-    long double PSmass_flash(long double p, long double smass);
+    CoolPropDbl PSmass_flash(CoolPropDbl p, CoolPropDbl smass);
 
 //    /// Calculate T given pressure and internal energy
 //    /**
@@ -157,27 +157,27 @@ public:
 //    @param p The pressure in Pa
 //    @returns T The temperature in K
 //    */
-//    long double PUmass_flash(long double p, long double umass);
+//    CoolPropDbl PUmass_flash(CoolPropDbl p, CoolPropDbl umass);
 
     /// We start with the functions that do not need a reference state
-    long double calc_rhomass(void){return fluid->rho(_T, _p, _fractions[0]);};
-    long double calc_cmass(void){return fluid->c(_T, _p, _fractions[0]);};
-    long double calc_cpmass(void){return cmass();};
-    long double calc_cvmass(void){return cmass();};
-    long double calc_viscosity(void){return fluid->visc(_T, _p, _fractions[0]);};
-    long double calc_conductivity(void){return fluid->cond(_T, _p, _fractions[0]);};
-    long double calc_T_freeze(void){return fluid->Tfreeze(_p, _fractions[0]);};
-    long double calc_melting_line(int param, int given, long double value);
-    long double calc_umass(void);
+    CoolPropDbl calc_rhomass(void){return fluid->rho(_T, _p, _fractions[0]);};
+    CoolPropDbl calc_cmass(void){return fluid->c(_T, _p, _fractions[0]);};
+    CoolPropDbl calc_cpmass(void){return cmass();};
+    CoolPropDbl calc_cvmass(void){return cmass();};
+    CoolPropDbl calc_viscosity(void){return fluid->visc(_T, _p, _fractions[0]);};
+    CoolPropDbl calc_conductivity(void){return fluid->cond(_T, _p, _fractions[0]);};
+    CoolPropDbl calc_T_freeze(void){return fluid->Tfreeze(_p, _fractions[0]);};
+    CoolPropDbl calc_melting_line(int param, int given, CoolPropDbl value);
+    CoolPropDbl calc_umass(void);
 
     /// ... and continue with the ones that depend on reference conditions.
-    long double calc_hmass(void);
-    long double calc_smass(void);
+    CoolPropDbl calc_hmass(void);
+    CoolPropDbl calc_smass(void);
 
 public:
     /// Functions that can be used with the solver, they miss the reference values!
-    long double raw_calc_hmass(double T, double p, double x);
-    long double raw_calc_smass(double T, double p, double x);
+    CoolPropDbl raw_calc_hmass(double T, double p, double x);
+    CoolPropDbl raw_calc_smass(double T, double p, double x);
 
 
 protected:
@@ -213,10 +213,10 @@ protected:
 
 public:
 	/// Constants from the fluid object
-    long double calc_Tmax(void){return fluid->getTmax();};
-    long double calc_Tmin(void){return fluid->getTmin();};
-    long double calc_fraction_min(void){return fluid->getxmin();};
-    long double calc_fraction_max(void){return fluid->getxmax();};
+    CoolPropDbl calc_Tmax(void){return fluid->getTmax();};
+    CoolPropDbl calc_Tmin(void){return fluid->getTmin();};
+    CoolPropDbl calc_fraction_min(void){return fluid->getxmin();};
+    CoolPropDbl calc_fraction_max(void){return fluid->getxmax();};
     std::string calc_name(void){return fluid->getDescription();};
 };
 

--- a/src/Backends/REFPROP/REFPROPBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPBackend.cpp
@@ -33,7 +33,7 @@ REFPROPBackend::REFPROPBackend(const std::string & fluid_name) {
     // Set the mole fraction to 1 in the base class (we can't set the mole fraction in this class, 
     // otherwise a NotImplementedError will be returned)
     if (get_mole_fractions().empty()){
-        std::vector<long double> x(1, 1.0); // (one element with value of 1.0)
+        std::vector<CoolPropDbl> x(1, 1.0); // (one element with value of 1.0)
         REFPROPMixtureBackend::set_mole_fractions(x);
     }
 }

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -416,7 +416,7 @@ void REFPROPMixtureBackend::set_REFPROP_fluids(const std::vector<std::string> &f
                 cached_component_string = mix;
                 if (CoolProp::get_debug_level() > 5){ std::cout << format("%s:%d: Successfully loaded REFPROP fluid: %s\n",__FILE__,__LINE__, components_joined.c_str()); }
                 if (dbg_refprop) std::cout << format("%s:%d: Successfully loaded REFPROP fluid: %s\n",__FILE__,__LINE__, components_joined.c_str());
-                set_mole_fractions(std::vector<long double>(x.begin(), x.begin()+N));
+                set_mole_fractions(std::vector<CoolPropDbl>(x.begin(), x.begin()+N));
                 return;
             }
             else{
@@ -477,7 +477,7 @@ void REFPROPMixtureBackend::set_REFPROP_fluids(const std::vector<std::string> &f
         }
     }
 }
-void REFPROPMixtureBackend::set_mole_fractions(const std::vector<long double> &mole_fractions)
+void REFPROPMixtureBackend::set_mole_fractions(const std::vector<CoolPropDbl> &mole_fractions)
 {
     if (mole_fractions.size() != this->Ncomp)
     {
@@ -491,7 +491,7 @@ void REFPROPMixtureBackend::set_mole_fractions(const std::vector<long double> &m
     this->mole_fractions_long_double = mole_fractions;
     _mole_fractions_set = true;
 }
-void REFPROPMixtureBackend::set_mass_fractions(const std::vector<long double> &mole_fractions)
+void REFPROPMixtureBackend::set_mass_fractions(const std::vector<CoolPropDbl> &mole_fractions)
 {
     throw NotImplementedError("Mass fractions not currently supported");
 }
@@ -532,73 +532,73 @@ void REFPROPMixtureBackend::limits(double &Tmin, double &Tmax, double &rhomolarm
     pmax = pmax_kPa*1000;
     rhomolarmax = Dmax_mol_L*1000;
 }
-long double REFPROPMixtureBackend::calc_pmax(void){
+CoolPropDbl REFPROPMixtureBackend::calc_pmax(void){
     double Tmin, Tmax, rhomolarmax, pmax;
     limits(Tmin, Tmax, rhomolarmax, pmax);
-    return static_cast<long double>(pmax);
+    return static_cast<CoolPropDbl>(pmax);
 };
-long double REFPROPMixtureBackend::calc_Tmax(void){
+CoolPropDbl REFPROPMixtureBackend::calc_Tmax(void){
     double Tmin, Tmax, rhomolarmax, pmax;
     limits(Tmin, Tmax, rhomolarmax, pmax);
-    return static_cast<long double>(Tmax);
+    return static_cast<CoolPropDbl>(Tmax);
 };
-long double REFPROPMixtureBackend::calc_T_critical(){
+CoolPropDbl REFPROPMixtureBackend::calc_T_critical(){
     this->check_loaded_fluid();
     long ierr = 0;
     char herr[255];
     double Tcrit, pcrit_kPa, dcrit_mol_L;
     CRITPdll(&(mole_fractions[0]),&Tcrit,&pcrit_kPa,&dcrit_mol_L,&ierr,herr,255);
     if (static_cast<int>(ierr) > 0) { throw ValueError(format("%s",herr).c_str()); } //else if (ierr < 0) {set_warning(format("%s",herr).c_str());}
-    return static_cast<long double>(Tcrit);
+    return static_cast<CoolPropDbl>(Tcrit);
 };
-long double REFPROPMixtureBackend::calc_p_critical(){
+CoolPropDbl REFPROPMixtureBackend::calc_p_critical(){
     this->check_loaded_fluid();
     long ierr = 0;
     char herr[255];
     double Tcrit, pcrit_kPa, dcrit_mol_L;
     CRITPdll(&(mole_fractions[0]),&Tcrit,&pcrit_kPa,&dcrit_mol_L,&ierr,herr,255); if (static_cast<int>(ierr) > 0) { throw ValueError(format("%s",herr).c_str()); } //else if (ierr < 0) {set_warning(format("%s",herr).c_str());}
-    return static_cast<long double>(pcrit_kPa*1000);
+    return static_cast<CoolPropDbl>(pcrit_kPa*1000);
 };
-long double REFPROPMixtureBackend::calc_rhomolar_critical(){
+CoolPropDbl REFPROPMixtureBackend::calc_rhomolar_critical(){
     long ierr = 0;
     char herr[255];
     double Tcrit, pcrit_kPa, dcrit_mol_L;
     CRITPdll(&(mole_fractions[0]),&Tcrit,&pcrit_kPa,&dcrit_mol_L,&ierr,herr,255); if (static_cast<int>(ierr) > 0) { throw ValueError(format("%s",herr).c_str()); } //else if (ierr < 0) {set_warning(format("%s",herr).c_str());}
-    return static_cast<long double>(dcrit_mol_L*1000);
+    return static_cast<CoolPropDbl>(dcrit_mol_L*1000);
 };
-long double REFPROPMixtureBackend::calc_T_reducing(){
+CoolPropDbl REFPROPMixtureBackend::calc_T_reducing(){
     this->check_loaded_fluid();
     double rhored_mol_L = 0, Tr = 0;
     REDXdll(&(mole_fractions[0]), &Tr, &rhored_mol_L);
-    return static_cast<long double>(Tr);
+    return static_cast<CoolPropDbl>(Tr);
 };
-long double REFPROPMixtureBackend::calc_rhomolar_reducing(){
+CoolPropDbl REFPROPMixtureBackend::calc_rhomolar_reducing(){
     this->check_loaded_fluid();
     double rhored_mol_L = 0, Tr = 0;
     REDXdll(&(mole_fractions[0]), &Tr, &rhored_mol_L);
-    return static_cast<long double>(rhored_mol_L*1000);
+    return static_cast<CoolPropDbl>(rhored_mol_L*1000);
 };
-long double REFPROPMixtureBackend::calc_Ttriple(){
+CoolPropDbl REFPROPMixtureBackend::calc_Ttriple(){
     this->check_loaded_fluid();
     if (mole_fractions.size() != 1){throw ValueError("calc_Ttriple cannot be evaluated for mixtures");}
     long icomp = 1;
     double wmm, ttrp, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
     INFOdll(&icomp, &wmm, &ttrp, &tnbpt, &tc, &pc, &Dc, &Zc, &acf, &dip, &Rgas);
-    return static_cast<long double>(ttrp);
+    return static_cast<CoolPropDbl>(ttrp);
 };
-long double REFPROPMixtureBackend::calc_gas_constant(){
+CoolPropDbl REFPROPMixtureBackend::calc_gas_constant(){
     this->check_loaded_fluid();
     double Rmix = 0;
     RMIX2dll(&(mole_fractions[0]), &Rmix);
-    return static_cast<long double>(Rmix);
+    return static_cast<CoolPropDbl>(Rmix);
 };
-long double REFPROPMixtureBackend::calc_molar_mass(void)
+CoolPropDbl REFPROPMixtureBackend::calc_molar_mass(void)
 {
     this->check_loaded_fluid();
     double wmm_kg_kmol;
     WMOLdll(&(mole_fractions[0]), &wmm_kg_kmol); // returns mole mass in kg/kmol
     _molar_mass = wmm_kg_kmol/1000; // kg/mol
-    return static_cast<long double>(_molar_mass.pt());
+    return static_cast<CoolPropDbl>(_molar_mass.pt());
 };
 
 double REFPROPMixtureBackend::calc_melt_Tmax()
@@ -617,7 +617,7 @@ double REFPROPMixtureBackend::calc_melt_Tmax()
     //else if (ierr < 0) {set_warning(format("%s",herr).c_str());}
     return Tmax_melt;
 }
-long double REFPROPMixtureBackend::calc_melting_line(int param, int given, long double value)
+CoolPropDbl REFPROPMixtureBackend::calc_melting_line(int param, int given, CoolPropDbl value)
 {
     this->check_loaded_fluid();
     long ierr = 0;
@@ -650,7 +650,7 @@ long double REFPROPMixtureBackend::calc_melting_line(int param, int given, long 
 }
 
 
-long double REFPROPMixtureBackend::calc_viscosity(void)
+CoolPropDbl REFPROPMixtureBackend::calc_viscosity(void)
 {
     this->check_loaded_fluid();
     double eta, tcx, rhomol_L = 0.001*_rhomolar;
@@ -665,13 +665,13 @@ long double REFPROPMixtureBackend::calc_viscosity(void)
     _conductivity = tcx;
     return static_cast<double>(_viscosity);
 }
-long double REFPROPMixtureBackend::calc_conductivity(void)
+CoolPropDbl REFPROPMixtureBackend::calc_conductivity(void)
 {
     // Calling viscosity also caches conductivity, use that to save calls
     calc_viscosity();
     return static_cast<double>(_conductivity);
 }
-long double REFPROPMixtureBackend::calc_surface_tension(void)
+CoolPropDbl REFPROPMixtureBackend::calc_surface_tension(void)
 {
     this->check_loaded_fluid();
     double sigma, rho_mol_L = 0.001*_rhomolar;
@@ -685,7 +685,7 @@ long double REFPROPMixtureBackend::calc_surface_tension(void)
     _surface_tension = sigma;
     return static_cast<double>(_surface_tension);
 }
-long double REFPROPMixtureBackend::calc_fugacity_coefficient(int i)
+CoolPropDbl REFPROPMixtureBackend::calc_fugacity_coefficient(int i)
 {
     this->check_loaded_fluid();
     double rho_mol_L = 0.001*_rhomolar;
@@ -698,7 +698,7 @@ long double REFPROPMixtureBackend::calc_fugacity_coefficient(int i)
              &ierr, herr, errormessagelength);       // Error message
     if (static_cast<int>(ierr) > 0) { throw ValueError(format("%s",herr).c_str()); }
     //else if (ierr < 0) {set_warning(format("%s",herr).c_str());}
-    return static_cast<long double>(fug_cof[i]);
+    return static_cast<CoolPropDbl>(fug_cof[i]);
 }
 
 void REFPROPMixtureBackend::calc_phase_envelope(const std::string &type)
@@ -710,13 +710,13 @@ void REFPROPMixtureBackend::calc_phase_envelope(const std::string &type)
                &ierr, herr, errormessagelength);       // Error message
     if (static_cast<int>(ierr) > 0) { throw ValueError(format("%s",herr).c_str()); }
 }
-long double REFPROPMixtureBackend::calc_cpmolar_idealgas(void)
+CoolPropDbl REFPROPMixtureBackend::calc_cpmolar_idealgas(void)
 {
     this->check_loaded_fluid();
     double rho_mol_L = 0.001*_rhomolar;
     double p0, e0, h0, s0, cv0, cp0, w0, A0, G0;
     THERM0dll(&_T,&rho_mol_L,&(mole_fractions[0]),&p0,&e0,&h0,&s0,&cv0,&cp0,&w0,&A0,&G0);
-    return static_cast<long double>(cp0);
+    return static_cast<CoolPropDbl>(cp0);
 }
 
 void REFPROPMixtureBackend::update(CoolProp::input_pairs input_pair, double value1, double value2)
@@ -1255,22 +1255,22 @@ void REFPROPMixtureBackend::update(CoolProp::input_pairs input_pair, double valu
     _delta = _rhomolar/calc_rhomolar_critical();
     _Q = q;
 }
-long double REFPROPMixtureBackend::call_phixdll(long itau, long idel)
+CoolPropDbl REFPROPMixtureBackend::call_phixdll(long itau, long idel)
 {
     this->check_loaded_fluid();
     double val = 0, tau = _tau, delta = _delta;
     if (PHIXdll == NULL){throw ValueError("PHIXdll function is not available in your version of REFPROP. Please upgrade");}
     PHIXdll(&itau, &idel, &tau, &delta, &(mole_fractions[0]), &val);
-    return static_cast<long double>(val)/pow(static_cast<long double>(_delta),idel)/pow(static_cast<long double>(_tau),itau);
+    return static_cast<CoolPropDbl>(val)/pow(static_cast<CoolPropDbl>(_delta),idel)/pow(static_cast<CoolPropDbl>(_tau),itau);
 }
-long double REFPROPMixtureBackend::call_phi0dll(long itau, long idel)
+CoolPropDbl REFPROPMixtureBackend::call_phi0dll(long itau, long idel)
 {
     this->check_loaded_fluid();
     throw ValueError("Temporarily the PHI0dll function is not available for REFPROP");
     double val = 0, tau = _tau, delta = _delta, __T = T(), __rho = rhomolar()/1000;
     if (PHI0dll == NULL){throw ValueError("PHI0dll function is not available in your version of REFPROP. Please upgrade");}
     PHI0dll(&itau, &idel, &__T, &__rho, &(mole_fractions[0]), &val);
-    return static_cast<long double>(val)/pow(delta,idel)/pow(tau,itau);
+    return static_cast<CoolPropDbl>(val)/pow(delta,idel)/pow(tau,itau);
 }
 
 } /* namespace CoolProp */

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.h
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.h
@@ -24,16 +24,16 @@ protected:
     
     static std::size_t instance_counter;
     static bool _REFPROP_supported;
-    std::vector<long double> mole_fractions_long_double; // read-only
+    std::vector<CoolPropDbl> mole_fractions_long_double; // read-only
     std::vector<double> mole_fractions, mass_fractions;
     std::vector<double> mole_fractions_liq, mole_fractions_vap;
 	std::vector<std::string> fluid_names;
 
 	
 	/// Call the PHIXdll function in the dll
-	long double call_phixdll(long itau, long idelta);
+	CoolPropDbl call_phixdll(long itau, long idelta);
 	/// Call the PHI0dll function in the dll
-	long double call_phi0dll(long itau, long idelta);
+	CoolPropDbl call_phi0dll(long itau, long idelta);
 	
 public:
     REFPROPMixtureBackend(){cached_component_string = ""; instance_counter++;};
@@ -66,14 +66,14 @@ public:
                 double value2
                 );
 
-    long double calc_molar_mass(void);
+    CoolPropDbl calc_molar_mass(void);
     
     void check_loaded_fluid(void);
 
     /// Returns true if REFPROP is supported on this platform
     bool REFPROP_supported(void);
 
-    long double calc_cpmolar_idealgas(void);
+    CoolPropDbl calc_cpmolar_idealgas(void);
 
     /// Set the fluids in REFPROP DLL by calling the SETUPdll function
     /**
@@ -85,81 +85,81 @@ public:
     /**
     @param mole_fractions The vector of mole fractions of the components
     */
-    void set_mole_fractions(const std::vector<long double> &mole_fractions);
+    void set_mole_fractions(const std::vector<CoolPropDbl> &mole_fractions);
 
     /// Set the mass fractions
     /**
     @param mass_fractions The vector of mass fractions of the components
     */
-    void set_mass_fractions(const std::vector<long double> &mass_fractions);
+    void set_mass_fractions(const std::vector<CoolPropDbl> &mass_fractions);
     
-    const std::vector<long double> &get_mole_fractions(){return mole_fractions_long_double;};
+    const std::vector<CoolPropDbl> &get_mole_fractions(){return mole_fractions_long_double;};
 
     void calc_phase_envelope(const std::string &type);
 
-    std::vector<long double> calc_mole_fractions_liquid(void){return std::vector<long double>(mole_fractions_liq.begin(), mole_fractions_liq.end());}
-    std::vector<long double> calc_mole_fractions_vapor(void){return std::vector<long double>(mole_fractions_vap.begin(), mole_fractions_vap.end());}
+    std::vector<CoolPropDbl> calc_mole_fractions_liquid(void){return std::vector<CoolPropDbl>(mole_fractions_liq.begin(), mole_fractions_liq.end());}
+    std::vector<CoolPropDbl> calc_mole_fractions_vapor(void){return std::vector<CoolPropDbl>(mole_fractions_vap.begin(), mole_fractions_vap.end());}
 
     /// Check if the mole fractions have been set, etc.
     void check_status();
 
     /// Get the viscosity [Pa-s] (based on the temperature and density in the state class)
-    long double calc_viscosity(void);
+    CoolPropDbl calc_viscosity(void);
     /// Get the thermal conductivity [W/m/K] (based on the temperature and density in the state class)
-    long double calc_conductivity(void);
+    CoolPropDbl calc_conductivity(void);
     /// Get the surface tension [N/m] (based on the temperature in the state class).  Invalid for temperatures above critical point or below triple point temperature
-    long double calc_surface_tension(void);
+    CoolPropDbl calc_surface_tension(void);
 
-    long double calc_fugacity_coefficient(int i);
-    long double calc_melting_line(int param, int given, long double value);
+    CoolPropDbl calc_fugacity_coefficient(int i);
+    CoolPropDbl calc_melting_line(int param, int given, CoolPropDbl value);
     bool has_melting_line(){return true;};
     double calc_melt_Tmax();
-    long double calc_T_critical(void);
-	long double calc_T_reducing(void);
-    long double calc_p_critical(void);
-    long double calc_rhomolar_critical(void);
-	long double calc_rhomolar_reducing(void);
-    long double calc_Ttriple(void);
-	long double calc_gas_constant(void);
+    CoolPropDbl calc_T_critical(void);
+	CoolPropDbl calc_T_reducing(void);
+    CoolPropDbl calc_p_critical(void);
+    CoolPropDbl calc_rhomolar_critical(void);
+	CoolPropDbl calc_rhomolar_reducing(void);
+    CoolPropDbl calc_Ttriple(void);
+	CoolPropDbl calc_gas_constant(void);
 
     /// A wrapper function to calculate the limits for the EOS
     void limits(double &Tmin, double &Tmax, double &rhomolarmax, double &pmax);
     /// Calculate the maximum pressure
-    long double calc_pmax(void);
+    CoolPropDbl calc_pmax(void);
     /// Calculate the maximum temperature
-    long double calc_Tmax(void);
+    CoolPropDbl calc_Tmax(void);
 	
 	/// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r\f$ (dimensionless)
-	long double calc_alphar(void){return call_phixdll(0,0);};
+	CoolPropDbl calc_alphar(void){return call_phixdll(0,0);};
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta}\f$ (dimensionless)
-	long double calc_dalphar_dDelta(void){ return call_phixdll(0,1); };
+	CoolPropDbl calc_dalphar_dDelta(void){ return call_phixdll(0,1); };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau}\f$ (dimensionless)
-	long double calc_dalphar_dTau(void){ return call_phixdll(1,0); };
+	CoolPropDbl calc_dalphar_dTau(void){ return call_phixdll(1,0); };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta}\f$ (dimensionless)
-	long double calc_d2alphar_dDelta2(void){ return call_phixdll(0,2); };
+	CoolPropDbl calc_d2alphar_dDelta2(void){ return call_phixdll(0,2); };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau}\f$ (dimensionless)
-	long double calc_d2alphar_dDelta_dTau(void){ return call_phixdll(1,1); };
+	CoolPropDbl calc_d2alphar_dDelta_dTau(void){ return call_phixdll(1,1); };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau}\f$ (dimensionless)
-	long double calc_d2alphar_dTau2(void){ return call_phixdll(2,0); };
+	CoolPropDbl calc_d2alphar_dTau2(void){ return call_phixdll(2,0); };
 	/// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\delta}\f$ (dimensionless)
-    long double calc_d3alphar_dDelta3(void){ return call_phixdll(0,3); };
+    CoolPropDbl calc_d3alphar_dDelta3(void){ return call_phixdll(0,3); };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\tau}\f$ (dimensionless)
-	long double calc_d3alphar_dDelta2_dTau(void){ return call_phixdll(1,2); };
+	CoolPropDbl calc_d3alphar_dDelta2_dTau(void){ return call_phixdll(1,2); };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau\tau}\f$ (dimensionless)
-	long double calc_d3alphar_dDelta_dTau2(void){ return call_phixdll(2,1); };
+	CoolPropDbl calc_d3alphar_dDelta_dTau2(void){ return call_phixdll(2,1); };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau\tau}\f$ (dimensionless)
-	long double calc_d3alphar_dTau3(void){ return call_phixdll(3,0); };
+	CoolPropDbl calc_d3alphar_dTau3(void){ return call_phixdll(3,0); };
 
-    long double calc_alpha0(void){ return call_phi0dll(0,0); };
-    long double calc_dalpha0_dDelta(void){ return call_phi0dll(0,1); };
-    long double calc_dalpha0_dTau(void){ return call_phi0dll(1,0); };
-    long double calc_d2alpha0_dDelta2(void){ return call_phi0dll(0,2); };
-    long double calc_d2alpha0_dDelta_dTau(void){ return call_phi0dll(1,1); };
-    long double calc_d2alpha0_dTau2(void){ return call_phi0dll(2,0); };
-    long double calc_d3alpha0_dDelta3(void){ return call_phi0dll(0,3); };
-    long double calc_d3alpha0_dDelta2_dTau(void){ return call_phi0dll(1,2);	};
-    long double calc_d3alpha0_dDelta_dTau2(void){ return call_phi0dll(2,1); };
-    long double calc_d3alpha0_dTau3(void){ return call_phi0dll(3,0); };
+    CoolPropDbl calc_alpha0(void){ return call_phi0dll(0,0); };
+    CoolPropDbl calc_dalpha0_dDelta(void){ return call_phi0dll(0,1); };
+    CoolPropDbl calc_dalpha0_dTau(void){ return call_phi0dll(1,0); };
+    CoolPropDbl calc_d2alpha0_dDelta2(void){ return call_phi0dll(0,2); };
+    CoolPropDbl calc_d2alpha0_dDelta_dTau(void){ return call_phi0dll(1,1); };
+    CoolPropDbl calc_d2alpha0_dTau2(void){ return call_phi0dll(2,0); };
+    CoolPropDbl calc_d3alpha0_dDelta3(void){ return call_phi0dll(0,3); };
+    CoolPropDbl calc_d3alpha0_dDelta2_dTau(void){ return call_phi0dll(1,2);	};
+    CoolPropDbl calc_d3alpha0_dDelta_dTau2(void){ return call_phi0dll(2,1); };
+    CoolPropDbl calc_d3alpha0_dTau3(void){ return call_phi0dll(3,0); };
 };
 
 } /* namespace CoolProp */

--- a/src/Backends/Tabular/TabularBackends.cpp
+++ b/src/Backends/Tabular/TabularBackends.cpp
@@ -9,7 +9,7 @@ namespace CoolProp{
 void GriddedTableBackend::build_tables(tabular_types type)
 {
     std::size_t Nx = 200, Ny = 200;
-    long double xmin, xmax, ymin, ymax, x, y;
+    CoolPropDbl xmin, xmax, ymin, ymax, x, y;
     bool logy, logx;
     const bool debug = get_debug_level() > 5 || false;
     
@@ -35,9 +35,9 @@ void GriddedTableBackend::build_tables(tabular_types type)
             
             // Check both the enthalpies at the Tmax isotherm to see whether to use low or high pressure
             AS->update(PT_INPUTS, 1e-10, AS->Tmax());
-            long double xmax1 = AS->hmolar();
+            CoolPropDbl xmax1 = AS->hmolar();
             AS->update(PT_INPUTS, AS->pmax(), AS->Tmax());
-            long double xmax2 = AS->hmolar();
+            CoolPropDbl xmax2 = AS->hmolar();
             xmax = std::min(xmax1, xmax2);
             
             ymax = AS->pmax();

--- a/src/Backends/Tabular/TabularBackends.h
+++ b/src/Backends/Tabular/TabularBackends.h
@@ -51,9 +51,9 @@ class GriddedTableBackend : public AbstractState
     bool using_volu_fractions(void){return false;}
     
     void update(CoolProp::input_pairs input_pair, double Value1, double Value2){};
-    void set_mole_fractions(const std::vector<long double> &mole_fractions){};
-    void set_mass_fractions(const std::vector<long double> &mass_fractions){};
-    const std::vector<long double> & get_mole_fractions(){throw NotImplementedError("get_mole_fractions not implemented for TTSE");};
+    void set_mole_fractions(const std::vector<CoolPropDbl> &mole_fractions){};
+    void set_mass_fractions(const std::vector<CoolPropDbl> &mass_fractions){};
+    const std::vector<CoolPropDbl> & get_mole_fractions(){throw NotImplementedError("get_mole_fractions not implemented for TTSE");};
     void build_tables(tabular_types type);
     void write_tables(std::string &directory);
     void load_tables(std::string &directory);

--- a/src/Helmholtz.cpp
+++ b/src/Helmholtz.cpp
@@ -3,10 +3,10 @@
 
 namespace CoolProp{
 
-long double kahanSum(std::vector<long double> &x)
+CoolPropDbl kahanSum(std::vector<CoolPropDbl> &x)
 {
-    long double sum = x[0], y, t;
-    long double c = 0.0;          //A running compensation for lost low-order bits.
+    CoolPropDbl sum = x[0], y, t;
+    CoolPropDbl c = 0.0;          //A running compensation for lost low-order bits.
     for (std::size_t i = 1; i < x.size(); ++i)
     {
         y = x[i] - c;    //So far, so good: c is zero.
@@ -16,7 +16,7 @@ long double kahanSum(std::vector<long double> &x)
     }
     return sum;
 }
-bool wayToSort(long double i, long double j) { return std::abs(i) > std::abs(j); }
+bool wayToSort(CoolPropDbl i, CoolPropDbl j) { return std::abs(i) > std::abs(j); }
 
 // define function to be applied coefficient-wise
 double ramp(double x)
@@ -28,7 +28,7 @@ double ramp(double x)
 }
 
 /*
-void ResidualHelmholtzGeneralizedExponential::allEigen(const long double &tau, const long double &delta, HelmholtzDerivatives &derivs) throw()
+void ResidualHelmholtzGeneralizedExponential::allEigen(const CoolPropDbl &tau, const CoolPropDbl &delta, HelmholtzDerivatives &derivs) throw()
 {
     double log_tau = log(tau), log_delta = log(delta), 
            one_over_delta = 1/delta, one_over_tau = 1/tau; // division is much slower than multiplication, so do one division here
@@ -74,12 +74,12 @@ void ResidualHelmholtzGeneralizedExponential::allEigen(const long double &tau, c
     }
     
 //    if (tau_mi_in_u){
-//        long double omegai = el.omega, m_double = el.m_double;
+//        CoolPropDbl omegai = el.omega, m_double = el.m_double;
 //        if (std::abs(m_double) > 0){
-//            long double u_increment = -omegai*pow(tau, m_double);
-//            long double du_dtau_increment = m_double*u_increment*one_over_tau;
-//            long double d2u_dtau2_increment = (m_double-1)*du_dtau_increment*one_over_tau;
-//            long double d3u_dtau3_increment = (m_double-2)*d2u_dtau2_increment*one_over_tau;
+//            CoolPropDbl u_increment = -omegai*pow(tau, m_double);
+//            CoolPropDbl du_dtau_increment = m_double*u_increment*one_over_tau;
+//            CoolPropDbl d2u_dtau2_increment = (m_double-1)*du_dtau_increment*one_over_tau;
+//            CoolPropDbl d3u_dtau3_increment = (m_double-2)*d2u_dtau2_increment*one_over_tau;
 //            u += u_increment;
 //            du_dtau += du_dtau_increment;
 //            d2u_dtau2 += d2u_dtau2_increment;
@@ -128,9 +128,9 @@ void ResidualHelmholtzGeneralizedExponential::allEigen(const long double &tau, c
     return;
 };
 */
-void ResidualHelmholtzGeneralizedExponential::all(const long double &tau, const long double &delta, HelmholtzDerivatives &derivs) throw()
+void ResidualHelmholtzGeneralizedExponential::all(const CoolPropDbl &tau, const CoolPropDbl &delta, HelmholtzDerivatives &derivs) throw()
 {
-    long double log_tau = log(tau), log_delta = log(delta), ndteu, 
+    CoolPropDbl log_tau = log(tau), log_delta = log(delta), ndteu, 
                 one_over_delta = 1/delta, one_over_tau = 1/tau; // division is much slower than multiplication, so do one division here
     
     // Maybe split the construction of u and other parts into two separate loops?  
@@ -139,25 +139,25 @@ void ResidualHelmholtzGeneralizedExponential::all(const long double &tau, const 
     for (std::size_t i = 0; i < N; ++i)
     {
         ResidualHelmholtzGeneralizedExponentialElement &el = elements[i];
-        long double ni = el.n, di = el.d, ti = el.t;
+        CoolPropDbl ni = el.n, di = el.d, ti = el.t;
         
         // Set the u part of exp(u) to zero
-        long double u = 0;
-        long double du_ddelta = 0;
-        long double du_dtau = 0;
-        long double d2u_ddelta2 = 0;
-        long double d2u_dtau2 = 0;
-        long double d3u_ddelta3 = 0;
-        long double d3u_dtau3 = 0;
+        CoolPropDbl u = 0;
+        CoolPropDbl du_ddelta = 0;
+        CoolPropDbl du_dtau = 0;
+        CoolPropDbl d2u_ddelta2 = 0;
+        CoolPropDbl d2u_dtau2 = 0;
+        CoolPropDbl d3u_ddelta3 = 0;
+        CoolPropDbl d3u_dtau3 = 0;
         
         if (delta_li_in_u){
-            long double  ci = el.c, l_double = el.l_double;
+            CoolPropDbl  ci = el.c, l_double = el.l_double;
             int l_int = el.l_int;
             if (ValidNumber(l_double) && l_int > 0){
-                long double u_increment = -ci*pow(delta, l_int);
-                long double du_ddelta_increment = l_double*u_increment*one_over_delta;
-                long double d2u_ddelta2_increment = (l_double-1)*du_ddelta_increment*one_over_delta;
-                long double d3u_ddelta3_increment = (l_double-2)*d2u_ddelta2_increment*one_over_delta;
+                CoolPropDbl u_increment = -ci*pow(delta, l_int);
+                CoolPropDbl du_ddelta_increment = l_double*u_increment*one_over_delta;
+                CoolPropDbl d2u_ddelta2_increment = (l_double-1)*du_ddelta_increment*one_over_delta;
+                CoolPropDbl d3u_ddelta3_increment = (l_double-2)*d2u_ddelta2_increment*one_over_delta;
                 u += u_increment;
                 du_ddelta += du_ddelta_increment;
                 d2u_ddelta2 += d2u_ddelta2_increment;
@@ -165,12 +165,12 @@ void ResidualHelmholtzGeneralizedExponential::all(const long double &tau, const 
             }
         }
         if (tau_mi_in_u){
-            long double omegai = el.omega, m_double = el.m_double;
+            CoolPropDbl omegai = el.omega, m_double = el.m_double;
             if (std::abs(m_double) > 0){
-                long double u_increment = -omegai*pow(tau, m_double);
-                long double du_dtau_increment = m_double*u_increment*one_over_tau;
-                long double d2u_dtau2_increment = (m_double-1)*du_dtau_increment*one_over_tau;
-                long double d3u_dtau3_increment = (m_double-2)*d2u_dtau2_increment*one_over_tau;
+                CoolPropDbl u_increment = -omegai*pow(tau, m_double);
+                CoolPropDbl du_dtau_increment = m_double*u_increment*one_over_tau;
+                CoolPropDbl d2u_dtau2_increment = (m_double-1)*du_dtau_increment*one_over_tau;
+                CoolPropDbl d3u_dtau3_increment = (m_double-2)*d2u_dtau2_increment*one_over_tau;
                 u += u_increment;
                 du_dtau += du_dtau_increment;
                 d2u_dtau2 += d2u_dtau2_increment;
@@ -178,14 +178,14 @@ void ResidualHelmholtzGeneralizedExponential::all(const long double &tau, const 
             }
         }
         if (eta1_in_u){
-            long double eta1 = el.eta1, epsilon1 = el.epsilon1;
+            CoolPropDbl eta1 = el.eta1, epsilon1 = el.epsilon1;
             if (ValidNumber(eta1)){
                 u += -eta1*(delta-epsilon1);
                 du_ddelta += -eta1;
             }
         }
         if (eta2_in_u){
-            long double eta2 = el.eta2, epsilon2 = el.epsilon2;
+            CoolPropDbl eta2 = el.eta2, epsilon2 = el.epsilon2;
             if (ValidNumber(eta2)){
                 u += -eta2*POW2(delta-epsilon2);
                 du_ddelta += -2*eta2*(delta-epsilon2);
@@ -193,14 +193,14 @@ void ResidualHelmholtzGeneralizedExponential::all(const long double &tau, const 
             }
         }
         if (beta1_in_u){
-            long double beta1 = el.beta1, gamma1 = el.gamma1;
+            CoolPropDbl beta1 = el.beta1, gamma1 = el.gamma1;
             if (ValidNumber(beta1)){
                 u += -beta1*(tau-gamma1);
                 du_dtau += -beta1;
             }
         }
         if (beta2_in_u){
-            long double beta2 = el.beta2, gamma2 = el.gamma2;
+            CoolPropDbl beta2 = el.beta2, gamma2 = el.gamma2;
             if (ValidNumber(beta2)){
                 u += -beta2*POW2(tau-gamma2);
                 du_dtau += -2*beta2*(tau-gamma2);
@@ -210,12 +210,12 @@ void ResidualHelmholtzGeneralizedExponential::all(const long double &tau, const 
         
         ndteu = ni*exp(ti*log_tau+di*log_delta+u);
         
-        long double B_delta = (delta*du_ddelta + di);
-        long double B_tau = (tau*du_dtau + ti);
-        long double B_delta2 = (POW2(delta)*(d2u_ddelta2 + POW2(du_ddelta)) + 2*di*delta*du_ddelta + di*(di-1));
-        long double B_tau2 = (POW2(tau)*(d2u_dtau2 + POW2(du_dtau)) + 2*ti*tau*du_dtau + ti*(ti-1));
-        long double B_delta3 = POW3(delta)*d3u_ddelta3 + 3*di*POW2(delta)*d2u_ddelta2+3*POW3(delta)*d2u_ddelta2*du_ddelta+3*di*POW2(delta*du_ddelta)+3*di*(di-1)*delta*du_ddelta+di*(di-1)*(di-2)+POW3(delta*du_ddelta);
-        long double B_tau3 = POW3(tau)*d3u_dtau3 + 3*ti*POW2(tau)*d2u_dtau2+3*POW3(tau)*d2u_dtau2*du_dtau+3*ti*POW2(tau*du_dtau)+3*ti*(ti-1)*tau*du_dtau+ti*(ti-1)*(ti-2)+POW3(tau*du_dtau);
+        CoolPropDbl B_delta = (delta*du_ddelta + di);
+        CoolPropDbl B_tau = (tau*du_dtau + ti);
+        CoolPropDbl B_delta2 = (POW2(delta)*(d2u_ddelta2 + POW2(du_ddelta)) + 2*di*delta*du_ddelta + di*(di-1));
+        CoolPropDbl B_tau2 = (POW2(tau)*(d2u_dtau2 + POW2(du_dtau)) + 2*ti*tau*du_dtau + ti*(ti-1));
+        CoolPropDbl B_delta3 = POW3(delta)*d3u_ddelta3 + 3*di*POW2(delta)*d2u_ddelta2+3*POW3(delta)*d2u_ddelta2*du_ddelta+3*di*POW2(delta*du_ddelta)+3*di*(di-1)*delta*du_ddelta+di*(di-1)*(di-2)+POW3(delta*du_ddelta);
+        CoolPropDbl B_tau3 = POW3(tau)*d3u_dtau3 + 3*ti*POW2(tau)*d2u_dtau2+3*POW3(tau)*d2u_dtau2*du_dtau+3*ti*POW2(tau*du_dtau)+3*ti*(ti-1)*tau*du_dtau+ti*(ti-1)*(ti-2)+POW3(tau*du_dtau);
         
         derivs.alphar += ndteu;
         
@@ -276,35 +276,35 @@ void ResidualHelmholtzNonAnalytic::to_json(rapidjson::Value &el, rapidjson::Docu
     el.AddMember("D",_D,doc.GetAllocator());
 }
 
-void ResidualHelmholtzNonAnalytic::all(const long double &tau, const long double &delta, HelmholtzDerivatives &derivs) throw()
+void ResidualHelmholtzNonAnalytic::all(const CoolPropDbl &tau, const CoolPropDbl &delta, HelmholtzDerivatives &derivs) throw()
 {
     if (N==0){return;}
     for (unsigned int i=0; i<N; ++i)
     {
         ResidualHelmholtzNonAnalyticElement &el = elements[i];
-        long double ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
-        long double Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
-        long double theta = (1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
-        long double dtheta_dDelta = Ai/(2*betai)*pow(pow(delta-1,2),1/(2*betai)-1)*2*(delta-1);
+        CoolPropDbl ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
+        CoolPropDbl Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
+        CoolPropDbl theta = (1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
+        CoolPropDbl dtheta_dDelta = Ai/(2*betai)*pow(pow(delta-1,2),1/(2*betai)-1)*2*(delta-1);
         
-        long double PSI = exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
-        long double dPSI_dDelta = -2.0*Ci*(delta-1.0)*PSI;
-        long double dPSI_dTau = -2.0*Di*(tau-1.0)*PSI;
-        long double dPSI2_dDelta2 = (2.0*Ci*pow(delta-1.0,2)-1.0)*2.0*Ci*PSI;
-        long double dPSI2_dDelta_dTau = 4.0*Ci*Di*(delta-1.0)*(tau-1.0)*PSI;
-        long double dPSI2_dTau2 = (2.0*Di*pow(tau-1.0,2)-1.0)*2.0*Di*PSI;
-        long double dPSI3_dDelta3 = 2.0*Ci*PSI*(-4*Ci*Ci*pow(delta-1.0,3)+6*Ci*(delta-1));
-        long double dPSI3_dDelta2_dTau = (2.0*Ci*pow(delta-1.0,2)-1.0)*2.0*Ci*dPSI_dTau;
-        long double dPSI3_dDelta_dTau2 = 2*Di*(2*Di*pow(tau-1,2)-1)*dPSI_dDelta;
-        long double dPSI3_dTau3 = 2.0*Di*PSI*(-4*Di*Di*pow(tau-1,3)+6*Di*(tau-1));
+        CoolPropDbl PSI = exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
+        CoolPropDbl dPSI_dDelta = -2.0*Ci*(delta-1.0)*PSI;
+        CoolPropDbl dPSI_dTau = -2.0*Di*(tau-1.0)*PSI;
+        CoolPropDbl dPSI2_dDelta2 = (2.0*Ci*pow(delta-1.0,2)-1.0)*2.0*Ci*PSI;
+        CoolPropDbl dPSI2_dDelta_dTau = 4.0*Ci*Di*(delta-1.0)*(tau-1.0)*PSI;
+        CoolPropDbl dPSI2_dTau2 = (2.0*Di*pow(tau-1.0,2)-1.0)*2.0*Di*PSI;
+        CoolPropDbl dPSI3_dDelta3 = 2.0*Ci*PSI*(-4*Ci*Ci*pow(delta-1.0,3)+6*Ci*(delta-1));
+        CoolPropDbl dPSI3_dDelta2_dTau = (2.0*Ci*pow(delta-1.0,2)-1.0)*2.0*Ci*dPSI_dTau;
+        CoolPropDbl dPSI3_dDelta_dTau2 = 2*Di*(2*Di*pow(tau-1,2)-1)*dPSI_dDelta;
+        CoolPropDbl dPSI3_dTau3 = 2.0*Di*PSI*(-4*Di*Di*pow(tau-1,3)+6*Di*(tau-1));
         
-        long double DELTA = pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
-        long double dDELTA_dTau = -2*theta;
-        long double dDELTA2_dDelta_dTau = 2.0*Ai/(betai)*pow(pow(delta-1,2),1.0/(2.0*betai)-0.5);
-        long double dDELTA_dDelta = (delta-1.0)*(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
-        long double dDELTA3_dDelta2_dTau = 2.0*Ai*(betai-1)/(betai*betai)*pow(pow(delta-1,2),1/(2*betai)-1.0);
+        CoolPropDbl DELTA = pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
+        CoolPropDbl dDELTA_dTau = -2*theta;
+        CoolPropDbl dDELTA2_dDelta_dTau = 2.0*Ai/(betai)*pow(pow(delta-1,2),1.0/(2.0*betai)-0.5);
+        CoolPropDbl dDELTA_dDelta = (delta-1.0)*(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
+        CoolPropDbl dDELTA3_dDelta2_dTau = 2.0*Ai*(betai-1)/(betai*betai)*pow(pow(delta-1,2),1/(2*betai)-1.0);
         
-        long double dDELTAbi_dDelta, dDELTA2_dDelta2, dDELTAbi2_dDelta2, dDELTAbi3_dDelta3, dDELTA3_dDelta3;
+        CoolPropDbl dDELTAbi_dDelta, dDELTA2_dDelta2, dDELTAbi2_dDelta2, dDELTAbi3_dDelta3, dDELTA3_dDelta3;
         if (std::abs(delta-1) < 10*DBL_EPSILON){
             dDELTAbi_dDelta = 0;
             dDELTA2_dDelta2 = 0;
@@ -314,22 +314,22 @@ void ResidualHelmholtzNonAnalytic::all(const long double &tau, const long double
         }
         else{
             dDELTAbi_dDelta=bi*pow(DELTA,bi-1.0)*dDELTA_dDelta;
-            long double dDELTA_dDelta_over_delta_minus_1=(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
+            CoolPropDbl dDELTA_dDelta_over_delta_minus_1=(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
             dDELTA2_dDelta2 = dDELTA_dDelta_over_delta_minus_1+pow(delta-1.0,2)*(4.0*Bi*ai*(ai-1.0)*pow(pow(delta-1,2),ai-2.0)+2.0*pow(Ai/betai,2)*pow(pow(pow(delta-1,2),1.0/(2.0*betai)-1.0),2)+Ai*theta*4.0/betai*(1.0/(2.0*betai)-1.0)*pow(pow(delta-1.0,2),1.0/(2.0*betai)-2.0));
-            long double PI = 4*Bi*ai*(ai-1)*pow(pow(delta-1,2),ai-2)+2*pow(Ai/betai,2)*pow(pow(delta-1,2),1/betai-2)+4*Ai*theta/betai*(1/(2*betai)-1)*pow(pow(delta-1,2),1/(2*betai)-2);
-            long double dPI_dDelta = -8*Bi*ai*(ai-1)*(ai-2)*pow(pow(delta-1,2),ai-5.0/2.0)-8*pow(Ai/betai,2)*(1/(2*betai)-1)*pow(pow(delta-1,2),1/betai-5.0/2.0)-(8*Ai*theta)/betai*(1/(2*betai)-1)*(1/(2*betai)-2)*pow(pow(delta-1,2),1/(2*betai)-5.0/2.0)+4*Ai/betai*(1/(2*betai)-1)*pow(pow(delta-1,2),1/(2*betai)-2)*dtheta_dDelta;
+            CoolPropDbl PI = 4*Bi*ai*(ai-1)*pow(pow(delta-1,2),ai-2)+2*pow(Ai/betai,2)*pow(pow(delta-1,2),1/betai-2)+4*Ai*theta/betai*(1/(2*betai)-1)*pow(pow(delta-1,2),1/(2*betai)-2);
+            CoolPropDbl dPI_dDelta = -8*Bi*ai*(ai-1)*(ai-2)*pow(pow(delta-1,2),ai-5.0/2.0)-8*pow(Ai/betai,2)*(1/(2*betai)-1)*pow(pow(delta-1,2),1/betai-5.0/2.0)-(8*Ai*theta)/betai*(1/(2*betai)-1)*(1/(2*betai)-2)*pow(pow(delta-1,2),1/(2*betai)-5.0/2.0)+4*Ai/betai*(1/(2*betai)-1)*pow(pow(delta-1,2),1/(2*betai)-2)*dtheta_dDelta;
             dDELTA3_dDelta3 = 1/(delta-1)*dDELTA2_dDelta2-1/pow(delta-1,2)*dDELTA_dDelta+pow(delta-1,2)*dPI_dDelta+2*(delta-1)*PI;
             dDELTAbi2_dDelta2 = bi*(pow(DELTA,bi-1)*dDELTA2_dDelta2+(bi-1.0)*pow(DELTA,bi-2.0)*pow(dDELTA_dDelta,2));
             dDELTAbi3_dDelta3 = bi*(pow(DELTA,bi-1)*dDELTA3_dDelta3+dDELTA2_dDelta2*(bi-1)*pow(DELTA,bi-2)*dDELTA_dDelta+(bi-1)*(pow(DELTA,bi-2)*2*dDELTA_dDelta*dDELTA2_dDelta2+pow(dDELTA_dDelta,2)*(bi-2)*pow(DELTA,bi-3)*dDELTA_dDelta));
         }
         
-        long double dDELTAbi_dTau = -2.0*theta*bi*pow(DELTA,bi-1.0);
+        CoolPropDbl dDELTAbi_dTau = -2.0*theta*bi*pow(DELTA,bi-1.0);
         
-        long double dDELTAbi2_dDelta_dTau=-Ai*bi*2.0/betai*pow(DELTA,bi-1.0)*(delta-1.0)*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)-2.0*theta*bi*(bi-1.0)*pow(DELTA,bi-2.0)*dDELTA_dDelta;
-        long double dDELTAbi2_dTau2 = 2.0*bi*pow(DELTA,bi-1.0)+4.0*pow(theta,2)*bi*(bi-1.0)*pow(DELTA,bi-2.0);
-        long double dDELTAbi3_dTau3 = -12.0*theta*bi*(bi-1.0)*pow(DELTA,bi-2)-8*pow(theta,3)*bi*(bi-1)*(bi-2)*pow(DELTA,bi-3);
-        long double dDELTAbi3_dDelta_dTau2 = 2*bi*(bi-1)*pow(DELTA,bi-2)*dDELTA_dDelta+4*pow(theta,2)*bi*(bi-1)*(bi-2)*pow(DELTA,bi-3)*dDELTA_dDelta+8*theta*bi*(bi-1)*pow(DELTA,bi-2)*dtheta_dDelta;
-        long double dDELTAbi3_dDelta2_dTau = bi*((bi-1)*pow(DELTA,bi-2)*dDELTA_dTau*dDELTA2_dDelta2 + pow(DELTA,bi-1)*dDELTA3_dDelta2_dTau+(bi-1)*((bi-2)*pow(DELTA,bi-3)*dDELTA_dTau*pow(dDELTA_dDelta,2)+pow(DELTA,bi-2)*2*dDELTA_dDelta*dDELTA2_dDelta_dTau));
+        CoolPropDbl dDELTAbi2_dDelta_dTau=-Ai*bi*2.0/betai*pow(DELTA,bi-1.0)*(delta-1.0)*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)-2.0*theta*bi*(bi-1.0)*pow(DELTA,bi-2.0)*dDELTA_dDelta;
+        CoolPropDbl dDELTAbi2_dTau2 = 2.0*bi*pow(DELTA,bi-1.0)+4.0*pow(theta,2)*bi*(bi-1.0)*pow(DELTA,bi-2.0);
+        CoolPropDbl dDELTAbi3_dTau3 = -12.0*theta*bi*(bi-1.0)*pow(DELTA,bi-2)-8*pow(theta,3)*bi*(bi-1)*(bi-2)*pow(DELTA,bi-3);
+        CoolPropDbl dDELTAbi3_dDelta_dTau2 = 2*bi*(bi-1)*pow(DELTA,bi-2)*dDELTA_dDelta+4*pow(theta,2)*bi*(bi-1)*(bi-2)*pow(DELTA,bi-3)*dDELTA_dDelta+8*theta*bi*(bi-1)*pow(DELTA,bi-2)*dtheta_dDelta;
+        CoolPropDbl dDELTAbi3_dDelta2_dTau = bi*((bi-1)*pow(DELTA,bi-2)*dDELTA_dTau*dDELTA2_dDelta2 + pow(DELTA,bi-1)*dDELTA3_dDelta2_dTau+(bi-1)*((bi-2)*pow(DELTA,bi-3)*dDELTA_dTau*pow(dDELTA_dDelta,2)+pow(DELTA,bi-2)*2*dDELTA_dDelta*dDELTA2_dDelta_dTau));
         
         derivs.alphar += ni*pow(DELTA, bi)*delta*PSI;
         
@@ -341,45 +341,45 @@ void ResidualHelmholtzNonAnalytic::all(const long double &tau, const long double
         derivs.d2alphar_dtau2 += ni*delta*(dDELTAbi2_dTau2*PSI+2.0*dDELTAbi_dTau*dPSI_dTau+pow(DELTA,bi)*dPSI2_dTau2);
         
         derivs.d3alphar_ddelta3 += ni*(pow(DELTA,bi)*(3.0*dPSI2_dDelta2+delta*dPSI3_dDelta3)+3.0*dDELTAbi_dDelta*(2*dPSI_dDelta+delta*dPSI2_dDelta2)+3*dDELTAbi2_dDelta2*(PSI+delta*dPSI_dDelta)+dDELTAbi3_dDelta3*PSI*delta);
-        long double Line1 = pow(DELTA,bi)*(2*dPSI2_dDelta_dTau+delta*dPSI3_dDelta2_dTau)+dDELTAbi_dTau*(2*dPSI_dDelta+delta*dPSI2_dDelta2);
-        long double Line2 = 2*dDELTAbi_dDelta*(dPSI_dTau+delta*dPSI2_dDelta_dTau)+2*dDELTAbi2_dDelta_dTau*(PSI+delta*dPSI_dDelta);
-        long double Line3 = dDELTAbi2_dDelta2*delta*dPSI_dTau + dDELTAbi3_dDelta2_dTau*delta*PSI;
+        CoolPropDbl Line1 = pow(DELTA,bi)*(2*dPSI2_dDelta_dTau+delta*dPSI3_dDelta2_dTau)+dDELTAbi_dTau*(2*dPSI_dDelta+delta*dPSI2_dDelta2);
+        CoolPropDbl Line2 = 2*dDELTAbi_dDelta*(dPSI_dTau+delta*dPSI2_dDelta_dTau)+2*dDELTAbi2_dDelta_dTau*(PSI+delta*dPSI_dDelta);
+        CoolPropDbl Line3 = dDELTAbi2_dDelta2*delta*dPSI_dTau + dDELTAbi3_dDelta2_dTau*delta*PSI;
         derivs.d3alphar_ddelta2_dtau += ni*(Line1+Line2+Line3);
         derivs.d3alphar_ddelta_dtau2 += ni*delta*(dDELTAbi2_dTau2*dPSI_dDelta+dDELTAbi3_dDelta_dTau2*PSI+2*dDELTAbi_dTau*dPSI2_dDelta_dTau+2.0*dDELTAbi2_dDelta_dTau*dPSI_dTau+pow(DELTA,bi)*dPSI3_dDelta_dTau2+dDELTAbi_dDelta*dPSI2_dTau2)+ni*(dDELTAbi2_dTau2*PSI+2.0*dDELTAbi_dTau*dPSI_dTau+pow(DELTA,bi)*dPSI2_dTau2);
         derivs.d3alphar_dtau3 += ni*delta*(dDELTAbi3_dTau3*PSI+(3.0*dDELTAbi2_dTau2)*dPSI_dTau+(3*dDELTAbi_dTau)*dPSI2_dTau2+pow(DELTA,bi)*dPSI3_dTau3);
     }
 }
 
-long double ResidualHelmholtzNonAnalytic::base(const long double &tau, const long double &delta) throw()
+CoolPropDbl ResidualHelmholtzNonAnalytic::base(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
     if (N==0){return 0.0;}
     for (unsigned int i=0; i<N; ++i)
     {
         ResidualHelmholtzNonAnalyticElement &el = elements[i];
-        long double ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
-        long double Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
-        long double theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
-        long double DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
-        long double PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
+        CoolPropDbl ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
+        CoolPropDbl Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
+        CoolPropDbl theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
+        CoolPropDbl DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
+        CoolPropDbl PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
 
         s[i] = ni*pow(DELTA, bi)*delta*PSI;
     }
     return std::accumulate(s.begin(), s.end(), 0.0);
 }
-long double ResidualHelmholtzNonAnalytic::dDelta(const long double &tau, const long double &delta) throw()
+CoolPropDbl ResidualHelmholtzNonAnalytic::dDelta(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
     if (N==0){return 0.0;}
     for (unsigned int i=0; i<N; ++i)
     {
         ResidualHelmholtzNonAnalyticElement &el = elements[i];
-        long double ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
-        long double Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
-        long double dDELTAbi_dDelta;
-        long double theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
-        long double DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
-        long double PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
-        long double dPSI_dDelta=-2.0*Ci*(delta-1.0)*PSI;
-        long double dDELTA_dDelta=(delta-1.0)*(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
+        CoolPropDbl ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
+        CoolPropDbl Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
+        CoolPropDbl dDELTAbi_dDelta;
+        CoolPropDbl theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
+        CoolPropDbl DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
+        CoolPropDbl PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
+        CoolPropDbl dPSI_dDelta=-2.0*Ci*(delta-1.0)*PSI;
+        CoolPropDbl dDELTA_dDelta=(delta-1.0)*(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
 
         // At critical point, DELTA is 0, and 1/0^n is undefined
         if (std::abs(DELTA) < 10*DBL_EPSILON)
@@ -393,44 +393,44 @@ long double ResidualHelmholtzNonAnalytic::dDelta(const long double &tau, const l
     }
     return std::accumulate(s.begin(), s.end(), 0.0);
 }
-long double ResidualHelmholtzNonAnalytic::dTau(const long double &tau, const long double &delta) throw()
+CoolPropDbl ResidualHelmholtzNonAnalytic::dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
     if (N==0){return 0.0;}
     for (unsigned int i=0; i<N; ++i)
     {
         ResidualHelmholtzNonAnalyticElement &el = elements[i];
-        long double ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
-        long double Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
-        long double theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
-        long double DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
-        long double PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
-        long double dPSI_dTau=-2.0*Di*(tau-1.0)*PSI;
-        long double dDELTAbi_dTau=-2.0*theta*bi*pow(DELTA,bi-1.0);
+        CoolPropDbl ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
+        CoolPropDbl Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
+        CoolPropDbl theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
+        CoolPropDbl DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
+        CoolPropDbl PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
+        CoolPropDbl dPSI_dTau=-2.0*Di*(tau-1.0)*PSI;
+        CoolPropDbl dDELTAbi_dTau=-2.0*theta*bi*pow(DELTA,bi-1.0);
 
         s[i] = ni*delta*(dDELTAbi_dTau*PSI+pow(DELTA,bi)*dPSI_dTau);
     }
     return std::accumulate(s.begin(), s.end(), 0.0);
 }
 
-long double ResidualHelmholtzNonAnalytic::dDelta2(const long double &tau, const long double &delta) throw()
+CoolPropDbl ResidualHelmholtzNonAnalytic::dDelta2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
-    long double dDELTA2_dDelta2, dDELTAbi2_dDelta2;
+    CoolPropDbl dDELTA2_dDelta2, dDELTAbi2_dDelta2;
     if (N==0){return 0.0;}
     for (unsigned int i=0; i<N; ++i)
     {
         ResidualHelmholtzNonAnalyticElement &el = elements[i];
-        long double ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
-        long double Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
-        long double dDELTAbi_dDelta;
-        long double theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
-        long double DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
-        long double PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
-        long double dPSI_dDelta=-2.0*Ci*(delta-1.0)*PSI;
-        long double dDELTA_dDelta=(delta-1.0)*(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
+        CoolPropDbl ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
+        CoolPropDbl Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
+        CoolPropDbl dDELTAbi_dDelta;
+        CoolPropDbl theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
+        CoolPropDbl DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
+        CoolPropDbl PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
+        CoolPropDbl dPSI_dDelta=-2.0*Ci*(delta-1.0)*PSI;
+        CoolPropDbl dDELTA_dDelta=(delta-1.0)*(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
 
-        long double dDELTA_dDelta_over_delta_minus_1=(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
+        CoolPropDbl dDELTA_dDelta_over_delta_minus_1=(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
 
-        long double dPSI2_dDelta2=(2.0*Ci*pow(delta-1.0,2)-1.0)*2.0*Ci*PSI;
+        CoolPropDbl dPSI2_dDelta2=(2.0*Ci*pow(delta-1.0,2)-1.0)*2.0*Ci*PSI;
 
         if (std::abs(delta-1) < 10*DBL_EPSILON){
             dDELTA2_dDelta2 = 0;
@@ -454,26 +454,26 @@ long double ResidualHelmholtzNonAnalytic::dDelta2(const long double &tau, const 
     }
     return std::accumulate(s.begin(), s.end(), 0.0);
 }
-long double ResidualHelmholtzNonAnalytic::dDelta_dTau(const long double &tau, const long double &delta) throw()
+CoolPropDbl ResidualHelmholtzNonAnalytic::dDelta_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
     if (N==0){return 0.0;}
     for (unsigned int i=0; i<N; ++i)
     {
         ResidualHelmholtzNonAnalyticElement &el = elements[i];
-        long double ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
-        long double Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
-        long double dDELTAbi_dDelta;
-        long double theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
-        long double DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
-        long double PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
-        long double dPSI_dDelta=-2.0*Ci*(delta-1.0)*PSI;
-        long double dDELTA_dDelta=(delta-1.0)*(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
+        CoolPropDbl ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
+        CoolPropDbl Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
+        CoolPropDbl dDELTAbi_dDelta;
+        CoolPropDbl theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
+        CoolPropDbl DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
+        CoolPropDbl PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
+        CoolPropDbl dPSI_dDelta=-2.0*Ci*(delta-1.0)*PSI;
+        CoolPropDbl dDELTA_dDelta=(delta-1.0)*(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
 
-        long double dPSI2_dDelta_dTau=4.0*Ci*Di*(delta-1.0)*(tau-1.0)*PSI;
-        long double dDELTAbi2_dDelta_dTau=-Ai*bi*2.0/betai*pow(DELTA,bi-1.0)*(delta-1.0)*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)-2.0*theta*bi*(bi-1.0)*pow(DELTA,bi-2.0)*dDELTA_dDelta;
+        CoolPropDbl dPSI2_dDelta_dTau=4.0*Ci*Di*(delta-1.0)*(tau-1.0)*PSI;
+        CoolPropDbl dDELTAbi2_dDelta_dTau=-Ai*bi*2.0/betai*pow(DELTA,bi-1.0)*(delta-1.0)*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)-2.0*theta*bi*(bi-1.0)*pow(DELTA,bi-2.0)*dDELTA_dDelta;
 
-        long double dPSI_dTau=-2.0*Di*(tau-1.0)*PSI;
-        long double dDELTAbi_dTau=-2.0*theta*bi*pow(DELTA,bi-1.0);
+        CoolPropDbl dPSI_dTau=-2.0*Di*(tau-1.0)*PSI;
+        CoolPropDbl dDELTAbi_dTau=-2.0*theta*bi*pow(DELTA,bi-1.0);
 
         // At critical point, DELTA is 0, and 1/0^n is undefined
         if (std::abs(DELTA) < 10*DBL_EPSILON)
@@ -488,53 +488,53 @@ long double ResidualHelmholtzNonAnalytic::dDelta_dTau(const long double &tau, co
     }
     return std::accumulate(s.begin(), s.end(), 0.0);
 }
-long double ResidualHelmholtzNonAnalytic::dTau2(const long double &tau, const long double &delta) throw()
+CoolPropDbl ResidualHelmholtzNonAnalytic::dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
     if (N==0){return 0.0;}
     for (unsigned int i=0; i<N; ++i)
     {
         ResidualHelmholtzNonAnalyticElement &el = elements[i];
-        long double ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
-        long double Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
+        CoolPropDbl ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
+        CoolPropDbl Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
 
-        long double theta = (1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
-        long double DELTA = pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
-        long double PSI = exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
-        long double dPSI_dTau = -2.0*Di*(tau-1.0)*PSI;
-        long double dDELTAbi_dTau = -2.0*theta*bi*pow(DELTA,bi-1.0);
-        long double dPSI2_dTau2 = (2.0*Di*pow(tau-1.0,2)-1.0)*2.0*Di*PSI;
-        long double dDELTAbi2_dTau2 = 2.0*bi*pow(DELTA,bi-1.0)+4.0*pow(theta,2)*bi*(bi-1.0)*pow(DELTA,bi-2.0);
+        CoolPropDbl theta = (1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
+        CoolPropDbl DELTA = pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
+        CoolPropDbl PSI = exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
+        CoolPropDbl dPSI_dTau = -2.0*Di*(tau-1.0)*PSI;
+        CoolPropDbl dDELTAbi_dTau = -2.0*theta*bi*pow(DELTA,bi-1.0);
+        CoolPropDbl dPSI2_dTau2 = (2.0*Di*pow(tau-1.0,2)-1.0)*2.0*Di*PSI;
+        CoolPropDbl dDELTAbi2_dTau2 = 2.0*bi*pow(DELTA,bi-1.0)+4.0*pow(theta,2)*bi*(bi-1.0)*pow(DELTA,bi-2.0);
 
         s[i] = ni*delta*(dDELTAbi2_dTau2*PSI+2.0*dDELTAbi_dTau*dPSI_dTau+pow(DELTA,bi)*dPSI2_dTau2);
     }
     return std::accumulate(s.begin(), s.end(), 0.0);
 }
 
-long double ResidualHelmholtzNonAnalytic::dDelta3(const long double &tau, const long double &delta) throw()
+CoolPropDbl ResidualHelmholtzNonAnalytic::dDelta3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
     if (N==0){return 0.0;}
     for (unsigned int i=0; i<N; ++i)
     {
         ResidualHelmholtzNonAnalyticElement &el = elements[i];
-        long double ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
-        long double Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
-        long double dDELTAbi_dDelta;
-        long double theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
-        long double DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
-        long double PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
-        long double dPSI_dDelta=-2.0*Ci*(delta-1.0)*PSI;
-        long double dDELTA_dDelta=(delta-1.0)*(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
+        CoolPropDbl ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
+        CoolPropDbl Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
+        CoolPropDbl dDELTAbi_dDelta;
+        CoolPropDbl theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
+        CoolPropDbl DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
+        CoolPropDbl PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
+        CoolPropDbl dPSI_dDelta=-2.0*Ci*(delta-1.0)*PSI;
+        CoolPropDbl dDELTA_dDelta=(delta-1.0)*(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
 
-        long double dPSI2_dDelta2=(2.0*Ci*pow(delta-1.0,2)-1.0)*2.0*Ci*PSI;
-        long double dDELTA2_dDelta2=1.0/(delta-1.0)*dDELTA_dDelta+pow(delta-1.0,2)*(4.0*Bi*ai*(ai-1.0)*pow(pow(delta-1.0,2),ai-2.0)+2.0*pow(Ai/betai,2)*pow(pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0),2)+Ai*theta*4.0/betai*(1.0/(2.0*betai)-1.0)*pow(pow(delta-1.0,2),1.0/(2.0*betai)-2.0));
-        long double dDELTAbi2_dDelta2=bi*(pow(DELTA,bi-1.0)*dDELTA2_dDelta2+(bi-1.0)*pow(DELTA,bi-2.0)*pow(dDELTA_dDelta,2));
+        CoolPropDbl dPSI2_dDelta2=(2.0*Ci*pow(delta-1.0,2)-1.0)*2.0*Ci*PSI;
+        CoolPropDbl dDELTA2_dDelta2=1.0/(delta-1.0)*dDELTA_dDelta+pow(delta-1.0,2)*(4.0*Bi*ai*(ai-1.0)*pow(pow(delta-1.0,2),ai-2.0)+2.0*pow(Ai/betai,2)*pow(pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0),2)+Ai*theta*4.0/betai*(1.0/(2.0*betai)-1.0)*pow(pow(delta-1.0,2),1.0/(2.0*betai)-2.0));
+        CoolPropDbl dDELTAbi2_dDelta2=bi*(pow(DELTA,bi-1.0)*dDELTA2_dDelta2+(bi-1.0)*pow(DELTA,bi-2.0)*pow(dDELTA_dDelta,2));
 
-        long double dtheta_dDelta = Ai/(2*betai)*pow(pow(delta-1,2),1/(2*betai)-1)*2*(delta-1);
-        long double dPSI3_dDelta3=2.0*Ci*PSI*(-4*Ci*Ci*pow(delta-1.0,3)+6*Ci*(delta-1));
-        long double PI = 4*Bi*ai*(ai-1)*pow(pow(delta-1,2),ai-2)+2*pow(Ai/betai,2)*pow(pow(delta-1,2),1/betai-2)+4*Ai*theta/betai*(1/(2*betai)-1)*pow(pow(delta-1,2),1/(2*betai)-2);
-        long double dPI_dDelta = -8*Bi*ai*(ai-1)*(ai-2)*pow(pow(delta-1,2),ai-5.0/2.0)-8*pow(Ai/betai,2)*(1/(2*betai)-1)*pow(pow(delta-1,2),1/betai-5.0/2.0)-(8*Ai*theta)/betai*(1/(2*betai)-1)*(1/(2*betai)-2)*pow(pow(delta-1,2),1/(2*betai)-5.0/2.0)+4*Ai/betai*(1/(2*betai)-1)*pow(pow(delta-1,2),1/(2*betai)-2)*dtheta_dDelta;
-        long double dDELTA3_dDelta3 = 1/(delta-1)*dDELTA2_dDelta2-1/pow(delta-1,2)*dDELTA_dDelta+pow(delta-1,2)*dPI_dDelta+2*(delta-1)*PI;
-        long double dDELTAbi3_dDelta3 = bi*(pow(DELTA,bi-1)*dDELTA3_dDelta3+dDELTA2_dDelta2*(bi-1)*pow(DELTA,bi-2)*dDELTA_dDelta+(bi-1)*(pow(DELTA,bi-2)*2*dDELTA_dDelta*dDELTA2_dDelta2+pow(dDELTA_dDelta,2)*(bi-2)*pow(DELTA,bi-3)*dDELTA_dDelta));
+        CoolPropDbl dtheta_dDelta = Ai/(2*betai)*pow(pow(delta-1,2),1/(2*betai)-1)*2*(delta-1);
+        CoolPropDbl dPSI3_dDelta3=2.0*Ci*PSI*(-4*Ci*Ci*pow(delta-1.0,3)+6*Ci*(delta-1));
+        CoolPropDbl PI = 4*Bi*ai*(ai-1)*pow(pow(delta-1,2),ai-2)+2*pow(Ai/betai,2)*pow(pow(delta-1,2),1/betai-2)+4*Ai*theta/betai*(1/(2*betai)-1)*pow(pow(delta-1,2),1/(2*betai)-2);
+        CoolPropDbl dPI_dDelta = -8*Bi*ai*(ai-1)*(ai-2)*pow(pow(delta-1,2),ai-5.0/2.0)-8*pow(Ai/betai,2)*(1/(2*betai)-1)*pow(pow(delta-1,2),1/betai-5.0/2.0)-(8*Ai*theta)/betai*(1/(2*betai)-1)*(1/(2*betai)-2)*pow(pow(delta-1,2),1/(2*betai)-5.0/2.0)+4*Ai/betai*(1/(2*betai)-1)*pow(pow(delta-1,2),1/(2*betai)-2)*dtheta_dDelta;
+        CoolPropDbl dDELTA3_dDelta3 = 1/(delta-1)*dDELTA2_dDelta2-1/pow(delta-1,2)*dDELTA_dDelta+pow(delta-1,2)*dPI_dDelta+2*(delta-1)*PI;
+        CoolPropDbl dDELTAbi3_dDelta3 = bi*(pow(DELTA,bi-1)*dDELTA3_dDelta3+dDELTA2_dDelta2*(bi-1)*pow(DELTA,bi-2)*dDELTA_dDelta+(bi-1)*(pow(DELTA,bi-2)*2*dDELTA_dDelta*dDELTA2_dDelta2+pow(dDELTA_dDelta,2)*(bi-2)*pow(DELTA,bi-3)*dDELTA_dDelta));
 
         // At critical point, DELTA is 0, and 1/0^n is undefined
         if (std::abs(DELTA) < 10*DBL_EPSILON)
@@ -549,35 +549,35 @@ long double ResidualHelmholtzNonAnalytic::dDelta3(const long double &tau, const 
     }
     return std::accumulate(s.begin(), s.end(), 0.0);
 }
-long double ResidualHelmholtzNonAnalytic::dDelta_dTau2(const long double &tau, const long double &delta) throw()
+CoolPropDbl ResidualHelmholtzNonAnalytic::dDelta_dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
     if (N==0){return 0.0;}
     for (unsigned int i=0; i<N; ++i)
     {
         ResidualHelmholtzNonAnalyticElement &el = elements[i];
-        long double ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
-        long double Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
+        CoolPropDbl ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
+        CoolPropDbl Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
 
-        long double dDELTAbi_dDelta;
-        long double theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
-        long double DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
-        long double PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
-        long double dPSI_dDelta=-2.0*Ci*(delta-1.0)*PSI;
-        long double dDELTA_dDelta=(delta-1.0)*(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
+        CoolPropDbl dDELTAbi_dDelta;
+        CoolPropDbl theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
+        CoolPropDbl DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
+        CoolPropDbl PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
+        CoolPropDbl dPSI_dDelta=-2.0*Ci*(delta-1.0)*PSI;
+        CoolPropDbl dDELTA_dDelta=(delta-1.0)*(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
 
-        long double dDELTAbi_dTau=-2.0*theta*bi*pow(DELTA,bi-1.0);
-        long double dPSI_dTau=-2.0*Di*(tau-1.0)*PSI;
+        CoolPropDbl dDELTAbi_dTau=-2.0*theta*bi*pow(DELTA,bi-1.0);
+        CoolPropDbl dPSI_dTau=-2.0*Di*(tau-1.0)*PSI;
 
-        long double dtheta_dDelta = Ai/(2*betai)*pow(pow(delta-1,2),1/(2*betai)-1)*2*(delta-1);
+        CoolPropDbl dtheta_dDelta = Ai/(2*betai)*pow(pow(delta-1,2),1/(2*betai)-1)*2*(delta-1);
 
-        long double dPSI2_dDelta_dTau=4.0*Ci*Di*(delta-1.0)*(tau-1.0)*PSI;
-        long double dDELTAbi2_dDelta_dTau=-Ai*bi*2.0/betai*pow(DELTA,bi-1.0)*(delta-1.0)*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)-2.0*theta*bi*(bi-1.0)*pow(DELTA,bi-2.0)*dDELTA_dDelta;
+        CoolPropDbl dPSI2_dDelta_dTau=4.0*Ci*Di*(delta-1.0)*(tau-1.0)*PSI;
+        CoolPropDbl dDELTAbi2_dDelta_dTau=-Ai*bi*2.0/betai*pow(DELTA,bi-1.0)*(delta-1.0)*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)-2.0*theta*bi*(bi-1.0)*pow(DELTA,bi-2.0)*dDELTA_dDelta;
 
-        long double dPSI2_dTau2=(2.0*Di*pow(tau-1.0,2)-1.0)*2.0*Di*PSI;
-        long double dDELTAbi2_dTau2=2.0*bi*pow(DELTA,bi-1.0)+4.0*pow(theta,2)*bi*(bi-1.0)*pow(DELTA,bi-2.0);
+        CoolPropDbl dPSI2_dTau2=(2.0*Di*pow(tau-1.0,2)-1.0)*2.0*Di*PSI;
+        CoolPropDbl dDELTAbi2_dTau2=2.0*bi*pow(DELTA,bi-1.0)+4.0*pow(theta,2)*bi*(bi-1.0)*pow(DELTA,bi-2.0);
 
-        long double dPSI3_dDelta_dTau2 = 2*Di*(2*Di*pow(tau-1,2)-1)*dPSI_dDelta;
-        long double dDELTAbi3_dDelta_dTau2 = 2*bi*(bi-1)*pow(DELTA,bi-2)*dDELTA_dDelta+4*pow(theta,2)*bi*(bi-1)*(bi-2)*pow(DELTA,bi-3)*dDELTA_dDelta+8*theta*bi*(bi-1)*pow(DELTA,bi-2)*dtheta_dDelta;
+        CoolPropDbl dPSI3_dDelta_dTau2 = 2*Di*(2*Di*pow(tau-1,2)-1)*dPSI_dDelta;
+        CoolPropDbl dDELTAbi3_dDelta_dTau2 = 2*bi*(bi-1)*pow(DELTA,bi-2)*dDELTA_dDelta+4*pow(theta,2)*bi*(bi-1)*(bi-2)*pow(DELTA,bi-3)*dDELTA_dDelta+8*theta*bi*(bi-1)*pow(DELTA,bi-2)*dtheta_dDelta;
 
         // At critical point, DELTA is 0, and 1/0^n is undefined
         if (std::abs(DELTA) < 10*DBL_EPSILON)
@@ -593,31 +593,31 @@ long double ResidualHelmholtzNonAnalytic::dDelta_dTau2(const long double &tau, c
     return std::accumulate(s.begin(), s.end(), 0.0);
 }
 
-long double ResidualHelmholtzNonAnalytic::dDelta2_dTau(const long double &tau, const long double &delta) throw()
+CoolPropDbl ResidualHelmholtzNonAnalytic::dDelta2_dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
     if (N==0){return 0.0;}
     for (unsigned int i=0; i<N; ++i)
     {
         ResidualHelmholtzNonAnalyticElement &el = elements[i];
-        long double ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
-        long double Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
+        CoolPropDbl ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
+        CoolPropDbl Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
 
-        long double dDELTAbi_dDelta;
-        long double theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
-        long double DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
-        long double PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
-        long double dPSI_dDelta=-2.0*Ci*(delta-1.0)*PSI;
-        long double dDELTA_dDelta=(delta-1.0)*(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
+        CoolPropDbl dDELTAbi_dDelta;
+        CoolPropDbl theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
+        CoolPropDbl DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
+        CoolPropDbl PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
+        CoolPropDbl dPSI_dDelta=-2.0*Ci*(delta-1.0)*PSI;
+        CoolPropDbl dDELTA_dDelta=(delta-1.0)*(Ai*theta*2.0/betai*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)+2.0*Bi*ai*pow(pow(delta-1.0,2),ai-1.0));
 
-        long double dDELTAbi_dTau=-2.0*theta*bi*pow(DELTA,bi-1.0);
-        long double dPSI_dTau=-2.0*Di*(tau-1.0)*PSI;
+        CoolPropDbl dDELTAbi_dTau=-2.0*theta*bi*pow(DELTA,bi-1.0);
+        CoolPropDbl dPSI_dTau=-2.0*Di*(tau-1.0)*PSI;
 
-        long double dPSI2_dDelta2=(2.0*Ci*pow(delta-1.0,2)-1.0)*2.0*Ci*PSI;
-        long double dDELTA2_dDelta2=1.0/(delta-1.0)*dDELTA_dDelta+pow(delta-1.0,2)*(4.0*Bi*ai*(ai-1.0)*pow(pow(delta-1.0,2),ai-2.0)+2.0*pow(Ai/betai,2)*pow(pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0),2)+Ai*theta*4.0/betai*(1.0/(2.0*betai)-1.0)*pow(pow(delta-1.0,2),1.0/(2.0*betai)-2.0));
-        long double dDELTAbi2_dDelta2=bi*(pow(DELTA,bi-1.0)*dDELTA2_dDelta2+(bi-1.0)*pow(DELTA,bi-2.0)*pow(dDELTA_dDelta,2));
+        CoolPropDbl dPSI2_dDelta2=(2.0*Ci*pow(delta-1.0,2)-1.0)*2.0*Ci*PSI;
+        CoolPropDbl dDELTA2_dDelta2=1.0/(delta-1.0)*dDELTA_dDelta+pow(delta-1.0,2)*(4.0*Bi*ai*(ai-1.0)*pow(pow(delta-1.0,2),ai-2.0)+2.0*pow(Ai/betai,2)*pow(pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0),2)+Ai*theta*4.0/betai*(1.0/(2.0*betai)-1.0)*pow(pow(delta-1.0,2),1.0/(2.0*betai)-2.0));
+        CoolPropDbl dDELTAbi2_dDelta2=bi*(pow(DELTA,bi-1.0)*dDELTA2_dDelta2+(bi-1.0)*pow(DELTA,bi-2.0)*pow(dDELTA_dDelta,2));
 
-        long double dPSI2_dDelta_dTau=4.0*Ci*Di*(delta-1.0)*(tau-1.0)*PSI;
-        long double dDELTAbi2_dDelta_dTau=-Ai*bi*2.0/betai*pow(DELTA,bi-1.0)*(delta-1.0)*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)-2.0*theta*bi*(bi-1.0)*pow(DELTA,bi-2.0)*dDELTA_dDelta;
+        CoolPropDbl dPSI2_dDelta_dTau=4.0*Ci*Di*(delta-1.0)*(tau-1.0)*PSI;
+        CoolPropDbl dDELTAbi2_dDelta_dTau=-Ai*bi*2.0/betai*pow(DELTA,bi-1.0)*(delta-1.0)*pow(pow(delta-1.0,2),1.0/(2.0*betai)-1.0)-2.0*theta*bi*(bi-1.0)*pow(DELTA,bi-2.0)*dDELTA_dDelta;
 
         // At critical point, DELTA is 0, and 1/0^n is undefined
         if (std::abs(DELTA) < 10*DBL_EPSILON)
@@ -628,41 +628,41 @@ long double ResidualHelmholtzNonAnalytic::dDelta2_dTau(const long double &tau, c
             dDELTAbi_dDelta=bi*pow(DELTA,bi-1.0)*dDELTA_dDelta;
         }
         //Following Terms added for this derivative
-        long double dPSI3_dDelta2_dTau = (2.0*Ci*pow(delta-1.0,2)-1.0)*2.0*Ci*dPSI_dTau;
-        long double dDELTA_dTau = -2*theta;
-        long double dDELTA2_dDelta_dTau = 2.0*Ai/(betai)*pow(pow(delta-1,2),1.0/(2.0*betai)-0.5);
-        long double dDELTA3_dDelta2_dTau = 2.0*Ai*(betai-1)/(betai*betai)*pow(pow(delta-1,2),1/(2*betai)-1.0);
+        CoolPropDbl dPSI3_dDelta2_dTau = (2.0*Ci*pow(delta-1.0,2)-1.0)*2.0*Ci*dPSI_dTau;
+        CoolPropDbl dDELTA_dTau = -2*theta;
+        CoolPropDbl dDELTA2_dDelta_dTau = 2.0*Ai/(betai)*pow(pow(delta-1,2),1.0/(2.0*betai)-0.5);
+        CoolPropDbl dDELTA3_dDelta2_dTau = 2.0*Ai*(betai-1)/(betai*betai)*pow(pow(delta-1,2),1/(2*betai)-1.0);
 
-        long double dDELTAbim1_dTau = (bi-1)*pow(DELTA,bi-2)*dDELTA_dTau;
-        long double dDELTAbim2_dTau = (bi-2)*pow(DELTA,bi-3)*dDELTA_dTau;
-        long double Line11 = dDELTAbim1_dTau*dDELTA2_dDelta2 + pow(DELTA,bi-1)*dDELTA3_dDelta2_dTau;
-        long double Line21 = (bi-1)*(dDELTAbim2_dTau*pow(dDELTA_dDelta,2)+pow(DELTA,bi-2)*2*dDELTA_dDelta*dDELTA2_dDelta_dTau);
-        long double dDELTAbi3_dDelta2_dTau = bi*(Line11+Line21);
+        CoolPropDbl dDELTAbim1_dTau = (bi-1)*pow(DELTA,bi-2)*dDELTA_dTau;
+        CoolPropDbl dDELTAbim2_dTau = (bi-2)*pow(DELTA,bi-3)*dDELTA_dTau;
+        CoolPropDbl Line11 = dDELTAbim1_dTau*dDELTA2_dDelta2 + pow(DELTA,bi-1)*dDELTA3_dDelta2_dTau;
+        CoolPropDbl Line21 = (bi-1)*(dDELTAbim2_dTau*pow(dDELTA_dDelta,2)+pow(DELTA,bi-2)*2*dDELTA_dDelta*dDELTA2_dDelta_dTau);
+        CoolPropDbl dDELTAbi3_dDelta2_dTau = bi*(Line11+Line21);
 
-        long double Line1 = pow(DELTA,bi)*(2*dPSI2_dDelta_dTau+delta*dPSI3_dDelta2_dTau)+dDELTAbi_dTau*(2*dPSI_dDelta+delta*dPSI2_dDelta2);
-        long double Line2 = 2*dDELTAbi_dDelta*(dPSI_dTau+delta*dPSI2_dDelta_dTau)+2*dDELTAbi2_dDelta_dTau*(PSI+delta*dPSI_dDelta);
-        long double Line3 = dDELTAbi2_dDelta2*delta*dPSI_dTau + dDELTAbi3_dDelta2_dTau*delta*PSI;
+        CoolPropDbl Line1 = pow(DELTA,bi)*(2*dPSI2_dDelta_dTau+delta*dPSI3_dDelta2_dTau)+dDELTAbi_dTau*(2*dPSI_dDelta+delta*dPSI2_dDelta2);
+        CoolPropDbl Line2 = 2*dDELTAbi_dDelta*(dPSI_dTau+delta*dPSI2_dDelta_dTau)+2*dDELTAbi2_dDelta_dTau*(PSI+delta*dPSI_dDelta);
+        CoolPropDbl Line3 = dDELTAbi2_dDelta2*delta*dPSI_dTau + dDELTAbi3_dDelta2_dTau*delta*PSI;
         s[i] = ni*(Line1+Line2+Line3);
     }
     return std::accumulate(s.begin(), s.end(), 0.0);
 }
-long double ResidualHelmholtzNonAnalytic::dTau3(const long double &tau, const long double &delta) throw()
+CoolPropDbl ResidualHelmholtzNonAnalytic::dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
     if (N==0){return 0.0;}
     for (unsigned int i=0; i<N; ++i)
     {
         ResidualHelmholtzNonAnalyticElement &el = elements[i];
-        long double ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
-        long double Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
-        long double theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
-        long double DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
-        long double PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
-        long double dPSI_dTau=-2.0*Di*(tau-1.0)*PSI;
-        long double dDELTAbi_dTau=-2.0*theta*bi*pow(DELTA,bi-1.0);
-        long double dPSI2_dTau2=(2.0*Di*pow(tau-1.0,2)-1.0)*2.0*Di*PSI;
-        long double dDELTAbi2_dTau2=2.0*bi*pow(DELTA,bi-1.0)+4.0*pow(theta,2)*bi*(bi-1.0)*pow(DELTA,bi-2.0);
-        long double dPSI3_dTau3=2.0*Di*PSI*(-4*Di*Di*pow(tau-1,3)+6*Di*(tau-1));
-        long double dDELTAbi3_dTau3 = -12.0*theta*bi*(bi-1.0)*pow(DELTA,bi-2)-8*pow(theta,3)*bi*(bi-1)*(bi-2)*pow(DELTA,bi-3.0);
+        CoolPropDbl ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
+        CoolPropDbl Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
+        CoolPropDbl theta=(1.0-tau)+Ai*pow(pow(delta-1.0,2),1.0/(2.0*betai));
+        CoolPropDbl DELTA=pow(theta,2)+Bi*pow(pow(delta-1.0,2),ai);
+        CoolPropDbl PSI=exp(-Ci*pow(delta-1.0,2)-Di*pow(tau-1.0,2));
+        CoolPropDbl dPSI_dTau=-2.0*Di*(tau-1.0)*PSI;
+        CoolPropDbl dDELTAbi_dTau=-2.0*theta*bi*pow(DELTA,bi-1.0);
+        CoolPropDbl dPSI2_dTau2=(2.0*Di*pow(tau-1.0,2)-1.0)*2.0*Di*PSI;
+        CoolPropDbl dDELTAbi2_dTau2=2.0*bi*pow(DELTA,bi-1.0)+4.0*pow(theta,2)*bi*(bi-1.0)*pow(DELTA,bi-2.0);
+        CoolPropDbl dPSI3_dTau3=2.0*Di*PSI*(-4*Di*Di*pow(tau-1,3)+6*Di*(tau-1));
+        CoolPropDbl dDELTAbi3_dTau3 = -12.0*theta*bi*(bi-1.0)*pow(DELTA,bi-2)-8*pow(theta,3)*bi*(bi-1)*(bi-2)*pow(DELTA,bi-3.0);
 
         s[i] = ni*delta*(dDELTAbi3_dTau3*PSI+(3.0*dDELTAbi2_dTau2)*dPSI_dTau+(3*dDELTAbi_dTau )*dPSI2_dTau2+pow(DELTA,bi)*dPSI3_dTau3);
     }
@@ -678,166 +678,166 @@ void ResidualHelmholtzSAFTAssociating::to_json(rapidjson::Value &el, rapidjson::
     el.AddMember("vbarn",vbarn,doc.GetAllocator());
     el.AddMember("kappabar",kappabar,doc.GetAllocator());
 }
-long double ResidualHelmholtzSAFTAssociating::Deltabar(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::Deltabar(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
     return this->g(this->eta(delta))*(exp(this->epsilonbar*tau)-1)*this->kappabar;
 }
-long double ResidualHelmholtzSAFTAssociating::dDeltabar_ddelta__consttau(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::dDeltabar_ddelta__consttau(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
     return this->dg_deta(this->eta(delta))*(exp(this->epsilonbar*tau)-1)*this->kappabar*this->vbarn;
 }
-long double ResidualHelmholtzSAFTAssociating::d2Deltabar_ddelta2__consttau(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::d2Deltabar_ddelta2__consttau(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
     return this->d2g_deta2(this->eta(delta))*(exp(this->epsilonbar*tau)-1)*this->kappabar*pow(this->vbarn,(int)2);
 }
-long double ResidualHelmholtzSAFTAssociating::dDeltabar_dtau__constdelta(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::dDeltabar_dtau__constdelta(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
     return this->g(this->eta(delta))*this->kappabar*exp(this->epsilonbar*tau)*this->epsilonbar;
 }
-long double ResidualHelmholtzSAFTAssociating::d2Deltabar_dtau2__constdelta(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::d2Deltabar_dtau2__constdelta(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
     return this->g(this->eta(delta))*this->kappabar*exp(this->epsilonbar*tau)*pow(this->epsilonbar,(int)2);
 }
-long double ResidualHelmholtzSAFTAssociating::d2Deltabar_ddelta_dtau(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::d2Deltabar_ddelta_dtau(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
     return this->dg_deta(this->eta(delta))*exp(this->epsilonbar*tau)*this->epsilonbar*this->kappabar*this->vbarn;
 }
-long double ResidualHelmholtzSAFTAssociating::d3Deltabar_dtau3__constdelta(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::d3Deltabar_dtau3__constdelta(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
     return this->g(this->eta(delta))*this->kappabar*exp(this->epsilonbar*tau)*pow(this->epsilonbar,(int)3);
 }
-long double ResidualHelmholtzSAFTAssociating::d3Deltabar_ddelta_dtau2(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::d3Deltabar_ddelta_dtau2(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
     return this->dg_deta(this->eta(delta))*this->kappabar*exp(this->epsilonbar*tau)*pow(this->epsilonbar,(int)2)*this->vbarn;
 }
-long double ResidualHelmholtzSAFTAssociating::d3Deltabar_ddelta2_dtau(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::d3Deltabar_ddelta2_dtau(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
     return this->d2g_deta2(this->eta(delta))*exp(this->epsilonbar*tau)*this->epsilonbar*this->kappabar*pow(this->vbarn,(int)2);
 }
-long double ResidualHelmholtzSAFTAssociating::d3Deltabar_ddelta3__consttau(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::d3Deltabar_ddelta3__consttau(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
     return this->d3g_deta3(this->eta(delta))*(exp(this->epsilonbar*tau)-1)*this->kappabar*pow(this->vbarn,(int)3);
 }
 
-long double ResidualHelmholtzSAFTAssociating::X(const long double &delta, const long double &Deltabar)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::X(const CoolPropDbl &delta, const CoolPropDbl &Deltabar)
 {
     return 2/(sqrt(1+4*Deltabar*delta)+1);
 }
-long double ResidualHelmholtzSAFTAssociating::dX_dDeltabar__constdelta(const long double &delta, const long double &Deltabar)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::dX_dDeltabar__constdelta(const CoolPropDbl &delta, const CoolPropDbl &Deltabar)
 {
-    long double X = this->X(delta,Deltabar);
+    CoolPropDbl X = this->X(delta,Deltabar);
     return -delta*X*X/(2*Deltabar*delta*X+1);
 }
-long double ResidualHelmholtzSAFTAssociating::dX_ddelta__constDeltabar(const long double &delta, const long double &Deltabar)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::dX_ddelta__constDeltabar(const CoolPropDbl &delta, const CoolPropDbl &Deltabar)
 {
-    long double X = this->X(delta,Deltabar);
+    CoolPropDbl X = this->X(delta,Deltabar);
     return -Deltabar*X*X/(2*Deltabar*delta*X+1);
 }
-long double ResidualHelmholtzSAFTAssociating::dX_dtau(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::dX_dtau(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
-    long double Deltabar = this->Deltabar(tau, delta);
+    CoolPropDbl Deltabar = this->Deltabar(tau, delta);
     return this->dX_dDeltabar__constdelta(delta, Deltabar)*this->dDeltabar_dtau__constdelta(tau, delta);
 }
-long double ResidualHelmholtzSAFTAssociating::dX_ddelta(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::dX_ddelta(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
-    long double Deltabar = this->Deltabar(tau, delta);
+    CoolPropDbl Deltabar = this->Deltabar(tau, delta);
     return (this->dX_ddelta__constDeltabar(delta, Deltabar)
            + this->dX_dDeltabar__constdelta(delta, Deltabar)*this->dDeltabar_ddelta__consttau(tau, delta));
 }
-long double ResidualHelmholtzSAFTAssociating::d2X_dtau2(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::d2X_dtau2(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
-    long double Deltabar = this->Deltabar(tau, delta);
-    long double X = this->X(delta, Deltabar);
-    long double beta = this->dDeltabar_dtau__constdelta(tau, delta);
-    long double d_dXdtau_dbeta = -delta*X*X/(2*Deltabar*delta*X+1);
-    long double d_dXdtau_dDeltabar = 2*delta*delta*X*X*X/pow(2*Deltabar*delta*X+1,2)*beta;
-    long double d_dXdtau_dX = -2*beta*delta*X*(Deltabar*delta*X+1)/pow(2*Deltabar*delta*X+1,2);
-    long double dbeta_dtau = this->d2Deltabar_dtau2__constdelta(tau, delta);
-    long double dX_dDeltabar = this->dX_dDeltabar__constdelta(delta, Deltabar);
+    CoolPropDbl Deltabar = this->Deltabar(tau, delta);
+    CoolPropDbl X = this->X(delta, Deltabar);
+    CoolPropDbl beta = this->dDeltabar_dtau__constdelta(tau, delta);
+    CoolPropDbl d_dXdtau_dbeta = -delta*X*X/(2*Deltabar*delta*X+1);
+    CoolPropDbl d_dXdtau_dDeltabar = 2*delta*delta*X*X*X/pow(2*Deltabar*delta*X+1,2)*beta;
+    CoolPropDbl d_dXdtau_dX = -2*beta*delta*X*(Deltabar*delta*X+1)/pow(2*Deltabar*delta*X+1,2);
+    CoolPropDbl dbeta_dtau = this->d2Deltabar_dtau2__constdelta(tau, delta);
+    CoolPropDbl dX_dDeltabar = this->dX_dDeltabar__constdelta(delta, Deltabar);
     return d_dXdtau_dX*dX_dDeltabar*beta+d_dXdtau_dDeltabar*beta+d_dXdtau_dbeta*dbeta_dtau;
 }
-long double ResidualHelmholtzSAFTAssociating::d2X_ddeltadtau(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::d2X_ddeltadtau(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
-    long double Deltabar = this->Deltabar(tau, delta);
-    long double X = this->X(delta, Deltabar);
-    long double alpha = this->dDeltabar_ddelta__consttau(tau, delta);
-    long double beta = this->dDeltabar_dtau__constdelta(tau, delta);
-    long double dalpha_dtau = this->d2Deltabar_ddelta_dtau(tau, delta);
-    long double d_dXddelta_dDeltabar = X*X*(2*delta*delta*X*alpha-1)/pow(2*Deltabar*delta*X+1,2);
-    long double d_dXddelta_dalpha = -delta*X*X/(2*Deltabar*delta*X+1);
-    long double d_dXddelta_dX = -(Deltabar+delta*alpha)*2*(Deltabar*delta*X*X+X)/pow(2*Deltabar*delta*X+1,2);
-    long double dX_dDeltabar = this->dX_dDeltabar__constdelta(delta, Deltabar);
+    CoolPropDbl Deltabar = this->Deltabar(tau, delta);
+    CoolPropDbl X = this->X(delta, Deltabar);
+    CoolPropDbl alpha = this->dDeltabar_ddelta__consttau(tau, delta);
+    CoolPropDbl beta = this->dDeltabar_dtau__constdelta(tau, delta);
+    CoolPropDbl dalpha_dtau = this->d2Deltabar_ddelta_dtau(tau, delta);
+    CoolPropDbl d_dXddelta_dDeltabar = X*X*(2*delta*delta*X*alpha-1)/pow(2*Deltabar*delta*X+1,2);
+    CoolPropDbl d_dXddelta_dalpha = -delta*X*X/(2*Deltabar*delta*X+1);
+    CoolPropDbl d_dXddelta_dX = -(Deltabar+delta*alpha)*2*(Deltabar*delta*X*X+X)/pow(2*Deltabar*delta*X+1,2);
+    CoolPropDbl dX_dDeltabar = this->dX_dDeltabar__constdelta(delta, Deltabar);
     return d_dXddelta_dX*dX_dDeltabar*beta+d_dXddelta_dDeltabar*beta+d_dXddelta_dalpha*dalpha_dtau;
 }
-long double ResidualHelmholtzSAFTAssociating::d2X_ddelta2(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::d2X_ddelta2(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
-    long double Deltabar = this->Deltabar(tau, delta);
-    long double X = this->X(delta, Deltabar);
-    long double alpha = this->dDeltabar_ddelta__consttau(tau, delta);
-    long double dalpha_ddelta = this->d2Deltabar_ddelta2__consttau(tau, delta);
+    CoolPropDbl Deltabar = this->Deltabar(tau, delta);
+    CoolPropDbl X = this->X(delta, Deltabar);
+    CoolPropDbl alpha = this->dDeltabar_ddelta__consttau(tau, delta);
+    CoolPropDbl dalpha_ddelta = this->d2Deltabar_ddelta2__consttau(tau, delta);
 
-    long double dX_ddelta_constall = X*X*(2*Deltabar*Deltabar*X-alpha)/pow(2*Deltabar*delta*X+1,2);
-    long double d_dXddelta_dX = -(Deltabar+delta*alpha)*2*(Deltabar*delta*X*X+X)/pow(2*Deltabar*delta*X+1,2);
-    long double d_dXddelta_dDeltabar = X*X*(2*delta*delta*X*alpha-1)/pow(2*Deltabar*delta*X+1,2);
-    long double d_dXddelta_dalpha = -delta*X*X/(2*Deltabar*delta*X+1);
+    CoolPropDbl dX_ddelta_constall = X*X*(2*Deltabar*Deltabar*X-alpha)/pow(2*Deltabar*delta*X+1,2);
+    CoolPropDbl d_dXddelta_dX = -(Deltabar+delta*alpha)*2*(Deltabar*delta*X*X+X)/pow(2*Deltabar*delta*X+1,2);
+    CoolPropDbl d_dXddelta_dDeltabar = X*X*(2*delta*delta*X*alpha-1)/pow(2*Deltabar*delta*X+1,2);
+    CoolPropDbl d_dXddelta_dalpha = -delta*X*X/(2*Deltabar*delta*X+1);
 
-    long double dX_dDeltabar = this->dX_dDeltabar__constdelta(delta, Deltabar);
-    long double dX_ddelta = this->dX_ddelta__constDeltabar(delta, Deltabar);
+    CoolPropDbl dX_dDeltabar = this->dX_dDeltabar__constdelta(delta, Deltabar);
+    CoolPropDbl dX_ddelta = this->dX_ddelta__constDeltabar(delta, Deltabar);
 
-    long double val = (dX_ddelta_constall
+    CoolPropDbl val = (dX_ddelta_constall
             + d_dXddelta_dX*dX_ddelta
             + d_dXddelta_dX*dX_dDeltabar*alpha
             + d_dXddelta_dDeltabar*alpha
             + d_dXddelta_dalpha*dalpha_ddelta);
     return val;
 }
-long double ResidualHelmholtzSAFTAssociating::d3X_dtau3(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::d3X_dtau3(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
-    long double Delta = this->Deltabar(tau, delta);
-    long double X = this->X(delta, Delta);
-    long double dX_dDelta = this->dX_dDeltabar__constdelta(delta, Delta);
-    long double Delta_t = this->dDeltabar_dtau__constdelta(tau, delta);
-    long double Delta_tt = this->d2Deltabar_dtau2__constdelta(tau, delta);
-    long double Delta_ttt = this->d3Deltabar_dtau3__constdelta(tau, delta);
-    long double dXtt_dX = 2*X*delta*(-6*Delta*pow(Delta_t, 2)*pow(X, 2)*pow(delta, 2)*(Delta*X*delta + 1) + 3*pow(Delta_t, 2)*X*delta*(2*Delta*X*delta + 1) - Delta_tt*pow(2*Delta*X*delta + 1, 3) + X*delta*(Delta*Delta_tt + 3*pow(Delta_t, 2))*pow(2*Delta*X*delta + 1, 2))/pow(2*Delta*X*delta + 1, 4);
-    long double dXtt_dDelta = 2*pow(X, 3)*pow(delta, 2)*(-6*pow(Delta_t, 2)*X*delta*(Delta*X*delta + 1) - 3*pow(Delta_t, 2)*X*delta*(2*Delta*X*delta + 1) + Delta_tt*pow(2*Delta*X*delta + 1, 2))/pow(2*Delta*X*delta + 1, 4);
-    long double dXtt_dDelta_t = 4*Delta_t*pow(X, 3)*pow(delta, 2)*(3*Delta*X*delta + 2)/pow(2*Delta*X*delta + 1, 3);
-    long double dXtt_dDelta_tt = -pow(X, 2)*delta/(2*Delta*X*delta + 1);
+    CoolPropDbl Delta = this->Deltabar(tau, delta);
+    CoolPropDbl X = this->X(delta, Delta);
+    CoolPropDbl dX_dDelta = this->dX_dDeltabar__constdelta(delta, Delta);
+    CoolPropDbl Delta_t = this->dDeltabar_dtau__constdelta(tau, delta);
+    CoolPropDbl Delta_tt = this->d2Deltabar_dtau2__constdelta(tau, delta);
+    CoolPropDbl Delta_ttt = this->d3Deltabar_dtau3__constdelta(tau, delta);
+    CoolPropDbl dXtt_dX = 2*X*delta*(-6*Delta*pow(Delta_t, 2)*pow(X, 2)*pow(delta, 2)*(Delta*X*delta + 1) + 3*pow(Delta_t, 2)*X*delta*(2*Delta*X*delta + 1) - Delta_tt*pow(2*Delta*X*delta + 1, 3) + X*delta*(Delta*Delta_tt + 3*pow(Delta_t, 2))*pow(2*Delta*X*delta + 1, 2))/pow(2*Delta*X*delta + 1, 4);
+    CoolPropDbl dXtt_dDelta = 2*pow(X, 3)*pow(delta, 2)*(-6*pow(Delta_t, 2)*X*delta*(Delta*X*delta + 1) - 3*pow(Delta_t, 2)*X*delta*(2*Delta*X*delta + 1) + Delta_tt*pow(2*Delta*X*delta + 1, 2))/pow(2*Delta*X*delta + 1, 4);
+    CoolPropDbl dXtt_dDelta_t = 4*Delta_t*pow(X, 3)*pow(delta, 2)*(3*Delta*X*delta + 2)/pow(2*Delta*X*delta + 1, 3);
+    CoolPropDbl dXtt_dDelta_tt = -pow(X, 2)*delta/(2*Delta*X*delta + 1);
     return dXtt_dX*dX_dDelta*Delta_t+dXtt_dDelta*Delta_t + dXtt_dDelta_t*Delta_tt + dXtt_dDelta_tt*Delta_ttt;
 }
-long double ResidualHelmholtzSAFTAssociating::d3X_ddeltadtau2(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::d3X_ddeltadtau2(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
-    long double Delta = this->Deltabar(tau, delta);
-    long double X = this->X(delta, Delta);
-    long double dX_ddelta = this->dX_ddelta__constDeltabar(delta, Delta);
-    long double dX_dDelta = this->dX_dDeltabar__constdelta(delta, Delta);
-    long double Delta_t = this->dDeltabar_dtau__constdelta(tau, delta);
-    long double Delta_d = this->dDeltabar_ddelta__consttau(tau, delta);
-    long double Delta_dt = this->d2Deltabar_ddelta_dtau(tau, delta);
-    long double Delta_tt = this->d2Deltabar_dtau2__constdelta(tau, delta);
-    long double Delta_dtt = this->d3Deltabar_ddelta_dtau2(tau, delta);
-    long double dXtt_ddelta = pow(X, 2)*(-12*Delta*pow(Delta_t, 2)*pow(X, 2)*pow(delta, 2)*(Delta*X*delta + 1) + 2*pow(Delta_t, 2)*X*delta*(-Delta*X*delta + 2)*(2*Delta*X*delta + 1) - Delta_tt*pow(2*Delta*X*delta + 1, 3) + 2*X*delta*(Delta*Delta_tt + 2*pow(Delta_t, 2))*pow(2*Delta*X*delta + 1, 2))/pow(2*Delta*X*delta + 1, 4);
-    long double dXtt_dX = 2*X*delta*(-6*Delta*pow(Delta_t, 2)*pow(X, 2)*pow(delta, 2)*(Delta*X*delta + 1) + 3*pow(Delta_t, 2)*X*delta*(2*Delta*X*delta + 1) - Delta_tt*pow(2*Delta*X*delta + 1, 3) + X*delta*(Delta*Delta_tt + 3*pow(Delta_t, 2))*pow(2*Delta*X*delta + 1, 2))/pow(2*Delta*X*delta + 1, 4);
-    long double dXtt_dDelta = 2*pow(X, 3)*pow(delta, 2)*(-6*pow(Delta_t, 2)*X*delta*(Delta*X*delta + 1) - 3*pow(Delta_t, 2)*X*delta*(2*Delta*X*delta + 1) + Delta_tt*pow(2*Delta*X*delta + 1, 2))/pow(2*Delta*X*delta + 1, 4);
-    long double dXtt_dDelta_t = 4*Delta_t*pow(X, 3)*pow(delta, 2)*(3*Delta*X*delta + 2)/pow(2*Delta*X*delta + 1, 3);
-    long double dXtt_dDelta_tt = -pow(X, 2)*delta/(2*Delta*X*delta + 1);
+    CoolPropDbl Delta = this->Deltabar(tau, delta);
+    CoolPropDbl X = this->X(delta, Delta);
+    CoolPropDbl dX_ddelta = this->dX_ddelta__constDeltabar(delta, Delta);
+    CoolPropDbl dX_dDelta = this->dX_dDeltabar__constdelta(delta, Delta);
+    CoolPropDbl Delta_t = this->dDeltabar_dtau__constdelta(tau, delta);
+    CoolPropDbl Delta_d = this->dDeltabar_ddelta__consttau(tau, delta);
+    CoolPropDbl Delta_dt = this->d2Deltabar_ddelta_dtau(tau, delta);
+    CoolPropDbl Delta_tt = this->d2Deltabar_dtau2__constdelta(tau, delta);
+    CoolPropDbl Delta_dtt = this->d3Deltabar_ddelta_dtau2(tau, delta);
+    CoolPropDbl dXtt_ddelta = pow(X, 2)*(-12*Delta*pow(Delta_t, 2)*pow(X, 2)*pow(delta, 2)*(Delta*X*delta + 1) + 2*pow(Delta_t, 2)*X*delta*(-Delta*X*delta + 2)*(2*Delta*X*delta + 1) - Delta_tt*pow(2*Delta*X*delta + 1, 3) + 2*X*delta*(Delta*Delta_tt + 2*pow(Delta_t, 2))*pow(2*Delta*X*delta + 1, 2))/pow(2*Delta*X*delta + 1, 4);
+    CoolPropDbl dXtt_dX = 2*X*delta*(-6*Delta*pow(Delta_t, 2)*pow(X, 2)*pow(delta, 2)*(Delta*X*delta + 1) + 3*pow(Delta_t, 2)*X*delta*(2*Delta*X*delta + 1) - Delta_tt*pow(2*Delta*X*delta + 1, 3) + X*delta*(Delta*Delta_tt + 3*pow(Delta_t, 2))*pow(2*Delta*X*delta + 1, 2))/pow(2*Delta*X*delta + 1, 4);
+    CoolPropDbl dXtt_dDelta = 2*pow(X, 3)*pow(delta, 2)*(-6*pow(Delta_t, 2)*X*delta*(Delta*X*delta + 1) - 3*pow(Delta_t, 2)*X*delta*(2*Delta*X*delta + 1) + Delta_tt*pow(2*Delta*X*delta + 1, 2))/pow(2*Delta*X*delta + 1, 4);
+    CoolPropDbl dXtt_dDelta_t = 4*Delta_t*pow(X, 3)*pow(delta, 2)*(3*Delta*X*delta + 2)/pow(2*Delta*X*delta + 1, 3);
+    CoolPropDbl dXtt_dDelta_tt = -pow(X, 2)*delta/(2*Delta*X*delta + 1);
     return dXtt_ddelta + dXtt_dX*dX_ddelta + dXtt_dX*dX_dDelta*Delta_d + dXtt_dDelta*Delta_d + dXtt_dDelta_t*Delta_dt + dXtt_dDelta_tt*Delta_dtt;
 }
 
-long double ResidualHelmholtzSAFTAssociating::d3X_ddelta2dtau(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::d3X_ddelta2dtau(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
-    long double Delta = this->Deltabar(tau, delta);
-    long double X = this->X(delta, Delta);
-    long double dX_dDelta = this->dX_dDeltabar__constdelta(delta, Delta);
-    long double Delta_t = this->dDeltabar_dtau__constdelta(tau, delta);
-    long double Delta_d = this->dDeltabar_ddelta__consttau(tau, delta);
-    long double Delta_dd = this->d2Deltabar_ddelta2__consttau(tau, delta);
-    long double Delta_dt = this->d2Deltabar_ddelta_dtau(tau, delta);
-    long double Delta_ddt = this->d3Deltabar_ddelta2_dtau(tau, delta);
-    long double dXdd_dX = 2*X*(-6*Delta*pow(X, 2)*delta*pow(Delta + Delta_d*delta, 2)*(Delta*X*delta + 1) - Delta_dd*delta*pow(2*Delta*X*delta + 1, 3) + 2*X*(2*Delta*X*delta + 1)*(-Delta*Delta_d*delta*(2*Delta_d*X*pow(delta, 2) - 1) - Delta*delta*(2*pow(Delta, 2)*X - Delta_d) + Delta*(Delta + Delta_d*delta)*(Delta*X*delta + 1) + Delta_d*delta*(Delta + Delta_d*delta)*(Delta*X*delta + 1)) + pow(2*Delta*X*delta + 1, 2)*(3*pow(Delta, 2)*X + Delta*Delta_dd*X*pow(delta, 2) + Delta*X*(Delta + Delta_d*delta) + pow(Delta_d, 2)*X*pow(delta, 2) + Delta_d*X*delta*(Delta + Delta_d*delta) + Delta_d*(2*Delta_d*X*pow(delta, 2) - 1) - Delta_d))/pow(2*Delta*X*delta + 1, 4);
-    long double dXdd_dDelta = pow(X, 3)*(-8*pow(Delta, 2)*Delta_d*pow(X, 2)*pow(delta, 3) + 8*pow(Delta, 2)*Delta_dd*pow(X, 2)*pow(delta, 4) + 10*pow(Delta, 2)*X*delta - 24*Delta*pow(Delta_d, 2)*pow(X, 2)*pow(delta, 4) + 8*Delta*Delta_d*X*pow(delta, 2) + 8*Delta*Delta_dd*X*pow(delta, 3) + 8*Delta - 18*pow(Delta_d, 2)*X*pow(delta, 3) + 12*Delta_d*delta + 2*Delta_dd*pow(delta, 2))/(16*pow(Delta, 4)*pow(X, 4)*pow(delta, 4) + 32*pow(Delta, 3)*pow(X, 3)*pow(delta, 3) + 24*pow(Delta, 2)*pow(X, 2)*pow(delta, 2) + 8*Delta*X*delta + 1);
-    long double dXdd_dDelta_d = 2*pow(X, 2)*(2*X*delta*(Delta + Delta_d*delta)*(Delta*X*delta + 1) + (2*Delta*X*delta + 1)*(2*Delta_d*X*pow(delta, 2) - 1))/pow(2*Delta*X*delta + 1, 3);
-    long double dXdd_dDelta_dd = -pow(X, 2)*delta/(2*Delta*X*delta + 1);
+    CoolPropDbl Delta = this->Deltabar(tau, delta);
+    CoolPropDbl X = this->X(delta, Delta);
+    CoolPropDbl dX_dDelta = this->dX_dDeltabar__constdelta(delta, Delta);
+    CoolPropDbl Delta_t = this->dDeltabar_dtau__constdelta(tau, delta);
+    CoolPropDbl Delta_d = this->dDeltabar_ddelta__consttau(tau, delta);
+    CoolPropDbl Delta_dd = this->d2Deltabar_ddelta2__consttau(tau, delta);
+    CoolPropDbl Delta_dt = this->d2Deltabar_ddelta_dtau(tau, delta);
+    CoolPropDbl Delta_ddt = this->d3Deltabar_ddelta2_dtau(tau, delta);
+    CoolPropDbl dXdd_dX = 2*X*(-6*Delta*pow(X, 2)*delta*pow(Delta + Delta_d*delta, 2)*(Delta*X*delta + 1) - Delta_dd*delta*pow(2*Delta*X*delta + 1, 3) + 2*X*(2*Delta*X*delta + 1)*(-Delta*Delta_d*delta*(2*Delta_d*X*pow(delta, 2) - 1) - Delta*delta*(2*pow(Delta, 2)*X - Delta_d) + Delta*(Delta + Delta_d*delta)*(Delta*X*delta + 1) + Delta_d*delta*(Delta + Delta_d*delta)*(Delta*X*delta + 1)) + pow(2*Delta*X*delta + 1, 2)*(3*pow(Delta, 2)*X + Delta*Delta_dd*X*pow(delta, 2) + Delta*X*(Delta + Delta_d*delta) + pow(Delta_d, 2)*X*pow(delta, 2) + Delta_d*X*delta*(Delta + Delta_d*delta) + Delta_d*(2*Delta_d*X*pow(delta, 2) - 1) - Delta_d))/pow(2*Delta*X*delta + 1, 4);
+    CoolPropDbl dXdd_dDelta = pow(X, 3)*(-8*pow(Delta, 2)*Delta_d*pow(X, 2)*pow(delta, 3) + 8*pow(Delta, 2)*Delta_dd*pow(X, 2)*pow(delta, 4) + 10*pow(Delta, 2)*X*delta - 24*Delta*pow(Delta_d, 2)*pow(X, 2)*pow(delta, 4) + 8*Delta*Delta_d*X*pow(delta, 2) + 8*Delta*Delta_dd*X*pow(delta, 3) + 8*Delta - 18*pow(Delta_d, 2)*X*pow(delta, 3) + 12*Delta_d*delta + 2*Delta_dd*pow(delta, 2))/(16*pow(Delta, 4)*pow(X, 4)*pow(delta, 4) + 32*pow(Delta, 3)*pow(X, 3)*pow(delta, 3) + 24*pow(Delta, 2)*pow(X, 2)*pow(delta, 2) + 8*Delta*X*delta + 1);
+    CoolPropDbl dXdd_dDelta_d = 2*pow(X, 2)*(2*X*delta*(Delta + Delta_d*delta)*(Delta*X*delta + 1) + (2*Delta*X*delta + 1)*(2*Delta_d*X*pow(delta, 2) - 1))/pow(2*Delta*X*delta + 1, 3);
+    CoolPropDbl dXdd_dDelta_dd = -pow(X, 2)*delta/(2*Delta*X*delta + 1);
 
     return dXdd_dX*dX_dDelta*Delta_t + dXdd_dDelta*Delta_t + dXdd_dDelta_d*Delta_dt + dXdd_dDelta_dd*Delta_ddt;
 }
@@ -847,57 +847,57 @@ double Xdd(double X, double delta, double Delta, double Delta_d, double Delta_dd
     return Delta*pow(X, 2)*(2*Delta + 2*Delta_d*delta)*(Delta*pow(X, 2)*delta + X)/pow(2*Delta*X*delta + 1, 3) + Delta_d*pow(X, 2)*delta*(2*Delta + 2*Delta_d*delta)*(Delta*pow(X, 2)*delta + X)/pow(2*Delta*X*delta + 1, 3) + Delta_d*pow(X, 2)*(2*Delta_d*X*pow(delta, 2) - 1)/pow(2*Delta*X*delta + 1, 2) - Delta_dd*pow(X, 2)*delta/(2*Delta*X*delta + 1) + pow(X, 2)*(2*pow(Delta, 2)*X - Delta_d)/pow(2*Delta*X*delta + 1, 2);
 }
 
-long double ResidualHelmholtzSAFTAssociating::d3X_ddelta3(const long double &tau, const long double &delta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::d3X_ddelta3(const CoolPropDbl &tau, const CoolPropDbl &delta)
 {
-    long double Delta = this->Deltabar(tau, delta);
-    long double X = this->X(delta, Delta);
-    long double dX_ddelta = this->dX_ddelta__constDeltabar(delta, Delta);
-    long double dX_dDelta = this->dX_dDeltabar__constdelta(delta, Delta);
-    long double Delta_d = this->dDeltabar_ddelta__consttau(tau, delta);
-    long double Delta_dd = this->d2Deltabar_ddelta2__consttau(tau, delta);
-    long double Delta_ddd = this->d3Deltabar_ddelta3__consttau(tau, delta);
+    CoolPropDbl Delta = this->Deltabar(tau, delta);
+    CoolPropDbl X = this->X(delta, Delta);
+    CoolPropDbl dX_ddelta = this->dX_ddelta__constDeltabar(delta, Delta);
+    CoolPropDbl dX_dDelta = this->dX_dDeltabar__constdelta(delta, Delta);
+    CoolPropDbl Delta_d = this->dDeltabar_ddelta__consttau(tau, delta);
+    CoolPropDbl Delta_dd = this->d2Deltabar_ddelta2__consttau(tau, delta);
+    CoolPropDbl Delta_ddd = this->d3Deltabar_ddelta3__consttau(tau, delta);
 
-    long double dXdd_dX = 2*X*(-6*Delta*pow(X, 2)*delta*pow(Delta + Delta_d*delta, 2)*(Delta*X*delta + 1) - Delta_dd*delta*pow(2*Delta*X*delta + 1, 3) + 2*X*(2*Delta*X*delta + 1)*(-Delta*Delta_d*delta*(2*Delta_d*X*pow(delta, 2) - 1) - Delta*delta*(2*pow(Delta, 2)*X - Delta_d) + Delta*(Delta + Delta_d*delta)*(Delta*X*delta + 1) + Delta_d*delta*(Delta + Delta_d*delta)*(Delta*X*delta + 1)) + pow(2*Delta*X*delta + 1, 2)*(3*pow(Delta, 2)*X + Delta*Delta_dd*X*pow(delta, 2) + Delta*X*(Delta + Delta_d*delta) + pow(Delta_d, 2)*X*pow(delta, 2) + Delta_d*X*delta*(Delta + Delta_d*delta) + Delta_d*(2*Delta_d*X*pow(delta, 2) - 1) - Delta_d))/pow(2*Delta*X*delta + 1, 4);
-    long double dXdd_ddelta = pow(X, 2)*(-24*pow(Delta, 4)*pow(X, 3)*delta - 8*pow(Delta, 3)*Delta_d*pow(X, 3)*pow(delta, 2) - 18*pow(Delta, 3)*pow(X, 2) + 8*pow(Delta, 2)*Delta_d*pow(X, 2)*delta - 4*pow(Delta, 2)*Delta_dd*pow(X, 2)*pow(delta, 2) + 10*Delta*pow(Delta_d, 2)*pow(X, 2)*pow(delta, 2) + 12*Delta*Delta_d*X - 4*Delta*Delta_dd*X*delta + 8*pow(Delta_d, 2)*X*delta - Delta_dd)/(16*pow(Delta, 4)*pow(X, 4)*pow(delta, 4) + 32*pow(Delta, 3)*pow(X, 3)*pow(delta, 3) + 24*pow(Delta, 2)*pow(X, 2)*pow(delta, 2) + 8*Delta*X*delta + 1);
-    long double dXdd_dDelta = pow(X, 3)*(-8*pow(Delta, 2)*Delta_d*pow(X, 2)*pow(delta, 3) + 8*pow(Delta, 2)*Delta_dd*pow(X, 2)*pow(delta, 4) + 10*pow(Delta, 2)*X*delta - 24*Delta*pow(Delta_d, 2)*pow(X, 2)*pow(delta, 4) + 8*Delta*Delta_d*X*pow(delta, 2) + 8*Delta*Delta_dd*X*pow(delta, 3) + 8*Delta - 18*pow(Delta_d, 2)*X*pow(delta, 3) + 12*Delta_d*delta + 2*Delta_dd*pow(delta, 2))/(16*pow(Delta, 4)*pow(X, 4)*pow(delta, 4) + 32*pow(Delta, 3)*pow(X, 3)*pow(delta, 3) + 24*pow(Delta, 2)*pow(X, 2)*pow(delta, 2) + 8*Delta*X*delta + 1);
-    long double dXdd_dDelta_d = 2*pow(X, 2)*(2*X*delta*(Delta + Delta_d*delta)*(Delta*X*delta + 1) + (2*Delta*X*delta + 1)*(2*Delta_d*X*pow(delta, 2) - 1))/pow(2*Delta*X*delta + 1, 3);
-    long double dXdd_dDelta_dd = -pow(X, 2)*delta/(2*Delta*X*delta + 1);
+    CoolPropDbl dXdd_dX = 2*X*(-6*Delta*pow(X, 2)*delta*pow(Delta + Delta_d*delta, 2)*(Delta*X*delta + 1) - Delta_dd*delta*pow(2*Delta*X*delta + 1, 3) + 2*X*(2*Delta*X*delta + 1)*(-Delta*Delta_d*delta*(2*Delta_d*X*pow(delta, 2) - 1) - Delta*delta*(2*pow(Delta, 2)*X - Delta_d) + Delta*(Delta + Delta_d*delta)*(Delta*X*delta + 1) + Delta_d*delta*(Delta + Delta_d*delta)*(Delta*X*delta + 1)) + pow(2*Delta*X*delta + 1, 2)*(3*pow(Delta, 2)*X + Delta*Delta_dd*X*pow(delta, 2) + Delta*X*(Delta + Delta_d*delta) + pow(Delta_d, 2)*X*pow(delta, 2) + Delta_d*X*delta*(Delta + Delta_d*delta) + Delta_d*(2*Delta_d*X*pow(delta, 2) - 1) - Delta_d))/pow(2*Delta*X*delta + 1, 4);
+    CoolPropDbl dXdd_ddelta = pow(X, 2)*(-24*pow(Delta, 4)*pow(X, 3)*delta - 8*pow(Delta, 3)*Delta_d*pow(X, 3)*pow(delta, 2) - 18*pow(Delta, 3)*pow(X, 2) + 8*pow(Delta, 2)*Delta_d*pow(X, 2)*delta - 4*pow(Delta, 2)*Delta_dd*pow(X, 2)*pow(delta, 2) + 10*Delta*pow(Delta_d, 2)*pow(X, 2)*pow(delta, 2) + 12*Delta*Delta_d*X - 4*Delta*Delta_dd*X*delta + 8*pow(Delta_d, 2)*X*delta - Delta_dd)/(16*pow(Delta, 4)*pow(X, 4)*pow(delta, 4) + 32*pow(Delta, 3)*pow(X, 3)*pow(delta, 3) + 24*pow(Delta, 2)*pow(X, 2)*pow(delta, 2) + 8*Delta*X*delta + 1);
+    CoolPropDbl dXdd_dDelta = pow(X, 3)*(-8*pow(Delta, 2)*Delta_d*pow(X, 2)*pow(delta, 3) + 8*pow(Delta, 2)*Delta_dd*pow(X, 2)*pow(delta, 4) + 10*pow(Delta, 2)*X*delta - 24*Delta*pow(Delta_d, 2)*pow(X, 2)*pow(delta, 4) + 8*Delta*Delta_d*X*pow(delta, 2) + 8*Delta*Delta_dd*X*pow(delta, 3) + 8*Delta - 18*pow(Delta_d, 2)*X*pow(delta, 3) + 12*Delta_d*delta + 2*Delta_dd*pow(delta, 2))/(16*pow(Delta, 4)*pow(X, 4)*pow(delta, 4) + 32*pow(Delta, 3)*pow(X, 3)*pow(delta, 3) + 24*pow(Delta, 2)*pow(X, 2)*pow(delta, 2) + 8*Delta*X*delta + 1);
+    CoolPropDbl dXdd_dDelta_d = 2*pow(X, 2)*(2*X*delta*(Delta + Delta_d*delta)*(Delta*X*delta + 1) + (2*Delta*X*delta + 1)*(2*Delta_d*X*pow(delta, 2) - 1))/pow(2*Delta*X*delta + 1, 3);
+    CoolPropDbl dXdd_dDelta_dd = -pow(X, 2)*delta/(2*Delta*X*delta + 1);
 
     return dXdd_ddelta + dXdd_dX*(dX_ddelta + dX_dDelta*Delta_d) + dXdd_dDelta*Delta_d + dXdd_dDelta_d*Delta_dd + dXdd_dDelta_dd*Delta_ddd;
 }
-long double ResidualHelmholtzSAFTAssociating::g(const long double &eta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::g(const CoolPropDbl &eta)
 {
     return 0.5*(2-eta)/pow(1-eta,(int)3);
 }
-long double ResidualHelmholtzSAFTAssociating::dg_deta(const long double &eta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::dg_deta(const CoolPropDbl &eta)
 {
     return 0.5*(5-2*eta)/pow(1-eta,(int)4);
 }
-long double ResidualHelmholtzSAFTAssociating::d2g_deta2(const long double &eta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::d2g_deta2(const CoolPropDbl &eta)
 {
     return 3*(3-eta)/pow(1-eta,(int)5);
 }
-long double ResidualHelmholtzSAFTAssociating::d3g_deta3(const long double &eta)
+CoolPropDbl ResidualHelmholtzSAFTAssociating::d3g_deta3(const CoolPropDbl &eta)
 {
     return 6*(7-2*eta)/pow(1-eta,(int)6);
 }
-long double ResidualHelmholtzSAFTAssociating::eta(const long double &delta){
+CoolPropDbl ResidualHelmholtzSAFTAssociating::eta(const CoolPropDbl &delta){
     return this->vbarn*delta;
 }
 
-void ResidualHelmholtzSAFTAssociating::all(const long double &tau, const long double &delta, HelmholtzDerivatives &deriv) throw()
+void ResidualHelmholtzSAFTAssociating::all(const CoolPropDbl &tau, const CoolPropDbl &delta, HelmholtzDerivatives &deriv) throw()
 {
     if (disabled){return;}
-    long double X = this->X(delta, this->Deltabar(tau, delta));
-    long double X_t = this->dX_dtau(tau, delta);
-    long double X_d = this->dX_ddelta(tau, delta);
-    long double X_tt = this->d2X_dtau2(tau, delta);
-    long double X_dd = this->d2X_ddelta2(tau, delta);
-    long double X_dt = this->d2X_ddeltadtau(tau, delta);
-    long double X_ttt = this->d3X_dtau3(tau, delta);
-    long double X_dtt = this->d3X_ddeltadtau2(tau, delta);
-    long double X_ddt = this->d3X_ddelta2dtau(tau, delta);
-    long double X_ddd = this->d3X_ddelta3(tau, delta);
+    CoolPropDbl X = this->X(delta, this->Deltabar(tau, delta));
+    CoolPropDbl X_t = this->dX_dtau(tau, delta);
+    CoolPropDbl X_d = this->dX_ddelta(tau, delta);
+    CoolPropDbl X_tt = this->d2X_dtau2(tau, delta);
+    CoolPropDbl X_dd = this->d2X_ddelta2(tau, delta);
+    CoolPropDbl X_dt = this->d2X_ddeltadtau(tau, delta);
+    CoolPropDbl X_ttt = this->d3X_dtau3(tau, delta);
+    CoolPropDbl X_dtt = this->d3X_ddeltadtau2(tau, delta);
+    CoolPropDbl X_ddt = this->d3X_ddelta2dtau(tau, delta);
+    CoolPropDbl X_ddd = this->d3X_ddelta3(tau, delta);
     
     deriv.alphar += this->m*this->a*((log(X)-X/2.0+0.5));
     deriv.dalphar_ddelta += this->m*this->a*(1/X-0.5)*this->dX_ddelta(tau, delta);
@@ -926,7 +926,7 @@ void IdealHelmholtzCP0PolyT::to_json(rapidjson::Value &el, rapidjson::Document &
     el.AddMember("Tc", static_cast<double>(Tc), doc.GetAllocator());
     el.AddMember("T0", static_cast<double>(T0), doc.GetAllocator());
 }
-long double IdealHelmholtzCP0PolyT::base(const long double &tau, const long double &delta) throw()
+CoolPropDbl IdealHelmholtzCP0PolyT::base(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
     double sum=0;
     for (std::size_t i = 0; i < N; ++i){
@@ -945,7 +945,7 @@ long double IdealHelmholtzCP0PolyT::base(const long double &tau, const long doub
     }
     return sum;
 }
-long double IdealHelmholtzCP0PolyT::dTau(const long double &tau, const long double &delta) throw()
+CoolPropDbl IdealHelmholtzCP0PolyT::dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
     double sum=0;
     for (std::size_t i = 0; i < N; ++i){
@@ -964,7 +964,7 @@ long double IdealHelmholtzCP0PolyT::dTau(const long double &tau, const long doub
     }
     return sum;
 }
-long double IdealHelmholtzCP0PolyT::dTau2(const long double &tau, const long double &delta) throw()
+CoolPropDbl IdealHelmholtzCP0PolyT::dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
     double sum=0;
     for (std::size_t i = 0; i < N; ++i){
@@ -983,7 +983,7 @@ long double IdealHelmholtzCP0PolyT::dTau2(const long double &tau, const long dou
     }
     return sum;
 }
-long double IdealHelmholtzCP0PolyT::dTau3(const long double &tau, const long double &delta) throw()
+CoolPropDbl IdealHelmholtzCP0PolyT::dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
     double sum=0;
     for (std::size_t i = 0; i < N; ++i){
@@ -1014,33 +1014,33 @@ void IdealHelmholtzCP0AlyLee::to_json(rapidjson::Value &el, rapidjson::Document 
     el.AddMember("Tc",static_cast<double>(Tc),doc.GetAllocator());
     el.AddMember("T0",static_cast<double>(T0),doc.GetAllocator());
 }
-long double IdealHelmholtzCP0AlyLee::base(const long double &tau, const long double &delta) throw()
+CoolPropDbl IdealHelmholtzCP0AlyLee::base(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
     if (!enabled){ return 0.0;}
     return -tau*(anti_deriv_cp0_tau2(tau)-anti_deriv_cp0_tau2(tau0))+(anti_deriv_cp0_tau(tau)-anti_deriv_cp0_tau(tau0));
 }
-long double IdealHelmholtzCP0AlyLee::dTau(const long double &tau, const long double &delta) throw()
+CoolPropDbl IdealHelmholtzCP0AlyLee::dTau(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
     if (!enabled){ return 0.0;}
     return -(anti_deriv_cp0_tau2(tau) - anti_deriv_cp0_tau2(tau0));
 }
-long double IdealHelmholtzCP0AlyLee::anti_deriv_cp0_tau2(const long double &tau)
+CoolPropDbl IdealHelmholtzCP0AlyLee::anti_deriv_cp0_tau2(const CoolPropDbl &tau)
 {
     return -c[0]/tau + 2*c[1]*c[2]/Tc/(exp(-2*c[2]*tau/Tc)-1) - 2*c[3]*c[4]/Tc*(exp(2*c[4]*tau/Tc)+1);
 }
-long double IdealHelmholtzCP0AlyLee::anti_deriv_cp0_tau(const long double &tau)
+CoolPropDbl IdealHelmholtzCP0AlyLee::anti_deriv_cp0_tau(const CoolPropDbl &tau)
 {
-    long double term1 = c[0]*log(tau);
-    long double term2 = 2*c[1]*c[2]*tau/(-Tc + Tc*exp(-2*c[2]*tau/Tc)) + c[1]*log(-1 + exp(-2*c[2]*tau/Tc)) + 2*c[1]*c[2]*tau/Tc;
-    long double term3 = -c[3]*(Tc*exp(2*c[4]*tau/Tc)*log(exp(2*c[4]*tau/Tc) + 1) + Tc*log(exp(2*c[4]*tau/Tc) + 1) - 2*c[4]*tau*exp(2*c[4]*tau/Tc))/(Tc*(exp(2*c[4]*tau/Tc) + 1));
+    CoolPropDbl term1 = c[0]*log(tau);
+    CoolPropDbl term2 = 2*c[1]*c[2]*tau/(-Tc + Tc*exp(-2*c[2]*tau/Tc)) + c[1]*log(-1 + exp(-2*c[2]*tau/Tc)) + 2*c[1]*c[2]*tau/Tc;
+    CoolPropDbl term3 = -c[3]*(Tc*exp(2*c[4]*tau/Tc)*log(exp(2*c[4]*tau/Tc) + 1) + Tc*log(exp(2*c[4]*tau/Tc) + 1) - 2*c[4]*tau*exp(2*c[4]*tau/Tc))/(Tc*(exp(2*c[4]*tau/Tc) + 1));
     return term1 + term2 + term3;
 }
-long double IdealHelmholtzCP0AlyLee::dTau2(const long double &tau, const long double &delta) throw()
+CoolPropDbl IdealHelmholtzCP0AlyLee::dTau2(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
     if (!enabled){ return 0.0;}
     return -c[0]/pow(tau,2) - c[1]*pow(c[2]/Tc/sinh(c[2]*tau/Tc),2) - c[3]*pow(c[4]/Tc/cosh(c[4]*tau/Tc),2);
 }
-long double IdealHelmholtzCP0AlyLee::dTau3(const long double &tau, const long double &delta) throw()
+CoolPropDbl IdealHelmholtzCP0AlyLee::dTau3(const CoolPropDbl &tau, const CoolPropDbl &delta) throw()
 {
     if (!enabled){ return 0.0;}
     return 2*c[0]/pow(tau,3) + 2*c[1]*pow(c[2]/Tc,3)*cosh(c[2]*tau/Tc)/pow(sinh(c[2]*tau/Tc),3) + 2*c[3]*pow(c[4]/Tc,3)*sinh(c[4]*tau/Tc)/pow(cosh(c[4]*tau/Tc),3);
@@ -1061,7 +1061,7 @@ IdealHelmholtzEnthalpyEntropyOffset EnthalpyEntropyOffset;
 class HelmholtzConsistencyFixture
 {
 public:
-    long double numerical, analytic;
+    CoolPropDbl numerical, analytic;
 
     shared_ptr<CoolProp::BaseHelmholtzTerm> PlanckEinstein, Lead, LogTau, IGPower, CP0Constant, CP0PolyT, SAFT, NonAnalytic;
     shared_ptr<CoolProp::ResidualHelmholtzGeneralizedExponential> Gaussian, Lemmon2005, Exponential, GERG2008, Power;
@@ -1070,22 +1070,22 @@ public:
         Lead.reset(new CoolProp::IdealHelmholtzLead(1,3));
         LogTau.reset(new CoolProp::IdealHelmholtzLogTau(1.5));
         {
-            std::vector<long double> n(4,0), t(4,1); n[0] = -0.1; n[2] = 0.1; t[1] = -1; t[2] = -2; t[3] = 2;
+            std::vector<CoolPropDbl> n(4,0), t(4,1); n[0] = -0.1; n[2] = 0.1; t[1] = -1; t[2] = -2; t[3] = 2;
             IGPower.reset(new CoolProp::IdealHelmholtzPower(n,t));
         }
         {
-            std::vector<long double> n(4,0), t(4,1), c(4,1), d(4,-1); n[0] = 0.1; n[2] = 0.5; t[0] = -1.5; t[1] = -1; t[2] = -2; t[3] = -2;
+            std::vector<CoolPropDbl> n(4,0), t(4,1), c(4,1), d(4,-1); n[0] = 0.1; n[2] = 0.5; t[0] = -1.5; t[1] = -1; t[2] = -2; t[3] = -2;
             PlanckEinstein.reset(new CoolProp::IdealHelmholtzPlanckEinsteinGeneralized(n, t, c, d));
         }
         {
-            long double T0 = 273.15, Tc = 345.857, c = 1.0578, t = 0.33;
-            CP0PolyT.reset(new CoolProp::IdealHelmholtzCP0PolyT(std::vector<long double>(1,c),
-                                                                std::vector<long double>(1,t),
+            CoolPropDbl T0 = 273.15, Tc = 345.857, c = 1.0578, t = 0.33;
+            CP0PolyT.reset(new CoolProp::IdealHelmholtzCP0PolyT(std::vector<CoolPropDbl>(1,c),
+                                                                std::vector<CoolPropDbl>(1,t),
                                                                 Tc, T0));
         }
         CP0Constant.reset(new CoolProp::IdealHelmholtzCP0Constant(4/8.314472,300,250));
         {
-            long double beta[] = {1.24, 0.821, 15.45, 2.21, 437, 0.743},
+            CoolPropDbl beta[] = {1.24, 0.821, 15.45, 2.21, 437, 0.743},
                         d[] = {1, 1, 2, 2, 3, 3},
                         epsilon[] = {0.6734, 0.9239, 0.8636, 1.0507, 0.8482, 0.7522},
                         eta[] = {0.9667, 1.5154, 1.0591, 1.6642, 12.4856, 0.9662},
@@ -1093,76 +1093,76 @@ public:
                         n[] = {1.2198, -0.4883, -0.0033293, -0.0035387, -0.51172, -0.16882},
                         t[] = {1, 2.124, 0.4, 3.5, 0.5, 2.7};
             Gaussian.reset(new CoolProp::ResidualHelmholtzGeneralizedExponential());
-            Gaussian->add_Gaussian(std::vector<long double>(n,n+sizeof(n)/sizeof(n[0])),
-                                   std::vector<long double>(d,d+sizeof(d)/sizeof(d[0])),
-                                   std::vector<long double>(t,t+sizeof(t)/sizeof(t[0])),
-                                   std::vector<long double>(eta,eta+sizeof(eta)/sizeof(eta[0])),
-                                   std::vector<long double>(epsilon,epsilon+sizeof(epsilon)/sizeof(epsilon[0])),
-                                   std::vector<long double>(beta,beta+sizeof(beta)/sizeof(beta[0])),
-                                   std::vector<long double>(gamma,gamma+sizeof(gamma)/sizeof(gamma[0]))
+            Gaussian->add_Gaussian(std::vector<CoolPropDbl>(n,n+sizeof(n)/sizeof(n[0])),
+                                   std::vector<CoolPropDbl>(d,d+sizeof(d)/sizeof(d[0])),
+                                   std::vector<CoolPropDbl>(t,t+sizeof(t)/sizeof(t[0])),
+                                   std::vector<CoolPropDbl>(eta,eta+sizeof(eta)/sizeof(eta[0])),
+                                   std::vector<CoolPropDbl>(epsilon,epsilon+sizeof(epsilon)/sizeof(epsilon[0])),
+                                   std::vector<CoolPropDbl>(beta,beta+sizeof(beta)/sizeof(beta[0])),
+                                   std::vector<CoolPropDbl>(gamma,gamma+sizeof(gamma)/sizeof(gamma[0]))
                                    );
         }
         {
-            long double d[] = {1, 1, 1, 2, 4, 1, 1, 2, 2, 3, 4, 5, 1, 5, 1, 2, 3, 5},
+            CoolPropDbl d[] = {1, 1, 1, 2, 4, 1, 1, 2, 2, 3, 4, 5, 1, 5, 1, 2, 3, 5},
                         l[] = {0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 2, 2, 3, 2, 3, 3},
                         m[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1.7, 7, 6},
                         n[] = {5.28076, -8.67658, 0.7501127, 0.7590023, 0.01451899, 4.777189, -3.330988, 3.775673, -2.290919, 0.8888268, -0.6234864, -0.04127263, -0.08455389, -0.1308752, 0.008344962, -1.532005, -0.05883649, 0.02296658},
                         t[]= {0.669, 1.05,2.75, 0.956, 1, 2, 2.75, 2.38, 3.37, 3.47, 2.63, 3.45, 0.72, 4.23, 0.2, 4.5, 29, 24};
             Lemmon2005.reset(new CoolProp::ResidualHelmholtzGeneralizedExponential());
-            Lemmon2005->add_Lemmon2005(std::vector<long double>(n, n+sizeof(n)/sizeof(n[0])),
-                                       std::vector<long double>(d, d+sizeof(d)/sizeof(d[0])),
-                                       std::vector<long double>(t, t+sizeof(t)/sizeof(t[0])),
-                                       std::vector<long double>(l, l+sizeof(l)/sizeof(l[0])),
-                                       std::vector<long double>(m, m+sizeof(m)/sizeof(m[0]))
+            Lemmon2005->add_Lemmon2005(std::vector<CoolPropDbl>(n, n+sizeof(n)/sizeof(n[0])),
+                                       std::vector<CoolPropDbl>(d, d+sizeof(d)/sizeof(d[0])),
+                                       std::vector<CoolPropDbl>(t, t+sizeof(t)/sizeof(t[0])),
+                                       std::vector<CoolPropDbl>(l, l+sizeof(l)/sizeof(l[0])),
+                                       std::vector<CoolPropDbl>(m, m+sizeof(m)/sizeof(m[0]))
                                        );
         }
         {
-            long double d[] = {1, 1, 1, 3, 7, 1, 2, 5, 1, 1, 4, 2},
+            CoolPropDbl d[] = {1, 1, 1, 3, 7, 1, 2, 5, 1, 1, 4, 2},
                         l[] = {0, 0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3},
                         n[] = {1.0038, -2.7662, 0.42921, 0.081363, 0.00024174, 0.48246, 0.75542, -0.00743, -0.4146, -0.016558, -0.10644, -0.021704},
                         t[] = {0.25, 1.25, 1.5, 0.25, 0.875, 2.375, 2, 2.125, 3.5, 6.5, 4.75, 12.5};
             Power.reset(new CoolProp::ResidualHelmholtzGeneralizedExponential());
-            Power->add_Power(std::vector<long double>(n, n+sizeof(n)/sizeof(n[0])),
-                             std::vector<long double>(d, d+sizeof(d)/sizeof(d[0])),
-                             std::vector<long double>(t, t+sizeof(t)/sizeof(t[0])),
-                             std::vector<long double>(l, l+sizeof(l)/sizeof(l[0]))
+            Power->add_Power(std::vector<CoolPropDbl>(n, n+sizeof(n)/sizeof(n[0])),
+                             std::vector<CoolPropDbl>(d, d+sizeof(d)/sizeof(d[0])),
+                             std::vector<CoolPropDbl>(t, t+sizeof(t)/sizeof(t[0])),
+                             std::vector<CoolPropDbl>(l, l+sizeof(l)/sizeof(l[0]))
                              );
         }
         {
 
-            long double a = 1, epsilonbar = 12.2735737, kappabar = 1.09117041e-05, m = 1.01871348, vbarn = 0.0444215309;
+            CoolPropDbl a = 1, epsilonbar = 12.2735737, kappabar = 1.09117041e-05, m = 1.01871348, vbarn = 0.0444215309;
             SAFT.reset(new CoolProp::ResidualHelmholtzSAFTAssociating(a,m,epsilonbar,vbarn,kappabar));
         }
         {
-            long double n[] = {-0.666422765408, 0.726086323499, 0.0550686686128},
+            CoolPropDbl n[] = {-0.666422765408, 0.726086323499, 0.0550686686128},
                 A[] = {0.7, 0.7, 0.7}, B[] = {0.3, 0.3, 1}, C[] = {10, 10, 12.5}, D[] = {275, 275, 275},
                 a[] = {3.5, 3.5, 3}, b[] = {0.875, 0.925, 0.875}, beta[] = {0.3, 0.3, 0.3};
-            NonAnalytic.reset(new CoolProp::ResidualHelmholtzNonAnalytic(std::vector<long double>(n, n+sizeof(n)/sizeof(n[0])),
-                                                             std::vector<long double>(a, a+sizeof(a)/sizeof(a[0])),
-                                                             std::vector<long double>(b, b+sizeof(b)/sizeof(b[0])),
-                                                             std::vector<long double>(beta, beta+sizeof(beta)/sizeof(beta[0])),
-                                                             std::vector<long double>(A, A+sizeof(A)/sizeof(A[0])),
-                                                             std::vector<long double>(B, B+sizeof(B)/sizeof(B[0])),
-                                                             std::vector<long double>(C, C+sizeof(C)/sizeof(C[0])),
-                                                             std::vector<long double>(D, D+sizeof(D)/sizeof(D[0]))
+            NonAnalytic.reset(new CoolProp::ResidualHelmholtzNonAnalytic(std::vector<CoolPropDbl>(n, n+sizeof(n)/sizeof(n[0])),
+                                                             std::vector<CoolPropDbl>(a, a+sizeof(a)/sizeof(a[0])),
+                                                             std::vector<CoolPropDbl>(b, b+sizeof(b)/sizeof(b[0])),
+                                                             std::vector<CoolPropDbl>(beta, beta+sizeof(beta)/sizeof(beta[0])),
+                                                             std::vector<CoolPropDbl>(A, A+sizeof(A)/sizeof(A[0])),
+                                                             std::vector<CoolPropDbl>(B, B+sizeof(B)/sizeof(B[0])),
+                                                             std::vector<CoolPropDbl>(C, C+sizeof(C)/sizeof(C[0])),
+                                                             std::vector<CoolPropDbl>(D, D+sizeof(D)/sizeof(D[0]))
                                                              ));
         }
         {
-            long double d[] = {2, 2, 2, 0, 0, 0},
+            CoolPropDbl d[] = {2, 2, 2, 0, 0, 0},
             g[] = {1.65533788, 1.65533788, 1.65533788, 1.65533788, 1.65533788, 1.65533788},
             l[] = {2, 2, 2, 2, 2, 2},
             n[] = {-3.821884669859, 8.30345065618981, -4.4832307260286, -1.02590136933231, 2.20786016506394, -1.07889905203761},
             t[] = {3, 4, 5, 3, 4, 5};
             Exponential.reset(new CoolProp::ResidualHelmholtzGeneralizedExponential());
-            Exponential->add_Exponential(std::vector<long double>(n, n+sizeof(n)/sizeof(n[0])),
-                                         std::vector<long double>(d, d+sizeof(d)/sizeof(n[0])),
-                                         std::vector<long double>(t, t+sizeof(t)/sizeof(d[0])),
-                                         std::vector<long double>(g, g+sizeof(g)/sizeof(t[0])),
-                                         std::vector<long double>(l, l+sizeof(l)/sizeof(l[0]))
+            Exponential->add_Exponential(std::vector<CoolPropDbl>(n, n+sizeof(n)/sizeof(n[0])),
+                                         std::vector<CoolPropDbl>(d, d+sizeof(d)/sizeof(n[0])),
+                                         std::vector<CoolPropDbl>(t, t+sizeof(t)/sizeof(d[0])),
+                                         std::vector<CoolPropDbl>(g, g+sizeof(g)/sizeof(t[0])),
+                                         std::vector<CoolPropDbl>(l, l+sizeof(l)/sizeof(l[0]))
                                          );
         }
         {
-            long double d[] = {1, 4, 1, 2, 2, 2, 2, 2, 3},
+            CoolPropDbl d[] = {1, 4, 1, 2, 2, 2, 2, 2, 3},
                 t[] = {0.0, 1.85, 7.85, 5.4, 0.0, 0.75, 2.8, 4.45, 4.25},
                 n[] = {-0.0098038985517335, 0.00042487270143005, -0.034800214576142, -0.13333813013896, -0.011993694974627, 0.069243379775168, -0.31022508148249, 0.24495491753226, 0.22369816716981},
                 eta[] = {0.0, 0.0, 1.0, 1.0, 0.25, 0.0, 0.0, 0.0, 0.0},
@@ -1170,18 +1170,18 @@ public:
                 beta[] = {0.0, 0.0, 1.0, 1.0, 2.5, 3.0, 3.0, 3.0, 3.0},
                 gamma[] = {0.0, 0.0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5};
             GERG2008.reset(new CoolProp::ResidualHelmholtzGeneralizedExponential());
-            GERG2008->add_GERG2008Gaussian(std::vector<long double>(n, n+sizeof(n)/sizeof(n[0])),
-                                           std::vector<long double>(d, d+sizeof(d)/sizeof(n[0])),
-                                           std::vector<long double>(t, t+sizeof(t)/sizeof(d[0])),
-                                           std::vector<long double>(eta, eta+sizeof(eta)/sizeof(eta[0])),
-                                           std::vector<long double>(epsilon, epsilon+sizeof(epsilon)/sizeof(epsilon[0])),
-                                           std::vector<long double>(beta, beta+sizeof(beta)/sizeof(beta[0])),
-                                           std::vector<long double>(gamma, gamma+sizeof(gamma)/sizeof(gamma[0]))
+            GERG2008->add_GERG2008Gaussian(std::vector<CoolPropDbl>(n, n+sizeof(n)/sizeof(n[0])),
+                                           std::vector<CoolPropDbl>(d, d+sizeof(d)/sizeof(n[0])),
+                                           std::vector<CoolPropDbl>(t, t+sizeof(t)/sizeof(d[0])),
+                                           std::vector<CoolPropDbl>(eta, eta+sizeof(eta)/sizeof(eta[0])),
+                                           std::vector<CoolPropDbl>(epsilon, epsilon+sizeof(epsilon)/sizeof(epsilon[0])),
+                                           std::vector<CoolPropDbl>(beta, beta+sizeof(beta)/sizeof(beta[0])),
+                                           std::vector<CoolPropDbl>(gamma, gamma+sizeof(gamma)/sizeof(gamma[0]))
                                            );
         }
 
     }
-    void call(std::string d, shared_ptr<CoolProp::BaseHelmholtzTerm> term, long double tau, long double delta, long double ddelta)
+    void call(std::string d, shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta)
     {
               if (!d.compare("dTau")){return dTau(term,tau,delta,ddelta);}
         else if (!d.compare("dTau2")){return dTau2(term,tau,delta,ddelta);}
@@ -1216,57 +1216,57 @@ public:
             throw CoolProp::ValueError(format("don't understand helmholtz type: %s",t.c_str()));
         }
     }
-    void dTau(shared_ptr<CoolProp::BaseHelmholtzTerm> term, long double tau, long double delta, long double dtau){
-        long double term_plus = term->base(tau + dtau, delta);
-        long double term_minus = term->base(tau - dtau, delta);
+    void dTau(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl dtau){
+        CoolPropDbl term_plus = term->base(tau + dtau, delta);
+        CoolPropDbl term_minus = term->base(tau - dtau, delta);
         numerical = (term_plus - term_minus)/(2*dtau);
         analytic = term->dTau(tau, delta);
     };
-    void dTau2(shared_ptr<CoolProp::BaseHelmholtzTerm> term, long double tau, long double delta, long double dtau){
-        long double term_plus = term->dTau(tau + dtau, delta);
-        long double term_minus = term->dTau(tau - dtau, delta);
+    void dTau2(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl dtau){
+        CoolPropDbl term_plus = term->dTau(tau + dtau, delta);
+        CoolPropDbl term_minus = term->dTau(tau - dtau, delta);
         numerical = (term_plus - term_minus)/(2*dtau);
         analytic = term->dTau2(tau, delta);
     };
-    void dTau3(shared_ptr<CoolProp::BaseHelmholtzTerm> term, long double tau, long double delta, long double dtau){
-        long double term_plus = term->dTau2(tau + dtau, delta);
-        long double term_minus = term->dTau2(tau - dtau, delta);
+    void dTau3(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl dtau){
+        CoolPropDbl term_plus = term->dTau2(tau + dtau, delta);
+        CoolPropDbl term_minus = term->dTau2(tau - dtau, delta);
         numerical = (term_plus - term_minus)/(2*dtau);
         analytic = term->dTau3(tau, delta);
     };
-    void dDelta(shared_ptr<CoolProp::BaseHelmholtzTerm> term, long double tau, long double delta, long double ddelta){
-        long double term_plus = term->base(tau, delta + ddelta);
-        long double term_minus = term->base(tau, delta - ddelta);
+    void dDelta(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta){
+        CoolPropDbl term_plus = term->base(tau, delta + ddelta);
+        CoolPropDbl term_minus = term->base(tau, delta - ddelta);
         numerical = (term_plus - term_minus)/(2*ddelta);
         analytic = term->dDelta(tau, delta);
     };
-    void dDelta2(shared_ptr<CoolProp::BaseHelmholtzTerm> term, long double tau, long double delta, long double ddelta){
-        long double term_plus = term->dDelta(tau, delta + ddelta);
-        long double term_minus = term->dDelta(tau, delta - ddelta);
+    void dDelta2(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta){
+        CoolPropDbl term_plus = term->dDelta(tau, delta + ddelta);
+        CoolPropDbl term_minus = term->dDelta(tau, delta - ddelta);
         numerical = (term_plus - term_minus)/(2*ddelta);
         analytic = term->dDelta2(tau, delta);
     };
-    void dDelta3(shared_ptr<CoolProp::BaseHelmholtzTerm> term, long double tau, long double delta, long double ddelta){
-        long double term_plus = term->dDelta2(tau, delta + ddelta);
-        long double term_minus = term->dDelta2(tau, delta - ddelta);
+    void dDelta3(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta){
+        CoolPropDbl term_plus = term->dDelta2(tau, delta + ddelta);
+        CoolPropDbl term_minus = term->dDelta2(tau, delta - ddelta);
         numerical = (term_plus - term_minus)/(2*ddelta);
         analytic = term->dDelta3(tau, delta);
     };
-    void dDelta_dTau(shared_ptr<CoolProp::BaseHelmholtzTerm> term, long double tau, long double delta, long double ddelta){
-        long double term_plus = term->dTau(tau, delta + ddelta);
-        long double term_minus = term->dTau(tau, delta - ddelta);
+    void dDelta_dTau(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta){
+        CoolPropDbl term_plus = term->dTau(tau, delta + ddelta);
+        CoolPropDbl term_minus = term->dTau(tau, delta - ddelta);
         numerical = (term_plus - term_minus)/(2*ddelta);
         analytic = term->dDelta_dTau(tau, delta);
     };
-    void dDelta_dTau2(shared_ptr<CoolProp::BaseHelmholtzTerm> term, long double tau, long double delta, long double ddelta){
-        long double term_plus = term->dTau2(tau, delta + ddelta);
-        long double term_minus = term->dTau2(tau, delta - ddelta);
+    void dDelta_dTau2(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta){
+        CoolPropDbl term_plus = term->dTau2(tau, delta + ddelta);
+        CoolPropDbl term_minus = term->dTau2(tau, delta - ddelta);
         numerical = (term_plus - term_minus)/(2*ddelta);
         analytic = term->dDelta_dTau2(tau, delta);
     };
-    void dDelta2_dTau(shared_ptr<CoolProp::BaseHelmholtzTerm> term, long double tau, long double delta, long double ddelta){
-        long double term_plus = term->dDelta_dTau(tau, delta + ddelta);
-        long double term_minus = term->dDelta_dTau(tau, delta - ddelta);
+    void dDelta2_dTau(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta){
+        CoolPropDbl term_plus = term->dDelta_dTau(tau, delta + ddelta);
+        CoolPropDbl term_minus = term->dDelta_dTau(tau, delta - ddelta);
         numerical = (term_plus - term_minus)/(2*ddelta);
         analytic = term->dDelta2_dTau(tau, delta);
     };

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -252,7 +252,7 @@ vel("EthylBenzene", "T", 617, "Dmass", 316, "V", 33.22e-6, 1e-2),
 class TransportValidationFixture
 {
 protected:
-    long double actual, x1, x2;
+    CoolPropDbl actual, x1, x2;
     shared_ptr<CoolProp::AbstractState> pState;
     CoolProp::input_pairs pair;
 public:
@@ -557,7 +557,7 @@ static CoolProp::input_pairs inputs[] = {
 class ConsistencyFixture
 {
 protected:
-    long double hmolar, pmolar, smolar, umolar, rhomolar, T, p, x1, x2;
+    CoolPropDbl hmolar, pmolar, smolar, umolar, rhomolar, T, p, x1, x2;
     shared_ptr<CoolProp::AbstractState> pState;
     CoolProp::input_pairs pair;
 public:
@@ -569,7 +569,7 @@ public:
     void set_pair(CoolProp::input_pairs pair){
         this->pair = pair;
     }
-    void set_TP(long double T, long double p)
+    void set_TP(CoolPropDbl T, CoolPropDbl p)
     {
         this->T = T; this->p = p;
         CoolProp::AbstractState &State = *pState;
@@ -988,7 +988,7 @@ TEST_CASE("Test first partial derivatives using PropsSI", "[derivatives]")
         T = 80+273.15;
         shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "Water"));
         AS->update(CoolProp::PT_INPUTS, 101325, T);
-        long double rhomolar = AS->rhomolar();
+        CoolPropDbl rhomolar = AS->rhomolar();
         double dpdrhomolar__T_AbstractState = AS->first_partial_deriv(CoolProp::iP, CoolProp::iDmolar, CoolProp::iT);
         double dpdrhomolar__T_PropsSI_num = (PropsSI("P","T",T,"Dmolar",rhomolar+1e-3,"Water") - PropsSI("P","T",T,"Dmolar",rhomolar-1e-3,"Water"))/(2*1e-3);
         double dpdrhomolar__T_PropsSI = PropsSI("d(P)/d(Dmolar)|T","T",T,"P",101325,"Water");
@@ -1006,7 +1006,7 @@ TEST_CASE("Test first partial derivatives using PropsSI", "[derivatives]")
         T = 80+273.15;
         shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "Water"));
         AS->update(CoolProp::PT_INPUTS, 101325, T);
-        long double rhomass = AS->rhomass();
+        CoolPropDbl rhomass = AS->rhomass();
         double dpdrhomass__T_AbstractState = AS->first_partial_deriv(CoolProp::iP, CoolProp::iDmass, CoolProp::iT);
         double dpdrhomass__T_PropsSI_num = (PropsSI("P","T",T,"Dmass",rhomass+1e-3,"Water") - PropsSI("P","T",T,"Dmass",rhomass-1e-3,"Water"))/(2*1e-3);
         double dpdrhomass__T_PropsSI = PropsSI("d(P)/d(Dmass)|T","T",T,"P",101325,"Water");
@@ -1071,31 +1071,31 @@ TEST_CASE("Test second partial derivatives", "[derivatives]")
         AS->update(CoolProp::DmolarT_INPUTS, rhomolar, T);
         
         // base state
-        long double T0 = AS->T(), rhomolar0 = AS->rhomolar(), hmolar0 = AS->hmolar(), smolar0 = AS->smolar(), umolar0 = AS->umolar(), p0 = AS->p();
-        long double dhdT_rho_ana = AS->first_partial_deriv(CoolProp::iHmolar, CoolProp::iT, CoolProp::iDmolar);
-        long double d2hdT2_rho_ana = AS->second_partial_deriv(CoolProp::iHmolar, CoolProp::iT, CoolProp::iDmolar, CoolProp::iT, CoolProp::iDmolar);
-        long double dsdT_rho_ana = AS->first_partial_deriv(CoolProp::iSmolar, CoolProp::iT, CoolProp::iDmolar);
-        long double d2sdT2_rho_ana = AS->second_partial_deriv(CoolProp::iSmolar, CoolProp::iT, CoolProp::iDmolar, CoolProp::iT, CoolProp::iDmolar);
-        long double dudT_rho_ana = AS->first_partial_deriv(CoolProp::iUmolar, CoolProp::iT, CoolProp::iDmolar);
-        long double d2udT2_rho_ana = AS->second_partial_deriv(CoolProp::iUmolar, CoolProp::iT, CoolProp::iDmolar, CoolProp::iT, CoolProp::iDmolar);
-        long double dpdT_rho_ana = AS->first_partial_deriv(CoolProp::iP, CoolProp::iT, CoolProp::iDmolar);
-        long double d2pdT2_rho_ana = AS->second_partial_deriv(CoolProp::iP, CoolProp::iT, CoolProp::iDmolar, CoolProp::iT, CoolProp::iDmolar);
+        CoolPropDbl T0 = AS->T(), rhomolar0 = AS->rhomolar(), hmolar0 = AS->hmolar(), smolar0 = AS->smolar(), umolar0 = AS->umolar(), p0 = AS->p();
+        CoolPropDbl dhdT_rho_ana = AS->first_partial_deriv(CoolProp::iHmolar, CoolProp::iT, CoolProp::iDmolar);
+        CoolPropDbl d2hdT2_rho_ana = AS->second_partial_deriv(CoolProp::iHmolar, CoolProp::iT, CoolProp::iDmolar, CoolProp::iT, CoolProp::iDmolar);
+        CoolPropDbl dsdT_rho_ana = AS->first_partial_deriv(CoolProp::iSmolar, CoolProp::iT, CoolProp::iDmolar);
+        CoolPropDbl d2sdT2_rho_ana = AS->second_partial_deriv(CoolProp::iSmolar, CoolProp::iT, CoolProp::iDmolar, CoolProp::iT, CoolProp::iDmolar);
+        CoolPropDbl dudT_rho_ana = AS->first_partial_deriv(CoolProp::iUmolar, CoolProp::iT, CoolProp::iDmolar);
+        CoolPropDbl d2udT2_rho_ana = AS->second_partial_deriv(CoolProp::iUmolar, CoolProp::iT, CoolProp::iDmolar, CoolProp::iT, CoolProp::iDmolar);
+        CoolPropDbl dpdT_rho_ana = AS->first_partial_deriv(CoolProp::iP, CoolProp::iT, CoolProp::iDmolar);
+        CoolPropDbl d2pdT2_rho_ana = AS->second_partial_deriv(CoolProp::iP, CoolProp::iT, CoolProp::iDmolar, CoolProp::iT, CoolProp::iDmolar);
         
         // increment T
         AS->update(CoolProp::DmolarT_INPUTS, rhomolar, T+dT);
-        long double Tpt = AS->T(), rhomolarpt = AS->rhomolar(), hmolarpt = AS->hmolar(), smolarpt = AS->smolar(), umolarpt = AS->umolar(), ppt = AS->p();
+        CoolPropDbl Tpt = AS->T(), rhomolarpt = AS->rhomolar(), hmolarpt = AS->hmolar(), smolarpt = AS->smolar(), umolarpt = AS->umolar(), ppt = AS->p();
         // decrement T
         AS->update(CoolProp::DmolarT_INPUTS, rhomolar, T-dT);
-        long double Tmt = AS->T(), rhomolarmt = AS->rhomolar(), hmolarmt = AS->hmolar(), smolarmt = AS->smolar(), umolarmt = AS->umolar(), pmt = AS->p();
+        CoolPropDbl Tmt = AS->T(), rhomolarmt = AS->rhomolar(), hmolarmt = AS->hmolar(), smolarmt = AS->smolar(), umolarmt = AS->umolar(), pmt = AS->p();
         
-        long double dhdT_rho_num = (hmolarpt-hmolarmt)/(2*dT);
-        long double d2hdT2_rho_num = (hmolarpt-2*hmolar0+hmolarmt)/pow(dT,2);
-        long double dsdT_rho_num = (smolarpt-smolarmt)/(2*dT);
-        long double d2sdT2_rho_num = (smolarpt-2*smolar0+smolarmt)/pow(dT,2);
-        long double dudT_rho_num = (umolarpt-umolarmt)/(2*dT);
-        long double d2udT2_rho_num = (umolarpt-2*umolar0+umolarmt)/pow(dT,2);
-        long double dpdT_rho_num = (ppt-pmt)/(2*dT);
-        long double d2pdT2_rho_num = (ppt-2*p0+pmt)/pow(dT,2);
+        CoolPropDbl dhdT_rho_num = (hmolarpt-hmolarmt)/(2*dT);
+        CoolPropDbl d2hdT2_rho_num = (hmolarpt-2*hmolar0+hmolarmt)/pow(dT,2);
+        CoolPropDbl dsdT_rho_num = (smolarpt-smolarmt)/(2*dT);
+        CoolPropDbl d2sdT2_rho_num = (smolarpt-2*smolar0+smolarmt)/pow(dT,2);
+        CoolPropDbl dudT_rho_num = (umolarpt-umolarmt)/(2*dT);
+        CoolPropDbl d2udT2_rho_num = (umolarpt-2*umolar0+umolarmt)/pow(dT,2);
+        CoolPropDbl dpdT_rho_num = (ppt-pmt)/(2*dT);
+        CoolPropDbl d2pdT2_rho_num = (ppt-2*p0+pmt)/pow(dT,2);
         
         CAPTURE(format("%0.15Lg",d2pdT2_rho_ana).c_str());
         
@@ -1117,31 +1117,31 @@ TEST_CASE("Test second partial derivatives", "[derivatives]")
         AS->update(CoolProp::DmolarT_INPUTS, rhomolar, T);
         
         // base state
-        long double T0 = AS->T(), rhomolar0 = AS->rhomolar(), hmolar0 = AS->hmolar(), smolar0 = AS->smolar(), umolar0 = AS->umolar(), p0 = AS->p();
-        long double dhdrho_T_ana = AS->first_partial_deriv(CoolProp::iHmolar, CoolProp::iDmolar, CoolProp::iT);
-        long double d2hdrho2_T_ana = AS->second_partial_deriv(CoolProp::iHmolar, CoolProp::iDmolar, CoolProp::iT, CoolProp::iDmolar, CoolProp::iT);
-        long double dsdrho_T_ana = AS->first_partial_deriv(CoolProp::iSmolar, CoolProp::iDmolar, CoolProp::iT);
-        long double d2sdrho2_T_ana = AS->second_partial_deriv(CoolProp::iSmolar, CoolProp::iDmolar, CoolProp::iT, CoolProp::iDmolar, CoolProp::iT);
-        long double dudrho_T_ana = AS->first_partial_deriv(CoolProp::iUmolar, CoolProp::iDmolar, CoolProp::iT);
-        long double d2udrho2_T_ana = AS->second_partial_deriv(CoolProp::iUmolar, CoolProp::iDmolar, CoolProp::iT, CoolProp::iDmolar, CoolProp::iT);
-        long double dpdrho_T_ana = AS->first_partial_deriv(CoolProp::iP, CoolProp::iDmolar, CoolProp::iT);
-        long double d2pdrho2_T_ana = AS->second_partial_deriv(CoolProp::iP, CoolProp::iDmolar, CoolProp::iT, CoolProp::iDmolar, CoolProp::iT);
+        CoolPropDbl T0 = AS->T(), rhomolar0 = AS->rhomolar(), hmolar0 = AS->hmolar(), smolar0 = AS->smolar(), umolar0 = AS->umolar(), p0 = AS->p();
+        CoolPropDbl dhdrho_T_ana = AS->first_partial_deriv(CoolProp::iHmolar, CoolProp::iDmolar, CoolProp::iT);
+        CoolPropDbl d2hdrho2_T_ana = AS->second_partial_deriv(CoolProp::iHmolar, CoolProp::iDmolar, CoolProp::iT, CoolProp::iDmolar, CoolProp::iT);
+        CoolPropDbl dsdrho_T_ana = AS->first_partial_deriv(CoolProp::iSmolar, CoolProp::iDmolar, CoolProp::iT);
+        CoolPropDbl d2sdrho2_T_ana = AS->second_partial_deriv(CoolProp::iSmolar, CoolProp::iDmolar, CoolProp::iT, CoolProp::iDmolar, CoolProp::iT);
+        CoolPropDbl dudrho_T_ana = AS->first_partial_deriv(CoolProp::iUmolar, CoolProp::iDmolar, CoolProp::iT);
+        CoolPropDbl d2udrho2_T_ana = AS->second_partial_deriv(CoolProp::iUmolar, CoolProp::iDmolar, CoolProp::iT, CoolProp::iDmolar, CoolProp::iT);
+        CoolPropDbl dpdrho_T_ana = AS->first_partial_deriv(CoolProp::iP, CoolProp::iDmolar, CoolProp::iT);
+        CoolPropDbl d2pdrho2_T_ana = AS->second_partial_deriv(CoolProp::iP, CoolProp::iDmolar, CoolProp::iT, CoolProp::iDmolar, CoolProp::iT);
         
         // increment rho
         AS->update(CoolProp::DmolarT_INPUTS, rhomolar+drho, T);
-        long double Tpr = AS->T(), rhomolarpr = AS->rhomolar(), hmolarpr = AS->hmolar(), smolarpr = AS->smolar(), umolarpr = AS->umolar(), ppr = AS->p();
+        CoolPropDbl Tpr = AS->T(), rhomolarpr = AS->rhomolar(), hmolarpr = AS->hmolar(), smolarpr = AS->smolar(), umolarpr = AS->umolar(), ppr = AS->p();
         // decrement rho
         AS->update(CoolProp::DmolarT_INPUTS, rhomolar-drho, T);
-        long double Tmr = AS->T(), rhomolarmr = AS->rhomolar(), hmolarmr = AS->hmolar(), smolarmr = AS->smolar(), umolarmr = AS->umolar(), pmr = AS->p();
+        CoolPropDbl Tmr = AS->T(), rhomolarmr = AS->rhomolar(), hmolarmr = AS->hmolar(), smolarmr = AS->smolar(), umolarmr = AS->umolar(), pmr = AS->p();
         
-        long double dhdrho_T_num = (hmolarpr-hmolarmr)/(2*drho);
-        long double d2hdrho2_T_num = (hmolarpr-2*hmolar0+hmolarmr)/pow(drho,2);
-        long double dsdrho_T_num = (smolarpr-smolarmr)/(2*drho);
-        long double d2sdrho2_T_num = (smolarpr-2*smolar0+smolarmr)/pow(drho,2);
-        long double dudrho_T_num = (umolarpr-umolarmr)/(2*drho);
-        long double d2udrho2_T_num = (umolarpr-2*umolar0+umolarmr)/pow(drho,2);
-        long double dpdrho_T_num = (ppr-pmr)/(2*drho);
-        long double d2pdrho2_T_num = (ppr-2*p0+pmr)/pow(drho,2);
+        CoolPropDbl dhdrho_T_num = (hmolarpr-hmolarmr)/(2*drho);
+        CoolPropDbl d2hdrho2_T_num = (hmolarpr-2*hmolar0+hmolarmr)/pow(drho,2);
+        CoolPropDbl dsdrho_T_num = (smolarpr-smolarmr)/(2*drho);
+        CoolPropDbl d2sdrho2_T_num = (smolarpr-2*smolar0+smolarmr)/pow(drho,2);
+        CoolPropDbl dudrho_T_num = (umolarpr-umolarmr)/(2*drho);
+        CoolPropDbl d2udrho2_T_num = (umolarpr-2*umolar0+umolarmr)/pow(drho,2);
+        CoolPropDbl dpdrho_T_num = (ppr-pmr)/(2*drho);
+        CoolPropDbl d2pdrho2_T_num = (ppr-2*p0+pmr)/pow(drho,2);
         
         CAPTURE(format("%0.15Lg",d2pdrho2_T_ana).c_str());
         
@@ -1447,22 +1447,22 @@ TEST_CASE("Check the first partial derivatives", "[first_saturation_partial_deri
 		SECTION(ss1.str(),"")
 		{
 			AS->update(QT_INPUTS, 1, 300);
-			long double p = AS->p();
-			long double analytical = AS->first_saturation_deriv(pairs[i].p1, pairs[i].p2);
+			CoolPropDbl p = AS->p();
+			CoolPropDbl analytical = AS->first_saturation_deriv(pairs[i].p1, pairs[i].p2);
 			CAPTURE(analytical);
-			long double numerical;
+			CoolPropDbl numerical;
 			if (pairs[i].p2 == iT){
 				AS->update(QT_INPUTS, 1, 300+1e-5);
-				long double v1 = AS->keyed_output(pairs[i].p1);
+				CoolPropDbl v1 = AS->keyed_output(pairs[i].p1);
 				AS->update(QT_INPUTS, 1, 300-1e-5);
-				long double v2 = AS->keyed_output(pairs[i].p1);
+				CoolPropDbl v2 = AS->keyed_output(pairs[i].p1);
 				numerical = (v1-v2)/(2e-5);
 			}
 			else if (pairs[i].p2 == iP){
 				AS->update(PQ_INPUTS, p+1e-2, 1);
-				long double v1 = AS->keyed_output(pairs[i].p1);
+				CoolPropDbl v1 = AS->keyed_output(pairs[i].p1);
 				AS->update(PQ_INPUTS, p-1e-2, 1);
-				long double v2 = AS->keyed_output(pairs[i].p1);
+				CoolPropDbl v2 = AS->keyed_output(pairs[i].p1);
 				numerical = (v1-v2)/(2e-2);
 			}
 			else{
@@ -1489,18 +1489,18 @@ TEST_CASE("Check the second saturation derivatives", "[second_saturation_partial
 		SECTION(ss1.str(),"")
 		{
 			AS->update(QT_INPUTS, 1, 300);
-			long double p = AS->p();
-			long double analytical = AS->second_saturation_deriv(pairs[i].p1, pairs[i].p2, pairs[i].p3, pairs[i].p4);
+			CoolPropDbl p = AS->p();
+			CoolPropDbl analytical = AS->second_saturation_deriv(pairs[i].p1, pairs[i].p2, pairs[i].p3, pairs[i].p4);
 			CAPTURE(analytical);
-			long double numerical;
+			CoolPropDbl numerical;
 			if (pairs[i].p2 == iT){
 				throw NotImplementedError();
 			}
 			else if (pairs[i].p2 == iP){
 				AS->update(PQ_INPUTS, p+1e-2, 1);
-				long double v1 = AS->first_saturation_deriv(pairs[i].p1, pairs[i].p2);
+				CoolPropDbl v1 = AS->first_saturation_deriv(pairs[i].p1, pairs[i].p2);
 				AS->update(PQ_INPUTS, p-1e-2, 1);
-				long double v2 = AS->first_saturation_deriv(pairs[i].p1, pairs[i].p2);
+				CoolPropDbl v2 = AS->first_saturation_deriv(pairs[i].p1, pairs[i].p2);
 				numerical = (v1-v2)/(2e-2);
 			}
 			else{
@@ -1527,22 +1527,22 @@ TEST_CASE("Check the first two-phase derivative", "[first_two_phase_deriv]")
 		SECTION(ss1.str(),"")
 		{
 			AS->update(QT_INPUTS, 0.3, 300);
-			long double numerical;
-            long double analytical = AS->first_two_phase_deriv(pairs[i].p1, pairs[i].p2, pairs[i].p3);
+			CoolPropDbl numerical;
+            CoolPropDbl analytical = AS->first_two_phase_deriv(pairs[i].p1, pairs[i].p2, pairs[i].p3);
 			CAPTURE(analytical);
             
-            long double out1, out2;
-            long double v2base, v3base;
+            CoolPropDbl out1, out2;
+            CoolPropDbl v2base, v3base;
             v2base = AS->keyed_output(pairs[i].p2);
             v3base = AS->keyed_output(pairs[i].p3);
-            long double v2plus = v2base*1.001;
-            long double v2minus = v2base*0.999;
+            CoolPropDbl v2plus = v2base*1.001;
+            CoolPropDbl v2minus = v2base*0.999;
             CoolProp::input_pairs input_pair1 = generate_update_pair(pairs[i].p2, v2plus, pairs[i].p3, v3base, out1, out2);
             AS->update(input_pair1, out1, out2);
-            long double v1 = AS->keyed_output(pairs[i].p1);
+            CoolPropDbl v1 = AS->keyed_output(pairs[i].p1);
             CoolProp::input_pairs input_pair2 = generate_update_pair(pairs[i].p2, v2minus, pairs[i].p3, v3base, out1, out2);
             AS->update(input_pair2, out1, out2);
-            long double v2 = AS->keyed_output(pairs[i].p1);
+            CoolPropDbl v2 = AS->keyed_output(pairs[i].p1);
             
             numerical = (v1 - v2)/(v2plus - v2minus);
 			CAPTURE(numerical);
@@ -1556,28 +1556,28 @@ TEST_CASE("Check the second two-phase derivative", "[second_two_phase_deriv]")
     SECTION("d2rhodhdp",""){
         shared_ptr<CoolProp::HelmholtzEOSBackend> AS(new CoolProp::HelmholtzEOSBackend("n-Propane"));
         AS->update(QT_INPUTS, 0.3, 300);
-        long double analytical = AS->second_two_phase_deriv(iDmolar, iHmolar, iP, iP, iHmolar);
+        CoolPropDbl analytical = AS->second_two_phase_deriv(iDmolar, iHmolar, iP, iP, iHmolar);
         CAPTURE(analytical);
-        long double pplus = AS->p()*1.001, pminus = AS->p()*0.999, h = AS->hmolar();
+        CoolPropDbl pplus = AS->p()*1.001, pminus = AS->p()*0.999, h = AS->hmolar();
         AS->update(HmolarP_INPUTS, h, pplus);
-        long double v1 = AS->first_two_phase_deriv(iDmolar, iHmolar, iP);
+        CoolPropDbl v1 = AS->first_two_phase_deriv(iDmolar, iHmolar, iP);
         AS->update(HmolarP_INPUTS, h, pminus);
-        long double v2 = AS->first_two_phase_deriv(iDmolar, iHmolar, iP);
-        long double numerical = (v1 - v2)/(pplus - pminus);
+        CoolPropDbl v2 = AS->first_two_phase_deriv(iDmolar, iHmolar, iP);
+        CoolPropDbl numerical = (v1 - v2)/(pplus - pminus);
         CAPTURE(numerical);
         CHECK(std::abs(numerical/analytical-1) < 1e-6);
     }
     SECTION("d2rhodhdp using mass",""){
         shared_ptr<CoolProp::HelmholtzEOSBackend> AS(new CoolProp::HelmholtzEOSBackend("n-Propane"));
         AS->update(QT_INPUTS, 0.3, 300);
-        long double analytical = AS->second_two_phase_deriv(iDmass, iHmass, iP, iP, iHmass);
+        CoolPropDbl analytical = AS->second_two_phase_deriv(iDmass, iHmass, iP, iP, iHmass);
         CAPTURE(analytical);
-        long double pplus = AS->p()*1.001, pminus = AS->p()*0.999, h = AS->hmass();
+        CoolPropDbl pplus = AS->p()*1.001, pminus = AS->p()*0.999, h = AS->hmass();
         AS->update(HmassP_INPUTS, h, pplus);
-        long double v1 = AS->first_two_phase_deriv(iDmass, iHmass, iP);
+        CoolPropDbl v1 = AS->first_two_phase_deriv(iDmass, iHmass, iP);
         AS->update(HmassP_INPUTS, h, pminus);
-        long double v2 = AS->first_two_phase_deriv(iDmass, iHmass, iP);
-        long double numerical = (v1 - v2)/(pplus - pminus);
+        CoolPropDbl v2 = AS->first_two_phase_deriv(iDmass, iHmass, iP);
+        CoolPropDbl numerical = (v1 - v2)/(pplus - pminus);
         CAPTURE(numerical);
         CHECK(std::abs(numerical/analytical-1) < 1e-6);
     }
@@ -1602,24 +1602,24 @@ TEST_CASE("Check the first two-phase derivative using splines", "[first_two_phas
 		SECTION(ss1.str(),"")
 		{
 			AS->update(QT_INPUTS, 0.2, 300);
-			long double numerical;
-            long double analytical = AS->first_two_phase_deriv_splined(pairs[i].p1, pairs[i].p2, pairs[i].p3, 0.3);
+			CoolPropDbl numerical;
+            CoolPropDbl analytical = AS->first_two_phase_deriv_splined(pairs[i].p1, pairs[i].p2, pairs[i].p3, 0.3);
 			CAPTURE(analytical);
             
-            long double out1, out2;
-            long double v2base, v3base;
+            CoolPropDbl out1, out2;
+            CoolPropDbl v2base, v3base;
             v2base = AS->keyed_output(pairs[i].p2);
             v3base = AS->keyed_output(pairs[i].p3);
-            long double v2plus = v2base*1.001;
-            long double v2minus = v2base*0.999;
+            CoolPropDbl v2plus = v2base*1.001;
+            CoolPropDbl v2minus = v2base*0.999;
             
             CoolProp::input_pairs input_pair1 = generate_update_pair(pairs[i].p2, v2plus, pairs[i].p3, v3base, out1, out2);
             AS->update(input_pair1, out1, out2);
-            long double v1 = AS->first_two_phase_deriv_splined(pairs[i].p1, pairs[i].p1, pairs[i].p1, 0.3);
+            CoolPropDbl v1 = AS->first_two_phase_deriv_splined(pairs[i].p1, pairs[i].p1, pairs[i].p1, 0.3);
             
             CoolProp::input_pairs input_pair2 = generate_update_pair(pairs[i].p2, v2minus, pairs[i].p3, v3base, out1, out2);
             AS->update(input_pair2, out1, out2);
-            long double v2 = AS->first_two_phase_deriv_splined(pairs[i].p1, pairs[i].p1, pairs[i].p1, 0.3);
+            CoolPropDbl v2 = AS->first_two_phase_deriv_splined(pairs[i].p1, pairs[i].p1, pairs[i].p1, 0.3);
             
             numerical = (v1 - v2)/(v2plus - v2minus);
 			CAPTURE(numerical);

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -495,9 +495,9 @@ int main()
 		::set_debug_level(0);
         
         shared_ptr<AbstractState> HEOS(AbstractState::factory("HEOS","Methane&Ethane"));
-        std::vector<long double> z(2, 0.8); z[1] = 1-z[0];
+        std::vector<CoolPropDbl> z(2, 0.8); z[1] = 1-z[0];
         //shared_ptr<AbstractState> HEOS(AbstractState::factory("HEOS","Methane&Propane&Ethane&n-Butane"));
-        //std::vector<long double> z(4, 0.1); z[1] = 0.35; z[2] = 0.35, z[3] = 0.2;
+        //std::vector<CoolPropDbl> z(4, 0.1); z[1] = 0.35; z[2] = 0.35, z[3] = 0.2;
         HEOS->set_mole_fractions(z);
         
         time_t t1, t2;
@@ -510,12 +510,12 @@ int main()
         }
         t2 = clock();
         HEOS->update(PSmolar_INPUTS, 4e6, 79.1048486373);
-        long double TT = HEOS->T();
+        CoolPropDbl TT = HEOS->T();
         HEOS->update(PQ_INPUTS, 1.3e5, 1);
         double ssat = HEOS->smolar();
         double hsat = HEOS->hmolar();
         double dsat = HEOS->rhomolar();
-        for (long double s = ssat + 60; s > ssat; s -= 5){
+        for (CoolPropDbl s = ssat + 60; s > ssat; s -= 5){
             HEOS->update(PSmolar_INPUTS, 1.3e5, s);
             std::cout << s << " " << HEOS->rhomolar() << " " << dsat << std::endl;
         }
@@ -600,7 +600,7 @@ int main()
         std::vector<std::string> names(1,"Propane");
         
         shared_ptr<HelmholtzEOSMixtureBackend> Water(new HelmholtzEOSMixtureBackend(names));
-        Water->set_mole_fractions(std::vector<long double>(1,1));
+        Water->set_mole_fractions(std::vector<CoolPropDbl>(1,1));
         ResidualHelmholtzGeneralizedExponential GenExp = Water->get_components()[0]->pEOS->alphar.GenExp;
         
         HelmholtzDerivatives derivs1, derivs2;
@@ -642,7 +642,7 @@ int main()
         ss = 0;
         {
             shared_ptr<REFPROPMixtureBackend> Water(new REFPROPMixtureBackend(names));
-            Water->set_mole_fractions(std::vector<long double>(1,1));
+            Water->set_mole_fractions(std::vector<CoolPropDbl>(1,1));
             
             t1 = clock();
             for (long i = 0; i < N; ++i){
@@ -658,7 +658,7 @@ int main()
     {
         std::vector<std::string> names(1,"Water");
         shared_ptr<HelmholtzEOSMixtureBackend> Water(new HelmholtzEOSMixtureBackend(names));
-        Water->set_mole_fractions(std::vector<long double>(1,1));
+        Water->set_mole_fractions(std::vector<CoolPropDbl>(1,1));
         Water->update(PQ_INPUTS, 101325, 0);
         
         HelmholtzDerivatives derivs;
@@ -670,7 +670,7 @@ int main()
         ResidualHelmholtzGeneralizedExponential GenExp = components[0]->pEOS->alphar.GenExp;
         ResidualHelmholtzNonAnalytic NonAnal = components[0]->pEOS->alphar.NonAnalytic;
         
-        long double tau = 0.8, delta = 2.2;
+        CoolPropDbl tau = 0.8, delta = 2.2;
         derivs.reset();
         GenExp.all(tau, delta, derivs);
         
@@ -686,16 +686,16 @@ int main()
         tau = 0.99; delta = 1.01;
         derivs.reset();
         NonAnal.all(tau, delta, derivs);
-        long double a00 = NonAnal.base(tau, delta);
-        long double a10 = NonAnal.dDelta(tau, delta);
-        long double a01 = NonAnal.dTau(tau, delta);
-        long double a20 = NonAnal.dDelta2(tau, delta);
-        long double a11 = NonAnal.dDelta_dTau(tau, delta);
-        long double a02 = NonAnal.dTau2(tau, delta);
-        long double a03 = NonAnal.dTau3(tau, delta);
-        long double a12 = NonAnal.dDelta_dTau2(tau, delta);
-        long double a21 = NonAnal.dDelta2_dTau(tau, delta);
-        long double a30 = NonAnal.dDelta3(tau, delta);
+        CoolPropDbl a00 = NonAnal.base(tau, delta);
+        CoolPropDbl a10 = NonAnal.dDelta(tau, delta);
+        CoolPropDbl a01 = NonAnal.dTau(tau, delta);
+        CoolPropDbl a20 = NonAnal.dDelta2(tau, delta);
+        CoolPropDbl a11 = NonAnal.dDelta_dTau(tau, delta);
+        CoolPropDbl a02 = NonAnal.dTau2(tau, delta);
+        CoolPropDbl a03 = NonAnal.dTau3(tau, delta);
+        CoolPropDbl a12 = NonAnal.dDelta_dTau2(tau, delta);
+        CoolPropDbl a21 = NonAnal.dDelta2_dTau(tau, delta);
+        CoolPropDbl a30 = NonAnal.dDelta3(tau, delta);
         
         exit(0);
     }
@@ -834,11 +834,11 @@ int main()
     {
         shared_ptr<AbstractState> MixRP(AbstractState::factory(std::string("REFPROP"),std::string("propane")));
         MixRP->update(QT_INPUTS, 0, 330);
-        long double s1 = MixRP->surface_tension();
+        CoolPropDbl s1 = MixRP->surface_tension();
 
         shared_ptr<AbstractState> Mix(AbstractState::factory(std::string("HEOS"), std::string("propane")));
         Mix->update(QT_INPUTS, 0, 330);
-        long double s2 = Mix->surface_tension();
+        CoolPropDbl s2 = Mix->surface_tension();
     }
 	#endif
     #if 0
@@ -888,7 +888,7 @@ int main()
     #if 0
     {
         int N = 2;
-        std::vector<long double> z(N, 1.0/N);
+        std::vector<CoolPropDbl> z(N, 1.0/N);
         double Q = 1, T = 250, p = 300000;
 
         int inputs = PQ_INPUTS; double val1 = p, val2 = Q;
@@ -924,7 +924,7 @@ int main()
     #if 0
     {
         int N = 2;
-        std::vector<long double> z(N, 1.0/N);
+        std::vector<CoolPropDbl> z(N, 1.0/N);
         double Q = 0, T = 250, p = 300000;
 
         shared_ptr<AbstractState> Mix(AbstractState::factory(std::string("HEOS"), std::string("Ethane,n-Propane")));
@@ -973,7 +973,7 @@ int main()
     {
         shared_ptr<AbstractState> State(AbstractState::factory(std::string("REFPROP"), std::string("Methane|Ethane")));
 
-        std::vector<long double> x(2,0.5);
+        std::vector<CoolPropDbl> x(2,0.5);
         State->set_mole_fractions(x);
         State->update(DmassT_INPUTS,1,250);
         double hh = State->hmolar();


### PR DESCRIPTION
Introduce CoolPropDbl to replace long doubles. This may help to overcome
possible portability problems, and test for efficiency and precision.