### PR TITLE
Parse out zero mole fraction components in PropsSI()

### DIFF
--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -148,11 +148,14 @@ std::string extract_fractions(const std::string &fluid_string, std::vector<doubl
             // If pEnd points to the last character in the string, it wasn't able to do the conversion
             if (pEnd == &(fraction[fraction.size()-1])){throw ValueError(format("Could not convert [%s] into number", fraction.c_str()));}
 
-            // And add to vector
-            fractions.push_back(f);
+            if (f > 0)  // Only push component if fraction is positive and non-zero
+            {
+                // And add to vector
+                fractions.push_back(f);
 
-            // Add name
-            names.push_back(name);
+                // Add name
+                names.push_back(name);
+            }
         }
 
         if (get_debug_level()>10) std::cout << format("%s:%d: Detected fractions of %s for %s.",__FILE__,__LINE__,vec_to_string(fractions).c_str(), (strjoin(names, "&")).c_str());

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -148,7 +148,7 @@ std::string extract_fractions(const std::string &fluid_string, std::vector<doubl
             // If pEnd points to the last character in the string, it wasn't able to do the conversion
             if (pEnd == &(fraction[fraction.size()-1])){throw ValueError(format("Could not convert [%s] into number", fraction.c_str()));}
 
-            if (f > 0)  // Only push component if fraction is positive and non-zero
+            if (f > 10*DBL_EPSILON)  // Only push component if fraction is positive and non-zero
             {
                 // And add to vector
                 fractions.push_back(f);


### PR DESCRIPTION
This PR closes #1603 and also closes #969 .

In High-Level interface only, when parsing the mixture string, do not add mixture components that have a mole fraction of 0 (or negative, which is nonsensical).  Unfortunately, cannot be applied to the low-level interface.

Tested in Mathcad wrapper (curiously, error could not be reproduced in Python wrapper, at least for this example).
![zerocomponenttest](https://user-images.githubusercontent.com/17114032/34616770-2dc0af52-f207-11e7-81f4-a5686c0ff587.PNG)
