### PR TITLE
Set _phase in REFPROP backend and return it in calc_phase()

### DIFF
--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -1156,6 +1156,44 @@ CoolPropDbl REFPROPMixtureBackend::calc_cpmolar_idealgas(void)
     return static_cast<CoolPropDbl>(cp0);
 }
 
+phases REFPROPMixtureBackend::GetRPphase()
+{
+    phases RPphase = iphase_unknown;
+    if (ValidNumber(_Q))
+    {
+        if ((_Q >= 0.00) && (_Q <= 1.00)) {      // CoolProp includes Q = 1 or 0 in the two phase region,
+            RPphase = iphase_twophase;            // whereas RefProp designates saturated liquid and saturated vapor.
+        }
+        else if (_Q > 1.00) {                    // Above saturation curve
+            RPphase = iphase_gas;
+            if (_T >= calc_T_critical()) {       //     ....AND T >= Tcrit
+                RPphase = iphase_supercritical_gas;
+            }
+        }
+        else if (_Q < 0.00) {                    // Below saturation curve
+            RPphase = iphase_liquid;
+            if (_p >= calc_p_critical()) {       //     ....AND P >= Pcrit
+                RPphase = iphase_supercritical_liquid;
+            }
+        }
+        else {                                   // RefProp might return Q = 920 for Metastable
+            RPphase = iphase_unknown;             // but CoolProp doesn't have an enumerator for this state,
+        }                                        // so it's unknown as well.
+
+        if ((_Q == 999) || (_Q == -997)) {       // One last check for _Q == 999||-997 (Supercritical)
+            RPphase = iphase_supercritical;       // T >= Tcrit AND P >= Pcrit
+            if ((std::abs(_T - calc_T_critical()) < 10 * DBL_EPSILON) &&   // IF (T == Tcrit) AND
+                (std::abs(_p - calc_p_critical()) < 10 * DBL_EPSILON)) {   //    (P == Pcrit) THEN
+                RPphase = iphase_critical_point;                            //    at critical point. 
+            };
+        }
+    }
+    else {
+            RPphase = iphase_unknown;
+    }
+    return RPphase;
+}
+
 void REFPROPMixtureBackend::update(CoolProp::input_pairs input_pair, double value1, double value2)
 {
     this->check_loaded_fluid();
@@ -1794,40 +1832,10 @@ void REFPROPMixtureBackend::update(CoolProp::input_pairs input_pair, double valu
     _tau = calc_T_reducing()/_T;
     _delta = _rhomolar/calc_rhomolar_reducing();
     _gibbsmolar = hmol-_T*smol;
-    _Q = q;  // Set the CoolProp _phase variable based on RefProp's quality value (q)
-    if (imposed_phase_index == iphase_not_imposed)   // If phase is imposed, _phase will already be set.
-    {
-        if (ValidNumber(_Q))
-        {
-            if ((_Q >= 0.00) && (_Q <= 1.00)) {      // CoolProp includes Q = 1 or 0 in the two phase region,
-                _phase = iphase_twophase;            // whereas RefProp designates saturated liquid and saturated vapor.
-            }
-            else if (_Q > 1.00) {                    // Above saturation curve
-                _phase = iphase_gas;
-                if (_T >= calc_T_critical()) {       //     ....AND T >= Tcrit
-                    _phase = iphase_supercritical_gas;
-                }
-            }
-            else if (_Q < 0.00) {                    // Below saturation curve
-                _phase = iphase_liquid;
-                if (_p >= calc_p_critical()) {       //     ....AND P >= Pcrit
-                    _phase = iphase_supercritical_liquid;
-                }
-            }
-            else {                                   // RefProp might return Q = 920 for Metastable
-                _phase = iphase_unknown;             // but CoolProp doesn't have an enumerator for this state,
-            }                                        // so it's unknown as well.
-
-            if ((_Q == 999) || (_Q == -997)) {       // One last check for _Q == 999||-997 (Supercritical)
-                _phase = iphase_supercritical;       // T >= Tcrit AND P >= Pcrit
-                if ((std::abs(_T - calc_T_critical()) < 10 * DBL_EPSILON) &&   // IF (T == Tcrit) AND
-                    (std::abs(_p - calc_p_critical()) < 10 * DBL_EPSILON)) {   //    (P == Pcrit) THEN
-                    _phase = iphase_critical_point;                            //    at critical point. 
-                };
-            }
-        }
-        else {
-            _phase = iphase_unknown;
+    _Q = q;
+    if (imposed_phase_index == iphase_not_imposed) {  // If phase is imposed, _phase will already be set.
+        if (Ncomp == 1) {          // Only set _phase for pure fluids
+            _phase = GetRPphase(); // Set the CoolProp _phase variable based on RefProp's quality value (q)
         }
     }
 }

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.h
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.h
@@ -77,7 +77,16 @@ public:
     bool using_mass_fractions(){return false;}
     bool using_volu_fractions(){return false;}
 
-    phases calc_phase(void) { return _phase; };
+    phases calc_phase(void) { 
+        if (this->Ncomp > 1) {
+            throw NotImplementedError("The REFPROP backend does not implement calc_phase function for mixtures.");
+        }
+        else {
+            return _phase;
+        }
+    };
+
+    phases REFPROPMixtureBackend::GetRPphase();
 
     /** \brief Specify the phase - this phase will always be used in calculations
      *

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.h
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.h
@@ -77,6 +77,8 @@ public:
     bool using_mass_fractions(){return false;}
     bool using_volu_fractions(){return false;}
 
+    phases calc_phase(void) { return _phase; };
+
     /** \brief Specify the phase - this phase will always be used in calculations
      *
      * @param phase_index The index from CoolProp::phases

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.h
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.h
@@ -77,6 +77,7 @@ public:
     bool using_mass_fractions(){return false;}
     bool using_volu_fractions(){return false;}
 
+    // Get _phase for pure fluids only
     phases calc_phase(void) { 
         if (this->Ncomp > 1) {
             throw NotImplementedError("The REFPROP backend does not implement calc_phase function for mixtures.");
@@ -86,7 +87,8 @@ public:
         }
     };
 
-    phases REFPROPMixtureBackend::GetRPphase();
+    // Utility function to determine the phase from quality value return from REFPROP
+    phases GetRPphase();
 
     /** \brief Specify the phase - this phase will always be used in calculations
      *

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -1060,8 +1060,8 @@ std::string phase_lookup_string(phases Phase)
         return "critical_point";
     case iphase_gas: ///< Subcritical gas
         return "gas";
-    case iphase_twophase: ///< Twophase
-        return "twophase";                    /// between saturation curves.
+    case iphase_twophase: ///< Twophase (between saturation curves - inclusive)
+        return "twophase";
     case iphase_unknown: ///< Unknown phase
         return "unknown";
     case iphase_not_imposed:
@@ -1071,7 +1071,6 @@ std::string phase_lookup_string(phases Phase)
 }
 std::string PhaseSI(const std::string &Name1, double Prop1, const std::string &Name2, double Prop2, const std::string &FluidName)
 {
-    double Q_val = -1;
     double Phase_double = PropsSI("Phase",Name1,Prop1,Name2,Prop2,FluidName);   // Attempt to get "Phase" from PropsSI()
     if (!ValidNumber(Phase_double)){                                            // if the returned phase is invalid...
         std::string strPhase = phase_lookup_string(iphase_unknown);             //     phase is unknown.

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -1048,29 +1048,30 @@ std::string phase_lookup_string(phases Phase)
 {
     switch (Phase)
     {
-        case iphase_liquid: ///< Liquid
-            return "liquid";
-        case iphase_supercritical: ///< Supercritical (p > pc, T > Tc)
-            return "supercritical";
-        case iphase_supercritical_gas: ///< Supercritical gas (p < pc, T > Tc)
-            return "supercritical_gas";
-        case iphase_supercritical_liquid: ///< Supercritical liquid (p > pc, T < Tc)
-            return "supercritical_liquid";
-        case iphase_critical_point: ///< At the critical point
-            return "critical_point";
-        case iphase_gas: ///< Subcritical gas
-            return "gas";
-        case iphase_twophase: ///< Twophase
-            return "twophase";
-        case iphase_unknown: ///< Unknown phase
-            return "unknown";
-        case iphase_not_imposed:
-            return "not_imposed";
+    case iphase_liquid: ///< Liquid
+        return "liquid";
+    case iphase_supercritical: ///< Supercritical (p > pc, T > Tc)
+        return "supercritical";
+    case iphase_supercritical_gas: ///< Supercritical gas (p < pc, T > Tc)
+        return "supercritical_gas";
+    case iphase_supercritical_liquid: ///< Supercritical liquid (p > pc, T < Tc)
+        return "supercritical_liquid";
+    case iphase_critical_point: ///< At the critical point
+        return "critical_point";
+    case iphase_gas: ///< Subcritical gas
+        return "gas";
+    case iphase_twophase: ///< Twophase
+        return "twophase";                    /// between saturation curves.
+    case iphase_unknown: ///< Unknown phase
+        return "unknown";
+    case iphase_not_imposed:
+        return "not_imposed";
     }
     throw ValueError("I should never be thrown");
 }
 std::string PhaseSI(const std::string &Name1, double Prop1, const std::string &Name2, double Prop2, const std::string &FluidName)
 {
+    double Q_val = -1;
     double Phase_double = PropsSI("Phase",Name1,Prop1,Name2,Prop2,FluidName);   // Attempt to get "Phase" from PropsSI()
     if (!ValidNumber(Phase_double)){                                            // if the returned phase is invalid...
         std::string strPhase = phase_lookup_string(iphase_unknown);             //     phase is unknown.


### PR DESCRIPTION
### Description of the Change

The REFPROP backend did not override the virtual function ``calc_phase()`` as the other backends do, leaving it undefined per Abstract State.  Change involves:

- At the end of ``REFPROPMixtureBackend::update()``, set value for _Q returned by REFPROP
- At the end of ``REFPROPMixtureBackend::update()``, use _Q to determine the phases value for _phase  
- Return the _phase value in ``REFPROPMIxtureBackend::calc_phase()``
- Pure fluids only; for REFPROP mixtures, a not implemented error is thrown.

### Benefits

- Allows a "Phase" value to be returned from ``PropsSI()`` when using REFPROP backend.
- Allows PhaseSI() to return a "pretty printing" phase string for REFPROP fluids.

### Possible Drawbacks

If REFPROP changes it's convention for phase values of q, this phase determination logic may need to be updated.
Might need to update the function ``update_with_guesses()`` as well.

### Verification Process

Returned values from ``calc_phase()`` and ``PhaseSI()`` were calculated for several REFPROP fluids and compared with the equivalent results from the HEOS fluid.  Tested for Water, Propane, and CO2 using a python script, results here:
```
Testing calc_phase() and PhaseSI() function with RefProp Backend.
===================================================================================================
|                                  CoolProp Version - 6.2.2\dev                                   |
===================================================================================================
|                        Fluid: |         REFPROP::Water         |          HEOS::Water           |
===================================================================================================
|    T    |     P     |    Q    | PropsSI() |                    | PropsSI() |                    |
|   [K]   |   [MPa]   |         |  "Phase"  |      PhaseSI()     |  "Phase"  |      PhaseSI()     |
===================================================================================================
| 460.128 |  1.67423  |(   -998)|     0     |       liquid       |     0     |       liquid       |
| 460.128 |  0.67423  |(    998)|     5     |        gas         |     5     |        gas         |
| 460.128 |( 1.17423 )|    1    |     6     |      twophase      |     6     |      twophase      |
| 460.128 |( 1.17423 )|   0.5   |     6     |      twophase      |     6     |      twophase      |
| 460.128 |( 1.17423 )|    0    |     6     |      twophase      |     6     |      twophase      |
| 460.128 | 23.06400  |(   -998)|     3     |supercritical_liquid|     3     |supercritical_liquid|
| 747.096 |  1.17423  |(    998)|     2     | supercritical_gas  |     2     | supercritical_gas  |
| 747.096 | 23.06400  |(    999)|     1     |   supercritical    |     1     |   supercritical    |
|[647.096]|[22.06400 ]|(    999)|     4     |   critical_point   |     4     |   critical_point   |
===================================================================================================
() = returned state value
[] = Critical point value

===================================================================================================
|                                  CoolProp Version - 6.2.2\dev                                   |
===================================================================================================
|                        Fluid: |        REFPROP::Propane        |         HEOS::Propane          |
===================================================================================================
|    T    |     P     |    Q    | PropsSI() |                    | PropsSI() |                    |
|   [K]   |   [MPa]   |         |  "Phase"  |      PhaseSI()     |  "Phase"  |      PhaseSI()     |
===================================================================================================
| 227.707 |  0.09728  |(   -998)|     0     |       liquid       |     0     |       liquid       |
| 227.707 |  0.07728  |(    998)|     5     |        gas         |     5     |        gas         |
| 227.707 |( 0.08728 )|    1    |     6     |      twophase      |     6     |      twophase      |
| 227.707 |( 0.08728 )|   0.5   |     6     |      twophase      |     6     |      twophase      |
| 227.707 |( 0.08728 )|    0    |     6     |      twophase      |     6     |      twophase      |
| 227.707 |  5.25120  |(   -998)|     3     |supercritical_liquid|     3     |supercritical_liquid|
| 469.890 |  0.08728  |(    998)|     2     | supercritical_gas  |     2     | supercritical_gas  |
| 469.890 |  5.25120  |(    999)|     1     |   supercritical    |     1     |   supercritical    |
|[369.890]|[ 4.25120 ]|(    999)|     4     |   critical_point   |     4     |   critical_point   |
===================================================================================================
() = returned state value
[] = Critical point value

===================================================================================================
|                                  CoolProp Version - 6.2.2\dev                                   |
===================================================================================================
|                        Fluid: |          REFPROP::CO2          |           HEOS::CO2            |
===================================================================================================
|    T    |     P     |    Q    | PropsSI() |                    | PropsSI() |                    |
|   [K]   |   [MPa]   |         |  "Phase"  |      PhaseSI()     |  "Phase"  |      PhaseSI()     |
===================================================================================================
| 260.360 |  2.45430  |(   -998)|     0     |       liquid       |     0     |       liquid       |
| 260.360 |  2.43430  |(    998)|     5     |        gas         |     5     |        gas         |
| 260.360 |( 2.44430 )|    1    |     6     |      twophase      |     6     |      twophase      |
| 260.360 |( 2.44430 )|   0.5   |     6     |      twophase      |     6     |      twophase      |
| 260.360 |( 2.44430 )|    0    |     6     |      twophase      |     6     |      twophase      |
| 260.360 |  8.37730  |(   -998)|     3     |supercritical_liquid|     3     |supercritical_liquid|
| 404.128 |  2.44430  |(    998)|     2     | supercritical_gas  |     2     | supercritical_gas  |
| 404.128 |  8.37730  |(    999)|     1     |   supercritical    |     1     |   supercritical    |
|[304.128]|[ 7.37730 ]|(    999)|     4     |   critical_point   |     4     |   critical_point   |
===================================================================================================
() = returned state value
[] = Critical point value

```
The logic is much more difficult for mixtures, so if the fluid has more than one component, throw a non-implemented error from ``REFPROPMixtureBackend::calc_phase()``.   The high-level function ``PhaseSI()`` 
already traps the error and returns "unknown" with the thrown error message appended per #1645 .
```
>>> import CoolProp.CoolProp as CP
>>> fluid = "REFPROP::Methane[0.8]&Ethane[0.2]"
>>> Tc = CP.PropsSI("Tcrit","",0,"",0,fluid)
>>> Tp = CP.PropsSI("Ttriple","",0,"",0,fluid)
>>> T = 0.5*(Tp + Tc)
>>> P = 1.1*CP.PropsSI("P","T",T,"Q",0,fluid)
>>> CP.PropsSI("Phase","T",T,"P",P,fluid)
Traceback [...]
ValueError: The REFPROP backend does not implement calc_phase function for mixtures. : PropsSI("Phase","T",156.0060684,"P",1168596.629,"REFPROP::Methane[0.8]&Ethane[0.2]")
>>> CP.PhaseSI("T",T,"P",P,fluid)
'unknown: The REFPROP backend does not implement calc_phase function for mixtures. : PropsSI("Phase","T",156.0060684,"P",1168596.629,"REFPROP::Methane[0.8]&Ethane[0.2]")'
```

### Applicable Issues

Closes #1708 
