### PR TITLE
Patch PropsSI for INCOMP fluid with zero mass fraction

### DIFF
--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -168,7 +168,8 @@ std::string extract_fractions(const std::string &fluid_string, std::vector<doubl
                 throw ValueError(format("fraction [%s] was not converted to a value between 0 and 1 inclusive", fraction.c_str()));
             }
 
-            if (f > 10*DBL_EPSILON)  // Only push component if fraction is positive and non-zero
+            if ((f > 10*DBL_EPSILON) ||  // Only push component if fraction is positive and non-zero
+                (pairs.size() == 1))     // ..or if there is only one fluid (i.e. INCOMP backend )
             {
                 // And add to vector
                 fractions.push_back(f);


### PR DESCRIPTION
### Description of the Change

Prior to 6.2.0, an error sometimes occurred if a user defined mixture with many components contained a component with a zero (0) mass fraction. PR #1628 modified PropsSI() to parse out any zero mass fraction components from the mixture fluid string and calculate the mixture based on the remaining components.  This had an adverse effect on incompressible fluids which can used the same [] syntax to specify the solute mass/volume fraction in water, which is allowed to be zero.  The change in PR#1628 would then strip out the incompressible fluid leaving an empty and invalid fluid string as reported in Issue #1756.

Change was to prevent a zero mass fraction component from being stripped if there is only one component in the fluid list (as is the case for incompressible fluids).  The alternative was to check the backend in use for "INCOMP", however this is a little rigid if other backends are added.

### Benefits

Single fluid components with a specified mixture fraction of [0] will not be stripped from the fluid list, allowing incompressible fluids to again specify a zero mass/volume fraction.

### Possible Drawbacks

Checks were made with all of the other backends to make sure they all behave as expected.  HEOS and REFPROP mixtures with a single component, although odd, are restored to the original behavior, even if the mixture fraction is zero.
![mono-mixture](https://user-images.githubusercontent.com/17114032/49492760-a4f91380-f827-11e8-8f80-313907e49a6c.PNG)

### Verification Process

Tested incompressible fluid behavior in both Mathcad and Python to ensure that a zero mass/volume fraction again returns a value and does not throw an error.

![incompressible](https://user-images.githubusercontent.com/17114032/49492902-1638c680-f828-11e8-9cc0-9ca729402354.PNG)

Tested normal user defined mixtures in both HEOS and REFPROP backends using both the Mathcad and Python wrappers to ensure mixture behavior was unaltered.

![mixtures](https://user-images.githubusercontent.com/17114032/49493018-7def1180-f828-11e8-8dfe-19b2d41c1ec0.PNG)

### Applicable Issues

Closes #1756 
