### PR TITLE
Enable infinity in MakeDoubleResult

### DIFF
--- a/wrappers/SMath/coolprop_wrapper/coolpropPlugin.cs
+++ b/wrappers/SMath/coolprop_wrapper/coolpropPlugin.cs
@@ -59,6 +59,25 @@ namespace coolprop_wrapper
 
     public static Term[] MakeDoubleResult(double result, SMath.Math.Symbolic.MItem unit)
     {
+        // override ResultIsAboveMaxAllowedPositiveNumber exception for +/- infinity results
+        if (double.IsInfinity(result))
+        {
+          List<Term> xTerms = new List<Term>();
+
+          xTerms.Add(new Term(Symbols.Infinity, TermType.Operand, 0));
+
+          if (result == double.NegativeInfinity)
+              xTerms.Add(new Term(Operators.Subtraction, TermType.Operator, 1));
+
+          if (unit != 1)
+          {
+              xTerms.AddRange(unit.ToTerms());
+              xTerms.Add(new Term(Operators.Multiplication, TermType.Operator, 2));
+          }
+
+         return xTerms.ToArray();
+      }
+
       var d = new SMath.Math.Numeric.TDouble(result);
       d.Units = unit;
       return d.ToTerms();


### PR DESCRIPTION
Looking around I think this change should be related to the issue #985
Since double.NegativeInfinity and double.PositiveInfinity are valid results from the solvers and SMath.Math.Numeric.TDouble(result) can't handle these values directly, this patch allows the users to see  ∞ / -∞ as results on the canvas