### PR TITLE
Added Python wrapper CMake generator for vc14 for when default is higher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,16 @@
 /dev/builder
 
 /wrappers/Python/build
+/wrappers/Python/cmake_build
+/wrappers/Python/CoolProp.egg-info
+/wrappers/Python/dist
 /wrappers/Python/CoolProp/*.o
+/wrappers/Python/CoolProp/AbstractState.html
+/wrappers/Python/CoolProp/CoolProp.cpp
+/wrappers/Python/CoolProp/CoolProp.html
+/wrappers/Python/CoolProp/_constants.*
+/wrappers/Python/CoolProp/constants*
+/wrappers/Python/CoolProp/HumidAirProp.html
 /wrappers/Excel/CoolProp_x64.dll
 /wrappers/Excel/CoolProp.dll
 

--- a/wrappers/Python/setup.py
+++ b/wrappers/Python/setup.py
@@ -116,6 +116,14 @@ if __name__=='__main__':
                 cmake_config_args += ['-G','"Visual Studio 10 2010 Win64"']
             else:
                 raise ValueError('cmake_bitness must be either 32 or 64; got ' + cmake_bitness)
+        elif cmake_compiler == 'vc14':
+            cmake_build_args = ['--config','"Release"']
+            if cmake_bitness == '32':
+                cmake_config_args += ['-G','"Visual Studio 14 2015"']
+            elif cmake_bitness == '64':
+                cmake_config_args += ['-G','"Visual Studio 14 2015 Win64"']
+            else:
+                raise ValueError('cmake_bitness must be either 32 or 64; got ' + cmake_bitness)
         elif cmake_compiler == 'mingw':
             cmake_config_args = ['-G','"MinGW Makefiles"']
             if cmake_bitness == '32':


### PR DESCRIPTION
With release of Visual Studio 2017 and 2018, VS2015 (vc14) may not be the highest default on the machine.  Python wrapper setup.py needed a cmake-compiler option for vc14 to force use of VS2015 (required for Python 3.5 & 3.6) for the build when higher compiler versions exist on the machine.

Also added some ignores for Python wrapper build files left behind when building right in the local git repo.