### PR TITLE
Solve cmake build error: include\catch.hpp(1938): error C2678: binary '<<': no operator found  which takes a left-hand operand of type 'std::ostringstream'

### DIFF
--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -1682,7 +1682,7 @@ public:
         
         std::ostringstream name;
         name << "Check state for " << state << " for " << fluid << " for reference state " << ref_state;
-        CAPTURE(name);
+        CAPTURE(&name);
         
         std::vector<std::string> fl(1, fluid);
         shared_ptr<CoolProp::HelmholtzEOSMixtureBackend> HEOS(new CoolProp::HelmholtzEOSMixtureBackend(fl));

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -1682,7 +1682,7 @@ public:
         
         std::ostringstream name;
         name << "Check state for " << state << " for " << fluid << " for reference state " << ref_state;
-        CAPTURE(&name);
+        CAPTURE(name.str());
         
         std::vector<std::string> fl(1, fluid);
         shared_ptr<CoolProp::HelmholtzEOSMixtureBackend> HEOS(new CoolProp::HelmholtzEOSMixtureBackend(fl));


### PR DESCRIPTION
When I conducted 
```
C:\Users\User\Documents\Howard-CoolProp\CoolProp\build>cmake .. -DCOOLPROP_CATCH_MODULE=ON -DBUILD_TESTING=ON -DCOOLPROP_DEBUG=ON

-- Building for: Visual Studio 14 2015
-- COOLPROP_INSTALL_PREFIX=C:/Users/User/Documents/Howard-CoolProp/CoolProp/install_root
-- The C compiler identification is MSVC 19.0.23506.0
-- The CXX compiler identification is MSVC 19.0.23506.0
-- Check for working C compiler using: Visual Studio 14 2015
-- Check for working C compiler using: Visual Studio 14 2015 -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler using: Visual Studio 14 2015
-- Check for working CXX compiler using: Visual Studio 14 2015 -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- CoolProp version: 6.1.1dev
-- Found PythonInterp: C:/Users/User/Anaconda3/python.exe (found suitable version "3.5.2", minimum required is "2.7")
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Users/User/Documents/Howard-CoolProp/CoolProp/build

C:\Users\User\Documents\Howard-CoolProp\CoolProp\build>cmake --build .
```

, I got the following error.

```
C:\Users\User\Documents\Howard-CoolProp\CoolProp\include\catch.hpp(1938): error C2678: binary '<<': no operator found
 which takes a left-hand operand of type 'std::ostringstream' (or there is no acceptable conversion) [C:\Users\User\Doc
uments\Howard-CoolProp\CoolProp\build\CatchTestRunner.vcxproj]
```

A further investigation at [StackOverflow](https://stackoverflow.com/questions/32199574/error-c2678-binary-no-operator-found-which-takes-a-left-hand-operand-of) refers to a problem related to the passing of the variables at function

```
        template<typename T>
        MessageBuilder& operator << ( T const& value ) {
            m_stream << value;
            return *this;
        }
```

in catch.hpp generated during the build process. So I changed the way a std::ostringstream object passed to the function *CAPTURE* in *./src/Test/CoolProp-Tests.cpp* and the build became ok. But I haven't tested it with other machines and I am not sure if it changes the way it's built under environment. Is it a problem specific to a version of cmake and Microsoft Visual Studio? I am using cmake version 3.4.1 with Visual Studio 14. Thanks.