### PR TITLE
Documentation Update

### DIFF
--- a/Web/Makefile
+++ b/Web/Makefile
@@ -14,6 +14,11 @@ PAPER         =
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d _build/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ifeq ($(OS),Windows_NT)
+	REMOVE_BUILD = rmdir /s /q _build
+else
+	REMOVE_BUILD = rm -rf _build/*
+endif
 
 .PHONY: help clean html dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest
 
@@ -31,7 +36,9 @@ help:
 	@echo "  doctest   to run all doctests embedded in the documentation (if enabled)"
 
 clean:
-	-rm -rf _build/*
+	$(info OS="$(OS)")
+	@echo "Removing existing _build directory."
+	$(REMOVE_BUILD)
 
 html: 
 	$(SPHINXBUILD) -j3 -b html $(ALLSPHINXOPTS) _build/html

--- a/Web/_static/.gitignore
+++ b/Web/_static/.gitignore
@@ -1,3 +1,4 @@
 /fluid_properties/
 /CoolPropLogoLong.png
+/CoolPropLogoLongLarge.png
 /CoolPropLogo.png

--- a/Web/coolprop/.gitignore
+++ b/Web/coolprop/.gitignore
@@ -1,0 +1,2 @@
+*.rst.in
+speed_script.py

--- a/Web/coolprop/HighLevelAPI.rst
+++ b/Web/coolprop/HighLevelAPI.rst
@@ -19,6 +19,8 @@ For many users, all that is needed is a simple call to the ``PropsSI`` function 
     # Saturation temperature of Water at 1 atm in K
     In [2]: PropsSI('T','P',101325,'Q',0,'Water')
 
+In this example, the first parameter, :math:`T`, is the *output* property that will be returned from ``PropsSI``.  The second and fourth parameters are the specified *input pair* of properties that determine the state point where the output property will be calculated.  The *output* property and *input pair* properties are text strings and must be quoted.  The third and fifth parameters are the *values* of the *input pair* properties and will determine the state point.  The sixth and last parameter is the fluid for which the *output* property will be calculated; also a quoted string. 
+  
 More information: 
 
 * :ref:`Table of inputs to PropsSI function <parameter_table>`
@@ -27,19 +29,44 @@ More information:
 
 All :ref:`the wrappers <wrappers>` wrap this function in exactly the same way.
 
-For pure and pseudo-pure fluids, two state points are required to fix the state.  The equations of state are based on :math:`T` and :math:`\rho` as state variables, so :math:`T, \rho` will always be the fastest inputs.  :math:`P,T` will be a bit slower (3-10 times), and then comes inputs where neither :math:`T` nor :math:`\rho` are given, like :math:`p,h`.  They will be much slower.  If speed is an issue, you can look into table-based interpolation methods using TTSE or bicubic interpolation. 
+For pure and pseudo-pure fluids, two state variables are required to fix the state.  The equations of state are based on :math:`T` and :math:`\rho` as state variables, so :math:`T, \rho` will always be the fastest inputs.  :math:`P,T` will be a bit slower (3-10 times), followed by input pairs where neither :math:`T` nor :math:`\rho` are specified, like :math:`P,H`; these will be much slower.  If speed is an issue, you can look into table-based interpolation methods using :ref:`TTSE or bicubic interpolation <Tabular_Interpolation>`; or if you are only interested in Water properties, you can look into using the :ref:`IF97 <IF97>` (industrial formulation) backend.  
+
+Vapor, Liquid, and Saturation States
+------------------------------------
+
+If the input pair (say, :math:`P,T`) defines a state point that lies in the *vapor* region, then the vapor property at that state point will be returned.  Likewise, if the state point lies in the *liquid* region, then the liquid state property at that state point will be returned.  If the state point defined by the input pair lies within 1E-4 % of the saturation pressure, then CoolProp may return an error, because both *liquid* and *vapor* are defined along the saturation curve.  
+
+To retrieve either the *vapor* or *liquid* properties along the saturation curve, provide an input pair that includes either the saturation temperature, :math:`T`, or saturation pressure, :math:`p`, along with the *vapor quality*, :math:`Q`.  Use a value of :math:`Q=1` for the saturated *vapor* property or :math:`Q=0` for the saturated *liquid* property.  For example, at a saturation pressure of 1 atm, the *liquid* and *vapor* enthalpies can be returned as follows.
+
+.. ipython::
+
+    # Import the PropsSI function
+    In [1]: from CoolProp.CoolProp import PropsSI
+    
+    # Saturated vapor enthalpy of Water at 1 atm in J/kg-K
+    In [2]: H_V = PropsSI('H','P',101325,'Q',1,'Water'); print(H_V)
+
+    # Saturated liquid enthalpy of Water at 1 atm in J/kg-K
+    In [3]: H_L = PropsSI('H','P',101325,'Q',0,'Water'); print(H_L)
+
+    # Latent heat of vaporization of Water at 1 atm in J/kg-K
+    In [4]: H_V - H_L
+
+.. note::
+   The *latent heat of vaporization* can be calculated using the difference between the vapor and liquid enthalpies at the same point on the saturation curve.
 
 Fluid information
 -----------------
 
 You can obtain string-encoded information about the fluid from the ``get_fluid_param_string`` function with something like:
 
- .. ipython::
+.. ipython::
 
     In [1]: import CoolProp.CoolProp as CP
     
     In [1]: for k in ['formula','CAS','aliases','ASHRAE34','REFPROP_name','pure','INCHI','INCHI_Key','CHEMSPIDER_ID']:
-       ...:     print k, '-->', CP.get_fluid_param_string("R125", k)
+       ...:     item = k + ' --> ' + CP.get_fluid_param_string("R125", k)
+       ...:     print(item)
        ...:
 
 .. _trivial_inputs:
@@ -350,13 +377,13 @@ The fluids in CoolProp are all compiled into the library itself, and are given i
     # Get the JSON structure for Water
     In [2]: jj = CP.get_fluid_param_string("Water", "JSON")
     
-    # Now load it back into CoolProp - oops this isn't going to work because it is already there
+    # Now load it back into CoolProp - Oops! This isn't going to work because it is already there.
     In [2]: CP.add_fluids_as_JSON("HEOS", jj)
 
     # Set the configuration variable allowing for overwriting
     In [2]: CP.set_config_bool(CP.OVERWRITE_FLUIDS, True)
 
-    # Now load it back into CoolProp - success
+    # Now load it back into CoolProp - Success!
     In [2]: CP.add_fluids_as_JSON("HEOS", jj)
 
     # Turn overwriting back off
@@ -381,9 +408,9 @@ Sample Code
 
     In [1]: import CoolProp as CP
     
-    In [1]: print CP.__version__
+    In [1]: print(CP.__version__)
     
-    In [1]: print CP.__gitrevision__
+    In [1]: print(CP.__gitrevision__)
     
     #Import the things you need 
     In [1]: from CoolProp.CoolProp import PropsSI
@@ -397,8 +424,11 @@ Sample Code
     # Saturation temperature of Water at 1 atm
     In [2]: PropsSI('T','P',101325,'Q',0,'Water')
     
-    # Saturated vapor density of R134a at 0C
+    # Saturated vapor enthalpy of R134a at 0C (Q=1)
     In [2]: PropsSI('H','T',273.15,'Q',1,'R134a')
+
+    # Saturated liquid enthalpy of R134a at 0C (Q=0)
+    In [2]: PropsSI('H','T',273.15,'Q',0,'R134a')
     
     # Using properties from CoolProp to get R410A density
     In [2]: PropsSI('D','T',300,'P',101325,'HEOS::R32[0.697615]&R125[0.302385]')
@@ -408,6 +438,12 @@ Sample Code
     
     # Check that the same as using pseudo-pure
     In [2]: PropsSI('D','T',300,'P',101325,'R410A')
+    
+    # Using IF97 to get Water saturated vapor density at 100C
+    In [2]: PropsSI('D','T',400,'Q',1,'IF97::Water')
+
+    # Check the IF97 result using the default HEOS
+    In [2]: PropsSI('D','T',400,'Q',1,'Water')
 
 .. _parameter_table:
 

--- a/Web/coolprop/LowLevelAPI.rst
+++ b/Web/coolprop/LowLevelAPI.rst
@@ -260,7 +260,7 @@ Here is an example showing how to change the reference state and demonstrating t
     
     # Note how the AS1 has its default value (change in reference state is not seen)
     # and AS2 does see the new reference state
-    In [1]: print AS1.hmass(), AS2.hmass()
+    In [1]: print('{0}, {1}'.format(AS1.hmass(), AS2.hmass()))
     
     # Back to the original value
     In [1]: CoolProp.CoolProp.set_reference_state('n-Propane','DEF')

--- a/Web/coolprop/wrappers/Python/.gitignore
+++ b/Web/coolprop/wrappers/Python/.gitignore
@@ -1,0 +1,2 @@
+Example.py
+Example.out

--- a/Web/coolprop/wrappers/Python/index.rst
+++ b/Web/coolprop/wrappers/Python/index.rst
@@ -52,6 +52,18 @@ script::
 
     sudo python2.7 setup.py install
 
+If you have multiple versions of Visual Studio installed and need to specify the version to use and choice of 32-bit or 64-bit compilation, you can use::
+
+    # 64-bit using VS2008 on Pytnon 2.7
+    sudo python setup.py install --cmake-compiler vc9 --cmake-bitness 64
+
+or, equivalently::
+
+    sudo python setup.py install cmake=vc9,64
+
+Omitting the cmake options will use the default (latest) compiler on the machine.
+
+
 Local installation
 ------------------
 
@@ -107,7 +119,7 @@ Once installed, you can use CoolProp for various things:
 
 * Solve `thermodynamics exercices`_
 
-* Make you own `more complex graphs`_ if you feel the graphing interface is lacking something
+* Make your own `more complex graphs`_ if you feel the graphing interface is lacking something
 
 * Make even more complex graphs using `3D stuff`_
 

--- a/Web/coolprop/wrappers/index.rst
+++ b/Web/coolprop/wrappers/index.rst
@@ -18,7 +18,7 @@ Target                                                  Operating Systems       
 :ref:`Python <Python>`                                  linux, OSX, win              Wrapper is Cython based
 :ref:`Octave <Octave>`                                  linux, OSX, win              Wrapper is SWIG based
 :ref:`C# <Csharp>`                                      linux, OSX, win              Wrapper is SWIG based
-:ref:`VB.net <VBdotNet>`                                windows only                 Wrapper is SWIG based
+:ref:`VB.net <VBdotNet>`                                Windows only                 Wrapper is SWIG based
 :ref:`MATLAB <MATLAB>`                                  linux, OSX, win              Wrapper is SWIG based
 :ref:`Java <Java>`                                      linux, OSX, win              Wrapper is SWIG based
 :ref:`R <R>`                                            linux, OSX, win              Wrapper is SWIG based
@@ -27,15 +27,15 @@ Target                                                  Operating Systems       
 `Modelica <https://github.com/modelica/ExternalMedia>`_ linux, OSX, win
 :ref:`PHP <PHP>`                                        linux, OSX, win              Mostly used on linux
 :ref:`Javascript <Javascript>`                          cross-platform               Works in all internet browsers
-:ref:`Labview <Labview>`                                windows only
+:ref:`Labview <Labview>`                                Windows only
 :ref:`Maple <Maple>`                                    linux, OSX, win              CoolProp is included in Maple 2016
-:ref:`MathCAD <MathCAD>`                                windows only
+:ref:`Mathcad <MathCAD>`                                Windows only
 :ref:`SMath Studio <SMath>`                             linux, OSX, win
 :ref:`Mathematica <Mathematica>`
 :ref:`FORTRAN <FORTRAN>`                                linux, OSX, win
-:ref:`EES <EES>`                                        windows only                 Included in the Windows :ref:`installer <Installers>`
-:ref:`Microsoft Excel <Excel>`                          windows only                 Included in the Windows :ref:`installer <Installers>`
-:ref:`LibreOffice <LibreOffice>`                        windows, linux
+:ref:`EES <EES>`                                        Windows only                 Included in the Windows :ref:`installer <Installers>`
+:ref:`Microsoft Excel <Excel>`                          Windows only                 Included in the Windows :ref:`installer <Installers>`
+:ref:`LibreOffice <LibreOffice>`                        Windows, linux
 :ref:`Delphi & Lazarus <Delphi>`                        linux, OSX, win
 :ref:`iOS (iPhone) <ios>`                       
 :ref:`Android <Android>`                       
@@ -79,9 +79,22 @@ For python, you should be using `Anaconda/Miniconda <https://store.continuum.io/
 
 For the C++ compiler, the options are a bit more complicated.  There are multiple (binary incompatible) versions of Visual Studio, as well as G++ ports for windows (MinGW).  Unless you are compiling the python wrappers, you can compile with MinGW, so you should obtain the `MinGW installer <http://sourceforge.net/projects/mingw/files/Installer/mingw-get-setup.exe/download>`_ and run it.  You should install all the packages available, and you MUST(!!) install to a path without spaces. ``C:\MinGW`` is recommended as an installation path. Be sure to add the folder ``C:\MinGw`` to your PATH variable.
 
-If you want to build 64-bit extensions, you MUST install professional versions of visual studio, which can be obtained for free if you have a student ID card from Microsoft Dreamspark.  You will require Visual Studio 2008 Professional for python 2.x, and Visual Studio 2010 Professional for python 3.x.  Otherwise you can select Visual Studio version freely.
+If you want to build 64-bit extensions, you MUST install Professional or later Community versions of Visual Studio, which can be obtained for free if you have a student ID card from Microsoft Dreamspark or just download one of the later Community versions from Microsoft for personal and open-source use.  Python/Cython was built with Visual Studio, so depending on your Python version, you will require **exactly** the Visual Studio versions listed in the table below.
 
-All three compilers should co-exist happily on the path, so you should be fine installing all three, but they are rather sizeable installs.
++---------------------+-------------+-------------------------+
+| Visual Studio       | Visual C++  | Python Versions         |
++=====================+=============+=========================+
+| 2008 Professional   | 9.0         | 2.6, 2.7, 3.0, 3.1, 3.2 |
++---------------------+-------------+-------------------------+
+| 2010 Professional   | 10.0        | 3.3, 3.4                |
++---------------------+-------------+-------------------------+
+| 2015 Professional   | 14.0        | 3.5, 3.6                |
+| or Community        |             |                         |
++---------------------+-------------+-------------------------+
+
+Otherwise, for wrappers other than Python, you can select a Visual Studio version freely.
+
+All four compilers should co-exist happily on the path, so you should be fine installing all four, but they are rather sizable installs. Be aware that downloads of VS2008 and 2010 are getting harder and harder to find, so this may influence your Python version of choice.  See this `WindowsCompilers <https://wiki.python.org/moin/WindowsCompilers>`_ page at wiki.python.org for more info on the Windows C++ compilers needed for the various Python/Cython versions and where to download them (most for free).
 
 Linux
 -----

--- a/Web/develop/documentation.rst
+++ b/Web/develop/documentation.rst
@@ -4,11 +4,16 @@
 Documentation
 *************
 
+General
+-------
+
+The CoolProp documentation at http://www.Coolprop.org ( and http://www.CoolProp.org/dev ) is built dynamically (nightly, in the case of the dev pages) by running a collection of `reStructuredText <http://docutils.sourceforge.net/rst.html>`_ (.rst) files through Sphinx, which converts them to html.  This is done so that pages can be easily edited/created in .rst format and iPython examples of running CoolProp can be embedded and executed dynamically using the latest version of CoolProp, displaying the example output in the resulting html documentation.  The instructions below serve to document how the automated builds are done as well as provide instruction for generating local documentation, useful for creating, editing, viewing, and debugging new contributor content.
+
 Build Sphinx documentation
 --------------------------
 
 0. On a Mac system, you need a working Latex distribution and some more command line tools that can be installed 
-   with ``brew install jpeg libpng libtiff libtool imagemagick``. Additonally, you should add the local string 
+   with ``brew install jpeg libpng libtiff libtool imagemagick``. Additionally, you should add the local string 
    to your bash environment in ``/Users/username/.bash_profile``::
 
     export LC_ALL=en_US.UTF-8
@@ -18,6 +23,7 @@ Build Sphinx documentation
 1. Check out the sources in the CoolProp/Web folder::
 
     git clone https://github.com/CoolProp/CoolProp --recursive
+    cd CoolProp/Web
 
 2. Make a virtualenv::
 
@@ -27,16 +33,22 @@ Build Sphinx documentation
 3. Then install prerequisites into this virtualenv::
 
     pip install --upgrade setuptools cython
-    pip install cython numpy scipy matplotlib python-dateutil pytz pandas
+    pip install numpy scipy matplotlib python-dateutil pytz pandas
     pip install sphinx ipython sphinxcontrib-bibtex sphinxcontrib-doxylink sphinxcontrib-napoleon cloud-sptheme
     pip install wxpython
 
 
-4. To build the documentation, go into the CoolProp/Web folder and run::
+4. Run setup script, `CoolProp\Web\scripts\__init__.py` to generate dynamic content::
+
+    cd scripts
+    python __init__.py
+    cd ..
+
+5. To build the documentation, go into the CoolProp/Web folder and run::
 
     make html
 
-5. Move the generated docs in ``_build`` to wherever you want
+6. Move the generated docs in ``_build`` to wherever you want
 
 
 Build Doxygen documentation
@@ -44,7 +56,7 @@ Build Doxygen documentation
 
 All the configuration is done in the ``Doxyfile`` file.
 
-1. If you don't have doxygen, install it from `doxygen downloads <http://www.stack.nl/~dimitri/doxygen/download.html>`.  Or on linux a ``sudo apt-get install doxygen`` should do it.
+1. If you don't have doxygen, install it from `doxygen downloads <http://www.stack.nl/~dimitri/doxygen/download.html>`.  Or on Linux a ``sudo apt-get install doxygen`` should do it.
 
 2. Simply fire up a shell in the root of the repo, and type::
 
@@ -63,3 +75,143 @@ Building the documentation on Linux
     sudo aptitude install libxml2-dev libxslt1-dev libxslt1.1 python-all-dev # pandas
 
 2. Follow the instructions above to create the virtual environment.
+
+
+Building the documentation on Windows
+-------------------------------------
+
+Use these instructions to build the CoolProp documentation (html) on 64-bit windows systems.  This should only be needed if you need to reproduce the site at http://www.CoolProp.org or http://www.CoolProp.org/dev on a local machine.  This is extremely useful (if not necessary) when contributing changes to the documentation to see how changes to the .rst files will look in the html documentation.  There are probably many ways to do this that will work, but the method below makes use of the **Conda** environments to create clean virtual environments with the requisite packages needed to build most of the documentation.  This is not meant to be a comprehensive build, as some of the scripts don't run well under windows Anaconda (e.g. pdfnup, rsync, etc.).  It will however assemble the bulk of the documentation for those who need to contribute or edit doc pages.
+
+**Prerequisites**
+
+1. Install GNUwin32 Make at http://gnuwin32.sourceforge.net/packages/make.htm and add ``C:\Program Files (x86)\GnuWin32\bin`` to the PATH environment variable.  This will ensure that `make` is available from any command window.  
+
+
+2. Install Anaconda using the 64-bit Windows Installer with the following installation options:
+
+ - Use the ``Per User`` installation (vice installing for all users).  This will allow the installation of python packages without having to open a window with administrative privileges.  Windows (8, 8.1, and 10) does a "lock-down" of the ``Program Files`` directories such that they can only be modified with administrative privileges.
+
+ - Choose Python version 2.7.x or 3.6.x
+
+ - Add Anaconda to the path.  This will ensure that the Anaconda/python commands (like Conda) are available from any command window.  
+
+ 
+3. If you want to generate the wrapper examples in the documentation, you will need to install the software packages that they use (e.g. Octave, REFPROP, etc.).  If they aren't installed, these examples will be skipped, but will generate some warnings and errors in the steps below.  These can be ignored.  
+	
+.. note::
+
+    The 64-bit Windows version of Anaconda will automatically install 64-bit versions of packages like **numpy** and **scipy** by default; something that is not guaranteed in other python environments for Windows.  Also, Anaconda is packaged with MKL-powered binary versions of some of the most popular numerical/scientific Python libraries for improved performance; including **numpy** and **scipy**.  This is a requisite for CoolProp Python scripts, and another reason to use Anaconda (or Miniconda) with CoolProp.  
+
+.. note:: 
+
+    For help in using Conda commands, this `Navigator Cheat Sheet <https://docs.continuum.io/_downloads/Anaconda_CheatSheet.pdf>`_ and `Conda Cheat Sheet <http://conda.pydata.org/docs/_downloads/conda-cheatsheet.pdf>`_ can be very useful.
+   
+**Setup a Virtual Python Environment**
+
+Set up a virtual python environment and name it something like CP27 (that's what is used in the examples below) or CP36 if you are using Python 3.6.  This virtual environment will contain all the modules needed to build the CoolProp documentation.  Setting up a virtual environment is a very simple thing to do in the Anaconda Navigator (Graphical Interface), but you can also set up the environment using the following commands in a command line window::
+
+    conda create --name CP27 python=2.7
+    activate CP27 # Will cause command prompt to be prefixed with (CP27)
+	
+.. note::
+
+   Any instructions below that take place on the Windows are assumed to be in the virtual environment created here.  For example, when opening a Windows command prompt (cmd), *activate CP27* (or CP36, or whatever you named your virtual environment) first before issing any other commands.
+
+**Install Required Python Modules**
+
+Most of the following modules can be installed from the Anaconda Navigator, and it is much simpler to do so.  Even if the module is already in the Anaconda environment, it is best to update the packages listed, making sure to get the latest Windows 64-bit versions.  However, some of the requisite modules are not in the Conda library and have to be installed from the command line using `pip install`.  These will be designated as such.  The versions of each module that have been tested for generating the docs on Windows are shown in the table below. 
+
++-------------------------+-------------+-------------+
+| Modules (Conda)         | Python 2.7  | Python 3.6  |
++=========================+=============+=============+
+| setuptools              | 27.2.0      | 36.4.0      |
++-------------------------+-------------+-------------+
+| cython                  | 0.25.2      | 0.26        |
++-------------------------+-------------+-------------+
+| numpy                   | 1.12.1      | 1.13.1      |
++-------------------------+-------------+-------------+
+| scipy                   | 0.19.0      | 0.19.1      |
++-------------------------+-------------+-------------+
+| matplotlib              | 2.0.2       | 2.0.2       |
++-------------------------+-------------+-------------+
+| python-dateutil         | 2.6.0       | 2.6.1       |
++-------------------------+-------------+-------------+
+| pytz                    | 2017.2      | 2017.2      |
++-------------------------+-------------+-------------+
+| pandas                  | 0.20.1      | 0.20.3      |
++-------------------------+-------------+-------------+
+| sphinx                  | 1.5.6       | 1.6.3       |
++-------------------------+-------------+-------------+
+| ipython                 | 5.3.0       | 6.1.0       |
++-------------------------+-------------+-------------+
+| wxpython                | 3.0         |     n/a     |
++-------------------------+-------------+-------------+
+
+The following modules will need to be installed using *pip install*.
+
++-------------------------+-------------+-------------+
+| Modules (pip)           | Python 2.7  | Python 3.6  |
++=========================+=============+=============+
+| sphinxcontrib-bibtex    | 0.3.5       | 0.3.5       |
++-------------------------+-------------+-------------+
+| sphinxcontrib-doxylink  | 1.3         | 1.3         |
++-------------------------+-------------+-------------+
+| sphinxcontrib-napoleon  | 0.6.1       | 0.6.1       |
++-------------------------+-------------+-------------+
+| cloud-sptheme           | 1.9.4       | 1.9.4       |
++-------------------------+-------------+-------------+
+| wxPython                |     n/a     | 4.0.0b1     |
++-------------------------+-------------+-------------+
+
+
+.. note::
+
+   Errors may occur during the install of some of the above Python modules or while making the html docs.  Make sure that all of the above Python modules are the most recent versions using pip install --upgrade.  There are known issues with the default sphinx version installed with Anaconda on Windows.
+   
+If updating the dev version of the documentation (i.e. the latest dev source files are loaded), the dev version of the CoolProp module will need to be installed.  This ensures that any example code will run properly with the latest CoolProp functions.::
+
+    pip install -vvv --pre
+     --trusted-host www.coolprop.dreamhosters.com
+     --find-links http://www.coolprop.dreamhosters.com/binaries/Python/ -U 
+     --force-reinstall CoolProp
+
+
+**Run Setup Scripts**
+
+There are a number of setup scripts that have to be run to generate dynamic content for the web documentation.  To run them, open a windows command prompt (cmd) and cd to the CoolProp\\Web\\scripts directory.  Then run the following scripts::
+
+    python ..\..\dev\scripts\examples\win64run.py
+    python coolprop.tabular.speed.py
+    python fluid_properties.phase_envelope.py
+    python fluid_properties.PurePseudoPure.py
+    python fluid_properties.Mixtures.py
+    python coolprop.parametric_table.py
+    python coolprop.configuration.py
+    # The next three scripts can take a while to run
+    python fluid_properties.Consistency.py  # Many errors/warnings generated; this is normal
+    python logo_2014.py
+    python fluid_properties.REFPROPcomparison.py  # Only if you have REFPROP
+
+.. note::
+
+   These scripts are normally run by the BuildBot using the Python 2.x initialization script, `CoolProp\\Web\\scripts\\__init__.py <https://github.com/CoolProp/CoolProp/blob/master/Web/scripts/__init__.py#L107>`_ (lines 107-122).  This script could be run to help with automation, however, there are linux and OSX shell scripts included that will not run on Windows.  Also, these scripts only need to be run once, and many may generate errors and warning messages that will be useful in debugging your python environment.  Once the dynamic content from these scripts has been generated, you're ready to build the documentation.
+   
+**Build the Documentation**
+
+There is a Makefile that will build the entire site.  This can take a while, especially the first time.  Open a Windows command prompt, activate your virtural environment, cd to the *CoolProp\\Web* directory and type::
+
+    make html
+
+This will create a new *CoolProp\\Web\\_build* directory that will contain the html pages.  If the build already exists, make will skip the parts of the documentation that have not changed.  You can look at built documentation pages by opening *CoolProp\\Web\\_build\\html\\index.html* in any web browser, or by double clicking on this file.
+
+To remove the docs, use::
+
+    make clean
+	
+Or to build a completely fresh version of the documentation (this will take longer) use::
+
+    make clean html
+	
+.. note::
+
+   Warnings and errors will be generated, depending on what packages you have installed.  If pages or sections are missing from your build, check that you have the prerequisites installed, have all the up-to-date python modules, and have run the setup scripts successfully.

--- a/Web/fluid_properties/.gitignore
+++ b/Web/fluid_properties/.gitignore
@@ -1,4 +1,7 @@
 /report/
+/fluids/
 *.pdf
+*.png
 *.csv
 *.bib.bak
+*.rst.in

--- a/Web/fluid_properties/IF97.rst
+++ b/Web/fluid_properties/IF97.rst
@@ -1,0 +1,197 @@
+
+
+.. _IF97:
+
+IF97 Steam/Water Properties
+=================================
+
+
+General Introduction
+--------------------
+
+Steam/Water properties are of critical importance in industry and specifically the power industry.  The standard for water properties is maintained by the International Association for the Properties of Water and Steam (IAPWS_).  The most recent formulation for thermodynamic properties is the Helmholtz formulation in IAPWS-95_, which is exactly what the CoolProp HEOS backend uses when specifying the fluid as ``Water`` or ``HEOS::Water``.  The Helmholtz equations of state are based on :math:`T` and :math:`\rho` as state variables, so :math:`T, \rho` will always be the fastest inputs, while :math:`p,T` will be a bit slower (3-10 times). Inputs where neither :math:`T` nor :math:`\rho` are given, like :math:`P,H`, will be much slower.
+
+Realizing the need for fast numerical computation of water properties, the IAPWS_ created a committee to develop a faster formulation for the steam power industry.  In 1997, the IAPWS release the "*IAPWS Industrial Formulation 1997 for the Thermodynamic Properties of Water and Steam*" or IAPWS-IF97_.  This formulation replaced the older IFC-67 formulation. It is pressure based (rather than density based), and uses fundamental equations for the Gibbs free energy and its derivatives.  While IAPWS-IF97_ is faster, it is less accurate than the IAPWS-95_ formulation, but within 1% uncertainty for all properties (and in many areas within 0.1%) except very near the critical point. Details of this formulation can be found in IAPWS-IF97_, released in 2007 and updated in 2012.
+
+The IF97 backend in CoolProp is based on the latest `IAPWS Releases`_ for thermodynamic and transport properties.  It was originally coded as a fast water property calculation for the :ref:`Humid Air <Humid-Air>` backend.  It has matured to include most of the forward and backward formulations in all fluid phase regions as released by the IAPWS_ and can provide a much faster calculation of water properties than the default HEOS backend (or the :ref:`REFPROP <REFPROP>` backend, which is also based on IAPWS-95_).  
+
+.. _IAPWS: http://www.iapws.org  
+.. _IAPWS Releases: http://www.iapws.org/release.html  
+.. _IAPWS-95: http://www.iapws.org/relguide/IAPWS-95.html
+.. _IAPWS-IF97: http://www.iapws.org/relguide/IF97-Rev.html
+
+IF97 Backend
+------------
+
+The IF97 backend can be accessed the same way as the other backends, by prefixing the fluid name in calls to ``PropsSI`` and ``Props1SI``.  However, Water is the only fluid name that can be specified, as ``IF97::Water``.  Most output variables and input pairs are accepted as of CoolProp 6.1.1, with a few exceptions:
+
+1. Generic Partial Derivatives are not yet supported.
+2. Mixtures are obviously not supported since this is a Water-only backend.
+3. The Reference State cannot be modified for the IF97 formulation.  *The reference state is fixed such that the specific internal energy,* :math:`U` *, and the specific entropy,* :math:`S` *, of the saturated liquid at the triple point are identically zero.*
+4. Solid properties are not supported in any of the ICE regions.
+5. The melting-sublimation curve is not used; rather, the property equations are limited uniformly at :math:`T_{min}=273.15K`.
+
+IF97 Range of Validity
+----------------------
+
+Although IF97 is generally faster than the other backends, it is only applicable over a much smaller range of temperatures and pressures than the HEOS or REFPROP Water formulations.  The IF97 properties are divided into several regions.  The valid range of these regions is shown in the following plot.  Attempts to retrieve properties outside of these regions will result in an "Out of Range" error.
+
+.. plot::
+
+    import matplotlib
+    import numpy as np
+    import CoolProp.CoolProp as CP
+    import matplotlib.pyplot as plt
+    import matplotlib.ticker as ticker
+    import scipy.interpolate
+
+    pc = CP.PropsSI('pcrit','IF97::Water')/1e6
+    Tc = CP.PropsSI('Tcrit','IF97::Water')
+    pt = CP.PropsSI('ptriple','IF97::Water')/1e6
+    Tt = CP.PropsSI('Ttriple','IF97::Water')
+    # Tmin = 273.15
+    Tmin = CP.PropsSI('Tmin','IF97::Water')
+    Tmax = CP.PropsSI('Tmax','IF97::Water')
+    pmax = CP.PropsSI('pmax','IF97::Water')/1e6
+    pmin = 0
+    Tb = 623.15
+    pb = 16.5291643
+    fillcolor = 'g'
+
+    fig = plt.figure(figsize = (9,6))
+    ax = plt.subplot2grid((1,9), (0,0), colspan=7)
+    ax.spines['right'].set_visible(False)
+    ax.spines['top'].set_visible(False)
+    ax.xaxis.set_ticks_position('bottom')
+    ax.yaxis.set_ticks_position('left')
+    ax.xaxis.set_major_formatter(ticker.FormatStrFormatter('%0.2f'))
+    lw = 3
+
+    # ----------------
+    # Saturation curve
+    # ----------------
+    Ts = np.linspace(Tt, Tc, 1000)
+    ps = CP.PropsSI('P','T',Ts,'Q',0,'IF97::Water')/1e6
+    plt.plot(Ts,ps,'orange',lw = lw, solid_capstyle = 'round')
+
+    # ------
+    # Labels
+    # ------
+
+    # ----------------
+    # Boundary lines
+    # ----------------
+    # plt.axhline(pc, dashes = [2, 2])
+    plt.axvline(x = Tb, ymin = pb/100, ymax = 1, dashes = [2, 2])
+    plt.axvline(x = Tmax, ymin = 0, ymax = 1, linewidth = 1, color = 'black')
+    plt.axhline(y = pmax, xmin = 0, xmax = (Tmax-Tmin)/(Tmax-Tmin+300), linewidth = 2, color = 'black')
+    plt.axhline(y = 50, xmin = (Tmax-Tmin)/(Tmax-Tmin+300), xmax = 1, linewidth = 1, color = 'black')
+
+    # -----------------------------
+    # Region 2-3 Boundary
+    # -----------------------------
+    n3 = 0.10192970039326e-2
+    n4 = 0.57254459862746e3
+    n5 = 0.1391883776670e2
+    PI = 2.0*np.arcsin(1.0)
+    TT = []
+    PP = list(np.linspace(pb,pmax,1000))
+    for p in PP:
+        TT.append(n4+np.sqrt((p-n5)/n3))
+
+    plt.plot(TT,PP,lw=1, dashes = [2,2])
+
+    # Labels
+    plt.text(1300, 51, '50 MPa',ha= 'center')
+    plt.text(473, 80, 'Region 1', fontsize = 14, ha = 'center')
+    plt.text(973, 80, 'Region 2', fontsize = 14, ha = 'center')
+    plt.text(720, 80, 'Region 3', fontsize = 14, ha = 'center')
+    plt.text(1300, 25, 'Region 5', fontsize = 14, ha = 'center')
+    plt.annotate('Region 4', xy=(570, 8), xytext=(700, 5), arrowprops=dict(facecolor='black', shrink=0.05), fontsize = 14)
+    plt.title('Regions and equations of IAPWS-IF97', fontsize = 14)
+
+    plt.ylim(pmin-1,pmax)
+    ax.set_xticks([Tt, Tb, Tmax])
+    plt.gca().set_xlim(Tt, Tmax+300)
+    plt.ylabel('Pressure [MPa]', fontsize = 11)
+    plt.xlabel('Temperature [K]', fontsize = 11)
+    plt.tight_layout()
+
+    # -----------------------------
+    # Extended Temperature Region 5
+    # -----------------------------
+    bx = plt.subplot2grid((1,9), (0,7), colspan=2)
+    bx.spines['right'].set_visible(False)
+    bx.spines['top'].set_visible(False)
+    bx.spines['left'].set_visible(False)
+    bx.xaxis.set_ticks_position('bottom')
+    bx.yaxis.set_ticks_position('none')
+    bx.axes.get_yaxis().set_visible(False)
+    bx.set_xticks([2273.15])
+    bx.xaxis.set_major_formatter(ticker.FormatStrFormatter('%0.2f'))
+
+    # ----------------
+    # Boundary lines
+    # ----------------
+    plt.axhline(50, linewidth = 1, color = 'black')
+    plt.axvline(x = 2272, ymin = 0, ymax = 0.5, linewidth = 1, color = 'black')
+
+    # ----------------
+    # Plot Formatting
+    # ----------------
+    plt.ylim(pmin-1,pmax)
+    plt.gca().set_xlim(2173.15, 2273.15)
+    plt.tight_layout()
+
+
+
+
+IF97 Water Property Examples
+----------------------------
+
+A call to the top-level function ``PropsSI`` can provide: temperature, pressure, density, specific heat, internal energy, enthalpy, entropy, speed of sound, viscosity, thermal conductivity, surface tension, and Prandtl Number. Hence, the available output keys are: ``T``, ``P``, ``D``, ``C``, ``Cvmass``, ``U``, ``H``, ``S``, ``A``, ``V``, ``L``, ``I``, and ``Prandtl``.  Molar quantities can also be returned, but IF97 is mass based.  Trivial outputs, such as ``M``, ``Tmin``, ``Tmax``, ``Pmin``, ``Pmax``, ``Ttriple``, ``Tcrit``, ``ptriple``, and ``pcrit``, are also available.
+
+.. ipython::
+
+    In [1]: from CoolProp.CoolProp import PropsSI
+	
+    #Specific heat capacity of Water at 500 K and 1 atm
+    In [3]: PropsSI('C','T',500,'P',101325,'IF97::Water')
+
+    #Density of Water at 500 K and 1 atm.
+    In [4]: PropsSI('D','T',500,'P',101325,'IF97::Water')
+    
+    #Round trip in thermodynamic properties
+    In [5]: T_init = 500.0
+    
+    In [6]: P_init = 101325
+    
+    In [7]: S_init = PropsSI('S','T',T_init,'P',P_init,'IF97::Water')
+    
+    In [8]: H_init = PropsSI('H','S',S_init,'P',P_init,'IF97::Water')
+    
+    In [9]: T_final = PropsSI('T','H',H_init,'P',P_init,'IF97::Water')
+    
+    #Round trip complete.  T_final should match T_init
+    In [10]: T_final
+
+    #Saturation pressure of Water at 500 K (Q can be 0 or 1)
+    In [11]: PropsSI('P','T',500,'Q',0,'IF97::Water')
+
+    #Saturated LIQUID enthalpy of Water at 500 K (Q = 0)
+    In [12]: H_L = PropsSI('H','T',500,'Q',0,'IF97::Water'); print(H_L)
+
+    #Saturated VAPOR enthalpy of Water at 500 K (Q = 1)
+    In [14]: H_V = PropsSI('H','T',500,'Q',1,'IF97::Water'); print(H_V)
+
+    #Latent heat of vaporization of Water at 500 K
+    In [16]: H_V - H_L
+	
+    #Critical temperature for Water
+    In [17]: PropsSI('Tcrit','T',0,'P',0,'IF97::Water')
+	
+    #Triple Point pressure for Water
+    In [17]: PropsSI('ptriple','T',0,'P',0,'IF97::Water')
+
+
+

--- a/Web/fluid_properties/index.rst
+++ b/Web/fluid_properties/index.rst
@@ -9,4 +9,5 @@ Fluid Properties
     Mixtures
     HumidAir
     Incompressibles
+    IF97
     more_reading

--- a/Web/fluid_properties/methane-ethane.py
+++ b/Web/fluid_properties/methane-ethane.py
@@ -8,13 +8,16 @@ for x0 in [0.02, 0.2, 0.4, 0.6, 0.8, 0.98]:
     try:
         HEOS.build_phase_envelope("dummy")
         PE = HEOS.get_phase_envelope_data()
-        plt.plot(PE.T, PE.p, '-')
+        PELabel = 'Methane, x = ' + str(x0)
+        plt.plot(PE.T, PE.p, '-', label=PELabel)
     except ValueError as VE:
         print(VE)
 
 plt.xlabel('Temperature [K]')
 plt.ylabel('Pressure [Pa]')
 plt.yscale('log')
+plt.title('Phase Envelope for Methane/Ethane Mixtures')
+plt.legend(loc='lower right', shadow=True)
 plt.savefig('methane-ethane.pdf')
 plt.savefig('methane-ethane.png')
 plt.close()

--- a/Web/scripts/.gitignore
+++ b/Web/scripts/.gitignore
@@ -1,2 +1,3 @@
 /last_run
+Example.py
 *.pdf


### PR DESCRIPTION
This is strictly a Documentation update (closes #1501 ). Changes include:

- [x] Added misc ignores so dynamic doc content can be built in repository
- [x] Update to documentation Makefile for clean html build on Windows
- [x] Updates to instructions for doc builds on Windows with Anaconda (includes suggestions from @jowr)
- [x] Added documentation page for IF97
- [x] Fixed errors on documentation page for Fluid_Properties/Mixtures
- [x] Updated HighLevelAPI doc page to include a section on calculating Vapor, Liquid, Saturation states (including latent heat calculation) that may head off some common new user questions.
- [x] Updated some print commands so docs can be built on Python 2 or 3
- [x] Updated documentation to compile the Python wrapper on Windows

This is a clean PR that replaces #1547 that got too far out of date.  @ibell & @jowr there are only minor changes from what you looked at before.  Because of the various areas affected, not sure if you want this to be "squashed" or maintain the separate commits as a documentation trail.