### PR TITLE
Free input strings in Mathematica interface

### DIFF
--- a/wrappers/Mathematica/CoolPropMathematica.cpp
+++ b/wrappers/Mathematica/CoolPropMathematica.cpp
@@ -19,6 +19,16 @@ extern "C" DLLEXPORT void WolframLibrary_uninitialize( WolframLibraryData libDat
 	return;
 }
 
+
+/* Adds one to the input, returning the result */
+extern "C" DLLEXPORT int plus_one( WolframLibraryData libData, mint Argc, MArgument *Args, MArgument Res) {
+    if (Argc != 1) return LIBRARY_FUNCTION_ERROR;
+	double x = MArgument_getReal(Args[0]);
+	MArgument_setReal(Res, x + 1.0);
+	return LIBRARY_NO_ERROR;
+}
+
+
 extern "C" DLLEXPORT int PropsSI( WolframLibraryData libData, mint Argc, MArgument *Args, MArgument Res) {
     if (Argc != 6) return LIBRARY_FUNCTION_ERROR;
 
@@ -40,6 +50,7 @@ extern "C" DLLEXPORT int PropsSI( WolframLibraryData libData, mint Argc, MArgume
 	
     return LIBRARY_NO_ERROR;
 }
+
 
 extern "C" DLLEXPORT int HAPropsSI( WolframLibraryData libData, mint Argc, MArgument *Args, MArgument Res) {
     if (Argc != 7) return LIBRARY_FUNCTION_ERROR;

--- a/wrappers/Mathematica/CoolPropMathematica.cpp
+++ b/wrappers/Mathematica/CoolPropMathematica.cpp
@@ -19,42 +19,47 @@ extern "C" DLLEXPORT void WolframLibrary_uninitialize( WolframLibraryData libDat
 	return;
 }
 
-/* Adds one to the input, returning the result  */
-extern "C" DLLEXPORT int plus_one( WolframLibraryData libData, mint Argc, MArgument *Args, MArgument Res) {
-	mreal I1;
-	I1 = MArgument_getReal(Args[0]);
-	MArgument_setReal(Res, I1+1.0);
-	return LIBRARY_NO_ERROR;
-}
-
 extern "C" DLLEXPORT int PropsSI( WolframLibraryData libData, mint Argc, MArgument *Args, MArgument Res) {
-    if (Argc != 6){ return LIBRARY_FUNCTION_ERROR; }
-    char *outstring = MArgument_getUTF8String(Args[0]);
-    char *In1string = MArgument_getUTF8String(Args[1]);
-    mreal In1val = MArgument_getReal(Args[2]);
-    char *In2string = MArgument_getUTF8String(Args[3]);
-    mreal In2val = MArgument_getReal(Args[4]);
-    char *Fluidstring = MArgument_getUTF8String(Args[5]);
+    if (Argc != 6) return LIBRARY_FUNCTION_ERROR;
+
+    char  *Output    = MArgument_getUTF8String(Args[0]);
+    char  *Name1     = MArgument_getUTF8String(Args[1]);
+    double Prop1     = MArgument_getReal(Args[2]);
+    char  *Name2     = MArgument_getUTF8String(Args[3]);
+    double Prop2     = MArgument_getReal(Args[4]);
+    char  *FluidName = MArgument_getUTF8String(Args[5]);
     
-    // PropsS version takes all strings, not single-character inputs
-	double val = CoolProp::PropsSI(outstring,In1string,(double)In1val,In2string,(double)In2val,Fluidstring);
+	double val = CoolProp::PropsSI(Output, Name1, Prop1, Name2, Prop2, FluidName);
+
+    libData->UTF8String_disown(Output);
+    libData->UTF8String_disown(Name1);
+    libData->UTF8String_disown(Name2);
+    libData->UTF8String_disown(FluidName);
+
 	MArgument_setReal(Res, val);
-	return LIBRARY_NO_ERROR;
+	
+    return LIBRARY_NO_ERROR;
 }
 
 extern "C" DLLEXPORT int HAPropsSI( WolframLibraryData libData, mint Argc, MArgument *Args, MArgument Res) {
-    if (Argc != 7){ return LIBRARY_FUNCTION_ERROR; }
-    char *outstring = MArgument_getUTF8String(Args[0]);
-    char *In1string = MArgument_getUTF8String(Args[1]);
-    mreal In1val = MArgument_getReal(Args[2]);
-    char *In2string = MArgument_getUTF8String(Args[3]);
-    mreal In2val = MArgument_getReal(Args[4]);
-    char *In3string = MArgument_getUTF8String(Args[5]);
-    mreal In3val = MArgument_getReal(Args[6]);
-    
-	double val = HumidAir::HAPropsSI(outstring,In1string,(double)In1val,In2string,(double)In2val,In3string,(double)In3val);
-	MArgument_setReal(Res, val);
-	return LIBRARY_NO_ERROR;
-}
+    if (Argc != 7) return LIBRARY_FUNCTION_ERROR;
 
+    char  *Output = MArgument_getUTF8String(Args[0]);
+    char  *Name1  = MArgument_getUTF8String(Args[1]);
+    double Prop1  = MArgument_getReal(Args[2]);
+    char  *Name2  = MArgument_getUTF8String(Args[3]);
+    double Prop2  = MArgument_getReal(Args[4]);
+    char  *Name3  = MArgument_getUTF8String(Args[5]);
+    double Prop3  = MArgument_getReal(Args[6]);
+    
+	double val = HumidAir::HAPropsSI(Output, Name1, Prop1, Name2, Prop2, Name3, Prop3);
+
+    libData->UTF8String_disown(Output);
+    libData->UTF8String_disown(Name1);
+    libData->UTF8String_disown(Name2);
+    libData->UTF8String_disown(Name3);
+
+	MArgument_setReal(Res, val);
 	
+    return LIBRARY_NO_ERROR;
+}


### PR DESCRIPTION
### Description of the Change

 - Fix memory leak, see https://github.com/CoolProp/CoolProp/issues/1759
 - Remove irrelevant code which appeared to be a test function.
 - Change `mreal` to `double` and remove casts. Recent versions of Mathematica use `double` instead of `mreal`. In older versions, `mreal` is a typedef for `double`.

### Verification Process

Compiled the library and checked the example notebook

### Applicable Issues

Closes #1759 
