### PR TITLE
A minor correction in case of COOLPROP_OBJECT_LIBRARY=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,8 +523,10 @@ IF ( COOLPROP_OBJECT_LIBRARY OR COOLPROP_STATIC_LIBRARY OR COOLPROP_SHARED_LIBRA
   ELSE()
     MESSAGE(FATAL_ERROR "You have to build a static or shared library.")
   ENDIF()
-
-  target_link_libraries (${LIB_NAME} ${CMAKE_DL_LIBS})
+ 
+  if (NOT COOLPROP_OBJECT_LIBRARY)
+    target_link_libraries (${LIB_NAME} ${CMAKE_DL_LIBS})
+  endif()
 
   # For windows systems, bug workaround for Eigen
   IF (MSVC90)


### PR DESCRIPTION
### Description of the Change

A minor correction of CMakeList.txt is done to suppress the configuration error in case of COOLPROP_OBJECT_LIBRARY=ON, which is a switch to build the objects, usually, required to build the ExternalMedia library in OpenModelica; what is done is just skipping the trouble spot of target_link_libraries for dl library in such a case.

### Benefits

Solving the configuration error during the build-process of libExternalMedia.a for the ExternalMedia package.

### Possible Drawbacks

N/A

### Verification Process

All the options of COOLPROP_OBJECT_LIBRARY, COOLPROP_SHARED_LIBRARY, and COOLPROP_STATIC_LIBRARY are checked in independent manner. After then, the make-process of the ExternalMedia library is also tested chaining the cmake project with COOLPROP_OBJECT_LIBRARY=ON.

### Applicable Issues

Closes #2010 if this PR closes an open issue.
