### PR TITLE
Align Tmax with REFPROP values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@
 /dev/all_incompressibles.json
 /dev/all_incompressibles_verbose.json
 /include/all_incompressibles_JSON.h
-fluids
 /meta.yaml
 /runner.py
 /build.sh

--- a/dev/fluids/Argon.json
+++ b/dev/fluids/Argon.json
@@ -271,7 +271,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 700, 
+      "T_max": 2000, 
       "T_max_units": "K", 
       "Ttriple": 83.806, 
       "Ttriple_units": "K", 

--- a/dev/fluids/CarbonDioxide.json
+++ b/dev/fluids/CarbonDioxide.json
@@ -272,7 +272,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 1100, 
+      "T_max": 2000, 
       "T_max_units": "K", 
       "Ttriple": 216.592, 
       "Ttriple_units": "K", 

--- a/dev/fluids/DimethylEther.json
+++ b/dev/fluids/DimethylEther.json
@@ -248,7 +248,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 550, 
+      "T_max": 525,
       "T_max_units": "K", 
       "Ttriple": 131.66, 
       "Ttriple_units": "K", 

--- a/dev/fluids/IsoButene.json
+++ b/dev/fluids/IsoButene.json
@@ -249,7 +249,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 525, 
+      "T_max": 550, 
       "T_max_units": "K", 
       "Ttriple": 132.4, 
       "Ttriple_units": "K", 

--- a/dev/fluids/Isohexane.json
+++ b/dev/fluids/Isohexane.json
@@ -248,7 +248,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 500, 
+      "T_max": 550, 
       "T_max_units": "K", 
       "Ttriple": 119.6, 
       "Ttriple_units": "K", 

--- a/dev/fluids/MM.json
+++ b/dev/fluids/MM.json
@@ -248,7 +248,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 580, 
+      "T_max": 673,
       "T_max_units": "K", 
       "Ttriple": 204.93, 
       "Ttriple_units": "K", 

--- a/dev/fluids/Methanol.json
+++ b/dev/fluids/Methanol.json
@@ -275,7 +275,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 580, 
+      "T_max": 620, 
       "T_max_units": "K", 
       "Ttriple": 175.61, 
       "Ttriple_units": "K", 

--- a/dev/fluids/MethylLinoleate.json
+++ b/dev/fluids/MethylLinoleate.json
@@ -248,7 +248,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 700, 
+      "T_max": 1000, 
       "T_max_units": "K", 
       "Ttriple": 238.1, 
       "Ttriple_units": "K", 

--- a/dev/fluids/MethylLinolenate.json
+++ b/dev/fluids/MethylLinolenate.json
@@ -237,7 +237,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 700, 
+      "T_max": 1000, 
       "T_max_units": "K", 
       "Ttriple": 218.65, 
       "Ttriple_units": "K", 

--- a/dev/fluids/MethylOleate.json
+++ b/dev/fluids/MethylOleate.json
@@ -248,7 +248,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 700, 
+      "T_max": 1000, 
       "T_max_units": "K", 
       "Ttriple": 253.47, 
       "Ttriple_units": "K", 

--- a/dev/fluids/MethylPalmitate.json
+++ b/dev/fluids/MethylPalmitate.json
@@ -250,7 +250,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 700, 
+      "T_max": 1000, 
       "T_max_units": "K", 
       "Ttriple": 302.71, 
       "Ttriple_units": "K", 

--- a/dev/fluids/MethylStearate.json
+++ b/dev/fluids/MethylStearate.json
@@ -250,7 +250,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 700, 
+      "T_max": 1000, 
       "T_max_units": "K", 
       "Ttriple": 311.84, 
       "Ttriple_units": "K", 

--- a/dev/fluids/Neon.json
+++ b/dev/fluids/Neon.json
@@ -268,7 +268,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 723, 
+      "T_max": 700, 
       "T_max_units": "K", 
       "Ttriple": 24.56, 
       "Ttriple_units": "K", 

--- a/dev/fluids/Nitrogen.json
+++ b/dev/fluids/Nitrogen.json
@@ -269,7 +269,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 1100, 
+      "T_max": 2000, 
       "T_max_units": "K", 
       "Ttriple": 63.151, 
       "Ttriple_units": "K", 

--- a/dev/fluids/Oxygen.json
+++ b/dev/fluids/Oxygen.json
@@ -265,7 +265,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 300, 
+      "T_max": 2000, 
       "T_max_units": "K", 
       "Ttriple": 54.361, 
       "Ttriple_units": "K", 

--- a/dev/fluids/R11.json
+++ b/dev/fluids/R11.json
@@ -245,7 +245,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 595, 
+      "T_max": 625, 
       "T_max_units": "K", 
       "Ttriple": 162.68, 
       "Ttriple_units": "K", 
@@ -489,7 +489,7 @@
           "rhomolar_units": "mol/m^3"
         }
       }, 
-      "T_max": 595, 
+      "T_max": 625,
       "T_max_units": "K", 
       "Ttriple": 162.68, 
       "Ttriple_units": "K", 

--- a/dev/fluids/R123.json
+++ b/dev/fluids/R123.json
@@ -245,7 +245,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 523, 
+      "T_max": 600,
       "T_max_units": "K", 
       "Ttriple": 166, 
       "Ttriple_units": "K", 
@@ -522,7 +522,7 @@
           "rhomolar_units": "mol/m^3"
         }
       }, 
-      "T_max": 523, 
+      "T_max": 600,
       "T_max_units": "K", 
       "Ttriple": 166, 
       "Ttriple_units": "K", 

--- a/dev/fluids/R143a.json
+++ b/dev/fluids/R143a.json
@@ -247,7 +247,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 450, 
+      "T_max": 650, 
       "T_max_units": "K", 
       "Ttriple": 161.34, 
       "Ttriple_units": "K", 

--- a/dev/fluids/R152A.json
+++ b/dev/fluids/R152A.json
@@ -247,7 +247,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 471, 
+      "T_max": 500, 
       "T_max_units": "K", 
       "Ttriple": 154.56, 
       "Ttriple_units": "K", 
@@ -520,7 +520,7 @@
           "rhomolar_units": "mol/m^3"
         }
       }, 
-      "T_max": 471, 
+      "T_max": 500,
       "T_max_units": "K", 
       "Ttriple": 154.56, 
       "Ttriple_units": "K", 

--- a/dev/fluids/R23.json
+++ b/dev/fluids/R23.json
@@ -247,7 +247,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 425, 
+      "T_max": 475, 
       "T_max_units": "K", 
       "Ttriple": 118.02, 
       "Ttriple_units": "K", 

--- a/dev/fluids/R404A.json
+++ b/dev/fluids/R404A.json
@@ -289,7 +289,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 450, 
+      "T_max": 500, 
       "T_max_units": "K", 
       "Ttriple": 200, 
       "Ttriple_units": "K", 

--- a/dev/fluids/R407C.json
+++ b/dev/fluids/R407C.json
@@ -289,7 +289,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 450, 
+      "T_max": 500, 
       "T_max_units": "K", 
       "Ttriple": 200, 
       "Ttriple_units": "K", 

--- a/dev/fluids/R410A.json
+++ b/dev/fluids/R410A.json
@@ -289,7 +289,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 450, 
+      "T_max": 500, 
       "T_max_units": "K", 
       "Ttriple": 200, 
       "Ttriple_units": "K", 

--- a/dev/fluids/R507A.json
+++ b/dev/fluids/R507A.json
@@ -289,7 +289,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 450, 
+      "T_max": 500, 
       "T_max_units": "K", 
       "Ttriple": 200, 
       "Ttriple_units": "K", 

--- a/dev/fluids/SulfurHexafluoride.json
+++ b/dev/fluids/SulfurHexafluoride.json
@@ -250,7 +250,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 650, 
+      "T_max": 625, 
       "T_max_units": "K", 
       "Ttriple": 223.555, 
       "Ttriple_units": "K", 

--- a/dev/fluids/Water.json
+++ b/dev/fluids/Water.json
@@ -312,7 +312,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 1273, 
+      "T_max": 2000,
       "T_max_units": "K", 
       "Ttriple": 273.16, 
       "Ttriple_units": "K", 

--- a/dev/fluids/n-Dodecane.json
+++ b/dev/fluids/n-Dodecane.json
@@ -253,7 +253,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 800, 
+      "T_max": 700, 
       "T_max_units": "K", 
       "Ttriple": 263.6, 
       "Ttriple_units": "K", 

--- a/dev/fluids/n-Hexane.json
+++ b/dev/fluids/n-Hexane.json
@@ -252,7 +252,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 548, 
+      "T_max": 600, 
       "T_max_units": "K", 
       "Ttriple": 177.83, 
       "Ttriple_units": "K", 

--- a/dev/fluids/n-Octane.json
+++ b/dev/fluids/n-Octane.json
@@ -254,7 +254,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 548, 
+      "T_max": 600, 
       "T_max_units": "K", 
       "Ttriple": 216.37, 
       "Ttriple_units": "K", 

--- a/dev/fluids/n-Pentane.json
+++ b/dev/fluids/n-Pentane.json
@@ -271,7 +271,7 @@
           "smolar_units": "J/mol/K"
         }
       }, 
-      "T_max": 573, 
+      "T_max": 600, 
       "T_max_units": "K", 
       "Ttriple": 143.47, 
       "Ttriple_units": "K", 


### PR DESCRIPTION
Align Tmax with REFPROP values. Fixes #257.
I used the list given in #257.
DME, C12, Neon, SF6 values went down.
R11, R123, R152A had two occurences in EOS, I changed both.

I also removed a non-operative gitignore rule.
This rule matches the /dev/fluids folder and all its
contents, but those were already in the repo, so the
rule is not in effect/useless.
You can find those with `git ls-files -i --exclude-standard`.

Pinging @ibell as per discussion in #257.