### PR TITLE
Added low-level binary parameter functions to Mathcad wrapper

### DIFF
--- a/wrappers/MathCAD/CoolPropMathcad.cpp
+++ b/wrappers/MathCAD/CoolPropMathcad.cpp
@@ -17,12 +17,16 @@ enum { MC_STRING = STRING };  // substitute enumeration variable MC_STRING for S
 #include "DataStructures.h"
 #include "HumidAirProp.h"
 
+namespace CoolProp {
+    extern void apply_simple_mixing_rule(const std::string &identifier1, const std::string &identifier2, const std::string &rule);
+}
 
 enum EC { MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,       // Mathcad Error Codes
           BAD_FLUID, BAD_PARAMETER, BAD_REF, NON_TRIVIAL,           // CoolProp Error Codes
           NO_REFPROP, NOT_AVAIL, BAD_INPUT_PAIR, BAD_QUAL,
           TWO_PHASE, T_OUT_OF_RANGE, P_OUT_OF_RANGE,
-          H_OUT_OF_RANGE, S_OUT_OF_RANGE, HA_INPUTS, UNKNOWN,
+          H_OUT_OF_RANGE, S_OUT_OF_RANGE, HA_INPUTS, 
+          BAD_BINARY_PAIR, BAD_RULE, PAIR_EXISTS, UNKNOWN, 
           NUMBER_OF_ERRORS };                                       // Dummy Code for Error Count
 
     // table of error messages
@@ -48,6 +52,9 @@ enum EC { MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,       // Mathcad E
         "Enthalpy out of range",
         "Entropy out of range",
         "At least one of the inputs must be [T], [R], [W], or [Tdp]",
+        "Could not match binary pair",
+        "Mixing rule must be \"linear\" or \"Lorentz-Berthelot\".",
+        "Specified binary pair already exists.",
         "ERROR: Use get_global_param_string(\"errstring\") for more info",
         "Error Count - Not Used"
     };
@@ -73,7 +80,7 @@ enum EC { MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,       // Mathcad E
         }
 
         // Must use MathcadAllocate(size) so Mathcad can track and release
-        char * c = MathcadAllocate(s.size()+1); // create a c-string (pointer) c with the same size as s
+        char * c = MathcadAllocate(static_cast<int>(s.size())+1); // create a c-string (pointer) c with the same size as s
         // copy s into c, this process avoids the const-cast type which would result from instead
         // converting the string using s.c_str()
         std::copy(s.begin(), s.end(), c); 
@@ -110,7 +117,7 @@ enum EC { MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,       // Mathcad E
         }
 
         // Must use MathcadAllocate(size) so Mathcad can track and release
-        char * c = MathcadAllocate(s.size()+1); // create a c-string (pointer) c with the same size as s
+        char * c = MathcadAllocate(static_cast<int>(s.size())+1); // create a c-string (pointer) c with the same size as s
         // copy s into c, this process avoids the const-cast type which would result from instead
         // converting the string using s.c_str()
         std::copy(s.begin(), s.end(), c); 
@@ -370,6 +377,138 @@ enum EC { MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,       // Mathcad E
         return 0;
     }
 
+    // this code executes the user function CP_get_mixture_binary_pair_data, which is a wrapper for
+    // the CoolProp.get_mixture_binary_pair_data() function, used to get the requested binary pair
+    // interaction parameter (always returned as a string).
+    LRESULT  CP_get_mixture_binary_pair_data(
+                            LPMCSTRING Value,   // output string (string contains value of parameter)
+                            LPCMCSTRING CAS1,   // FIrst component
+                            LPCMCSTRING CAS2,   // Second component
+                            LPCMCSTRING Key )   // name of the binary pair parameter (string) to retrieve
+    {  
+        std::string s;
+        // Invoke the std::string form of get_global_param_string() function, save result to a new string s
+        try {
+            s = CoolProp::get_mixture_binary_pair_data(CAS1->str, CAS2->str, Key->str);
+        }
+        catch (const CoolProp::ValueError& e) {
+            std::string emsg(e.what());
+            CoolProp::set_error_string(emsg);
+            if (emsg.find("parameter")!=std::string::npos)
+                return MAKELRESULT(BAD_PARAMETER,3);
+            else if (emsg.find("binary pair")!=std::string::npos)
+                return MAKELRESULT(BAD_BINARY_PAIR,1);
+            else
+                return MAKELRESULT(UNKNOWN,1);
+        }
+
+        // Must use MathcadAllocate(size) so Mathcad can track and release
+        char * c = MathcadAllocate(static_cast<int>(s.size())+1); // create a c-string (pointer) c with the same size as s
+        // copy s into c, this process avoids the const-cast type which would result from instead
+        // converting the string using s.c_str()
+        std::copy(s.begin(), s.end(), c); 
+        c[s.size()] = '\0';
+        // assign the string to the function's output parameter
+        Value->str = c;
+
+        // normal return
+        return 0;
+    }
+
+    // this code executes the user function CP_apply_simple_mixing_rule, which is a wrapper for
+    // the CoolProp.apply_simple_mixing_rule() function, used to set the mixing rule for a
+    // specific binary pair.
+    LRESULT  CP_apply_simple_mixing_rule(
+                            LPMCSTRING Msg,     // output string (verification message)
+                            LPCMCSTRING CAS1,   // First component
+                            LPCMCSTRING CAS2,   // Second component
+                            LPCMCSTRING Rule )  // Mixing rule, either 'linear' or 'Lorentz-Berthelot'
+    {  
+        std::string s = Rule->str;
+        s.append(" mixing rule set.");
+        // Invoke the std::string form of get_global_param_string() function, save result to a new string s
+        try {
+            CoolProp::apply_simple_mixing_rule(CAS1->str, CAS2->str, Rule->str);
+        }
+        catch (const CoolProp::ValueError& e) {
+            std::string emsg(e.what());
+            CoolProp::set_error_string(emsg);
+            if (emsg.find("simple mixing rule")!=std::string::npos) {
+                return MAKELRESULT(BAD_RULE,3);
+            } else if (emsg.find("already in")!=std::string::npos) {
+                return MAKELRESULT(PAIR_EXISTS,1);
+            } else if (emsg.find("key")!=std::string::npos) {
+                if (emsg.find(CAS1->str)!=std::string::npos) {
+                    return MAKELRESULT(BAD_FLUID,1);
+                } else if (emsg.find(CAS2->str)!=std::string::npos) {
+                    return MAKELRESULT(BAD_FLUID,2);
+                } else return MAKELRESULT(UNKNOWN,1);
+            } else
+                return MAKELRESULT(UNKNOWN,1);
+        }
+
+        // Must use MathcadAllocate(size) so Mathcad can track and release
+        char * c = MathcadAllocate(static_cast<int>(s.size())+1); // create a c-string (pointer) c with the same size as s
+        // copy s into c, this process avoids the const-cast type which would result from instead
+        // converting the string using s.c_str()
+        std::copy(s.begin(), s.end(), c); 
+        c[s.size()] = '\0';
+        // assign the string to the function's output parameter
+        Msg->str = c;
+
+        // normal return
+        return 0;
+    }
+
+    // this code executes the user function CP_set_mixture_binary_pair_data, which is a wrapper for
+    // the CoolProp.set_mixture_binary_pair_data() function, used to set the mixing rule for a
+    // specific binary pair.
+    LRESULT  CP_set_mixture_binary_pair_data(
+                            LPMCSTRING Msg,           // output string (verification message)
+                            LPCMCSTRING CAS1,         // First component
+                            LPCMCSTRING CAS2,         // Second component
+                            LPCMCSTRING Param,        // Parameter Name String to set
+                            LPCCOMPLEXSCALAR Value )  // Parameter Value
+    {  
+        std::string s = Param->str;
+        s.append(" parameter set.");
+
+        // check that the first scalar argument is real
+        if (Value->imag != 0.0)
+            return MAKELRESULT( MUST_BE_REAL, 4);  // if not, display "must be real" under scalar argument
+
+        // Invoke the std::string form of get_global_param_string() function, save result to a new string s
+        try {
+            CoolProp::set_mixture_binary_pair_data(CAS1->str, CAS2->str, Param->str, Value->real);
+        }
+        catch (const CoolProp::ValueError& e) {
+            std::string emsg(e.what());
+            CoolProp::set_error_string(emsg);
+            if (emsg.find("parameter")!=std::string::npos) {
+                return MAKELRESULT(BAD_PARAMETER,3);
+            } else if (emsg.find("key")!=std::string::npos){
+                if (emsg.find(CAS1->str)!=std::string::npos)
+                    return MAKELRESULT(BAD_FLUID,1);
+                else
+                    return MAKELRESULT(BAD_FLUID,2);
+            } else
+                return MAKELRESULT(UNKNOWN,1);
+        }
+
+        // Must use MathcadAllocate(size) so Mathcad can track and release
+        char * c = MathcadAllocate(static_cast<int>(s.size())+1); // create a c-string (pointer) c with the same size as s
+        // copy s into c, this process avoids the const-cast type which would result from instead
+        // converting the string using s.c_str()
+        std::copy(s.begin(), s.end(), c); 
+        c[s.size()] = '\0';
+        // assign the string to the function's output parameter
+        Msg->str = c;
+
+        // normal return
+        return 0;
+    }
+
+
     // fill out a FUNCTIONINFO structure with the information needed for registering the function with Mathcad
     FUNCTIONINFO PropsParam = 
     {
@@ -441,6 +580,40 @@ enum EC { MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,       // Mathcad E
     {MC_STRING, MC_STRING, COMPLEX_SCALAR, MC_STRING, COMPLEX_SCALAR, MC_STRING, COMPLEX_SCALAR} // Argument types 
     };
 
+    FUNCTIONINFO GetMixtureData = 
+    {
+    "get_mixture_binary_pair_data", // Name by which MathCAD will recognize the function   
+    "CAS 1, CAS 2, Name of the parameter to retrieve", // Description of input parameters
+    "Returns the value of the requested CoolProps parameter", // description of the function for the Insert Function dialog box       
+    (LPCFUNCTION)CP_get_mixture_binary_pair_data, // Pointer to the function code. 
+    MC_STRING, // Returns a MathCAD string
+    3, // Number of arguments
+    {MC_STRING, MC_STRING, MC_STRING} // Argument types 
+    };	
+
+    FUNCTIONINFO ApplyMixingRule = 
+    {
+    "apply_simple_mixing_rule", // Name by which MathCAD will recognize the function   
+    "CAS 1, CAS 2, Mixing Rule", // Description of input parameters
+    "Sets a simple mixing rule for binary pair", // description of the function for the Insert Function dialog box       
+    (LPCFUNCTION)CP_apply_simple_mixing_rule, // Pointer to the function code. 
+    MC_STRING, // Returns a MathCAD string
+    3, // Number of arguments
+    {MC_STRING, MC_STRING, MC_STRING} // Argument types 
+    };	
+
+    FUNCTIONINFO SetMixtureData = 
+    {
+    "set_mixture_binary_pair_data", // Name by which MathCAD will recognize the function   
+    "CAS 1, CAS 2, Parameter Name, Parameter value", // Description of input parameters
+    "Sets the value of the specified binary mixing parameter", // description of the function for the Insert Function dialog box       
+    (LPCFUNCTION)CP_set_mixture_binary_pair_data, // Pointer to the function code. 
+    MC_STRING, // Returns a MathCAD string
+    4, // Number of arguments
+    {MC_STRING, MC_STRING, MC_STRING, COMPLEX_SCALAR} // Argument types 
+    };	
+
+
     // ************************************************************************************
     // DLL entry point code.  
     // ************************************************************************************
@@ -477,6 +650,9 @@ enum EC { MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,       // Mathcad E
                     CreateUserFunction( hDLL, &Props1SI );
                     CreateUserFunction( hDLL, &PropsSI );
                     CreateUserFunction( hDLL, &HAPropsSI );
+                    CreateUserFunction( hDLL, &GetMixtureData );
+                    CreateUserFunction( hDLL, &SetMixtureData );
+                    CreateUserFunction( hDLL, &ApplyMixingRule );
                     break;
 
                 case DLL_THREAD_ATTACH:

--- a/wrappers/MathCAD/CoolProp_EN.xml
+++ b/wrappers/MathCAD/CoolProp_EN.xml
@@ -45,5 +45,26 @@
         <category>CoolProp</category>
         <description>Sets the reference state for a specific fluid one of the standard reference states: "IIR", "ASHRAE", "NBP", or "DEF" (CoolProp default).</description>
     </function>
+    <function>
+        <name>get_mixture_binary_pair_data</name>
+        <local_name>get_mixture_binary_pair_data</local_name>
+        <params>"CAS1", "CAS2", "Parameter"</params>
+        <category>CoolProp</category>
+        <description>Gets the binary mixing parameter for a specified binary pair.  Fluid names MUST be the "CAS" string for each of the components.  Parameter must be one of ["name1", "name2", "function", "type", "F", "xi", "zeta", "gammaT", "gammaV", "betaT", "betaV"].</description>
+    </function>
+    <function>
+        <name>set_mixture_binary_pair_data</name>
+        <local_name>set_mixture_binary_pair_data</local_name>
+        <params>"CAS1", "CAS2", "Parameter", Value</params>
+        <category>CoolProp</category>
+        <description>Sets the binary mixing parameter for a specified binary pair.  Fluid names MUST be the "CAS" string for each of the components.  "Parameter" must be one of ["F", "xi", "zeta", "gammaT", "gammaV", "betaT", "betaV"].  Value, is the numeric value of the parameter being set.</description>
+    </function>
+    <function>
+        <name>apply_simple_mixing_rule</name>
+        <local_name>apply_simple_mixing_rule</local_name>
+        <params>"CAS1", "CAS2", "Parameter", Value</params>
+        <category>CoolProp</category>
+        <description>Sets the binary mixing rule for a specified binary pair.  Fluid names can be either the "CAS" string or one of the fluid alias strings for each of the components.  "Rule" must be either "linear" (to set a linear function of molar composition) or "Lorentz-Berthelot" (all interaction parameters set to 1.0).</description>
+    </function>
 
 </FUNCTIONS>


### PR DESCRIPTION
Low level mixture parameter functions added:
- [x] get_mixture_binary_pair_data
- [x] apply_simple_mixing_rule
- [x] set_mixture_binary_pair_data

Mathcad function documentation was also updated for these three functions.

Should be used with caution in Mathcad, but can successfully be used to add binary pairs to the rule set and adjust mixing parameter values.  Example from the web documentation shown here in Mathcad for verification:

![mixing1](https://cloud.githubusercontent.com/assets/17114032/25314028/8a1f7fb2-2809-11e7-8fed-477248e3d9da.PNG)
![mixing2](https://cloud.githubusercontent.com/assets/17114032/25314030/8f06a942-2809-11e7-92d4-987629693896.PNG)
