### PR TITLE
Add a short note to the documentation of Excel wrapper

### DIFF
--- a/Web/coolprop/wrappers/Excel/index.rst
+++ b/Web/coolprop/wrappers/Excel/index.rst
@@ -50,6 +50,11 @@ For a manual installation,
 
 .. [#] If you are having problems with the path to the XLAM in your worksheet appearing as the complete path to the xlam (but not the correct path), you might need to go into ``Data->Update Links`` in Excel, select CoolProp.xlam, and select ``Change Source...`` and select the location of your xlam file.  That should update all the links.
 
+ One possible cause of this problem is the security feature of Windows. You can avoid it by manually giving the permission for ordinary access to the xlam file as follows:
+  1. Right-click the xlam file and open Properties.
+  2. There might be a security message "This file came from another computer and ...".
+  3. Check the **Unblock** checkbox (or button other than Windows 10) and click **Apply** at the bottom.
+  4. After confirming the security message has disappeared, click **OK** to exit from Properties.
     
 Pre-compiled Binaries for OSX
 =============================

--- a/Web/coolprop/wrappers/Excel/index.rst
+++ b/Web/coolprop/wrappers/Excel/index.rst
@@ -51,10 +51,11 @@ For a manual installation,
 .. [#] If you are having problems with the path to the XLAM in your worksheet appearing as the complete path to the xlam (but not the correct path), you might need to go into ``Data->Update Links`` in Excel, select CoolProp.xlam, and select ``Change Source...`` and select the location of your xlam file.  That should update all the links.
 
  One possible cause of this problem is the security feature of Windows. You can avoid it by manually giving the permission for ordinary access to the xlam file as follows:
-  1. Right-click the xlam file and open Properties.
-  2. There might be a security message "This file came from another computer and ...".
-  3. Check the **Unblock** checkbox (or button other than Windows 10) and click **Apply** at the bottom.
-  4. After confirming the security message has disappeared, click **OK** to exit from Properties.
+
+ 1. Right-click the xlam file and open Properties.
+ 2. There might be a security message "This file came from another computer and ...".
+ 3. Check the **Unblock** checkbox (or button other than Windows 10) and click **Apply** at the bottom.
+ 4. After confirming the security message has disappeared, click **OK** to exit from Properties.
     
 Pre-compiled Binaries for OSX
 =============================


### PR DESCRIPTION
### Description of the Change

If the Excel add-in file "CoolProp.xlam" is manually installed, the full path to the xlam file appears in the cells with CoolProp functions after restarting Excel. And the function evaluations of the cells always fail. This problem seems to be due to the Windows security feature which automatically blocks the files downloaded from the internet. This problem is avoided by unblocking the xlam file in the properties window of the file.
 
### Verification Process

I verified the workaround on my Window 10 PC in Japan as a following figure:
![image](https://user-images.githubusercontent.com/26346697/42409489-f1e5d45e-8215-11e8-81b8-2aff27c968a6.png)
This solved the problem perfectly.

### Applicable Issues

``#1180``: already closed, but this is a new workaround.
