### PR TITLE
set_reference_state for AbstractSate

### DIFF
--- a/include/AbstractState.h
+++ b/include/AbstractState.h
@@ -452,6 +452,41 @@ public:
     virtual void set_mass_fractions(const std::vector<CoolPropDbl> &mass_fractions) = 0;
     virtual void set_volu_fractions(const std::vector<CoolPropDbl> &mass_fractions){ throw NotImplementedError("Volume composition has not been implemented."); }
 
+
+
+    /**
+    \brief Set the reference state based on a string representation
+
+    @param reference_state The reference state to use, one of
+
+    Reference State | Description
+    -------------   | -------------------
+    "IIR"           | h = 200 kJ/kg, s=1 kJ/kg/K at 0C saturated liquid
+    "ASHRAE"        | h = 0, s = 0 @ -40C saturated liquid
+    "NBP"           | h = 0, s = 0 @ 1.0 bar saturated liquid
+    "DEF"           | Reset to the default reference state for the fluid
+    "RESET"         | Remove the offset
+
+    The offset in the ideal gas Helmholtz energy can be obtained from
+    \f[
+    \displaystyle\frac{\Delta s}{R_u/M}+\frac{\Delta h}{(R_u/M)T}\tau
+    \f]
+    where \f$ \Delta s = s-s_{spec} \f$ and \f$ \Delta h = h-h_{spec} \f$
+    */
+    virtual void set_reference_stateS(const std::string &reference_state){
+        throw NotImplementedError("Setting reference state has not been implemented for this backend. Try using CoolProp::set_reference_stateD instead.");
+    }
+
+    /// Set the reference state based on a thermodynamic state point specified by temperature and molar density
+    /// @param T Temperature at reference state [K]
+    /// @param rhomolar Molar density at reference state [mol/m^3]
+    /// @param hmolar0 Molar enthalpy at reference state [J/mol]
+    /// @param smolar0 Molar entropy at reference state [J/mol/K]
+    virtual void set_reference_stateD(double T, double rhomolar, double hmolar0, double smolar0){
+        throw NotImplementedError("Setting reference state has not been implemented for this backend. Try using CoolProp::set_reference_stateD instead.");
+    }
+
+
 #ifndef COOLPROPDBL_MAPS_TO_DOUBLE
     void set_mole_fractions(const std::vector<double> &mole_fractions){ set_mole_fractions(std::vector<CoolPropDbl>(mole_fractions.begin(), mole_fractions.end())); };
     void set_mass_fractions(const std::vector<double> &mass_fractions){ set_mass_fractions(std::vector<CoolPropDbl>(mass_fractions.begin(), mass_fractions.end())); };

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
@@ -56,6 +56,9 @@ protected:
     
     /// This overload is protected because it doesn't follow the base class definition, since this function is needed for constructing spinodals
     std::vector<CoolProp::CriticalState> _calc_all_critical_points(bool find_critical_points = true);
+
+    static void set_fluid_enthalpy_entropy_offset(CoolPropFluid& component, double delta_a1, double delta_a2, const std::string &ref);
+
 public:
     HelmholtzEOSMixtureBackend();
     HelmholtzEOSMixtureBackend(const std::vector<CoolPropFluid> &components, bool generate_SatL_and_SatV = true);
@@ -96,6 +99,12 @@ public:
     /// Return a string from the backend for the mixture/fluid
     std::string fluid_param_string(const std::string &);
     
+    /// brief Set the reference state based on a string representation
+    virtual void set_reference_stateS(const std::string &reference_state);
+
+    /// Set the reference state based on a thermodynamic state point specified by temperature and molar density
+    virtual void set_reference_stateD(double T, double rhomolar, double hmolar0, double smolar0);
+
     /// Set binary mixture floating point parameter
     virtual void set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string &parameter, const double value);
     /// Get binary mixture double value


### PR DESCRIPTION
this allows for setting reference state without changing the state of
the JSONLibrary (now without C++11)