### PR TITLE
Update Mathcad wrapper to use MathcadAllocate() for returned strings.

### DIFF
--- a/wrappers/MathCAD/CoolPropMathcad.cpp
+++ b/wrappers/MathCAD/CoolPropMathcad.cpp
@@ -17,14 +17,6 @@ enum { MC_STRING = STRING };  // substitute enumeration variable MC_STRING for S
 #include "DataStructures.h"
 #include "HumidAirProp.h"
 
-/*
-#define MSGBOX(x) \
-{ \
-   std::ostringstream oss; \
-   oss << x; \
-   MessageBox(NULL,oss.str().c_str(), "CoolProp Error Message", MB_OK | MB_ICONINFORMATION); \
-}
-*/
 
 enum EC { MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,       // Mathcad Error Codes
           BAD_FLUID, BAD_PARAMETER, BAD_REF, NON_TRIVIAL,           // CoolProp Error Codes
@@ -80,7 +72,8 @@ enum EC { MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,       // Mathcad E
                 return MAKELRESULT(UNKNOWN,1);
         }
 
-        char * c = new char [s.size()+1]; // create a c-string (pointer) c with the same size as s
+        // Must use MathcadAllocate(size) so Mathcad can track and release
+        char * c = MathcadAllocate(s.size()+1); // create a c-string (pointer) c with the same size as s
         // copy s into c, this process avoids the const-cast type which would result from instead
         // converting the string using s.c_str()
         std::copy(s.begin(), s.end(), c); 
@@ -116,7 +109,8 @@ enum EC { MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,       // Mathcad E
                 return MAKELRESULT(UNKNOWN,1);
         }
 
-        char * c = new char [s.size()+1]; // create a c-string (pointer) c with the same size as s
+        // Must use MathcadAllocate(size) so Mathcad can track and release
+        char * c = MathcadAllocate(s.size()+1); // create a c-string (pointer) c with the same size as s
         // copy s into c, this process avoids the const-cast type which would result from instead
         // converting the string using s.c_str()
         std::copy(s.begin(), s.end(), c); 


### PR DESCRIPTION
Closes #1462 .  Tracked to legacy code in Mathcad wrapper that used standard memory allocation methods for strings (`new`) instead of using the provided `MathcadAllocate()` function, which allows Mathcad 15 and Prime to track and release memory allocations when they are no longer needed and provides consistent memory allocation across DLL boundaries.  This didn't cause a crash in either Mathcad version when compiled with VS2010, but does with VS2015 and may have been causing an undetected memory leak.  No sign of a memory leak now.  Two functions were affected, `get_global_param_string()` and `get_fluid_param_string()`.

Interestingly, I found S. Polak's inquiry about this very issue on the [Mathcad support forum](https://www.ptcusercommunity.com/thread/51416) in 2012.  It was answered correctly, but apparently never implemented in the CoolProp repository (it was on SourceForge then and version 4.0.0). 

Also cleaned up some commented code that was previously used for debugging and no longer needed.