### PR TITLE
Patch PT_flash() to update _phase with imposed phase, in case it changed

### DIFF
--- a/include/CoolProp.h
+++ b/include/CoolProp.h
@@ -18,6 +18,7 @@ You might want to start by looking at CoolProp.h
 
     #include <string>
     #include <vector>
+    #include "DataStructures.h"
 
     namespace CoolProp {
 
@@ -179,6 +180,11 @@ You might want to start by looking at CoolProp.h
      * @return The fluids, as a '&' delimited string
      */
     std::string extract_fractions(const std::string &fluid_string, std::vector<double> &fractions);
+
+    /// An internal function to extract the phase string, given the phase index;
+    /// Handy for printing the actual phase string in debug, warning, and error messages.
+    /// @param Phase The enumerated phase index to be looked up
+    std::string phase_lookup_string(phases Phase);
     
     } /* namespace CoolProp */
 #endif

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -115,6 +115,11 @@ void FlashRoutines::PT_flash(HelmholtzEOSMixtureBackend &HEOS)
                 throw ValueError("twophase not implemented yet");
             }
         }
+        else
+        {
+            // Phase is imposed.  Update _phase in case it was reset elsewhere by another call
+            HEOS._phase = HEOS.imposed_phase_index;
+        }
         // Find density
         HEOS._rhomolar = HEOS.solver_rho_Tp(HEOS._T, HEOS._p);
         HEOS._Q = -1;


### PR DESCRIPTION
Fixes #1602 (see that issue for behavior).  Low-level calls to update on saturation line reset internal variable ``_phase`` to ``iphase_twophase``.  Subsequent single phase calculation using PT_flash did not check to see if ``_phase`` had gotten out of sync with ``imposed_phase_index``.

- [x] Patches _phase getting reset when phase is imposed
- [x] Bonus: Makes ``phase_lookup_string(phases Phase)`` available through CoolProp.h header.  This is VERY handy for printing the phase string instead of the phase index in debug, warning, and error messages.  Was used to debug this issue.

Tested with Python script:

```python
import CoolProp

p_Pa = 15E5
T_K = 400

HEOS = CoolProp.AbstractState('HEOS','D2O')

print("PT Update with no phase set:")
HEOS.update(CoolProp.PT_INPUTS, p_Pa, T_K)
print("hmass = {:.2f} kJ/kg".format(HEOS.hmass()/1000.0))
print(" ")

print("PT Update with iphase_liquid imposed")
HEOS.specify_phase(CoolProp.iphase_liquid)
HEOS.update(CoolProp.PT_INPUTS, p_Pa, T_K)
print("hmass = {:.2f} kJ/kg".format(HEOS.hmass()/1000.0))
print(" ")

print("PQ Update on saturation curve")
HEOS.update(CoolProp.PQ_INPUTS, p_Pa, 0)
print("Tsat = {:0.2f} K".format(HEOS.T()))
print(" ")

print("PT Update again; imposed phase should still be iphase_liquid")
HEOS.update(CoolProp.PT_INPUTS, p_Pa, T_K)
print("hmass = {:.2f} kJ/kg".format(HEOS.hmass()/1000.0))
```
Script output:
```
PT Update with no phase set:
hmass = 108.50 kJ/kg

PT Update with iphase_liquid imposed
hmass = 108.50 kJ/kg

PQ Update on saturation curve
Tsat = 471.68 K

PT Update again; imposed phase should still be iphase_liquid
hmass = 108.50 kJ/kg
```