### PR TITLE
Let DARWIN build with libc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,10 @@ option (COOLPROP_MSVC_DYNAMIC
 option (COOLPROP_MSVC_DEBUG
        "Link the debug version of Microsoft Standard library to the debug builds."
        ON)
+       
+option (DARWIN_USE_LIBCPP
+        "On Darwin systems, compile and link with -std=libc++ instead of the default -std=libstdc++"
+        OFF)
 
 IF ( COOLPROP_RELEASE AND COOLPROP_DEBUG )
   MESSAGE(FATAL_ERROR "You can only make a release OR and debug build.")
@@ -400,9 +404,14 @@ IF ( COOLPROP_OBJECT_LIBRARY OR COOLPROP_STATIC_LIBRARY OR COOLPROP_SHARED_LIBRA
     ENDIF()
     # For Mac systems
     IF ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
-      # see https://support.enthought.com/hc/en-us/articles/204469410-OS-X-GCC-Clang-and-Cython-in-10-9-Mavericks
-      SET_PROPERTY(TARGET ${LIB_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS " -stdlib=libstdc++ -mmacosx-version-min=10.6")
-      SET_PROPERTY(TARGET ${LIB_NAME} APPEND_STRING PROPERTY LINK_FLAGS " -stdlib=libstdc++ -mmacosx-version-min=10.6")
+        IF (DARWIN_USE_LIBCPP)
+          SET_PROPERTY(TARGET ${LIB_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS " -stdlib=libc++ -mmacosx-version-min=10.6")
+          SET_PROPERTY(TARGET ${LIB_NAME} APPEND_STRING PROPERTY LINK_FLAGS " -stdlib=libc++ -mmacosx-version-min=10.6")
+        ELSE()
+          # see https://support.enthought.com/hc/en-us/articles/204469410-OS-X-GCC-Clang-and-Cython-in-10-9-Mavericks
+          SET_PROPERTY(TARGET ${LIB_NAME} APPEND_STRING PROPERTY COMPILE_FLAGS " -stdlib=libstdc++ -mmacosx-version-min=10.6")
+          SET_PROPERTY(TARGET ${LIB_NAME} APPEND_STRING PROPERTY LINK_FLAGS " -stdlib=libstdc++ -mmacosx-version-min=10.6")
+        ENDIF()
     ENDIF()
   ELSE()
     MESSAGE(FATAL_ERROR "You have to build a static or shared library.")


### PR DESCRIPTION
Added DARWIN_USE_LIBCPP cmake flag to allow for OSX builds to use the libc++ library.

This was needed by me since another project was built with libc++ and it caused issues trying to call CoolProp from it, adding cxx make flags did not work since libstdc++ was hard coded in the CMakeLists. Allows for and closes #1671 