### PR TITLE
Export cubic's alpha functions

### DIFF
--- a/include/AbstractState.h
+++ b/include/AbstractState.h
@@ -515,9 +515,9 @@ public:
     /// Apply a simple mixing rule (EXPERT USE ONLY!!!)
     virtual void apply_simple_mixing_rule(std::size_t i, std::size_t j, const std::string &model) { throw NotImplementedError("apply_simple_mixing_rule is not implemented for this backend"); };
     /// Set the cubic alpha function's constants:
-    virtual void set_cubic_alpha_C(const size_t i, const std::string parameter, const double c1, const double c2, const double c3) { throw ValueError("set_cubic_alpha_C only defined for cubic backends"); };
+    virtual void set_cubic_alpha_C(const size_t i, const std::string &parameter, const double c1, const double c2, const double c3) { throw ValueError("set_cubic_alpha_C only defined for cubic backends"); };
     /// Set fluid parameter (currently the volume translation parameter for cubic)
-	virtual void set_fluid_parameter_double(const size_t i, const std::string parameter, const double value) { throw ValueError("set_fluid_parameter_double only defined for cubic backends"); };
+	virtual void set_fluid_parameter_double(const size_t i, const std::string &parameter, const double value) { throw ValueError("set_fluid_parameter_double only defined for cubic backends"); };
 
     /// Clear all the cached values
     virtual bool clear();

--- a/include/AbstractState.h
+++ b/include/AbstractState.h
@@ -514,7 +514,9 @@ public:
     virtual std::string get_binary_interaction_string(const std::string &CAS1, const std::string &CAS2, const std::string &parameter){ throw NotImplementedError("get_binary_interaction_string is not implemented for this backend"); };
     /// Apply a simple mixing rule (EXPERT USE ONLY!!!)
     virtual void apply_simple_mixing_rule(std::size_t i, std::size_t j, const std::string &model) { throw NotImplementedError("apply_simple_mixing_rule is not implemented for this backend"); };
-    // Set fluid parameter (currently the volume translation parameter for cubic)
+    /// Set the cubic alpha function's constants:
+    virtual void set_cubic_alpha_C(const size_t i, const std::string parameter, const double c1, const double c2, const double c3) { throw ValueError("set_cubic_alpha_C only defined for cubic backends"); };
+    /// Set fluid parameter (currently the volume translation parameter for cubic)
 	virtual void set_fluid_parameter_double(const size_t i, const std::string parameter, const double value) { throw ValueError("set_fluid_parameter_double only defined for cubic backends"); };
 
     /// Clear all the cached values

--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -418,6 +418,21 @@
     */
     EXPORT_CODE void CONVENTION AbstractState_set_binary_interaction_double(const long handle, const long i, const long j, const char* parameter, const double value, long *errcode, char *message_buffer, const long buffer_length);
 
+        /**
+    * @brief Set cubic's alpha function parameters
+    * @param handle The integer handle for the state class stored in memory
+    * @param i indice of the fluid the parramter should be applied too (for mixtures)
+	* @param parameter the string specifying the alpha function to use, ex "TWU" for the TWU alpha function
+    * @param c1 the first parameter for the alpha function
+    * @param c2 the second parameter for the alpha function
+    * @param c3 the third parameter for the alpha function
+    * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+    * @param message_buffer A buffer for the error code
+    * @param buffer_length The length of the buffer for the error code
+    * @return
+    */
+    EXPORT_CODE void CONVENTION  AbstractState_set_cubic_alpha_C(const long handle, const long i, const char* parameter, const double c1, const double c2, const double c3 , long *errcode, char *message_buffer, const long buffer_length);
+
     /**
     * @brief Set some fluid parameter (ie volume translation for cubic)
     * @param handle The integer handle for the state class stored in memory

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -531,24 +531,7 @@ void CoolProp::AbstractCubicBackend::copy_k(AbstractCubicBackend *donor){
     }
 }
 
-void CoolProp::AbstractCubicBackend::set_C_MC(double c1, double c2, double c3)
-{
-    get_cubic()->set_C_MC(c1, c2, c3);
-    for (std::vector<shared_ptr<HelmholtzEOSMixtureBackend> >::iterator it = linked_states.begin(); it != linked_states.end(); ++it) {
-        AbstractCubicBackend *ACB = static_cast<AbstractCubicBackend *>(it->get());
-        ACB->set_C_MC(c1,c2,c3);
-    }
-}
-
-void CoolProp::AbstractCubicBackend::set_C_Twu(double L, double M, double N){
-    get_cubic()->set_C_Twu(L, M, N);
-    for (std::vector<shared_ptr<HelmholtzEOSMixtureBackend> >::iterator it = linked_states.begin(); it != linked_states.end(); ++it) {
-        AbstractCubicBackend *ACB = static_cast<AbstractCubicBackend *>(it->get());
-        ACB->set_C_Twu(L,M,N);
-    }
-}
-
-void CoolProp::AbstractCubicBackend::set_cubic_alpha_C(const size_t i, const std::string parameter, const double c1, const double c2, const double c3){
+void CoolProp::AbstractCubicBackend::set_cubic_alpha_C(const size_t i, const std::string &parameter, const double c1, const double c2, const double c3){
 	if (parameter == "MC" || parameter == "mc" || parameter == "Mathias-Copeman") {
 		get_cubic()->set_C_MC(i,c1, c2, c3);
 	}
@@ -564,7 +547,7 @@ void CoolProp::AbstractCubicBackend::set_cubic_alpha_C(const size_t i, const std
 	}
 }
 
-void CoolProp::AbstractCubicBackend::set_fluid_parameter_double(const size_t i, const std::string parameter, const double value)
+void CoolProp::AbstractCubicBackend::set_fluid_parameter_double(const size_t i, const std::string &parameter, const double value)
 {
 	// Set the volume translation parrameter, currently applied to the whole fluid, not to components.
 	if (parameter == "c" || parameter == "cm" || parameter == "c_m") {

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -532,32 +532,32 @@ void CoolProp::AbstractCubicBackend::copy_k(AbstractCubicBackend *donor){
 }
 
 void CoolProp::AbstractCubicBackend::set_cubic_alpha_C(const size_t i, const std::string &parameter, const double c1, const double c2, const double c3){
-	if (parameter == "MC" || parameter == "mc" || parameter == "Mathias-Copeman") {
-		get_cubic()->set_C_MC(i,c1, c2, c3);
-	}
-	else if (parameter == "TWU" || parameter == "Twu" || parameter == "twu") {
-		get_cubic()->set_C_Twu(i,c1, c2, c3);
-	}
-	else {
-		throw ValueError(format("I don't know what to do with parameter [%s]", parameter.c_str()));
-	}
-	for (std::vector<shared_ptr<HelmholtzEOSMixtureBackend> >::iterator it = linked_states.begin(); it != linked_states.end(); ++it) {
-		AbstractCubicBackend *ACB = static_cast<AbstractCubicBackend *>(it->get());
-		ACB->set_cubic_alpha_C(i, parameter, c1, c2, c3);
-	}
+    if (parameter == "MC" || parameter == "mc" || parameter == "Mathias-Copeman") {
+        get_cubic()->set_C_MC(i,c1, c2, c3);
+    }
+    else if (parameter == "TWU" || parameter == "Twu" || parameter == "twu") {
+        get_cubic()->set_C_Twu(i,c1, c2, c3);
+    }
+    else {
+        throw ValueError(format("I don't know what to do with parameter [%s]", parameter.c_str()));
+    }
+    for (std::vector<shared_ptr<HelmholtzEOSMixtureBackend> >::iterator it = linked_states.begin(); it != linked_states.end(); ++it) {
+        AbstractCubicBackend *ACB = static_cast<AbstractCubicBackend *>(it->get());
+        ACB->set_cubic_alpha_C(i, parameter, c1, c2, c3);
+    }
 }
 
 void CoolProp::AbstractCubicBackend::set_fluid_parameter_double(const size_t i, const std::string &parameter, const double value)
 {
-	// Set the volume translation parrameter, currently applied to the whole fluid, not to components.
-	if (parameter == "c" || parameter == "cm" || parameter == "c_m") {
-		get_cubic()->set_cm(value);
-		for (std::vector<shared_ptr<HelmholtzEOSMixtureBackend> >::iterator it = linked_states.begin(); it != linked_states.end(); ++it) {
+    // Set the volume translation parrameter, currently applied to the whole fluid, not to components.
+    if (parameter == "c" || parameter == "cm" || parameter == "c_m") {
+        get_cubic()->set_cm(value);
+        for (std::vector<shared_ptr<HelmholtzEOSMixtureBackend> >::iterator it = linked_states.begin(); it != linked_states.end(); ++it) {
             AbstractCubicBackend *ACB = static_cast<AbstractCubicBackend *>(it->get());
             ACB->set_fluid_parameter_double(i, parameter, value);
         }
-	}
-	else {
-		throw ValueError(format("I don't know what to do with parameter [%s]", parameter.c_str()));
-	}
+    }
+    else {
+        throw ValueError(format("I don't know what to do with parameter [%s]", parameter.c_str()));
+    }
 }

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -548,13 +548,31 @@ void CoolProp::AbstractCubicBackend::set_C_Twu(double L, double M, double N){
     }
 }
 
+void CoolProp::AbstractCubicBackend::set_cubic_alpha_C(const size_t i, const std::string parameter, const double c1, const double c2, const double c3){
+	if (parameter == "MC" || parameter == "mc" || parameter == "Mathias-Copeman") {
+		get_cubic()->set_C_MC(i,c1, c2, c3);
+	}
+	else if (parameter == "TWU" || parameter == "Twu" || parameter == "twu") {
+		get_cubic()->set_C_Twu(i,c1, c2, c3);
+	}
+	else {
+		throw ValueError(format("I don't know what to do with parameter [%s]", parameter.c_str()));
+	}
+	for (std::vector<shared_ptr<HelmholtzEOSMixtureBackend> >::iterator it = linked_states.begin(); it != linked_states.end(); ++it) {
+		AbstractCubicBackend *ACB = static_cast<AbstractCubicBackend *>(it->get());
+		ACB->set_cubic_alpha_C(i, parameter, c1, c2, c3);
+	}
+}
+
 void CoolProp::AbstractCubicBackend::set_fluid_parameter_double(const size_t i, const std::string parameter, const double value)
 {
 	// Set the volume translation parrameter, currently applied to the whole fluid, not to components.
 	if (parameter == "c" || parameter == "cm" || parameter == "c_m") {
 		get_cubic()->set_cm(value);
-		if (this->SatL.get() != NULL) { this->SatL->set_fluid_parameter_double(i, "cm", value); }
-		if (this->SatV.get() != NULL) { this->SatV->set_fluid_parameter_double(i, "cm", value); }
+		for (std::vector<shared_ptr<HelmholtzEOSMixtureBackend> >::iterator it = linked_states.begin(); it != linked_states.end(); ++it) {
+            AbstractCubicBackend *ACB = static_cast<AbstractCubicBackend *>(it->get());
+            ACB->set_fluid_parameter_double(i, parameter, value);
+        }
 	}
 	else {
 		throw ValueError(format("I don't know what to do with parameter [%s]", parameter.c_str()));

--- a/src/Backends/Cubics/CubicBackend.h
+++ b/src/Backends/Cubics/CubicBackend.h
@@ -190,18 +190,12 @@ public:
     
     //
     void copy_all_alpha_functions(AbstractCubicBackend *donor);
-
-    // Set the Mathias-Copeman constants c1,c2,c3 for a pure fluid
-    void set_C_MC(double c1, double c2, double c3);
-    
-    // Set the Twu constants L,M,N for a pure fluid
-    void set_C_Twu(double L, double M, double N);
     
     // Set the cubic alpha function's constants:
-    void set_cubic_alpha_C(const size_t i, const std::string parameter, const double c1, const double c2, const double c3);
+    void set_cubic_alpha_C(const size_t i, const std::string &parameter, const double c1, const double c2, const double c3);
 
     // Set fluid parameter (currently the volume translation parameter)
-    void set_fluid_parameter_double(const size_t i, const std::string parameter, const double value);
+    void set_fluid_parameter_double(const size_t i, const std::string &parameter, const double value);
     
 };
 

--- a/src/Backends/Cubics/CubicBackend.h
+++ b/src/Backends/Cubics/CubicBackend.h
@@ -196,9 +196,12 @@ public:
     
     // Set the Twu constants L,M,N for a pure fluid
     void set_C_Twu(double L, double M, double N);
+    
+    // Set the cubic alpha function's constants:
+    void set_cubic_alpha_C(const size_t i, const std::string parameter, const double c1, const double c2, const double c3);
 
-	// Set fluid parameter (currently the volume translation parameter)
-	void set_fluid_parameter_double(const size_t i, const std::string parameter, const double value);
+    // Set fluid parameter (currently the volume translation parameter)
+    void set_fluid_parameter_double(const size_t i, const std::string parameter, const double value);
     
 };
 

--- a/src/Backends/Cubics/GeneralizedCubic.cpp
+++ b/src/Backends/Cubics/GeneralizedCubic.cpp
@@ -84,7 +84,7 @@ double TwuAlphaFunction::term(double tau, std::size_t itau){
     double d3B1_dtau3 = (itau < 4) ? 0 : -N / powInt(tau, 4)*(L*powInt(M, 4)*powInt(N, 3)*A + 6 * L*M*M*M*N*N*A + 11 * L*M*M*N*A + 6 * L*M*A - 6 * M + 6);
 
     double dam_dtau, d2am_dtau2, d3am_dtau3, d4am_dtau4;
-    double am = a0*pow(Tr_over_Tci / tau, N*(M - 1))*exp(L*(1 - pow(Tr_over_Tci / tau, M*N)));
+    double am = a0*pow(Tr_over_Tci / tau, N*(M - 1))*exp(L*(1 - A));
 
     if (itau == 0) {
         return am;

--- a/src/Backends/Cubics/GeneralizedCubic.h
+++ b/src/Backends/Cubics/GeneralizedCubic.h
@@ -119,17 +119,9 @@ public:
     double get_Delta_2(){ return Delta_2; }
     /// Read-only accessor for value of R_u (universal gas constant)
     double get_R_u(){ return R_u; }
-    /// Set the three Mathias-Copeman constants in one shot for a pure fluid
-    void set_C_MC(double c1, double c2, double c3){
-        alpha[0].reset(new MathiasCopemanAlphaFunction(a0_ii(0),c1,c2,c3,T_r/Tc[0]));
-    }
     /// Set the three Mathias-Copeman constants in one shot for the component i of a mixturee
     void set_C_MC(std::size_t i,double c1, double c2, double c3){
         alpha[i].reset(new MathiasCopemanAlphaFunction(a0_ii(i),c1,c2,c3,T_r/Tc[i]));
-    }
-    /// Set the three Twu constants in one shot for a pure fluid
-    void set_C_Twu(double L, double M, double N){
-        alpha[0].reset(new TwuAlphaFunction(a0_ii(0),L,M,N,T_r/Tc[0]));
     }
     /// Set the three Twu constants in one shot for the component i of a mixture
     void set_C_Twu(std::size_t i,double L, double M, double N){

--- a/src/Backends/Cubics/GeneralizedCubic.h
+++ b/src/Backends/Cubics/GeneralizedCubic.h
@@ -119,7 +119,7 @@ public:
     double get_Delta_2(){ return Delta_2; }
     /// Read-only accessor for value of R_u (universal gas constant)
     double get_R_u(){ return R_u; }
-    /// Set the three Mathias-Copeman constants in one shot for the component i of a mixturee
+    /// Set the three Mathias-Copeman constants in one shot for the component i of a mixture
     void set_C_MC(std::size_t i,double c1, double c2, double c3){
         alpha[i].reset(new MathiasCopemanAlphaFunction(a0_ii(i),c1,c2,c3,T_r/Tc[i]));
     }

--- a/src/Backends/Cubics/GeneralizedCubic.h
+++ b/src/Backends/Cubics/GeneralizedCubic.h
@@ -125,7 +125,7 @@ public:
     }
     /// Set the three Mathias-Copeman constants in one shot for the component i of a mixturee
     void set_C_MC(std::size_t i,double c1, double c2, double c3){
-        alpha[i].reset(new MathiasCopemanAlphaFunction(a0_ii(0),c1,c2,c3,T_r/Tc[0]));
+        alpha[i].reset(new MathiasCopemanAlphaFunction(a0_ii(i),c1,c2,c3,T_r/Tc[i]));
     }
     /// Set the three Twu constants in one shot for a pure fluid
     void set_C_Twu(double L, double M, double N){
@@ -133,7 +133,7 @@ public:
     }
     /// Set the three Twu constants in one shot for the component i of a mixture
     void set_C_Twu(std::size_t i,double L, double M, double N){
-        alpha[i].reset(new TwuAlphaFunction(a0_ii(0),L,M,N,T_r/Tc[0]));
+        alpha[i].reset(new TwuAlphaFunction(a0_ii(i),L,M,N,T_r/Tc[i]));
     }
     /// Get the leading constant in the expression for the pure fluid attractive energy term
     /// (must be implemented by derived classes)

--- a/src/Backends/Cubics/GeneralizedCubic.h
+++ b/src/Backends/Cubics/GeneralizedCubic.h
@@ -123,9 +123,17 @@ public:
     void set_C_MC(double c1, double c2, double c3){
         alpha[0].reset(new MathiasCopemanAlphaFunction(a0_ii(0),c1,c2,c3,T_r/Tc[0]));
     }
+    /// Set the three Mathias-Copeman constants in one shot for the component i of a mixturee
+    void set_C_MC(std::size_t i,double c1, double c2, double c3){
+        alpha[i].reset(new MathiasCopemanAlphaFunction(a0_ii(0),c1,c2,c3,T_r/Tc[0]));
+    }
     /// Set the three Twu constants in one shot for a pure fluid
     void set_C_Twu(double L, double M, double N){
         alpha[0].reset(new TwuAlphaFunction(a0_ii(0),L,M,N,T_r/Tc[0]));
+    }
+    /// Set the three Twu constants in one shot for the component i of a mixture
+    void set_C_Twu(std::size_t i,double L, double M, double N){
+        alpha[i].reset(new TwuAlphaFunction(a0_ii(0),L,M,N,T_r/Tc[0]));
     }
     /// Get the leading constant in the expression for the pure fluid attractive energy term
     /// (must be implemented by derived classes)

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
@@ -106,10 +106,10 @@ public:
     void apply_simple_mixing_rule(std::size_t i, std::size_t j, const std::string &model);
 
     // Set the cubic alpha function's constants:
-    virtual void set_cubic_alpha_C(const size_t i, const std::string parameter, const double c1, const double c2, const double c3) { throw ValueError("set_cubic_alpha_C only defined for cubic backends"); };
+    virtual void set_cubic_alpha_C(const size_t i, const std::string &parameter, const double c1, const double c2, const double c3) { throw ValueError("set_cubic_alpha_C only defined for cubic backends"); };
 
     // Set fluid parameter (currently the volume translation parameter for cubic)
-    virtual void set_fluid_parameter_double(const size_t i, const std::string parameter, const double value) { throw ValueError("set_fluid_parameter_double only defined for cubic backends"); };
+    virtual void set_fluid_parameter_double(const size_t i, const std::string &parameter, const double value) { throw ValueError("set_fluid_parameter_double only defined for cubic backends"); };
 
     phases calc_phase(void){return _phase;};
     

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
@@ -105,6 +105,9 @@ public:
     /// Apply a simple mixing rule
     void apply_simple_mixing_rule(std::size_t i, std::size_t j, const std::string &model);
 
+    // Set the cubic alpha function's constants:
+    virtual void set_cubic_alpha_C(const size_t i, const std::string parameter, const double c1, const double c2, const double c3) { throw ValueError("set_cubic_alpha_C only defined for cubic backends"); };
+
     // Set fluid parameter (currently the volume translation parameter for cubic)
     virtual void set_fluid_parameter_double(const size_t i, const std::string parameter, const double value) { throw ValueError("set_fluid_parameter_double only defined for cubic backends"); };
 

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -591,7 +591,7 @@ EXPORT_CODE void CONVENTION  AbstractState_set_cubic_alpha_C(const long handle, 
     *errcode = 0;
     try {
         shared_ptr<CoolProp::AbstractState> &AS = handle_manager.get(handle);
-        AS->set_cubic_alpha_C(static_cast<std::size_t>(i),std::string(parameter), c1, c2, c3);
+        AS->set_cubic_alpha_C(static_cast<std::size_t>(i),parameter, c1, c2, c3);
     }
     catch (...) {
 		HandleException(errcode, message_buffer, buffer_length);
@@ -602,7 +602,7 @@ EXPORT_CODE void CONVENTION  AbstractState_set_fluid_parameter_double(const long
     *errcode = 0;
     try {
         shared_ptr<CoolProp::AbstractState> &AS = handle_manager.get(handle);
-        AS->set_fluid_parameter_double(static_cast<std::size_t>(i), std::string(parameter), value);
+        AS->set_fluid_parameter_double(static_cast<std::size_t>(i), parameter, value);
     }
     catch (...) {
 		HandleException(errcode, message_buffer, buffer_length);

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -580,7 +580,7 @@ EXPORT_CODE void CONVENTION AbstractState_set_binary_interaction_double(const lo
     *errcode = 0;
     try {
         shared_ptr<CoolProp::AbstractState> &AS = handle_manager.get(handle);
-        AS->set_binary_interaction_double(static_cast<std::size_t>(i), static_cast<std::size_t>(j), std::string(parameter), value);
+        AS->set_binary_interaction_double(static_cast<std::size_t>(i), static_cast<std::size_t>(j), parameter, value);
     }
     catch (...) {
 		HandleException(errcode, message_buffer, buffer_length);

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -580,7 +580,18 @@ EXPORT_CODE void CONVENTION AbstractState_set_binary_interaction_double(const lo
     *errcode = 0;
     try {
         shared_ptr<CoolProp::AbstractState> &AS = handle_manager.get(handle);
-        AS->set_binary_interaction_double(static_cast<std::size_t>(i), static_cast<std::size_t>(j), parameter, value);
+        AS->set_binary_interaction_double(static_cast<std::size_t>(i), static_cast<std::size_t>(j), std::string(parameter), value);
+    }
+    catch (...) {
+		HandleException(errcode, message_buffer, buffer_length);
+	}
+}
+
+EXPORT_CODE void CONVENTION  AbstractState_set_cubic_alpha_C(const long handle, const long i, const char* parameter, const double c1, const double c2, const double c3 , long *errcode, char *message_buffer, const long buffer_length) {
+    *errcode = 0;
+    try {
+        shared_ptr<CoolProp::AbstractState> &AS = handle_manager.get(handle);
+        AS->set_cubic_alpha_C(static_cast<std::size_t>(i),std::string(parameter), c1, c2, c3);
     }
     catch (...) {
 		HandleException(errcode, message_buffer, buffer_length);
@@ -591,7 +602,7 @@ EXPORT_CODE void CONVENTION  AbstractState_set_fluid_parameter_double(const long
     *errcode = 0;
     try {
         shared_ptr<CoolProp::AbstractState> &AS = handle_manager.get(handle);
-        AS->set_fluid_parameter_double(static_cast<std::size_t>(i), parameter, value);
+        AS->set_fluid_parameter_double(static_cast<std::size_t>(i), std::string(parameter), value);
     }
     catch (...) {
 		HandleException(errcode, message_buffer, buffer_length);

--- a/wrappers/Julia/CoolProp.jl
+++ b/wrappers/Julia/CoolProp.jl
@@ -1,7 +1,7 @@
 VERSION < v"0.4.0" && __precompile__()
 module CoolProp
 
-export PropsSI, PhaseSI, get_global_param_string, get_parameter_information_string,get_fluid_param_string,set_reference_stateS, get_param_index, get_input_pair_index, set_config_string, F2K, K2F, HAPropsSI, AbstractState_factory, AbstractState_free, AbstractState_set_fractions, AbstractState_update, AbstractState_specify_phase, AbstractState_unspecify_phase, AbstractState_keyed_output, AbstractState_output, AbstractState_update_and_common_out, AbstractState_update_and_1_out, AbstractState_update_and_5_out, AbstractState_set_binary_interaction_double, AbstractState_set_fluid_parameter_double
+export PropsSI, PhaseSI, get_global_param_string, get_parameter_information_string,get_fluid_param_string,set_reference_stateS, get_param_index, get_input_pair_index, set_config_string, F2K, K2F, HAPropsSI, AbstractState_factory, AbstractState_free, AbstractState_set_fractions, AbstractState_update, AbstractState_specify_phase, AbstractState_unspecify_phase, AbstractState_keyed_output, AbstractState_output, AbstractState_update_and_common_out, AbstractState_update_and_1_out, AbstractState_update_and_5_out, AbstractState_set_binary_interaction_double, AbstractState_set_cubic_alpha_C, AbstractState_set_fluid_parameter_double
 
 # Check the current Julia version to make this Julia 0.4 code compatible with older version
 if VERSION <= VersionNumber(0,4)
@@ -389,6 +389,27 @@ end
 # value the value of the binary interaction parameter
 function AbstractState_set_binary_interaction_double(handle::Clong,i::Int, j::Int, parameter::AbstractString, value::Cdouble)
   ccall( (:AbstractState_set_binary_interaction_double, "CoolProp"), Void, (Clong,Clong,Clong,Ptr{UInt8},Cdouble,Ref{Clong},Ptr{UInt8},Clong), handle,i,j,parameter,value,errcode,message_buffer::Array{UInt8,1},buffer_length)
+  if errcode[] != 0
+    if errcode[] == 1
+      error("CoolProp: ", bytestring(convert(Ptr{UInt8}, pointer(message_buffer))))
+    elseif errcode[] == 2
+      error("CoolProp: message buffer too small")
+    else # == 3
+      error("CoolProp: unknown error")
+    end
+  end
+  return nothing
+end
+
+#  Set cubic's alpha function parameters
+# handle The integer handle for the state class stored in memory
+# i indice of the fluid the parramter should be applied too (for mixtures)
+# parameter the string specifying the alpha function to use, ex "TWU" for the TWU alpha function
+# c1 the first parameter for the alpha function
+# c2 the second parameter for the alpha function
+# c3 the third parameter for the alpha function
+function AbstractState_set_cubic_alpha_C(handle::Clong, i::Int, parameter::AbstractString, c1::Cdouble, c2::Cdouble, c3::Cdouble)
+  ccall( (:AbstractState_set_cubic_alpha_C, "CoolProp"), Void, (Clong,Clong,Ptr{UInt8},Cdouble,Cdouble,Cdouble,Ref{Clong},Ptr{UInt8},Clong), handle,i,parameter,c1,c2,c3,errcode,message_buffer::Array{UInt8,1},buffer_length)
   if errcode[] != 0
     if errcode[] == 1
       error("CoolProp: ", bytestring(convert(Ptr{UInt8}, pointer(message_buffer))))


### PR DESCRIPTION
Allows to set coefficients for Mathias-Copemann and TWU from the shared library.
Functionality also added to the Julia Wrapper
