### PR TITLE
Add pure fluid check to VTPR

### DIFF
--- a/src/Backends/Cubics/VTPRBackend.cpp
+++ b/src/Backends/Cubics/VTPRBackend.cpp
@@ -14,6 +14,9 @@ static UNIFAQLibrary::UNIFAQParameterLibrary lib;
 void CoolProp::VTPRBackend::setup(const std::vector<std::string> &names, bool generate_SatL_and_SatV){
 
     R = get_config_double(R_U_CODATA);
+
+    // Set the pure fluid flag
+    is_pure_or_pseudopure = (N == 1);
     
     // Reset the residual Helmholtz energy class
     residual_helmholtz.reset(new CubicResidualHelmholtz(this));


### PR DESCRIPTION
Allows for instance to retrieve the critical values used for the pure components in VTPR.
Was always false before.