### PR TITLE
fix typos in pcsaft json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 /wrappers/Python/CoolProp.egg-info
 /wrappers/Python/dist
 /wrappers/Python/CoolProp/*.o
+/wrappers/Python/CoolProp/*.so
 /wrappers/Python/CoolProp/AbstractState.html
 /wrappers/Python/CoolProp/CoolProp.cpp
 /wrappers/Python/CoolProp/CoolProp.html
@@ -40,7 +41,7 @@
 /dev/all_fluids_verbose.json
 /dev/all_fluids.json
 /include/all_fluids_JSON.h
-/include/all_pcsaft_JSON.h 
+/include/all_pcsaft_JSON.h
 /include/gitrevision.h
 /include/mixture_excess_term_JSON.h
 /include/mixture_reducing_parameters_JSON.h

--- a/dev/pcsaft/mixture_binary_pairs_pcsaft.json
+++ b/dev/pcsaft/mixture_binary_pairs_pcsaft.json
@@ -236,7 +236,7 @@
     "CAS1": "1333-74-0",
     "CAS2": "592-76-7",
     "Name1": "HYDROGEN",
-    "Name2": "HEPTENE",
+    "Name2": "1-HEPTENE",
     "kij": 0.0
   },
   {
@@ -244,7 +244,7 @@
     "CAS1": "1333-74-0",
     "CAS2": "111-66-0",
     "Name1": "HYDROGEN",
-    "Name2": "OCTENE",
+    "Name2": "1-OCTENE",
     "kij": 0.0
   },
   {


### PR DESCRIPTION
### Description of the Change

Two compounds were misnamed in the file containing PC-SAFT interaction parameters (mixture_binary_pairs_pcsaft.json). "HEPTENE" and "OCTENE" should be "1-HEPTENE" and "1-OCTENE". The .so pattern was also missing from .gitignore.

### Benefits

Now the names here match with those in the json file containing pure compound PC-SAFT parameters.

### Possible Drawbacks

I guess there's always the chance I accidentally added more typos...

### Verification Process



### Applicable Issues


