### PR TITLE
Set VTPR constants through the set_binary_interaction_parameter function, closes #1311

### DIFF
--- a/src/Backends/Cubics/GeneralizedCubic.h
+++ b/src/Backends/Cubics/GeneralizedCubic.h
@@ -523,7 +523,7 @@ public:
                      +2*d_PI_12_dxi(delta, x, idelta, j, xN_independent)*d_PI_12_dxi(delta, x, idelta, k, xN_independent)*d_bm_term_dxi(x,i, xN_independent)
                      );
     };
-    // Allows to modify the unifac interaction parameters aij, bij and cij
+    // Allows to modify the unifac interaction parameters aij, bij and cij. Only for use with VTPR backend.
     virtual void set_interaction_parameter(const std::size_t mgi1, const std::size_t mgi2, const std::string &parameter, const double value){throw CoolProp::NotImplementedError("set_interaction_parameter is not implemented for this backend");}
 };
 

--- a/src/Backends/Cubics/GeneralizedCubic.h
+++ b/src/Backends/Cubics/GeneralizedCubic.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <cmath>
 #include "crossplatform_shared_ptr.h"
+#include "Exceptions.h"
 
 /// An abstract alpha function for the EOS, defining the interface for the alpha function
 class AbstractCubicAlphaFunction{
@@ -522,6 +523,8 @@ public:
                      +2*d_PI_12_dxi(delta, x, idelta, j, xN_independent)*d_PI_12_dxi(delta, x, idelta, k, xN_independent)*d_bm_term_dxi(x,i, xN_independent)
                      );
     };
+    // Allows to modify the unifac interaction parameters aij, bij and cij
+    virtual void set_interaction_parameter(const std::size_t mgi1, const std::size_t mgi2, const std::string &parameter, const double value){throw CoolProp::NotImplementedError("set_interaction_parameter is not implemented for this backend");}
 };
 
 class PengRobinson : public AbstractCubic

--- a/src/Backends/Cubics/UNIFAQ.h
+++ b/src/Backends/Cubics/UNIFAQ.h
@@ -5,6 +5,7 @@
 
 #include "UNIFAQLibrary.h"
 #include "CachedElement.h"
+#include "Exceptions.h"
 
 /// Structure containing data for the pure fluid in the mixture
 struct ComponentData {
@@ -59,6 +60,7 @@ namespace UNIFAQ
         * permutations represent the set of posisble binary interactions
         */
         void set_interaction_parameters();
+        void set_interaction_parameter(const std::size_t mgi1, const std::size_t mgi2, const std::string &parameter, const double value);
 
         /// Set the mole fractions of the components in the mixtures (not the groups)
         void set_mole_fractions(const std::vector<double> &z);

--- a/src/Backends/Cubics/VTPRBackend.cpp
+++ b/src/Backends/Cubics/VTPRBackend.cpp
@@ -100,6 +100,13 @@ CoolPropDbl CoolProp::VTPRBackend::calc_molar_mass(void)
     return summer;
 }
 
+void CoolProp::VTPRBackend::set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string &parameter, const double value) {
+    cubic->set_interaction_parameter(i, j, parameter, value);
+    for (std::vector<shared_ptr<HelmholtzEOSMixtureBackend> >::iterator it = linked_states.begin(); it != linked_states.end(); ++it) {
+        (*it)->set_binary_interaction_double(i, j, parameter, value);
+    }
+};
+
 const UNIFAQLibrary::UNIFAQParameterLibrary & CoolProp::VTPRBackend::LoadLibrary(){
     if (!lib.is_populated()){
         std::string UNIFAQ_path = get_config_string(VTPR_UNIFAQ_PATH);

--- a/src/Backends/Cubics/VTPRBackend.h
+++ b/src/Backends/Cubics/VTPRBackend.h
@@ -88,6 +88,9 @@ public:
 
     /// Calculate the molar mass
     CoolPropDbl calc_molar_mass(void);
+
+    /// Allows to modify the interactions parameters aij, bij and cij
+    void set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string &parameter, const double value);
     
 };
     

--- a/src/Backends/Cubics/VTPRCubic.h
+++ b/src/Backends/Cubics/VTPRCubic.h
@@ -195,6 +195,11 @@ public:
     {
         return 0;
     }
+    // Allows to modify the unifac interaction parameters aij, bij and cij
+    void set_interaction_parameter(const std::size_t mgi1, const std::size_t mgi2, const std::string &parameter, const double value)
+    {
+        unifaq.set_interaction_parameter(mgi1, mgi2, parameter, value);
+    }
 };
 
 #endif /* VTPRCubic_h */


### PR DESCRIPTION
For instance, for a mixture with Ethane and Acetone:
```Julia
AbstractState_set_binary_interaction_double(AS,1, 9, "aij", 433.6)
AbstractState_set_binary_interaction_double(AS,9, 1, "aij", 199)
AbstractState_set_binary_interaction_double(AS,1, 9, "bij", 0.1473)
AbstractState_set_binary_interaction_double(AS,9, 1, "bij", -0.8709)
AbstractState_set_binary_interaction_double(AS,1, 9, "cij", 0)
AbstractState_set_binary_interaction_double(AS,9, 1, "cij", 0)
```
Allows to use Dortmund's parameters instead of Poling's.

Also reduces execution time of VTPR (cut by ~39% in my QT_INPUTS test case) by moving a part of pure fluid code that do not need to be executed more than once and by saving the values of Psi instead of calling it a lot of time.
It still much heavier than PR (around 10 times in my test case, but there is much less to execute in PR). I think next speed improvement will have to be made by adapting some of the iterative solvers (like adapting the way guesses are made, as cubic are not iterative, they do not benefit from guesses).