### PR TITLE
Add a compile note for gcc debug build

### DIFF
--- a/Web/coolprop/wrappers/StaticLibrary/index.rst
+++ b/Web/coolprop/wrappers/StaticLibrary/index.rst
@@ -83,6 +83,12 @@ You can build the static library using::
         cmake .. -G "Visual Studio 12 2013 Win64" -DCOOLPROP_STATIC_LIBRARY=ON
         
     which is a 64-bit build for Microsoft Visual Studio 2013 (even express version) for instance.  You can get the full list of supported generators on your machine by doing `cmake --help`.
+    
+.. note::
+    
+    If you use gcc with libstdc++ (like on ubuntu) and want to build the debug library, you should add the proper cxx flags to link to the correct debug libstdc++ librariries::
+    
+        cmake .. -DCOOLPROP_DEBUG=ON -DCMAKE_CXX_FLAGS_DEBUG='-g -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC'
 
 Usage
 -----


### PR DESCRIPTION
This change is the result from the user group ?: https://groups.google.com/forum/#!topic/coolprop-users/bI01hf8sQnY

### Requirements

* Fill out this template to the extent possible so that this PR can be reviewed in a timely manner.
* Replace the bracketed text below with your own.
* All new code requires tests to ensure against regressions.

### Description of the Change

Update an index.rst with a note on how to compile coolprops in debug with gcc.

### Benefits

Makes it easier for users to figure out why their debug build is missing symbols with gcc.

### Possible Drawbacks

None.

### Verification Process

Linked a debug library with the build cool props debug, and it worked as expected.

*Describe the actions you performed (e.g. text you typed, commands you ran, etc.), and describe the results you observed.*  

*Please attach here any python test sessions or image captures of testing in other wrappers.* ]

### Applicable Issues

[ *Enter any applicable Issues here.  Use ``Closes #????`` if this PR closes an open issue.* ]