### PR TITLE
Show an actual DeprecationWarning if Props() used.

### DIFF
--- a/wrappers/Python/CoolProp/CoolProp.pyx
+++ b/wrappers/Python/CoolProp/CoolProp.pyx
@@ -12,6 +12,17 @@ cimport cython
 import math
 import warnings
 
+#
+# Ensure that all deprecation warnings triggered in __main__ are displayed by default
+# Note: Python deprecation warning behavior varies by version
+#       3.7+       - Show all deprecation warnings
+#       3.2 to 3.6 - Hide all deprecation warnings
+#       before 3.2 - Show all deprecation warnings
+#       The filter below will ensure that all dep. warnings show
+#       in all versions of Python 
+#
+warnings.filterwarnings('default', category=DeprecationWarning, module='__main__')
+
 from .typedefs cimport CoolPropDbl
 
 try:
@@ -310,8 +321,10 @@ cpdef Props(in1, in2, in3 = None, in4 = None, in5 = None, in6 = None):
     This function is deprecated, use PropsSI instead
     """
     import warnings
+    # Issue deprecation warning....
     dep_warning = "Props() function is deprecated; Use the PropsSI() function"
-    warnings.warn_explicit(dep_warning, category=UserWarning, filename='CoolProp.pyx', lineno = -1)
+    warnings.warn(dep_warning, DeprecationWarning)
+    # ...but process Props() function anyway...
     if len(in2) != 1:
         raise ValueError('Length of input name #1 must be 1 character')
     if len(in4) != 1:


### PR DESCRIPTION
### Description of the Change

When using the deprecated Props() routine, deprecation warnings were issued as a _UserWarning_ instead of _DeprecationWarning_ through the warnings module, using warnings.**warn_explicit()**.
1.  Issue warning using warnings.**warn(dep_message, DeprecationWarning)** instead
2. Set warnings filter when loading the CoolProp module to display all DeprecationWarnings triggered by ``__main__``.

### Benefits

1. Issues an actual DeprecationWarning which can be filtered by the calling script
2. Gives the name of the calling routine and line number where Props() call was made (i.e. previous warn_explicit() call reported `CoolProp.pyx` on line ``-1``.
3. Sets filter so that all versions of Python will report deprecation warnings.  Python 3.2 to 3.6 ignored all DeprecationWarnings, which is probably why UserWarnings was used in the first place.  Manually setting the warnings filter ensures consistent behavior across all versions of Python.
4. Calling routine/script can override the filter to ignore the DeprecationWarning messages for legacy codes that are too difficult to change; otherwise, existing behavior of warning on all calls to Props() is not changed.

### Possible Drawbacks

Because the warnings filter is being set explicitly in CoolProp.pyx for consistency, the calling routine/script must make any filter modifications after the import CoolProp is made.  Additionally, adjusting the warnings filter on the command line will not work as it will be overridden when the import of CoolProp is performed within the script. 

This could still print a whole slew of Deprecation messages (as is the current behavior), making the problem and solution hard to find.  An alternative would be to set the CoolProp filter action to ``once``, which would only display the first DeprecationWarning and then ignore the rest; letting the user know that a deprecated function is being used without flooding stdout with warnings.  However, a single warning message could also easily escape attention.

### Verification Process

After recompiling the Python wrapper, the following Python script, TestProps.py was used to test the warnings behavior.
```py
from CoolProp.CoolProp import Props
import CoolProp;
print("\nTesting warnings for deprecated Props() function.")
print("======================================================================")
print("CoolProp version - {}".format(CoolProp.__version__))
print("======================================================================")

Rho = Props('D','T',298.15,'P',10000,'R744')
print("R744 Density at {} K and {} kPa      = {} kg/m³".format(298.15, 10000, Rho))
H = Props('H','T',298.15,'Q',1,'R134a');
print("R134a Saturated Liquid Enthalpy at {} K = {} kJ/kg".format(298.15, H))
Rho = Props('D','T',298.15,'P',10000,'R744');
print("R744 Density at {} K and {} kPa      = {} kg/m³".format(298.15, 10000, Rho))
H = Props('H','T',298.15,'Q',1,'R134a');
print("R134a Saturated Liquid Enthalpy at {} K = {} kJ/kg".format(298.15, H))
print("======================================================================\n")
```
Output from the script now shows actual DeprecationWarnings at the location of the Props() call in the calling routine/script.

```
Testing warnings for deprecated Props() function.
======================================================================
CoolProp version - 6.1.1dev
======================================================================
TestProps.py:14: DeprecationWarning: Props() function is deprecated; Use the PropsSI() function
  Rho = Props('D','T',298.15,'P',10000,'R744')
R744 Density at 298.15 K and 10000 kPa      = 817.6273812375758 kg/m³
TestProps.py:16: DeprecationWarning: Props() function is deprecated; Use the PropsSI() function
  H = Props('H','T',298.15,'Q',1,'R134a');
R134a Saturated Liquid Enthalpy at 298.15 K = 412.33395323186807 kJ/kg
TestProps.py:18: DeprecationWarning: Props() function is deprecated; Use the PropsSI() function
  Rho = Props('D','T',298.15,'P',10000,'R744');
R744 Density at 298.15 K and 10000 kPa      = 817.6273812375758 kg/m³
TestProps.py:20: DeprecationWarning: Props() function is deprecated; Use the PropsSI() function
  H = Props('H','T',298.15,'Q',1,'R134a');
R134a Saturated Liquid Enthalpy at 298.15 K = 412.33395323186807 kJ/kg
======================================================================
```
Legacy applications can create a filter override to ignore **_all_** deprecation warnings:
```py
import warnings
warnings.filterwarnings('ignore', category=DeprecationWarning)
```
or just the deprecation messages containing the string  "**_Props()_**":
```py
import warnings
warnings.filterwarnings('ignore', 'Props()', category=DeprecationWarning)
```
As shown by the modified test script below, Props() deprecation messages are ignored, while non-Props() deprecation messages are still displayed.
```py
from CoolProp.CoolProp import Props
import CoolProp;
print("\nTesting warnings for deprecated Props() function.")
print("======================================================================")
print("CoolProp version - {}".format(CoolProp.__version__))

# Filter out deprecation warning messages containing the string 'Props()'
# Only takes effect if issued AFTER the CoolProp import
import warnings
warnings.filterwarnings(action='ignore', message='Props()', category=DeprecationWarning)
print("Props() DeprecationWarnings ignored")
print("======================================================================")

Rho = Props('D','T',298.15,'P',10000,'R744')
print("R744 Density at {} K and {} kPa      = {} kg/m³".format(298.15, 10000, Rho))
H = Props('H','T',298.15,'Q',1,'R134a');
print("R134a Saturated Liquid Enthalpy at {} K = {} kJ/kg".format(298.15, H))
Rho = Props('D','T',298.15,'P',10000,'R744');
print("R744 Density at {} K and {} kPa      = {} kg/m³".format(298.15, 10000, Rho))
H = Props('H','T',298.15,'Q',1,'R134a');
print("R134a Saturated Liquid Enthalpy at {} K = {} kJ/kg".format(298.15, H))
print("======================================================================\n")

warnings.warn("This is a deprecation message that is not filtered.", DeprecationWarning)
print("done.")
```
with the following results:
```
Testing warnings for deprecated Props() function.
======================================================================
CoolProp version - 6.1.1dev
Props() DeprecationWarnings ignored
======================================================================
R744 Density at 298.15 K and 10000 kPa      = 817.6273812375758 kg/m³
R134a Saturated Liquid Enthalpy at 298.15 K = 412.33395323186807 kJ/kg
R744 Density at 298.15 K and 10000 kPa      = 817.6273812375758 kg/m³
R134a Saturated Liquid Enthalpy at 298.15 K = 412.33395323186807 kJ/kg
======================================================================

TestProps.py:24: DeprecationWarning: This is a deprecation message that is not filtered.
  warnings.warn("This is a deprecation message that is not filtered.", DeprecationWarning)
done.
```

### Applicable Issues

Closes #1734 
