### PR TITLE
Fix uppercase-only fluid naming

### DIFF
--- a/src/Backends/Cubics/CubicsLibrary.cpp
+++ b/src/Backends/Cubics/CubicsLibrary.cpp
@@ -51,11 +51,11 @@ public:
                 val.alpha0 = JSONFluidLibrary::parse_alpha0((*itr)["alpha0"]);
             }
             std::pair<std::map<std::string, CubicsValues>::iterator, bool> ret;
-            ret = fluid_map.insert(std::pair<std::string, CubicsValues>(val.name, val) );
+            ret = fluid_map.insert(std::pair<std::string, CubicsValues>(upper(val.name), val) );
             if (ret.second == false && get_config_bool(OVERWRITE_FLUIDS)) {
                 // Already there, see http://www.cplusplus.com/reference/map/map/insert/
                 fluid_map.erase(ret.first);
-                ret = fluid_map.insert(std::pair<std::string, CubicsValues>(val.name, val));
+                ret = fluid_map.insert(std::pair<std::string, CubicsValues>(upper(val.name), val));
                 if (get_debug_level() > 0){
                     std::cout << "added the cubic fluid: "+val.name << std::endl;
                 }
@@ -65,7 +65,7 @@ public:
             for (std::vector<std::string>::const_iterator it = val.aliases.begin(); it != val.aliases.end(); ++it){
                 if (aliases_map.find(*it) == aliases_map.end()){
                     // It's not already in aliases map
-                    aliases_map.insert(std::pair<std::string, std::string>(*it, val.name) );
+                    aliases_map.insert(std::pair<std::string, std::string>(*it, upper(val.name)));
                 }
             }
             counter ++;
@@ -80,7 +80,7 @@ public:
         if (it != fluid_map.end()) {
             return it->second;
         } else {
-            std::map<std::string, std::string>::iterator italias = aliases_map.find(uppercase_identifier);
+            std::map<std::string, std::string>::iterator italias = aliases_map.find(identifier);
             if (italias != aliases_map.end()){
                 // Alias was found, use it to get the fluid name, and then the cubic values
                 return fluid_map.find(italias->second)->second;


### PR DESCRIPTION
### Description of the Change

It was annoying specifying all fluid names in caps when adding new fluids to the cubic backend. Simply removing the uppercasing when searching for the fluid in the database is not a good idea cause of the need to specify all possible name spellings in the aliases. Now all fluid names adding to the database uppercased and aliases stay the same.

### Benefits

No need to uppercase fluid names anymore.

### Possible Drawbacks

I can't come up with any.

### Verification Process

I just tried to add new fluid.

```python
import json
import CoolProp.CoolProp as CP


fluid_data = {
    'CAS': '79-01-6',
    'Tc': 571.0,
    'Tc_units': 'K',
    'acentric': 0.217,
    'aliases': ['tce', "TCE"],
    'molemass': 0.131387,
    'molemass_units': 'kg/mol',
    'name': 'trichloroethylene',
    'pc': 4910000.0,
    'pc_units': 'Pa'
}

CP.add_fluids_as_JSON("PR", json.dumps([fluid_data]))
T1 = CP.PropsSI("T", "P", 101325, "Q", 0,"PR::Trichloroethylene")
T2 = CP.PropsSI("T", "P", 101325, "Q", 0,"PR::tce")
T3 = CP.PropsSI("T", "P", 101325, "Q", 0,"PR::TCE")
print(T1 == T2 == T3)  # True
print(T3)  # 359.23423445653344
```

### Applicable Issues

I don't know any.