### PR TITLE
const, ref and iterator optimization

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -53,11 +53,11 @@ class ConfigurationItem
         ConfigurationDataTypes type;
         
         /// Cast to boolean
-        operator bool() { check_data_type(CONFIGURATION_BOOL_TYPE);  return v_bool; };
+        operator bool() const { check_data_type(CONFIGURATION_BOOL_TYPE);  return v_bool; };
         /// Cast to double
-        operator double() { check_data_type(CONFIGURATION_DOUBLE_TYPE);  return v_double; };
+        operator double() const { check_data_type(CONFIGURATION_DOUBLE_TYPE);  return v_double; };
         /// Cast to string
-        operator std::string() { check_data_type(CONFIGURATION_STRING_TYPE);  return v_string; };
+        operator std::string() const { check_data_type(CONFIGURATION_STRING_TYPE);  return v_string; };
         // Initializer for bool
         ConfigurationItem(configuration_keys key, bool val){
             this->key = key; type = CONFIGURATION_BOOL_TYPE; v_bool = val;
@@ -75,7 +75,7 @@ class ConfigurationItem
             this->key = key; type = CONFIGURATION_STRING_TYPE; v_string = val;
         };
         // Initializer for string
-        ConfigurationItem(configuration_keys key, std::string val){
+        ConfigurationItem(configuration_keys key, const std::string &val){
             this->key = key; type = CONFIGURATION_STRING_TYPE; v_string = val;
         };
 		void set_bool(bool val){
@@ -90,17 +90,17 @@ class ConfigurationItem
 			check_data_type(CONFIGURATION_DOUBLE_TYPE);
 			v_double = val;
 		}
-		void set_string(std::string val){
+		void set_string(const std::string &val){
 			check_data_type(CONFIGURATION_STRING_TYPE);
 			v_string = val;
 		}
 		
-        configuration_keys get_key(void){
+        configuration_keys get_key(void) const {
             return this->key;
         }
 		#if !defined(SWIG)
         /// Cast to rapidjson::Value
-        void add_to_json(rapidjson::Value &val, rapidjson::Document &d){
+        void add_to_json(rapidjson::Value &val, rapidjson::Document &d) const {
             std::string name_string = config_key_to_string(key);
             rapidjson::Value name(name_string.c_str(), d.GetAllocator());
             switch (type){
@@ -143,7 +143,7 @@ class ConfigurationItem
 		#endif // !defined(SWIG)
          
     protected:
-        void check_data_type(ConfigurationDataTypes type){
+        void check_data_type(ConfigurationDataTypes type) const {
             if (type != this->type){
                 throw ValueError(format("type does not match"));
             }
@@ -166,9 +166,8 @@ class Configuration
         
         /// Get an item from the configuration
         ConfigurationItem &get_item(configuration_keys key){
-            std::map<configuration_keys,ConfigurationItem>::iterator it;
             // Try to find it
-            it = items.find(key);
+            std::map<configuration_keys,ConfigurationItem>::iterator it = items.find(key);
             // If equal to end, not found
             if (it != items.end()){
                 // Found, return it
@@ -222,12 +221,12 @@ std::string get_config_as_json_string();
 
 void set_config_bool(configuration_keys key, bool val);
 void set_config_double(configuration_keys key, double val);
-void set_config_string(configuration_keys key, std::string val);
+void set_config_string(configuration_keys key, const std::string &val);
 /// Set values in the configuration based on a json file
 #if !defined(SWIG) // Hide this for swig - Swig gets confused
 void set_config_json(rapidjson::Document &doc);
 #endif
-void set_config_as_json_string(std::string &s);
+void set_config_as_json_string(const std::string &s);
 }
 
 #endif // COOLPROP_CONFIGURATION

--- a/include/CoolProp.h
+++ b/include/CoolProp.h
@@ -24,7 +24,7 @@ You might want to start by looking at CoolProp.h
     /// Return a value that does not depend on the thermodynamic state - this is a convenience function that does the call PropsSI(Output, "", 0, "", 0, FluidName)
     /// @param FluidName The fluid name
     /// @param Output The output parameter, one of "Tcrit","D","H",etc.
-    double Props1SI(const std::string &FluidName, const std::string &Output);
+    double Props1SI(std::string FluidName, std::string Output);
     /// Return a value that depends on the thermodynamic state
     /// @param Output The output parameter, one of "T","D","H",etc.
     /// @param Name1 The first state variable name, one of "T","D","H",etc.
@@ -174,7 +174,7 @@ You might want to start by looking at CoolProp.h
      * @param backend The output backend, if none found, "?"
      * @param fluid The output fluid string (minus the backend string)
      */
-    void extract_backend(const std::string &fluid_string, std::string &backend, std::string &fluid);
+    void extract_backend(std::string fluid_string, std::string &backend, std::string &fluid);
     
     /**
      * @brief Extract fractions (molar, mass, etc.) encoded in the string if any

--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -131,7 +131,7 @@
      * 
      * \note If there is an error, a huge value will be returned, you can get the error message by doing something like get_global_param_string("errstring",output)
      */
-    EXPORT_CODE void CONVENTION propssi_(const char *Output, const char *Name1, double *Prop1, const char *Name2, double *Prop2, const char * Ref, double *output);
+    EXPORT_CODE void CONVENTION propssi_(const char *Output, const char *Name1, const double *Prop1, const char *Name2, const double *Prop2, const char * Ref, double *output);
     /** \brief An overload of \ref CoolProp::PropsSI with the mole fractions passed as an array of doubles and the number of 
      * \overload
      * \sa \ref CoolProp::PropsSIZ
@@ -190,7 +190,7 @@
      * 
      * \note If there is an error, a huge value will be returned, you can get the error message by doing something like get_global_param_string("errstring",output)
      */
-    EXPORT_CODE void CONVENTION hapropssi_(const char *Output, const char *Name1, double *Prop1, const char *Name2, double *Prop2, const char *Name3, double *Prop3, double *output);
+    EXPORT_CODE void CONVENTION hapropssi_(const char *Output, const char *Name1, const double *Prop1, const char *Name2, const double *Prop2, const char *Name3, const double *Prop3, double *output);
     
     /** \brief DLL wrapper of the HAProps function
      * 
@@ -208,7 +208,7 @@
      * 
      * \note If there is an error, a huge value will be returned, you can get the error message by doing something like get_global_param_string("errstring",output)
      */
-    EXPORT_CODE void CONVENTION haprops_(const char *Output, const char *Name1, double *Prop1, const char *Name2, double *Prop2, const char *Name3, double *Prop3, double *output);
+    EXPORT_CODE void CONVENTION haprops_(const char *Output, const char *Name1, const double *Prop1, const char *Name2, const double *Prop2, const char *Name3, const double *Prop3, double *output);
     
     
 

--- a/include/CoolPropTools.h
+++ b/include/CoolPropTools.h
@@ -212,16 +212,14 @@
     // Missing string split - like in Python
     std::vector<std::string> strsplit(const std::string &s, char del);
 
-    inline std::string upper(const std::string str_)
+    inline std::string upper(std::string str)
     {
-        std::string str = str_;
         std::transform(str.begin(), str.end(), str.begin(), ::toupper);
         return str;
     }
 	
-	inline std::string lower(const std::string str_)
+	inline std::string lower(std::string str)
     {
-        std::string str = str_;
         std::transform(str.begin(), str.end(), str.begin(), ::tolower);
         return str;
     }

--- a/include/DataStructures.h
+++ b/include/DataStructures.h
@@ -152,7 +152,7 @@ enum phases{iphase_liquid, ///< Subcritical liquid
 /// Return information about the parameter
 /// @param key The key, one of iT, iP, etc.
 /// @param info The thing you want, one of "IO" ("IO" if input/output, "O" if output only), "short" (very short description), "long" (a longer description), "units"
-std::string get_parameter_information(int key, std::string info);
+std::string get_parameter_information(int key, const std::string &info);
 
 /// Return the enum key corresponding to the parameter name ("Dmolar" for instance)
 parameters get_parameter_index(const std::string &param_name);
@@ -349,10 +349,10 @@ template<class T> CoolProp::input_pairs generate_update_pair(parameters key1, T 
     };
 
 /// Return the short description of an input pair key ("DmolarT_INPUTS" for instance)
-std::string get_input_pair_short_desc(int pair);
+const std::string& get_input_pair_short_desc(int pair);
 
 /// Return the long description of an input pair key ("Molar density in mol/m^3, Temperature in K" for instance)
-std::string get_input_pair_long_desc(int pair);
+const std::string& get_input_pair_long_desc(int pair);
 
 /// Split an input pair into parameters for the two parts that form the pair
 void split_input_pair(input_pairs pair, parameters &p1, parameters &p2);

--- a/include/Helmholtz.h
+++ b/include/Helmholtz.h
@@ -578,13 +578,13 @@ private:
     bool enabled;
     std::string reference;
 public:
-    IdealHelmholtzEnthalpyEntropyOffset(){enabled = false;};
+    IdealHelmholtzEnthalpyEntropyOffset():enabled(false){}
 
     // Constructor
-    IdealHelmholtzEnthalpyEntropyOffset(CoolPropDbl a1, CoolPropDbl a2, std::string reference):a1(a1), a2(a2){this->reference = reference; enabled = true;};
+    IdealHelmholtzEnthalpyEntropyOffset(CoolPropDbl a1, CoolPropDbl a2, const std::string &ref):a1(a1),a2(a2),reference(ref),enabled(true) {}
 
     // Set the values in the class
-    void set(CoolPropDbl a1, CoolPropDbl a2, std::string reference){this->a1 = a1; this->a2 = a2; this->reference = reference; enabled = true;}
+    void set(CoolPropDbl a1, CoolPropDbl a2, const std::string &ref){this->a1 = a1; this->a2 = a2; this->reference = ref; enabled = true;}
 
     //Destructor
     ~IdealHelmholtzEnthalpyEntropyOffset(){};

--- a/include/IncompressibleFluid.h
+++ b/include/IncompressibleFluid.h
@@ -146,9 +146,9 @@ public:
     double getTbase() const {return Tbase;}
     double getxbase() const {return xbase;}
 
-    void setName(std::string name) {this->name = name;}
-    void setDescription(std::string description) {this->description = description;}
-    void setReference(std::string reference) {this->reference = reference;}
+    void setName(const std::string &name) {this->name = name;}
+    void setDescription(const std::string &description) {this->description = description;}
+    void setReference(const std::string &reference) {this->reference = reference;}
     void setTmax(double Tmax) {this->Tmax = Tmax;}
     void setTmin(double Tmin) {this->Tmin = Tmin;}
     void setxmax(double xmax) {this->xmax = xmax;}

--- a/include/MatrixMath.h
+++ b/include/MatrixMath.h
@@ -296,7 +296,7 @@ template <class T> void removeColumn(Eigen::Matrix<T,Eigen::Dynamic,Eigen::Dynam
 static const char* stdFmt = "%8.3f";
 
 ///Templates for turning vectors (1D-matrices) into strings
-template<class T> std::string vec_to_string(const             std::vector<T>   &a, const char *fmt) {
+template<class T> std::string vec_to_string(const std::vector<T> &a, const char *fmt) {
     if (a.size()<1) return std::string("");
     std::stringstream out;
     out << "[ " << format(fmt,a[0]);
@@ -306,17 +306,17 @@ template<class T> std::string vec_to_string(const             std::vector<T>   &
     out << " ]";
     return out.str();
 };
-template<class T> std::string vec_to_string(const             std::vector<T>   &a) {
+template<class T> std::string vec_to_string(const std::vector<T> &a) {
     return vec_to_string(std::vector<double>(a.begin(), a.end()), stdFmt);
 };
 
 /// Templates for turning numbers (0D-matrices) into strings
-template<class T> std::string vec_to_string(const                         T    &a, const char *fmt) {
+template<class T> std::string vec_to_string(const T &a, const char *fmt) {
     std::vector<T> vec;
     vec.push_back(a);
     return vec_to_string(vec, fmt);
 };
-template<class T> std::string vec_to_string(const                         T    &a) {
+template<class T> std::string vec_to_string(const T &a) {
     return vec_to_string((double) a, stdFmt);
 };
 

--- a/include/SpeedTest.h
+++ b/include/SpeedTest.h
@@ -5,7 +5,7 @@
 
 namespace CoolProp{
 
-void compare_REFPROP_and_CoolProp(std::string fluid, int inputs, double val1, double val2, std::size_t N, double d1 = 0, double d2 = 0);
+void compare_REFPROP_and_CoolProp(const std::string &fluid, int inputs, double val1, double val2, std::size_t N, double d1 = 0, double d2 = 0);
 
 } /* namespace CoolProp */
 

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -18,8 +18,8 @@ namespace CoolProp {
 
 AbstractState * AbstractState::factory(const std::string &backend, const std::vector<std::string> &fluid_names)
 {
-    static std::string HEOS_string = "HEOS";
-    if (!backend.compare("HEOS"))
+    static const std::string HEOS_string = "HEOS";
+    if (!backend.compare(HEOS_string))
     {
         if (fluid_names.size() == 1){
             return new HelmholtzEOSBackend(fluid_names[0]);
@@ -65,7 +65,7 @@ AbstractState * AbstractState::factory(const std::string &backend, const std::ve
         else
         {
             // Split string at the '::' into two std::string, call again
-            return factory(std::string(fluid_names[0].begin(), fluid_names[0].begin() + idel), std::string(fluid_names[0].begin()+idel+2, fluid_names[0].end()));
+            return factory(std::string(fluid_names[0].begin(), fluid_names[0].begin() + idel), std::string(fluid_names[0].begin()+(idel+2), fluid_names[0].end()));
         }
     }
     else

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -60,7 +60,7 @@ void FlashRoutines::PT_flash_mixtures(HelmholtzEOSMixtureBackend &HEOS)
                 }
                 HEOS.update_DmolarT_direct(rhomolar, HEOS._T);
             }
-            catch(std::exception &){
+            catch(...){
                 // If that fails, try a bounded solver
                 CoolPropDbl rhomolar = Brent(resid, closest_state.rhomolar, 1e-10, DBL_EPSILON, 1e-10, 100, errstr);
                 // Make sure the solution is within the bounds
@@ -282,7 +282,7 @@ void FlashRoutines::QT_flash(HelmholtzEOSMixtureBackend &HEOS)
                     throw ValueError("pseudo-pure failed");
                 }
             }
-            catch (std::exception &){
+            catch (...){
                 // Near the critical point, the behavior is not very nice, so we will just use the ancillary
                 rhoLsat = rhoLanc;
                 rhoVsat = rhoVanc;
@@ -394,7 +394,7 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend &HEOS)
                         // If you get here, there was no error, all is well
                         break;
                     }
-                    catch(std::exception &){
+                    catch(...){
                         if (omega < 1.1*increment){
                             throw;
                         }
@@ -402,7 +402,7 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend &HEOS)
                     }
                 }
             }
-            catch(std::exception &){
+            catch(...){
                 // We may need to polish the solution at low pressure
                 SaturationSolvers::saturation_P_pure_1D_T(HEOS, HEOS._p, options);
             }
@@ -473,7 +473,7 @@ void FlashRoutines::PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend &HEOS, parame
         // *********************************************************
         // Find the correct solution
         std::vector<std::size_t> solutions;
-        for (std::vector< std::pair<std::size_t, std::size_t> >::iterator it = intersections.begin(); it != intersections.end(); ++it){
+        for (std::vector< std::pair<std::size_t, std::size_t> >::const_iterator it = intersections.begin(); it != intersections.end(); ++it){
             if (std::abs(env.Q[it->first] - HEOS._Q) < 10*DBL_EPSILON && std::abs(env.Q[it->second] - HEOS._Q) < 10*DBL_EPSILON ){
                 solutions.push_back(it->first);
             }
@@ -547,7 +547,7 @@ void FlashRoutines::PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend &HEOS, parame
         
          // Find the correct solution
         std::vector<std::size_t> liquid_solutions, vapor_solutions;
-        for (std::vector< std::pair<std::size_t, std::size_t> >::iterator it = intersections.begin(); it != intersections.end(); ++it){
+        for (std::vector< std::pair<std::size_t, std::size_t> >::const_iterator it = intersections.begin(); it != intersections.end(); ++it){
             if (std::abs(env.Q[it->first] - 0) < 10*DBL_EPSILON && std::abs(env.Q[it->second] - 0) < 10*DBL_EPSILON ){
                 liquid_solutions.push_back(it->first);
             }
@@ -1024,7 +1024,7 @@ void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend &HE
         // Un-specify the phase of the fluid
         HEOS.unspecify_phase();
     }
-    catch(std::exception &){
+    catch(...){
         // Un-specify the phase of the fluid
         HEOS.unspecify_phase();
         
@@ -1280,7 +1280,7 @@ void FlashRoutines::HS_flash_singlephase(HelmholtzEOSMixtureBackend &HEOS, CoolP
                 good_solution = true;
                 break;
             }
-            catch(std::exception &){
+            catch(...){
                 HEOS.clear();
                 continue;
             }            
@@ -1415,7 +1415,7 @@ void FlashRoutines::HS_flash(HelmholtzEOSMixtureBackend &HEOS)
                     HEOS.update(DmolarT_INPUTS, HEOS_copy->rhomolar(), HEOS_copy->T());
                     break;
                 }
-                catch(std::exception &){
+                catch(...){
                     try{
                         // Trying again with another guessed value
                         HEOS_copy->update(DmolarT_INPUTS, HEOS.rhomolar_critical()*1.3, HEOS.Tmax());
@@ -1424,7 +1424,7 @@ void FlashRoutines::HS_flash(HelmholtzEOSMixtureBackend &HEOS)
                         HEOS.update(DmolarT_INPUTS, HEOS_copy->rhomolar(), HEOS_copy->T());
                         break;
                     }
-                    catch (std::exception &){
+                    catch (...){
                         // Trying again with another guessed value
                         HEOS_copy->update(DmolarT_INPUTS, HEOS.rhomolar_critical(), 0.5*HEOS.Tmax() + 0.5*HEOS.T_critical());
                         HS_flash_singlephase(*HEOS_copy, HEOS.hmolar(), HEOS.smolar(), options);

--- a/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
+++ b/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
@@ -23,7 +23,7 @@ SaturationAncillaryFunction::SaturationAncillaryFunction(rapidjson::Value &json_
             Tmin = cpjson::get_double(json_code,"Tmin");
             Tmax = cpjson::get_double(json_code,"Tmax");
         }
-        catch (std::exception &){
+        catch (...){
             Tmin = _HUGE;
             Tmax = _HUGE;
         }
@@ -115,7 +115,7 @@ double SaturationAncillaryFunction::invert(double value, double min_bound, doubl
         // because then you get (negative number)^(double) which is undefined.
         return Brent(resid,min_bound,max_bound,DBL_EPSILON,1e-10,100,errstring);
     }
-    catch(std::exception &){
+    catch(...){
         return Secant(resid,max_bound, -0.01, 1e-12, 100, errstring);
     }
 }

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
@@ -23,7 +23,7 @@ JSONFluidLibrary & get_library(void){
     return library;
 }
 
-CoolPropFluid& get_fluid(std::string fluid_string){
+CoolPropFluid& get_fluid(const std::string &fluid_string){
     if (library.is_empty()){ load(); }
     return library.get(fluid_string);
 }

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.h
@@ -1171,9 +1171,8 @@ public:
     */
     CoolPropFluid& get(const std::string &key)
     {
-        std::map<std::string, std::size_t>::iterator it;
         // Try to find it
-        it = string_to_index_map.find(key);
+        std::map<std::string, std::size_t>::const_iterator it = string_to_index_map.find(key);
         // If it is found
         if (it != string_to_index_map.end()){
             return get(it->second);
@@ -1188,9 +1187,8 @@ public:
     */
     CoolPropFluid& get(std::size_t key)
     {
-        std::map<std::size_t,CoolPropFluid>::iterator it;
         // Try to find it
-        it = fluid_map.find(key);
+        std::map<std::size_t, CoolPropFluid>::iterator it = fluid_map.find(key);
         // If it is found
         if (it != fluid_map.end()){
             return it->second;
@@ -1213,7 +1211,7 @@ JSONFluidLibrary & get_library(void);
 std::string get_fluid_list(void);
 
 /// Get the fluid structure returned as a reference
-CoolPropFluid& get_fluid(std::string fluid_string);
+CoolPropFluid& get_fluid(const std::string &fluid_string);
 
 } /* namespace CoolProp */
 #endif

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -1791,7 +1791,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::solver_for_rho_given_T_oneof_HSU(CoolPro
             CoolPropDbl rhomolar = Brent(resid, rhomin, rhoV, LDBL_EPSILON, 1e-12, 100, errstring);
             return rhomolar;
         }
-        catch(std::exception &)
+        catch(...)
         {
             throw ValueError();
         }
@@ -1887,7 +1887,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::solver_rho_Tp(CoolPropDbl T, CoolPropDbl
         }
         return rhomolar;
     }
-    catch(std::exception &)
+    catch(...)
     {
         try{
             // Next we try with Secant method shooting off from the guess value
@@ -1896,7 +1896,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::solver_rho_Tp(CoolPropDbl T, CoolPropDbl
             return rhomolar;
             
         }
-        catch(std::exception &)
+        catch(...)
         {
             try{
                 // Next we try with a Brent method bounded solver since the function is 1-1

--- a/src/Backends/Helmholtz/MixtureParameters.cpp
+++ b/src/Backends/Helmholtz/MixtureParameters.cpp
@@ -40,7 +40,7 @@ static PredefinedMixturesLibrary predefined_mixtures_library;
 std::string get_csv_predefined_mixtures()
 {
     std::vector<std::string> out;
-    for (std::map< std::string, Dictionary >::iterator it = predefined_mixtures_library.predefined_mixture_map.begin(); it != predefined_mixtures_library.predefined_mixture_map.end(); ++it)
+    for (std::map< std::string, Dictionary >::const_iterator it = predefined_mixtures_library.predefined_mixture_map.begin(); it != predefined_mixtures_library.predefined_mixture_map.end(); ++it)
     {
         out.push_back(it->first);
     }
@@ -48,7 +48,7 @@ std::string get_csv_predefined_mixtures()
 }
 
 bool is_predefined_mixture(const std::string &name, Dictionary &dict){
-    std::map<std::string, Dictionary>::iterator iter = predefined_mixtures_library.predefined_mixture_map.find(name);
+    std::map<std::string, Dictionary>::const_iterator iter = predefined_mixtures_library.predefined_mixture_map.find(name);
     if (iter != predefined_mixtures_library.predefined_mixture_map.end()){
         dict = iter->second;
         return true;
@@ -145,7 +145,7 @@ static MixtureBinaryPairLibrary mixturebinarypairlibrary;
 std::string get_csv_mixture_binary_pairs()
 {
     std::vector<std::string> out;
-    for (std::map< std::vector<std::string>, std::vector<Dictionary> >::iterator it = mixturebinarypairlibrary.binary_pair_map.begin(); it != mixturebinarypairlibrary.binary_pair_map.end(); ++it)
+    for (std::map< std::vector<std::string>, std::vector<Dictionary> >::const_iterator it = mixturebinarypairlibrary.binary_pair_map.begin(); it != mixturebinarypairlibrary.binary_pair_map.end(); ++it)
     {
         out.push_back(strjoin(it->first, "&"));
     }
@@ -176,7 +176,7 @@ std::string get_mixture_binary_pair_data(const std::string &CAS1, const std::str
             else if (key == "betaV"){ return format("%0.16g", v[0].get_double("betaV")); }
             else{ }
         }
-        catch(std::exception &){ }
+        catch(...){ }
         throw ValueError(format("Could not match the parameter [%s] for the binary pair [%s,%s] - for now this is an error.", key.c_str(), CAS1.c_str(), CAS2.c_str()));
     }
     else{
@@ -267,7 +267,7 @@ public:
                 //
                 // Collect all the current names for departure functions for a nicer error message
                 std::vector<std::string> names;
-                for (std::map<std::string, Dictionary>::iterator it = departure_function_map.begin(); it != departure_function_map.end(); ++it)
+                for (std::map<std::string, Dictionary>::const_iterator it = departure_function_map.begin(); it != departure_function_map.end(); ++it)
                 {
                     names.push_back(it->first);
                 }

--- a/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
+++ b/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
@@ -145,7 +145,7 @@ void PhaseEnvelopeRoutines::build(HelmholtzEOSMixtureBackend &HEOS)
                 throw ValueError("Invalid number");
             }
         }
-        catch(std::exception &){
+        catch(...){
             //std::cout << e.what() << std::endl;
             //std::cout << IO.T << " " << IO.p << std::endl;
             // Try again, but with a smaller step
@@ -258,7 +258,7 @@ void PhaseEnvelopeRoutines::refine(HelmholtzEOSMixtureBackend &HEOS)
                                      IO.hmolar_vap, IO.smolar_liq, IO.smolar_vap, IO.x, IO.y, i+1);
                 std::cout << "dv " << IO.rhomolar_vap << " dl " << IO.rhomolar_liq << " T " << IO.T << " p " << IO.p  << " hl " << IO.hmolar_liq  << " hv " << IO.hmolar_vap  << " sl " << IO.smolar_liq  << " sv " << IO.smolar_vap << " x " << vec_to_string(IO.x, "%0.10Lg")  << " Ns " << IO.Nsteps << std::endl;
             }
-            catch(std::exception &){
+            catch(...){
                 continue;
             }
             i++;

--- a/src/Backends/Helmholtz/TransportRoutines.cpp
+++ b/src/Backends/Helmholtz/TransportRoutines.cpp
@@ -978,7 +978,7 @@ void TransportRoutines::conformal_state_solver(HelmholtzEOSMixtureBackend &HEOS,
                 T0 = T_new; rhomolar0 = rhomolar_new;
                 break;
             }
-            catch(std::exception &){
+            catch(...){
                 continue;
             }
         }

--- a/src/Backends/Incompressible/IncompressibleLibrary.cpp
+++ b/src/Backends/Incompressible/IncompressibleLibrary.cpp
@@ -344,7 +344,7 @@ JSONIncompressibleLibrary::~JSONIncompressibleLibrary(){
 };
 
 /// A general function to parse the json files that hold the coefficient matrices
-IncompressibleData JSONIncompressibleLibrary::parse_coefficients(rapidjson::Value &obj, std::string id, bool vital){
+IncompressibleData JSONIncompressibleLibrary::parse_coefficients(rapidjson::Value &obj, const std::string &id, bool vital){
     IncompressibleData fluidData;
     if (obj.HasMember(id.c_str())) {
         //rapidjson::Value value = obj[id.c_str()];
@@ -400,7 +400,7 @@ IncompressibleData JSONIncompressibleLibrary::parse_coefficients(rapidjson::Valu
 }
 
 /// Get a double from the JSON storage if it is defined, otherwise return def
-double JSONIncompressibleLibrary::parse_value(rapidjson::Value &obj, std::string id, bool vital, double def=0.0){
+double JSONIncompressibleLibrary::parse_value(rapidjson::Value &obj, const std::string &id, bool vital, double def = 0.0){
     if (obj.HasMember(id.c_str())) {
         return cpjson::get_double(obj, id);
     }
@@ -415,7 +415,7 @@ double JSONIncompressibleLibrary::parse_value(rapidjson::Value &obj, std::string
 }
 
 /// Get an integer from the JSON storage to identify the composition
-composition_types JSONIncompressibleLibrary::parse_ifrac(rapidjson::Value &obj, std::string id){
+composition_types JSONIncompressibleLibrary::parse_ifrac(rapidjson::Value &obj, const std::string &id){
     std::string res = cpjson::get_string(obj, id);
     if (!res.compare("mass")) return IFRAC_MASS;
     if (!res.compare("mole")) return IFRAC_MOLE;
@@ -508,7 +508,7 @@ void JSONIncompressibleLibrary::add_one(rapidjson::Value &fluid_json) {
 
 };
 
-void JSONIncompressibleLibrary::add_obj(IncompressibleFluid fluid_obj) {
+void JSONIncompressibleLibrary::add_obj(const IncompressibleFluid &fluid_obj) {
     _is_empty = false;
 
     // Get the next index for this fluid
@@ -528,10 +528,9 @@ void JSONIncompressibleLibrary::add_obj(IncompressibleFluid fluid_obj) {
 }
 
 // Get an IncompressibleFluid instance stored in this library
-IncompressibleFluid& JSONIncompressibleLibrary::get(std::string key) {
-    std::map<std::string, std::size_t>::iterator it;
+IncompressibleFluid& JSONIncompressibleLibrary::get(const std::string &key) {
     // Try to find it
-    it = string_to_index_map.find(key);
+    std::map<std::string, std::size_t>::const_iterator it = string_to_index_map.find(key);
     // If it is found
     if (it != string_to_index_map.end()) {
         return get(it->second);
@@ -550,9 +549,8 @@ IncompressibleFluid& JSONIncompressibleLibrary::get(std::string key) {
  @param key The index of the fluid in the map
  */
 IncompressibleFluid& JSONIncompressibleLibrary::get(std::size_t key) {
-    std::map<std::size_t, IncompressibleFluid>::iterator it;
     // Try to find it
-    it = fluid_map.find(key);
+    std::map<std::size_t, IncompressibleFluid>::iterator it = fluid_map.find(key);
     // If it is found
     if (it != fluid_map.end()) {
         return it->second;
@@ -607,7 +605,7 @@ JSONIncompressibleLibrary & get_incompressible_library(void){
     return library;
 }
 
-IncompressibleFluid& get_incompressible_fluid(std::string fluid_string){
+IncompressibleFluid& get_incompressible_fluid(const std::string &fluid_string){
     if (library.is_empty()){ load_incompressible_library(); }
     return library.get(fluid_string);
 }

--- a/src/Backends/Incompressible/IncompressibleLibrary.h
+++ b/src/Backends/Incompressible/IncompressibleLibrary.h
@@ -153,9 +153,9 @@ class JSONIncompressibleLibrary
 
 protected:
     /// A general function to parse the json files that hold the coefficient matrices
-    IncompressibleData parse_coefficients(rapidjson::Value &obj, std::string id, bool vital);
-    double parse_value(rapidjson::Value &obj, std::string id, bool vital, double def);
-    composition_types parse_ifrac(rapidjson::Value &obj, std::string id);
+    IncompressibleData parse_coefficients(rapidjson::Value &obj, const std::string &id, bool vital);
+    double parse_value(rapidjson::Value &obj, const std::string &id, bool vital, double def);
+    composition_types parse_ifrac(rapidjson::Value &obj, const std::string &id);
 
 public:
     // Default constructor;
@@ -167,13 +167,13 @@ public:
     /// Add all the fluid entries in the rapidjson::Value instance passed in
     void add_many(rapidjson::Value &listing);
     void add_one(rapidjson::Value &fluid_json);
-    void add_obj(IncompressibleFluid fluid_obj);
+    void add_obj(const IncompressibleFluid &fluid_obj);
 
     /** \brief Get an IncompressibleFluid instance stored in this library
      *
      * @param name Name of the fluid
      */
-    IncompressibleFluid& get(std::string name);
+    IncompressibleFluid& get(const std::string &name);
 
     /** \brief Get a CoolPropFluid instance stored in this library
      *
@@ -197,7 +197,7 @@ std::string get_incompressible_list_pure(void);
 std::string get_incompressible_list_solution(void);
 
 /// Get the fluid structure returned as a reference
-IncompressibleFluid& get_incompressible_fluid(std::string fluid_string);
+IncompressibleFluid& get_incompressible_fluid(const std::string &fluid_string);
 
 } /* namespace CoolProp */
 #endif

--- a/src/Backends/Tabular/TabularBackends.cpp
+++ b/src/Backends/Tabular/TabularBackends.cpp
@@ -153,12 +153,12 @@ void GriddedTableBackend::build_tables(tabular_types type)
     }
 }
 
-void GriddedTableBackend::write_tables(std::string &directory){
+void GriddedTableBackend::write_tables(const std::string &directory){
     std::ofstream ofs("single_phase.bin", std::ofstream::binary);
     msgpack::pack(ofs, single_phase);
     ofs.close();
 }
-void GriddedTableBackend::load_tables(std::string &directory){
+void GriddedTableBackend::load_tables(const std::string &directory){
     
     std::ifstream ifs("single_phase.bin", std::ifstream::binary);
     std::stringstream buffer;

--- a/src/Backends/Tabular/TabularBackends.h
+++ b/src/Backends/Tabular/TabularBackends.h
@@ -55,8 +55,8 @@ class GriddedTableBackend : public AbstractState
     void set_mass_fractions(const std::vector<CoolPropDbl> &mass_fractions){};
     const std::vector<CoolPropDbl> & get_mole_fractions(){throw NotImplementedError("get_mole_fractions not implemented for TTSE");};
     void build_tables(tabular_types type);
-    void write_tables(std::string &directory);
-    void load_tables(std::string &directory);
+    void write_tables(const std::string &directory);
+    void load_tables(const std::string &directory);
     void bounding_curves(void);
     
 };

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -20,7 +20,7 @@ std::string config_key_to_string(configuration_keys keys)
 }; 
 
 /// Go from string to enum key
-configuration_keys config_string_to_key(std::string &s)
+configuration_keys config_string_to_key(const std::string &s)
 {
     /* See http://stackoverflow.com/a/148610
      * See http://stackoverflow.com/questions/147267/easy-way-to-use-variables-of-enum-types-as-string-in-c#202511
@@ -42,7 +42,7 @@ void set_config_bool(configuration_keys key, bool val){
 void set_config_double(configuration_keys key, double val){ 
 	config.get_item(key).set_double(val); 
 }
-void set_config_string(configuration_keys key, std::string val){ 
+void set_config_string(configuration_keys key, const std::string &val){ 
     config.get_item(key).set_string(val); 
 }
 
@@ -58,7 +58,7 @@ std::string get_config_string(configuration_keys key){
 void get_config_as_json(rapidjson::Document &doc){
     // Get the items
     std::map<configuration_keys, ConfigurationItem> items = config.get_items();
-    for (std::map<configuration_keys, ConfigurationItem>::iterator it = items.begin(); it != items.end(); ++it){
+    for (std::map<configuration_keys, ConfigurationItem>::const_iterator it = items.begin(); it != items.end(); ++it){
         it->second.add_to_json(doc, doc);
     }
 }
@@ -102,7 +102,7 @@ void set_config_as_json(rapidjson::Value &val){
         }
     }
 }
-void set_config_as_json_string(std::string &s){
+void set_config_as_json_string(const std::string &s){
     // Init the rapidjson doc
     rapidjson::Document doc;
     doc.Parse<0>(s.c_str());

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -108,13 +108,12 @@ EXPORT_CODE long CONVENTION redirect_stdout(const char* file){
 }
 EXPORT_CODE int CONVENTION set_reference_stateS(const char *Ref, const char *reference_state)
 {
-    std::string _Ref = Ref, _reference_state = reference_state;
     try{
-        CoolProp::set_reference_stateS(_Ref, _reference_state);
+        CoolProp::set_reference_stateS(std::string(Ref), std::string(reference_state));
         reset_fpu();
         return true;
     }
-    catch(std::exception &){
+    catch(...){
         reset_fpu();
         return false;
     }
@@ -126,7 +125,7 @@ EXPORT_CODE int CONVENTION set_reference_stateD(const char *Ref, double T, doubl
         reset_fpu();
         return true;
     }
-    catch(std::exception &){
+    catch(...){
         reset_fpu();
         return false;
     }
@@ -172,8 +171,7 @@ EXPORT_CODE double CONVENTION saturation_ancillary(const char *fluid_name, const
 {
     try
     {
-        std::string _output = output, _input = input;
-        double val = CoolProp::saturation_ancillary(fluid_name, _output, Q, _input, value);
+        double val = CoolProp::saturation_ancillary(fluid_name, std::string(output), Q, std::string(input), value);
         reset_fpu();
         return val;
     }
@@ -182,31 +180,21 @@ EXPORT_CODE double CONVENTION saturation_ancillary(const char *fluid_name, const
 }
 EXPORT_CODE double CONVENTION Props1SI(const char *FluidName, const char *Output)
 {
-    std::string _Output = Output, _FluidName = FluidName;
-    double val = CoolProp::Props1SI(_FluidName, _Output);
+    double val = CoolProp::Props1SI(std::string(FluidName), std::string(Output));
     reset_fpu();
     return val;
 }
 EXPORT_CODE double CONVENTION PropsSI(const char *Output, const char *Name1, double Prop1, const char *Name2, double Prop2, const char * FluidName)
 {
-    std::string _Output = Output, _Name1 = Name1, _Name2 = Name2, _FluidName = FluidName;
-    double val = CoolProp::PropsSI(_Output, _Name1, Prop1, _Name2, Prop2, _FluidName);
+    double val = CoolProp::PropsSI(std::string(Output), std::string(Name1), Prop1, std::string(Name2), Prop2, std::string(FluidName));
     reset_fpu();
     return val;
 }
 EXPORT_CODE long CONVENTION PhaseSI(const char *Name1, double Prop1, const char *Name2, double Prop2, const char * FluidName, char *phase, int n)
 {
-    std::string _Name1 = Name1, _Name2 = Name2, _FluidName = FluidName;
-    std::string s = CoolProp::PhaseSI(_Name1, Prop1, _Name2, Prop2, _FluidName);
-    if (s.size() < static_cast<unsigned int>(n)){
-        strcpy(phase, s.c_str());
-        reset_fpu();
-        return 1;
-    }
-    else{
-        reset_fpu();
-        return 0;
-    }
+    std::string s = CoolProp::PhaseSI(std::string(Name1), Prop1, std::string(Name2), Prop2, std::string(FluidName));
+    reset_fpu();
+    return str2buf(s, phase, n) ? 1 : 0;
 }
 /*
  * EXPORT_CODE double CONVENTION PropsSIZ(const char *Output, const char *Name1, double Prop1, const char *Name2, double Prop2, const char * FluidName, const double *z, int n)
@@ -217,11 +205,9 @@ EXPORT_CODE long CONVENTION PhaseSI(const char *Name1, double Prop1, const char 
     return val;
 }
  * */
-EXPORT_CODE void CONVENTION propssi_(const char *Output, const char *Name1, double *Prop1, const char *Name2, double *Prop2, const char * FluidName, double *output)
+EXPORT_CODE void CONVENTION propssi_(const char *Output, const char *Name1, const double *Prop1, const char *Name2, const double *Prop2, const char * FluidName, double *output)
 {
-    std::string _Output = Output, _Name1 = Name1, _Name2 = Name2, _FluidName = FluidName;
-    *output = CoolProp::PropsSI(_Output, _Name1, *Prop1, _Name2, *Prop2, _FluidName);
-    reset_fpu();
+    *output = PropsSI(Output, Name1, *Prop1, Name2, *Prop2, FluidName);
 }
 
 EXPORT_CODE double CONVENTION K2F(double T){
@@ -240,84 +226,62 @@ EXPORT_CODE long CONVENTION get_param_index(const char * param){
     try{
         return CoolProp::get_parameter_index(param);
     }
-    catch(std::exception &){
+    catch(...){
         return -1;
     }
 }
 EXPORT_CODE long CONVENTION get_global_param_string(const char *param, char * Output, int n)
 {
-    std::string s;
     try{
-        s = CoolProp::get_global_param_string(param);
+        std::string s = CoolProp::get_global_param_string(param);
+        return str2buf(s, Output, n) ? 1 : 0;
     }
-    catch(std::exception &){
-        return 0;
-    }
-    if (s.size() < static_cast<unsigned int>(n)){
-        strcpy(Output, s.c_str()); 
-        return 1;
-    }
-    else{
+    catch(...){
         return 0;
     }
 }
 EXPORT_CODE long CONVENTION get_parameter_information_string(const char *param, char * Output, int n)
 {
-    int key;
     try{
-        key = CoolProp::get_parameter_index(param);
+        int key = CoolProp::get_parameter_index(param);
+        if (key >= 0){
+            std::string s = CoolProp::get_parameter_information(key, Output);
+            return str2buf(s, Output, n) ? 1 : 0;
+        }
+        else{
+            str2buf(format("parameter is invalid: %s", param), Output, n);
+        }
     }
-    catch(std::exception &){
-        return 0;
-    }
-    if (key >= 0){
-        std::string s = CoolProp::get_parameter_information(key, Output);
-        return str2buf(s, Output, n) ? 1 : 0;
-    }
-    else{
-        str2buf(format("parameter is invalid: %s", param), Output, n);
-        return 0;
-    }
+    catch(...){}
+    return 0;
 }
 EXPORT_CODE long CONVENTION get_fluid_param_string(const char *fluid, const char *param, char * Output, int n)
 {
-    std::string s;
     try{
-        s = CoolProp::get_fluid_param_string(std::string(fluid), std::string(param));
+        std::string s = CoolProp::get_fluid_param_string(std::string(fluid), std::string(param));
+        return str2buf(s, Output, n) ? 1 : 0;
     }
-    catch(std::exception &){
-        return 0;
-    }
-    if (s.size() < static_cast<unsigned int>(n)){
-        strcpy(Output, s.c_str()); 
-        return 1;
-    }
-    else{
+    catch(...){
         return 0;
     }
 }
 EXPORT_CODE double CONVENTION HAPropsSI(const char *Output, const char *Name1, double Prop1, const char *Name2, double Prop2, const char * Name3, double Prop3)
 {
-    std::string _Output = Output, _Name1 = Name1, _Name2 = Name2, _Name3 = Name3;
-    double val = HumidAir::HAPropsSI(Output, _Name1, Prop1, _Name2, Prop2, _Name3, Prop3);
+    double val = HumidAir::HAPropsSI(std::string(Output), std::string(Name1), Prop1, std::string(Name2), Prop2, std::string(Name3), Prop3);
     reset_fpu();
     return val;
 }
-EXPORT_CODE void CONVENTION hapropssi_(const char *Output, const char *Name1, double *Prop1, const char *Name2, double *Prop2, const char * Name3, double * Prop3, double *output)
+EXPORT_CODE void CONVENTION hapropssi_(const char *Output, const char *Name1, const double *Prop1, const char *Name2, const double *Prop2, const char * Name3, const double * Prop3, double *output)
 {
-    std::string _Output = Output, _Name1 = Name1, _Name2 = Name2, _Name3 = Name3;
-    *output = HumidAir::HAPropsSI(_Output, _Name1, *Prop1, _Name2, *Prop2, _Name3, *Prop3);
-    reset_fpu();
+    *output = HAPropsSI(Output, Name1, *Prop1, Name2, *Prop2, Name3, *Prop3);
 }
 EXPORT_CODE double CONVENTION HAProps(const char *Output, const char *Name1, double Prop1, const char *Name2, double Prop2, const char * Name3, double Prop3)
 {
-    std::string _Output = Output, _Name1 = Name1, _Name2 = Name2, _Name3 = Name3;
-    double val = HumidAir::HAProps(Output, _Name1, Prop1, _Name2, Prop2, _Name3, Prop3);
+    double val = HumidAir::HAProps(std::string(Output), std::string(Name1), Prop1, std::string(Name2), Prop2, std::string(Name3), Prop3);
     reset_fpu();
     return val;
 }
-EXPORT_CODE void CONVENTION haprops_(const char *Output, const char *Name1, double *Prop1, const char *Name2, double *Prop2, const char * Name3, double * Prop3, double *output)
+EXPORT_CODE void CONVENTION haprops_(const char *Output, const char *Name1, const double *Prop1, const char *Name2, const double *Prop2, const char * Name3, const double * Prop3, double *output)
 {
     *output = HAProps(Output, Name1, *Prop1, Name2, *Prop2, Name3, *Prop3);
-    reset_fpu();
 }

--- a/src/DataStructures.cpp
+++ b/src/DataStructures.cpp
@@ -10,88 +10,86 @@ namespace CoolProp{
 struct parameter_info
 {    
     int key;
-    std::string short_desc, IO, units, description;
+    const char *short_desc, *IO, *units, *description;
     bool trivial; ///< True if the input is trivial, and can be directly calculated (constants like critical properties, etc.)
-public:
-    parameter_info(int key, std::string short_desc, std::string IO, std::string units, std::string description, bool trivial): key(key), short_desc(short_desc), IO(IO), units(units), description(description), trivial(trivial){};
 };
 
-parameter_info parameter_info_list[] = {
+const parameter_info parameter_info_list[] = {
     /// Input/Output parameters
-    parameter_info(iT, "T", "IO", "K", "Temperature",false),
-    parameter_info(iP, "P", "IO", "Pa", "Pressure",false),
-    parameter_info(iDmolar, "Dmolar","IO","mol/m^3","Molar density",false),
-    parameter_info(iHmolar, "Hmolar","IO","J/mol","Molar specific enthalpy",false),
-    parameter_info(iSmolar, "Smolar","IO","J/mol/K","Molar specific entropy",false),
-    parameter_info(iUmolar, "Umolar","IO","J/mol","Molar specific internal energy",false),
-    parameter_info(iGmolar, "Gmolar","O","J/mol","Molar specific Gibbs energy",false),
-    parameter_info(iDmass, "Dmass","IO","kg/m^3","Mass density",false),
-    parameter_info(iHmass, "Hmass","IO","J/kg","Mass specific enthalpy",false),
-    parameter_info(iSmass, "Smass","IO","J/kg/K","Mass specific entropy",false),
-    parameter_info(iUmass, "Umass","IO","J/kg","Mass specific internal energy",false),
-    parameter_info(iGmass, "Gmass","O","J/kg","Mass specific Gibbs energy",false),
-    parameter_info(iQ, "Q","IO","mol/mol","Mass vapor quality",false),
-    parameter_info(iDelta, "Delta","IO","-","Reduced density (rho/rhoc)",false),
-    parameter_info(iTau, "Tau","IO","-","Reciprocal reduced temperature (Tc/T)",false),
+    parameter_info{ iT, "T", "IO", "K", "Temperature", false },
+    parameter_info{ iP, "P", "IO", "Pa", "Pressure", false },
+    parameter_info{ iDmolar, "Dmolar", "IO", "mol/m^3", "Molar density", false },
+    parameter_info{ iHmolar, "Hmolar", "IO", "J/mol", "Molar specific enthalpy", false },
+    parameter_info{ iSmolar, "Smolar", "IO", "J/mol/K", "Molar specific entropy", false },
+    parameter_info{ iUmolar, "Umolar", "IO", "J/mol", "Molar specific internal energy", false },
+    parameter_info{ iGmolar, "Gmolar", "O", "J/mol", "Molar specific Gibbs energy", false },
+    parameter_info{ iDmass, "Dmass", "IO", "kg/m^3", "Mass density", false },
+    parameter_info{ iHmass, "Hmass", "IO", "J/kg", "Mass specific enthalpy", false },
+    parameter_info{ iSmass, "Smass", "IO", "J/kg/K", "Mass specific entropy", false },
+    parameter_info{ iUmass, "Umass", "IO", "J/kg", "Mass specific internal energy", false },
+    parameter_info{ iGmass, "Gmass", "O", "J/kg", "Mass specific Gibbs energy", false },
+    parameter_info{ iQ, "Q", "IO", "mol/mol", "Mass vapor quality", false },
+    parameter_info{ iDelta, "Delta", "IO", "-", "Reduced density (rho/rhoc)", false },
+    parameter_info{ iTau, "Tau", "IO", "-", "Reciprocal reduced temperature (Tc/T)", false },
     /// Output only
-    parameter_info(iCpmolar, "Cpmolar","O","J/mol/K","Molar specific constant presssure specific heat",false),
-    parameter_info(iCpmass, "Cpmass","O","J/kg/K","Mass specific constant presssure specific heat",false),
-    parameter_info(iCvmolar, "Cvmolar","O","J/mol/K","Molar specific constant volume specific heat",false),
-    parameter_info(iCvmass, "Cvmass","O","J/kg/K","Mass specific constant volume specific heat",false),
-    parameter_info(iCp0molar, "Cp0molar","O","J/mol/K","Ideal gas molar specific constant presssure specific heat",false),
-    parameter_info(iCp0mass, "Cp0mass","O","J/kg/K","Ideal gas mass specific constant presssure specific heat",false),
-    parameter_info(iGWP20, "GWP20","O","-","20-year gobal warming potential",true),
-    parameter_info(iGWP100, "GWP100","O","-","100-year gobal warming potential",true),
-    parameter_info(iGWP500, "GWP500","O","-","500-year gobal warming potential",true),
-    parameter_info(iFH, "FH","O","-","Flammability hazard",true),
-    parameter_info(iHH, "HH","O","-","Health hazard",true),
-    parameter_info(iPH, "PH","O","-","Physical hazard",true),
-    parameter_info(iODP, "ODP","O","-","Ozone depletion potential",true),
-    parameter_info(iBvirial, "Bvirial","O","-","Second virial coefficient",false),
-    parameter_info(iCvirial, "Cvirial","O","-","Third virial coefficient",false),
-    parameter_info(idBvirial_dT, "dBvirial_dT","O","-","Derivative of second virial coefficient with respect to T",false),
-    parameter_info(idCvirial_dT, "dCvirial_dT","O","-","Derivative of third virial coefficient with respect to T",false),
-    parameter_info(igas_constant, "gas_constant","O","J/mol/K","Molar gas constant",true),
-	parameter_info(imolar_mass, "molar_mass","O","kg/mol","Molar mass",true),
-    parameter_info(iacentric_factor, "acentric","O","-","Acentric factor",true),
-    parameter_info(irhomass_reducing, "rhomass_reducing","O","kg/m^3","Mass density at reducing point",true),
-    parameter_info(irhomolar_reducing, "rhomolar_reducing","O","mol/m^3","Molar density at reducing point",true),
-    parameter_info(irhomolar_critical, "rhomolar_critical","O","mol/m^3","Molar density at critical point",true),
-    parameter_info(irhomass_critical, "rhomass_critical","O","kg/m^3","Mass density at critical point",true),
-    parameter_info(iT_reducing, "T_reducing","O","K","Temperature at the reducing point",true),
-    parameter_info(iT_critical, "T_critical","O","K","Temperature at the critical point",true),
-    parameter_info(iT_triple, "T_triple","O","K","Temperature at the triple point",true),
-    parameter_info(iT_max, "T_max","O","K","Maximum temperature limit",true),
-    parameter_info(iT_min, "T_min","O","K","Minimum temperature limit",true),
-    parameter_info(iP_min, "P_min","O","Pa","Minimum pressure limit",true),
-    parameter_info(iP_max, "P_max","O","Pa","Maximum pressure limit",true),
-    parameter_info(iP_critical, "p_critical","O","Pa","Pressure at the critical point",true),
-	parameter_info(iP_reducing, "p_reducing","O","Pa","Pressure at the reducing point",true),
-    parameter_info(iP_triple, "p_triple","O","Pa","Pressure at the triple point (pure only)",true),
-    parameter_info(ifraction_min, "fraction_min","O","-","Fraction (mole, mass, volume) minimum value for incompressible solutions",true),
-    parameter_info(ifraction_max, "fraction_max","O","-","Fraction (mole, mass, volume) maximum value for incompressible solutions",true),
-    parameter_info(iT_freeze, "T_freeze","O","K","Freezing temperature for incompressible solutions",true),
+    parameter_info{ iCpmolar, "Cpmolar", "O", "J/mol/K", "Molar specific constant presssure specific heat", false },
+    parameter_info{ iCpmass, "Cpmass", "O", "J/kg/K", "Mass specific constant presssure specific heat", false },
+    parameter_info{ iCvmolar, "Cvmolar", "O", "J/mol/K", "Molar specific constant volume specific heat", false },
+    parameter_info{ iCvmass, "Cvmass", "O", "J/kg/K", "Mass specific constant volume specific heat", false },
+    parameter_info{ iCp0molar, "Cp0molar", "O", "J/mol/K", "Ideal gas molar specific constant presssure specific heat", false },
+    parameter_info{ iCp0mass, "Cp0mass", "O", "J/kg/K", "Ideal gas mass specific constant presssure specific heat", false },
+    parameter_info{ iGWP20, "GWP20", "O", "-", "20-year gobal warming potential", true },
+    parameter_info{ iGWP100, "GWP100", "O", "-", "100-year gobal warming potential", true },
+    parameter_info{ iGWP500, "GWP500", "O", "-", "500-year gobal warming potential", true },
+    parameter_info{ iFH, "FH", "O", "-", "Flammability hazard", true },
+    parameter_info{ iHH, "HH", "O", "-", "Health hazard", true },
+    parameter_info{ iPH, "PH", "O", "-", "Physical hazard", true },
+    parameter_info{ iODP, "ODP", "O", "-", "Ozone depletion potential", true },
+    parameter_info{ iBvirial, "Bvirial", "O", "-", "Second virial coefficient", false },
+    parameter_info{ iCvirial, "Cvirial", "O", "-", "Third virial coefficient", false },
+    parameter_info{ idBvirial_dT, "dBvirial_dT", "O", "-", "Derivative of second virial coefficient with respect to T", false },
+    parameter_info{ idCvirial_dT, "dCvirial_dT", "O", "-", "Derivative of third virial coefficient with respect to T", false },
+    parameter_info{ igas_constant, "gas_constant", "O", "J/mol/K", "Molar gas constant", true },
+    parameter_info{ imolar_mass, "molar_mass", "O", "kg/mol", "Molar mass", true },
+    parameter_info{ iacentric_factor, "acentric", "O", "-", "Acentric factor", true },
+    parameter_info{ irhomass_reducing, "rhomass_reducing", "O", "kg/m^3", "Mass density at reducing point", true },
+    parameter_info{ irhomolar_reducing, "rhomolar_reducing", "O", "mol/m^3", "Molar density at reducing point", true },
+    parameter_info{ irhomolar_critical, "rhomolar_critical", "O", "mol/m^3", "Molar density at critical point", true },
+    parameter_info{ irhomass_critical, "rhomass_critical", "O", "kg/m^3", "Mass density at critical point", true },
+    parameter_info{ iT_reducing, "T_reducing", "O", "K", "Temperature at the reducing point", true },
+    parameter_info{ iT_critical, "T_critical", "O", "K", "Temperature at the critical point", true },
+    parameter_info{ iT_triple, "T_triple", "O", "K", "Temperature at the triple point", true },
+    parameter_info{ iT_max, "T_max", "O", "K", "Maximum temperature limit", true },
+    parameter_info{ iT_min, "T_min", "O", "K", "Minimum temperature limit", true },
+    parameter_info{ iP_min, "P_min", "O", "Pa", "Minimum pressure limit", true },
+    parameter_info{ iP_max, "P_max", "O", "Pa", "Maximum pressure limit", true },
+    parameter_info{ iP_critical, "p_critical", "O", "Pa", "Pressure at the critical point", true },
+    parameter_info{ iP_reducing, "p_reducing", "O", "Pa", "Pressure at the reducing point", true },
+    parameter_info{ iP_triple, "p_triple", "O", "Pa", "Pressure at the triple point (pure only)", true },
+    parameter_info{ ifraction_min, "fraction_min", "O", "-", "Fraction (mole, mass, volume) minimum value for incompressible solutions", true },
+    parameter_info{ ifraction_max, "fraction_max", "O", "-", "Fraction (mole, mass, volume) maximum value for incompressible solutions", true },
+    parameter_info{ iT_freeze, "T_freeze", "O", "K", "Freezing temperature for incompressible solutions", true },
     
-    parameter_info(ispeed_sound, "speed_of_sound","O","m/s","Speed of sound",false),
-    parameter_info(iviscosity, "viscosity","O","Pa-s","Viscosity",false),
-    parameter_info(iconductivity, "conductivity","O","W/m/K","Thermal conductivity",false),
-    parameter_info(isurface_tension, "surface_tension","O","N/m","Surface tension",false),
-    parameter_info(iPrandtl, "Prandtl","O","-","Prandtl number",false),
+    parameter_info{ ispeed_sound, "speed_of_sound", "O", "m/s", "Speed of sound", false },
+    parameter_info{ iviscosity, "viscosity", "O", "Pa-s", "Viscosity", false },
+    parameter_info{ iconductivity, "conductivity", "O", "W/m/K", "Thermal conductivity", false },
+    parameter_info{ isurface_tension, "surface_tension", "O", "N/m", "Surface tension", false },
+    parameter_info{ iPrandtl, "Prandtl", "O", "-", "Prandtl number", false },
     
-    parameter_info(iisothermal_compressibility, "isothermal_compressibility","O","1/Pa","Isothermal compressibility",false),
-    parameter_info(iisobaric_expansion_coefficient, "isobaric_expansion_coefficient","O","1/K","Isobaric expansion coefficient",false),
-    parameter_info(iZ, "Z","O","-","Compressibility factor",false),
-    parameter_info(ifundamental_derivative_of_gas_dynamics, "fundamental_derivative_of_gas_dynamics","O","-","Fundamental_derivative_of_gas_dynamics",false),
+    parameter_info{ iisothermal_compressibility, "isothermal_compressibility", "O", "1/Pa", "Isothermal compressibility", false },
+    parameter_info{ iisobaric_expansion_coefficient, "isobaric_expansion_coefficient", "O", "1/K", "Isobaric expansion coefficient", false },
+    parameter_info{ iZ, "Z", "O", "-", "Compressibility factor", false },
+    parameter_info{ ifundamental_derivative_of_gas_dynamics, "fundamental_derivative_of_gas_dynamics", "O", "-", "Fundamental_derivative_of_gas_dynamics", false },
     
-    parameter_info(ialphar, "alphar","O","-","Residual Helmholtz energy",false),
-    parameter_info(idalphar_dtau_constdelta, "dalphar_dtau_constdelta","O","-","Derivative of residual Helmholtz energy with tau",false),
-    parameter_info(idalphar_ddelta_consttau, "dalphar_ddelta_consttau","O","-","Derivative of residual Helmholtz energy with delta",false),
+    parameter_info{ ialphar, "alphar", "O", "-", "Residual Helmholtz energy", false },
+    parameter_info{ idalphar_dtau_constdelta, "dalphar_dtau_constdelta", "O", "-", "Derivative of residual Helmholtz energy with tau", false },
+    parameter_info{ idalphar_ddelta_consttau, "dalphar_ddelta_consttau", "O", "-", "Derivative of residual Helmholtz energy with delta", false },
     
-    parameter_info(ialpha0, "alpha0","O","-","Ideal Helmholtz energy",false),
-    parameter_info(idalpha0_dtau_constdelta, "dalpha0_dtau_constdelta","O","-","Derivative of ideal Helmholtz energy with tau",false),
-    parameter_info(idalpha0_ddelta_consttau, "dalpha0_ddelta_consttau","O","-","Derivative of ideal Helmholtz energy with delta",false),
+    parameter_info{ ialpha0, "alpha0", "O", "-", "Ideal Helmholtz energy", false },
+    parameter_info{ idalpha0_dtau_constdelta, "dalpha0_dtau_constdelta", "O", "-", "Derivative of ideal Helmholtz energy with tau", false },
+    parameter_info{ idalpha0_ddelta_consttau, "dalpha0_ddelta_consttau", "O", "-", "Derivative of ideal Helmholtz energy with delta", false },
     
-    parameter_info(iPhase, "Phase","O","-","Phase index as a float",false),
+    parameter_info{ iPhase, "Phase", "O", "-", "Phase index as a float", false },
     
 };
 
@@ -103,48 +101,45 @@ public:
     std::map<std::string, int> index_map;
     ParameterInformation()
     {
-        int N = sizeof(parameter_info_list)/sizeof(parameter_info_list[0]);
-        for (int i = 0; i < N; ++i)
+        const parameter_info* const end = parameter_info_list + sizeof(parameter_info_list) / sizeof(parameter_info_list[0]);
+        for (const parameter_info* el = parameter_info_list; el != end; ++el)
         {
-            parameter_info &el = parameter_info_list[i];
-            short_desc_map.insert(std::pair<int, std::string>(el.key, el.short_desc));
-            IO_map.insert(std::pair<int, std::string>(el.key, el.IO));
-            units_map.insert(std::pair<int, std::string>(el.key, el.units));
-            description_map.insert(std::pair<int, std::string>(el.key, el.description));
-            index_map.insert(std::pair<std::string, int>(el.short_desc, el.key));
-            trivial_map.insert(std::pair<int, bool>(el.key, el.trivial));
+            short_desc_map.insert(std::pair<int, std::string>(el->key, el->short_desc));
+            IO_map.insert(std::pair<int, std::string>(el->key, el->IO));
+            units_map.insert(std::pair<int, std::string>(el->key, el->units));
+            description_map.insert(std::pair<int, std::string>(el->key, el->description));
+            index_map_insert(el->short_desc, el->key);
+            trivial_map.insert(std::pair<int, bool>(el->key, el->trivial));
         }
         // Backward compatibility aliases
-        index_map.insert(std::pair<std::string, int>("D", iDmass));
-        index_map.insert(std::pair<std::string, int>("H", iHmass));
-        index_map.insert(std::pair<std::string, int>("M", imolar_mass));
-        index_map.insert(std::pair<std::string, int>("S", iSmass));
-        index_map.insert(std::pair<std::string, int>("U", iUmass));
-        index_map.insert(std::pair<std::string, int>("C", iCpmass));
-        index_map.insert(std::pair<std::string, int>("O", iCvmass));
-        index_map.insert(std::pair<std::string, int>("V", iviscosity));
-        index_map.insert(std::pair<std::string, int>("L", iconductivity));
-        index_map.insert(std::pair<std::string, int>("pcrit", iP_critical));
-        index_map.insert(std::pair<std::string, int>("Pcrit", iP_critical));
-        index_map.insert(std::pair<std::string, int>("Tcrit", iT_critical));
-        index_map.insert(std::pair<std::string, int>("Ttriple", iT_triple));
-        index_map.insert(std::pair<std::string, int>("ptriple", iP_triple));
-        index_map.insert(std::pair<std::string, int>("rhocrit", irhomass_critical));
-        index_map.insert(std::pair<std::string, int>("Tmin", iT_min));
-        index_map.insert(std::pair<std::string, int>("Tmax", iT_max));
-        index_map.insert(std::pair<std::string, int>("pmax", iP_max));
-        index_map.insert(std::pair<std::string, int>("pmin", iP_min));
-        index_map.insert(std::pair<std::string, int>("molemass", imolar_mass));
-        index_map.insert(std::pair<std::string, int>("molarmass", imolar_mass));
-        index_map.insert(std::pair<std::string, int>("A", ispeed_sound));
-		index_map.insert(std::pair<std::string, int>("I", isurface_tension));
-
-        std::map<std::string,int>::iterator it;
-        for(it = index_map.begin(); it != index_map.end(); ++it )
-        {
-            // Add all upper-case aliases for EES support (fine to just do it if is already there)
-            index_map.insert(std::pair<std::string, int>(upper(it->first), it->second));
-        }
+        index_map_insert("D", iDmass);
+        index_map_insert("H", iHmass);
+        index_map_insert("M", imolar_mass);
+        index_map_insert("S", iSmass);
+        index_map_insert("U", iUmass);
+        index_map_insert("C", iCpmass);
+        index_map_insert("O", iCvmass);
+        index_map_insert("V", iviscosity);
+        index_map_insert("L", iconductivity);
+        index_map_insert("pcrit", iP_critical);
+        index_map_insert("Pcrit", iP_critical);
+        index_map_insert("Tcrit", iT_critical);
+        index_map_insert("Ttriple", iT_triple);
+        index_map_insert("ptriple", iP_triple);
+        index_map_insert("rhocrit", irhomass_critical);
+        index_map_insert("Tmin", iT_min);
+        index_map_insert("Tmax", iT_max);
+        index_map_insert("pmax", iP_max);
+        index_map_insert("pmin", iP_min);
+        index_map_insert("molemass", imolar_mass);
+        index_map_insert("molarmass", imolar_mass);
+        index_map_insert("A", ispeed_sound);
+		index_map_insert("I", isurface_tension);
+    }
+private:
+    void index_map_insert(const std::string &desc, int key) {
+        index_map.insert(std::pair<std::string, int>(desc, key));
+        index_map.insert(std::pair<std::string, int>(upper(desc), key));
     }
 };
 
@@ -152,10 +147,8 @@ static ParameterInformation parameter_information;
 
 bool is_trivial_parameter(int key)
 {
-    std::map<int, bool>::iterator it;
-
     // Try to find it
-    it = parameter_information.trivial_map.find(key);
+    std::map<int, bool>::const_iterator it = parameter_information.trivial_map.find(key);
     // If equal to end, not found
     if (it != parameter_information.trivial_map.end())
     {
@@ -168,10 +161,9 @@ bool is_trivial_parameter(int key)
     }
 }
 
-std::string get_parameter_information(int key, std::string info)
+std::string get_parameter_information(int key, const std::string &info)
 {
     std::map<int, std::string> *M;
-    std::map<int, std::string>::iterator it;
 
     // Hook up the right map (since they are all of the same type)
     if (!info.compare("IO")){
@@ -190,9 +182,9 @@ std::string get_parameter_information(int key, std::string info)
         throw ValueError(format("Bad info string [%s] to get_parameter_information",info.c_str()));
 
     // Try to find it
-    it = (*M).find(key);
+    std::map<int, std::string>::const_iterator it = M->find(key);
     // If equal to end, not found
-    if (it != (*M).end())
+    if (it != M->end())
     {
         // Found it, return it
         return it->second;
@@ -207,8 +199,7 @@ std::string get_parameter_information(int key, std::string info)
 std::string get_csv_parameter_list()
 {
     std::vector<std::string> strings;
-    std::map<std::string,int>::iterator it;
-    for(it = parameter_information.index_map.begin(); it != parameter_information.index_map.end(); ++it )
+    for(std::map<std::string,int>::const_iterator it = parameter_information.index_map.begin(); it != parameter_information.index_map.end(); ++it )
     {
         strings.push_back(it->first);
     }
@@ -216,10 +207,8 @@ std::string get_csv_parameter_list()
 }
 bool is_valid_parameter(const std::string &param_name, parameters &iOutput)
 {
-    std::map<std::string, int>::iterator it;
-    
     // Try to find it
-    it = parameter_information.index_map.find(param_name);
+    std::map<std::string, int>::const_iterator it = parameter_information.index_map.find(param_name);
     // If equal to end, not found
     if (it != parameter_information.index_map.end()){
         // Found, return it
@@ -231,10 +220,8 @@ bool is_valid_parameter(const std::string &param_name, parameters &iOutput)
     }
 }
 
-bool is_valid_first_derivative(const std::string & name, parameters &iOf, parameters &iWrt, parameters &iConstant)
+bool is_valid_first_derivative(const std::string &name, parameters &iOf, parameters &iWrt, parameters &iConstant)
 {
-    std::size_t iN0, iN1, iD0, iD1;
-    parameters Of, Wrt, Constant;
     if (get_debug_level() > 5){std::cout << format("is_valid_first_derivative(%s)",name.c_str());}
     // There should be exactly one /
     // There should be exactly one |
@@ -246,16 +233,17 @@ bool is_valid_first_derivative(const std::string & name, parameters &iOf, parame
     std::vector<std::string> split_at_slash = strsplit(split_at_bar[0], '/'); // "d(P)" and "d(T)"
     if (split_at_slash.size() != 2){return false;}
     
-    iN0 = split_at_slash[0].find("(");
-    iN1 = split_at_slash[0].find(")", iN0);
-    if (!(iN0 > 0 && iN1 > 0 && iN1 > iN0)){return false;}
-    std::string num = split_at_slash[0].substr(iN0+1, iN1-2);
+    std::size_t i0 = split_at_slash[0].find("(");
+    std::size_t i1 = split_at_slash[0].find(")", i0);
+    if (!((i0 > 0) && (i0 != std::string::npos) && (i1 > (i0+1)) && (i1 != std::string::npos))){return false;}
+    std::string num = split_at_slash[0].substr(i0+1, i1-i0-1);
     
-    iD0 = split_at_slash[1].find("(");
-    iD1 = split_at_slash[1].find(")", iD0);
-    if (!(iD0 > 0 && iD1 > 0 && iD1 > iD0)){return false;}
-    std::string den = split_at_slash[1].substr(iD0+1, iD1-2);
+    i0 = split_at_slash[1].find("(");
+    i1 = split_at_slash[1].find(")", i0);
+    if (!((i0 > 0) && (i0 != std::string::npos) && (i1 > (i0+1)) && (i1 != std::string::npos))){return false;}
+    std::string den = split_at_slash[1].substr(i0+1, i1-i0-1);
     
+    parameters Of, Wrt, Constant;
     if (is_valid_parameter(num, Of) && is_valid_parameter(den, Wrt) && is_valid_parameter(split_at_bar[1], Constant)){
         iOf = Of; iWrt = Wrt; iConstant = Constant; return true;
     }
@@ -264,32 +252,32 @@ bool is_valid_first_derivative(const std::string & name, parameters &iOf, parame
     }
 }
 
-bool is_valid_second_derivative(const std::string & name, parameters &iOf1, parameters &iWrt1, parameters &iConstant1, parameters &iWrt2, parameters &iConstant2)
+bool is_valid_second_derivative(const std::string &name, parameters &iOf1, parameters &iWrt1, parameters &iConstant1, parameters &iWrt2, parameters &iConstant2)
 {
     if (get_debug_level() > 5){std::cout << format("is_valid_second_derivative(%s)",name.c_str());}
     
     // Suppose we start with "d(d(P)/d(Dmolar)|T)/d(Dmolar)|T"
-    std::size_t i_bar = name.rfind('|');
-    if (i_bar == std::string::npos){return false;}
-    std::string constant2 = name.substr(i_bar+1); // "T"
+    std::size_t i = name.rfind('|');
+    if ((i == 0) || (i == std::string::npos)){return false;}
+    std::string constant2 = name.substr(i+1); // "T"
     if (!is_valid_parameter(constant2, iConstant2)){return false;};
-    std::string left_of_bar = name.substr(0, i_bar); // "d(d(P)/d(Dmolar)|T)/d(Dmolar)"
+    std::string left_of_bar = name.substr(0, i); // "d(d(P)/d(Dmolar)|T)/d(Dmolar)"
     
-    std::size_t i_slash = left_of_bar.rfind('/');
-    if (i_slash == std::string::npos){return false;}
-    
-    std::string left_of_slash = left_of_bar.substr(0, i_slash); // "d(d(P)/d(Dmolar)|T)"
-    std::size_t iN0 = left_of_slash.find("(");
-    std::size_t iN1 = left_of_slash.rfind(")");
-    if (!(iN0 > 0 && iN1 > 0 && iN1 > iN0)){return false;}
-    std::string num = left_of_slash.substr(iN0+1, iN1-2); // "d(P)/d(Dmolar)|T"
+    i = left_of_bar.rfind('/');
+    if ((i == 0) || (i == std::string::npos)){return false;}
+    std::string left_of_slash = left_of_bar.substr(0, i); // "d(d(P)/d(Dmolar)|T)"
+    std::string right_of_slash = left_of_bar.substr(i + 1); // "d(Dmolar)"
+
+    i = left_of_slash.find("(");
+    std::size_t i1 = left_of_slash.rfind(")");
+    if (!((i > 0) && (i != std::string::npos) && (i1 > (i+1)) && (i1 != std::string::npos))){return false;}
+    std::string num = left_of_slash.substr(i+1, i1-i-1); // "d(P)/d(Dmolar)|T"
     if (!is_valid_first_derivative(num, iOf1, iWrt1, iConstant1)){return false;}
     
-    std::string right_of_slash = left_of_bar.substr(i_slash+1); // "d(Dmolar)"
-    std::size_t iD0 = right_of_slash.find("(");
-    std::size_t iD1 = right_of_slash.rfind(")");
-    if (!(iD0 > 0 && iD1 > 0 && iD1 > iD0)){return false;}
-    std::string den = right_of_slash.substr(iD0+1, iD1-2); // "Dmolar"
+    i = right_of_slash.find("(");
+    i1 = right_of_slash.rfind(")");
+    if (!((i > 0) && (i != std::string::npos) && (i1 > (i+1)) && (i1 != std::string::npos))){return false;}
+    std::string den = right_of_slash.substr(i+1, i1-i-1); // "Dmolar"
     if (!is_valid_parameter(den, iWrt2)){return false;}
     
     // If we haven't quit yet, all is well
@@ -299,21 +287,19 @@ bool is_valid_second_derivative(const std::string & name, parameters &iOf1, para
 struct phase_info
 {    
     phases key;
-    std::string short_desc, long_desc;
-public:
-    phase_info(phases key, std::string short_desc, std::string long_desc): key(key), short_desc(short_desc), long_desc(long_desc){};
+    const char *short_desc, *long_desc;
 };
-            
-phase_info phase_info_list[] = {
-    phase_info(iphase_liquid, "phase_liquid",""),
-    phase_info(iphase_gas, "phase_gas",""),
-    phase_info(iphase_twophase, "phase_twophase",""),
-    phase_info(iphase_supercritical, "phase_supercritical", ""),
-    phase_info(iphase_supercritical_gas, "phase_supercritical_gas", "p < pc, T > Tc"),
-    phase_info(iphase_supercritical_liquid, "phase_supercritical_liquid", "p > pc, T < Tc"),
-    phase_info(iphase_critical_point, "phase_critical_point", "p = pc, T = Tc"),
-    phase_info(iphase_unknown, "phase_unknown", ""),
-    phase_info(iphase_not_imposed, "phase_not_imposed", ""),
+
+const phase_info phase_info_list[] = {
+    phase_info{ iphase_liquid, "phase_liquid", "" },
+    phase_info{ iphase_gas, "phase_gas", "" },
+    phase_info{ iphase_twophase, "phase_twophase", "" },
+    phase_info{ iphase_supercritical, "phase_supercritical", "" },
+    phase_info{ iphase_supercritical_gas, "phase_supercritical_gas", "p < pc, T > Tc" },
+    phase_info{ iphase_supercritical_liquid, "phase_supercritical_liquid", "p > pc, T < Tc" },
+    phase_info{ iphase_critical_point, "phase_critical_point", "p = pc, T = Tc" },
+    phase_info{ iphase_unknown, "phase_unknown", "" },
+    phase_info{ iphase_not_imposed, "phase_not_imposed", "" },
 };
 
 class PhaseInformation
@@ -323,28 +309,25 @@ public:
     std::map<std::string, phases> index_map;
     PhaseInformation()
     {
-        int N = sizeof(phase_info_list)/sizeof(phase_info_list[0]);
-        for (int i = 0; i < N; ++i)
+        const phase_info* const end = phase_info_list + sizeof(phase_info_list) / sizeof(phase_info_list[0]);
+        for (const phase_info* el = phase_info_list; el != end; ++el)
         {
-            phase_info &el = phase_info_list[i];
-            short_desc_map.insert(std::pair<phases, std::string>(el.key, el.short_desc));
-            long_desc_map.insert(std::pair<phases, std::string>(el.key, el.long_desc));
-            index_map.insert(std::pair<std::string, phases>(el.short_desc, el.key));
+            short_desc_map.insert(std::pair<phases, std::string>(el->key, el->short_desc));
+            long_desc_map.insert(std::pair<phases, std::string>(el->key, el->long_desc));
+            index_map.insert(std::pair<std::string, phases>(el->short_desc, el->key));
         }
     }
 };
 static PhaseInformation phase_information;
 
-std::string get_phase_short_desc(phases phase)
+const std::string& get_phase_short_desc(phases phase)
 {
     return phase_information.short_desc_map[phase];
 }
 bool is_valid_phase(const std::string &phase_name, phases &iOutput)
 {
-    std::map<std::string, phases>::iterator it;
-    
     // Try to find it
-    it = phase_information.index_map.find(phase_name);
+    std::map<std::string, phases>::const_iterator it = phase_information.index_map.find(phase_name);
     // If equal to end, not found
     if (it != phase_information.index_map.end()){
         // Found, return it
@@ -380,51 +363,49 @@ parameters get_parameter_index(const std::string &param_name)
 struct input_pair_info
 {
     int key;
-    std::string short_desc, long_desc;
-public:
-    input_pair_info(int key, std::string short_desc, std::string long_desc): key(key), short_desc(short_desc), long_desc(long_desc){};
+    const char *short_desc, *long_desc;
 };
 
-input_pair_info input_pair_list[] = {
-    input_pair_info(QT_INPUTS,"QT_INPUTS","Molar quality, Temperature in K"),
-    input_pair_info(QSmolar_INPUTS,"QS_INPUTS","Molar quality, Entropy in J/mol/K"),
-    input_pair_info(QSmass_INPUTS,"QS_INPUTS","Molar quality, Entropy in J/kg/K"),
-    input_pair_info(HmolarQ_INPUTS,"HQ_INPUTS","Enthalpy in J/mol, Molar quality"),
-    input_pair_info(HmassQ_INPUTS,"HQ_INPUTS","Enthalpy in J/kg, Molar quality"),
-    input_pair_info(PQ_INPUTS,"PQ_INPUTS","Pressure in Pa, Molar quality"),
+const input_pair_info input_pair_list[] = {
+    input_pair_info{ QT_INPUTS, "QT_INPUTS", "Molar quality, Temperature in K" },
+    input_pair_info{ QSmolar_INPUTS, "QS_INPUTS", "Molar quality, Entropy in J/mol/K" },
+    input_pair_info{ QSmass_INPUTS, "QS_INPUTS", "Molar quality, Entropy in J/kg/K" },
+    input_pair_info{ HmolarQ_INPUTS, "HQ_INPUTS", "Enthalpy in J/mol, Molar quality" },
+    input_pair_info{ HmassQ_INPUTS, "HQ_INPUTS", "Enthalpy in J/kg, Molar quality" },
+    input_pair_info{ PQ_INPUTS, "PQ_INPUTS", "Pressure in Pa, Molar quality" },
     
-    input_pair_info(PT_INPUTS, "PT_INPUTS","Pressure in Pa, Temperature in K"),
+    input_pair_info{ PT_INPUTS, "PT_INPUTS", "Pressure in Pa, Temperature in K" },
     
 
-    input_pair_info(DmassT_INPUTS, "DmassT_INPUTS", "Mass density in kg/m^3, Temperature in K"),
-    input_pair_info(DmolarT_INPUTS, "DmolarT_INPUTS", "Molar density in mol/m^3, Temperature in K"),
-    input_pair_info(HmassT_INPUTS, "HmassT_INPUTS", "Enthalpy in J/kg, Temperature in K"),
-    input_pair_info(HmolarT_INPUTS, "HmolarT_INPUTS", "Enthalpy in J/mol, Temperature in K"),
-    input_pair_info(SmassT_INPUTS, "SmassT_INPUTS", "Entropy in J/kg/K, Temperature in K"),
-    input_pair_info(SmolarT_INPUTS, "SmolarT_INPUTS", "Entropy in J/mol/K, Temperature in K"),
-    input_pair_info(TUmass_INPUTS, "TUmass_INPUTS", "Temperature in K, Internal energy in J/kg"),
-    input_pair_info(TUmolar_INPUTS, "TUmolar_INPUTS", "Temperature in K, Internal energy in J/mol"),
+    input_pair_info{ DmassT_INPUTS, "DmassT_INPUTS", "Mass density in kg/m^3, Temperature in K" },
+    input_pair_info{ DmolarT_INPUTS, "DmolarT_INPUTS", "Molar density in mol/m^3, Temperature in K" },
+    input_pair_info{ HmassT_INPUTS, "HmassT_INPUTS", "Enthalpy in J/kg, Temperature in K" },
+    input_pair_info{ HmolarT_INPUTS, "HmolarT_INPUTS", "Enthalpy in J/mol, Temperature in K" },
+    input_pair_info{ SmassT_INPUTS, "SmassT_INPUTS", "Entropy in J/kg/K, Temperature in K" },
+    input_pair_info{ SmolarT_INPUTS, "SmolarT_INPUTS", "Entropy in J/mol/K, Temperature in K" },
+    input_pair_info{ TUmass_INPUTS, "TUmass_INPUTS", "Temperature in K, Internal energy in J/kg" },
+    input_pair_info{ TUmolar_INPUTS, "TUmolar_INPUTS", "Temperature in K, Internal energy in J/mol" },
 
-    input_pair_info(DmassP_INPUTS, "DmassP_INPUTS", "Mass density in kg/m^3, Pressure in Pa"),
-    input_pair_info(DmolarP_INPUTS, "DmolarP_INPUTS", "Molar density in mol/m^3, Pressure in Pa"),
-    input_pair_info(HmassP_INPUTS, "HmassP_INPUTS", "Enthalpy in J/kg, Pressure in Pa"),
-    input_pair_info(HmolarP_INPUTS, "HmolarP_INPUTS", "Enthalpy in J/mol, Pressure in Pa"),
-    input_pair_info(PSmass_INPUTS, "PSmass_INPUTS", "Pressure in Pa, Entropy in J/kg/K"),
-    input_pair_info(PSmolar_INPUTS, "PSmolar_INPUTS", "Pressure in Pa, Entropy in J/mol/K "),
-    input_pair_info(PUmass_INPUTS, "PUmass_INPUTS", "Pressure in Pa, Internal energy in J/kg"),
-    input_pair_info(PUmolar_INPUTS, "PUmolar_INPUTS", "Pressure in Pa, Internal energy in J/mol"),
+    input_pair_info{ DmassP_INPUTS, "DmassP_INPUTS", "Mass density in kg/m^3, Pressure in Pa" },
+    input_pair_info{ DmolarP_INPUTS, "DmolarP_INPUTS", "Molar density in mol/m^3, Pressure in Pa" },
+    input_pair_info{ HmassP_INPUTS, "HmassP_INPUTS", "Enthalpy in J/kg, Pressure in Pa" },
+    input_pair_info{ HmolarP_INPUTS, "HmolarP_INPUTS", "Enthalpy in J/mol, Pressure in Pa" },
+    input_pair_info{ PSmass_INPUTS, "PSmass_INPUTS", "Pressure in Pa, Entropy in J/kg/K" },
+    input_pair_info{ PSmolar_INPUTS, "PSmolar_INPUTS", "Pressure in Pa, Entropy in J/mol/K " },
+    input_pair_info{ PUmass_INPUTS, "PUmass_INPUTS", "Pressure in Pa, Internal energy in J/kg" },
+    input_pair_info{ PUmolar_INPUTS, "PUmolar_INPUTS", "Pressure in Pa, Internal energy in J/mol" },
 
-    input_pair_info(DmassHmass_INPUTS, "DmassHmass_INPUTS","Mass density in kg/m^3, Enthalpy in J/kg"),
-    input_pair_info(DmolarHmolar_INPUTS, "DmolarHmolar_INPUTS","Molar density in mol/m^3, Enthalpy in J/mol"),
-    input_pair_info(DmassSmass_INPUTS, "DmassSmass_INPUTS","Mass density in kg/m^3, Entropy in J/kg/K"),
-    input_pair_info(DmolarSmolar_INPUTS, "DmolarSmolar_INPUTS","Molar density in mol/m^3, Entropy in J/mol/K"),
-    input_pair_info(DmassUmass_INPUTS, "DmassUmass_INPUTS","Mass density in kg/m^3, Internal energy in J/kg"),
-    input_pair_info(DmolarUmolar_INPUTS, "DmolarUmolar_INPUTS","Molar density in mol/m^3, Internal energy in J/mol"),
+    input_pair_info{ DmassHmass_INPUTS, "DmassHmass_INPUTS", "Mass density in kg/m^3, Enthalpy in J/kg" },
+    input_pair_info{ DmolarHmolar_INPUTS, "DmolarHmolar_INPUTS", "Molar density in mol/m^3, Enthalpy in J/mol" },
+    input_pair_info{ DmassSmass_INPUTS, "DmassSmass_INPUTS", "Mass density in kg/m^3, Entropy in J/kg/K" },
+    input_pair_info{ DmolarSmolar_INPUTS, "DmolarSmolar_INPUTS", "Molar density in mol/m^3, Entropy in J/mol/K" },
+    input_pair_info{ DmassUmass_INPUTS, "DmassUmass_INPUTS", "Mass density in kg/m^3, Internal energy in J/kg" },
+    input_pair_info{ DmolarUmolar_INPUTS, "DmolarUmolar_INPUTS", "Molar density in mol/m^3, Internal energy in J/mol" },
 
-    input_pair_info(HmassSmass_INPUTS, "HmassSmass_INPUTS", "Enthalpy in J/kg, Entropy in J/kg/K"),
-    input_pair_info(HmolarSmolar_INPUTS, "HmolarSmolar_INPUTS", "Enthalpy in J/mol, Entropy in J/mol/K"),
-    input_pair_info(SmassUmass_INPUTS, "SmassUmass_INPUTS", "Entropy in J/kg/K, Internal energy in J/kg"),
-    input_pair_info(SmolarUmolar_INPUTS, "SmolarUmolar_INPUTS", "Entropy in J/mol/K, Internal energy in J/mol"),
+    input_pair_info{ HmassSmass_INPUTS, "HmassSmass_INPUTS", "Enthalpy in J/kg, Entropy in J/kg/K" },
+    input_pair_info{ HmolarSmolar_INPUTS, "HmolarSmolar_INPUTS", "Enthalpy in J/mol, Entropy in J/mol/K" },
+    input_pair_info{ SmassUmass_INPUTS, "SmassUmass_INPUTS", "Entropy in J/kg/K, Internal energy in J/kg" },
+    input_pair_info{ SmolarUmolar_INPUTS, "SmolarUmolar_INPUTS", "Entropy in J/mol/K, Internal energy in J/mol" },
 };
 
 class InputPairInformation
@@ -433,22 +414,22 @@ public:
     std::map<int, std::string> short_desc_map, long_desc_map;
     InputPairInformation()
     {
-        int N = sizeof(input_pair_list)/sizeof(input_pair_list[0]);
-        for (int i = 0; i < N; ++i)
+        const input_pair_info* const end = input_pair_list + sizeof(input_pair_list) / sizeof(input_pair_list[0]);
+        for (const input_pair_info* el = input_pair_list; el != end; ++el)
         {
-            short_desc_map.insert(std::pair<int, std::string>(input_pair_list[i].key, input_pair_list[i].short_desc));
-            long_desc_map.insert(std::pair<int, std::string>(input_pair_list[i].key, input_pair_list[i].long_desc));
+            short_desc_map.insert(std::pair<int, std::string>(el->key, el->short_desc));
+            long_desc_map.insert(std::pair<int, std::string>(el->key, el->long_desc));
         }
     }
 };
 
 static InputPairInformation input_pair_information;
 
-std::string get_input_pair_short_desc(int pair)
+const std::string& get_input_pair_short_desc(int pair)
 {
     return input_pair_information.short_desc_map[pair];
 }
-std::string get_input_pair_long_desc(int pair)
+const std::string& get_input_pair_long_desc(int pair)
 {
     return input_pair_information.long_desc_map[pair];
 }

--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -23,12 +23,18 @@
 #include <list>
 
 /// This is a stub overload to help with all the strcmp calls below and avoid needing to rewrite all of them
-std::size_t strcmp(const std::string &s, const std::string e){
+std::size_t strcmp(const std::string &s, const std::string &e){
     return s.compare(e);
+}
+std::size_t strcmp(const std::string &s, const char *e){ // To avoid unnecessary constructors
+    return s.compare(e);
+}
+std::size_t strcmp(const char *e, const std::string &s){
+    return -s.compare(e);
 }
 
 // This is a lazy stub function to avoid recoding all the strcpy calls below
-void strcpy(std::string &s, const std::string e){
+void strcpy(std::string &s, const std::string &e){
     s = e;
 }
 
@@ -38,7 +44,7 @@ namespace HumidAir
 {
     enum givens{GIVEN_INVALID=0, GIVEN_TDP,GIVEN_PSIW, GIVEN_HUMRAT,GIVEN_VDA, GIVEN_VHA,GIVEN_TWB,GIVEN_RH,GIVEN_ENTHALPY,GIVEN_ENTHALPY_HA,GIVEN_ENTROPY,GIVEN_ENTROPY_HA, GIVEN_T,GIVEN_P,GIVEN_VISC,GIVEN_COND,GIVEN_CP,GIVEN_CPHA};
     
-    double _HAPropsSI_inputs(double p, const std::vector<givens> &input_keys, const std::vector<double> &input_vals, double &T, double &psi_w);
+    void _HAPropsSI_inputs(double p, const std::vector<givens> &input_keys, const std::vector<double> &input_vals, double &T, double &psi_w);
     double _HAPropsSI_outputs(givens OuputType, double p, double T, double psi_w);
 
 void check_fluid_instantiation()
@@ -178,7 +184,6 @@ static double Brent_HAProps_T(givens OutputKey, double p, givens In1Name, double
 
     BrentSolverResids BSR = BrentSolverResids(OutputKey, p, In1Name, Input1, TargetVal);
 
-    std::string errstr;
     // Now we need to check the bounds and make sure that they are ok (don't yield invalid output)
     // and actually bound the solution
     double r_min = BSR.call(T_min);
@@ -204,6 +209,7 @@ static double Brent_HAProps_T(givens OutputKey, double p, givens In1Name, double
             T_min_valid = ValidNumber(r_min);
         }
     }
+    std::string errstr;
     // We will do a secant call if the values at T_min and T_max have the same sign
     if (r_min*r_max > 0){
         if (std::abs(r_min) < std::abs(r_max)){
@@ -1116,7 +1122,7 @@ double WetbulbTemperature(double T, double p, double psi_w)
         // Solution obtained is out of range (T>Tmax)
         if (return_val > Tmax + 1) {throw CoolProp::ValueError();}
     }
-    catch(std::exception &)
+    catch(...)
     {
         // The lowest wetbulb temperature that is possible for a given dry bulb temperature
         // is the saturated air temperature which yields the enthalpy of dry air at dry bulb temperature
@@ -1130,7 +1136,7 @@ double WetbulbTemperature(double T, double p, double psi_w)
 
             return_val = Brent(WBS,Tmin-30,Tmax-1,1e-12,1e-12,50,errstr);
         }
-        catch(std::exception)
+        catch(...)
         {
             return_val = _HUGE;
         }
@@ -1348,7 +1354,7 @@ bool match_input_key(const std::vector<givens> &input_keys, givens key)
 }
 
 /// Calculate T (dry bulb temp) and psi_w (water mole fraction) given the pair of inputs
-double _HAPropsSI_inputs(double p, const std::vector<givens> &input_keys, const std::vector<double> &input_vals, double &T, double &psi_w)
+void _HAPropsSI_inputs(double p, const std::vector<givens> &input_keys, const std::vector<double> &input_vals, double &T, double &psi_w)
 {
     long key = get_input_key(input_keys, GIVEN_T);
     if (key >= 0) // Found T (or alias) as an input
@@ -1422,7 +1428,7 @@ double _HAPropsSI_inputs(double p, const std::vector<givens> &input_keys, const 
         }
         catch(std::exception &e){
             CoolProp::set_error_string(e.what());
-            return _HUGE;
+            return;
         }
         
         // Otherwise, find psi_w for further calculations in the following section
@@ -1589,185 +1595,182 @@ double HAProps_Aux(const char* Name,double T, double p, double W, char *units)
     double psi_w,B_aa,C_aaa,B_ww,C_www,B_aw,C_aaw,C_aww,v_bar;
 
     try{
-    if (!strcmp(Name,"Baa"))
-    {
-        B_aa=B_Air(T); // [m^3/mol]
-        strcpy(units,"m^3/mol");
-        return B_aa;
-    }
-    else if (!strcmp(Name,"Caaa"))
-    {
-        C_aaa=C_Air(T); // [m^6/mol^2]
-        strcpy(units,"m^6/mol^2");
-        return C_aaa;
-    }
-    else if (!strcmp(Name,"Bww"))
-    {
-        B_ww=B_Water(T); // [m^3/mol]
-        strcpy(units,"m^3/mol");
-        return B_ww;
-    }
-    else if (!strcmp(Name,"Cwww"))
-    {
-        C_www=C_Water(T); // [m^6/mol^2]
-        strcpy(units,"m^6/mol^2");
-        return C_www;
-    }
-    else if (!strcmp(Name,"dBaa"))
-    {
-        B_aa=dBdT_Air(T); // [m^3/mol]
-        strcpy(units,"m^3/mol");
-        return B_aa;
-    }
-    else if (!strcmp(Name,"dCaaa"))
-    {
-        C_aaa=dCdT_Air(T); // [m^6/mol^2]
-        strcpy(units,"m^6/mol^2");
-        return C_aaa;
-    }
-    else if (!strcmp(Name,"dBww"))
-    {
-        B_ww=dBdT_Water(T); // [m^3/mol]
-        strcpy(units,"m^3/mol");
-        return B_ww;
-    }
-    else if (!strcmp(Name,"dCwww"))
-    {
-        C_www=dCdT_Water(T); // [m^6/mol^2]
-        strcpy(units,"m^6/mol^2");
-        return C_www;
-    }
-    else if (!strcmp(Name,"Baw"))
-    {
-        B_aw=_B_aw(T); // [m^3/mol]
-        strcpy(units,"m^3/mol");
-        return B_aw;
-    }
-    else if (!strcmp(Name,"Caww"))
-    {
-        C_aww=_C_aww(T); // [m^6/mol^2]
-        strcpy(units,"m^6/mol^2");
-        return C_aww;
-    }
-    else if (!strcmp(Name,"Caaw"))
-    {
-        C_aaw=_C_aaw(T); // [m^6/mol^2]
-        strcpy(units,"m^6/mol^2");
-        return C_aaw;
-    }
-    else if (!strcmp(Name,"dBaw"))
-    {
-        double dB_aw=_dB_aw_dT(T); // [m^3/mol]
-        strcpy(units,"m^3/mol");
-        return dB_aw;
-    }
-    else if (!strcmp(Name,"dCaww"))
-    {
-        double dC_aww=_dC_aww_dT(T); // [m^6/mol^2]
-        strcpy(units,"m^6/mol^2");
-        return dC_aww;
-    }
-    else if (!strcmp(Name,"dCaaw"))
-    {
-        double dC_aaw=_dC_aaw_dT(T); // [m^6/mol^2]
-        strcpy(units,"m^6/mol^2");
-        return dC_aaw;
-    }
-    else if (!strcmp(Name,"beta_H"))
-    {
-        strcpy(units,"1/Pa");
-        return HenryConstant(T);
-    }
-    else if (!strcmp(Name,"kT"))
-    {
-        strcpy(units,"1/Pa");
-        if (T>273.16)
+        if (!strcmp(Name,"Baa"))
         {
-            Water->update(CoolProp::PT_INPUTS, p, T);
-            return Water->keyed_output(CoolProp::iisothermal_compressibility);
+            B_aa=B_Air(T); // [m^3/mol]
+            strcpy(units,"m^3/mol");
+            return B_aa;
+        }
+        else if (!strcmp(Name,"Caaa"))
+        {
+            C_aaa=C_Air(T); // [m^6/mol^2]
+            strcpy(units,"m^6/mol^2");
+            return C_aaa;
+        }
+        else if (!strcmp(Name,"Bww"))
+        {
+            B_ww=B_Water(T); // [m^3/mol]
+            strcpy(units,"m^3/mol");
+            return B_ww;
+        }
+        else if (!strcmp(Name,"Cwww"))
+        {
+            C_www=C_Water(T); // [m^6/mol^2]
+            strcpy(units,"m^6/mol^2");
+            return C_www;
+        }
+        else if (!strcmp(Name,"dBaa"))
+        {
+            B_aa=dBdT_Air(T); // [m^3/mol]
+            strcpy(units,"m^3/mol");
+            return B_aa;
+        }
+        else if (!strcmp(Name,"dCaaa"))
+        {
+            C_aaa=dCdT_Air(T); // [m^6/mol^2]
+            strcpy(units,"m^6/mol^2");
+            return C_aaa;
+        }
+        else if (!strcmp(Name,"dBww"))
+        {
+            B_ww=dBdT_Water(T); // [m^3/mol]
+            strcpy(units,"m^3/mol");
+            return B_ww;
+        }
+        else if (!strcmp(Name,"dCwww"))
+        {
+            C_www=dCdT_Water(T); // [m^6/mol^2]
+            strcpy(units,"m^6/mol^2");
+            return C_www;
+        }
+        else if (!strcmp(Name,"Baw"))
+        {
+            B_aw=_B_aw(T); // [m^3/mol]
+            strcpy(units,"m^3/mol");
+            return B_aw;
+        }
+        else if (!strcmp(Name,"Caww"))
+        {
+            C_aww=_C_aww(T); // [m^6/mol^2]
+            strcpy(units,"m^6/mol^2");
+            return C_aww;
+        }
+        else if (!strcmp(Name,"Caaw"))
+        {
+            C_aaw=_C_aaw(T); // [m^6/mol^2]
+            strcpy(units,"m^6/mol^2");
+            return C_aaw;
+        }
+        else if (!strcmp(Name,"dBaw"))
+        {
+            double dB_aw=_dB_aw_dT(T); // [m^3/mol]
+            strcpy(units,"m^3/mol");
+            return dB_aw;
+        }
+        else if (!strcmp(Name,"dCaww"))
+        {
+            double dC_aww=_dC_aww_dT(T); // [m^6/mol^2]
+            strcpy(units,"m^6/mol^2");
+            return dC_aww;
+        }
+        else if (!strcmp(Name,"dCaaw"))
+        {
+            double dC_aaw=_dC_aaw_dT(T); // [m^6/mol^2]
+            strcpy(units,"m^6/mol^2");
+            return dC_aaw;
+        }
+        else if (!strcmp(Name,"beta_H"))
+        {
+            strcpy(units,"1/Pa");
+            return HenryConstant(T);
+        }
+        else if (!strcmp(Name,"kT"))
+        {
+            strcpy(units,"1/Pa");
+            if (T>273.16)
+            {
+                Water->update(CoolProp::PT_INPUTS, p, T);
+                return Water->keyed_output(CoolProp::iisothermal_compressibility);
+            }
+            else
+                return IsothermCompress_Ice(T,p); //[1/Pa]
+        }
+        else if (!strcmp(Name,"p_ws"))
+        {
+            strcpy(units,"Pa");
+            if (T>273.16)
+            {
+                Water->update(CoolProp::QT_INPUTS, 0, T);
+                return Water->keyed_output(CoolProp::iP);
+            }
+            else
+                return psub_Ice(T);
+        }
+        else if (!strcmp(Name,"vbar_ws"))
+        {
+            strcpy(units,"m^3/mol");
+            if (T>273.16)
+            {
+                Water->update(CoolProp::QT_INPUTS, 0, T);
+                return 1.0/Water->keyed_output(CoolProp::iDmolar);
+            }
+            else
+            {
+                // It is ice
+                return dg_dp_Ice(T,p)*MM_Water()/1000/1000; //[m^3/mol]
+            }
+        }
+        else if (!strcmp(Name,"f"))
+        {
+            strcpy(units,"-");
+            return f_factor(T,p);
+        }
+        // Get psi_w since everything else wants it
+        psi_w=MoleFractionWater(T,p,GIVEN_HUMRAT,W);
+        if (!strcmp(Name,"Bm"))
+        {
+            strcpy(units,"m^3/mol");
+            return B_m(T,psi_w);
+        }
+        else if (!strcmp(Name,"Cm"))
+        {
+            strcpy(units,"m^6/mol^2");
+            return C_m(T,psi_w);
+        }
+        else if (!strcmp(Name,"hvirial"))
+        {
+            v_bar=MolarVolume(T,p,psi_w);
+            return 8.3145*T*((B_m(T,psi_w)-T*dB_m_dT(T,psi_w))/v_bar+(C_m(T,psi_w)-T/2.0*dC_m_dT(T,psi_w))/(v_bar*v_bar));
+        }
+        //else if (!strcmp(Name,"ha"))
+        //{
+        //    delta=1.1/322; tau=132/T;
+        //    return 1+tau*DerivTerms("dphi0_dTau",tau,delta,"Water");
+        //}
+        //else if (!strcmp(Name,"hw"))
+        //{
+        //    //~ return Props('D','T',T,'P',p,"Water")/322; tau=647/T;
+        //    delta=1000/322; tau=647/T;
+        //    //~ delta=rho_Water(T,p,TYPE_TP);tau=647/T;
+        //    return 1+tau*DerivTerms("dphi0_dTau",tau,delta,"Water");
+        //}
+        else if (!strcmp(Name,"hbaro_w"))
+        {
+            v_bar=MolarVolume(T,p,psi_w);
+            return IdealGasMolarEnthalpy_Water(T,v_bar);
+        }
+        else if (!strcmp(Name,"hbaro_a"))
+        {
+            v_bar=MolarVolume(T,p,psi_w);
+            return IdealGasMolarEnthalpy_Air(T,v_bar);
         }
         else
-            return IsothermCompress_Ice(T,p); //[1/Pa]
-    }
-    else if (!strcmp(Name,"p_ws"))
-    {
-        strcpy(units,"Pa");
-        if (T>273.16)
         {
-            Water->update(CoolProp::QT_INPUTS, 0, T);
-            return Water->keyed_output(CoolProp::iP);
-        }
-        else
-            return psub_Ice(T);
-    }
-    else if (!strcmp(Name,"vbar_ws"))
-    {
-        strcpy(units,"m^3/mol");
-        if (T>273.16)
-        {
-            Water->update(CoolProp::QT_INPUTS, 0, T);
-            return 1.0/Water->keyed_output(CoolProp::iDmolar);
-        }
-        else
-        {
-            // It is ice
-            return dg_dp_Ice(T,p)*MM_Water()/1000/1000; //[m^3/mol]
+            printf("Sorry I didn't understand your input [%s] to HAProps_Aux\n",Name);
+            return -1;
         }
     }
-    else if (!strcmp(Name,"f"))
-    {
-        strcpy(units,"-");
-        return f_factor(T,p);
-    }
-    // Get psi_w since everything else wants it
-    psi_w=MoleFractionWater(T,p,GIVEN_HUMRAT,W);
-    if (!strcmp(Name,"Bm"))
-    {
-        strcpy(units,"m^3/mol");
-        return B_m(T,psi_w);
-    }
-    else if (!strcmp(Name,"Cm"))
-    {
-        strcpy(units,"m^6/mol^2");
-        return C_m(T,psi_w);
-    }
-    else if (!strcmp(Name,"hvirial"))
-    {
-        v_bar=MolarVolume(T,p,psi_w);
-        return 8.3145*T*((B_m(T,psi_w)-T*dB_m_dT(T,psi_w))/v_bar+(C_m(T,psi_w)-T/2.0*dC_m_dT(T,psi_w))/(v_bar*v_bar));
-    }
-    //else if (!strcmp(Name,"ha"))
-    //{
-    //    delta=1.1/322; tau=132/T;
-    //    return 1+tau*DerivTerms("dphi0_dTau",tau,delta,"Water");
-    //}
-    //else if (!strcmp(Name,"hw"))
-    //{
-    //    //~ return Props('D','T',T,'P',p,"Water")/322; tau=647/T;
-    //    delta=1000/322; tau=647/T;
-    //    //~ delta=rho_Water(T,p,TYPE_TP);tau=647/T;
-    //    return 1+tau*DerivTerms("dphi0_dTau",tau,delta,"Water");
-    //}
-    else if (!strcmp(Name,"hbaro_w"))
-    {
-        v_bar=MolarVolume(T,p,psi_w);
-        return IdealGasMolarEnthalpy_Water(T,v_bar);
-    }
-    else if (!strcmp(Name,"hbaro_a"))
-    {
-        v_bar=MolarVolume(T,p,psi_w);
-        return IdealGasMolarEnthalpy_Air(T,v_bar);
-    }
-    else
-    {
-        printf("Sorry I didn't understand your input [%s] to HAProps_Aux\n",Name);
-        return -1;
-    }
-    }
-    catch(std::exception &)
-    {
-        return _HUGE;
-    }
+    catch(...){}
     return _HUGE;
 }
 double cair_sat(double T)

--- a/src/SpeedTest.cpp
+++ b/src/SpeedTest.cpp
@@ -13,7 +13,7 @@
 
 namespace CoolProp{
 
-void compare_REFPROP_and_CoolProp(std::string fluid, CoolProp::input_pairs inputs, double val1, double val2, std::size_t N, double d1, double d2)
+void compare_REFPROP_and_CoolProp(const std::string &fluid, CoolProp::input_pairs inputs, double val1, double val2, std::size_t N, double d1, double d2)
 {
     time_t t1,t2;
 

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -1376,7 +1376,7 @@ TEST_CASE("Test that reference states are correct", "[reference_states]")
                     // Then try to set to the specified reference state
                     set_reference_stateS(fluids[i], ref_state[j]);
                 }
-                catch(std::exception &e){
+                catch(...){
                     // Then set the reference state back to the default
                     set_reference_stateS(fluids[i],"RESET");
                     break;
@@ -1408,7 +1408,7 @@ TEST_CASE("Test that reference states are correct", "[reference_states]")
                         throw ValueError("hmolar is not valid number");
                     }
                 }
-                catch(std::exception &e){
+                catch(...){
                     // Then set the reference state back to the default
                     set_reference_stateS(fluids[i],"RESET");
                     break;


### PR DESCRIPTION
1. Another set of arguments optimized:
* args-by-val converted to args-by-ref
* in some cases, opposite has been done, if that is better: if the
object's copy is modified in the func, it's better to avoid extra copy
from arg to local var
2. some const functions marked as such (this is just a beginning)
3. iterators were replaced with const_iterators where applicable
4. catches that catch std::exception& changed to catch (...) - that is
safer; if exception handling is restructured, this will have to be
reconsidered anyway
5. removed some basic structures' constructors; changed them to hold
const char*s to avoid unnecessary string constructions;
6. in some places, moved variable declarations to their definitions, to
avoid calling default constructors and then assigning
7. removed some unnecessary shared_pointers in favor of local objects;
8. in FORTRAN-style functions, added const specifiers to input doubles;
9. fixed a place where values were inserted into a map while iterating
through it
10. fixed is_valid_*_derivative: they could accept incorrect values and
throw when upper index is less than lower
11. Simplified strsplit