### PR TITLE
Change for compiler directive name in Cython 0.26

### DIFF
--- a/wrappers/Python/setup.py
+++ b/wrappers/Python/setup.py
@@ -196,11 +196,13 @@ if __name__=='__main__':
         else:
             _profiling_enabled = False
 
-        if _profiling_enabled:
-            cython_directives = dict(profile = True,
-                                     embed_signature = True)
+        # use different compiler directives for Cython 0.26 or above
+        if parse_version(Cython.__version__) >= parse_version('0.26'):
+            cython_directives = dict(profile = _profiling_enabled,
+                                     embedsignature = True)
         else:
-            cython_directives = dict(embed_signature = True)
+            cython_directives = dict(profile = _profiling_enabled,
+                                     embed_signature = True)
     else:
         cython_directives = {}
 


### PR DESCRIPTION
I was trying to work on another feature but needed to fix this first before moving forward. Please check if it can be merged. Thanks.

To solve the *ValueError* encountered during the compilation of Python wrappers using Cython 0.26:
```
Traceback (most recent call last):
  File "setup.py", line 305, in <module>
    ext_modules = cythonize(ext_modules, compiler_directives = cython_directives)
  File "C:\Users\User\Anaconda3\lib\site-packages\Cython\Build\Dependencies.py", line 886, in cythonize
    c_options = CompilationOptions(**options)
  File "C:\Users\User\Anaconda3\lib\site-packages\Cython\Compiler\Main.py", line 568, in __init__
    raise ValueError(message)
ValueError: got unknown compiler directive: embed_signature
```
Cython 0.26 changes its compiler directive name from *embed_signature* to *embedsignature*. Hence an if-statement is added to facilitate compilation of Python wrappers using the new compiler directive name when Cython 0.26 is used.

References:
Cython 0.26 Documentation:
http://cython.readthedocs.io/en/latest/src/reference/compilation.html