### PR TITLE
Export first_partial_deriv, see #946

### DIFF
--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -295,7 +295,20 @@
     * @return
     */
     EXPORT_CODE double CONVENTION AbstractState_first_saturation_deriv(const long handle, const long Of, const long Wrt, long *errcode, char *message_buffer, const long buffer_length);
-            
+    
+    /**
+    * @brief Calculate the first partial derivative in homogeneous phases from the AbstractState using integer values for the desired parameters
+    * @param handle The integer handle for the state class stored in memory
+    * @param Of The parameter of which the derivative is being taken
+    * @param Wrt The derivative with with respect to this parameter
+    * @param Constant The parameter that is not affected by the derivative
+    * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+    * @param message_buffer A buffer for the error code
+    * @param buffer_length The length of the buffer for the error code
+    * @return
+    */
+    EXPORT_CODE double CONVENTION AbstractState_first_partial_deriv(const long handle, const long Of, const long Wrt, const long Constant, long *errcode, char *message_buffer, const long buffer_length);
+    
     /**
     * @brief Update the state of the AbstractState and get an output value five common outputs (temperature, pressure, molar density, molar enthalpy and molar entropy)
     * @brief from the AbstractState using pointers as inputs and output to allow array computation.

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -523,6 +523,39 @@ EXPORT_CODE double CONVENTION AbstractState_first_saturation_deriv(const long ha
     return _HUGE;
 }
 
+EXPORT_CODE double CONVENTION AbstractState_first_partial_deriv(const long handle, const long Of, const long Wrt, const long Constant, long *errcode, char *message_buffer, const long buffer_length)
+{
+    *errcode = 0;
+    try{
+        shared_ptr<CoolProp::AbstractState> &AS = handle_manager.get(handle);
+        return AS->first_partial_deriv(static_cast<CoolProp::parameters>(Of), static_cast<CoolProp::parameters>(Wrt), static_cast<CoolProp::parameters>(Constant));
+    }
+    catch (CoolProp::HandleError &e){
+        std::string errmsg = std::string("HandleError: ") + e.what();
+        if (errmsg.size() < static_cast<std::size_t>(buffer_length)){
+            *errcode = 1;
+            strcpy(message_buffer, errmsg.c_str());
+        }
+        else{
+            *errcode = 2;
+        }
+    }
+    catch (CoolProp::CoolPropBaseError &e){
+        std::string errmsg = std::string("Error: ") + e.what();
+        if (errmsg.size() < static_cast<std::size_t>(buffer_length)){
+            *errcode = 1;
+            strcpy(message_buffer, errmsg.c_str());
+        }
+        else{
+            *errcode = 2;
+        }
+    }
+    catch (...){
+        *errcode = 3;
+    }
+    return _HUGE;
+}
+
 EXPORT_CODE void CONVENTION AbstractState_update_and_common_out(const long handle, const long input_pair, const double* value1, const double* value2, const long length, double* T, double* p, double* rhomolar, double* hmolar, double* smolar, long *errcode, char *message_buffer, const long buffer_length)
 {
     *errcode = 0;


### PR DESCRIPTION
The file `CoolPropLib.def` has not been updated in in this patch.