### PR TITLE
Primitive structures simplification attempt 2

### DIFF
--- a/src/CoolPropTools.cpp
+++ b/src/CoolPropTools.cpp
@@ -4,7 +4,6 @@
 #include <cstdio>
 #include <cstdarg>
 #include <stdlib.h>
-#include <memory>
 #include "math.h"
 #include "stdio.h"
 #include "float.h"

--- a/src/CoolPropTools.cpp
+++ b/src/CoolPropTools.cpp
@@ -45,7 +45,7 @@ double root_sum_square(const std::vector<double> &x)
 std::string format(const char* fmt, ...)
 {
     const int size = 512;
-    struct deleter{ static void delarray(void* p) { delete[] p; } }; // to use delete[]
+    struct deleter{ static void delarray(char* p) { delete[] p; } }; // to use delete[]
     shared_ptr<char> buffer(new char[size], deleter::delarray); // I'd prefer unique_ptr, but it's only available since c++11
     va_list vl;
     va_start(vl,fmt);

--- a/src/DataStructures.cpp
+++ b/src/DataStructures.cpp
@@ -10,88 +10,86 @@ namespace CoolProp{
 struct parameter_info
 {    
     int key;
-    std::string short_desc, IO, units, description;
+    const char *short_desc, *IO, *units, *description;
     bool trivial; ///< True if the input is trivial, and can be directly calculated (constants like critical properties, etc.)
-public:
-    parameter_info(int key, std::string short_desc, std::string IO, std::string units, std::string description, bool trivial): key(key), short_desc(short_desc), IO(IO), units(units), description(description), trivial(trivial){};
 };
 
-parameter_info parameter_info_list[] = {
+const parameter_info parameter_info_list[] = {
     /// Input/Output parameters
-    parameter_info(iT, "T", "IO", "K", "Temperature",false),
-    parameter_info(iP, "P", "IO", "Pa", "Pressure",false),
-    parameter_info(iDmolar, "Dmolar","IO","mol/m^3","Molar density",false),
-    parameter_info(iHmolar, "Hmolar","IO","J/mol","Molar specific enthalpy",false),
-    parameter_info(iSmolar, "Smolar","IO","J/mol/K","Molar specific entropy",false),
-    parameter_info(iUmolar, "Umolar","IO","J/mol","Molar specific internal energy",false),
-    parameter_info(iGmolar, "Gmolar","O","J/mol","Molar specific Gibbs energy",false),
-    parameter_info(iDmass, "Dmass","IO","kg/m^3","Mass density",false),
-    parameter_info(iHmass, "Hmass","IO","J/kg","Mass specific enthalpy",false),
-    parameter_info(iSmass, "Smass","IO","J/kg/K","Mass specific entropy",false),
-    parameter_info(iUmass, "Umass","IO","J/kg","Mass specific internal energy",false),
-    parameter_info(iGmass, "Gmass","O","J/kg","Mass specific Gibbs energy",false),
-    parameter_info(iQ, "Q","IO","mol/mol","Mass vapor quality",false),
-    parameter_info(iDelta, "Delta","IO","-","Reduced density (rho/rhoc)",false),
-    parameter_info(iTau, "Tau","IO","-","Reciprocal reduced temperature (Tc/T)",false),
+    {iT,      "T",      "IO", "K",       "Temperature",                           false},
+    {iP,      "P",      "IO", "Pa",      "Pressure",                              false},
+    {iDmolar, "Dmolar", "IO", "mol/m^3", "Molar density",                         false},
+    {iHmolar, "Hmolar", "IO", "J/mol",   "Molar specific enthalpy",               false},
+    {iSmolar, "Smolar", "IO", "J/mol/K", "Molar specific entropy",                false},
+    {iUmolar, "Umolar", "IO", "J/mol",   "Molar specific internal energy",        false},
+    {iGmolar, "Gmolar", "O",  "J/mol",   "Molar specific Gibbs energy",           false},
+    {iDmass,  "Dmass",  "IO", "kg/m^3",  "Mass density",                          false},
+    {iHmass,  "Hmass",  "IO", "J/kg",    "Mass specific enthalpy",                false},
+    {iSmass,  "Smass",  "IO", "J/kg/K",  "Mass specific entropy",                 false},
+    {iUmass,  "Umass",  "IO", "J/kg",    "Mass specific internal energy",         false},
+    {iGmass,  "Gmass",  "O",  "J/kg",    "Mass specific Gibbs energy",            false},
+    {iQ,      "Q",      "IO", "mol/mol", "Mass vapor quality",                    false},
+    {iDelta,  "Delta",  "IO", "-",       "Reduced density (rho/rhoc)",            false},
+    {iTau,    "Tau",    "IO", "-",       "Reciprocal reduced temperature (Tc/T)", false},
     /// Output only
-    parameter_info(iCpmolar, "Cpmolar","O","J/mol/K","Molar specific constant presssure specific heat",false),
-    parameter_info(iCpmass, "Cpmass","O","J/kg/K","Mass specific constant presssure specific heat",false),
-    parameter_info(iCvmolar, "Cvmolar","O","J/mol/K","Molar specific constant volume specific heat",false),
-    parameter_info(iCvmass, "Cvmass","O","J/kg/K","Mass specific constant volume specific heat",false),
-    parameter_info(iCp0molar, "Cp0molar","O","J/mol/K","Ideal gas molar specific constant presssure specific heat",false),
-    parameter_info(iCp0mass, "Cp0mass","O","J/kg/K","Ideal gas mass specific constant presssure specific heat",false),
-    parameter_info(iGWP20, "GWP20","O","-","20-year gobal warming potential",true),
-    parameter_info(iGWP100, "GWP100","O","-","100-year gobal warming potential",true),
-    parameter_info(iGWP500, "GWP500","O","-","500-year gobal warming potential",true),
-    parameter_info(iFH, "FH","O","-","Flammability hazard",true),
-    parameter_info(iHH, "HH","O","-","Health hazard",true),
-    parameter_info(iPH, "PH","O","-","Physical hazard",true),
-    parameter_info(iODP, "ODP","O","-","Ozone depletion potential",true),
-    parameter_info(iBvirial, "Bvirial","O","-","Second virial coefficient",false),
-    parameter_info(iCvirial, "Cvirial","O","-","Third virial coefficient",false),
-    parameter_info(idBvirial_dT, "dBvirial_dT","O","-","Derivative of second virial coefficient with respect to T",false),
-    parameter_info(idCvirial_dT, "dCvirial_dT","O","-","Derivative of third virial coefficient with respect to T",false),
-    parameter_info(igas_constant, "gas_constant","O","J/mol/K","Molar gas constant",true),
-	parameter_info(imolar_mass, "molar_mass","O","kg/mol","Molar mass",true),
-    parameter_info(iacentric_factor, "acentric","O","-","Acentric factor",true),
-    parameter_info(irhomass_reducing, "rhomass_reducing","O","kg/m^3","Mass density at reducing point",true),
-    parameter_info(irhomolar_reducing, "rhomolar_reducing","O","mol/m^3","Molar density at reducing point",true),
-    parameter_info(irhomolar_critical, "rhomolar_critical","O","mol/m^3","Molar density at critical point",true),
-    parameter_info(irhomass_critical, "rhomass_critical","O","kg/m^3","Mass density at critical point",true),
-    parameter_info(iT_reducing, "T_reducing","O","K","Temperature at the reducing point",true),
-    parameter_info(iT_critical, "T_critical","O","K","Temperature at the critical point",true),
-    parameter_info(iT_triple, "T_triple","O","K","Temperature at the triple point",true),
-    parameter_info(iT_max, "T_max","O","K","Maximum temperature limit",true),
-    parameter_info(iT_min, "T_min","O","K","Minimum temperature limit",true),
-    parameter_info(iP_min, "P_min","O","Pa","Minimum pressure limit",true),
-    parameter_info(iP_max, "P_max","O","Pa","Maximum pressure limit",true),
-    parameter_info(iP_critical, "p_critical","O","Pa","Pressure at the critical point",true),
-	parameter_info(iP_reducing, "p_reducing","O","Pa","Pressure at the reducing point",true),
-    parameter_info(iP_triple, "p_triple","O","Pa","Pressure at the triple point (pure only)",true),
-    parameter_info(ifraction_min, "fraction_min","O","-","Fraction (mole, mass, volume) minimum value for incompressible solutions",true),
-    parameter_info(ifraction_max, "fraction_max","O","-","Fraction (mole, mass, volume) maximum value for incompressible solutions",true),
-    parameter_info(iT_freeze, "T_freeze","O","K","Freezing temperature for incompressible solutions",true),
+    {iCpmolar,           "Cpmolar",           "O", "J/mol/K", "Molar specific constant presssure specific heat", false},
+    {iCpmass,            "Cpmass",            "O", "J/kg/K",  "Mass specific constant presssure specific heat",  false},
+    {iCvmolar,           "Cvmolar",           "O", "J/mol/K", "Molar specific constant volume specific heat",    false},
+    {iCvmass,            "Cvmass",            "O", "J/kg/K",  "Mass specific constant volume specific heat",     false},
+    {iCp0molar,          "Cp0molar",          "O", "J/mol/K", "Ideal gas molar specific constant presssure specific heat",false},
+    {iCp0mass,           "Cp0mass",           "O", "J/kg/K",  "Ideal gas mass specific constant presssure specific heat",false},
+    {iGWP20,             "GWP20",             "O", "-",       "20-year gobal warming potential",                 true},
+    {iGWP100,            "GWP100",            "O", "-",       "100-year gobal warming potential",                true},
+    {iGWP500,            "GWP500",            "O", "-",       "500-year gobal warming potential",                true},
+    {iFH,                "FH",                "O", "-",       "Flammability hazard",                             true},
+    {iHH,                "HH",                "O", "-",       "Health hazard",                                   true},
+    {iPH,                "PH",                "O", "-",       "Physical hazard",                                 true},
+    {iODP,               "ODP",               "O", "-",       "Ozone depletion potential",                       true},
+    {iBvirial,           "Bvirial",           "O", "-",       "Second virial coefficient",                       false},
+    {iCvirial,           "Cvirial",           "O", "-",       "Third virial coefficient",                        false},
+    {idBvirial_dT,       "dBvirial_dT",       "O", "-",       "Derivative of second virial coefficient with respect to T",false},
+    {idCvirial_dT,       "dCvirial_dT",       "O", "-",       "Derivative of third virial coefficient with respect to T",false},
+    {igas_constant,      "gas_constant",      "O", "J/mol/K", "Molar gas constant",                              true},
+	{imolar_mass,        "molar_mass",        "O", "kg/mol",  "Molar mass",                                      true},
+    {iacentric_factor,   "acentric",          "O", "-",       "Acentric factor",                                 true},
+    {irhomass_reducing,  "rhomass_reducing",  "O", "kg/m^3",  "Mass density at reducing point",                  true},
+    {irhomolar_reducing, "rhomolar_reducing", "O", "mol/m^3", "Molar density at reducing point",                 true},
+    {irhomolar_critical, "rhomolar_critical", "O", "mol/m^3", "Molar density at critical point",                 true},
+    {irhomass_critical,  "rhomass_critical",  "O", "kg/m^3",  "Mass density at critical point",                  true},
+    {iT_reducing,        "T_reducing",        "O", "K",       "Temperature at the reducing point",               true},
+    {iT_critical,        "T_critical",        "O", "K",       "Temperature at the critical point",               true},
+    {iT_triple,          "T_triple",          "O", "K",       "Temperature at the triple point",                 true},
+    {iT_max,             "T_max",             "O", "K",       "Maximum temperature limit",                       true},
+    {iT_min,             "T_min",             "O", "K",       "Minimum temperature limit",                       true},
+    {iP_min,             "P_min",             "O", "Pa",      "Minimum pressure limit",                          true},
+    {iP_max,             "P_max",             "O", "Pa",      "Maximum pressure limit",                          true},
+    {iP_critical,        "p_critical",        "O", "Pa",      "Pressure at the critical point",                  true},
+	{iP_reducing,        "p_reducing",        "O", "Pa",      "Pressure at the reducing point",                  true},
+    {iP_triple,          "p_triple",          "O", "Pa",      "Pressure at the triple point (pure only)",        true},
+    {ifraction_min,      "fraction_min",      "O", "-",       "Fraction (mole, mass, volume) minimum value for incompressible solutions",true},
+    {ifraction_max,      "fraction_max",      "O", "-",       "Fraction (mole, mass, volume) maximum value for incompressible solutions",true},
+    {iT_freeze,          "T_freeze",          "O", "K",       "Freezing temperature for incompressible solutions",true},
     
-    parameter_info(ispeed_sound, "speed_of_sound","O","m/s","Speed of sound",false),
-    parameter_info(iviscosity, "viscosity","O","Pa-s","Viscosity",false),
-    parameter_info(iconductivity, "conductivity","O","W/m/K","Thermal conductivity",false),
-    parameter_info(isurface_tension, "surface_tension","O","N/m","Surface tension",false),
-    parameter_info(iPrandtl, "Prandtl","O","-","Prandtl number",false),
+    {ispeed_sound,     "speed_of_sound",  "O", "m/s",   "Speed of sound",       false},
+    {iviscosity,       "viscosity",       "O", "Pa-s",  "Viscosity",            false},
+    {iconductivity,    "conductivity",    "O", "W/m/K", "Thermal conductivity", false},
+    {isurface_tension, "surface_tension", "O", "N/m",   "Surface tension",      false},
+    {iPrandtl,         "Prandtl",         "O", "-",     "Prandtl number",       false},
     
-    parameter_info(iisothermal_compressibility, "isothermal_compressibility","O","1/Pa","Isothermal compressibility",false),
-    parameter_info(iisobaric_expansion_coefficient, "isobaric_expansion_coefficient","O","1/K","Isobaric expansion coefficient",false),
-    parameter_info(iZ, "Z","O","-","Compressibility factor",false),
-    parameter_info(ifundamental_derivative_of_gas_dynamics, "fundamental_derivative_of_gas_dynamics","O","-","Fundamental_derivative_of_gas_dynamics",false),
+    {iisothermal_compressibility,             "isothermal_compressibility",             "O", "1/Pa", "Isothermal compressibility",false},
+    {iisobaric_expansion_coefficient,         "isobaric_expansion_coefficient",         "O", "1/K",  "Isobaric expansion coefficient",false},
+    {iZ,                                      "Z",                                      "O", "-",    "Compressibility factor",false},
+    {ifundamental_derivative_of_gas_dynamics, "fundamental_derivative_of_gas_dynamics", "O", "-",    "Fundamental_derivative_of_gas_dynamics",false},
     
-    parameter_info(ialphar, "alphar","O","-","Residual Helmholtz energy",false),
-    parameter_info(idalphar_dtau_constdelta, "dalphar_dtau_constdelta","O","-","Derivative of residual Helmholtz energy with tau",false),
-    parameter_info(idalphar_ddelta_consttau, "dalphar_ddelta_consttau","O","-","Derivative of residual Helmholtz energy with delta",false),
+    {ialphar,                  "alphar",                  "O", "-", "Residual Helmholtz energy", false},
+    {idalphar_dtau_constdelta, "dalphar_dtau_constdelta", "O", "-", "Derivative of residual Helmholtz energy with tau",false},
+    {idalphar_ddelta_consttau, "dalphar_ddelta_consttau", "O", "-", "Derivative of residual Helmholtz energy with delta",false},
     
-    parameter_info(ialpha0, "alpha0","O","-","Ideal Helmholtz energy",false),
-    parameter_info(idalpha0_dtau_constdelta, "dalpha0_dtau_constdelta","O","-","Derivative of ideal Helmholtz energy with tau",false),
-    parameter_info(idalpha0_ddelta_consttau, "dalpha0_ddelta_consttau","O","-","Derivative of ideal Helmholtz energy with delta",false),
+    {ialpha0,                  "alpha0",                  "O", "-", "Ideal Helmholtz energy", false},
+    {idalpha0_dtau_constdelta, "dalpha0_dtau_constdelta", "O", "-", "Derivative of ideal Helmholtz energy with tau",false},
+    {idalpha0_ddelta_consttau, "dalpha0_ddelta_consttau", "O", "-", "Derivative of ideal Helmholtz energy with delta",false},
     
-    parameter_info(iPhase, "Phase","O","-","Phase index as a float",false),
+    {iPhase, "Phase", "O", "-", "Phase index as a float", false},
     
 };
 
@@ -289,21 +287,19 @@ bool is_valid_second_derivative(const std::string &name, parameters &iOf1, param
 struct phase_info
 {    
     phases key;
-    std::string short_desc, long_desc;
-public:
-    phase_info(phases key, std::string short_desc, std::string long_desc): key(key), short_desc(short_desc), long_desc(long_desc){};
+    const char *short_desc, *long_desc;
 };
             
-phase_info phase_info_list[] = {
-    phase_info(iphase_liquid, "phase_liquid",""),
-    phase_info(iphase_gas, "phase_gas",""),
-    phase_info(iphase_twophase, "phase_twophase",""),
-    phase_info(iphase_supercritical, "phase_supercritical", ""),
-    phase_info(iphase_supercritical_gas, "phase_supercritical_gas", "p < pc, T > Tc"),
-    phase_info(iphase_supercritical_liquid, "phase_supercritical_liquid", "p > pc, T < Tc"),
-    phase_info(iphase_critical_point, "phase_critical_point", "p = pc, T = Tc"),
-    phase_info(iphase_unknown, "phase_unknown", ""),
-    phase_info(iphase_not_imposed, "phase_not_imposed", ""),
+const phase_info phase_info_list[] = {
+    { iphase_liquid,               "phase_liquid",               ""               },
+    { iphase_gas,                  "phase_gas",                  ""               },
+    { iphase_twophase,             "phase_twophase",             ""               },
+    { iphase_supercritical,        "phase_supercritical",        ""               },
+    { iphase_supercritical_gas,    "phase_supercritical_gas",    "p < pc, T > Tc" },
+    { iphase_supercritical_liquid, "phase_supercritical_liquid", "p > pc, T < Tc" },
+    { iphase_critical_point,       "phase_critical_point",       "p = pc, T = Tc" },
+    { iphase_unknown,              "phase_unknown",              ""               },
+    { iphase_not_imposed,          "phase_not_imposed",          ""               },
 };
 
 class PhaseInformation
@@ -367,51 +363,49 @@ parameters get_parameter_index(const std::string &param_name)
 struct input_pair_info
 {
     input_pairs key;
-    std::string short_desc, long_desc;
-public:
-    input_pair_info(input_pairs key, std::string short_desc, std::string long_desc): key(key), short_desc(short_desc), long_desc(long_desc){};
+    const char *short_desc, *long_desc;
 };
 
-input_pair_info input_pair_list[] = {
-    input_pair_info( QT_INPUTS, "QT_INPUTS", "Molar quality, Temperature in K" ),
-    input_pair_info( QSmolar_INPUTS, "QS_INPUTS", "Molar quality, Entropy in J/mol/K" ),
-    input_pair_info( QSmass_INPUTS, "QS_INPUTS", "Molar quality, Entropy in J/kg/K" ),
-    input_pair_info( HmolarQ_INPUTS, "HQ_INPUTS", "Enthalpy in J/mol, Molar quality" ),
-    input_pair_info( HmassQ_INPUTS, "HQ_INPUTS", "Enthalpy in J/kg, Molar quality" ),
-    input_pair_info( PQ_INPUTS, "PQ_INPUTS", "Pressure in Pa, Molar quality" ),
+const input_pair_info input_pair_list[] = {
+    { QT_INPUTS,           "QT_INPUTS",           "Molar quality, Temperature in K"                    },
+    { QSmolar_INPUTS,      "QS_INPUTS",           "Molar quality, Entropy in J/mol/K"                  },
+    { QSmass_INPUTS,       "QS_INPUTS",           "Molar quality, Entropy in J/kg/K"                   },
+    { HmolarQ_INPUTS,      "HQ_INPUTS",           "Enthalpy in J/mol, Molar quality"                   },
+    { HmassQ_INPUTS,       "HQ_INPUTS",           "Enthalpy in J/kg, Molar quality"                    },
+    { PQ_INPUTS,           "PQ_INPUTS",           "Pressure in Pa, Molar quality"                      },
     
-    input_pair_info( PT_INPUTS, "PT_INPUTS", "Pressure in Pa, Temperature in K" ),
+    { PT_INPUTS,           "PT_INPUTS",           "Pressure in Pa, Temperature in K"                   },
     
 
-    input_pair_info( DmassT_INPUTS, "DmassT_INPUTS", "Mass density in kg/m^3, Temperature in K" ),
-    input_pair_info( DmolarT_INPUTS, "DmolarT_INPUTS", "Molar density in mol/m^3, Temperature in K" ),
-    input_pair_info( HmassT_INPUTS, "HmassT_INPUTS", "Enthalpy in J/kg, Temperature in K" ),
-    input_pair_info( HmolarT_INPUTS, "HmolarT_INPUTS", "Enthalpy in J/mol, Temperature in K" ),
-    input_pair_info( SmassT_INPUTS, "SmassT_INPUTS", "Entropy in J/kg/K, Temperature in K" ),
-    input_pair_info( SmolarT_INPUTS, "SmolarT_INPUTS", "Entropy in J/mol/K, Temperature in K" ),
-    input_pair_info( TUmass_INPUTS, "TUmass_INPUTS", "Temperature in K, Internal energy in J/kg" ),
-    input_pair_info( TUmolar_INPUTS, "TUmolar_INPUTS", "Temperature in K, Internal energy in J/mol" ),
+    { DmassT_INPUTS,       "DmassT_INPUTS",       "Mass density in kg/m^3, Temperature in K"           },
+    { DmolarT_INPUTS,      "DmolarT_INPUTS",      "Molar density in mol/m^3, Temperature in K"         },
+    { HmassT_INPUTS,       "HmassT_INPUTS",       "Enthalpy in J/kg, Temperature in K"                 },
+    { HmolarT_INPUTS,      "HmolarT_INPUTS",      "Enthalpy in J/mol, Temperature in K"                },
+    { SmassT_INPUTS,       "SmassT_INPUTS",       "Entropy in J/kg/K, Temperature in K"                },
+    { SmolarT_INPUTS,      "SmolarT_INPUTS",      "Entropy in J/mol/K, Temperature in K"               },
+    { TUmass_INPUTS,       "TUmass_INPUTS",       "Temperature in K, Internal energy in J/kg"          },
+    { TUmolar_INPUTS,      "TUmolar_INPUTS",      "Temperature in K, Internal energy in J/mol"         },
 
-    input_pair_info( DmassP_INPUTS, "DmassP_INPUTS", "Mass density in kg/m^3, Pressure in Pa" ),
-    input_pair_info( DmolarP_INPUTS, "DmolarP_INPUTS", "Molar density in mol/m^3, Pressure in Pa" ),
-    input_pair_info( HmassP_INPUTS, "HmassP_INPUTS", "Enthalpy in J/kg, Pressure in Pa" ),
-    input_pair_info( HmolarP_INPUTS, "HmolarP_INPUTS", "Enthalpy in J/mol, Pressure in Pa" ),
-    input_pair_info( PSmass_INPUTS, "PSmass_INPUTS", "Pressure in Pa, Entropy in J/kg/K" ),
-    input_pair_info( PSmolar_INPUTS, "PSmolar_INPUTS", "Pressure in Pa, Entropy in J/mol/K " ),
-    input_pair_info( PUmass_INPUTS, "PUmass_INPUTS", "Pressure in Pa, Internal energy in J/kg" ),
-    input_pair_info( PUmolar_INPUTS, "PUmolar_INPUTS", "Pressure in Pa, Internal energy in J/mol" ),
+    { DmassP_INPUTS,       "DmassP_INPUTS",       "Mass density in kg/m^3, Pressure in Pa"             },
+    { DmolarP_INPUTS,      "DmolarP_INPUTS",      "Molar density in mol/m^3, Pressure in Pa"           },
+    { HmassP_INPUTS,       "HmassP_INPUTS",       "Enthalpy in J/kg, Pressure in Pa"                   },
+    { HmolarP_INPUTS,      "HmolarP_INPUTS",      "Enthalpy in J/mol, Pressure in Pa"                  },
+    { PSmass_INPUTS,       "PSmass_INPUTS",       "Pressure in Pa, Entropy in J/kg/K"                  },
+    { PSmolar_INPUTS,      "PSmolar_INPUTS",      "Pressure in Pa, Entropy in J/mol/K "                },
+    { PUmass_INPUTS,       "PUmass_INPUTS",       "Pressure in Pa, Internal energy in J/kg"            },
+    { PUmolar_INPUTS,      "PUmolar_INPUTS",      "Pressure in Pa, Internal energy in J/mol"           },
 
-    input_pair_info( DmassHmass_INPUTS, "DmassHmass_INPUTS", "Mass density in kg/m^3, Enthalpy in J/kg" ),
-    input_pair_info( DmolarHmolar_INPUTS, "DmolarHmolar_INPUTS", "Molar density in mol/m^3, Enthalpy in J/mol" ),
-    input_pair_info( DmassSmass_INPUTS, "DmassSmass_INPUTS", "Mass density in kg/m^3, Entropy in J/kg/K" ),
-    input_pair_info( DmolarSmolar_INPUTS, "DmolarSmolar_INPUTS", "Molar density in mol/m^3, Entropy in J/mol/K" ),
-    input_pair_info( DmassUmass_INPUTS, "DmassUmass_INPUTS", "Mass density in kg/m^3, Internal energy in J/kg" ),
-    input_pair_info( DmolarUmolar_INPUTS, "DmolarUmolar_INPUTS", "Molar density in mol/m^3, Internal energy in J/mol" ),
+    { DmassHmass_INPUTS,   "DmassHmass_INPUTS",   "Mass density in kg/m^3, Enthalpy in J/kg"           },
+    { DmolarHmolar_INPUTS, "DmolarHmolar_INPUTS", "Molar density in mol/m^3, Enthalpy in J/mol"        },
+    { DmassSmass_INPUTS,   "DmassSmass_INPUTS",   "Mass density in kg/m^3, Entropy in J/kg/K"          },
+    { DmolarSmolar_INPUTS, "DmolarSmolar_INPUTS", "Molar density in mol/m^3, Entropy in J/mol/K"       },
+    { DmassUmass_INPUTS,   "DmassUmass_INPUTS",   "Mass density in kg/m^3, Internal energy in J/kg"    },
+    { DmolarUmolar_INPUTS, "DmolarUmolar_INPUTS", "Molar density in mol/m^3, Internal energy in J/mol" },
 
-    input_pair_info( HmassSmass_INPUTS, "HmassSmass_INPUTS", "Enthalpy in J/kg, Entropy in J/kg/K" ),
-    input_pair_info( HmolarSmolar_INPUTS, "HmolarSmolar_INPUTS", "Enthalpy in J/mol, Entropy in J/mol/K" ),
-    input_pair_info( SmassUmass_INPUTS, "SmassUmass_INPUTS", "Entropy in J/kg/K, Internal energy in J/kg" ),
-    input_pair_info( SmolarUmolar_INPUTS, "SmolarUmolar_INPUTS", "Entropy in J/mol/K, Internal energy in J/mol" ),
+    { HmassSmass_INPUTS,   "HmassSmass_INPUTS",   "Enthalpy in J/kg, Entropy in J/kg/K"                },
+    { HmolarSmolar_INPUTS, "HmolarSmolar_INPUTS", "Enthalpy in J/mol, Entropy in J/mol/K"              },
+    { SmassUmass_INPUTS,   "SmassUmass_INPUTS",   "Entropy in J/kg/K, Internal energy in J/kg"         },
+    { SmolarUmolar_INPUTS, "SmolarUmolar_INPUTS", "Entropy in J/mol/K, Internal energy in J/mol"       },
 };
 
 class InputPairInformation


### PR DESCRIPTION
This time I tested everything under Ubuntu.

-> I reworked primitive structures simplification. This time I don't use c++11 syntax
```c++
var = struct{init_list}
```
Instead, good old structure initializer
```c++
var = {init_list}
```
is used. I'm doing this to allow compiler to compile these primitive structures into library as blobs, ready to use without initialization. They are anyway only needed to initialize smart classes. Now it looks like this:
- strings and numbers are stored in the library binary (data section) and loaded into the memory on library load
- this data is used to initialize array of structs (using a number of calls to struct contructor, and to std::string constructors inside)
- this array is used to initialize static info class object (through its constructor).

I hope to do this:
- array with strings and numbers is stored in library binary and loaded into memory
- this array is used to initialize static info class object

-> Removed <memory> include that I added to use std::shared_ptr (reverted by b28583f4b6e2e861b75a0293c07d9bf9bc0e4005).

-> Fixed compiler warning that deleting void* is undefined

Further commits will be tested under Linux, too. Hope that I will not create much troubles anymore. Sorry for being ignorant.