### PR TITLE
Adding Github QA docs for contributing

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy toward other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying and demonstrating the 
+standards of acceptable behavior and are expected to take appropriate and 
+fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the CoolProp project or its community. 
+Examples of representing the CoolProp project or community include using an 
+official project e-mail address, posting via an official social media account, 
+or acting as an appointed representative at an on-line or off-line event. 
+Representation of the CoolProp project may be further defined and clarified 
+by the core development team.
+
+## Enforcement
+
+Any witnessed violation of this Code of Conduct will be reviewed and investigated 
+and will result in a response that is deemed necessary and appropriate to the 
+circumstances. The project core team is obligated to maintain confidentiality 
+with regard to reports of an incident. Further details of specific enforcement 
+policies may be posted separately.
+
+The CoolProp project maintainers who do not follow or enforce the Code of Conduct 
+in good faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,136 @@
+# Contributing to CoolProp
+
+Thank you for taking the time to contribute!
+
+The following is a set of guidelines for contributing to CoolProp and its submodules, which are hosted at [CoolProp](https://github.com/CoolProp) on GitHub. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+#### Table Of Contents
+
+[I don't want to read this whole thing, I just have a question!!!](#i-dont-want-to-read-this-whole-thing-i-just-have-a-question)
+
+[How Can I Contribute?](#how-can-i-contribute)
+  * [Reporting Bugs](#reporting-bugs)
+  * [Suggesting Enhancements](#suggesting-enhancements)
+  * [Your First Code Contribution](#your-first-code-contribution)
+  * [Pull Requests](#pull-requests-prs)
+
+[Styleguides](#styleguides)
+  * [Git Commit Messages](#git-commit-messages)
+  * [C++ Code](#C++-Code-Style-Guidance)
+
+[Additional Notes](#additional-notes)
+  * [Issue and Pull Request Labels](#issue-and-pull-request-labels)
+
+## I don't want to read this whole thing I just have a question!!!
+
+> **Note:** Please don't file an issue to ask a question. You'll get faster results by using the resources below.
+
+We have an official Google Group, where the community chimes in with helpful advice if you have questions, and a fairly detailed set of on-line documentation.
+
+* [Discuss, the official CoolProp User Group](https://goo.gl/Pa7FBT)
+* CoolProp documentation: [Release Version](http://www.coolprop.org) and [Development Version](http://www.coolprop.org/dev)
+
+## How Can I Contribute?
+
+### Reporting Bugs
+
+This section guides you through submitting a bug report for CoolProp. Following these guidelines helps maintainers and the community understand your report, reproduce the behavior, and find related reports.
+
+Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don't need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-issue-report). Fill out [the required template](ISSUE_TEMPLATE.md), the information it asks for helps us resolve issues faster.
+
+> **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, and you are using the latest CoolProp version that includes that issue resolution, open a new issue and include a link to the original issue in the body of your new one.
+
+#### Before Submitting A Bug Report
+
+* **Check the [FAQs file](https://github.com/CoolProp/CoolProp/FAQ.md)** for a list of common questions and problems.
+* **Check the [release](http://www.CoolProp.org) and [development](http://www.CoolProp.org) CoolProp documentation**.
+* **Perform a [cursory search](https://github.com/search?q=+is%3Aissue+user%3ACoolProp)** to see if the problem has already been reported. If it has **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
+
+#### How Do I Submit A (Good) Issue Report?
+
+Issues are tracked as [GitHub issues](https://guides.github.com/features/issues/). After you've determined the need to report an issue, create an issue on the CoolProp repository and provide the following information by filling in [the template](ISSUE_TEMPLATE.md).
+
+Explain the problem and include additional details to help maintainers reproduce the problem:
+
+* **Use a clear and descriptive title** for the issue to identify the problem.
+* **Describe the exact steps which reproduce the problem** in as many details as possible. For example, start by explaining how you started CoolProp, e.g. which command exactly you used in the terminal, or how you started CoolProp otherwise. When listing steps, **don't just say what you did, but explain how you did it**. 
+* **Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples. If you're providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+* **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
+* **Explain which behavior you expected to see instead and why.**
+* **Include screenshots and code segments** which show you following the described steps and clearly demonstrate the problem. 
+* **If you're reporting that CoolProp crashed**, include the error message with a stack trace from the operating system.
+
+Provide more context by answering these questions:
+
+* **Did the problem start happening recently** (e.g. after updating to a new version of CoolProp) or was this always a problem?
+* If the problem started happening recently, **can you reproduce the problem in an older version of CoolProp or on a different OS?** What's the most recent version in which the problem doesn't happen? 
+* **Can you reliably reproduce the issue?** If not, provide details about how often the problem happens and under which conditions it normally happens.
+* If the problem is related to working with a specific fluid, **does the problem happen for all fluids or only some?**
+
+Include details about your configuration and environment:
+
+* **Which version of CoolProp are you using?** You can get the exact version in Python by printing CoolProp.__version__ or by calling get_global_param_string("version") in most interfaces.  
+* **What's the name and version of the OS you're using**?  
+* **Which interface or CoolProp wrapper are you using (e.g. direct C++ calls, Python, Excel, Mathcad, etc.)  
+* **If using Python, which version (e.g. 2.7, 3.6, etc.)**  
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for CoolProp, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion and find related suggestions.
+
+Before creating enhancement suggestions, please check [this list](#before-submitting-an-enhancement-suggestion) as you might find out that you don't need to create one. When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion). Fill in [the template](ISSUE_TEMPLATE.md), including the steps that you imagine you would take if the feature you're requesting existed.
+
+#### Before Submitting An Enhancement Suggestion
+
+* **Check the [development documentation](http://www.coolprop.org/dev)** — you might discover that the enhancement is already available or planned for the next official release. Most importantly, check if you're using [the latest version of CoolProp](http://www.coolprop.org/dev/coolprop/changelog.html) and if you can get the desired behavior by updating CoolProp.  
+* **Perform a [cursory search](https://github.com/search?q=+is%3Aissue+label%3Awishlist+user%3ACoolProp)** to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+
+#### How Do I Submit A (Good) Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an issue on that repository and provide the following information:
+
+* **Use a clear and descriptive title** for the issue to identify the suggestion.
+* **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
+* **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+* **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
+* **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of CoolProp which the suggestion is related to. 
+* **Explain why this enhancement would be useful** to most CoolProp users. 
+* **Specify which version of CoolProp you're using.** 
+* **Specify the name and version of the OS you're using.**
+
+### Your First Code Contribution
+
+Unsure where to begin contributing to CoolProp? You can start by looking through these `beginner` and `help-wanted` issues:
+
+* [Beginner issues][beginner] - issues which should only require a few lines of code, and a test or two.
+* [Help wanted issues][help-wanted] - issues which should be a bit more involved than `beginner` issues.
+
+Both issue lists are sorted by total number of comments. While not perfect, number of comments is a reasonable proxy for impact a given change will have.
+
+#### Local development
+
+CoolProp can be developed locally on your machine.  Once code changes are completed and tested, make a Pull Request (PR) to the CoolProp repository.  Please see the [Wiki](https://github.com/CoolProp/CoolProp/wiki) on contributing to CoolProp.  
+
+### Pull Requests (PRs)
+
+* Fill in [the required template](PULL_REQUEST_TEMPLATE.md)
+* Do not include issue numbers in the PR title
+* Include screenshots in your pull request whenever possible.
+* Follow the [C++ Coding Guidelines](https://github.com/CoolProp/CoolProp/wiki/Coding-Guidelines).
+* Document new code based on the Documentation Styleguide
+* Avoid platform-dependent code 
+
+## Styleguides
+
+### Git Commit Messages
+
+* Use the present tense ("Add feature" not "Added feature")
+* Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+* Limit the first line to 72 characters or less
+* Reference issues and pull requests liberally after the first line
+* When only changing documentation (i.e. no actual code), include `[ci skip]` in the commit title
+
+## Additional Notes
+
+[beginner]:https://github.com/search?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+label%3Abeginner+user%3Acoolprop
+[help-wanted]:https://github.com/search?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted+user%3Acoolprop  

--- a/FAQ.md
+++ b/FAQ.md
@@ -5,7 +5,7 @@ Frequently Asked Questions
 Usage
 -----
 
-1. My enthalpy and entropy values are not the same as what are used in REFPROP, or EES, or ...
+1. **My enthalpy and entropy values are not the same as what are used in REFPROP, or EES, or ...**
 
     Values for enthalpy, entropy and internal energy are calculated as *differences* 
     with respect to an arbitrarily chosen reference state. 
@@ -17,31 +17,38 @@ Usage
     NBP: saturated liquid (Q=0) at p=101325.0 Pa
     
     
-2. My calls to REFPROP fail with a mysterious `Segementation Fault`: 
+2. **My calls to REFPROP fail with a mysterious `Segmentation Fault`:** 
 
     Make sure that you have at least REFPROP version 9.1 installed. If you have a license for 9.0, 
     the upgrade is for free: http://www.nist.gov/srd/nist23.cfm
     
-3. Transport properties
-  1. Fluid XY does not have viscosity/thermal conductivity/ ... 
+3. **Transport properties missing**
 
-    Please have a look at 
-    http://www.coolprop.org/fluid_properties/PurePseudoPure.html#list-of-fluids 
-    if there is no reference for your property, we do not have the information required to 
-    implement the functionality. If you file an issue, please provide information and 
-    a link to a publication with the required data. 
+    a. Fluid XY does not have viscosity/thermal conductivity/ ... 
+
+       Please have a look at 
+       http://www.coolprop.org/fluid_properties/PurePseudoPure.html#list-of-fluids 
+       if there is no reference for your property, we do not have the information required to 
+       implement the functionality. If you file an issue, please provide information and 
+       a link to a publication with the required data. 
     
-  1. ..but it used to work in an earlier version of CoolProp
+    b. ..but it used to work in an earlier version of CoolProp
     
-    For some fluids, version 5 does not have transport properties even though version 4 had 
-    that information. We decided to remove some correlations, which had very large uncertainties 
-    and we would like to make the user aware of the fact that the old implementation was 
-    experimental and results were not reliable at all.
+       For some fluids, version 5 does not have transport properties even though version 4 had 
+       that information. We decided to remove some correlations, which had very large uncertainties 
+       and we would like to make the user aware of the fact that the old implementation was 
+       experimental and results were not reliable at all.
+
+4. **Mixture calculation gives error: Could not match the binary pair [0000-00-0,11-11-1] - for now this is an error.**  
+
+    Mixture calculations require binary interaction parameters for each pair in the mixture.  While many binary interaction parameters are available in the CoolProp library, sadly, many are not.  If you get this error message, then the binary interaction parameters for the CAS fluids listed are not available in CoolProp.  
     
+    If you have data for the binary interaction parameters, you can enter them interactively using the [set_mixture_binary_pair_data](http://www.coolprop.org/dev/fluid_properties/Mixtures.html#id826) function in CoolProp.  Otherwise, a more sophisticated mixing model is needed, like the ones in NIST RefProp.
+
 Compilation
 -----------
 
-1. I'm on linux and I get compilation errors like
+1. **I'm on Linux and I get compilation errors like**
 
     ```
     gcc: error trying to exec 'cc1plus': execvp: No such file or directory
@@ -62,4 +69,11 @@ Compilation
     sudo apt-get install g++
     ```
     
+2. **Building Python wrapper on Windows fails with an error similar to**
+
+    ```
+    error: Microsoft Visual C++ 14.0 is required. Get it with "Microsoft Visual C++ Build Tools": http://landinghub.visualstudio.com/visual-cpp-build-tools
+    ```
+    
+    Different versions of Python (2.7, 3.6, etc.) are built with and require specific versions of the Microsoft Visual C++ compiler.  Please see the [common wrapper prerequisites](http://www.coolprop.org/dev/coolprop/wrappers/index.html#wrapper-common-prereqs) specifically for Windows build requirements.
     

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,34 @@
+Do you want to ask a question? Are you looking for technical support? For any kind of question regarding CoolProp and its usage, you can ask the [CoolProp user group](https://goo.gl/Pa7FBT)
+
+If you have an issue to report, please continue and fill out the applicable sections below.  The details provided will help to resolve this issue as quickly as possible.
+
+### Prerequisites
+
+Before posting an issue, please:  
+    * Check the [CoolProp User Group](https://goo.gl/Pa7FBT) for common solutions.  
+    * Check that your issue isn't already filed under [CoolProp Issues](https://github.com/CoolProp/CoolProp/issues).  
+    * Check the CoolProp [latest release](http://www.coolprop.org) and [development version](http://www.coolprop.org/dev) documentation.  
+
+### Description
+
+[Description of the issue]
+
+### Steps to Reproduce
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Expected behavior:** [What you expect to happen]
+
+**Actual behavior:** [What actually happens]
+
+### Versions
+
+**CoolProp Version:** [CoolProp version you are using]  
+**Operating System and Version:** [OS you are running CoolProp on]  
+**Access Method:** [How you are accessing CoolProp (i.e. Python, other wrapper, direct C++ calls, etc.)]  
+
+### Additional Information
+
+If possible, please post examples and/or screenshots of the issue.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+### Requirements
+
+* Fill out this template to the extent possible so that this PR can be reviewed in a timely manner.
+* Replace the bracketed text below with your own.
+* All new code requires tests to ensure against regressions.
+
+### Description of the Change
+
+[ *We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the wrapper code being implemented, so please walk us through the concepts.* ]
+
+### Benefits
+
+[ *What benefits will be realized by the code change?* ]
+
+### Possible Drawbacks
+
+[ *What are the possible side-effects or negative impacts of the code change?* ]
+
+### Verification Process
+
+[ *What process did you follow to verify that your change has the desired effects?*
+
+- *How did you verify that all new functionality works as expected?*
+- *How did you verify that all changed functionality works as expected?*
+- *How did you verify that the change has not introduced any regressions?*
+
+*Describe the actions you performed (e.g. text you typed, commands you ran, etc.), and describe the results you observed.*  
+
+*Please attach here any python test sessions or image captures of testing in other wrappers.* ]
+
+### Applicable Issues
+
+[ *Enter any applicable Issues here.  Use ``Closes #????`` if this PR closes an open issue.* ]

--- a/Readme.rst
+++ b/Readme.rst
@@ -22,6 +22,10 @@ It was originally developed by Ian Bell, currently a post-doc at the University 
 
 * If you found a bug or have an issue that requires the developers to become active, please file an issue in our `issue tracker <https://github.com/CoolProp/CoolProp/issues>`_ 
 
+* `Contributions <https://github.com/CoolProp/CoolProp/blob/master/CONTRIBUTING.md>`_ to this project are welcomed and encouraged!  If you wish to `contribute <https://github.com/CoolProp/CoolProp/blob/master/CONTRIBUTING.md>`_ bug fixes, patches, or new features, wrappers, or material properties, please submit a Pull Request with your code.
+
+* If you are new to Git and Github, please see the `CoolProp Wiki <https://github.com/CoolProp/CoolProp/wiki>`_ for guidance on becoming a contributor to the project.
+
 * Accelerate development of things you really need implemented by posting at `Bountysource <https://www.bountysource.com/teams/coolprop>`_ 
 
 * Check Travis CI for build failures |travisbuilds| and have a look at the coverity stats |coveritystatus|


### PR DESCRIPTION
Adding QA docs to get us up to Github recommended standards per discussion with @ibell.  These QA Docs are intended to:
 - encourage contributions to the CoolProp project through README update and CONTRIBUTING guidelines
 - encourage "better" Issues and Pull Requests with needed information through Issue and Pull Request templates
 - encourage a positive community environment

Core developers and contributors alike are encouraged to review these and submit any "tweaks" that are deemed necessary.  Also polished up formatting of FAQs and added a couple of new items that come up with some frequency. 