### PR TITLE
Allow list delimiter to be changed

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -44,7 +44,8 @@
     X(USE_GUESSES_IN_PROPSSI, "USE_GUESSES_IN_PROPSSI", false, "If true, calls to the vectorized versions of PropsSI use the previous state as guess value while looping over the input vectors, only makes sense when working with a single fluid and with points that are not too far from each other.") \
     X(ASSUME_CRITICAL_POINT_STABLE, "ASSUME_CRIT_POINT_STABLE", false, "If true, evaluation of the stability of critical point will be skipped and point will be assumed to be stable") \
     X(VTPR_ALWAYS_RELOAD_LIBRARY, "VTPR_ALWAYS_RELOAD_LIBRARY", false, "If true, the library will always be reloaded, no matter what is currently loaded") \
-    X(FLOAT_PUNCTUATION, "FLOAT_PUNCTUATION", ".", "The first character of this string will be used as the separator between the number fraction.")
+    X(FLOAT_PUNCTUATION, "FLOAT_PUNCTUATION", ".", "The first character of this string will be used as the separator between the number fraction.") \
+    X(LIST_STRING_DELIMITER, "LIST_STRING_DELIMITER", ", ", "The delimiter to be used when converting a list of strings to a string")
 
 
  // Use preprocessor to create the Enum

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.h
@@ -1310,7 +1310,7 @@ public:
     /// Return a comma-separated list of fluid names
     std::string get_fluid_list(void)
     {
-        return strjoin(name_vector, ",");
+        return strjoin(name_vector, get_config_string(LIST_STRING_DELIMITER));
     };
 };
 

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -217,7 +217,7 @@ std::string HelmholtzEOSMixtureBackend::fluid_param_string(const std::string &Pa
         return cpfluid.name;
     }
     else if (!ParamName.compare("aliases")){
-        return strjoin(cpfluid.aliases, ", ");
+        return strjoin(cpfluid.aliases, get_config_string(LIST_STRING_DELIMITER));
     }
     else if (!ParamName.compare("CAS") || !ParamName.compare("CAS_number")){
         return cpfluid.CAS;


### PR DESCRIPTION
 important for fluids like 1,1,2-trifluoroethane with commas in them

### Description of the Change

Allow for the ability to change the delimiter that is used to turn lists of strings into strings.

### Benefits

Allows the base names for fluids to contain a comma, such as many alkane derivatives

### Possible Drawbacks

None, backwards compatible, changing delimiter between threads might be dangerous