### PR TITLE
Asymmetric BIPs

### DIFF
--- a/include/AbstractState.h
+++ b/include/AbstractState.h
@@ -574,6 +574,10 @@ public:
     virtual void set_binary_interaction_string(const std::string &CAS1, const std::string &CAS2, const std::string &parameter, const std::string &value){ throw NotImplementedError("set_binary_interaction_string is not implemented for this backend"); };
     /// Set binary mixture string parameter (EXPERT USE ONLY!!!)
     virtual void set_binary_interaction_string(const std::size_t i, const std::size_t j, const std::string &parameter, const std::string &value){ throw NotImplementedError("set_binary_interaction_string is not implemented for this backend"); };
+    /// Set binary mixture string parameter (EXPERT USE ONLY!!!)
+    virtual void set_binary_interaction_double(const std::string &CAS1, const std::string &CAS2, const std::string &parameter, const double value, const bool symmetric){ throw NotImplementedError("set_binary_interaction_double is not implemented for this backend"); };
+    /// Set binary mixture string parameter (EXPERT USE ONLY!!!)
+    virtual void set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string &parameter, const double value, const bool symmetric){ throw NotImplementedError("set_binary_interaction_double is not implemented for this backend"); };
     /// Get binary mixture double value (EXPERT USE ONLY!!!)
     virtual double get_binary_interaction_double(const std::string &CAS1, const std::string &CAS2, const std::string &parameter){ throw NotImplementedError("get_binary_interaction_double is not implemented for this backend"); };
     /// Get binary mixture double value (EXPERT USE ONLY!!!)

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -519,8 +519,11 @@ CoolPropDbl CoolProp::AbstractCubicBackend::calc_molar_mass(void)
 }
 
 void CoolProp::AbstractCubicBackend::set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string &parameter, const double value){
+    CoolProp::AbstractCubicBackend::set_binary_interaction_double(i, j, parameter, value, false);
+}
+void CoolProp::AbstractCubicBackend::set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string &parameter, const double value, const bool symmetric){
     if (parameter == "kij" || parameter == "k_ij"){
-        get_cubic()->set_kij(i, j, value);
+        get_cubic()->set_kij(i, j, value, symmetric);
     }
     else{
         throw ValueError(format("I don't know what to do with parameter [%s]", parameter.c_str()));

--- a/src/Backends/Cubics/CubicBackend.h
+++ b/src/Backends/Cubics/CubicBackend.h
@@ -197,9 +197,11 @@ public:
     CoolPropDbl calc_molar_mass(void);
     
     void set_binary_interaction_double(const std::size_t i1, const std::size_t i2, const std::string &parameter, const double value);
+    void set_binary_interaction_double(const std::size_t i1, const std::size_t i2, const std::string &parameter, const double value, const bool symmetric);    
     double get_binary_interaction_double(const std::size_t i1, const std::size_t i2, const std::string &parameter);
     
     void set_binary_interaction_double(const std::string &CAS1, const std::string &CAS2, const std::string &parameter, const double value){throw ValueError("set_binary_interaction_double not defined for AbstractCubic not defined for CAS #"); }
+    void set_binary_interaction_double(const std::string &CAS1, const std::string &CAS2, const std::string &parameter, const double value, const bool symmetric){throw ValueError("set_binary_interaction_double not defined for AbstractCubic not defined for CAS #"); }
     double get_binary_interaction_double(const std::string &CAS1, const std::string &CAS2, const std::string &parameter){throw ValueError("get_binary_interaction_double not defined for AbstractCubic not defined for CAS #"); };
 
     // Return a 1-1 copy of this class

--- a/src/Backends/Cubics/GeneralizedCubic.h
+++ b/src/Backends/Cubics/GeneralizedCubic.h
@@ -111,7 +111,11 @@ public:
     /// Set the entire kij matrix in one shot
     void set_kmat(const std::vector< std::vector<double> > &k){ this->k = k; };
     /// Set the kij factor for the ij pair
-    void set_kij(std::size_t i, std::size_t j, double val){ k[i][j] = val; k[j][i] = val;}
+    void set_kij(std::size_t i, std::size_t j, double val, double symmetric){ 
+        k[i][j] = val;
+        if (symmetric)
+            k[j][i] = val;
+    }
     /// Get the kij factor for the ij pair
     double get_kij(std::size_t i, std::size_t j){ return k[i][j]; }
     /// Get the vector of critical temperatures (in K)

--- a/wrappers/Python/CoolProp/AbstractState.pxd
+++ b/wrappers/Python/CoolProp/AbstractState.pxd
@@ -52,7 +52,7 @@ cdef class AbstractState:
     cpdef set_mass_fractions(self, vector[double] z)
     cpdef set_volu_fractions(self, vector[double] z)
 
-    cpdef set_binary_interaction_double(self, string_or_size_t CAS1, string_or_size_t CAS2, string parameter, double val)
+    cpdef set_binary_interaction_double(self, string_or_size_t CAS1, string_or_size_t CAS2, string parameter, double val, bool sym=*)
     cpdef double get_binary_interaction_double(self, string_or_size_t CAS1, string_or_size_t CAS2, string parameter) except *
     cpdef set_binary_interaction_string(self, string_or_size_t CAS1, string_or_size_t CAS2, string parameter, string val)
     cpdef string get_binary_interaction_string(self, string CAS1, string CAS2, string parameter) except *

--- a/wrappers/Python/CoolProp/AbstractState.pyx
+++ b/wrappers/Python/CoolProp/AbstractState.pyx
@@ -67,12 +67,12 @@ cdef class AbstractState:
         """ Apply a simple mixing rule - wrapper of c++ function :cpapi:`CoolProp::AbstractState::apply_simple_mixing_rule` """
         self.thisptr.apply_simple_mixing_rule(i, j, model)
 
-    cpdef set_binary_interaction_double(self, string_or_size_t CAS1, string_or_size_t CAS2, string parameter, double val):
+    cpdef set_binary_interaction_double(self, string_or_size_t CAS1, string_or_size_t CAS2, string parameter, double val, bool sym=True):
         """ Set a double precision interaction parameter - wrapper of c++ function :cpapi:`CoolProp::AbstractState::set_binary_interaction_double` """
         if string_or_size_t in cython.integral:
-            self.thisptr.set_binary_interaction_double(<size_t>CAS1, <size_t>CAS2, parameter, val)
+            self.thisptr.set_binary_interaction_double(<size_t>CAS1, <size_t>CAS2, parameter, val, sym)
         else:
-            self.thisptr.set_binary_interaction_double(<string>CAS1, <string>CAS2, parameter, val)
+            self.thisptr.set_binary_interaction_double(<string>CAS1, <string>CAS2, parameter, val, sym)
     cpdef double get_binary_interaction_double(self, string_or_size_t CAS1, string_or_size_t CAS2, string parameter) except *:
         """ Get a double precision interaction parameter - wrapper of c++ function :cpapi:`CoolProp::AbstractState::get_binary_interaction_double` """
         if string_or_size_t in cython.integral:

--- a/wrappers/Python/CoolProp/cAbstractState.pxd
+++ b/wrappers/Python/CoolProp/cAbstractState.pxd
@@ -53,6 +53,7 @@ cdef extern from "AbstractState.h" namespace "CoolProp":
         void change_EOS(const size_t, const string &) except +ValueError
 
         void set_binary_interaction_double(const string, const string &, const string &, const double s) except +ValueError
+        void set_binary_interaction_double(const string, const string &, const string &, const double s, const bool) except +ValueError
         void set_binary_interaction_string(const string &, const string &, const string &, const string &) except +ValueError
         double get_binary_interaction_double(const string &, const string &, const string &) except +ValueError
         string get_binary_interaction_string(const string &, const string &, const string &) except +ValueError
@@ -61,6 +62,7 @@ cdef extern from "AbstractState.h" namespace "CoolProp":
 
         double get_binary_interaction_double(const size_t, const size_t, const string &) except +ValueError
         void set_binary_interaction_double(const size_t, const size_t, const string &, const double s) except +ValueError
+        void set_binary_interaction_double(const size_t, const size_t, const string &, const double s, const bool) except +ValueError
 
         string name() except +ValueError
         string backend_name() except +ValueError


### PR DESCRIPTION
### Description of the Change

Some new mixing rules require the matrix of binary interaction parameters (BIPs) to be asymmetric, so I have done my best to add such functionality. Methods `set_binary_interaction_double` were overwritten to accept an additional (optional) parameter which specifies whether to set Kij symmetrically or not (symmetrically by default).

### Benefits

Now you can specify the matrix of BIPs asymmetrically.

### Possible Drawbacks

Adds new ways to inexperienced users to ruin their calculations =D

### Verification Process

The following python script shows the use and effect of the introduced changes.

```python
import CoolProp.CoolProp as CP

AS = CP.AbstractState("PR", "benzene&toluene")
AS.set_binary_interaction_double(0, 1, "kij", 0.05)  # symmetrically
k01 = AS.get_binary_interaction_double(0, 1, "kij")
k10 = AS.get_binary_interaction_double(1, 0, "kij")
print(f"k01 = {k01}; k10 = {k10}")
# Output: k01 = 0.05; k10 = 0.05
AS.set_mole_fractions([0.3, 0.7])
AS.update(CP.PQ_INPUTS, 101325, 0)
ys = AS.mole_fractions_vapor()
print(ys)
# Output: [0.5042805536100579, 0.49571944638994214]

AS.set_binary_interaction_double(0, 1, "kij", 0.1, False)  # asymmetrically
k01 = AS.get_binary_interaction_double(0, 1, "kij")
k10 = AS.get_binary_interaction_double(1, 0, "kij")
print(f"k01 = {k01}; k10 = {k10}")
# Output: k01 = 0.1; k10 = 0.05
AS.update(CP.PQ_INPUTS, 101325, 0)
ys = AS.mole_fractions_vapor()
print(ys)
# Output: [0.5050982763042872, 0.49490172369571284]
```

### Applicable Issues
My own old issue #1890 
