### PR TITLE
Disambiguate IF97 Fluid Names - Water only

### DIFF
--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -54,8 +54,20 @@ void register_backend(const backend_families &bf, shared_ptr<AbstractStateGenera
 
 class IF97BackendGenerator : public AbstractStateGenerator{
 public:
-    AbstractState * get_AbstractState(const std::vector<std::string> &fluid_names){
-        return new IF97Backend();
+    AbstractState * get_AbstractState(const std::vector<std::string> &fluid_names) {
+        if (fluid_names.size() == 1) {           // Check that fluid_names[0] has only one component
+            std::string str = fluid_names[0];    // Check that the fluid name is an alias for "Water"
+            if ((upper(str) == "WATER") ||
+                (upper(str) == "H2O")) {
+                return new IF97Backend();
+            }
+            else {
+                throw ValueError(format("The IF97 backend returns Water props only; fluid name [%s] not allowed", fluid_names[0].c_str()));
+            }
+        }
+        else {
+            throw ValueError(format("The IF97 backend does not support mixtures, only Water"));
+        };
     };
 } ;
 // This static initialization will cause the generator to register

--- a/wrappers/MathCAD/CoolPropMathcad.cpp
+++ b/wrappers/MathCAD/CoolPropMathcad.cpp
@@ -22,7 +22,7 @@ namespace CoolProp {
 }
 
 enum EC { MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,       // Mathcad Error Codes
-          BAD_FLUID, BAD_PARAMETER, BAD_PHASE,                      // CoolProp Error Codes
+          BAD_FLUID, BAD_IF97_FLUID, BAD_PARAMETER, BAD_PHASE,      // CoolProp Error Codes
           ONLY_ONE_PHASE_SPEC, BAD_REF, NON_TRIVIAL,
           NO_REFPROP, NOT_AVAIL, BAD_INPUT_PAIR, BAD_QUAL,
           TWO_PHASE, NON_TWO_PHASE, T_OUT_OF_RANGE, P_OUT_OF_RANGE,
@@ -40,6 +40,7 @@ enum EC { MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,       // Mathcad E
         "Insufficient Memory",
         "Argument must be real",
         "Invalid Fluid String",
+        "IF97 Backend supports pure water only",
         "Invalid Parameter String",
         "Invalid Phase String",
         "Only one input key phase specification allowed",
@@ -191,17 +192,26 @@ enum EC { MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,       // Mathcad E
             std::string emsg = CoolProp::get_global_param_string("errstring");
             CoolProp::set_error_string(emsg);  // reset error string so Mathcad can retrieve it
             if (emsg.find("valid fluid")!=std::string::npos) {
-                if (emsg.find("Neither input")!=std::string::npos)
-                    if (emsg.find("REFPROP")!=std::string::npos) {
+                if (emsg.find("Neither input") != std::string::npos) {
+                    if (emsg.find("REFPROP") != std::string::npos) {
                         // Fluid can be in either parameter location, find out which.
                         // It will be in brackets in the error message.
-                        if (FluidString.find("REFPROP")!=std::string::npos)
+                        if (FluidString.find("REFPROP") != std::string::npos)
                             errPos = 1;  // [REFPROP::???] is in Fluid->str, i.e. position 1
                         else
                             errPos = 2;  // [REFPROP::???] is in PropName->str, i.e. position 2
-                        return MAKELRESULT(NO_REFPROP,errPos);
-                    } else
-                        return MAKELRESULT(BAD_FLUID,1);
+                        return MAKELRESULT(BAD_FLUID, errPos);
+                    }
+                    else if (emsg.find("IF97") != std::string::npos) {
+                        if (FluidString.find("IF97") != std::string::npos)
+                            errPos = 1; // [IF97::???] is in Fluid->str, i.e. position 1
+                        else
+                            errPos = 2; // [IF97::???] is in PropName-str, i.e. position 2
+                        return MAKELRESULT(BAD_IF97_FLUID, errPos);
+                    }
+                    else
+                        return MAKELRESULT(BAD_FLUID, 1);
+                }
                 else //  "Both inputs"
                     return MAKELRESULT(BAD_PARAMETER,2);
             } else if (emsg.find("Unable to use")!=std::string::npos) {
@@ -306,6 +316,8 @@ enum EC { MUST_BE_REAL = 1, INSUFFICIENT_MEMORY, INTERRUPTED,       // Mathcad E
                         return MAKELRESULT(NO_REFPROP,6);
                     else
                         return MAKELRESULT(BAD_FLUID,6);
+                } else if (emsg.find("IF97") != std::string::npos) {
+                    return MAKELRESULT(BAD_IF97_FLUID, 6);
                 } else
                     return MAKELRESULT(BAD_FLUID,6);
             } else if (emsg.find("Temperature")!=std::string::npos) {


### PR DESCRIPTION
### Description of the Change

Modified the IF97 Abstract State Generator to throw an error if the fluid name is anything other than "Water" or "H2O".

### Benefits

The IF97 backend would allow fluid strings like:
- "IF97::Water" (_OK_)
- "IF97::H2O" (_OK_)
- "IF97::Propane" (_not OK_)
- "IF97::Water[0.5]&Ethanol[0.5]" (_not OK_)

While it should be obvious that IF97 only returns Water properties, this call (which does not throw an error or warning) could be confusing or mis-leading:
```
In [5]: CP.PropsSI("D","T",295,"P",101325,"IF97::Propane")
Out[5]: 997.806810732084

In [6]: CP.PropsSI("D","T",295,"P",101325,"IF97::Water[0.5]&Ethanol[0.5]")
Out[6]: 997.806810732084
```

Throwing an error if attempting to initialize the IF97 backend with anything other than Water removes any ambiguity.

### Possible Drawbacks

- Does not check for any other potential aliases in the Water.JSON file (R718?; User supplied?)
- Could possibly break user calling code that hasn't been supplying a valid fluid name

### Verification Process

- *Verified that proper error messages were thrown in Python and Mathcad*
- *Errors generated from IF97 backend initialization, so won't affect other backends*
- *Calls to PropsSI and Props1SI with "IF97::Water" and "IF97::H2O" function normally*

```
>>> import CoolProp.CoolProp as CP
>>> CP.PropsSI("D","T",295,"P",101325,"IF97::Water")
997.806810732084
>>> CP.PropsSI("D","T",295,"P",101325,"IF97::H2O")
997.806810732084
>>> CP.PropsSI("D","T",295,"P",101325,"IF97::H2O[0.5]&Ethanol[0.5]")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "CoolProp\CoolProp.pyx", line 348, in CoolProp.CoolProp.PropsSI
  File "CoolProp\CoolProp.pyx", line 428, in CoolProp.CoolProp.PropsSI
  File "CoolProp\CoolProp.pyx", line 315, in CoolProp.CoolProp.__Props_err2
ValueError: Initialize failed for backend: "IF97", fluid: "H2O&Ethanol" fractions "[ 0.5000000000, 0.5000000000 ]"; error: The IF97 backend does not support mixtures, only Water : PropsSI("D","T",295,"P",101325,"IF97::H2O[0.5]&Ethanol[0.5]")
>>> CP.PropsSI("D","T",295,"P",101325,"IF97::Propane")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "CoolProp\CoolProp.pyx", line 348, in CoolProp.CoolProp.PropsSI
  File "CoolProp\CoolProp.pyx", line 428, in CoolProp.CoolProp.PropsSI
  File "CoolProp\CoolProp.pyx", line 315, in CoolProp.CoolProp.__Props_err2
ValueError: Initialize failed for backend: "IF97", fluid: "Propane" fractions "[ 1.0000000000 ]"; error: The IF97 backend returns Water props only; fluid name [Propane] not allowed : PropsSI("D","T",295,"P",101325,"IF97::Propane")
>>> CP.PropsSI("D","T",295,"P",101325,"IF97::h2o")
997.806810732084
>>> CP.PropsSI("D","T",295,"P",101325,"IF97::water")
997.806810732084
>>> CP.PropsSI("D","T",295,"P",101325,"IF97::WATER")
997.806810732084
```

### Applicable Issues

No reported issues to close.  Discovered accidentally while testing PR #1765. 
