### PR TITLE
Export set_binary_interaction_double + Julia wrapper improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@
 /include/gitrevision.h
 /include/mixture_excess_term_JSON.h
 /include/mixture_reducing_parameters_JSON.h
-/include/cubic_fluids_schema_JSON.h
 /include/version.h
 /include/catch.hpp
 /build/

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@
 /build.sh
 /bld.bat
 /conda/
+/include/cubic_fluids_schema_JSON.h

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 /include/gitrevision.h
 /include/mixture_excess_term_JSON.h
 /include/mixture_reducing_parameters_JSON.h
+/include/cubic_fluids_schema_JSON.h
 /include/version.h
 /include/catch.hpp
 /build/
@@ -47,4 +48,3 @@
 /build.sh
 /bld.bat
 /conda/
-/include/cubic_fluids_schema_JSON.h

--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -349,6 +349,8 @@
     * @param message_buffer A buffer for the error code
     * @param buffer_length The length of the buffer for the error code
     * @return
+	*
+	* @note If there is an error in an update call for one of the inputs, no change in the output array will be made
 	*/
     EXPORT_CODE void CONVENTION AbstractState_update_and_5_out(const long handle, const long input_pair, const double* value1, const double* value2, const long length, long *outputs, double* out1, double* out2, double* out3, double* out4, double* out5, long *errcode, char *message_buffer, const long buffer_length);
 
@@ -363,8 +365,6 @@
 	* @param message_buffer A buffer for the error code
 	* @param buffer_length The length of the buffer for the error code
 	* @return
-	*
-	* @note If there is an error in an update call for one of the inputs, no change in the output array will be made
 	*/
 	EXPORT_CODE void CONVENTION AbstractState_set_binary_interaction_double(const long handle, const size_t i, const size_t j, const char* parameter, const double value, long *errcode, char *message_buffer, const long buffer_length);
 

--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -349,24 +349,24 @@
     * @param message_buffer A buffer for the error code
     * @param buffer_length The length of the buffer for the error code
     * @return
-	*
-	* @note If there is an error in an update call for one of the inputs, no change in the output array will be made
-	*/
+    *
+    * @note If there is an error in an update call for one of the inputs, no change in the output array will be made
+    */
     EXPORT_CODE void CONVENTION AbstractState_update_and_5_out(const long handle, const long input_pair, const double* value1, const double* value2, const long length, long *outputs, double* out1, double* out2, double* out3, double* out4, double* out5, long *errcode, char *message_buffer, const long buffer_length);
 
-	/**
-	* @brief Set binary interraction parrameter for mixtures
-	* @param handle The integer handle for the state class stored in memory
-	* @param i indice of the first fluid of the binary pair
-	* @param j indice of the second fluid of the binary pair
-	* @param parameter string wit the name of the parameter
-	* @param value the value of the binary interaction parameter
-	* @param errcode The errorcode that is returned (0 = no error, !0 = error)
-	* @param message_buffer A buffer for the error code
-	* @param buffer_length The length of the buffer for the error code
-	* @return
-	*/
-	EXPORT_CODE void CONVENTION AbstractState_set_binary_interaction_double(const long handle, const size_t i, const size_t j, const char* parameter, const double value, long *errcode, char *message_buffer, const long buffer_length);
+    /**
+    * @brief Set binary interraction parrameter for mixtures
+    * @param handle The integer handle for the state class stored in memory
+    * @param i indice of the first fluid of the binary pair
+    * @param j indice of the second fluid of the binary pair
+    * @param parameter string wit the name of the parameter
+    * @param value the value of the binary interaction parameter
+    * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+    * @param message_buffer A buffer for the error code
+    * @param buffer_length The length of the buffer for the error code
+    * @return
+    */
+    EXPORT_CODE void CONVENTION AbstractState_set_binary_interaction_double(const long handle, const size_t i, const size_t j, const char* parameter, const double value, long *errcode, char *message_buffer, const long buffer_length);
 
     // *************************************************************************************
     // *************************************************************************************

--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -349,11 +349,24 @@
     * @param message_buffer A buffer for the error code
     * @param buffer_length The length of the buffer for the error code
     * @return
-    *
-    * @note If there is an error in an update call for one of the inputs, no change in the output array will be made
-    */
+	*/
     EXPORT_CODE void CONVENTION AbstractState_update_and_5_out(const long handle, const long input_pair, const double* value1, const double* value2, const long length, long *outputs, double* out1, double* out2, double* out3, double* out4, double* out5, long *errcode, char *message_buffer, const long buffer_length);
 
+	/**
+	* @brief Set binary interraction parrameter for mixtures
+	* @param handle The integer handle for the state class stored in memory
+	* @param i indice of the first fluid of the binary pair
+	* @param j indice of the second fluid of the binary pair
+	* @param parameter string wit the name of the parameter
+	* @param value the value of the binary interaction parameter
+	* @param errcode The errorcode that is returned (0 = no error, !0 = error)
+	* @param message_buffer A buffer for the error code
+	* @param buffer_length The length of the buffer for the error code
+	* @return
+	*
+	* @note If there is an error in an update call for one of the inputs, no change in the output array will be made
+	*/
+	EXPORT_CODE void CONVENTION AbstractState_set_binary_interaction_double(const long handle, const size_t i, const size_t j, const char* parameter, const double value, long *errcode, char *message_buffer, const long buffer_length);
 
     // *************************************************************************************
     // *************************************************************************************

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -626,6 +626,38 @@ EXPORT_CODE void CONVENTION AbstractState_update_and_5_out(const long handle, co
     }
 }
 
+EXPORT_CODE void CONVENTION AbstractState_set_binary_interaction_double(const long handle, const size_t i, const size_t j, const char* parameter, const double value, long *errcode, char *message_buffer, const long buffer_length)
+{
+	*errcode = 0;
+	try {
+		shared_ptr<CoolProp::AbstractState> &AS = handle_manager.get(handle);
+		AS->set_binary_interaction_double(i, j, parameter, value);
+	}
+	catch (CoolProp::HandleError &e) {
+		std::string errmsg = std::string("HandleError: ") + e.what();
+		if (errmsg.size() < static_cast<std::size_t>(buffer_length)) {
+			*errcode = 1;
+			strcpy(message_buffer, errmsg.c_str());
+		}
+		else {
+			*errcode = 2;
+		}
+	}
+	catch (CoolProp::CoolPropBaseError &e) {
+		std::string errmsg = std::string("Error: ") + e.what();
+		if (errmsg.size() < static_cast<std::size_t>(buffer_length)) {
+			*errcode = 1;
+			strcpy(message_buffer, errmsg.c_str());
+		}
+		else {
+			*errcode = 2;
+		}
+	}
+	catch (...) {
+		*errcode = 3;
+	}
+}
+
 
 /// *********************************************************************************
 /// *********************************************************************************

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -628,34 +628,34 @@ EXPORT_CODE void CONVENTION AbstractState_update_and_5_out(const long handle, co
 
 EXPORT_CODE void CONVENTION AbstractState_set_binary_interaction_double(const long handle, const size_t i, const size_t j, const char* parameter, const double value, long *errcode, char *message_buffer, const long buffer_length)
 {
-	*errcode = 0;
-	try {
-		shared_ptr<CoolProp::AbstractState> &AS = handle_manager.get(handle);
-		AS->set_binary_interaction_double(i, j, parameter, value);
-	}
-	catch (CoolProp::HandleError &e) {
-		std::string errmsg = std::string("HandleError: ") + e.what();
-		if (errmsg.size() < static_cast<std::size_t>(buffer_length)) {
-			*errcode = 1;
-			strcpy(message_buffer, errmsg.c_str());
-		}
-		else {
-			*errcode = 2;
-		}
-	}
-	catch (CoolProp::CoolPropBaseError &e) {
-		std::string errmsg = std::string("Error: ") + e.what();
-		if (errmsg.size() < static_cast<std::size_t>(buffer_length)) {
-			*errcode = 1;
-			strcpy(message_buffer, errmsg.c_str());
-		}
-		else {
-			*errcode = 2;
-		}
-	}
-	catch (...) {
-		*errcode = 3;
-	}
+    *errcode = 0;
+    try {
+        shared_ptr<CoolProp::AbstractState> &AS = handle_manager.get(handle);
+        AS->set_binary_interaction_double(i, j, parameter, value);
+    }
+    catch (CoolProp::HandleError &e) {
+        std::string errmsg = std::string("HandleError: ") + e.what();
+        if (errmsg.size() < static_cast<std::size_t>(buffer_length)) {
+            *errcode = 1;
+            strcpy(message_buffer, errmsg.c_str());
+        }
+        else {
+            *errcode = 2;
+        }
+    }
+    catch (CoolProp::CoolPropBaseError &e) {
+        std::string errmsg = std::string("Error: ") + e.what();
+        if (errmsg.size() < static_cast<std::size_t>(buffer_length)) {
+            *errcode = 1;
+            strcpy(message_buffer, errmsg.c_str());
+        }
+        else {
+            *errcode = 2;
+        }
+    }
+    catch (...) {
+        *errcode = 3;
+    }
 }
 
 

--- a/src/CoolPropLib.def
+++ b/src/CoolPropLib.def
@@ -10,6 +10,7 @@ EXPORTS
   AbstractState_first_partial_deriv = _AbstractState_first_partial_deriv@28
   AbstractState_update_and_5_out = _AbstractState_update_and_5_out@56
   AbstractState_update_and_common_out = _AbstractState_update_and_common_out@52
+  AbstractState_set_binary_interaction_double = AbstractState_set_binary_interaction_double@36
   F2K = _F2K@8
   HAProps = _HAProps@40
   HAPropsSI = _HAPropsSI@40

--- a/wrappers/Julia/CoolProp.jl
+++ b/wrappers/Julia/CoolProp.jl
@@ -1,3 +1,4 @@
+__precompile__()
 module CoolProp
 
 export PropsSI, PhaseSI, get_global_param_string, get_parameter_information_string,get_fluid_param_string,set_reference_stateS, get_param_index, get_input_pair_index, F2K, K2F, HAPropsSI, AbstractState_factory, AbstractState_free, AbstractState_set_fractions, AbstractState_update, AbstractState_keyed_output

--- a/wrappers/Julia/CoolProp.jl
+++ b/wrappers/Julia/CoolProp.jl
@@ -1,4 +1,4 @@
-__precompile__()
+VERSION < v"0.4.0" && __precompile__()
 module CoolProp
 
 export PropsSI, PhaseSI, get_global_param_string, get_parameter_information_string,get_fluid_param_string,set_reference_stateS, get_param_index, get_input_pair_index, F2K, K2F, HAPropsSI, AbstractState_factory, AbstractState_free, AbstractState_set_fractions, AbstractState_update, AbstractState_keyed_output

--- a/wrappers/Julia/CoolProp.jl
+++ b/wrappers/Julia/CoolProp.jl
@@ -1,7 +1,7 @@
 VERSION < v"0.4.0" && __precompile__()
 module CoolProp
 
-export PropsSI, PhaseSI, get_global_param_string, get_parameter_information_string,get_fluid_param_string,set_reference_stateS, get_param_index, get_input_pair_index, F2K, K2F, HAPropsSI, AbstractState_factory, AbstractState_free, AbstractState_set_fractions, AbstractState_update, AbstractState_keyed_output
+export PropsSI, PhaseSI, get_global_param_string, get_parameter_information_string,get_fluid_param_string,set_reference_stateS, get_param_index, get_input_pair_index, F2K, K2F, HAPropsSI, AbstractState_factory, AbstractState_free, AbstractState_set_fractions, AbstractState_update, AbstractState_keyed_output, AbstractState_set_binary_interaction_double
 
 # Check the current Julia version to make this Julia 0.4 code compatible with older version
 if VERSION <= VersionNumber(0,4)
@@ -225,6 +225,20 @@ function AbstractState_keyed_output(handle::Clong, param::Clong)
     error("CoolProp: no correct state has been set with AbstractState_update")
   end
   return output
+end
+
+function AbstractState_set_binary_interaction_double(handle::Clong,i::Int, j::Int, parameter::AbstractString, value::Cdouble)
+  ccall( (:AbstractState_set_binary_interaction_double, "CoolProp"), Void, (Clong,Csize_t,Csize_t,Ptr{UInt8},Cdouble,Ref{Clong},Ptr{UInt8},Clong), handle,i,j,parameter,value,errcode,message_buffer::Array{UInt8,1},buffer_length)
+  if errcode[] != 0
+    if errcode[] == 1
+      error("CoolProp: ", bytestring(convert(Ptr{UInt8}, pointer(message_buffer))))
+    elseif errcode[] == 2
+      error("CoolProp: message buffer too small")
+    else # == 3
+      error("CoolProp: unknown error")
+    end
+  end
+  return nothing
 end
 
 end #module


### PR DESCRIPTION
Shared library:
- Export set_binary_interaction_double

Julia wrapper:
- Precompile at first load for Julia 0.4
- Add functions: 
 - set_binary_interaction_double
 - AbstractState_update_and_common_out
 - AbstractState_update_and_5_out