### PR TITLE
Add conda install instructions from conda-forge

### DIFF
--- a/Web/coolprop/wrappers/Python/index.rst
+++ b/Web/coolprop/wrappers/Python/index.rst
@@ -13,19 +13,15 @@ Using the ``pip`` installation program, you can install the official release fro
 
     pip install CoolProp
 
-If you dare, you can also try the latest nightly release from :sfnightly:`Python` 
+There are also unofficial `Conda <https://conda.io>`__ packages available from the ``conda-forge`` channel. To
+install, use::
+
+    conda install conda-forge::coolprop
+
+If you dare, you can also try the latest nightly release from :sfnightly:`Python`
 or get it directly from the development server using::
 
     pip install -vvv --pre --trusted-host www.coolprop.dreamhosters.com --find-links http://www.coolprop.dreamhosters.com/binaries/Python/ -U --force-reinstall CoolProp
-    
-.. For those of you who prefer the Anaconda or Miniconda distributions, you can run::
-   
-       conda install -c https://conda.binstar.org/coolprop coolprop
-       
-   You can also find our nightly development snapshots on binstar::
-    
-       conda install -c https://conda.binstar.org/coolprop/label/dev coolprop 
-
 
 Manual installation
 ===================


### PR DESCRIPTION
### Description of the Change

As discussed in #1777, this PR introduces instructions to install the Conda package from the conda-forge channel.

### Benefits

This installation method supports those users with Conda distributions of Python.

### Possible Drawbacks

Conda-forge may decide to stop maintaining the package, resulting in these instructions becoming out of date.

### Verification Process

I did not do any verification of this change.