### PR TITLE
Allow nD-array input to PropsSI

### DIFF
--- a/wrappers/Python/CoolProp/CoolProp.pyx
+++ b/wrappers/Python/CoolProp/CoolProp.pyx
@@ -393,10 +393,10 @@ cpdef PropsSI(in1, in2, in3 = None, in4 = None, in5 = None, in6 = None, in7 = No
         is_iterable3 = iterable(in3)
         is_iterable5 = iterable(in5)
 
-        if _numpy_supported and is_iterable3 and isinstance(in3, np.ndarray) and (np.prod(in3.shape) != max(in3.shape)):
-            raise ValueError("Input 3 is not one-dimensional")
-        if _numpy_supported and is_iterable5 and isinstance(in5, np.ndarray) and (np.prod(in5.shape) != max(in5.shape)):
-            raise ValueError("Input 5 is not one-dimensional")
+        #if _numpy_supported and is_iterable3 and isinstance(in3, np.ndarray) and (np.prod(in3.shape) != max(in3.shape)):
+        #    raise ValueError("Input 3 is not one-dimensional")
+        #if _numpy_supported and is_iterable5 and isinstance(in5, np.ndarray) and (np.prod(in5.shape) != max(in5.shape)):
+        #    raise ValueError("Input 5 is not one-dimensional")
 
         if is_iterable1 or is_iterable3 or is_iterable5:
             # Prepare the output datatype
@@ -405,24 +405,34 @@ cpdef PropsSI(in1, in2, in3 = None, in4 = None, in5 = None, in6 = None, in7 = No
             else:
                 vin1 = in1
 
+            target_shape = None # out.reshape(target_shape)
+            target_size = None
             # Resize state variable inputs
             if is_iterable3 and is_iterable5:
-                if len(in3) != len(in5):
-                    raise TypeError("Sizes of Prop1 {n1:d} and Prop2 {n2:d} to PropsSI are not the same".format(n1 = len(in3), n2 = len(in5)))
+                target_shape = in3.shape
+                target_size = in3.size
+                if in3.shape != in5.shape:
+                    raise TypeError("Shapes of Prop1 {n1} and Prop2 {n2} to PropsSI are not the same".format(n1 = in3.shape, n2 = in5.shape))
                 else:
-                    vval1 = in3
-                    vval2 = in5
+                    vval1 = np.ravel(in3)
+                    vval2 = np.ravel(in5)
             elif is_iterable3 and not is_iterable5:
-                vval1 = in3
-                vval2.resize(len(in3))
-                templist = [in5]*len(in3)
+                target_shape = in3.shape
+                target_size = in3.size
+                vval1 = np.ravel(in3)
+                vval2.resize(target_size)
+                templist = [in5]*target_size
                 vval2 = templist
             elif is_iterable5 and not is_iterable3:
-                vval1.resize(len(in5))
-                templist = [in3]*len(in5)
+                target_shape = in5.shape
+                target_size = in5.size
+                vval1.resize(target_size)
+                templist = [in3]*target_size
                 vval1 = templist
-                vval2 = in5
+                vval2 = np.ravel(in5)
             else:
+                target_shape = None
+                target_size = None
                 vval1.resize(1)
                 vval1[0] = in3
                 vval2.resize(1)
@@ -444,8 +454,10 @@ cpdef PropsSI(in1, in2, in3 = None, in4 = None, in5 = None, in6 = None, in7 = No
             # Check that we got some output
             if outmat.empty():
                 raise ValueError(_get_global_param_string(b'errstring'))
-
-            return ndarray_or_iterable(outmat)
+            if target_shape is not None:
+                return ndarray_or_iterable(outmat).reshape(target_shape)
+            else:
+                return ndarray_or_iterable(outmat)
         else:
             # This version takes doubles
             val = _PropsSI(in1, in2, in3, in4, in5, in6)


### PR DESCRIPTION
### Description of the Change

Added a reshape operation to the Python wrapper. nD inputs are converted to 1D vectors before PropsSImulti is called and the result is converted back to the original shape.

### Benefits

No more messing with the array shape prior to calling CoolProp.

### Possible Drawbacks

None

### Verification Process

```Python
from CoolProp.CoolProp import PropsSI
import numpy as np

in1 = np.array([280, 290, 300, 280, 290, 300])
in2 = np.array([0, 0.5, 1, 0.0, 0.5, 1])

out1 = PropsSI('P', 'T', in1, 'Q', in2, 'R134a')
out2 = PropsSI('P', 'T', in1.reshape(2, 3), 'Q', in2.reshape(2, 3), 'R134a')
print(np.allclose(out1, np.ravel(out2)))
print(np.allclose(out1.reshape(2, 3), out2))

out1 = PropsSI('P', 'T', in1, 'Q', 0.5, 'R134a')
out2 = PropsSI('P', 'T', in1.reshape(2, 3), 'Q', 0.5, 'R134a')
print(np.allclose(out1, np.ravel(out2)))
print(np.allclose(out1.reshape(2, 3), out2))

out1 = PropsSI('P', 'T', 300, 'Q', in2, 'R134a')
out2 = PropsSI('P', 'T', 300, 'Q', in2.reshape(2, 3), 'R134a')
print(np.allclose(out1, np.ravel(out2)))
print(np.allclose(out1.reshape(2, 3), out2))


try:
    out = PropsSI('P', 'T', in1.reshape(2, 3), 'Q', in2, 'R134a')
except Exception as e:
    print(e)
    
try:
    out = PropsSI('P', 'T', in1, 'Q', in2.reshape(2, 3), 'R134a')
except Exception as e:
    print(e)
```

### Applicable Issues

- closes #1898