### PR TITLE
Fixed Minor MSVC Compiler Warnings

### DIFF
--- a/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
+++ b/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
@@ -453,8 +453,8 @@ double PhaseEnvelopeRoutines::evaluate(const PhaseEnvelopeData &env, parameters 
         case iSmolar: x = &(env.smolar_vap); break;
         default: throw ValueError("Pointer to vector x is unset in is_inside");
     }
-	if ( _i + 2 >= y->size() ){ _i--; }
-	if ( _i + 1 >= y->size() ){ _i--; }
+	if ( _i + 2 >= int(y->size()) ){ _i--; }
+	if ( _i + 1 >= int(y->size()) ){ _i--; }
 	if ( _i - 1 < 0 ){ _i++; }
 
     double outval = CubicInterp(*x, *y, _i - 1, _i, _i + 1, _i + 2, inval);

--- a/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
+++ b/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
@@ -453,8 +453,8 @@ double PhaseEnvelopeRoutines::evaluate(const PhaseEnvelopeData &env, parameters 
         case iSmolar: x = &(env.smolar_vap); break;
         default: throw ValueError("Pointer to vector x is unset in is_inside");
     }
-	if ( _i + 2 >= int(y->size()) ){ _i--; }
-	if ( _i + 1 >= int(y->size()) ){ _i--; }
+	if ( _i + 2 >= static_cast<int>(y->size()) ){ _i--; }
+	if ( _i + 1 >= static_cast<int>(y->size()) ){ _i--; }
 	if ( _i - 1 < 0 ){ _i++; }
 
     double outval = CubicInterp(*x, *y, _i - 1, _i, _i + 1, _i + 2, inval);

--- a/src/Backends/Helmholtz/VLERoutines.h
+++ b/src/Backends/Helmholtz/VLERoutines.h
@@ -216,7 +216,7 @@ namespace SaturationSolvers
         if (input_type == imposed_T && (std::abs(beta) < 1e-12 || std::abs(beta-1) < 1e-12)){
             const std::vector<double> z = HEOS.get_mole_fractions_ref();
             bool beta0 = std::abs(beta) < 1e-12; // True is beta is approx. zero
-            for (int i = 0; i < z.size(); ++i)
+            for (int i = 0; i < int(z.size()); ++i)
             {
                 double pci = HEOS.get_fluid_constant(i,iP_critical);
                 double Tci = HEOS.get_fluid_constant(i,iT_critical);
@@ -232,7 +232,7 @@ namespace SaturationSolvers
                 out = 1/out; // summation is for 1/p, take reciprocal to get p
             }
             std::vector<CoolPropDbl> &K = HEOS.get_K();
-            for (int i = 0; i < z.size(); ++i)
+            for (int i = 0; i < int(z.size()); ++i)
             {
                 double pci = HEOS.get_fluid_constant(i,iP_critical);
                 double Tci = HEOS.get_fluid_constant(i,iT_critical);

--- a/src/Backends/Helmholtz/VLERoutines.h
+++ b/src/Backends/Helmholtz/VLERoutines.h
@@ -216,7 +216,7 @@ namespace SaturationSolvers
         if (input_type == imposed_T && (std::abs(beta) < 1e-12 || std::abs(beta-1) < 1e-12)){
             const std::vector<double> z = HEOS.get_mole_fractions_ref();
             bool beta0 = std::abs(beta) < 1e-12; // True is beta is approx. zero
-            for (int i = 0; i < int(z.size()); ++i)
+            for (int i = 0; i < static_cast<int>(z.size()); ++i)
             {
                 double pci = HEOS.get_fluid_constant(i,iP_critical);
                 double Tci = HEOS.get_fluid_constant(i,iT_critical);
@@ -232,7 +232,7 @@ namespace SaturationSolvers
                 out = 1/out; // summation is for 1/p, take reciprocal to get p
             }
             std::vector<CoolPropDbl> &K = HEOS.get_K();
-            for (int i = 0; i < int(z.size()); ++i)
+            for (int i = 0; i < static_cast<int>(z.size()); ++i)
             {
                 double pci = HEOS.get_fluid_constant(i,iP_critical);
                 double Tci = HEOS.get_fluid_constant(i,iT_critical);

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -366,7 +366,7 @@ void REFPROPMixtureBackend::set_REFPROP_fluids(const std::vector<std::string> &f
             if (strlen(_components_joined) > 10000) { throw ValueError(format("components_joined (%s) is too long", _components_joined)); }
             strcpy(component_string, _components_joined);
             // Pad the fluid string all the way to 10k characters with spaces to deal with string parsing bug in REFPROP in SETUPdll
-            for (int i = int(components_joined.size()); i < 10000; ++i){
+            for (int i = static_cast<int>(components_joined.size()); i < 10000; ++i){
                 component_string[i] = ' ';
             }
 

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -366,7 +366,7 @@ void REFPROPMixtureBackend::set_REFPROP_fluids(const std::vector<std::string> &f
             if (strlen(_components_joined) > 10000) { throw ValueError(format("components_joined (%s) is too long", _components_joined)); }
             strcpy(component_string, _components_joined);
             // Pad the fluid string all the way to 10k characters with spaces to deal with string parsing bug in REFPROP in SETUPdll
-            for (int i = components_joined.size(); i < 10000; ++i){
+            for (int i = int(components_joined.size()); i < 10000; ++i){
                 component_string[i] = ' ';
             }
 


### PR DESCRIPTION
int vs unsigned in several comparisons and one initialization.  Wrapped the unsigned values with int().