### PR TITLE
Add IF97 links to CoolProp homepage and backends page

### DIFF
--- a/Web/develop/backends.rst
+++ b/Web/develop/backends.rst
@@ -16,6 +16,7 @@ The backends in CoolProp provide the implementation of the protocol defined by t
 * :cpapi:`HelmholtzEOSMixtureBackend` : This backend is the backend that provides properties using the CoolProp code.
 * :cpapi:`IncompressibleBackend` : This backend provides the thermophysical properties for incompressible pure fluids, incompressible mixtures, and brines
 * :cpapi:`REFPROPMixtureBackend` : This backend provides a clean interface between CoolProp and REFPROP
+* :cpapi:`IF97Backend` : This backend provides an IAPWS-IF97 implemenation for the properties of steam/water
 
 Example Backend
 ---------------

--- a/Web/index.rst
+++ b/Web/index.rst
@@ -17,6 +17,7 @@ CoolProp is a C++ library that implements:
 - :ref:`Correlations of properties of incompressible fluids and brines <Pure>`
 - :ref:`Highest accuracy psychrometric routines <Humid-Air>`
 - :ref:`User-friendly interface around the full capabilities of NIST REFPROP <REFPROP>`
+- :ref:`Fast IAPWS-IF97 (Industrial Formulation) for Water/Steam <IF97>`
 - :ref:`Cubic equations of state (SRK, PR) <cubic_backend>`
 
 Environments Supported


### PR DESCRIPTION
### Description of the Change

Add IF97 page link to CoolProp homepage and develop/backends page.

### Benefits

Advertises IF97 capability on CoolProp homepage and provides link to the doxygen IF97Backend Class Reference for easier lookup.

### Verification Process

Simple link additions.  Will verify once the dev/docs are built.

### Applicable Issues

Per @ibell request in #1762.
