### PR TITLE
Correct get_parameter_information_string, fixes #974

### DIFF
--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -251,15 +251,12 @@ EXPORT_CODE long CONVENTION get_parameter_information_string(const char *param, 
 {
     try{
         int key = CoolProp::get_parameter_index(param);
-        if (key >= 0){
-            std::string s = CoolProp::get_parameter_information(key, Output);
-            return str2buf(s, Output, n) ? 1 : 0;
-        }
-        else{
-            str2buf(format("parameter is invalid: %s", param), Output, n);
-        }
+        std::string s = CoolProp::get_parameter_information(key, "long");
+        return str2buf(s, Output, n) ? 1 : 0;
     }
-    catch(...){}
+    catch(...){
+		str2buf(format("parameter is invalid: %s", param), Output, n);
+	}
     return 0;
 }
 EXPORT_CODE long CONVENTION get_fluid_param_string(const char *fluid, const char *param, char * Output, int n)


### PR DESCRIPTION
Put the catch in a more useful way and solves the call to CoolProp::get_parameter_information:
The `int key = CoolProp::get_parameter_index(param);` will trigger the catch if the `param` is not valid (as no `int` is furnished in that case), which will give the correct output message now.
When `param` is valid, this will run the corrected `CoolProp::get_parameter_information(key, "long")`.