### PR TITLE
Fixes out-of-sync fluids map when replacing a JSON fluid.

### DIFF
--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
@@ -215,10 +215,10 @@ void JSONFluidLibrary::add_one(rapidjson::Value &fluid_json)
         if (string_to_index_map.find(fluid.CAS) != string_to_index_map.end()){
             index = string_to_index_map.find(fluid.CAS)->second;                 //if CAS found, grab index
         }
-        if (string_to_index_map.find(fluid.name) != string_to_index_map.end()){
+        else if (string_to_index_map.find(fluid.name) != string_to_index_map.end()){
             index = string_to_index_map.find(fluid.name)->second;                // if name found, grab index
         }
-        if (string_to_index_map.find(upper(fluid.name)) != string_to_index_map.end()){
+        else if (string_to_index_map.find(upper(fluid.name)) != string_to_index_map.end()){
             index = string_to_index_map.find(upper(fluid.name))->second;         // if uppercase name found, grab index
         }
         else{
@@ -237,8 +237,9 @@ void JSONFluidLibrary::add_one(rapidjson::Value &fluid_json)
         }
         
         if (index != fluid_map.size()){        // Fluid already in list if index was reset to < fluid_map.size()
+            name_vector.pop_back();            // Pop duplicate name off the back of the name vector; otherwise it keeps growing!
             if (!get_config_bool(OVERWRITE_FLUIDS)){
-                throw ValueError(format("Cannot load fluid [%s:%s] because it is already in library; consider enabling the config boolean variable OVERWRITE_FLUIDS", fluid.name.c_str(), fluid.CAS.c_str()));
+                throw ValueError(format("Cannot load fluid [%s:%s] because it is already in library; index = [%i] of [%i]; Consider enabling the config boolean variable OVERWRITE_FLUIDS", fluid.name.c_str(), fluid.CAS.c_str(), index, fluid_map.size()));
             }
         }
         

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.h
@@ -26,7 +26,7 @@ a rapidjson array of fluids to the add_many function.
 */
 class JSONFluidLibrary
 {
-    /// Map from CAS code to JSON instance.  For pseudo-pure fluids, use name in place of CAS code since no CASE number is defined for mixtures
+    /// Map from CAS code to JSON instance.  For pseudo-pure fluids, use name in place of CAS code since no CAS number is defined for mixtures
     std::map<std::size_t, CoolPropFluid> fluid_map;
     /// Map from index of fluid to a string
     std::map<std::size_t, std::string> JSONstring_map;


### PR DESCRIPTION
As discussed in issue #1548, when a JSON fluid is added to the FluidLibrary, replacing a fluid that already exists, as in the example in the High-Level Interface docs, the fluid_map gets corrupted.  The fluid to be replaced is being erased from the fluid_map, and then added back in at the max index + 1.  Unfortunately, the fluids with higher indices are not re-indexed, and so the last fluid in the list (Xenon in this case) gets overwritten.  Future references to Xenon then pull all fluid info and properties for the fluid that was re-inserted; the Xenon data is lost.  Logic is not flawed when new fluids are added, as they are when the initial JSON library is loaded.

The fix proposed here to the `JSONFluidLibrary:add_one` routine does not erase the fluid to be replaced, but sets the insertion index appropriately to overwrite the old fluid data.  None of the other fluids are then affected and the size of the fluid_map is unchanged.  IMHO, the resulting code is a little cleaner without all the erasure code.  The fixed code has been tested under python for the sequence of actions that was causing errors to crop up in the dev/docs.  A before and after sequence is attached as PDF files to show that the bad behavior has been corrected and the materials involved are left unchanged.

[Before Fix.pdf](https://github.com/CoolProp/CoolProp/files/1364293/Before.Fix.pdf)
[After Fix.pdf](https://github.com/CoolProp/CoolProp/files/1364294/After.Fix.pdf)

This patch closes #1548 .