### PR TITLE
Update index.rst

### DIFF
--- a/Web/coolprop/wrappers/Scilab/index.rst
+++ b/Web/coolprop/wrappers/Scilab/index.rst
@@ -30,6 +30,22 @@ Run the sample file using something like this at the scilab prompt::
     
 The ``-1`` is to ensure that all lines are not echoed (unelated question: why is echoing all lines in a script the default behavior in scilab?)
 
+If you always use CoolProp, you might find it convenient to have the shared library load automatically when you start Scilab. To do that, just rename the 'sample.sce' file to 'scilab.ini' and put it in the scilab home directory which can be found by executing 'SCIHOME' in the scilab console window, the result will be something like that:
+
+For Linux:
+
+-->SCIHOME
+ SCIHOME  =
+ 
+ /home/username/.Scilab/scilab-5.5.2
+
+For Windows:
+
+-->SCIHOME
+ SCIHOME  =
+ 
+ C:\Users\username\AppData\Roaming\Scilab\scilab-5.5.2
+
 .. note:: 
 
     It is possible that on linux, you might need to add the path to the directory containing ``libCoolProp.so`` to the ``LD_LIBRARY_PATH`` environmental variable.  At the terminal, or in your ~/.bash_profile file, add: ``export LD_LIBRARY_PATH=/path/to/directory``


### PR DESCRIPTION
For the path of the shared library in Linux, it is enough to put the 'libCoolProp.so' in '/usr/lib/scilab' and use the sample.sce file as it is now. I don't know the equivalent folder in windows.

note: As I say in my first comment, "English is not my mother tongue; please excuse any errors on my part."