### PR TITLE
Bigger buffer size for Julia wrapper

### DIFF
--- a/wrappers/Julia/CoolProp.jl
+++ b/wrappers/Julia/CoolProp.jl
@@ -13,7 +13,7 @@ else
   errcode = Ref{Clong}(0)
 end
 
-const buffer_length = 10000
+const buffer_length = 20000
 message_buffer = Array(UInt8, buffer_length)
 
 # ---------------------------------


### PR DESCRIPTION
As discussed in #1293 , we need something at least of size 14 301, so 20 000 should do the trick for now.