### PR TITLE
Submodules track master branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,6 +25,7 @@
 [submodule "externals/pybind11"]
 	path = externals/pybind11
 	url = https://github.com/pybind/pybind11.git
+	branch = master
 [submodule "externals/rapidjson"]
 	path = externals/rapidjson
 	url = https://github.com/Tencent/rapidjson.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,27 +1,31 @@
 [submodule "externals/Catch"]
 	path = externals/Catch
 	url = https://github.com/philsquared/Catch
+	branch = master
 [submodule "externals/Eigen"]
 	path = externals/Eigen
 	url = https://github.com/RLovelett/eigen.git
-[submodule "externals/REFPROP-headers"]
-	path = externals/REFPROP-headers
-	url = https://github.com/CoolProp/REFPROP-headers.git
-[submodule "externals/FindMathematica"]
-	path = externals/FindMathematica
-	url = https://github.com/sakra/FindMathematica
-[submodule "externals/msgpack-c"]
-	path = externals/msgpack-c
-	url = https://github.com/msgpack/msgpack-c
-[submodule "externals/IF97"]
-	path = externals/IF97
-	url = https://github.com/CoolProp/IF97
-[submodule "externals/cppformat"]
-	path = externals/cppformat
-	url = https://github.com/cppformat/cppformat.git
+	branch = master
 [submodule "externals/ExcelAddinInstaller"]
 	path = externals/ExcelAddinInstaller
 	url = https://github.com/CoolProp/ExcelAddinInstaller.git
+[submodule "externals/FindMathematica"]
+	path = externals/FindMathematica
+	url = https://github.com/sakra/FindMathematica
+[submodule "externals/IF97"]
+	path = externals/IF97
+	url = https://github.com/CoolProp/IF97
+[submodule "externals/REFPROP-headers"]
+	path = externals/REFPROP-headers
+	url = https://github.com/CoolProp/REFPROP-headers.git
+[submodule "externals/cppformat"]
+	path = externals/cppformat
+	url = https://github.com/cppformat/cppformat.git
+	branch = master
+[submodule "externals/msgpack-c"]
+	path = externals/msgpack-c
+	url = https://github.com/msgpack/msgpack-c
+	branch = master
 [submodule "externals/pybind11"]
 	path = externals/pybind11
 	url = https://github.com/pybind/pybind11.git
@@ -29,3 +33,4 @@
 [submodule "externals/rapidjson"]
 	path = externals/rapidjson
 	url = https://github.com/Tencent/rapidjson.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,15 +9,19 @@
 [submodule "externals/ExcelAddinInstaller"]
 	path = externals/ExcelAddinInstaller
 	url = https://github.com/CoolProp/ExcelAddinInstaller.git
+	branch = master
 [submodule "externals/FindMathematica"]
 	path = externals/FindMathematica
 	url = https://github.com/sakra/FindMathematica
+	branch = master
 [submodule "externals/IF97"]
 	path = externals/IF97
 	url = https://github.com/CoolProp/IF97
+	branch = master
 [submodule "externals/REFPROP-headers"]
 	path = externals/REFPROP-headers
 	url = https://github.com/CoolProp/REFPROP-headers.git
+	branch = master
 [submodule "externals/cppformat"]
 	path = externals/cppformat
 	url = https://github.com/cppformat/cppformat.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
 
 git:
   depth: 5
-  submodules_depth: 100
+  #submodules_depth: 100
 
 language:
   - cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ notifications:
 
 git:
   depth: 5
+  submodules_depth: 100
 
 language:
   - cpp


### PR DESCRIPTION
This is a follow-up for #1610 
Turns out it does not save a significant amount of time.

One could also remove the submodule_depth again, and only keep the other changes:
sorted the submodules alphabetically, specified to use master branch, and pulled the latest master