### PR TITLE
Remove warnings when using Julia 0.4 realease

### DIFF
--- a/wrappers/Julia/CoolProp.jl
+++ b/wrappers/Julia/CoolProp.jl
@@ -8,6 +8,7 @@ if VERSION <= VersionNumber(0,4)
   typealias Ref Ptr
   typealias RefValue Array
   errcode = Array(Clong, 1)
+  typealias AbstractString String
 else
   errcode = Ref{Clong}(0)
 end
@@ -23,7 +24,7 @@ function K2F(TK::Number)
   return ccall( (:K2F, "CoolProp"), Cdouble, (Cdouble,), TK)
 end
 
-function HAPropsSI(Output::String, Name1::String, Value1::Number, Name2::String, Value2::Number, Name3::String, Value3::Number)
+function HAPropsSI(Output::AbstractString, Name1::AbstractString, Value1::Number, Name2::AbstractString, Value2::Number, Name3::AbstractString, Value3::Number)
   val = ccall( (:HAPropsSI, "CoolProp"), Cdouble, (Ptr{UInt8},Ptr{UInt8},Float64,Ptr{UInt8},Float64,Ptr{UInt8},Float64), Output,Name1,Value1,Name2,Value2,Name3,Value3)
   if val == Inf
     error("CoolProp: ", get_global_param_string("errstring"))
@@ -31,7 +32,7 @@ function HAPropsSI(Output::String, Name1::String, Value1::Number, Name2::String,
   return val
 end
 
-function PropsSI(Output::String, Name1::String, Value1::Number, Name2::String, Value2::Number, Fluid::String)
+function PropsSI(Output::AbstractString, Name1::AbstractString, Value1::Number, Name2::AbstractString, Value2::Number, Fluid::AbstractString)
   val = ccall( (:PropsSI, "CoolProp"), Cdouble, (Ptr{UInt8},Ptr{UInt8},Float64,Ptr{UInt8},Float64,Ptr{UInt8}), Output,Name1,Value1,Name2,Value2,Fluid)
   if val == Inf
     error("CoolProp: ", get_global_param_string("errstring"))
@@ -39,7 +40,7 @@ function PropsSI(Output::String, Name1::String, Value1::Number, Name2::String, V
   return val
 end
 
-function PropsSI(FluidName::String, Output::String)
+function PropsSI(FluidName::AbstractString, Output::AbstractString)
   val = ccall( (:Props1SI, "CoolProp"), Cdouble, (Ptr{UInt8},Ptr{UInt8}), FluidName,Output)
   if val == Inf
     error("CoolProp: ", get_global_param_string("errstring"))
@@ -47,20 +48,20 @@ function PropsSI(FluidName::String, Output::String)
   return val
 end
 
-function PhaseSI(Name1::String, Value1::Number, Name2::String, Value2::Number, Fluid::String)
-  val = ccall( (:PhaseSI, "CoolProp"), Int32, (Ptr{UInt8},Float64,Ptr{UInt8},Float64,Ptr{UInt8}, Ptr{UInt8}, Int), Name1,Value1,Name2,Value2,Fluid,message_buffer::Array{Uint8,1},buffer_length)
-  return bytestring(convert(Ptr{UInt8}, pointer(message_buffer::Array{Uint8,1})))
+function PhaseSI(Name1::AbstractString, Value1::Number, Name2::AbstractString, Value2::Number, Fluid::AbstractString)
+  val = ccall( (:PhaseSI, "CoolProp"), Int32, (Ptr{UInt8},Float64,Ptr{UInt8},Float64,Ptr{UInt8}, Ptr{UInt8}, Int), Name1,Value1,Name2,Value2,Fluid,message_buffer::Array{UInt8,1},buffer_length)
+  return bytestring(convert(Ptr{UInt8}, pointer(message_buffer::Array{UInt8,1})))
 end
 
 # This function returns the output string in pre-allocated char buffer.  If buffer is not large enough, no copy is made
-function get_global_param_string(Key::String)
-  val = ccall( (:get_global_param_string, "CoolProp"), Clong, (Ptr{UInt8},Ptr{UInt8},Int), Key,message_buffer::Array{Uint8,1},buffer_length)
-  return bytestring(convert(Ptr{UInt8}, pointer(message_buffer::Array{Uint8,1})))
+function get_global_param_string(Key::AbstractString)
+  val = ccall( (:get_global_param_string, "CoolProp"), Clong, (Ptr{UInt8},Ptr{UInt8},Int), Key,message_buffer::Array{UInt8,1},buffer_length)
+  return bytestring(convert(Ptr{UInt8}, pointer(message_buffer::Array{UInt8,1})))
 end
 
 # Get the index for a parameter "T", "P", etc.
 # returns the index as a long.
-function get_param_index(Param::String)
+function get_param_index(Param::AbstractString)
   val = ccall( (:get_param_index, "CoolProp"), Clong, (Ptr{UInt8},), Param)
   if val == -1
     error("CoolProp: Unknown parameter: ", Param)
@@ -70,7 +71,7 @@ end
 
 # Get the index for an input pair for AbstractState.update function
 # returns the index as a long.
-function get_input_pair_index(Param::String)
+function get_input_pair_index(Param::AbstractString)
   val = ccall( (:get_input_pair_index, "CoolProp"), Clong, (Ptr{UInt8},), Param)
   if val == -1
     error("CoolProp: Unknown input pair: ", Param)
@@ -98,8 +99,8 @@ end
 # param backend The backend you will use, "HEOS", "REFPROP", etc.
 # param fluids '&' delimited list of fluids
 # return A handle to the state class generated
-function AbstractState_factory(backend::String, fluids::String)
-  AbstractState = ccall( (:AbstractState_factory, "CoolProp"), Clong, (Ptr{UInt8},Ptr{UInt8},Ref{Clong},Ptr{UInt8},Clong), backend,fluids,errcode::RefValue{Clong,1},message_buffer::Array{Uint8,1},buffer_length)
+function AbstractState_factory(backend::AbstractString, fluids::AbstractString)
+  AbstractState = ccall( (:AbstractState_factory, "CoolProp"), Clong, (Ptr{UInt8},Ptr{UInt8},Ref{Clong},Ptr{UInt8},Clong), backend,fluids,errcode::RefValue{Clong,1},message_buffer::Array{UInt8,1},buffer_length)
   if errcode[] != 0
     if errcode[] == 1
       error("CoolProp: ", bytestring(convert(Ptr{UInt8}, pointer(message_buffer))))
@@ -115,7 +116,7 @@ end
 # Release a state class generated by the low-level interface wrapper
 # param handle The integer handle for the state class stored in memory
 function AbstractState_free(handle::Clong)
-  ccall( (:AbstractState_free, "CoolProp"), Void, (Clong,Ref{Clong},Ptr{UInt8},Clong), handle,errcode::RefValue{Clong,1},message_buffer::Array{Uint8,1},buffer_length)
+  ccall( (:AbstractState_free, "CoolProp"), Void, (Clong,Ref{Clong},Ptr{UInt8},Clong), handle,errcode::RefValue{Clong,1},message_buffer::Array{UInt8,1},buffer_length)
   if errcode[] != 0
     if errcode[] == 1
       error("CoolProp: ", bytestring(convert(Ptr{UInt8}, pointer(message_buffer))))
@@ -132,7 +133,7 @@ end
 # param handle The integer handle for the state class stored in memory
 # param fractions The array of fractions
 function AbstractState_set_fractions(handle::Clong,fractions::Array)
-  ccall( (:AbstractState_set_fractions, "CoolProp"), Void, (Clong,Ptr{Cdouble},Clong,Ref{Clong},Ptr{UInt8},Clong), handle,fractions,length(fractions),errcode::RefValue{Clong,1},message_buffer::Array{Uint8,1},buffer_length)
+  ccall( (:AbstractState_set_fractions, "CoolProp"), Void, (Clong,Ptr{Cdouble},Clong,Ref{Clong},Ptr{UInt8},Clong), handle,fractions,length(fractions),errcode::RefValue{Clong,1},message_buffer::Array{UInt8,1},buffer_length)
   if errcode[] != 0
     if errcode[] == 1
       error("CoolProp: ", bytestring(convert(Ptr{UInt8}, pointer(message_buffer))))
@@ -147,11 +148,11 @@ end
 
 # Update the state of the AbstractState
 # param handle The integer handle for the state class stored in memory
-# param input_pair The integer value for the input pair obtained from get_input_pair_index(Param::String)
+# param input_pair The integer value for the input pair obtained from get_input_pair_index(Param::AbstractString)
 # param value1 The first input value
 # param value2 The second input value
 function AbstractState_update(handle::Clong,input_pair::Clong,value1::Number,value2::Number)
-  ccall( (:AbstractState_update, "CoolProp"), Void, (Clong,Clong,Cdouble,Cdouble,Ref{Clong},Ptr{UInt8},Clong), handle,input_pair,value1,value2,errcode::RefValue{Clong,1},message_buffer::Array{Uint8,1},buffer_length)
+  ccall( (:AbstractState_update, "CoolProp"), Void, (Clong,Clong,Cdouble,Cdouble,Ref{Clong},Ptr{UInt8},Clong), handle,input_pair,value1,value2,errcode::RefValue{Clong,1},message_buffer::Array{UInt8,1},buffer_length)
   if errcode[] != 0
     if errcode[] == 1
       error("CoolProp: ", bytestring(convert(Ptr{UInt8}, pointer(message_buffer))))
@@ -168,7 +169,7 @@ end
 # param handle The integer handle for the state class stored in memory
 # param param The integer value for the parameter you want
 function AbstractState_keyed_output(handle::Clong, param::Clong)
-  output = ccall( (:AbstractState_keyed_output, "CoolProp"), Cdouble, (Clong,Clong,Ref{Clong},Ptr{UInt8},Clong), handle,param,errcode::RefValue{Clong,1},message_buffer::Array{Uint8,1},buffer_length)
+  output = ccall( (:AbstractState_keyed_output, "CoolProp"), Cdouble, (Clong,Clong,Ref{Clong},Ptr{UInt8},Clong), handle,param,errcode::RefValue{Clong,1},message_buffer::Array{UInt8,1},buffer_length)
   if errcode[] != 0
     if errcode[] == 1
       error("CoolProp: ", bytestring(convert(Ptr{UInt8}, pointer(message_buffer))))


### PR DESCRIPTION
Some change in Julia 0.4 have occurred since the last update of this wrapper.
This update should now ensure better behaviour with Julia 0.4 which is now in release state.
https://raw.githubusercontent.com/JuliaLang/julia/0ff703b40afddf9b705bd6a06d3a59cb4c089ea5/NEWS.md