### PR TITLE
Make string->float conversion aware of the locale

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -43,7 +43,8 @@
     X(OVERWRITE_BINARY_INTERACTION, "OVERWRITE_BINARY_INTERACTION", false, "If true, and a pair of binary interaction pairs to be added is already there, rather than not adding the binary interaction pair (and probably throwing an exception), overwrite it") \
     X(USE_GUESSES_IN_PROPSSI, "USE_GUESSES_IN_PROPSSI", false, "If true, calls to the vectorized versions of PropsSI use the previous state as guess value while looping over the input vectors, only makes sense when working with a single fluid and with points that are not too far from each other.") \
     X(ASSUME_CRITICAL_POINT_STABLE, "ASSUME_CRIT_POINT_STABLE", false, "If true, evaluation of the stability of critical point will be skipped and point will be assumed to be stable") \
-    X(VTPR_ALWAYS_RELOAD_LIBRARY, "VTPR_ALWAYS_RELOAD_LIBRARY", false, "If true, the library will always be reloaded, no matter what is currently loaded")
+    X(VTPR_ALWAYS_RELOAD_LIBRARY, "VTPR_ALWAYS_RELOAD_LIBRARY", false, "If true, the library will always be reloaded, no matter what is currently loaded") \
+    X(FLOAT_LOCALE_NAME, "FLOAT_LOCALE_NAME", "en_US", "This locale name will be used for conversion of floating point numbers in strings to floating point numbers.  The default system locale is not used.")
 
 
  // Use preprocessor to create the Enum

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -34,6 +34,7 @@
 #include <exception>
 #include <stdio.h>
 #include <string>
+#include <locale>
 #include "CoolPropTools.h"
 #include "Solvers.h"
 #include "MatrixMath.h"

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -149,7 +149,7 @@ std::string extract_fractions(const std::string &fluid_string, std::vector<doubl
             // to something more convenient for you
             std::stringstream ssfraction(fraction);
             std::string localename = get_config_string(FLOAT_LOCALE_NAME);
-            ssfraction.imbue(std::locale(localename));
+            ssfraction.imbue(std::locale(localename.c_str()));
             double f;
             ssfraction >> f;
             if (ssfraction.rdbuf()->in_avail() != 0){

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -141,12 +141,23 @@ std::string extract_fractions(const std::string &fluid_string, std::vector<doubl
             if (name_fraction.size() != 2){throw ValueError(format("Could not break [%s] into name/fraction", fluid.substr(0, fluid.size()-1).c_str()));}
 
             // Convert fraction to a double
-            char *pEnd;
             const std::string &name = name_fraction[0], &fraction = name_fraction[1];
-            double f = strtod(fraction.c_str(), &pEnd);
-
-            // If pEnd points to the last character in the string, it wasn't able to do the conversion
-            if (pEnd == &(fraction[fraction.size()-1])){throw ValueError(format("Could not convert [%s] into number", fraction.c_str()));}
+            // The default locale for conversion from string to double is en_US with . as the deliminter
+            // Good: 0.1234 Bad: 0,1234
+            // But you can change the locale with the configuration variable FLOAT_LOCALE_NAME to change the locale
+            // to something more convenient for you
+            std::stringstream ssfraction(fraction);
+            std::string localename = get_config_string(FLOAT_LOCALE_NAME);
+            ssfraction.imbue(std::locale(localename));
+            double f;
+            ssfraction >> f;
+            if (ssfraction.rdbuf()->in_avail() != 0){
+                throw ValueError(format("fraction [%s] was not converted fully", fraction.c_str()));
+            }
+            
+            if (f > 1 || f < 0){
+                throw ValueError(format("fraction [%s] was not converted to a value between 0 and 1 inclusive", fraction.c_str()));
+            }
 
             if (f > 10*DBL_EPSILON)  // Only push component if fraction is positive and non-zero
             {


### PR DESCRIPTION
Locale is specified by configuration variable FLOAT_LOCALE_NAME

Cannot use the system-default locale because some things (e.g., naughty matplotlib) change the system locale and it cannot be relied upon to be stable.

Closes #1551 
Closes #1662 
Closes #1647 