### PR TITLE
Update PropsSI() to Parse Imposed Phase Strings on Input Keys

### DIFF
--- a/Web/coolprop/HighLevelAPI.rst
+++ b/Web/coolprop/HighLevelAPI.rst
@@ -55,6 +55,55 @@ To retrieve either the *vapor* or *liquid* properties along the saturation curve
 .. note::
    The *latent heat of vaporization* can be calculated using the difference between the vapor and liquid enthalpies at the same point on the saturation curve.
 
+Imposing the Phase (Optional)
+-----------------------------
+
+Each call to ``PropsSI()`` requires the phase to be determined based on the provided input pair, and may require a non-trivial flash calculation to determine if the state point is in the single-phase or two-phase region and to generate a sensible initial guess for the solver. For computational efficiency, ``PropsSI()`` allows the phase to be manually imposed through the input key parameters.  If unspecified, PropsSI will attempt to determine the phase automatically. 
+
+Depending on the input pair, there may or may not be a speed benefit to imposing a phase.  However, some state points may not be able to find a suitable initial guess for the solver and being able to impose the phase manually may offer a solution if the solver is failing.  Additionally,  with an input pair in the two-phase region, it can be useful to impose a liquid or gas phase to instruct ``PropsSI()`` to return the saturated liquid or saturated gas properties.  
+
+To specify the phase to be used, add the "|" delimiter to one (and only one) of the input key strings followed by one of the phase strings in the table below:
+
++---------------------------------+----------------------------------------------------+
+| Phase String                    | Phase Region                                       |
++=================================+====================================================+
+| "liquid"                        | p < pcrit & T < Tcrit ; above saturation           |
++---------------------------------+----------------------------------------------------+
+| "gas"                           | p < pcrit & T < Tcrit ; below saturation           |
++---------------------------------+----------------------------------------------------+
+| "twophase"                      | p < pcrit & T < Tcrit ; mixed liquid/gas           |
++---------------------------------+----------------------------------------------------+
+| "supercritical_liquid"          | p > pcrit & T < Tcrit                              |
++---------------------------------+----------------------------------------------------+
+| "supercritical_gas"             | p < pcrit & T > Tcrit                              |
++---------------------------------+----------------------------------------------------+
+| "supercritical"                 | p > pcrit & T > Tcrit                              |
++---------------------------------+----------------------------------------------------+
+| "not_imposed"                   | (Default) CoolProp to determine phase              |
++---------------------------------+----------------------------------------------------+
+
+For example:
+    
+.. ipython::
+
+    # Get the density of Water at T = 461.1 K and P = 5.0e6 Pa, imposing the liquid phase
+    In [0]: PropsSI('D','T|liquid',461.1,'P',5e6,'Water')
+
+    # Get the density of Water at T = 597.9 K and P = 5.0e6 Pa, imposing the gas phase
+    In [0]: PropsSI('D','T',597.9,'P|gas',5e6,'Water')
+
+On each call to ``PropsSI()``, the imposed phase is reset to "not_imposed" as long as no imposed phase strings are used.  A phase string must be appended to an Input key string on each and every call to ``PropsSI()`` to impose the phase.  ``PropsSI()`` will return an error for any of the following syntax conditions:
+
+* If anything other than the pipe, "|", symbol is used as the delimiter
+* If the phase string is not one of the valid phase strings in the table above
+* If the phase string is applied to more than one of the Input key parameters
+
+In addition, for consistency with the low-level interface, the valid phase strings in the table above may be prefixed with either "phase_" or "iphase_" and still be recognized as a valid phase string.
+
+.. warning::
+
+   When specifying an imposed phase, it is absolutely **critical** that the input pair actually lie within the imposed phase region.  If an incorrect phase is imposed for the given input pair, ``PropsSI()`` may throw unexpected errors or incorrect results may possibly be returned from the property functions.  If the state point phase is not absolutely known, it is best to let CoolProp determine the phase.
+
 Fluid information
 -----------------
 

--- a/include/DataStructures.h
+++ b/include/DataStructures.h
@@ -149,6 +149,7 @@ enum parameters{
     
 };
 // !! If you add a parameter, update the map in the corresponding CPP file !!
+// !! Also update phase_lookup_string() in CoolProp.cpp                    !!
 
 /// These are constants for the phases of the fluid
 enum phases{iphase_liquid, ///< Subcritical liquid 
@@ -168,6 +169,11 @@ std::string get_parameter_information(int key, const std::string &info);
 
 /// Return the enum key corresponding to the parameter name ("Dmolar" for instance)
 parameters get_parameter_index(const std::string &param_name);
+
+/// Return true if passed phase name is valid, otherwise false
+/// @param phase_name The phase name string to be checked ("phase_liquid" for instance)
+/// @param iOutput Gets updated with the phases enum value if phase_name is found
+bool is_valid_phase(const std::string &phase_name, phases &iOutput);
 
 /// Return the enum key corresponding to the phase name ("phase_liquid" for instance)
 phases get_phase_index(const std::string &param_name);

--- a/wrappers/MathCAD/CoolPropMathcad.cpp
+++ b/wrappers/MathCAD/CoolPropMathcad.cpp
@@ -22,7 +22,8 @@ namespace CoolProp {
 }
 
 enum EC { MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,       // Mathcad Error Codes
-          BAD_FLUID, BAD_PARAMETER, BAD_REF, NON_TRIVIAL,           // CoolProp Error Codes
+          BAD_FLUID, BAD_PARAMETER, BAD_PHASE,                      // CoolProp Error Codes
+          ONLY_ONE_PHASE_SPEC, BAD_REF, NON_TRIVIAL,
           NO_REFPROP, NOT_AVAIL, BAD_INPUT_PAIR, BAD_QUAL,
           TWO_PHASE, T_OUT_OF_RANGE, P_OUT_OF_RANGE,
           H_OUT_OF_RANGE, S_OUT_OF_RANGE, HA_INPUTS, 
@@ -40,6 +41,8 @@ enum EC { MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,       // Mathcad E
         "Argument must be real",
         "Invalid Fluid String",
         "Invalid Parameter String",
+        "Invalid Phase String",
+        "Only one input key phase specification allowed",
         "Cannot use this REF State with this fluid",
         "Input Parameter is Non-Trivial",
         "REFPROP not installed correctly",
@@ -264,7 +267,24 @@ enum EC { MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,       // Mathcad E
                 else  // must be the second input parameter that's bad
                     errPos = 4;  // Second input parameter string; position 4.
                 return MAKELRESULT(BAD_PARAMETER,errPos);
-            } else if (emsg.find("This pair of inputs")!=std::string::npos) {
+            }
+            else if (emsg.find("Input Name1") != std::string::npos) {
+                return MAKELRESULT(BAD_PARAMETER, 2);  // first position input parameter
+            }
+            else if (emsg.find("Input Name2") != std::string::npos) {
+                return MAKELRESULT(BAD_PARAMETER, 4);  // second position input parameter
+            }
+            else if (emsg.find("Phase can only be specified on one") != std::string::npos) {
+                return MAKELRESULT(ONLY_ONE_PHASE_SPEC, 4);  // second position parameter
+            }
+            else if (emsg.find("valid phase") != std::string::npos) {
+                if (!is_valid_parameter(Prop1Name, key1))
+                    errPos = 2;  // First input parameter string; position 2.
+                else  // must be the second input parameter that's bad
+                    errPos = 4;  // Second input parameter string; position 4.
+                return MAKELRESULT(BAD_PHASE, errPos);  // second position parameter
+            }
+            else if (emsg.find("This pair of inputs") != std::string::npos) {
                 return MAKELRESULT(BAD_INPUT_PAIR,2);  // second position parameter
             } else if (emsg.find("Input vapor quality")!=std::string::npos) {
                 if (Prop1Name == "Q")


### PR DESCRIPTION
**_PropsSI()_** is updated to allow the phase to be imposed by tagging one of the input key strings with the pipe symbol, **"|"** followed by a phase string (e.g. "**T|liquid**" or "**P|supercritical_gas**").  If a valid phase string is found, **_State_**->**_specify_phase()_** is called with the corresponding phase index before the call to **_update()_**.  Only one Input key string can be tagged with a phase string and error checking makes sure that:

- Imposed phase is a valid phase string
- Only one Input key is tagged with a phase
- Phase strings prefixed with "phase_" or "iphase_" are acceptable

High-Level Interface documentation is also updated to explain how to use this feature.  It has been successfully tested in both Python and Mathcad wrappers (updated to catch phase syntax errors).
Closes #1279 