### PR TITLE
Solves a bug with cubic and mixtures

### DIFF
--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -408,6 +408,7 @@ CoolPropDbl CoolProp::AbstractCubicBackend::solver_rho_Tp(CoolPropDbl T, CoolPro
         else{
             if (p < p_critical()){
                 add_transient_pure_state();
+		transient_pure_state->set_mole_fractions(this->mole_fractions);
                 transient_pure_state->update(PQ_INPUTS, p, 0);
                 if (T > transient_pure_state->T()){
                     double rhoV = transient_pure_state->saturated_vapor_keyed_output(iDmolar);


### PR DESCRIPTION
The transient_pure_state has no mole fractions when created, this was triggering a CoolProp: `Mole fractions must be set` error.

I guess it's because that transient state is supposed to be pure, but this fix allows to get the answer.
Is there something more elegant to do?