### PR TITLE
Return 'n/a'  REFPROP version when not loaded or supported.

### DIFF
--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -236,7 +236,9 @@ std::string REFPROPMixtureBackend::version(){
     long N = -1;
     long ierr = 0;
     char fluids[10000] = "", hmx[] = "HMX.BNC", default_reference_state[] = "DEF", herr[255] = "";
-    REFPROPMixtureBackend::REFPROP_supported();
+    if (!REFPROP_supported()) {
+      return "n/a";
+    };
     // Pad the version string with NULL characters
     for (int i = 0; i < 255; ++i){
         herr[i] = '\0';


### PR DESCRIPTION
Create a pull request to solve issue #1368. When the `REFPROPMixtureBackend::version()` is called, the method will return `n\a` when `REFPROPMixtureBackend::REFPROP_supported()` returns `false`. This should prevent the segmentation fault when getting the REFPROP version if REFPROP is not installed. What do you think? Is returning 'n/a' a good solution or do you prefer to raise a ValueError when `SETUPdll == NULL`? My reasoning behind this implementation is that a complete check if REFPROP is supported and safe to load was already implemented in `REFPROP_supported()`, so it would make sense to just trust the value it returns.

P.S. I noticed that my editor removed some trailing white spaces I hope this is not a problem?