### PR TITLE
Use std::shared_ptr if available in VS

### DIFF
--- a/include/crossplatform_shared_ptr.h
+++ b/include/crossplatform_shared_ptr.h
@@ -42,7 +42,12 @@
     using namespace std::tr1;
 #elif defined(__ISWINDOWS__) && !defined(__MINGW32__)
     #include <memory>
-    using namespace std::tr1;
+    // VS2008 has std::shared_ptr from C++11 
+    #if defined(_MSC_VER) && _MSC_VER >= 1500
+        using std::shared_ptr;
+    #else
+        using namespace std::tr1;
+    #endif
 #else
     #pragma error
 #endif


### PR DESCRIPTION
### Requirements

* Fill out this template to the extent possible so that this PR can be reviewed in a timely manner.
* Replace the bracketed text below with your own.
* All new code requires tests to ensure against regressions.

### Description of the Change

Fix compilation with VS2017, where std::tr1 is no longer enabled by default

### Benefits

Compilation with VS2017 works flawlessly. `std::shared_ptr` should be used if available.

### Possible Drawbacks

Not known.

### Verification Process

Compilation works.

### Applicable Issues

Somehow related to #1781, but does not check for the presence of a C++11 compiler, but the first VS version (= 2008) supporting `std::shared_ptr`.
