### PR TITLE
Added PQ and QT Input Pairs to provide Saturation Values to IF97 Backend

### DIFF
--- a/src/Backends/IF97/IF97Backend.h
+++ b/src/Backends/IF97/IF97Backend.h
@@ -14,9 +14,9 @@ class IF97Backend : public AbstractState  {
 
 protected:
 
-	/// Additional cached elements used only in this backend since the "normal"
+    /// Additional cached elements used only in this backend since the "normal"
     /// backends use only molar units while IF97 uses mass-based units
-	CachedElement  _cpmass, _cvmass, _hmass, _rhomass, _smass, _umass;
+    CachedElement  _cpmass, _cvmass, _hmass, _rhomass, _smass, _umass;
 
 public:
     /// The name of the backend being used
@@ -35,12 +35,13 @@ public:
     bool clear() {
     // Reset all instances of CachedElement and overwrite
     // the internal double values with -_HUGE
+    // Default phase condition is no phase imposed
+    // IF97 will make phase/region determination
         this->_rhomolar = -_HUGE;
         this->_T = -_HUGE;
         this->_p = -_HUGE;
         this->_Q = -_HUGE;
-        this->_phase = iphase_not_imposed; // Default condition is no phse imposed
-
+        this->_phase = iphase_not_imposed; 
         return true;
     };
 
@@ -62,28 +63,14 @@ public:
             case PQ_INPUTS: 
                 _p = value1; 
                 _Q = value2; 
-                _T = IF97::Tsat97(_p); 
-                if (std::abs(_Q) < 1e-10){
-                    _phase = iphase_liquid; // bubble point
-                }
-                else if (std::abs(value2-1) < 1e-10){
-                    _phase = iphase_gas; // dew point
-                }
-                else
-                    _phase = iphase_twophase;
+                _T = IF97::Tsat97(_p);  // ...will throw exception if _P not on saturation curve
+                _phase = iphase_twophase;
                 break;
             case QT_INPUTS: 
                 _Q = value1; 
                 _T = value2; 
-                _p = IF97::psat97(_T); 
-                if (std::abs(_Q) < 1e-10){
-                    _phase = iphase_liquid; // bubble point
-                }
-                else if (std::abs(value2-1) < 1e-10){
-                    _phase = iphase_gas; // dew point
-                }
-                else
-                    _phase = iphase_twophase;
+                _p = IF97::psat97(_T);  // ...will throw exception if _P not on saturation curve
+                _phase = iphase_twophase;
                 break;
             default:
                 throw ValueError("Bad input_pair");
@@ -91,14 +78,14 @@ public:
     };
 
     /*  We have to override some of the functions from the AbstractState.
-	 *  IF97 is only mass-based and does not support conversion
-	 *  from mass- to molar-specific quantities.
-	 */
+     *  IF97 is only mass-based and does not support conversion
+     *  from mass- to molar-specific quantities.
+     */
     // ************************************************************************* //
     //                   Basic Thermodynamic Functions                           //
     // ************************************************************************* //
     //
-    double calc_Liquid(parameters iCalc) {
+    double calc_SatLiquid(parameters iCalc) {
         switch(iCalc){
         case iDmass:  return IF97::rholiq_p(_p); break; ///< Mass-based density
         case iHmass:  return IF97::hliq_p(_p); break;   ///< Mass-based enthalpy
@@ -110,7 +97,7 @@ public:
         default: return -_HUGE;
         };
     }
-    double calc_Vapor(parameters iCalc) {
+    double calc_SatVapor(parameters iCalc) {
         switch(iCalc){
         case iDmass:  return IF97::rhovap_p(_p); break; ///< Mass-based density
         case iHmass:  return IF97::hvap_p(_p); break;   ///< Mass-based enthalpy
@@ -124,26 +111,29 @@ public:
     }
     double calc_Flash(parameters iCalc) {
         switch(_phase){
-            case iphase_liquid: 
-                return calc_Liquid(iCalc); 
+            case iphase_twophase:   // In saturation envelope
+                if (std::abs(_Q) < 1e-10){
+                    return calc_SatLiquid(iCalc);    // bubble point (Q == 0) on Sat. Liquid curve
+                }
+                else if (std::abs(_Q-1) < 1e-10){
+                    return calc_SatVapor(iCalc);     // dew point (Q == 1) on Sat. Vapor curve
+                }
+                else {                               // else "inside" bubble ( 0 < Q < 1 )    
+                    switch(iCalc){ 
+                    case iDmass:
+                        return 1.0/(_Q/calc_SatVapor(iDmass) + (1.0-_Q)/calc_SatLiquid(iDmass)); break;
+                    case iCpmass:
+                        throw NotImplementedError(format("Isobaric Specific Heat not implemented in two phase region")); break;
+                    case iCvmass:
+                        throw NotImplementedError(format("Isochoric Specific Heat not implemented in two phase region")); break;
+                    case ispeed_sound:
+                        throw NotImplementedError(format("Speed of Sound not implemented in two phase region")); break;
+                    default:
+                        return _Q*calc_SatVapor(iCalc) + (1.0-_Q)*calc_SatLiquid(iCalc);
+                    };
+                }
                 break;
-            case iphase_gas:    
-                return calc_Vapor(iCalc); 
-                break;
-            case iphase_twophase:
-                switch(iCalc){ 
-                case iDmass:
-                    return 1.0/(_Q/calc_Vapor(iCalc) + (1.0-_Q)/calc_Liquid(iCalc)); break;
-                case iCpmass:
-                    throw NotImplementedError(format("Isobaric Specific Heat not implemented in two phase region")); break;
-                case iCvmass:
-                    throw NotImplementedError(format("Isochoric Specific Heat not implemented in two phase region")); break;
-                case ispeed_sound:
-                    throw NotImplementedError(format("Speed of Sound not implemented in two phase region")); break;
-                default:
-                    return _Q*calc_Vapor(iCalc) + (1.0-_Q)*calc_Liquid(iCalc);
-                }; break;
-            default: 
+            default:    // Outside saturation envelope (iphase_not_imposed), let IF97 determine phase/region
                 switch(iCalc){
                 case iDmass:  return IF97::rhomass_Tp(_T, _p); break; ///< Mass-based density
                 case iHmass:  return IF97::hmass_Tp(_T, _p); break;   ///< Mass-based enthalpy
@@ -156,38 +146,38 @@ public:
                 };
         }
     }
-	/// Return the mass density in kg/m³
+    /// Return the mass density in kg/m³
     double rhomass(void){ return calc_rhomass(); };
     double calc_rhomass(void){ return calc_Flash(iDmass); };
     /// Return the molar density in mol/m³
     double rhomolar(void){ return calc_rhomolar(); };
     double calc_rhomolar(void){ return rhomass()/molar_mass(); };    /// kg/m³ * mol/kg = mol/m³
 
-	/// Return the mass enthalpy in J/kg
+    /// Return the mass enthalpy in J/kg
     double hmass(void){ return calc_hmass(); };
     double calc_hmass(void){ return calc_Flash(iHmass); };
-	/// Return the molar enthalpy in J/mol
+    /// Return the molar enthalpy in J/mol
     double hmolar(void){ return calc_hmolar(); };
     double calc_hmolar(void){ return hmass()*molar_mass(); };        /// J/kg * kg/mol = J/mol
 
-	/// Return the mass entropy in J/kg/K
+    /// Return the mass entropy in J/kg/K
     double smass(void){ return calc_smass(); };
     double calc_smass(void){ return calc_Flash(iSmass); };
-	/// Return the molar entropy in J/mol/K
+    /// Return the molar entropy in J/mol/K
     double smolar(void){ return calc_smolar(); };
     double calc_smolar(void){ return smass()*molar_mass(); };        /// J/kg-K * kg/mol = J/mol-K
 
-	/// Return the mass internal energy in J/kg
+    /// Return the mass internal energy in J/kg
     double umass(void){ return calc_umass(); };
     double calc_umass(void){ return calc_Flash(iUmass); };
-	/// Return the molar internal energy in J/mol
+    /// Return the molar internal energy in J/mol
     double umolar(void){ return calc_umolar(); };
     double calc_umolar(void){ return umass()*molar_mass(); };        /// J/kg * kg/mol = J/mol
 
-	/// Return the mass-based constant pressure specific heat in J/kg/K
+    /// Return the mass-based constant pressure specific heat in J/kg/K
     double cpmass(void){ return calc_cpmass(); };
     double calc_cpmass(void){ return calc_Flash(iCpmass); };
-	/// Return the molar-based constant pressure specific heat in J/mol/K
+    /// Return the molar-based constant pressure specific heat in J/mol/K
     double cpmolar(void){ return calc_cpmolar(); };
     double calc_cpmolar(void){ return cpmass()*molar_mass(); };      /// J/kg-K * kg/mol = J/mol-K
 

--- a/src/Backends/IF97/IF97Backend.h
+++ b/src/Backends/IF97/IF97Backend.h
@@ -31,24 +31,62 @@ public:
     void set_volu_fractions(const std::vector<CoolPropDbl> &volu_fractions){throw NotImplementedError("Volume composition has not been implemented.");};
     const std::vector<CoolPropDbl> & get_mole_fractions(void){throw NotImplementedError("get_mole_fractions composition has not been implemented.");};
 
-    /// Updating function for incompressible fluid
+    /// Override clear() function of IF97 Water
+    bool clear() {
+    // Reset all instances of CachedElement and overwrite
+    // the internal double values with -_HUGE
+        this->_rhomolar = -_HUGE;
+        this->_T = -_HUGE;
+        this->_p = -_HUGE;
+        this->_Q = -_HUGE;
+        this->_phase = iphase_not_imposed; // Default condition is no phse imposed
+
+        return true;
+    };
+
+    /// Updating function for IF97 Water
     /**
     In this function we take a pair of thermodynamic states, those defined in the input_pairs
-    enumeration and update all the internal variables that we can.
+    enumeration and update the bare minimum values needed to calculate the other values.
 
     @param input_pair Integer key from CoolProp::input_pairs to the two inputs that will be passed to the function
     @param value1 First input value
     @param value2 Second input value
     */
     void update(CoolProp::input_pairs input_pair, double value1, double value2){
+        
+        clear();  //clear the few cached values we are using
+
         switch(input_pair){
             case PT_INPUTS: _p = value1; _T = value2; break;
-            /* TODO:  Add input pairs for saturation functions 
-            case PQ_INPUTS: _p = value1; _Q = value2; break;
-            case QT_INPUTS: _Q = value1; _T = value2; break;
-            */
+            case PQ_INPUTS: 
+                _p = value1; 
+                _Q = value2; 
+                _T = IF97::Tsat97(_p); 
+                if (std::abs(_Q) < 1e-10){
+                    _phase = iphase_liquid; // bubble point
+                }
+                else if (std::abs(value2-1) < 1e-10){
+                    _phase = iphase_gas; // dew point
+                }
+                else
+                    _phase = iphase_twophase;
+                break;
+            case QT_INPUTS: 
+                _Q = value1; 
+                _T = value2; 
+                _p = IF97::psat97(_T); 
+                if (std::abs(_Q) < 1e-10){
+                    _phase = iphase_liquid; // bubble point
+                }
+                else if (std::abs(value2-1) < 1e-10){
+                    _phase = iphase_gas; // dew point
+                }
+                else
+                    _phase = iphase_twophase;
+                break;
             default:
-                throw ValueError("bad input_pair");
+                throw ValueError("Bad input_pair");
         }
     };
 
@@ -59,31 +97,109 @@ public:
     // ************************************************************************* //
     //                   Basic Thermodynamic Functions                           //
     // ************************************************************************* //
-	/// Return the mass density in kg/m^3
+    //
+    double calc_Liquid(parameters iCalc) {
+        switch(iCalc){
+        case iDmass:  return IF97::rholiq_p(_p); break; ///< Mass-based density
+        case iHmass:  return IF97::hliq_p(_p); break;   ///< Mass-based enthalpy
+        case iSmass:  return IF97::sliq_p(_p); break;   ///< Mass-based entropy
+        case iCpmass: return IF97::cpliq_p(_p); break;  ///< Mass-based constant-pressure specific heat
+        case iCvmass: return IF97::cvliq_p(_p); break;  ///< Mass-based constant-volume specific heat
+        case iUmass:  return IF97::uliq_p(_p); break;   ///< Mass-based internal energy
+        case ispeed_sound: return IF97::speed_soundliq_p(_p); break;  ///< Speed of Sound
+        default: return -_HUGE;
+        };
+    }
+    double calc_Vapor(parameters iCalc) {
+        switch(iCalc){
+        case iDmass:  return IF97::rhovap_p(_p); break; ///< Mass-based density
+        case iHmass:  return IF97::hvap_p(_p); break;   ///< Mass-based enthalpy
+        case iSmass:  return IF97::svap_p(_p); break;   ///< Mass-based entropy
+        case iCpmass: return IF97::cpvap_p(_p); break;  ///< Mass-based constant-pressure specific heat
+        case iCvmass: return IF97::cvvap_p(_p); break;  ///< Mass-based constant-volume specific heat
+        case iUmass:  return IF97::uvap_p(_p); break;   ///< Mass-based internal energy
+        case ispeed_sound: return IF97::speed_soundvap_p(_p); break;  ///< Speed of Sound
+        default: return -_HUGE;
+        };
+    }
+    double calc_Flash(parameters iCalc) {
+        switch(_phase){
+            case iphase_liquid: 
+                return calc_Liquid(iCalc); 
+                break;
+            case iphase_gas:    
+                return calc_Vapor(iCalc); 
+                break;
+            case iphase_twophase:
+                switch(iCalc){ 
+                case iDmass:
+                    return 1.0/(_Q/calc_Vapor(iCalc) + (1.0-_Q)/calc_Liquid(iCalc)); break;
+                case iCpmass:
+                    throw NotImplementedError(format("Isobaric Specific Heat not implemented in two phase region")); break;
+                case iCvmass:
+                    throw NotImplementedError(format("Isochoric Specific Heat not implemented in two phase region")); break;
+                case ispeed_sound:
+                    throw NotImplementedError(format("Speed of Sound not implemented in two phase region")); break;
+                default:
+                    return _Q*calc_Vapor(iCalc) + (1.0-_Q)*calc_Liquid(iCalc);
+                }; break;
+            default: 
+                switch(iCalc){
+                case iDmass:  return IF97::rhomass_Tp(_T, _p); break; ///< Mass-based density
+                case iHmass:  return IF97::hmass_Tp(_T, _p); break;   ///< Mass-based enthalpy
+                case iSmass:  return IF97::smass_Tp(_T, _p); break;   ///< Mass-based entropy
+                case iCpmass: return IF97::cpmass_Tp(_T, _p); break;  ///< Mass-based constant-pressure specific heat
+                case iCvmass: return IF97::cvmass_Tp(_T, _p); break;  ///< Mass-based constant-volume specific heat
+                case iUmass:  return IF97::umass_Tp(_T, _p); break;   ///< Mass-based internal energy
+                case ispeed_sound: return IF97::speed_sound_Tp(_T, _p); break;  ///< speed of sound
+                default: throw NotImplementedError(format("Output variable not implemented in IF97 Backend"));
+                };
+        }
+    }
+	/// Return the mass density in kg/m³
     double rhomass(void){ return calc_rhomass(); };
-    double calc_rhomass(void){ return IF97::rhomass_Tp(_T, _p); };
-	/// Return the mass enthalpy in J/kg
-	double hmass(void){return calc_hmass();};
-    double calc_hmass(void){ return IF97::hmass_Tp(_T, _p); };
-	/// Return the molar entropy in J/mol/K
-	double smass(void){return calc_smass();};
-    double calc_smass(void){ return IF97::smass_Tp(_T, _p); };
-	/// Return the molar internal energy in J/mol
-	double umass(void){return calc_umass();};
-    double calc_umass(void){ return IF97::umass_Tp(_T, _p); };
-	/// Return the mass-based constant pressure specific heat in J/kg/K
-	double cpmass(void){return calc_cpmass();};
-    double calc_cpmass(void){ return IF97::cpmass_Tp(_T, _p); };
-    /// Return the mass-based constant volume specific heat in J/kg/K
-	double cvmass(void){return calc_cvmass();};
-    double calc_cvmass(void){ return IF97::cvmass_Tp(_T, _p); };
-    /// Return the speed of sound
-    double speed_sound(void){ return calc_speed_sound(); };
-    double calc_speed_sound(void) { return IF97::speed_sound_Tp(_T, _p); };
+    double calc_rhomass(void){ return calc_Flash(iDmass); };
+    /// Return the molar density in mol/m³
+    double rhomolar(void){ return calc_rhomass()/molar_mass(); };    /// kg/m³ * mol/kg = mol/m³
 
+	/// Return the mass enthalpy in J/kg
+	double hmass(void){ return calc_hmass(); };
+    double calc_hmass(void){ return calc_Flash(iHmass); };
+	/// Return the molar enthalpy in J/mol
+	double hmolar(void){ return calc_hmass()*molar_mass(); };        /// J/kg * kg/mol = J/mol
+
+	/// Return the mass entropy in J/kg/K
+	double smass(void){ return calc_smass(); };
+    double calc_smass(void){ return calc_Flash(iSmass); };
+	/// Return the molar entropy in J/mol/K
+	double smolar(void){ return calc_smass()*molar_mass(); };        /// J/kg-K * kg/mol = J/mol-K
+
+	/// Return the mass internal energy in J/kg
+	double umass(void){ return calc_umass(); };
+    double calc_umass(void){ return calc_Flash(iUmass); };
+	/// Return the molar internal energy in J/mol
+	double umolar(void){ return calc_umass()*molar_mass(); };        /// J/kg * kg/mol = J/mol
+
+	/// Return the mass-based constant pressure specific heat in J/kg/K
+	double cpmass(void){ return calc_cpmass(); };
+    double calc_cpmass(void){ return calc_Flash(iCpmass); };
+	/// Return the molar-based constant pressure specific heat in J/mol/K
+	double cpmolar(void){ return calc_cpmass()*molar_mass(); };        /// J/kg-K * kg/mol = J/mol-K
+
+    /// Return the mass-based constant volume specific heat in J/kg/K
+	double cvmass(void){ return calc_cvmass(); };
+    double calc_cvmass(void){ return calc_Flash(iCvmass); };
+    /// Return the molar-based constant volume specific heat in J/mol/K
+	double cvmolar(void){ return calc_cvmass()*molar_mass(); };        /// J/kg-K * kg/mol = J/mol-K
+
+    /// Return the speed of sound in m/s
+    double speed_sound(void){ return calc_speed_sound(); };
+    double calc_speed_sound(void) { return calc_Flash(ispeed_sound); };
+    //
     // ************************************************************************* //
     //                         Trivial Functions                                 //
     // ************************************************************************* //
+    //
     /// Using this backend, get the triple point temperature in K
     double calc_Ttriple(void){ return IF97::get_Ttrip(); };
     /// Using this backend, get the triple point pressure in Pa
@@ -119,7 +235,12 @@ public:
     // Overwrite the virtual calc_ functions for density
     double calc_rhomolar_critical(void){ return rhomass_critical()/molar_mass(); };
     double calc_rhomass_critical(void){ return IF97::get_rhocrit(); };
-
+    //
+    // ************************************************************************* //
+    //                      Saturation Functions                                 //
+    // ************************************************************************* //
+    //
+    double calc_pressure(void){ return _p; };
 };
 
 } /* namespace CoolProp */

--- a/src/Backends/IF97/IF97Backend.h
+++ b/src/Backends/IF97/IF97Backend.h
@@ -160,37 +160,43 @@ public:
     double rhomass(void){ return calc_rhomass(); };
     double calc_rhomass(void){ return calc_Flash(iDmass); };
     /// Return the molar density in mol/m³
-    double rhomolar(void){ return calc_rhomass()/molar_mass(); };    /// kg/m³ * mol/kg = mol/m³
+    double rhomolar(void){ return calc_rhomolar(); };
+    double calc_rhomolar(void){ return rhomass()/molar_mass(); };    /// kg/m³ * mol/kg = mol/m³
 
 	/// Return the mass enthalpy in J/kg
     double hmass(void){ return calc_hmass(); };
     double calc_hmass(void){ return calc_Flash(iHmass); };
 	/// Return the molar enthalpy in J/mol
-    double hmolar(void){ return calc_hmass()*molar_mass(); };        /// J/kg * kg/mol = J/mol
+    double hmolar(void){ return calc_hmolar(); };
+    double calc_hmolar(void){ return hmass()*molar_mass(); };        /// J/kg * kg/mol = J/mol
 
 	/// Return the mass entropy in J/kg/K
     double smass(void){ return calc_smass(); };
     double calc_smass(void){ return calc_Flash(iSmass); };
 	/// Return the molar entropy in J/mol/K
-    double smolar(void){ return calc_smass()*molar_mass(); };        /// J/kg-K * kg/mol = J/mol-K
+    double smolar(void){ return calc_smolar(); };
+    double calc_smolar(void){ return smass()*molar_mass(); };        /// J/kg-K * kg/mol = J/mol-K
 
 	/// Return the mass internal energy in J/kg
     double umass(void){ return calc_umass(); };
     double calc_umass(void){ return calc_Flash(iUmass); };
 	/// Return the molar internal energy in J/mol
-    double umolar(void){ return calc_umass()*molar_mass(); };        /// J/kg * kg/mol = J/mol
+    double umolar(void){ return calc_umolar(); };
+    double calc_umolar(void){ return umass()*molar_mass(); };        /// J/kg * kg/mol = J/mol
 
 	/// Return the mass-based constant pressure specific heat in J/kg/K
     double cpmass(void){ return calc_cpmass(); };
     double calc_cpmass(void){ return calc_Flash(iCpmass); };
 	/// Return the molar-based constant pressure specific heat in J/mol/K
-    double cpmolar(void){ return calc_cpmass()*molar_mass(); };        /// J/kg-K * kg/mol = J/mol-K
+    double cpmolar(void){ return calc_cpmolar(); };
+    double calc_cpmolar(void){ return cpmass()*molar_mass(); };      /// J/kg-K * kg/mol = J/mol-K
 
     /// Return the mass-based constant volume specific heat in J/kg/K
     double cvmass(void){ return calc_cvmass(); };
     double calc_cvmass(void){ return calc_Flash(iCvmass); };
     /// Return the molar-based constant volume specific heat in J/mol/K
-    double cvmolar(void){ return calc_cvmass()*molar_mass(); };        /// J/kg-K * kg/mol = J/mol-K
+    double cvmolar(void){ return calc_cvmolar(); };
+    double calc_cvmolar(void){ return cvmass()*molar_mass(); };      /// J/kg-K * kg/mol = J/mol-K
 
     /// Return the speed of sound in m/s
     double speed_sound(void){ return calc_speed_sound(); };
@@ -241,6 +247,11 @@ public:
     // ************************************************************************* //
     //
     double calc_pressure(void){ return _p; };
+    //
+    // ************************************************************************* //
+    //                      Saturation Functions                                 //
+    // ************************************************************************* //
+    //
 };
 
 } /* namespace CoolProp */

--- a/src/Backends/IF97/IF97Backend.h
+++ b/src/Backends/IF97/IF97Backend.h
@@ -163,34 +163,34 @@ public:
     double rhomolar(void){ return calc_rhomass()/molar_mass(); };    /// kg/m³ * mol/kg = mol/m³
 
 	/// Return the mass enthalpy in J/kg
-	double hmass(void){ return calc_hmass(); };
+    double hmass(void){ return calc_hmass(); };
     double calc_hmass(void){ return calc_Flash(iHmass); };
 	/// Return the molar enthalpy in J/mol
-	double hmolar(void){ return calc_hmass()*molar_mass(); };        /// J/kg * kg/mol = J/mol
+    double hmolar(void){ return calc_hmass()*molar_mass(); };        /// J/kg * kg/mol = J/mol
 
 	/// Return the mass entropy in J/kg/K
-	double smass(void){ return calc_smass(); };
+    double smass(void){ return calc_smass(); };
     double calc_smass(void){ return calc_Flash(iSmass); };
 	/// Return the molar entropy in J/mol/K
-	double smolar(void){ return calc_smass()*molar_mass(); };        /// J/kg-K * kg/mol = J/mol-K
+    double smolar(void){ return calc_smass()*molar_mass(); };        /// J/kg-K * kg/mol = J/mol-K
 
 	/// Return the mass internal energy in J/kg
-	double umass(void){ return calc_umass(); };
+    double umass(void){ return calc_umass(); };
     double calc_umass(void){ return calc_Flash(iUmass); };
 	/// Return the molar internal energy in J/mol
-	double umolar(void){ return calc_umass()*molar_mass(); };        /// J/kg * kg/mol = J/mol
+    double umolar(void){ return calc_umass()*molar_mass(); };        /// J/kg * kg/mol = J/mol
 
 	/// Return the mass-based constant pressure specific heat in J/kg/K
-	double cpmass(void){ return calc_cpmass(); };
+    double cpmass(void){ return calc_cpmass(); };
     double calc_cpmass(void){ return calc_Flash(iCpmass); };
 	/// Return the molar-based constant pressure specific heat in J/mol/K
-	double cpmolar(void){ return calc_cpmass()*molar_mass(); };        /// J/kg-K * kg/mol = J/mol-K
+    double cpmolar(void){ return calc_cpmass()*molar_mass(); };        /// J/kg-K * kg/mol = J/mol-K
 
     /// Return the mass-based constant volume specific heat in J/kg/K
-	double cvmass(void){ return calc_cvmass(); };
+    double cvmass(void){ return calc_cvmass(); };
     double calc_cvmass(void){ return calc_Flash(iCvmass); };
     /// Return the molar-based constant volume specific heat in J/mol/K
-	double cvmolar(void){ return calc_cvmass()*molar_mass(); };        /// J/kg-K * kg/mol = J/mol-K
+    double cvmolar(void){ return calc_cvmass()*molar_mass(); };        /// J/kg-K * kg/mol = J/mol-K
 
     /// Return the speed of sound in m/s
     double speed_sound(void){ return calc_speed_sound(); };

--- a/wrappers/MathCAD/CoolPropMathcad.cpp
+++ b/wrappers/MathCAD/CoolPropMathcad.cpp
@@ -7,7 +7,7 @@
 #define NOMINMAX
 #endif
 #include "mcadincl.h"
-#undef NOMINMAX; 
+#undef NOMINMAX 
 
 enum { MC_STRING = STRING };  // substitute enumeration variable MC_STRING for STRING, use MC_STRING below
 #undef STRING                 // undefine STRING as it conflicts with STRING enum in cppformat/format.h


### PR DESCRIPTION
- [x] Added PQ and QT Input Pair Facility for all Thermo props.  
- [x] Implemented Temperature/Pressure saturation curve (both ways).  
- [x] Handle mixed Vapor/Liquid inside saturation dome for Dmass, Hmass, Smass, Umass by linear mixing when 0 < Q < 1.  However, Cpmass, Cvmass, and speed of sound throw and exception as these values are not defined in the two phase region.  
- [x] Also implemented Molar values by multiplying (or dividing) by molar_mass().
- [x] Touched up some other minor nits.

Partial verification (through Mathcad wrapper) shown below.  You may want to verify that Cpmass, Cvmass, and speed of sound are properly throwing the exception messages (e.g. in Python) as I can't see them in Mathcad yet.
![saturation verif1](https://cloud.githubusercontent.com/assets/17114032/20045277/a9066dc0-a46d-11e6-912e-631e52f0b5b6.PNG)
![saturation verif2](https://cloud.githubusercontent.com/assets/17114032/20045282/b2069008-a46d-11e6-828b-6c94693c6cfe.PNG)
![saturation verif3](https://cloud.githubusercontent.com/assets/17114032/20045283/b4b5eb82-a46d-11e6-9213-b249310990f8.PNG)
![saturation verif4](https://cloud.githubusercontent.com/assets/17114032/20045285/b8220d1e-a46d-11e6-9c71-f9f801de167e.PNG)
![saturation verif5](https://cloud.githubusercontent.com/assets/17114032/20045286/bb833af0-a46d-11e6-9ea9-fe3c76e11d61.PNG)
