### PR TITLE
Misc. typos

### DIFF
--- a/TTD.txt
+++ b/TTD.txt
@@ -134,7 +134,7 @@ Methane
 NF3:
     MBWR
     
----------------------------------------------------------- CANT BE DONE YET
+---------------------------------------------------------- CAN'T BE DONE YET
 D2
     Deuterium preprint en route at some point
 D2O

--- a/Web/coolprop/Configuration.rst
+++ b/Web/coolprop/Configuration.rst
@@ -8,7 +8,7 @@ At runtime, there are a several configuration variables that can be used to chan
 
 .. warning:: The adjustment of the internal configuration variables might have side effects that you are not expecting, use with caution!!
 
-From C++ and the SWIG wrappers, the values can be directly set/changed by using the type-specified getter/setter functions :cpapi:`get_config_bool`, :cpapi:`set_config_bool`, :cpapi:`get_config_string`, :cpapi:`set_config_string`, etc., as in sonething like:
+From C++ and the SWIG wrappers, the values can be directly set/changed by using the type-specified getter/setter functions :cpapi:`get_config_bool`, :cpapi:`set_config_bool`, :cpapi:`get_config_string`, :cpapi:`set_config_string`, etc., as in something like:
 
 .. ipython::
 

--- a/Web/coolprop/REFPROP.rst
+++ b/Web/coolprop/REFPROP.rst
@@ -150,7 +150,7 @@ If you want to use the GERG-2008 model, you can do this at the beginning of your
     
     In [1]: CP.set_config_bool(CP.REFPROP_USE_GERG, True)
 
-Subsquently, all calculations will be done with the simplified EOS from the GERG-2008 model
+Subsequently, all calculations will be done with the simplified EOS from the GERG-2008 model
 
 And now we set them back to their default values
 

--- a/Web/coolprop/changelog.rst
+++ b/Web/coolprop/changelog.rst
@@ -243,7 +243,7 @@ Issues Closed:
 * `#926 <http://github.com/CoolProp/CoolProp/issues/926>`_ : hydrogen formula is wrong
 * `#925 <http://github.com/CoolProp/CoolProp/issues/925>`_ : Fix HS inputs 
 * `#921 <http://github.com/CoolProp/CoolProp/issues/921>`_ : Tabular calcs with mixtures often return Dew T< Bubble T using PQ input pair
-* `#920 <http://github.com/CoolProp/CoolProp/issues/920>`_ : Cant find temperature at pressure and entropy
+* `#920 <http://github.com/CoolProp/CoolProp/issues/920>`_ : Can't find temperature at pressure and entropy
 * `#917 <http://github.com/CoolProp/CoolProp/issues/917>`_ : Fix errors in docs
 * `#907 <http://github.com/CoolProp/CoolProp/issues/907>`_ : Replace string formatting with C++ format library
 * `#905 <http://github.com/CoolProp/CoolProp/issues/905>`_ : Using conda recipes

--- a/Web/coolprop/wrappers/Android/index.rst
+++ b/Web/coolprop/wrappers/Android/index.rst
@@ -34,28 +34,28 @@ Linux & OSX
 
 * Install NDK from here: https://developer.android.com/ndk/downloads/index.html
 
-* To Build 
+* To Build
     - Check out the sources for CoolProp::
-    
+
         git clone https://github.com/CoolProp/CoolProp --recursive
-        
+
     - Open the CMakeLists.txt file in the CoolProp directory for editing
     - Within the COOLPROP_ANDROID_MODULE modify the command:  ``set(ANDROID_PACKAGE_NAME "CoolProp")`` to reflect your package name
     - Make and move into a build folder::
-    
+
         mkdir -p CoolProp/build && cd CoolProp/build
-        
+
     - If a target architecture other than the default (armeabi) is desired, the ndk-build can be modified by editing wrappers/Android/Android.mk.template.  For details see https://developer.android.com/ndk/guides/index.html
     - Construct the makefile using CMake::
-    
+
         cmake .. -DCOOLPROP_ANDROID_MODULE=ON -DNDK_PATH=~/Downloads/android-ndk-r10e (change path based on your installation)
-        
+
     - Now actually do the build::
-    
+
         cmake --build .
 
 * To Incorporate into an Android Studio Project
-    - Copy the java files from the package directory (i.e build/com/example/myprogram) to the pacakge directory of the android proejct
+    - Copy the java files from the package directory (i.e build/com/example/myprogram) to the package directory of the android project
     - Copy the the build/libs/armeabi folder containing the .so file to the app/src/main/jniLibs folder of the Android Project (you may have create the jniLibs folder).
     - In the main activity of the Android Project add the code below so the CoolProp functions can be called as described in the java wrapper documentation::
 
@@ -69,7 +69,7 @@ Example Code
 
 * mainactivity.java
 
-.. code:: java 
+.. code:: java
 
     package com.example.coolprop.androidexample;
 
@@ -81,46 +81,46 @@ Example Code
 
 
     public class MainActivity extends ActionBarActivity {
-    
+
         static {
             System.loadLibrary("CoolProp");
         }
-    
+
         @Override
         protected void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
             setContentView(R.layout.activity_main);
-    
+
             TextView CoolPropsDisplay = (TextView) findViewById(R.id.CoolPropsDisplay);
             CoolPropsDisplay.setText(Double.toString(CoolProp.PropsSI("T", "P", 101300, "Q", 0, "Water")));
         }
-    
+
         @Override
         public boolean onCreateOptionsMenu(Menu menu) {
             // Inflate the menu; this adds items to the action bar if it is present.
             getMenuInflater().inflate(R.menu.menu_main, menu);
             return true;
         }
-    
+
         @Override
         public boolean onOptionsItemSelected(MenuItem item) {
             // Handle action bar item clicks here. The action bar will
             // automatically handle clicks on the Home/Up button, so long
             // as you specify a parent activity in AndroidManifest.xml.
             int id = item.getItemId();
-    
+
             //noinspection SimplifiableIfStatement
             if (id == R.id.action_settings) {
                 return true;
             }
-    
+
             return super.onOptionsItemSelected(item);
         }
     }
 
 * activity_main.xml
 
-.. code:: xml 
+.. code:: xml
 
     <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
@@ -128,12 +128,12 @@ Example Code
         android:paddingRight="@dimen/activity_horizontal_margin"
         android:paddingTop="@dimen/activity_vertical_margin"
         android:paddingBottom="@dimen/activity_vertical_margin" tools:context=".MainActivity">
-    
+
         <LinearLayout
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
             android:orientation="vertical">
-    
+
             <TextView
                 android:layout_width="fill_parent"
                 android:layout_height="fill_parent"
@@ -142,7 +142,7 @@ Example Code
                 android:id="@+id/CoolPropsDisplay"
                 android:layout_weight="1"
                 android:textAlignment="gravity" />
-    
+
         </LinearLayout>
-    
+
     </RelativeLayout>

--- a/Web/coolprop/wrappers/Excel/index.rst
+++ b/Web/coolprop/wrappers/Excel/index.rst
@@ -44,7 +44,7 @@ For a manual installation,
      - Go to **File | Options** on the main menu and select Cusomize Ribbon
      - Make sure that the Developer main tab is checked (ON)
      
-  5. Open the Visual Basic editor and use **Edit | Replace** to replace all occurances of **CoolProp_stdcall.dll** with the full path to the alternate location for your DLL files, making sure to press the save button (disk image) or **File | Save** before exiting the VBA editor.
+  5. Open the Visual Basic editor and use **Edit | Replace** to replace all occurrences of **CoolProp_stdcall.dll** with the full path to the alternate location for your DLL files, making sure to press the save button (disk image) or **File | Save** before exiting the VBA editor.
   6. Save the CoolProp.xlam file.
 
 

--- a/Web/coolprop/wrappers/FORTRAN/index.rst
+++ b/Web/coolprop/wrappers/FORTRAN/index.rst
@@ -150,7 +150,7 @@ On OSX, you must do the linking stage with true gcc so that it finds the right s
 
 .. warning::
 
-    You MUST(!!!) put the -lstdc++ standard libary *after* libCoolProp.a.  Same thing if you compile the fortran to object file, static library must always be at the end.
+    You MUST(!!!) put the -lstdc++ standard library *after* libCoolProp.a.  Same thing if you compile the fortran to object file, static library must always be at the end.
 
 .. _FORTRAN77:
 

--- a/Web/coolprop/wrappers/Javascript/index.rst
+++ b/Web/coolprop/wrappers/Javascript/index.rst
@@ -12,7 +12,7 @@ Pre-Compiled Binaries
 
 * You can load your js file into your website, following the structure of `the example here <https://github.com/CoolProp/CoolProp/blob/master/Web/coolprop/wrappers/Javascript/index.html>`_, which is also included at the above download. 
 
-* Alternatively, you can link to our server directly to make sure that you always have the latest version of CoolProp. To do so, include the address ``<script src="http://www.coolprop.sourceforge.net/jscript/coolprop.js"></script>`` in your HTML header instad of the relative path ``<script src="coolprop.js"></script>``.
+* Alternatively, you can link to our server directly to make sure that you always have the latest version of CoolProp. To do so, include the address ``<script src="http://www.coolprop.sourceforge.net/jscript/coolprop.js"></script>`` in your HTML header instead of the relative path ``<script src="coolprop.js"></script>``.
 
 * A live demo of the Javascript library in action can also be found `online <http://www.coolprop.sourceforge.net/jscript/index.html>`_.
 

--- a/Web/coolprop/wrappers/LibreOffice/index.rst
+++ b/Web/coolprop/wrappers/LibreOffice/index.rst
@@ -24,7 +24,7 @@ Linux using python
 
     # Install python script provider (uses python 3)
     sudo apt-get install libreoffice-script-provider-python
-    # pyton scripting in LibreOffice uses python3, make sure we populate the right python site-packages folder
+    # python scripting in LibreOffice uses python3, make sure we populate the right python site-packages folder
     sudo apt-get install python3-pip
     sudo pip3 install Cython
     # Compile CoolProp v5+ manually

--- a/Web/coolprop/wrappers/MATLAB/LowLevelHighLevelMATLAB.m
+++ b/Web/coolprop/wrappers/MATLAB/LowLevelHighLevelMATLAB.m
@@ -68,7 +68,7 @@ outputs=zeros(5,1);
 [outputs(4,1), so4] = calllib('coolprop','get_param_index','Hmolar');
 [outputs(5,1), so5] = calllib('coolprop','get_param_index','Smolar');
 
-%Creating ouput pointers
+%Creating output pointers
 out1Ptr = libpointer('doublePtr',zeros(length,1));
 out2Ptr = libpointer('doublePtr',zeros(length,1));
 out3Ptr = libpointer('doublePtr',zeros(length,1));

--- a/Web/coolprop/wrappers/MATLAB/index.rst
+++ b/Web/coolprop/wrappers/MATLAB/index.rst
@@ -136,7 +136,7 @@ Once the dependencies are installed, you can run the builder and tests using::
     # Build the makefile using CMake with the path hacked to use our swig
     PATH=swig-matlab-bin/bin:%{PATH} cmake .. -DCOOLPROP_MATLAB_MODULE=ON -DSWIG_DIR=swig-matlab-bin/bin
     # Make the MEX files (by default files will be generated in folder install_root/MATLAB relative to CMakeLists.txt file)
-    # Setting the SWIG_LIB explictly is dangerous, but for now it doesn't seem there is a better solution
+    # Setting the SWIG_LIB explicitly is dangerous, but for now it doesn't seem there is a better solution
     SWIG_LIB=swig-matlab-bin/share/swig/3.0.3 make install
 
 Windows (32-bit and 64-bit)
@@ -157,7 +157,7 @@ You need to just slightly modify the building procedure::
     # Build the makefile using CMake with the path hacked to use our swig
     set "PATH=swig-matlab-bin\bin:%{PATH}" && cmake .. -DCOOLPROP_MATLAB_MODULE=ON -DSWIG_DIR=swig-matlab-bin\bin
     # Make the MEX files (by default files will be generated in folder install_root/MATLAB relative to CMakeLists.txt file)
-    # Setting the SWIG_LIB explictly is dangerous, but for now it doesn't seem there is a better solution
+    # Setting the SWIG_LIB explicitly is dangerous, but for now it doesn't seem there is a better solution
     set "SWIG_LIB=swig-matlab-bin\share\swig\3.0.3" && make install
     
 Example Code

--- a/Web/coolprop/wrappers/Octave/index.rst
+++ b/Web/coolprop/wrappers/Octave/index.rst
@@ -15,7 +15,7 @@ On Linux systems you can put the generated .oct file in
 privileges to do this.
 
 If you place .oct file somewhere outside octave path, you have to use
-"addpath" function at begining of your code.
+"addpath" function at beginning of your code.
 
 Example: adding the folder that contains CoolProp.oct file to the Octave path::
 

--- a/Web/coolprop/wrappers/SMath/index.rst
+++ b/Web/coolprop/wrappers/SMath/index.rst
@@ -62,7 +62,7 @@ http://en.smath.info/forum/yaf_postst2568_CoolProp.aspx#post13310
 
 Notes :
 - In October 2014 SMath Studio with CoolProp worked on Windows only. 
-- The portable SMath Studio distribution is provided on the SMath Studio site, however so far it's indicated as inofficial (October 2014) 
+- The portable SMath Studio distribution is provided on the SMath Studio site, however so far it's indicated as unofficial (October 2014) 
 
 More information on SMath Studio is given under :
 http://en.wikipedia.org/wiki/SMath_Studio

--- a/Web/develop/buildbot.rst
+++ b/Web/develop/buildbot.rst
@@ -355,7 +355,7 @@ your computer. For Debian/Ubuntu, we recommend a script like::
 Which then can be added to the scheduler with ``update-rc.d buildworker defaults``.
 This should gracefully terminate the bot at shutdown and restart it again after reboot.
 To disable the service, run ``update-rc.d -f buildworker remove``. You can enable and
-disable the daemon by runnning ``update-rc.d buildworker enable|disable``.
+disable the daemon by running ``update-rc.d buildworker enable|disable``.
 
 If you run a distribution that uses systemd, like CentOS, you might find the
 following unit file helpful, which can be placed in ``/etc/systemd/system/coolpropworker.service``
@@ -475,7 +475,7 @@ Starting VirtualBox images at boot
 ==================================
 
 You can use the built-in functionality https://www.virtualbox.org/manual/ch09.html#autostart on Linux and Mac or use
-your own configuration and create a daemon entry in Libray/LaunchDaemons.  Make sure you use full paths to VBoxManage::
+your own configuration and create a daemon entry in Library/LaunchDaemons.  Make sure you use full paths to VBoxManage::
 
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -549,7 +549,7 @@ build system:
     docker run -d --env-file ./Dockerfile64.worker.env.list --name=CoolProp64-worker coolprop/workerpython 
     docker run -d --env-file ./Dockerfile32.worker.env.list --name=CoolProp32-worker coolprop/workerpython32
     
-  The above commands launch background processes using the docker containes for the Python buildworkers in 
+  The above commands launch background processes using the docker contains for the Python buildworkers in 
   64bit and 32bit, respectively. 
 
 * Some steps require the upload of files to different servers. In such cases, you 

--- a/Web/develop/documentation.rst
+++ b/Web/develop/documentation.rst
@@ -198,7 +198,7 @@ There are a number of setup scripts that have to be run to generate dynamic cont
    
 **Build the Documentation**
 
-There is a Makefile that will build the entire site.  This can take a while, especially the first time.  Open a Windows command prompt, activate your virtural environment, cd to the *CoolProp\\Web* directory and type::
+There is a Makefile that will build the entire site.  This can take a while, especially the first time.  Open a Windows command prompt, activate your virtual environment, cd to the *CoolProp\\Web* directory and type::
 
     make html
 

--- a/Web/fluid_properties/Mixtures.rst
+++ b/Web/fluid_properties/Mixtures.rst
@@ -65,7 +65,7 @@ If you have your own interaction parameters that you would like to use, you can 
 
     In [1]: CAS_Xe = CP.get_fluid_param_string('Xenon','CAS')
 
-    @supress
+    @suppress
     In [1]: CP.set_config_bool(CP.OVERWRITE_BINARY_INTERACTION, True)
 
     # This adds a dummy entry in the library of interaction parameters if the mixture is not already there

--- a/Web/scripts/CPWeb/UnicodeTools.py
+++ b/Web/scripts/CPWeb/UnicodeTools.py
@@ -59,7 +59,7 @@ class UnicodeWriter:
         # Fetch UTF-8 output from the queue ...
         data = self.queue.getvalue()
         data = data.decode("utf-8")
-        # ... and reencode it into the target encoding
+        # ... and re-encode it into the target encoding
         data = self.encoder.encode(data)
         # write to the target stream
         self.stream.write(data)

--- a/dev/TTSE/TimeComp.py
+++ b/dev/TTSE/TimeComp.py
@@ -32,7 +32,7 @@ def range_brace(x_min, x_max, mid=0.5,
     ax.plot(x, y,'-')
     ax.plot(y, x,'-')
     """
-    # determine x0 adaptively values using second derivitive
+    # determine x0 adaptively values using second derivative
     # could be replaced with less snazzy:
     #   x0 = NP.arange(0, 0.5, .001)
     x0 = np.array(())

--- a/dev/cmake/Modules/FindOctave.cmake
+++ b/dev/cmake/Modules/FindOctave.cmake
@@ -6,7 +6,7 @@
 # OCTAVE_CXXFLAGS - extra flags
 # OCTAVE_INCLUDE_DIRS - include directories
 # OCTAVE_LINK_DIRS - link directories
-# OCTAVE_LIBRARY_RELEASE - the relase version
+# OCTAVE_LIBRARY_RELEASE - the release version
 # OCTAVE_LIBRARY_DEBUG - the debug version
 # OCTAVE_LIBRARY - a default library, with priority debug.
 

--- a/dev/cmake/Modules/FindR.cmake
+++ b/dev/cmake/Modules/FindR.cmake
@@ -23,7 +23,7 @@ find_program(R_EXEC
              NO_CMAKE_PATH
              )
 MESSAGE(STATUS "R_EXEC= ${R_EXEC}")
-# Parse the output of the R path commmand, removing whitespace
+# Parse the output of the R path command, removing whitespace
 FUNCTION(chomp arg1 arg2)
     string(REPLACE "\n" ";" arg1list ${arg1})
     list(GET arg1list 1 arg1line)

--- a/dev/genetic.py
+++ b/dev/genetic.py
@@ -127,7 +127,7 @@ class GeneticAncillaryFitter(object):
 
     def generate_random_chromosomes(self,):
         '''
-        Create a list of random chromosomes to seed our alogrithm.
+        Create a list of random chromosomes to seed our algorithm.
         '''
         chromos = []
         while len(chromos) < self.num_samples:

--- a/dev/incompressible_liquids/CPIncomp/DataObjects.py
+++ b/dev/incompressible_liquids/CPIncomp/DataObjects.py
@@ -308,7 +308,7 @@ class DigitalData(SolutionData):
     def getArray(self, dataID=None, func=None, x_in=None, y_in=None, DEBUG=False):
         """ Tries to read a data file, overwrites it if x or y do not match
 
-        :param dataID  : ID to contruct the path to the data file
+        :param dataID  : ID to construct the path to the data file
         :param func    : Callable object that can take x_in and y_in
         :param x_in    : a 1D array in x direction or 2D with one column, most likely temperature
         :param y_in    : a 1D array in y direction or 2D with one row, most likely cocentration
@@ -401,7 +401,7 @@ class CoefficientData(SolutionData):
 
     def convertSecCoolArray(self, array):
         if len(array)!=18:
-            raise ValueError("The lenght is not equal to 18!")
+            raise ValueError("The length is not equal to 18!")
 
         self.reference = "SecCool software"
         array = np.array(array)
@@ -455,7 +455,7 @@ class CoefficientData(SolutionData):
         That is why the implementation is in a transposed form..."""
 
         if len(array)!=18:
-            raise ValueError("The lenght is not equal to 18!")
+            raise ValueError("The length is not equal to 18!")
 
         #self.reference = "Melinder Book"
         array = np.array(array)
@@ -496,9 +496,9 @@ class CoefficientData(SolutionData):
         from the very first CoolProp implementation
         based on the book by Melinder"""
         if len(array)!=18:
-            raise ValueError("The lenght is not equal to 18!")
+            raise ValueError("The length is not equal to 18!")
         if len(array[0])!=5:
-            raise ValueError("The lenght is not equal to 5!")
+            raise ValueError("The length is not equal to 5!")
         array = np.array(array)
         tmp = np.zeros((18,5))
 

--- a/dev/incompressible_liquids/CPIncomp/WriterObjects.py
+++ b/dev/incompressible_liquids/CPIncomp/WriterObjects.py
@@ -74,7 +74,7 @@ class UnicodeWriter:
         # Fetch UTF-8 output from the queue ...
         data = self.queue.getvalue()
         data = data.decode("utf-8")
-        # ... and reencode it into the target encoding
+        # ... and re-encode it into the target encoding
         data = self.encoder.encode(data)
         # write to the target stream
         self.stream.write(data)

--- a/dev/incompressible_liquids/CPIncomp/__init__.py
+++ b/dev/incompressible_liquids/CPIncomp/__init__.py
@@ -83,7 +83,7 @@ def getDigitalFluids():
     fluid data can be accessed from python in the
     form of another library.
     c) There are data files that contain the experimental
-    data. The fit has to be done after laoding the fluids.
+    data. The fit has to be done after loading the fluids.
     """
     classes = []
     ignList = getIgnoreNames()

--- a/dev/incompressible_liquids/DEPRECATED_fit_incompressible.py
+++ b/dev/incompressible_liquids/DEPRECATED_fit_incompressible.py
@@ -170,7 +170,7 @@ class IncompLiquidFit(object):
     def _PropsFit(self,coefficients,inVal,T=0):
         """
         Calculates a property from a given set of
-        coefficents for a certain temperature. Is used
+        coefficients for a certain temperature. Is used
         to obtain data to feed to the optimisation
         procedures.
         """

--- a/dev/scripts/git-archive-all
+++ b/dev/scripts/git-archive-all
@@ -320,7 +320,7 @@ class GitArchiver(object):
             raise ValueError("repo_abspath MUST be absolute path.")
 
         if not path.isabs(abspath):
-            raise ValueError("abspath MUST be absoulte path.")
+            raise ValueError("abspath MUST be absolute path.")
 
         if not path.commonprefix([repo_abspath, abspath]):
             raise ValueError("abspath (\"{0}\") MUST have common prefix with repo_abspath (\"{1}\")".format(abspath, repo_abspath))

--- a/dev/scripts/gitMirror.bsh
+++ b/dev/scripts/gitMirror.bsh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# This script relys on a modified ~/.ssh/config to specify the
+# This script relies on a modified ~/.ssh/config to specify the
 # correct identity files to be used with the host aliases
 # git.code.sf.net-ibell, git.code.sf.net-jorritw and 
 # github.com-jowr.

--- a/doc/notebooks/Maxwell_Loop.ipynb
+++ b/doc/notebooks/Maxwell_Loop.ipynb
@@ -329,7 +329,7 @@
       "# for plotting, we will use volume (d_min is high v, d_max is low v)\n",
       "vs = 1/rhos\n",
       "\n",
-      "# calcualte Helmholtz energy and pressure for that density range, at T_iso\n",
+      "# calculate Helmholtz energy and pressure for that density range, at T_iso\n",
       "fs = np.ones(nPoints)\n",
       "ps = np.ones(nPoints)\n",
       "fms = np.ones(nPoints)\n",

--- a/doc/notebooks/Saturation.ipynb
+++ b/doc/notebooks/Saturation.ipynb
@@ -276,7 +276,7 @@
       "  = \\frac{\\frac{d^2s}{dT^2}\\frac{dh}{dT}-\\frac{ds}{dT}\\frac{d^2h}{dT^2}}{\\left(\\frac{dh}{dT}\\right)^3}\n",
       "\\end{equation}\n",
       "\n",
-      "### Eigth example: $d^2s/(dh dp)$  \n",
+      "### Eighth example: $d^2s/(dh dp)$  \n",
       "First:\n",
       "\\begin{equation}\n",
       "  N = \\frac{ds}{dh} = \\frac{{ds}/{dT}}{{dh}/{dT}}\n",

--- a/include/AbstractState.h
+++ b/include/AbstractState.h
@@ -1149,7 +1149,7 @@ public:
 };
 
 /** Register a backend in the backend library (statically defined in AbstractState.cpp and not
- *  publically accessible)
+ *  publicly accessible)
  */
 void register_backend(const backend_families &bf, shared_ptr<AbstractStateGenerator> gen);
     

--- a/include/Ancillaries.h
+++ b/include/Ancillaries.h
@@ -90,7 +90,7 @@ private:
         struct{                    // For TYPE_NOT_EXPONENTIAL & TYPE_EXPONENTIAL
             bool using_tau_r; ///< Whether the term \f$ \frac{T_c}{T} \f$ is included in the 
             CoolPropDbl reducing_value, ///< The value used to reduce the output variable
-                        T_r; ///< The temperature in K used to reduce the temperature (ususally the critical temperature)
+                        T_r; ///< The temperature in K used to reduce the temperature (usually the critical temperature)
             std::size_t N; ///< The number of values in the arrays
         };
     };

--- a/include/Helmholtz.h
+++ b/include/Helmholtz.h
@@ -71,7 +71,7 @@ struct HelmholtzDerivatives
         return _new;
     }
     HelmholtzDerivatives(){reset(0.0);};
-    /// Retrive a single value based on the number of derivatives with respect to tau and delta
+    /// Retrieve a single value based on the number of derivatives with respect to tau and delta
     double get(std::size_t itau, std::size_t idelta){
         if (itau == 0){
             if (idelta == 0){ return alphar; }

--- a/include/miniz.h
+++ b/include/miniz.h
@@ -9,7 +9,7 @@
    * Change History
      10/13/13 v1.15 r4 - Interim bugfix release while I work on the next major release with Zip64 support (almost there!):
        - Critical fix for the MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY bug (thanks kahmyong.moon@hp.com) which could cause locate files to not find files. This bug
-        would only have occured in earlier versions if you explicitly used this flag, OR if you used mz_zip_extract_archive_file_to_heap() or mz_zip_add_mem_to_archive_file_in_place()
+        would only have occurred in earlier versions if you explicitly used this flag, OR if you used mz_zip_extract_archive_file_to_heap() or mz_zip_add_mem_to_archive_file_in_place()
         (which used this flag). If you can't switch to v1.15 but want to fix this bug, just remove the uses of this flag from both helper funcs (and of course don't use the flag).
        - Bugfix in mz_zip_reader_extract_to_mem_no_alloc() from kymoon when pUser_read_buf is not NULL and compressed size is > uncompressed size
        - Fixing mz_zip_reader_extract_*() funcs so they don't try to extract compressed data from directory entries, to account for weird zipfiles which contain zero-size compressed data on dir entries.
@@ -3123,7 +3123,7 @@ static MZ_FORCEINLINE mz_bool mz_zip_reader_filename_less(const mz_zip_array *pC
 
 #define MZ_SWAP_UINT32(a, b) do { mz_uint32 t = a; a = b; b = t; } MZ_MACRO_END
 
-// Heap sort of lowercased filenames, used to help accelerate plain central directory searches by mz_zip_reader_locate_file(). (Could also use qsort(), but it could allocate memory.)
+// Heap sort of lowercase filenames, used to help accelerate plain central directory searches by mz_zip_reader_locate_file(). (Could also use qsort(), but it could allocate memory.)
 static void mz_zip_reader_sort_central_dir_offsets_by_filename(mz_zip_archive *pZip)
 {
   mz_zip_internal_state *pState = pZip->m_pState;

--- a/src/Backends/Cubics/CubicBackend.h
+++ b/src/Backends/Cubics/CubicBackend.h
@@ -26,7 +26,7 @@ by Ian H. Bell and Andreas Jaeger, J. Res. NIST, 2016
 
 namespace CoolProp {
 
-// Forward declaration for use in initalization of AbstractCubicBackend
+// Forward declaration for use in initialization of AbstractCubicBackend
 class CubicResidualHelmholtz;
 
 class AbstractCubicBackend : public HelmholtzEOSMixtureBackend  {

--- a/src/Backends/Cubics/GeneralizedCubic.cpp
+++ b/src/Backends/Cubics/GeneralizedCubic.cpp
@@ -694,19 +694,19 @@ double AbstractCubic::d3_alphar_dxidxjdxk(double tau, double delta, const std::v
 
 double SRK::a0_ii(std::size_t i)
 {
-    // Values from Soave, 1972 (Equilibium constants from a ..)
+    // Values from Soave, 1972 (Equilibrium constants from a ..)
     double a = 0.42747*R_u*R_u*Tc[i]*Tc[i]/pc[i];
     return a;
 }
 double SRK::b0_ii(std::size_t i)
 {
-    // Values from Soave, 1972 (Equilibium constants from a ..)
+    // Values from Soave, 1972 (Equilibrium constants from a ..)
     double b = 0.08664*R_u*Tc[i]/pc[i];
     return b;
 }
 double SRK::m_ii(std::size_t i)
 {
-    // Values from Soave, 1972 (Equilibium constants from a ..)
+    // Values from Soave, 1972 (Equilibrium constants from a ..)
     double omega = acentric[i];
     double m = 0.480 + 1.574*omega - 0.176*omega*omega;
     return m;

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -399,7 +399,7 @@ void FlashRoutines::QT_flash(HelmholtzEOSMixtureBackend &HEOS)
         }
         else if (!(HEOS.components[0].EOS().pseudo_pure))
         {
-            // Set some imput options
+            // Set some input options
             SaturationSolvers::saturation_T_pure_Akasaka_options options(false);
 
             // Actually call the solver
@@ -582,7 +582,7 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend &HEOS)
             // It is a pure fluid
             // ------------------
 
-            // Set some imput options
+            // Set some input options
             SaturationSolvers::saturation_PHSU_pure_options options;
             // Specified variable is pressure
             options.specified_variable = SaturationSolvers::saturation_PHSU_pure_options::IMPOSED_PL;
@@ -629,7 +629,7 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend &HEOS)
         }
         else{
 			
-			// Set some imput options
+			// Set some input options
 			SaturationSolvers::mixture_VLE_IO io;
 			io.sstype = SaturationSolvers::imposed_p;
 			io.Nstep_max = 10;

--- a/src/Backends/Helmholtz/MixtureParameters.cpp
+++ b/src/Backends/Helmholtz/MixtureParameters.cpp
@@ -571,7 +571,7 @@ void MixtureParameters::set_mixture_parameters(HelmholtzEOSMixtureBackend &HEOS)
             CAS[1] = components[j].CAS;
             std::sort(CAS.begin(), CAS.end());
 
-            // The variable swapped is true if a swap occured.
+            // The variable swapped is true if a swap occurred.
             bool swapped = (CAS1.compare(CAS[0]) != 0);
 
             // ***************************************************

--- a/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
+++ b/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
@@ -111,7 +111,7 @@ void PhaseEnvelopeRoutines::build(HelmholtzEOSMixtureBackend &HEOS, const std::s
 //        };
     
         std::size_t failure_count = 0;
-        // Set some imput options
+        // Set some input options
         SaturationSolvers::mixture_VLE_IO io;
         io.sstype = SaturationSolvers::imposed_p;
         io.Nstep_max = 20;

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -716,7 +716,7 @@ void SaturationSolvers::saturation_D_pure(HelmholtzEOSMixtureBackend &HEOS, Cool
 }
 void SaturationSolvers::saturation_T_pure(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl T, saturation_T_pure_options &options)
 {
-    // Set some imput options
+    // Set some input options
     SaturationSolvers::saturation_T_pure_Akasaka_options _options(false);
     _options.omega = 1.0;
     try{

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -1936,7 +1936,7 @@ CoolPropDbl REFPROPMixtureBackend::call_phi0dll(long itau, long idel)
     double val = 0, tau = _tau, __T = T(), __rho = rhomolar()/1000;
     if (PHI0dll == NULL){throw ValueError("PHI0dll function is not available in your version of REFPROP. Please upgrade");}
     PHI0dll(&itau, &idel, &__T, &__rho, &(mole_fractions[0]), &val);
-    return static_cast<CoolPropDbl>(val)/pow(tau,itau); // Not multplied by delta^idel
+    return static_cast<CoolPropDbl>(val)/pow(tau,itau); // Not multiplied by delta^idel
 }
 /// Calculate excess properties
 void REFPROPMixtureBackend::calc_excess_properties(){

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.h
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.h
@@ -43,7 +43,7 @@ public:
     /// @param fluid_names The vector of strings of the fluid components, without file ending
     REFPROPMixtureBackend(const std::vector<std::string>& fluid_names) {construct(fluid_names);};
     
-    /// A function to actually do the initalization to allow it to be called in derived classes
+    /// A function to actually do the initialization to allow it to be called in derived classes
     void construct(const std::vector<std::string>& fluid_names);
     
     std::string backend_name(void) { return get_backend_string(REFPROP_BACKEND_MIX); }

--- a/src/Backends/Tabular/TTSEBackend.cpp
+++ b/src/Backends/Tabular/TTSEBackend.cpp
@@ -54,7 +54,7 @@ void CoolProp::TTSEBackend::invert_single_phase_x(const SinglePhaseGriddedTableD
     double deltax1 = (-b + sqrt(b*b - 4*a*c))/(2*a);
     double deltax2 = (-b - sqrt(b*b - 4*a*c))/(2*a);
 
-    // If only one is less than a multiple of x spacing, thats your solution
+    // If only one is less than a multiple of x spacing, that's your solution
     double xspacing, xratio, val;
     if (!table.logx){
         xspacing = table.xvec[1] - table.xvec[0];
@@ -112,7 +112,7 @@ void CoolProp::TTSEBackend::invert_single_phase_y(const SinglePhaseGriddedTableD
     double deltay1 = (-b + sqrt(b*b - 4*a*c))/(2*a);
     double deltay2 = (-b - sqrt(b*b - 4*a*c))/(2*a);
 
-    // If only one is less than a multiple of x spacing, thats your solution
+    // If only one is less than a multiple of x spacing, that's your solution
     double yspacing, yratio, val;
     if (!table.logy){
         yspacing = table.yvec[1] - table.yvec[0];

--- a/src/Backends/Tabular/TabularBackends.cpp
+++ b/src/Backends/Tabular/TabularBackends.cpp
@@ -840,7 +840,7 @@ void CoolProp::TabularBackend::update(CoolProp::input_pairs input_pair, double v
     mass_to_molar_inputs(input_pair, ld_value1, ld_value2);
     val1 = ld_value1; val2 = ld_value2;
 
-    // Check the tables, build if neccessary
+    // Check the tables, build if necessary
     check_tables();
 
     // Flush the cached indices (set to large number)

--- a/src/DataStructures.cpp
+++ b/src/DataStructures.cpp
@@ -636,7 +636,7 @@ std::string get_backend_string(backends backend) {
 #ifdef ENABLE_CATCH
 #include "catch.hpp"
 
-TEST_CASE("Check that all parameters are descibed","")
+TEST_CASE("Check that all parameters are described","")
 {
     for (int i = 1; i < CoolProp::iundefined_parameter; ++i){
         std::ostringstream ss;
@@ -653,7 +653,7 @@ TEST_CASE("Check that all parameters are descibed","")
     }
 }
 
-TEST_CASE("Check that all phases are descibed","[phase_index]")
+TEST_CASE("Check that all phases are described","[phase_index]")
 {
     for (int i = 0; i < CoolProp::iphase_not_imposed; ++i){
         std::ostringstream ss;

--- a/src/Solvers.cpp
+++ b/src/Solvers.cpp
@@ -106,7 +106,7 @@ std::vector<double> NDNewtonRaphson_Jacobian(FuncWrapperND *f, const std::vector
 In the newton function, a 1-D Newton-Raphson solver is implemented using exact solutions.  An initial guess for the solution is provided.
 
 @param f A pointer to an instance of the FuncWrapper1D class that implements the call() function
-@param x0 The inital guess for the solution
+@param x0 The initial guess for the solution
 @param ftol The absolute value of the tolerance accepted for the objective function
 @param maxiter Maximum number of iterations
 @returns If no errors are found, the solution, otherwise the value _HUGE, the value for infinity
@@ -151,7 +151,7 @@ x_{n+1} = x_n - \frac {2 f(x_n) f'(x_n)} {2 {[f'(x_n)]}^2 - f(x_n) f''(x_n)}
 http://en.wikipedia.org/wiki/Halley%27s_method
 
 @param f A pointer to an instance of the FuncWrapper1DWithTwoDerivs class that implements the call() and two derivatives
-@param x0 The inital guess for the solution
+@param x0 The initial guess for the solution
 @param ftol The absolute value of the tolerance accepted for the objective function
 @param maxiter Maximum number of iterations
 @param xtol_rel The minimum allowable (relative) step size
@@ -213,7 +213,7 @@ double Halley(FuncWrapper1DWithTwoDerivs* f, double x0, double ftol, int maxiter
 http://numbers.computation.free.fr/Constants/Algorithms/newton.ps
  
  @param f A pointer to an instance of the FuncWrapper1DWithThreeDerivs class that implements the call() and three derivatives
- @param x0 The inital guess for the solution
+ @param x0 The initial guess for the solution
  @param ftol The absolute value of the tolerance accepted for the objective function
  @param maxiter Maximum number of iterations
  @param xtol_rel The minimum allowable (relative) step size
@@ -276,7 +276,7 @@ double Householder4(FuncWrapper1DWithThreeDerivs* f, double x0, double ftol, int
 In the secant function, a 1-D Newton-Raphson solver is implemented.  An initial guess for the solution is provided.
 
 @param f A pointer to an instance of the FuncWrapper1D class that implements the call() function
-@param x0 The inital guess for the solutionh
+@param x0 The initial guess for the solutionh
 @param dx The initial amount that is added to x in order to build the numerical derivative
 @param tol The absolute value of the tolerance accepted for the objective function
 @param maxiter Maximum number of iterations
@@ -348,7 +348,7 @@ double Secant(FuncWrapper1D* f, double x0, double dx, double tol, int maxiter)
 In the secant function, a 1-D Newton-Raphson solver is implemented.  An initial guess for the solution is provided.
 
 @param f A pointer to an instance of the FuncWrapper1D class that implements the call() function
-@param x0 The inital guess for the solution
+@param x0 The initial guess for the solution
 @param xmax The upper bound for the solution
 @param xmin The lower bound for the solution
 @param dx The initial amount that is added to x in order to build the numerical derivative
@@ -408,7 +408,7 @@ at least one solution in the interval [a,b].
 @param b The maximum bound for the solution of f=0
 @param macheps The machine precision
 @param t Tolerance (absolute)
-@param maxiter Maximum numer of steps allowed.  Will throw a SolutionError if the solution cannot be found
+@param maxiter Maximum number of steps allowed.  Will throw a SolutionError if the solution cannot be found
 */
 double Brent(FuncWrapper1D* f, double a, double b, double macheps, double t, int maxiter)
 {

--- a/wrappers/Delphi/Readme.rst
+++ b/wrappers/Delphi/Readme.rst
@@ -45,7 +45,7 @@ isentropic lines.  If anyone has the urge to add these I would like to get
 an update.
 
 
-Just to hilight some of the other features, I have added a few simpler command line
+Just to highlight some of the other features, I have added a few simpler command line
 versions.
 
 

--- a/wrappers/EES/main.cpp
+++ b/wrappers/EES/main.cpp
@@ -4,9 +4,9 @@
 //                                  -------------------------                                 //
 //                                                                                            //
 //  This dll is an interface between EES and CoolProp.                                        //
-//  In EES, external functions need to be implemented in dynamic librairies.  The first       //
+//  In EES, external functions need to be implemented in dynamic libraries.  The first       //
 //  argument sent by EES is a 256 characters char variable. The second argument is pointer    //
-//  structure conaining "double" values.  The third argument is a linked list for the         //
+//  structure containing "double" values.  The third argument is a linked list for the         //
 //  input data                                                                                //
 //                                                                                            //
 //  The arguments are defined as follows :                                                    //

--- a/wrappers/Fluent/compile_only_udf.sh
+++ b/wrappers/Fluent/compile_only_udf.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This Script only links the udf with the coolprop library, usefull if the coolprop library is already compiled
+# This Script only links the udf with the coolprop library, useful if the coolprop library is already compiled
 
 # Warning: this script deletes directory libudf before creating a new one
 

--- a/wrappers/Fortran/detailed_example/README.md
+++ b/wrappers/Fortran/detailed_example/README.md
@@ -27,12 +27,12 @@ To build FORTRAN example
     
 .. warning::
 
-    You MUST(!!!) put the -lstdc++ standard libary *after* the cool_fortran_bind.f90  Same thing if you compile the fortran to object file, static library must always be at the end.
+    You MUST(!!!) put the -lstdc++ standard library *after* the cool_fortran_bind.f90  Same thing if you compile the fortran to object file, static library must always be at the end.
 
 Compiling on Windows
 --------------------
 
-At the moment, the most reliable mixed compilation seems to be using the mingw-provided gfortran/gcc combination from mingw-get.  Theese are the versions used as of June 20, 2014::
+At the moment, the most reliable mixed compilation seems to be using the mingw-provided gfortran/gcc combination from mingw-get.  These are the versions used as of June 20, 2014::
 
     >gfortran --version
     GNU Fortran (GCC) 4.8.1

--- a/wrappers/Fortran/simple_example/README.md
+++ b/wrappers/Fortran/simple_example/README.md
@@ -38,7 +38,7 @@ Running ``main`` should yield something like::
 Compiling on Windows
 ====================
 
-At the moment, the most reliable mixed compilation seems to be using the mingw-provided gfortran/gcc combination from mingw-get.  Theese are the versions used as of June 20, 2014::
+At the moment, the most reliable mixed compilation seems to be using the mingw-provided gfortran/gcc combination from mingw-get.  These are the versions used as of June 20, 2014::
 
     >gfortran --version
     GNU Fortran (GCC) 4.8.1

--- a/wrappers/Julia/CoolProp.jl
+++ b/wrappers/Julia/CoolProp.jl
@@ -598,7 +598,7 @@ DLL wrapper of the HAPropsSI function.
 * `name1`, `name2`, `name3`: Input name of  given state values, one must be "P"
 
 # Note
-Here, all outputs calculated as functions of these three: "Y"(Water mole fraction), "T" and "P", as "P" is mandatory so more perfomance achived when "Y" and "T" is given (or at least one of them).
+Here, all outputs calculated as functions of these three: "Y"(Water mole fraction), "T" and "P", as "P" is mandatory so more performance achieved when "Y" and "T" is given (or at least one of them).
 
 Parameter(s) name     |Description                                 |Unit      |Formula
 :---------------------|:-------------------------------------------|:---------|:-------------------------------
@@ -830,7 +830,7 @@ Specify the phase to be used for all further calculations.
 
 # Arguments
 * `handle`: The integer handle for the state class stored in memory
-* `phase`: The string with the phase to use. Possible candidates are listed bellow:
+* `phase`: The string with the phase to use. Possible candidates are listed below:
 
 Phase name                 |Condition
 :--------------------------|-----------------------
@@ -1006,7 +1006,7 @@ end
 """
     AbstractState_set_binary_interaction_double(handle::Clong, i::Int, j::Int, parameter::AbstractString, value::Float64)
 
-Set binary interraction parameter for diffrent mixtures model e.g.: "linear", "Lorentz-Berthelot"
+Set binary interraction parameter for different mixtures model e.g.: "linear", "Lorentz-Berthelot"
 
 # Arguments
 * `handle`: The integer handle for the state class stored in memory
@@ -1041,7 +1041,7 @@ Set cubic's alpha function parameters.
 
 # Arguments
 * `handle`: The integer handle for the state class stored in memory
-* `i`: indice of the fluid the paramter should be applied too (for mixtures)
+* `i`: indice of the fluid the parameter should be applied too (for mixtures)
 * `parameter`: the string specifying the alpha function to use, e.g. "TWU" for the Twu or "MC" for Mathias-Copeman alpha function.
 * `c1`: the first parameter for the alpha function
 * `c2`: the second parameter for the alpha function
@@ -1060,7 +1060,7 @@ Set some fluid parameter (ie volume translation for cubic). Currently applied to
 
 # Arguments
 * `handle`: The integer handle for the state class stored in memory
-* `i`: indice of the fluid the paramter should be applied to (for mixtures)
+* `i`: indice of the fluid the parameter should be applied to (for mixtures)
 * `parameter`: string wit the name of the parameter, e.g. "c", "cm", "c_m" for volume translation parameter.
 * `value`: the value of the parameter
 """

--- a/wrappers/Modelica/src/FluidProp_IF.cpp
+++ b/wrappers/Modelica/src/FluidProp_IF.cpp
@@ -64,7 +64,7 @@ TFluidProp::~TFluidProp()
    // Free FluidProp object
    FluidProp_COM->Release();
 
-   // Unitialize OLE
+   // Uninitialize OLE
    CoUninitialize();
 }
 

--- a/wrappers/Modelica/src/basesolver.cpp
+++ b/wrappers/Modelica/src/basesolver.cpp
@@ -390,7 +390,7 @@ double BaseSolver::isentropicEnthalpy(double &p, ExternalThermodynamicState *con
 //! Set saturation properties from p
 /*!
   This function sets the saturation properties for the given pressure p.
-  The computed values are written to the ExternalSaturationProperties propery struct.
+  The computed values are written to the ExternalSaturationProperties property struct.
 
   Must be re-implemented in the specific solver
   @param p Pressure
@@ -404,7 +404,7 @@ void BaseSolver::setSat_p(double &p, ExternalSaturationProperties *const propert
 //! Set saturation properties from T
 /*!
   This function sets the saturation properties for the given temperature T.
-  The computed values are written to the ExternalSaturationProperties propery struct.
+  The computed values are written to the ExternalSaturationProperties property struct.
 
   Must be re-implemented in the specific solver
   @param T Temperature

--- a/wrappers/Modelica/src/externalmedialib.h
+++ b/wrappers/Modelica/src/externalmedialib.h
@@ -22,7 +22,7 @@
 // Define struct
 //! ExternalThermodynamicState property struct
 /*!
-  The ExternalThermodynamicState propery struct defines all the properties that
+  The ExternalThermodynamicState property struct defines all the properties that
   are computed by external Modelica medium models extending from
   PartialExternalTwoPhaseMedium.
 */
@@ -64,7 +64,7 @@ typedef struct {
 
 //! ExternalSaturationProperties property struct
 /*!
-  The ExternalSaturationProperties propery struct defines all the saturation properties
+  The ExternalSaturationProperties property struct defines all the saturation properties
   for the dew and the bubble line that are computed by external Modelica medium models
   extending from PartialExternalTwoPhaseMedium.
 */

--- a/wrappers/Modelica/src/testsolver.h
+++ b/wrappers/Modelica/src/testsolver.h
@@ -19,7 +19,7 @@
       300 K  < T < 350 K ;
   results returned with inputs outside that range (possibly corresponding 
   to two-phase or vapour points) are not reliable.
-  Saturation properies are computed in the range 
+  Saturation properties are computed in the range 
       1e5 Pa < psat < 2e5 Pa ;
   results obtained outside that range might be unrealistic.
 

--- a/wrappers/Python/CoolProp/CoolProp.pyx
+++ b/wrappers/Python/CoolProp/CoolProp.pyx
@@ -92,7 +92,7 @@ from . cimport constants_header
 
 cdef bint iterable(object a):
     """
-    If numpy is supported, this function retuns true if the argument is a
+    If numpy is supported, this function returns true if the argument is a
     numpy array or another iterable, otherwise just checks if list or tuple
     """
     if _numpy_supported:

--- a/wrappers/Python/CoolProp/Plots/SimpleCycles.py
+++ b/wrappers/Python/CoolProp/Plots/SimpleCycles.py
@@ -748,7 +748,7 @@ class BaseCycle(BasePlot):
             elif typ[i] == 'log':
                 val.append(np.logspace(np.log10(start[v]), np.log10(end[v]), self.steps))
             else:
-                raise ValueError("Unknow range generator {0:s}".format(str(typ[i])))
+                raise ValueError("Unknown range generator {0:s}".format(str(typ[i])))
 
         sc = StateContainer(self._system)
         for i,_ in enumerate(val[0]):

--- a/wrappers/Python/CoolProp/Plots/psy.py
+++ b/wrappers/Python/CoolProp/Plots/psy.py
@@ -242,7 +242,7 @@ class PsyCoolprop(object):
 
     @classmethod
     def calculatePlot(cls, parent):
-        """Funtion to calculate points in chart"""
+        """Function to calculate points in chart"""
 
         data = {}
         P = Preferences.getfloat("General", "P")

--- a/wrappers/Python/examples/example.py
+++ b/wrappers/Python/examples/example.py
@@ -84,7 +84,7 @@ try:
     print('P,H -> T,D', p, ',', h, '-->', T, ',', D)
 except:
     print(' ')
-    print('************ CANT USE REFPROP ************')
+    print('************ CAN'T USE REFPROP ************')
     print(' ')
 
 print(' ')

--- a/wrappers/SMath/coolprop_wrapper/Unit.cs
+++ b/wrappers/SMath/coolprop_wrapper/Unit.cs
@@ -63,9 +63,9 @@ namespace coolprop_wrapper
                      "FRACTION_MAX", "fraction_max",                               //           O  Fraction (mole, mass, volume) maximum value for incompressible solutions
                      "FRACTION_MIN", "fraction_min",                               //           O  Fraction (mole, mass, volume) minimum value for incompressible solutions
                      "FUNDAMENTAL_DERIVATIVE_OF_GAS_DYNAMICS", "fundamental_derivative_of_gas_dynamics", // O Fundamental_derivative_of_gas_dynamics
-                     "GWP100",                                                     //           O  100-year gobal warming potential
-                     "GWP20",                                                      //           O  20-year gobal warming potential
-                     "GWP500",                                                     //           O  500-year gobal warming potential
+                     "GWP100",                                                     //           O  100-year global warming potential
+                     "GWP20",                                                      //           O  20-year global warming potential
+                     "GWP500",                                                     //           O  500-year global warming potential
                      "HH",                                                         //           O  Health hazard
                      "ODP",                                                        //           O  Ozone depletion potential
                      "PHASE", "Phase",                                             //           O  Phase index as a float


### PR DESCRIPTION
Found via `codespell -i 3 -w -I ../coolprop-word-whitelist.txt` whereby whitelist consists of:  
```
cas
formate
hel
nd
te
tim
ue
uint
```