### PR TITLE
Remap CoolPropDbl to double

### DIFF
--- a/include/CoolPropTools.h
+++ b/include/CoolPropTools.h
@@ -69,7 +69,7 @@
         #endif
     #endif
 
-	//#define COOLPROPDBL_MAPS_TO_DOUBLE
+	#define COOLPROPDBL_MAPS_TO_DOUBLE
 	#ifdef COOLPROPDBL_MAPS_TO_DOUBLE
 		typedef double CoolPropDbl;
 	#else

--- a/src/Backends/Helmholtz/TransportRoutines.cpp
+++ b/src/Backends/Helmholtz/TransportRoutines.cpp
@@ -362,7 +362,7 @@ CoolPropDbl TransportRoutines::viscosity_heptane_higher_order_hardcoded(Helmholt
 
     // Output is in Pa-s
     double c[] = {0, 22.15000/1e6, -15.00870/1e6, 3.71791/1e6, 77.72818/1e6, 9.73449, 9.51900, -6.34076, -2.51909};
-    return pow(rhor,2.0L/3.0L)*sqrt(Tr)*(c[1]*rhor+c[2]*pow(rhor,2)+c[3]*pow(rhor,3)+c[4]*rhor/(c[5]+c[6]*Tr+c[7]*rhor+rhor*rhor+c[8]*rhor*Tr));
+    return pow(rhor,static_cast<CoolPropDbl>(2.0L/3.0L))*sqrt(Tr)*(c[1]*rhor+c[2]*pow(rhor,2)+c[3]*pow(rhor,3)+c[4]*rhor/(c[5]+c[6]*Tr+c[7]*rhor+rhor*rhor+c[8]*rhor*Tr));
 }
 
 CoolPropDbl TransportRoutines::viscosity_higher_order_friction_theory(HelmholtzEOSMixtureBackend &HEOS)
@@ -1230,7 +1230,7 @@ CoolPropDbl TransportRoutines::viscosity_ECS(HelmholtzEOSMixtureBackend &HEOS, H
     CoolPropDbl eta_resid = HEOS_Reference.calc_viscosity_background();
 
     // The F factor
-    CoolPropDbl F_eta = sqrt(f)*pow(h, -2.0L/3.0L)*sqrt(M/M0);
+    CoolPropDbl F_eta = sqrt(f)*pow(h, -static_cast<CoolPropDbl>(2.0L/3.0L))*sqrt(M/M0);
 
     // The total viscosity considering the contributions of the fluid of interest and the reference fluid [Pa-s]
     CoolPropDbl eta = eta_dilute + eta_resid*F_eta;

--- a/src/Helmholtz.cpp
+++ b/src/Helmholtz.cpp
@@ -483,10 +483,10 @@ void ResidualHelmholtzSRK::all(const CoolPropDbl &tau, const CoolPropDbl &delta,
     CoolPropDbl amix = a*pow(kappa_times_Trbracket, 2);
 
     // Derivatives of amix with respect to tau
-    CoolPropDbl damix_dTau = a*kappa/pow(tau, 3.0L/2.0)*kappa_times_Trbracket;
-    CoolPropDbl d2amix_dTau2 = a*kappa/2.0*(kappa/pow(tau,3)-3/pow(tau, 5.0L/2.0)*kappa_times_Trbracket);
-    CoolPropDbl d3amix_dTau3 = 3.0*a*kappa/4.0*(-3.0*kappa/pow(tau, 4)+5/pow(tau, 7.0L/2.0)*kappa_times_Trbracket);
-    CoolPropDbl d4amix_dTau4 = 3.0*a*kappa/8.0*(29.0*kappa/pow(tau, 5)-35/pow(tau, 9.0L/2.0)*kappa_times_Trbracket);
+    CoolPropDbl damix_dTau = a*kappa/pow(tau, static_cast<CoolPropDbl>(3.0L/2.0))*kappa_times_Trbracket;
+    CoolPropDbl d2amix_dTau2 = a*kappa/2.0*(kappa/pow(tau,3)-3/pow(tau, static_cast<CoolPropDbl>(5.0L/2.0))*kappa_times_Trbracket);
+    CoolPropDbl d3amix_dTau3 = 3.0*a*kappa/4.0*(-3.0*kappa/pow(tau, 4)+5/pow(tau, static_cast<CoolPropDbl>(7.0L/2.0))*kappa_times_Trbracket);
+    CoolPropDbl d4amix_dTau4 = 3.0*a*kappa/8.0*(29.0*kappa/pow(tau, 5)-35/pow(tau, static_cast<CoolPropDbl>(9.0L/2.0))*kappa_times_Trbracket);
 
     derivs.alphar += -log(1-b*delta*rhor)-tau*amix/(R*Treducing*b)*log(b*delta*rhor + 1);
 

--- a/wrappers/Python/CoolProp/AbstractState.pxd
+++ b/wrappers/Python/CoolProp/AbstractState.pxd
@@ -4,6 +4,7 @@ from libcpp.string cimport string
 # A header defining the AbstractState class
 cimport cAbstractState
 
+from typedefs cimport *
 cimport constants_header
 
 cdef class PyPhaseEnvelopeData:
@@ -89,7 +90,7 @@ cdef class AbstractState:
     cpdef double delta(self) except *
     cpdef double viscosity(self) except *
     cpdef double conductivity(self) except *
-    cpdef dict conformal_state(self, string, long double, long double)
+    cpdef dict conformal_state(self, string, CoolPropDbl, CoolPropDbl)
     cpdef dict conductivity_contributions(self)
     cpdef dict viscosity_contributions(self)
     cpdef double surface_tension(self) except *
@@ -116,10 +117,10 @@ cdef class AbstractState:
     ##        Derivatives
     ## ----------------------------------------
     
-    cpdef long double first_partial_deriv(self, constants_header.parameters, constants_header.parameters, constants_header.parameters) except *
-    cpdef long double second_partial_deriv(self, constants_header.parameters, constants_header.parameters, constants_header.parameters, constants_header.parameters, constants_header.parameters) except *
-    cpdef long double first_saturation_deriv(self, constants_header.parameters, constants_header.parameters) except *
-    cpdef long double second_saturation_deriv(self, constants_header.parameters, constants_header.parameters, constants_header.parameters) except *
+    cpdef CoolPropDbl first_partial_deriv(self, constants_header.parameters, constants_header.parameters, constants_header.parameters) except *
+    cpdef CoolPropDbl second_partial_deriv(self, constants_header.parameters, constants_header.parameters, constants_header.parameters, constants_header.parameters, constants_header.parameters) except *
+    cpdef CoolPropDbl first_saturation_deriv(self, constants_header.parameters, constants_header.parameters) except *
+    cpdef CoolPropDbl second_saturation_deriv(self, constants_header.parameters, constants_header.parameters, constants_header.parameters) except *
     
     cpdef double first_two_phase_deriv(self, constants_header.parameters Of, constants_header.parameters Wrt, constants_header.parameters Constant) except *
     cpdef double second_two_phase_deriv(self, constants_header.parameters Of, constants_header.parameters Wrt1, constants_header.parameters Constant1, constants_header.parameters Wrt2, constants_header.parameters Constant2) except *
@@ -137,24 +138,24 @@ cdef class AbstractState:
     cpdef get_mass_fractions(self) 
     cpdef get_mole_fractions(self)
     
-    cpdef long double alpha0(self) except *
-    cpdef long double dalpha0_dDelta(self) except *
-    cpdef long double dalpha0_dTau(v) except *
-    cpdef long double d2alpha0_dDelta2(self) except *
-    cpdef long double d2alpha0_dDelta_dTau(self) except *
-    cpdef long double d2alpha0_dTau2(self) except *
-    cpdef long double d3alpha0_dTau3(self) except *
-    cpdef long double d3alpha0_dDelta_dTau2(self) except *
-    cpdef long double d3alpha0_dDelta2_dTau(self) except *
-    cpdef long double d3alpha0_dDelta3(self) except *
+    cpdef CoolPropDbl alpha0(self) except *
+    cpdef CoolPropDbl dalpha0_dDelta(self) except *
+    cpdef CoolPropDbl dalpha0_dTau(v) except *
+    cpdef CoolPropDbl d2alpha0_dDelta2(self) except *
+    cpdef CoolPropDbl d2alpha0_dDelta_dTau(self) except *
+    cpdef CoolPropDbl d2alpha0_dTau2(self) except *
+    cpdef CoolPropDbl d3alpha0_dTau3(self) except *
+    cpdef CoolPropDbl d3alpha0_dDelta_dTau2(self) except *
+    cpdef CoolPropDbl d3alpha0_dDelta2_dTau(self) except *
+    cpdef CoolPropDbl d3alpha0_dDelta3(self) except *
 
-    cpdef long double alphar(self) except *
-    cpdef long double dalphar_dDelta(self) except *
-    cpdef long double dalphar_dTau(self) except *
-    cpdef long double d2alphar_dDelta2(self) except *
-    cpdef long double d2alphar_dDelta_dTau(self) except *
-    cpdef long double d2alphar_dTau2(self) except *
-    cpdef long double d3alphar_dDelta3(self) except *
-    cpdef long double d3alphar_dDelta2_dTau(self) except *
-    cpdef long double d3alphar_dDelta_dTau2(self) except *
-    cpdef long double d3alphar_dTau3(self) except *
+    cpdef CoolPropDbl alphar(self) except *
+    cpdef CoolPropDbl dalphar_dDelta(self) except *
+    cpdef CoolPropDbl dalphar_dTau(self) except *
+    cpdef CoolPropDbl d2alphar_dDelta2(self) except *
+    cpdef CoolPropDbl d2alphar_dDelta_dTau(self) except *
+    cpdef CoolPropDbl d2alphar_dTau2(self) except *
+    cpdef CoolPropDbl d3alphar_dDelta3(self) except *
+    cpdef CoolPropDbl d3alphar_dDelta2_dTau(self) except *
+    cpdef CoolPropDbl d3alphar_dDelta_dTau2(self) except *
+    cpdef CoolPropDbl d3alphar_dTau3(self) except *

--- a/wrappers/Python/CoolProp/AbstractState.pyx
+++ b/wrappers/Python/CoolProp/AbstractState.pyx
@@ -293,19 +293,19 @@ cdef class AbstractState:
         cdef double T = 1e99, rho = 1e99
         self.thisptr.true_critical_point(T, rho)
         return T, rho
-    cpdef dict conformal_state(self, string reference_fluid, long double T, long double rho):
+    cpdef dict conformal_state(self, string reference_fluid, CoolPropDbl T, CoolPropDbl rho):
         """ Solve for conformal state used in extended corresponding states - wrapper of c++ function :cpapi:`CoolProp::AbstractState::conformal_state` """
-        cdef long double T0 = T, rho0 = rho
+        cdef CoolPropDbl T0 = T, rho0 = rho
         self.thisptr.conformal_state(reference_fluid, T0, rho0)
         return dict(T = T0, rhomolar = rho0)
     cpdef dict conductivity_contributions(self):
         """ Retrieve each of the contributions to the conductivity, each in W/m/K - wrapper of c++ function :cpapi:`CoolProp::AbstractState::conductivity_contributions` """
-        cdef long double dilute = 0, initial_density = 0, residual = 0, critical = 0
+        cdef CoolPropDbl dilute = 0, initial_density = 0, residual = 0, critical = 0
         self.thisptr.conductivity_contributions(dilute, initial_density, residual, critical)
         return dict(dilute = dilute, initial_density = initial_density, residual = residual, critical = critical)
     cpdef dict viscosity_contributions(self):
         """ Retrieve each of the contributions to the viscosity, each in Pa-s - wrapper of c++ function :cpapi:`CoolProp::AbstractState::viscosity_contributions` """
-        cdef long double dilute = 0, initial_density = 0, residual = 0, critical = 0
+        cdef CoolPropDbl dilute = 0, initial_density = 0, residual = 0, critical = 0
         self.thisptr.viscosity_contributions(dilute, initial_density, residual, critical)
         return dict(dilute = dilute, initial_density = initial_density, residual = residual, critical = critical)
 
@@ -313,16 +313,16 @@ cdef class AbstractState:
     ##        Derivatives
     ## ----------------------------------------
     
-    cpdef long double first_partial_deriv(self, constants_header.parameters OF , constants_header.parameters WRT, constants_header.parameters CONSTANT) except *: 
+    cpdef CoolPropDbl first_partial_deriv(self, constants_header.parameters OF , constants_header.parameters WRT, constants_header.parameters CONSTANT) except *: 
         """ Get the first partial derivative - wrapper of c++ function :cpapi:`CoolProp::AbstractState::first_partial_deriv` """
         return self.thisptr.first_partial_deriv(OF, WRT, CONSTANT)
-    cpdef long double second_partial_deriv(self, constants_header.parameters OF , constants_header.parameters WRT1, constants_header.parameters CONSTANT1, constants_header.parameters WRT2, constants_header.parameters CONSTANT2) except *: 
+    cpdef CoolPropDbl second_partial_deriv(self, constants_header.parameters OF , constants_header.parameters WRT1, constants_header.parameters CONSTANT1, constants_header.parameters WRT2, constants_header.parameters CONSTANT2) except *: 
         """ Get the second partial derivative - wrapper of c++ function :cpapi:`CoolProp::AbstractState::second_partial_deriv` """
         return self.thisptr.second_partial_deriv(OF, WRT1, CONSTANT1, WRT2, CONSTANT2)
-    cpdef long double first_saturation_deriv(self, constants_header.parameters OF , constants_header.parameters WRT) except *: 
+    cpdef CoolPropDbl first_saturation_deriv(self, constants_header.parameters OF , constants_header.parameters WRT) except *: 
         """ Get the first derivative along the saturation curve - wrapper of c++ function :cpapi:`CoolProp::AbstractState::first_saturation_deriv` """
         return self.thisptr.first_saturation_deriv(OF, WRT)
-    cpdef long double second_saturation_deriv(self, constants_header.parameters OF1 , constants_header.parameters WRT1, constants_header.parameters WRT2) except *: 
+    cpdef CoolPropDbl second_saturation_deriv(self, constants_header.parameters OF1 , constants_header.parameters WRT1, constants_header.parameters WRT2) except *: 
         """ Get the second derivative along the saturation curve - wrapper of c++ function :cpapi:`CoolProp::AbstractState::second_saturation_deriv` """
         return self.thisptr.second_saturation_deriv(OF1, WRT1, WRT2)
     cpdef double first_two_phase_deriv(self, constants_header.parameters Of, constants_header.parameters Wrt, constants_header.parameters Constant) except *:
@@ -388,64 +388,64 @@ cdef class AbstractState:
     ##   Helmholtz energy derivatives
     ## -----------------------------------------
     
-    cpdef long double alpha0(self) except *:
+    cpdef CoolPropDbl alpha0(self) except *:
         """ Get the ideal-gas reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::alpha0` """
         return self.thisptr.alpha0()
-    cpdef long double dalpha0_dDelta(self) except *:
+    cpdef CoolPropDbl dalpha0_dDelta(self) except *:
         """ Get the ideal-gas reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::dalpha0_dDelta` """
         return self.thisptr.dalpha0_dDelta()
-    cpdef long double dalpha0_dTau(self) except *:
+    cpdef CoolPropDbl dalpha0_dTau(self) except *:
         """ Get the ideal-gas reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::dalpha0_dTau` """
         return self.thisptr.dalpha0_dTau()
-    cpdef long double d2alpha0_dDelta2(self) except *:
+    cpdef CoolPropDbl d2alpha0_dDelta2(self) except *:
         """ Get the ideal-gas reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::d2alpha0_dDelta2` """
         return self.thisptr.d2alpha0_dDelta2()
-    cpdef long double d2alpha0_dDelta_dTau(self) except *:
+    cpdef CoolPropDbl d2alpha0_dDelta_dTau(self) except *:
         """ Get the ideal-gas reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::d2alpha0_dDelta_dTau` """
         return self.thisptr.d2alpha0_dDelta_dTau()
-    cpdef long double d2alpha0_dTau2(self) except *:
+    cpdef CoolPropDbl d2alpha0_dTau2(self) except *:
         """ Get the ideal-gas reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::d2alpha0_dTau2` """
         return self.thisptr.d2alpha0_dTau2()
-    cpdef long double d3alpha0_dTau3(self) except *:
+    cpdef CoolPropDbl d3alpha0_dTau3(self) except *:
         """ Get the ideal-gas reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::d3alpha0_dTau3` """
         return self.thisptr.d3alpha0_dTau3()
-    cpdef long double d3alpha0_dDelta_dTau2(self) except *:
+    cpdef CoolPropDbl d3alpha0_dDelta_dTau2(self) except *:
         """ Get the ideal-gas reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::d3alpha0_dDelta_dTau2` """
         return self.thisptr.d3alpha0_dDelta_dTau2()
-    cpdef long double d3alpha0_dDelta2_dTau(self) except *:
+    cpdef CoolPropDbl d3alpha0_dDelta2_dTau(self) except *:
         """ Get the ideal-gas reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::d3alpha0_dDelta2_dTau` """
         return self.thisptr.d3alpha0_dDelta2_dTau()
-    cpdef long double d3alpha0_dDelta3(self) except *:
+    cpdef CoolPropDbl d3alpha0_dDelta3(self) except *:
         """ Get the ideal-gas reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::d3alpha0_dDelta3` """
         return self.thisptr.d3alpha0_dDelta3()
         
-    cpdef long double alphar(self) except *:
+    cpdef CoolPropDbl alphar(self) except *:
         """ Get the residual reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::alphar` """
         return self.thisptr.alphar()
-    cpdef long double dalphar_dDelta(self) except *:
+    cpdef CoolPropDbl dalphar_dDelta(self) except *:
         """ Get the residual reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::dalphar_dDelta` """
         return self.thisptr.dalphar_dDelta()
-    cpdef long double dalphar_dTau(self) except *:
+    cpdef CoolPropDbl dalphar_dTau(self) except *:
         """ Get the residual reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::dalphar_dTau` """
         return self.thisptr.dalphar_dTau()
-    cpdef long double d2alphar_dDelta2(self) except *:
+    cpdef CoolPropDbl d2alphar_dDelta2(self) except *:
         """ Get the residual reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::d2alphar_dDelta2` """
         return self.thisptr.d2alphar_dDelta2()
-    cpdef long double d2alphar_dDelta_dTau(self) except *:
+    cpdef CoolPropDbl d2alphar_dDelta_dTau(self) except *:
         """ Get the residual reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::d2alphar_dDelta_dTau` """
         return self.thisptr.d2alphar_dDelta_dTau()
-    cpdef long double d2alphar_dTau2(self) except *:
+    cpdef CoolPropDbl d2alphar_dTau2(self) except *:
         """ Get the residual reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::d2alphar_dTau2` """
         return self.thisptr.d2alphar_dTau2()
-    cpdef long double d3alphar_dTau3(self) except *:
+    cpdef CoolPropDbl d3alphar_dTau3(self) except *:
         """ Get the residual reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::d3alphar_dTau3` """
         return self.thisptr.d3alphar_dTau3()
-    cpdef long double d3alphar_dDelta_dTau2(self) except *:
+    cpdef CoolPropDbl d3alphar_dDelta_dTau2(self) except *:
         """ Get the residual reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::d3alphar_dDelta_dTau2` """
         return self.thisptr.d3alphar_dDelta_dTau2()
-    cpdef long double d3alphar_dDelta2_dTau(self) except *:
+    cpdef CoolPropDbl d3alphar_dDelta2_dTau(self) except *:
         """ Get the residual reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::d3alphar_dDelta2_dTau` """
         return self.thisptr.d3alphar_dDelta2_dTau()
-    cpdef long double d3alphar_dDelta3(self) except *:
+    cpdef CoolPropDbl d3alphar_dDelta3(self) except *:
         """ Get the residual reduced Helmholtz energy - wrapper of c++ function :cpapi:`CoolProp::AbstractState::d3alphar_dDelta3` """
         return self.thisptr.d3alphar_dDelta3()

--- a/wrappers/Python/CoolProp/CoolProp.pxd
+++ b/wrappers/Python/CoolProp/CoolProp.pxd
@@ -4,6 +4,8 @@ cimport cython
 
 from libcpp.vector cimport vector
 
+from typedefs cimport *
+
 include "AbstractState.pxd"
        
 cdef class State:

--- a/wrappers/Python/CoolProp/CoolProp.pyx
+++ b/wrappers/Python/CoolProp/CoolProp.pyx
@@ -12,6 +12,8 @@ cimport cython
 import math
 import warnings
 
+from typedefs cimport CoolPropDbl
+
 try:
     import numpy as np
     _numpy_supported = True

--- a/wrappers/Python/CoolProp/cAbstractState.pxd
+++ b/wrappers/Python/CoolProp/cAbstractState.pxd
@@ -4,6 +4,8 @@ from libcpp.vector cimport vector
 
 cimport constants_header
 
+from typedefs cimport CoolPropDbl
+
 cdef extern from "PhaseEnvelope.h" namespace "CoolProp":
     cdef cppclass PhaseEnvelopeData:
         bool TypeI
@@ -35,10 +37,10 @@ cdef extern from "AbstractState.h" namespace "CoolProp":
         void set_mass_fractions(vector[double]) except+ValueError
         void set_volu_fractions(vector[double]) except+ValueError
         
-        vector[long double] mole_fractions_liquid() except +ValueError
-        vector[long double] mole_fractions_vapor() except +ValueError
-        vector[long double] get_mole_fractions() except +ValueError
-        vector[long double] get_mass_fractions() except +ValueError
+        vector[CoolPropDbl] mole_fractions_liquid() except +ValueError
+        vector[CoolPropDbl] mole_fractions_vapor() except +ValueError
+        vector[CoolPropDbl] get_mole_fractions() except +ValueError
+        vector[CoolPropDbl] get_mass_fractions() except +ValueError
         
         constants_header.phases phase() except +ValueError
         void specify_phase(constants_header.phases phase) except +ValueError
@@ -110,9 +112,9 @@ cdef extern from "AbstractState.h" namespace "CoolProp":
         double delta() except +ValueError
         double viscosity() except+ValueError
         double conductivity() except+ValueError
-        void conformal_state(const string &, long double &, long double &) except +ValueError
-        void conductivity_contributions(long double &dilute, long double &initial_density, long double &residual, long double &critical) except +ValueError
-        void viscosity_contributions(long double &dilute, long double &initial_density, long double &residual, long double &critical) except +ValueError
+        void conformal_state(const string &, CoolPropDbl &, CoolPropDbl &) except +ValueError
+        void conductivity_contributions(CoolPropDbl &dilute, CoolPropDbl &initial_density, CoolPropDbl &residual, CoolPropDbl &critical) except +ValueError
+        void viscosity_contributions(CoolPropDbl &dilute, CoolPropDbl &initial_density, CoolPropDbl &residual, CoolPropDbl &critical) except +ValueError
 
         double surface_tension() except+ValueError
         double Prandtl() except +ValueError
@@ -133,10 +135,10 @@ cdef extern from "AbstractState.h" namespace "CoolProp":
         double acentric_factor() except+ValueError
         double gas_constant() except+ValueError
         
-        long double first_partial_deriv(constants_header.parameters, constants_header.parameters, constants_header.parameters) except+ValueError
-        long double second_partial_deriv(constants_header.parameters, constants_header.parameters, constants_header.parameters, constants_header.parameters, constants_header.parameters) except+ValueError
-        long double first_saturation_deriv(constants_header.parameters, constants_header.parameters) except+ValueError
-        long double second_saturation_deriv(constants_header.parameters, constants_header.parameters, constants_header.parameters) except+ValueError
+        CoolPropDbl first_partial_deriv(constants_header.parameters, constants_header.parameters, constants_header.parameters) except+ValueError
+        CoolPropDbl second_partial_deriv(constants_header.parameters, constants_header.parameters, constants_header.parameters, constants_header.parameters, constants_header.parameters) except+ValueError
+        CoolPropDbl first_saturation_deriv(constants_header.parameters, constants_header.parameters) except+ValueError
+        CoolPropDbl second_saturation_deriv(constants_header.parameters, constants_header.parameters, constants_header.parameters) except+ValueError
         double first_two_phase_deriv(constants_header.parameters Of, constants_header.parameters Wrt, constants_header.parameters Constant) except+ValueError
         double second_two_phase_deriv(constants_header.parameters Of, constants_header.parameters Wrt1, constants_header.parameters Constant1, constants_header.parameters Wrt2, constants_header.parameters Constant2) except+ValueError
         double first_two_phase_deriv_splined(constants_header.parameters Of, constants_header.parameters Wrt, constants_header.parameters Constant, double x_end) except+ValueError
@@ -150,27 +152,27 @@ cdef extern from "AbstractState.h" namespace "CoolProp":
         void build_phase_envelope(string) except+ValueError
         PhaseEnvelopeData get_phase_envelope_data() except+ValueError
         
-        long double alpha0() except+ValueError
-        long double dalpha0_dDelta() except+ValueError
-        long double dalpha0_dTau() except+ValueError
-        long double d2alpha0_dDelta2() except+ValueError
-        long double d2alpha0_dDelta_dTau() except+ValueError
-        long double d2alpha0_dTau2() except+ValueError
-        long double d3alpha0_dTau3() except+ValueError
-        long double d3alpha0_dDelta_dTau2() except+ValueError
-        long double d3alpha0_dDelta2_dTau() except+ValueError
-        long double d3alpha0_dDelta3() except+ValueError
+        CoolPropDbl alpha0() except+ValueError
+        CoolPropDbl dalpha0_dDelta() except+ValueError
+        CoolPropDbl dalpha0_dTau() except+ValueError
+        CoolPropDbl d2alpha0_dDelta2() except+ValueError
+        CoolPropDbl d2alpha0_dDelta_dTau() except+ValueError
+        CoolPropDbl d2alpha0_dTau2() except+ValueError
+        CoolPropDbl d3alpha0_dTau3() except+ValueError
+        CoolPropDbl d3alpha0_dDelta_dTau2() except+ValueError
+        CoolPropDbl d3alpha0_dDelta2_dTau() except+ValueError
+        CoolPropDbl d3alpha0_dDelta3() except+ValueError
 
-        long double alphar() except+ValueError
-        long double dalphar_dDelta() except+ValueError
-        long double dalphar_dTau() except+ValueError
-        long double d2alphar_dDelta2() except+ValueError
-        long double d2alphar_dDelta_dTau() except+ValueError
-        long double d2alphar_dTau2() except+ValueError
-        long double d3alphar_dDelta3() except+ValueError
-        long double d3alphar_dDelta2_dTau() except+ValueError
-        long double d3alphar_dDelta_dTau2() except+ValueError
-        long double d3alphar_dTau3() except+ValueError
+        CoolPropDbl alphar() except+ValueError
+        CoolPropDbl dalphar_dDelta() except+ValueError
+        CoolPropDbl dalphar_dTau() except+ValueError
+        CoolPropDbl d2alphar_dDelta2() except+ValueError
+        CoolPropDbl d2alphar_dDelta_dTau() except+ValueError
+        CoolPropDbl d2alphar_dTau2() except+ValueError
+        CoolPropDbl d3alphar_dDelta3() except+ValueError
+        CoolPropDbl d3alphar_dDelta2_dTau() except+ValueError
+        CoolPropDbl d3alphar_dDelta_dTau2() except+ValueError
+        CoolPropDbl d3alphar_dTau3() except+ValueError
 
 # The static factory method for the AbstractState
 cdef extern from "AbstractState.h" namespace "CoolProp::AbstractState":

--- a/wrappers/Python/CoolProp/typedefs.pxd
+++ b/wrappers/Python/CoolProp/typedefs.pxd
@@ -1,0 +1,1 @@
+ctypedef double CoolPropDbl


### PR DESCRIPTION
Remap CoolPropDbl to actually be a double, not a long double, in preparation for removal of CoolPropDbl entirely.

closes #931 