### PR TITLE
Fixed crash in PTflash_twophase::build_arrays

### DIFF
--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -47,6 +47,7 @@ void FlashRoutines::PT_flash_mixtures(HelmholtzEOSMixtureBackend &HEOS)
                 }
             }
             HEOS.unspecify_phase();
+            HEOS._Q = -1;
         }
         else{
             // Liquid solution

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -2049,7 +2049,7 @@ void StabilityRoutines::StabilityEvaluationClass::rho_TP_SRK_translated(){
                 J(k,j) = (IO.z[j] - IO.x[j])/POW2(IO.y[j]-IO.x[j]);
                 J(k,j+N-1) = -(IO.z[j] - IO.x[j])/POW2(IO.y[j]-IO.x[j]);
             }
-            std::size_t j = N-1;
+            std::size_t j = N-2;
             J(k,j) = -(IO.z[j] - IO.x[j])/POW2(IO.y[j]-IO.x[j]);
             J(k,j+N-1) = +(IO.z[j] - IO.x[j])/POW2(IO.y[j]-IO.x[j]);
         }


### PR DESCRIPTION
Fixed crash in SaturationSolvers::PTflash_twophase::build_arrays for mixtures with 3 or more components.

### Requirements

* Fill out this template to the extent possible so that this PR can be reviewed in a timely manner.
* Replace the bracketed text below with your own.
* All new code requires tests to ensure against regressions.

### Description of the Change

changed used index

### Benefits

code crashed hard because of wrong index

### Possible Drawbacks


### Verification Process

Please check, if numerical properties of algorithm are now correct

- *How did you verify that all new functionality works as expected?*
- *How did you verify that all changed functionality works as expected?*
- *How did you verify that the change has not introduced any regressions?*

*Describe the actions you performed (e.g. text you typed, commands you ran, etc.), and describe the results you observed.*  

*Please attach here any python test sessions or image captures of testing in other wrappers.* ]

### Applicable Issues

