### PR TITLE
Github Actions: add shared library and doxygen workflows.

### DIFF
--- a/.github/workflows/BuildSharedLibrary.yml
+++ b/.github/workflows/BuildSharedLibrary.yml
@@ -58,24 +58,68 @@ jobs:
     #  # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
     #  run: ctest -C $BUILD_TYPE
 
+
+    - name: Extract OSApp version from CMakeLists.txt
+      shell: python
+      run: |
+        import re
+        from pathlib import Path
+
+        with open('CMakeLists.txt', 'r') as f:
+            content = f.read()
+
+        no_comments_lines = []
+        for line in content.splitlines():
+            l = line.strip().split('#')[0]
+            if l:
+                no_comments_lines.append(l)
+        content = "\n".join(no_comments_lines)
+
+        m_major = re.search(r'set\s*\(COOLPROP_VERSION_MAJOR (\d+)\)', content)
+        m_minor = re.search(r'set\s*\(COOLPROP_VERSION_MINOR (\d+)\)', content)
+        m_patch = re.search(r'set\s*\(COOLPROP_VERSION_PATCH (\d+)\)', content)
+        m_rev = re.search(r'set\s*\(COOLPROP_VERSION_REVISION "*(.*?)"*\)', content)
+
+        coolprop_version = ''
+        if m_major:
+            COOLPROP_VERSION_MAJOR = m_major.groups()[0]
+            coolprop_version += COOLPROP_VERSION_MAJOR
+
+
+        if m_minor:
+            COOLPROP_VERSION_MINOR = m_minor.groups()[0]
+            coolprop_version += "." + COOLPROP_VERSION_MINOR
+
+        if m_patch:
+            COOLPROP_VERSION_PATCH = m_patch.groups()[0]
+            coolprop_version += "." + COOLPROP_VERSION_PATCH
+
+        if m_rev:
+            COOLPROP_VERSION_REV = m_rev.groups()[0]
+            coolprop_version += "-" + COOLPROP_VERSION_REV
+
+        with open(os.environ['GITHUB_ENV'], 'a') as f:
+            f.write(f"\COOLPROP_VERSION={coolprop_version}")
+        print(f"{coolprop_version=}")
+
     - name: Tar.gz the shared library to maintain case sensitivy and file permissions
       working-directory: ./install_root/shared_library/
       shell: bash
       run: |
-        tar -cvzf CoolProp-shared-${{ matrix.os }}.tar.gz ./*
+        tar -cvzf CoolProp-${{ env.COOLPROP_VERSION }}-shared-${{ matrix.os }}.tar.gz ./*
 
     - name: Archive TGZ or ZIP artifacts
       uses: actions/upload-artifact@v2
       with:
-          name: CoolProp-shared-${{ matrix.os }}.tar.gz
-          path: install_root/shared_library/CoolProp-shared-${{ matrix.os }}.tar.gz
+          name: CoolProp-${{ env.COOLPROP_VERSION }}-shared-${{ matrix.os }}.tar.gz
+          path: install_root/shared_library/CoolProp-${{ env.COOLPROP_VERSION }}-shared-${{ matrix.os }}.tar.gz
 
     - name: Upload TGZ or ZIP to release
       if: contains(github.ref, 'refs/tags')
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: install_root/shared_library/CoolProp-shared-${{ matrix.os }}.tar.gz
+        file: install_root/shared_library/CoolProp-${{ env.COOLPROP_VERSION }}-shared-${{ matrix.os }}.tar.gz
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: false

--- a/.github/workflows/BuildSharedLibrary.yml
+++ b/.github/workflows/BuildSharedLibrary.yml
@@ -67,6 +67,7 @@ jobs:
     - name: Archive TGZ or ZIP artifacts
       uses: actions/upload-artifact@v2
       with:
+          name: CoolProp-shared-${{ matrix.os }}.tar.gz
           path: install_root/shared_library/CoolProp-shared-${{ matrix.os }}.tar.gz
 
     - name: Upload TGZ or ZIP to release

--- a/.github/workflows/BuildSharedLibrary.yml
+++ b/.github/workflows/BuildSharedLibrary.yml
@@ -1,0 +1,80 @@
+name: BuildSharedLibrary
+
+on:
+  push:
+    branches: [ master, develop, actions_shared ]
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  pull_request:
+    branches: [ master, develop ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macOS-latest]
+        include:
+        - os: windows-latest
+          nproc: 2
+        - os: ubuntu-latest
+          nproc: 2
+        - os: macOS-latest
+          nproc: 3
+
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Create Build Environment
+      shell: bash
+      run: |
+        mkdir build
+
+    - name: Configure CMake
+      working-directory: ./build
+      shell: bash
+      run: cmake -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE -DCOOLPROP_SHARED_LIBRARY:BOOL=ON ..
+
+    - name: Build
+      working-directory: ./build
+      shell: bash
+      run: |
+        cmake --build . --target install -j $(nproc) --config $BUILD_TYPE
+
+    # TODO: enable testing. -DBUILD_TESTING:BOOL=ON does nothing unless you have Csharp. There is an undocumentated -DCOOLPROP_CATCH_MODULE:BOOL=ON but that fails to build
+    #- name: Test
+    #  working-directory: ${{runner.workspace}}/build
+    #  shell: bash
+    #  # Execute tests defined by the CMake configuration.
+    #  # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+    #  run: ctest -C $BUILD_TYPE
+
+    - name: Tar.gz the shared library to maintain case sensitivy and file permissions
+      working-directory: ./install_root/shared_library/
+      shell: bash
+      run: |
+        tar -cvzf CoolProp-shared-${{ matrix.os }}.tar.gz ./*
+
+    - name: Archive TGZ or ZIP artifacts
+      uses: actions/upload-artifact@v2
+      with:
+          path: install_root/shared_library/CoolProp-shared-${{ matrix.os }}.tar.gz
+
+    - name: Upload TGZ or ZIP to release
+      if: contains(github.ref, 'refs/tags')
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: install_root/shared_library/CoolProp-shared-${{ matrix.os }}.tar.gz
+        tag: ${{ github.ref }}
+        overwrite: true
+        file_glob: false

--- a/.github/workflows/BuildSharedLibrary.yml
+++ b/.github/workflows/BuildSharedLibrary.yml
@@ -18,6 +18,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
+      fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macOS-latest]
         include:
@@ -62,9 +64,6 @@ jobs:
     #  # Execute tests defined by the CMake configuration.
     #  # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
     #  run: ctest -C $BUILD_TYPE
-
-
-
 
     - name: Tar.gz the shared library to maintain case sensitivy and file permissions
       working-directory: ./install_root/shared_library/

--- a/.github/workflows/BuildSharedLibrary.yml
+++ b/.github/workflows/BuildSharedLibrary.yml
@@ -22,14 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macOS-latest]
-        include:
-        - os: windows-latest
-          nproc: 2
-        - os: ubuntu-latest
-          nproc: 2
-        - os: macOS-latest
-          nproc: 3
-
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/BuildSharedLibrary.yml
+++ b/.github/workflows/BuildSharedLibrary.yml
@@ -36,6 +36,10 @@ jobs:
       with:
         submodules: recursive
 
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
     - name: Extract CoolProp version from CMakeLists.txt
       shell: bash
       run: |

--- a/.github/workflows/BuildSharedLibrary.yml
+++ b/.github/workflows/BuildSharedLibrary.yml
@@ -34,9 +34,13 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Create Build Environment
+    - name: Extract CoolProp version from CMakeLists.txt
       shell: bash
       run: |
+        set -x
+        COOLPROP_VERSION=$(python dev/extract_version.py)
+        echo COOLPROP_VERSION=$COOLPROP_VERSION >> $GITHUB_ENV
+        # Create the build directory too
         mkdir build
 
     - name: Configure CMake
@@ -48,6 +52,7 @@ jobs:
       working-directory: ./build
       shell: bash
       run: |
+        set -x
         cmake --build . --target install -j $(nproc) --config $BUILD_TYPE
 
     # TODO: enable testing. -DBUILD_TESTING:BOOL=ON does nothing unless you have Csharp. There is an undocumentated -DCOOLPROP_CATCH_MODULE:BOOL=ON but that fails to build
@@ -59,53 +64,13 @@ jobs:
     #  run: ctest -C $BUILD_TYPE
 
 
-    - name: Extract OSApp version from CMakeLists.txt
-      shell: python
-      run: |
-        import re
-        from pathlib import Path
 
-        with open('CMakeLists.txt', 'r') as f:
-            content = f.read()
-
-        no_comments_lines = []
-        for line in content.splitlines():
-            l = line.strip().split('#')[0]
-            if l:
-                no_comments_lines.append(l)
-        content = "\n".join(no_comments_lines)
-
-        m_major = re.search(r'set\s*\(COOLPROP_VERSION_MAJOR (\d+)\)', content)
-        m_minor = re.search(r'set\s*\(COOLPROP_VERSION_MINOR (\d+)\)', content)
-        m_patch = re.search(r'set\s*\(COOLPROP_VERSION_PATCH (\d+)\)', content)
-        m_rev = re.search(r'set\s*\(COOLPROP_VERSION_REVISION "*(.*?)"*\)', content)
-
-        coolprop_version = ''
-        if m_major:
-            COOLPROP_VERSION_MAJOR = m_major.groups()[0]
-            coolprop_version += COOLPROP_VERSION_MAJOR
-
-
-        if m_minor:
-            COOLPROP_VERSION_MINOR = m_minor.groups()[0]
-            coolprop_version += "." + COOLPROP_VERSION_MINOR
-
-        if m_patch:
-            COOLPROP_VERSION_PATCH = m_patch.groups()[0]
-            coolprop_version += "." + COOLPROP_VERSION_PATCH
-
-        if m_rev:
-            COOLPROP_VERSION_REV = m_rev.groups()[0]
-            coolprop_version += "-" + COOLPROP_VERSION_REV
-
-        with open(os.environ['GITHUB_ENV'], 'a') as f:
-            f.write(f"\COOLPROP_VERSION={coolprop_version}")
-        print(f"{coolprop_version=}")
 
     - name: Tar.gz the shared library to maintain case sensitivy and file permissions
       working-directory: ./install_root/shared_library/
       shell: bash
       run: |
+        set -x
         tar -cvzf CoolProp-${{ env.COOLPROP_VERSION }}-shared-${{ matrix.os }}.tar.gz ./*
 
     - name: Archive TGZ or ZIP artifacts

--- a/.github/workflows/BuildSharedLibrary.yml
+++ b/.github/workflows/BuildSharedLibrary.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Configure CMake
       working-directory: ./build
       shell: bash
-      run: cmake -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE -DCOOLPROP_SHARED_LIBRARY:BOOL=ON ..
+      run: cmake -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE -DCOOLPROP_SHARED_LIBRARY:BOOL=ON -DCOOLPROP_CATCH_MODULE:BOOL=ON ..
 
     - name: Build
       working-directory: ./build
@@ -54,12 +54,13 @@ jobs:
         cmake --build . --target install -j $(nproc) --config $BUILD_TYPE
 
     # TODO: enable testing. -DBUILD_TESTING:BOOL=ON does nothing unless you have Csharp. There is an undocumentated -DCOOLPROP_CATCH_MODULE:BOOL=ON but that fails to build
-    #- name: Test
-    #  working-directory: ${{runner.workspace}}/build
-    #  shell: bash
-    #  # Execute tests defined by the CMake configuration.
-    #  # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-    #  run: ctest -C $BUILD_TYPE
+    - name: Test
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: |
+        ./CatchTestRunner
 
     - name: Tar.gz the shared library to maintain case sensitivy and file permissions
       working-directory: ./install_root/shared_library/

--- a/.github/workflows/BuildSharedLibrary.yml
+++ b/.github/workflows/BuildSharedLibrary.yml
@@ -55,7 +55,7 @@ jobs:
 
     # TODO: enable testing. -DBUILD_TESTING:BOOL=ON does nothing unless you have Csharp. There is an undocumentated -DCOOLPROP_CATCH_MODULE:BOOL=ON but that fails to build
     - name: Test
-      working-directory: ${{runner.workspace}}/build
+      working-directory: ./build
       shell: bash
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail

--- a/.github/workflows/BuildSharedLibrary.yml
+++ b/.github/workflows/BuildSharedLibrary.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Configure CMake
       working-directory: ./build
       shell: bash
-      run: cmake -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE -DCOOLPROP_SHARED_LIBRARY:BOOL=ON -DCOOLPROP_CATCH_MODULE:BOOL=ON ..
+      run: cmake -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE -DCOOLPROP_SHARED_LIBRARY:BOOL=ON ..
 
     - name: Build
       working-directory: ./build
@@ -52,15 +52,6 @@ jobs:
       run: |
         set -x
         cmake --build . --target install -j $(nproc) --config $BUILD_TYPE
-
-    # TODO: enable testing. -DBUILD_TESTING:BOOL=ON does nothing unless you have Csharp. There is an undocumentated -DCOOLPROP_CATCH_MODULE:BOOL=ON but that fails to build
-    - name: Test
-      working-directory: ./build
-      shell: bash
-      # Execute tests defined by the CMake configuration.
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: |
-        ./CatchTestRunner
 
     - name: Tar.gz the shared library to maintain case sensitivy and file permissions
       working-directory: ./install_root/shared_library/

--- a/.github/workflows/coolprop_tests.yml
+++ b/.github/workflows/coolprop_tests.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: recursive
 
     - name: Extract CoolProp version from CMakeLists.txt
       shell: bash
@@ -43,7 +45,7 @@ jobs:
         cmake --build . --target install -j $(nproc) --config $BUILD_TYPE
 
     - name: Test
-      working-directory: ${{runner.workspace}}/build
+      working-directory: ./build
       shell: bash
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail

--- a/.github/workflows/coolprop_tests.yml
+++ b/.github/workflows/coolprop_tests.yml
@@ -1,0 +1,51 @@
+name: Catch2 Testing
+
+on:
+  push:
+    branches: [ master, develop, actions_shared ]
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  pull_request:
+    branches: [ master, develop ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Extract CoolProp version from CMakeLists.txt
+      shell: bash
+      run: |
+        set -x
+        COOLPROP_VERSION=$(python dev/extract_version.py)
+        echo COOLPROP_VERSION=$COOLPROP_VERSION >> $GITHUB_ENV
+        # Create the build directory too
+        mkdir build
+
+    - name: Configure CMake
+      working-directory: ./build
+      shell: bash
+      run: cmake -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE -DCOOLPROP_SHARED_LIBRARY:BOOL=ON -DCOOLPROP_CATCH_MODULE:BOOL=ON ..
+
+    - name: Build
+      working-directory: ./build
+      shell: bash
+      run: |
+        set -x
+        cmake --build . --target install -j $(nproc) --config $BUILD_TYPE
+
+    - name: Test
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: |
+        ./CatchTestRunner

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,4 +1,4 @@
-name: BuildSharedLibrary
+name: Doxygen documentation
 
 on:
   push:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,52 @@
+name: BuildSharedLibrary
+
+on:
+  push:
+    branches: [ master, develop, actions_shared ]
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install system dependencies
+      shell: bash
+      run: |
+        set -x
+        sudo apt update
+        sudo apt install doxygen
+
+    - name: Build documentation with Doxygen
+      shell: bash
+      run: doxygen
+
+    - name: Zip the HTML documentation
+      working-directory: ./Web/_static/doxygen/html/
+      shell: bash
+      run: |
+        tar -cvzf CoolProp-documentation-html.tar.gz ./*
+
+    - name: Archive TGZ or ZIP artifacts
+      uses: actions/upload-artifact@v2
+      with:
+          name: CoolProp-documentation-html.tar.gz
+          path: Web/_static/doxygen/html/CoolProp-documentation-html.tar.gz
+
+    - name: Upload TGZ or ZIP to release
+      if: contains(github.ref, 'refs/tags')
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: Web/_static/doxygen/html/CoolProp-documentation-html.tar.gz
+        tag: ${{ github.ref }}
+        overwrite: true
+        file_glob: false
+

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,6 +24,13 @@ jobs:
         sudo apt update
         sudo apt install doxygen
 
+    - name: Extract CoolProp version from CMakeLists.txt
+      shell: bash
+      run: |
+        set -x
+        COOLPROP_VERSION=$(python dev/extract_version.py)
+        echo COOLPROP_VERSION=$COOLPROP_VERSION >> $GITHUB_ENV
+
     - name: Build documentation with Doxygen
       shell: bash
       run: doxygen
@@ -32,20 +39,20 @@ jobs:
       working-directory: ./Web/_static/doxygen/html/
       shell: bash
       run: |
-        tar -cvzf CoolProp-documentation-html.tar.gz ./*
+        tar -cvzf CoolProp-${{ env.COOLPROP_VERSION }}-documentation-html.tar.gz ./*
 
     - name: Archive TGZ or ZIP artifacts
       uses: actions/upload-artifact@v2
       with:
-          name: CoolProp-documentation-html.tar.gz
-          path: Web/_static/doxygen/html/CoolProp-documentation-html.tar.gz
+          name: CoolProp-${{ env.COOLPROP_VERSION }}-documentation-html.tar.gz
+          path: Web/_static/doxygen/html/CoolProp-${{ env.COOLPROP_VERSION }}-documentation-html.tar.gz
 
     - name: Upload TGZ or ZIP to release
       if: contains(github.ref, 'refs/tags')
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: Web/_static/doxygen/html/CoolProp-documentation-html.tar.gz
+        file: Web/_static/doxygen/html/CoolProp-${{ env.COOLPROP_VERSION }}-documentation-html.tar.gz
         tag: ${{ github.ref }}
         overwrite: true
         file_glob: false

--- a/.github/workflows/windows_installer.yml
+++ b/.github/workflows/windows_installer.yml
@@ -25,6 +25,8 @@ jobs:
         set -x
         COOLPROP_VERSION=$(python dev/extract_version.py)
         echo COOLPROP_VERSION=$COOLPROP_VERSION >> $GITHUB_ENV
+        # Create the build directory too
+        mkdir build
 
     - name: Configure CMake
       working-directory: ./build

--- a/.github/workflows/windows_installer.yml
+++ b/.github/workflows/windows_installer.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ master, develop ]
 
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
 jobs:
   build:
 

--- a/.github/workflows/windows_installer.yml
+++ b/.github/workflows/windows_installer.yml
@@ -1,0 +1,62 @@
+name: Windows Installer
+
+on:
+  push:
+    branches: [ master, develop, actions_shared ]
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Extract CoolProp version from CMakeLists.txt
+      shell: bash
+      run: |
+        set -x
+        COOLPROP_VERSION=$(python dev/extract_version.py)
+        echo COOLPROP_VERSION=$COOLPROP_VERSION >> $GITHUB_ENV
+
+    - name: Configure CMake
+      working-directory: ./build
+      shell: bash
+      run: cmake -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE -DCOOLPROP_WINDOWS_PACKAGE:BOOL=ON ..
+
+    - name: Build
+      working-directory: ./build
+      shell: bash
+      run: |
+        set -x
+        cmake --build . --target COOLPROP_WINDOWS_PACKAGE_INSTALLER -j $(nproc) --config $BUILD_TYPE
+
+    - name: Tar.gz the shared library to maintain case sensitivy and file permissions
+      working-directory: ./build/InnoScript/bin/
+      shell: bash
+      run: |
+        set -x
+        tar -cvzf CoolProp-${{ env.COOLPROP_VERSION }}-WindowsInstaller.tar.gz ./*
+
+    - name: Archive TGZ or ZIP artifacts
+      uses: actions/upload-artifact@v2
+      with:
+          name: CoolProp-${{ env.COOLPROP_VERSION }}-WindowsInstaller.tar.gz
+          path: build/InnoScript/bin/CoolProp-${{ env.COOLPROP_VERSION }}-WindowsInstaller.tar.gz
+
+    - name: Upload TGZ or ZIP to release
+      if: contains(github.ref, 'refs/tags')
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: build/InnoScript/bin/CoolProp-${{ env.COOLPROP_VERSION }}-WindowsInstaller.tar.gz
+        tag: ${{ github.ref }}
+        overwrite: true
+        file_glob: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,9 @@ option (COOLPROP_NO_EXAMPLES
 #        "On Darwin systems, compile and link with -std=libc++ instead of the default -std=libstdc++"
 #        ON)
 
+# Force C++11 since lambdas are used in CPStrings.h
+set(CMAKE_CXX_STANDARD 11)
+
 # see
 # https://stackoverflow.com/questions/52509602/cant-compile-c-program-on-a-mac-after-upgrade-to-mojave
 # https://support.enthought.com/hc/en-us/articles/204469410-OS-X-GCC-Clang-and-Cython-in-10-9-Mavericks

--- a/dev/extract_version.py
+++ b/dev/extract_version.py
@@ -1,0 +1,39 @@
+import re
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).parent.parent
+
+with open(ROOT_DIR / 'CMakeLists.txt', 'r') as f:
+    content = f.read()
+
+no_comments_lines = []
+for line in content.splitlines():
+    l = line.strip().split('#')[0]
+    if l:
+        no_comments_lines.append(l)
+content = "\n".join(no_comments_lines)
+
+m_major = re.search(r'set\s*\(COOLPROP_VERSION_MAJOR (\d+)\)', content)
+m_minor = re.search(r'set\s*\(COOLPROP_VERSION_MINOR (\d+)\)', content)
+m_patch = re.search(r'set\s*\(COOLPROP_VERSION_PATCH (\d+)\)', content)
+m_rev = re.search(r'set\s*\(COOLPROP_VERSION_REVISION "*(.*?)"*\)', content)
+
+coolprop_version = ''
+if m_major:
+    COOLPROP_VERSION_MAJOR = m_major.groups()[0]
+    coolprop_version += COOLPROP_VERSION_MAJOR
+
+
+if m_minor:
+    COOLPROP_VERSION_MINOR = m_minor.groups()[0]
+    coolprop_version += "." + COOLPROP_VERSION_MINOR
+
+if m_patch:
+    COOLPROP_VERSION_PATCH = m_patch.groups()[0]
+    coolprop_version += "." + COOLPROP_VERSION_PATCH
+
+if m_rev:
+    COOLPROP_VERSION_REV = m_rev.groups()[0]
+    coolprop_version += "-" + COOLPROP_VERSION_REV
+
+print(f"{coolprop_version}")

--- a/dev/extract_version.py
+++ b/dev/extract_version.py
@@ -36,4 +36,4 @@ if m_rev:
     COOLPROP_VERSION_REV = m_rev.groups()[0]
     coolprop_version += "-" + COOLPROP_VERSION_REV
 
-print(f"{coolprop_version}")
+print(coolprop_version)


### PR DESCRIPTION
Reacting to a comment on https://github.com/CoolProp/CoolProp/pull/2097#issuecomment-1067484987

@ibell  I honestly don't know if that's what you had in mind or not, and I definitely don't understand what the "Installer package" is supposed to be, is that the `COOLPROP_WINDOWS_PACKAGE` ?

Anyways, this will build the shared lib, and package it up nicely in a version-named tar.gz, uploaded as an artifact.
If you trigger a release (via github, but that effectively creates a tag which is the actual trigger), it will also upload them to the release page.

The HTML version of the documentation is also packaged in a tar.gz and has the same upload treatment. Not sure if that's what you needed either.

---

**Edit**:

- Windows isntaller package, checkout this run: https://github.com/jmarrec/CoolProp/actions/runs/1985940859
```
CoolProp-6.4.2-dev-WindowsInstaller.tar.gz
├── Installers
│   └── Windows
│       └── CoolProp_v6.4.2.0.exe
└── MicrosoftExcel
    ├── CoolProp.xla
    ├── CoolProp.xlam
    └── TestExcel.xlsx

3 directories, 4 files
```


- Checkout this release on my fork, to showcase the upload of artifacts to the release page: https://github.com/jmarrec/CoolProp/releases/tag/v6.4.2-dev

<img width="1228" alt="Screen Shot 2022-03-15 at 11 42 35" src="https://user-images.githubusercontent.com/5479063/158360643-066123bd-9d39-412c-861d-3afa480031ff.png">

