### PR TITLE
fixed typo in getos() and else statement

### DIFF
--- a/Web/coolprop/HighLevelAPI.rst
+++ b/Web/coolprop/HighLevelAPI.rst
@@ -15,13 +15,13 @@ For many users, all that is needed is a simple call to the ``PropsSI`` function 
 
     # Import the PropsSI function
     In [1]: from CoolProp.CoolProp import PropsSI
-    
+
     # Saturation temperature of Water at 1 atm in K
     In [2]: PropsSI('T','P',101325,'Q',0,'Water')
 
-In this example, the first parameter, :math:`T`, is the *output* property that will be returned from ``PropsSI``.  The second and fourth parameters are the specified *input pair* of properties that determine the state point where the output property will be calculated.  The *output* property and *input pair* properties are text strings and must be quoted.  The third and fifth parameters are the *values* of the *input pair* properties and will determine the state point.  The sixth and last parameter is the fluid for which the *output* property will be calculated; also a quoted string. 
-  
-More information: 
+In this example, the first parameter, :math:`T`, is the *output* property that will be returned from ``PropsSI``.  The second and fourth parameters are the specified *input pair* of properties that determine the state point where the output property will be calculated.  The *output* property and *input pair* properties are text strings and must be quoted.  The third and fifth parameters are the *values* of the *input pair* properties and will determine the state point.  The sixth and last parameter is the fluid for which the *output* property will be calculated; also a quoted string.
+
+More information:
 
 * :ref:`Table of inputs to PropsSI function <parameter_table>`
 * :ref:`More examples of the high-level API <Props_Sample>`
@@ -29,12 +29,12 @@ More information:
 
 All :ref:`the wrappers <wrappers>` wrap this function in exactly the same way.
 
-For pure and pseudo-pure fluids, two state variables are required to fix the state.  The equations of state are based on :math:`T` and :math:`\rho` as state variables, so :math:`T, \rho` will always be the fastest inputs.  :math:`P,T` will be a bit slower (3-10 times), followed by input pairs where neither :math:`T` nor :math:`\rho` are specified, like :math:`P,H`; these will be much slower.  If speed is an issue, you can look into table-based interpolation methods using :ref:`TTSE or bicubic interpolation <Tabular_Interpolation>`; or if you are only interested in Water properties, you can look into using the :ref:`IF97 <IF97>` (industrial formulation) backend.  
+For pure and pseudo-pure fluids, two state variables are required to fix the state.  The equations of state are based on :math:`T` and :math:`\rho` as state variables, so :math:`T, \rho` will always be the fastest inputs.  :math:`P,T` will be a bit slower (3-10 times), followed by input pairs where neither :math:`T` nor :math:`\rho` are specified, like :math:`P,H`; these will be much slower.  If speed is an issue, you can look into table-based interpolation methods using :ref:`TTSE or bicubic interpolation <Tabular_Interpolation>`; or if you are only interested in Water properties, you can look into using the :ref:`IF97 <IF97>` (industrial formulation) backend.
 
 Vapor, Liquid, and Saturation States
 ------------------------------------
 
-If the input pair (say, :math:`P,T`) defines a state point that lies in the *vapor* region, then the vapor property at that state point will be returned.  Likewise, if the state point lies in the *liquid* region, then the liquid state property at that state point will be returned.  If the state point defined by the input pair lies within 1E-4 % of the saturation pressure, then CoolProp may return an error, because both *liquid* and *vapor* are defined along the saturation curve.  
+If the input pair (say, :math:`P,T`) defines a state point that lies in the *vapor* region, then the vapor property at that state point will be returned.  Likewise, if the state point lies in the *liquid* region, then the liquid state property at that state point will be returned.  If the state point defined by the input pair lies within 1E-4 % of the saturation pressure, then CoolProp may return an error, because both *liquid* and *vapor* are defined along the saturation curve.
 
 To retrieve either the *vapor* or *liquid* properties along the saturation curve, provide an input pair that includes either the saturation temperature, :math:`T`, or saturation pressure, :math:`p`, along with the *vapor quality*, :math:`Q`.  Use a value of :math:`Q=1` for the saturated *vapor* property or :math:`Q=0` for the saturated *liquid* property.  For example, at a saturation pressure of 1 atm, the *liquid* and *vapor* enthalpies can be returned as follows.
 
@@ -42,14 +42,14 @@ To retrieve either the *vapor* or *liquid* properties along the saturation curve
 
     # Import the PropsSI function
     In [1]: from CoolProp.CoolProp import PropsSI
-    
-    # Saturated vapor enthalpy of Water at 1 atm in J/kg-K
+
+    # Saturated vapor enthalpy of Water at 1 atm in J/kg
     In [2]: H_V = PropsSI('H','P',101325,'Q',1,'Water'); print(H_V)
 
-    # Saturated liquid enthalpy of Water at 1 atm in J/kg-K
+    # Saturated liquid enthalpy of Water at 1 atm in J/kg
     In [3]: H_L = PropsSI('H','P',101325,'Q',0,'Water'); print(H_L)
 
-    # Latent heat of vaporization of Water at 1 atm in J/kg-K
+    # Latent heat of vaporization of Water at 1 atm in J/kg
     In [4]: H_V - H_L
 
 .. note::
@@ -58,9 +58,9 @@ To retrieve either the *vapor* or *liquid* properties along the saturation curve
 Imposing the Phase (Optional)
 -----------------------------
 
-Each call to ``PropsSI()`` requires the phase to be determined based on the provided input pair, and may require a non-trivial flash calculation to determine if the state point is in the single-phase or two-phase region and to generate a sensible initial guess for the solver. For computational efficiency, ``PropsSI()`` allows the phase to be manually imposed through the input key parameters.  If unspecified, PropsSI will attempt to determine the phase automatically. 
+Each call to ``PropsSI()`` requires the phase to be determined based on the provided input pair, and may require a non-trivial flash calculation to determine if the state point is in the single-phase or two-phase region and to generate a sensible initial guess for the solver. For computational efficiency, ``PropsSI()`` allows the phase to be manually imposed through the input key parameters.  If unspecified, PropsSI will attempt to determine the phase automatically.
 
-Depending on the input pair, there may or may not be a speed benefit to imposing a phase.  However, some state points may not be able to find a suitable initial guess for the solver and being able to impose the phase manually may offer a solution if the solver is failing.  Additionally,  with an input pair in the two-phase region, it can be useful to impose a liquid or gas phase to instruct ``PropsSI()`` to return the saturated liquid or saturated gas properties.  
+Depending on the input pair, there may or may not be a speed benefit to imposing a phase.  However, some state points may not be able to find a suitable initial guess for the solver and being able to impose the phase manually may offer a solution if the solver is failing.  Additionally,  with an input pair in the two-phase region, it can be useful to impose a liquid or gas phase to instruct ``PropsSI()`` to return the saturated liquid or saturated gas properties.
 
 To specify the phase to be used, add the "|" delimiter to one (and only one) of the input key strings followed by one of the phase strings in the table below:
 
@@ -83,7 +83,7 @@ To specify the phase to be used, add the "|" delimiter to one (and only one) of 
 +---------------------------------+----------------------------------------------------+
 
 For example:
-    
+
 .. ipython::
 
     # Get the density of Water at T = 461.1 K and P = 5.0e6 Pa, imposing the liquid phase
@@ -112,7 +112,7 @@ You can obtain string-encoded information about the fluid from the ``get_fluid_p
 .. ipython::
 
     In [1]: import CoolProp.CoolProp as CP
-    
+
     In [1]: for k in ['formula','CAS','aliases','ASHRAE34','REFPROP_name','pure','INCHI','INCHI_Key','CHEMSPIDER_ID']:
        ...:     item = k + ' --> ' + CP.get_fluid_param_string("R125", k)
        ...:     print(item)
@@ -127,25 +127,25 @@ Trivial inputs
 In order to obtain trivial inputs that do not depend on the thermodynamic state, in wrappers that support the ``Props1SI`` function, you can obtain the trivial parameter (in this case the critical temperature of water) like:
 
     Props1SI("Tcrit","Water")
-    
+
 In python, the ``PropsSI`` function is overloaded to also accept two inputs:
 
 .. ipython::
 
     In [1]: import CoolProp.CoolProp as CP
-    
+
     In [1]: CP.PropsSI("Tcrit","Water")
-    
+
     In [1]: CP.PropsSI("Tcrit","REFPROP::Water")
-    
+
 Furthermore, you can in all languages call the ``PropsSI`` function directly using dummy arguments for the other unused parameters:
 
 .. ipython::
 
     In [1]: import CoolProp.CoolProp as CP
-    
+
     In [1]: CP.PropsSI("Tcrit","",0,"",0,"Water")
-    
+
 PhaseSI function
 ----------------
 
@@ -154,7 +154,7 @@ It can be useful to know what the phase of a given state point is.  A high-level
 .. ipython::
 
     In [1]: import CoolProp.CoolProp as CP
-    
+
     In [5]: CP.PhaseSI('P',101325,'Q',0,'Water')
 
 The phase index (as floating point number) can also be obtained using the PropsSI function. In python you would do:
@@ -162,9 +162,9 @@ The phase index (as floating point number) can also be obtained using the PropsS
 .. ipython::
 
     In [1]: import CoolProp.CoolProp as CP
-    
+
     In [5]: CP.PropsSI('Phase','P',101325,'Q',0,'Water')
-    
+
 where you can obtain the integer indices corresponding to the phase flags using the ``get_phase_index`` function:
 
 .. ipython::
@@ -172,10 +172,10 @@ where you can obtain the integer indices corresponding to the phase flags using 
     In [1]: import CoolProp.CoolProp as CP
 
     In [6]: CP.get_phase_index('phase_twophase')
-    
+
     # Or for liquid
     In [6]: CP.get_phase_index('phase_liquid')
-    
+
 For a given fluid, the phase can be plotted in T-p coordinates:
 
 .. plot::
@@ -243,25 +243,25 @@ For a given fluid, the phase can be plotted in T-p coordinates:
     plt.text(450, 5e4, 'gas', rotation = 45)
 
     plt.ylim(611,1e9)
-    plt.gca().set_yscale('log')    
+    plt.gca().set_yscale('log')
     plt.gca().set_xlim(240, 1000)
     plt.ylabel('Pressure [Pa]')
     plt.xlabel('Temperature [K]')
     plt.tight_layout()
-    
+
 .. _partial_derivatives_high_level:
-    
+
 Partial Derivatives
 -------------------
 
 First Partial Derivatives for Single-phase States
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-For some applications it can be useful to have access to partial derivatives of thermodynamic properties.  A generalized first partial derivative has been implemented into CoolProp, which can be obtained using the ``PropsSI`` function by encoding the desired derivative as a string.  The format of the string is ``d(OF)/d(WRT)|CONSTANT`` which is the same as 
+For some applications it can be useful to have access to partial derivatives of thermodynamic properties.  A generalized first partial derivative has been implemented into CoolProp, which can be obtained using the ``PropsSI`` function by encoding the desired derivative as a string.  The format of the string is ``d(OF)/d(WRT)|CONSTANT`` which is the same as
 
 .. math::
 
     \left. \frac{\partial OF}{\partial WRT}\right|_{CONSTANT}
-    
+
 At the low-level, the CoolProp code calls the function :cpapi:`AbstractState::first_partial_deriv`.  Refer to the function documentation to see how the generalized derivative works.
 
 .. warning::
@@ -273,16 +273,16 @@ Here is an example of calculating the constant pressure specific heat, which is 
 .. math::
 
     c_p = \left.\frac{\partial h}{\partial T}\right|_{p}
-    
+
 and called through python
 
 .. ipython::
 
     In [1]: import CoolProp.CoolProp as CP
-    
+
     # c_p using c_p
     In [5]: CP.PropsSI('C','P',101325,'T',300,'Water')
-    
+
     # c_p using derivative
     In [5]: CP.PropsSI('d(Hmass)/d(T)|P','P',101325,'T',300,'Water')
 
@@ -296,7 +296,7 @@ In a similar fashion it is possible to evaluate second derivatives.  For instanc
 .. ipython::
 
     In [1]: import CoolProp.CoolProp as CP
-    
+
     # c_p using derivative
     In [1]: CP.PropsSI('d(d(Hmass)/d(T)|P)/d(Hmass)|P','P',101325,'T',300,'Water')
 
@@ -305,7 +305,7 @@ where the inner part ``d(Hmass)/d(T)|P`` is the definition of :math:`c_p`.
 .. warning::
 
     This derivative formulation is currently only valid for homogeneous (single-phase) states.  Two phase derivatives are not defined, and are for many combinations, invalid.
-    
+
 It is also possible to call the derivatives directly using the :ref:`low-level partial derivatives functionality <partial_derivatives_low_level>`.  The low-level routine is in general faster because it avoids the string parsing.
 
 First Saturation Derivatives
@@ -315,17 +315,17 @@ It is also possible to retrieve the derivatives along the saturation curves usin
 
 .. warning::
 
-    This derivative formulation is currently only valid for saturated states where the vapor quality is either 0 or 1.  
+    This derivative formulation is currently only valid for saturated states where the vapor quality is either 0 or 1.
 
 For instance, to calculate the saturation derivative of enthalpy ALONG the saturated vapor curve, you could do:
 
 .. ipython::
 
     In [1]: import CoolProp
-    
+
     In [1]: CoolProp.CoolProp.PropsSI('d(Hmolar)/d(T)|sigma','P',101325,'Q',1,'Water')
 
-It is also possible to call the derivatives directly using the :ref:`low-level partial derivatives functionality <partial_derivatives_low_level>`.  The low-level routine is in general faster because it avoids the string parsing. 
+It is also possible to call the derivatives directly using the :ref:`low-level partial derivatives functionality <partial_derivatives_low_level>`.  The low-level routine is in general faster because it avoids the string parsing.
 
 .. _predefined_mixtures:
 
@@ -337,17 +337,17 @@ A number of predefined mixtures are included in CoolProp.  You can retrieve the 
 .. ipython::
 
     In [1]: import CoolProp.CoolProp as CP
-    
+
     In [1]: CP.get_global_param_string('predefined_mixtures').split(',')[0:6]
-    
+
 and then to calculate the density of air using the mixture model at 1 atmosphere (=101325 Pa) and 300 K, you could do
 
 .. ipython::
 
     In [1]: import CoolProp.CoolProp as CP
-    
+
     In [1]: CP.PropsSI('D','P',101325,'T',300,'Air.mix')
-    
+
 Exactly the same methodology can be used from other wrappers.
 
 User-Defined Mixtures
@@ -358,9 +358,9 @@ When using mixtures in CoolProp, you can specify mixture components and composit
 .. ipython::
 
     In [1]: import CoolProp.CoolProp as CP
-    
+
     In [1]: CP.PropsSI('D','T',300,'P',101325,'HEOS::R32[0.697615]&R125[0.302385]')
-    
+
 You can handle ternary and multi-component mixtures in the same fashion, just add the other components to the fluid string with a ``&`` separating components and the fraction of the component in ``[`` and ``]`` brackets
 
 .. _high_level_set_reference_state:
@@ -370,11 +370,11 @@ Reference States
 
 Enthalpy and entropy are *relative* properties!  You should always be comparing *differences* in enthalpy rather than absolute values of the enthalpy or entropy.  That said, if can be useful to set the reference state values for enthalpy and entropy to one of a few standard values.  This is done by the use of the ``set_reference_state`` function in python, or the ``set_reference_stateS`` function most everywhere else.  For documentation of the underlying C++ function, see :cpapi:`CoolProp::set_reference_stateS`.
 
-.. warning:: 
+.. warning::
 
     The changing of the reference state should be part of the initialization of your program, and it is not recommended to change the reference state during the course of making calculations
 
-A number of reference states can be used: 
+A number of reference states can be used:
 
 * ``IIR``: h = 200 kJ/kg, s=1 kJ/kg/K at 0C saturated liquid
 * ``ASHRAE``: h = 0, s = 0 @ -40C saturated liquid
@@ -386,18 +386,18 @@ which can be used like
 .. ipython::
 
     In [1]: import CoolProp.CoolProp as CP
-    
+
     In [1]: CP.set_reference_state('n-Propane','ASHRAE')
-    
+
     # Should be zero (or very close to it)
     In [1]: CP.PropsSI('H', 'T', 233.15, 'Q', 0, 'n-Propane')
-    
+
     # Back to the original value
     In [1]: CP.set_reference_state('n-Propane','DEF')
-    
+
     # Should not be zero
     In [1]: CP.PropsSI('H', 'T', 233.15, 'Q', 0, 'n-Propane')
-    
+
 Calling REFPROP
 ---------------
 
@@ -406,10 +406,10 @@ If you have the `REFPROP library <http://www.nist.gov/srd/nist23.cfm>`_ installe
 .. ipython::
 
     In [1]: import CoolProp.CoolProp as CP
-    
+
     # Using properties from CoolProp to get R410A density
     In [2]: CP.PropsSI('D','T',300,'P',101325,'HEOS::R32[0.697615]&R125[0.302385]')
-    
+
     # Using properties from REFPROP to get R410A density
     In [2]: CP.PropsSI('D','T',300,'P',101325,'REFPROP::R32[0.697615]&R125[0.302385]')
 
@@ -422,10 +422,10 @@ The fluids in CoolProp are all compiled into the library itself, and are given i
     :okexcept:
 
     In [1]: import CoolProp.CoolProp as CP
-    
+
     # Get the JSON structure for Water
     In [2]: jj = CP.get_fluid_param_string("Water", "JSON")
-    
+
     # Now load it back into CoolProp - Oops! This isn't going to work because it is already there.
     In [2]: CP.add_fluids_as_JSON("HEOS", jj)
 
@@ -456,38 +456,38 @@ Sample Code
 .. ipython::
 
     In [1]: import CoolProp as CP
-    
+
     In [1]: print(CP.__version__)
-    
+
     In [1]: print(CP.__gitrevision__)
-    
-    #Import the things you need 
+
+    #Import the things you need
     In [1]: from CoolProp.CoolProp import PropsSI
-    
+
     # Specific heat (J/kg/K) of 20% ethylene glycol as a function of T
     In [2]: PropsSI('C','T',298.15,'P',101325,'INCOMP::MEG-20%')
-    
+
     # Density of Air at standard atmosphere in kg/m^3
     In [2]: PropsSI('D','T',298.15,'P',101325,'Air')
-    
+
     # Saturation temperature of Water at 1 atm
     In [2]: PropsSI('T','P',101325,'Q',0,'Water')
-    
+
     # Saturated vapor enthalpy of R134a at 0C (Q=1)
     In [2]: PropsSI('H','T',273.15,'Q',1,'R134a')
 
     # Saturated liquid enthalpy of R134a at 0C (Q=0)
     In [2]: PropsSI('H','T',273.15,'Q',0,'R134a')
-    
+
     # Using properties from CoolProp to get R410A density
     In [2]: PropsSI('D','T',300,'P',101325,'HEOS::R32[0.697615]&R125[0.302385]')
-    
+
     # Using properties from REFPROP to get R410A density
     In [2]: PropsSI('D','T',300,'P',101325,'REFPROP::R32[0.697615]&R125[0.302385]')
-    
+
     # Check that the same as using pseudo-pure
     In [2]: PropsSI('D','T',300,'P',101325,'R410A')
-    
+
     # Using IF97 to get Water saturated vapor density at 100C
     In [2]: PropsSI('D','T',400,'Q',1,'IF97::Water')
 
@@ -500,7 +500,7 @@ Table of string inputs to PropsSI function
 ------------------------------------------
 
 .. note::
-   
+
    Please note that any parameter that is indicated as a trivial parameter can be obtained from the ``Props1SI`` function as shown above in :ref:`trivial_inputs`
-   
+
 .. include:: parameter_table.rst.in

--- a/Web/coolprop/wrappers/Scilab/sample.sce
+++ b/Web/coolprop/wrappers/Scilab/sample.sce
@@ -6,7 +6,7 @@
 //
 // Conveniently, FORTRAN77 also requires that all functions take all arguments by
 // reference, and we added FORTRAN77-compatible versions of HAPropsSI and PropsSI
-// (but no other functions).  So these reference-only functions will work with 
+// (but no other functions).  So these reference-only functions will work with
 // scilab's crippled shared library interface.
 //
 // Below we have made small Scilab wrapper functions around these FORTRAN77-compatible
@@ -17,9 +17,9 @@ if (getos() == "Windows") then
     else
         link('CoolProp.dll', ['propssi_','hapropssi_'], 'c');
     end
-elseif (getOS() == "Darwin") then
+elseif (getos() == "Darwin") then
     link('libCoolProp.dylib', ['propssi_','hapropssi_'], 'c');
-else: // Linux
+else // Linux
     link('libCoolProp.so', ['propssi_','hapropssi_'], 'c');
 end
 


### PR DESCRIPTION
Fixed a couple of typos that prevent Scilab to run the Coolprop's library under Linux.