### PR TITLE
Calculation of first-order derivatives of isochoric specific heat, isobaric specific heat and speed of sound

### DIFF
--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -743,7 +743,7 @@ void get_dT_drho(AbstractState &AS, parameters index, CoolPropDbl &dT, CoolPropD
     {
         // dcp/dT|rho = d2h/dT2 + dh/drho * dP/dT * d2P/drhodT / ( dp/drho )^2 - ( d2h/dTdrho * dP/dT + dh/drho * d2P/dT2 ) / ( dP/drho )
         dT = R/T*pow(tau, 2)*(tau*(AS.d3alpha0_dTau3()+AS.d3alphar_dTau3()) + 2*(AS.d2alpha0_dTau2()+AS.d2alphar_dTau2()) + delta*AS.d3alphar_dDelta_dTau2());
-        dT += (T*R/rho*(tau*delta*AS.d2alphar_dDelta_dTau()+delta*AS.dalphar_dDelta()+pow(delta,2)*AS.d2alphar_dDelta2())) * (R*T*(1+2*delta*AS.dalphar_dDelta()+pow(delta, 2)*AS.d2alphar_dDelta2())) * (R*(1+2*delta*AS.dalphar_dDelta() +pow(delta,2)*AS.d2alphar_dDelta2() - 2*delta*tau*AS.d2alphar_dDelta_dTau() - tau*pow(delta, 2)*AS.d3alphar_dDelta2_dTau())) / pow(R*T*(1+2*delta*AS.dalphar_dDelta()+pow(delta, 2)*AS.d2alphar_dDelta2()), 2);
+        dT += (T*R/rho*(tau*delta*AS.d2alphar_dDelta_dTau()+delta*AS.dalphar_dDelta()+pow(delta,2)*AS.d2alphar_dDelta2())) * (rho*R*(1+delta*AS.dalphar_dDelta() - tau*delta*AS.d2alphar_dDelta_dTau())) * (R*(1+2*delta*AS.dalphar_dDelta() +pow(delta,2)*AS.d2alphar_dDelta2() - 2*delta*tau*AS.d2alphar_dDelta_dTau() - tau*pow(delta, 2)*AS.d3alphar_dDelta2_dTau())) / pow(R*T*(1+2*delta*AS.dalphar_dDelta()+pow(delta, 2)*AS.d2alphar_dDelta2()), 2);
         dT -= ((R/rho*delta*(delta*AS.d2alphar_dDelta2() - pow(tau,2)*AS.d3alphar_dDelta_dTau2() + AS.dalphar_dDelta() - tau*delta*AS.d3alphar_dDelta2_dTau() - tau*AS.d2alphar_dDelta_dTau())) * (rho*R*(1+delta*AS.dalphar_dDelta() - tau*delta*AS.d2alphar_dDelta_dTau())) + (T*R/rho*(tau*delta*AS.d2alphar_dDelta_dTau()+delta*AS.dalphar_dDelta()+pow(delta,2)*AS.d2alphar_dDelta2())) * (rho*R/T*(pow(tau,2)*delta*AS.d3alphar_dDelta_dTau2()))) / (R*T*(1+2*delta*AS.dalphar_dDelta()+pow(delta, 2)*AS.d2alphar_dDelta2()));
         // dcpdrho|T = d2h/dTdrho + dh/drho * dP/dT * d2P/drho2 / ( dp/drho )^2 - ( d2h/drho2 * dP/dT + dh/drho * d2P/dTdrho ) / ( dP/drho )
         drho = R/rho*delta*(delta*AS.d2alphar_dDelta2() - pow(tau,2)*AS.d3alphar_dDelta_dTau2() + AS.dalphar_dDelta() - tau*delta*AS.d3alphar_dDelta2_dTau() - tau*AS.d2alphar_dDelta_dTau()); //d2h/dTdrho
@@ -761,7 +761,7 @@ void get_dT_drho(AbstractState &AS, parameters index, CoolPropDbl &dT, CoolPropD
         double aa = 1.0+delta*AS.dalphar_dDelta()-delta*tau*AS.d2alphar_dDelta_dTau();
         double bb = pow(tau, 2)*(AS.d2alpha0_dTau2()+AS.d2alphar_dTau2());
         double daa_dTau = -delta*tau*AS.d3alphar_dDelta_dTau2();
-        double dbb_dTau = pow(tau, 2)*(AS.d3alpha0_dTau3()+AS.d3alphar_dDelta3())+2.0*tau*(AS.d2alpha0_dTau2()+AS.d2alphar_dDelta2());
+        double dbb_dTau = pow(tau, 2)*(AS.d3alpha0_dTau3()+AS.d3alphar_dTau3())+2.0*tau*(AS.d2alpha0_dTau2()+AS.d2alphar_dTau2());
         double w = AS.speed_sound();
         dT = 1.0/2.0/w/T*(pow(w, 2)-R*Tr/AS.molar_mass()*(2.0*delta*AS.d2alphar_dDelta_dTau()+pow(delta, 2)*AS.d3alphar_dDelta2_dTau()-(2*aa/bb*daa_dTau-pow(aa/bb, 2)*dbb_dTau)));
         //dwdrho

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -763,7 +763,7 @@ void get_dT_drho(AbstractState &AS, parameters index, CoolPropDbl &dT, CoolPropD
         double daa_dTau = delta*d2alphar_dDelta_dTau()-delta*d2alphar_dDelta_dTau()-delta*tau*d3alphar_dDelta_dTau2();
         double dbb_dTau = pow(tau, 2)*(d3alpha0_dTau3()+d3alphar_dDelta3())+2.0*tau*(d2alpha0_dTau2()+d2alphar_dDelta2());
         double w = AS.speed_sound();
-        dT = 0.5/w*(pow(w, 2)/T-R*tau/AS.molar_mass()*(2.0*delta*d2alphar_dDelta_dTau()+pow(delta, 2)*d3alphar_dDelta2_dTau()-(2*aa/b*daa_dTau-pow(aa, 2)/bb*dbb_dTau)));
+        dT = 1.0/2.0/w/T*(pow(w, 2)-R*Tr/AS.molar_mass()*(2.0*delta*d2alphar_dDelta_dTau()+pow(delta, 2)*d3alphar_dDelta2_dTau()-(2*aa/b*daa_dTau-pow(aa, 2)/bb*dbb_dTau)));
         //dwdrho
         double daa_dDelta = dalphar_dDelta()+delta*d2alphar_dDelta2()-tau*(d2alphar_dDelta_dTau()+delta*d3alphar_dDelta2_dTau());
         double dbb_dDelta = pow(tau, 2)*(d3alpha0_dDelta_dTau2()+d3alphar_dDelta_dTau2());

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -741,13 +741,13 @@ void get_dT_drho(AbstractState &AS, parameters index, CoolPropDbl &dT, CoolPropD
     case iCpmolar:
     case iCpmass:
     {
-        // dcpdT|rho = d2h/dT2 + dh/drho * dP/dT * d2P/dTdrho / ( dp/drho )^2 - ( d2h/dTdrho * dP/dT + dh/drho * d2PdT2 ) / dp/drho
-        dT = R/T*pow(tau, 2)*(tau*(AS.d3alpha0_dTau3()+AS.d3alphar_dTau3()) + 2*(AS.d2alpha0_dTau2()+AS.d2alphar_dTau2()) + delta*AS.d3alphar_dDelta_dTau2()); // d2hdT2
-        dT += (T*R/rho*(tau*delta*AS.d2alphar_dDelta_dTau()+delta*AS.dalphar_dDelta()+pow(delta,2)*AS.d2alphar_dDelta2())) * (rho*R*(1+delta*AS.dalphar_dDelta() - tau*delta*AS.d2alphar_dDelta_dTau())) * (R*(1+2*delta*AS.dalphar_dDelta() +pow(delta,2)*AS.d2alphar_dDelta2() - 2*delta*tau*AS.d2alphar_dDelta_dTau() - tau*pow(delta, 2)*AS.d3alphar_dDelta2_dTau())) / pow(R*T*(1+2*delta*AS.dalphar_dDelta()+pow(delta, 2)*AS.d2alphar_dDelta2()), 2);
-        dT -= ((R/rho*delta*(delta*AS.d2alphar_dDelta2() - pow(tau,2)*AS.d3alphar_dDelta_dTau2() + AS.dalphar_dDelta() - tau*delta*AS.d3alphar_dDelta2_dTau() - tau*AS.d2alphar_dDelta_dTau())) * (rho*R*(1+delta*AS.dalphar_dDelta() - tau*delta*AS.d2alphar_dDelta_dTau())) + (T*R/rho*(tau*delta*AS.d2alphar_dDelta_dTau()+delta*AS.dalphar_dDelta()+pow(delta,2)*AS.d2alphar_dDelta2())) * (rho*R/T*(pow(tau,2)*delta*AS.d3alphar_dDelta_dTau2()))) / (R*T*(1+2*delta*AS.dalphar_dDelta()+pow(delta, 2)*AS.d2alphar_dDelta2()))
-        // dcp/drho|T = d2h/dTdrho + dh/drho * dP/dT * d2P/drho2 / ( dp/drho )^2 - ( d2h/drho2 * dP/dT + dh/drho * d2P/dTdrho ) / ( dP/drho )
-        drho = R/rho*delta*(delta*AS.d2alphar_dDelta2() - pow(tau,2)*AS.d3alphar_dDelta_dTau2() + AS.dalphar_dDelta() - tau*delta*AS.d3alphar_dDelta2_dTau() - tau*AS.d2alphar_dDelta_dTau());
-        drho += (T*R/rho*(tau*delta*AS.d2alphar_dDelta_dTau()+delta*AS.dalphar_dDelta()+pow(delta,2)*AS.d2alphar_dDelta2())) * (R*T*(1+2*delta*AS.dalphar_dDelta()+pow(delta, 2)*AS.d2alphar_dDelta2())) * (T*R/rho*(2*delta*AS.dalphar_dDelta()+4*pow(delta,2)*AS.d2alphar_dDelta2()+pow(delta,3)*AS.d3alphar_dDelta3())) / pow(R*T*(1+2*delta*AS.dalphar_dDelta()+pow(delta, 2)*AS.d2alphar_dDelta2()), 2);
+        // dcp/dT|rho = d2h/dT2 + dh/drho * dP/dT * d2P/drhodT / ( dp/drho )^2 - ( d2h/dTdrho * dP/dT + dh/drho * d2P/dT2 ) / ( dP/drho )
+        dT = R/T*pow(tau, 2)*(tau*(AS.d3alpha0_dTau3()+AS.d3alphar_dTau3()) + 2*(AS.d2alpha0_dTau2()+AS.d2alphar_dTau2()) + delta*AS.d3alphar_dDelta_dTau2());
+        dT += (T*R/rho*(tau*delta*AS.d2alphar_dDelta_dTau()+delta*AS.dalphar_dDelta()+pow(delta,2)*AS.d2alphar_dDelta2())) * (R*T*(1+2*delta*AS.dalphar_dDelta()+pow(delta, 2)*AS.d2alphar_dDelta2())) * (R*(1+2*delta*AS.dalphar_dDelta() +pow(delta,2)*AS.d2alphar_dDelta2() - 2*delta*tau*AS.d2alphar_dDelta_dTau() - tau*pow(delta, 2)*AS.d3alphar_dDelta2_dTau())) / pow(R*T*(1+2*delta*AS.dalphar_dDelta()+pow(delta, 2)*AS.d2alphar_dDelta2()), 2);
+        dT -= ((R/rho*delta*(delta*AS.d2alphar_dDelta2() - pow(tau,2)*AS.d3alphar_dDelta_dTau2() + AS.dalphar_dDelta() - tau*delta*AS.d3alphar_dDelta2_dTau() - tau*AS.d2alphar_dDelta_dTau())) * (rho*R*(1+delta*AS.dalphar_dDelta() - tau*delta*AS.d2alphar_dDelta_dTau())) + (T*R/rho*(tau*delta*AS.d2alphar_dDelta_dTau()+delta*AS.dalphar_dDelta()+pow(delta,2)*AS.d2alphar_dDelta2())) * (rho*R/T*(pow(tau,2)*delta*AS.d3alphar_dDelta_dTau2()))) / (R*T*(1+2*delta*AS.dalphar_dDelta()+pow(delta, 2)*AS.d2alphar_dDelta2()));
+        // dcpdrho|T = d2h/dTdrho + dh/drho * dP/dT * d2P/drho2 / ( dp/drho )^2 - ( d2h/drho2 * dP/dT + dh/drho * d2P/dTdrho ) / ( dP/drho )
+        drho = R/rho*delta*(delta*AS.d2alphar_dDelta2() - pow(tau,2)*AS.d3alphar_dDelta_dTau2() + AS.dalphar_dDelta() - tau*delta*AS.d3alphar_dDelta2_dTau() - tau*AS.d2alphar_dDelta_dTau()); //d2h/dTdrho
+        drho += (T*R/rho*(tau*delta*AS.d2alphar_dDelta_dTau()+delta*AS.dalphar_dDelta()+pow(delta,2)*AS.d2alphar_dDelta2())) * (rho*R*(1+delta*AS.dalphar_dDelta() - tau*delta*AS.d2alphar_dDelta_dTau())) * (T*R/rho*(2*delta*AS.dalphar_dDelta()+4*pow(delta,2)*AS.d2alphar_dDelta2()+pow(delta,3)*AS.d3alphar_dDelta3())) / pow(R*T*(1+2*delta*AS.dalphar_dDelta()+pow(delta, 2)*AS.d2alphar_dDelta2()), 2);
         drho -= ((R*T*pow(delta/rho,2)*(tau*AS.d3alphar_dDelta2_dTau() + 2*AS.d2alphar_dDelta2() + delta*AS.d3alphar_dDelta3())) * (rho*R*(1+delta*AS.dalphar_dDelta() - tau*delta*AS.d2alphar_dDelta_dTau())) + (T*R/rho*(tau*delta*AS.d2alphar_dDelta_dTau()+delta*AS.dalphar_dDelta()+pow(delta,2)*AS.d2alphar_dDelta2())) * (R*(1+2*delta*AS.dalphar_dDelta() +pow(delta,2)*AS.d2alphar_dDelta2() - 2*delta*tau*AS.d2alphar_dDelta_dTau() - tau*pow(delta, 2)*AS.d3alphar_dDelta2_dTau()))) / (R*T*(1+2*delta*AS.dalphar_dDelta()+pow(delta, 2)*AS.d2alphar_dDelta2()));
         if (index == iCpmass){
             drho /= AS.molar_mass();
@@ -758,16 +758,16 @@ void get_dT_drho(AbstractState &AS, parameters index, CoolPropDbl &dT, CoolPropD
     case ispeed_sound:
     {
         //dwdT
-        double aa = 1.0+delta*AS.dalphar_dDelta()-delta*tau*d2alphar_dDelta_dTau();
-        double bb = pow(tau, 2)*(d2alpha0_dTau2()+d2alphar_dTau2());
-        double daa_dTau = delta*d2alphar_dDelta_dTau()-delta*d2alphar_dDelta_dTau()-delta*tau*d3alphar_dDelta_dTau2();
-        double dbb_dTau = pow(tau, 2)*(d3alpha0_dTau3()+d3alphar_dDelta3())+2.0*tau*(d2alpha0_dTau2()+d2alphar_dDelta2());
+        double aa = 1.0+delta*AS.dalphar_dDelta()-delta*tau*AS.d2alphar_dDelta_dTau();
+        double bb = pow(tau, 2)*(AS.d2alpha0_dTau2()+AS.d2alphar_dTau2());
+        double daa_dTau = -delta*tau*AS.d3alphar_dDelta_dTau2();
+        double dbb_dTau = pow(tau, 2)*(AS.d3alpha0_dTau3()+AS.d3alphar_dDelta3())+2.0*tau*(AS.d2alpha0_dTau2()+AS.d2alphar_dDelta2());
         double w = AS.speed_sound();
-        dT = 1.0/2.0/w/T*(pow(w, 2)-R*Tr/AS.molar_mass()*(2.0*delta*d2alphar_dDelta_dTau()+pow(delta, 2)*d3alphar_dDelta2_dTau()-(2*aa/b*daa_dTau-pow(aa, 2)/bb*dbb_dTau)));
+        dT = 1.0/2.0/w/T*(pow(w, 2)-R*Tr/AS.molar_mass()*(2.0*delta*AS.d2alphar_dDelta_dTau()+pow(delta, 2)*AS.d3alphar_dDelta2_dTau()-(2*aa/bb*daa_dTau-pow(aa/bb, 2)*dbb_dTau)));
         //dwdrho
-        double daa_dDelta = dalphar_dDelta()+delta*d2alphar_dDelta2()-tau*(d2alphar_dDelta_dTau()+delta*d3alphar_dDelta2_dTau());
-        double dbb_dDelta = pow(tau, 2)*(d3alpha0_dDelta_dTau2()+d3alphar_dDelta_dTau2());
-        drho = R*T/2.0/AS.molar_mass()/w/rhor*(2.0*(dalphar_dDelta()+delta*d2alphar_dDelta2())+(2.0*delta*d2alphar_dDelta2()+pow(delta, 2)*d3alphar_dDelta3())-(2*aa/bb*daa_dDelta-pow(aa, 2)/bb*dbb_dDelta));
+        double daa_dDelta = AS.dalphar_dDelta()+delta*AS.d2alphar_dDelta2()-tau*(AS.d2alphar_dDelta_dTau()+delta*AS.d3alphar_dDelta2_dTau());
+        double dbb_dDelta = pow(tau, 2)*(AS.d3alpha0_dDelta_dTau2()+AS.d3alphar_dDelta_dTau2());
+        drho = R*T/2.0/AS.molar_mass()/w/rhor*(2.0*(AS.dalphar_dDelta()+delta*AS.d2alphar_dDelta2())+(2.0*delta*AS.d2alphar_dDelta2()+pow(delta, 2)*AS.d3alphar_dDelta3())-(2*aa/bb*daa_dDelta-pow(aa/bb, 2)*dbb_dDelta));
         break;
     }
     default:


### PR DESCRIPTION
I would like to use CoolProp to calculate the first-order derivative of isochoric specific heat, isobaric specific heat and speed of sound, and I am writing the corresponding code in AbstractState.cpp using the formulas as described below:

Cv: second-order derivative of specific internal energy
Cp: first-order derivative equations following Thorade and Saadt (2013) like all the other derivatives in CoolProp
Speed of sound: with the formula in the following pdf and LaTeX file
[first_derivative_speed_of_sound.pdf](https://github.com/CoolProp/CoolProp/files/1184575/first_derivative_speed_of_sound.pdf)
[first_derivative_speed_of_sound .txt](https://github.com/CoolProp/CoolProp/files/1184576/first_derivative_speed_of_sound.txt)

Unfortunately, I am unable to build the Catch testrunners and cannot run the test case. Instead, I compile the Python wrapper of the fork and did the following test:

```python
#!/usr/bin/python3

"""
    Test derivative calculation in CoolProp
"""

from CoolProp.CoolProp import PropsSI

# list variables to be checked
VARS = [
    'Cvmolar', 'Cpmolar', 'Cvmass', 'Cpmass', 'speed_of_sound'
]

# calculate a valid condition
TEMP = 300
REF = 'R290'
RHO = PropsSI('Dmolar', 'T', TEMP, 'Q', 1.0, REF)*0.9

delta = 1.e-5
thres = 1.e-3
for VAR in VARS:
    PROP = PropsSI(VAR, 'T', TEMP, 'Dmolar', RHO, REF)
    PROP_TUP = PropsSI(VAR, 'T', TEMP*(1+delta), 'Dmolar', RHO, REF)
    PROP_DUP = PropsSI(VAR, 'T', TEMP, 'Dmolar', RHO*(1+delta), REF)
    NUM_DT = (PROP_TUP-PROP)/TEMP/delta
    NUM_DRHO = (PROP_DUP-PROP)/RHO/delta
    ANA_DT = PropsSI(
        ''.join(['d(', VAR, ')/d(T)|Dmolar']), 'T', TEMP,
        'Dmolar', RHO, REF
    )
    ANA_DRHO = PropsSI(
        ''.join(['d(', VAR, ')/d(Dmolar)|T']), 'T', TEMP,
        'Dmolar', RHO, REF
    )
    print(
        'Comparing for temperature derivative of', VAR, 'at', ANA_DT,
        'and', NUM_DT
    )
    try:
        assert abs((ANA_DT - NUM_DT)/NUM_DT) < thres
    except AssertionError:
        import pdb; pdb.set_trace()
    print(
        'Comparing for density derivative of', VAR, 'at', ANA_DRHO,
        'and', NUM_DRHO
    )
    try:
        assert abs((ANA_DRHO - NUM_DRHO)/NUM_DRHO) < thres
    except AssertionError:
        import pdb; pdb.set_trace()

print('The derivatives look ok!')
```

and the results are

```

Comparing for temperature derivative of Cvmolar at 0.14889920648862562 and 0.14890048190352442
Comparing for density derivative of Cvmolar at 0.010925217719411089 and 0.010925244591567951
Comparing for temperature derivative of Cpmolar at 0.02162567831690363 and 0.02163142020113658
Comparing for density derivative of Cpmolar at 0.04624648874881631 and 0.046246720615905804
Comparing for temperature derivative of Cvmass at 3.3767346164681573 and 3.3767635403213108
Comparing for density derivative of Cvmass at 0.24776197090348404 and 0.24776258034147944
Comparing for temperature derivative of Cpmass at 0.4904269021935428 and 0.49055711656365014
Comparing for density derivative of Cpmass at 1.0487773785427283 and 1.0487826368201276
Comparing for temperature derivative of speed_of_sound at 0.5751772494005515 and 0.5751730920261858
Comparing for density derivative of speed_of_sound at -0.07802950887889115 and -0.07802952593442371
The derivatives look ok!
```

So the derivative calculation should be good to go.

