### PR TITLE
Patch HEOS phase determination when p = p_crit

### DIFF
--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -1498,9 +1498,15 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
         // First try the ancillaries, use them to determine the state if you can
         
         // Calculate dew and bubble temps from the ancillaries (everything needs them)
-        _TLanc = components[0].ancillaries.pL.invert(_p);
-        _TVanc = components[0].ancillaries.pV.invert(_p);
-        
+        if ( (psat_max-_p) < 10*DBL_EPSILON ) {                 // However, if right at the critical pressure...
+            _TLanc = components[0].ancillaries.pL.get_Tmax();   //     Secant method in ancillaries::invert(_p) will fail,
+            _TVanc = components[0].ancillaries.pV.get_Tmax();   //     so just set T to Tmax = Tcrit = "tip" of the curve.
+        }
+        else {                                                  // Otherwise, invert the ancillary with no problems
+            _TLanc = components[0].ancillaries.pL.invert(_p);   //     Find T on liquid saturation line
+            _TVanc = components[0].ancillaries.pV.invert(_p);   //     Find T on vapor saturation line
+        }
+
         bool definitely_two_phase = false;
         
         // Try using the ancillaries for P,H,S if they are there


### PR DESCRIPTION
### Description of the Change

The reverse ancillaries fail for water when determining phase from Pressure and either H, S, or U when the pressure is equal to the critical pressure.  The error is coming from Secant() which only gets called when the Brent() solver fails when called from the ancillaries invert() function.  This occurs because pcrit is at the very edge of the ancillary curve and any values calculated that exceed this limit, even from round off error, will cause an error.  Solution is to check for p = pcrit and set T = Tcrit without calling the ancillary solver.

### Benefits

Prevents errors that occur at any values of H, S, or U when p = pcrit.

```python
from CoolProp import AbstractState
import CoolProp.CoolProp as CP

backend="?"
fluid="water"

state = AbstractState(backend, fluid)

pcrit = CP.PropsSI(fluid, "pcrit")

print("critical point")
state.update(CP.PQ_INPUTS, pcrit, 0)

smass = 4000
print("pcrit, smass={}".format(smass))
state.update(CP.PSmass_INPUTS, pcrit, smass)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "CoolProp/AbstractState.pyx", line 90, in CoolProp.CoolProp.AbstractState.update (CoolProp/CoolProp.cpp:17930)
  File "CoolProp/AbstractState.pyx", line 92, in CoolProp.CoolProp.AbstractState.update (CoolProp/CoolProp.cpp:17822)
ValueError: Residual function in secant returned invalid number
```
Pressures just above and just below (by as small an increment as 1E-9) do not return these errors:
```python
>>> state.update(CP.PSmass_INPUTS, pcrit, smass)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "CoolProp\AbstractState.pyx", line 94, in CoolProp.CoolProp.AbstractState.update
  File "CoolProp\AbstractState.pyx", line 96, in CoolProp.CoolProp.AbstractState.update
ValueError: Residual function in secant returned invalid number
>>> state.update(CP.PSmass_INPUTS, pcrit+0.01, smass)
>>> state.update(CP.PSmass_INPUTS, pcrit-0.01, smass)
```
Same error occurs for all values of smass as long as p = pcrit.  Same error occurs with PUmass_INPUTS and HmassP_INPUTS for all values of U and H respectively when p = pcrit. 

### Possible Drawbacks

Root cause lies in Brent() and Secant() which are failing and should handle an input end-point on the curve.  This PR patches the P_Phase_Determination at p = pcrit for ``other`` inputs of H, S, or U, but does not fix the underlying issue with Secant().

### Verification Process

Patch was tested with above python sample script as well as high level calls in Mathcad.  There are no errors being thrown when update is called at p = pcrit and the expected results are returned.

```python
>>> state.update(CP.PSmass_INPUTS, pcrit, smass)
>>> state.update(CP.PSmass_INPUTS, pcrit+0.01, smass)
>>> state.update(CP.PSmass_INPUTS, pcrit-0.01, smass)
```
State is also updated all values of smass (liquid and vapor) and for PUmass_INPUTS and HmassP_INPUTS as well.  

### Applicable Issues

Closes #1678.
