### PR TITLE
Bump Catch  1 to Catch v3.0.0-preview4

### DIFF
--- a/.github/workflows/coolprop_tests.yml
+++ b/.github/workflows/coolprop_tests.yml
@@ -50,4 +50,23 @@ jobs:
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: |
+        ctest -j $(nproc)
+
+    - name: Rerun failed Tests
+      if: failure()
+      working-directory: ./build
+      shell: bash
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: |
+        ctest -j $(nproc) --rerun-failed --output-on-failure
+
+    # TODO: pick one style, for now I'm doing this so I can report zero new failures compared to catch1
+    - name: Rerun failed Tests in CatchTestRunner directly
+      if: failure()
+      working-directory: ./build
+      shell: bash
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: |
         ./CatchTestRunner

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "externals/Catch"]
-	path = externals/Catch
+	path = externals/Catch2
 	url = https://github.com/catchorg/Catch2
 	branch = master
 [submodule "externals/Eigen"]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1964,21 +1964,27 @@ endif()
 
 ###      COOLPROP TESTING APP       ###
 if(COOLPROP_CATCH_MODULE)
+
+  add_subdirectory("externals/Catch2")
   enable_testing()
 
-  list(APPEND APP_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/test_main.cxx")
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests.cpp")
 
   # CATCH TEST, compile everything with catch and set test entry point
   add_executable(CatchTestRunner ${APP_SOURCES})
-  add_dependencies(CatchTestRunner generate_headers)
-  set_target_properties(
-    CatchTestRunner PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -DENABLE_CATCH")
+
+  target_link_libraries(CatchTestRunner PRIVATE Catch2::Catch2WithMain)
+  target_compile_definitions(CatchTestRunner PRIVATE ENABLE_CATCH)
   if(UNIX)
     target_link_libraries(CatchTestRunner ${CMAKE_DL_LIBS})
   endif()
-  add_test(ProcedureTests CatchTestRunner)
+
+  target_link_libraries(CatchTestRunner PRIVATE ${COOLPROP_LIBRARY_NAME})
+
+  include(CTest)
+  include(${CMAKE_CURRENT_SOURCE_DIR}/externals/Catch2/extras/Catch.cmake)
+  catch_discover_tests(CatchTestRunner)
 
   if(COOLPROP_IWYU)
     find_program(iwyu_path NAMES include-what-you-use iwyu)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1980,8 +1980,6 @@ if(COOLPROP_CATCH_MODULE)
     target_link_libraries(CatchTestRunner ${CMAKE_DL_LIBS})
   endif()
 
-  target_link_libraries(CatchTestRunner PRIVATE ${COOLPROP_LIBRARY_NAME})
-
   include(CTest)
   include(${CMAKE_CURRENT_SOURCE_DIR}/externals/Catch2/extras/Catch.cmake)
   catch_discover_tests(CatchTestRunner)

--- a/dev/generate_headers.py
+++ b/dev/generate_headers.py
@@ -292,9 +292,10 @@ def combine_json(root_dir):
 
 def generate():
 
-    import shutil
-    shutil.copy2(os.path.join(repo_root_path, 'externals', 'Catch', 'single_include', 'catch.hpp'), os.path.join(repo_root_path, 'include', 'catch.hpp'))
-    #shutil.copy2(os.path.join(repo_root_path, 'externals','REFPROP-headers','REFPROP_lib.h'),os.path.join(repo_root_path,'include','REFPROP_lib.h'))
+    # import shutil
+    # shutil.copy2(
+    #    os.path.join(repo_root_path, 'externals', 'REFPROP-headers', 'REFPROP_lib.h'),
+    #    os.path.join(repo_root_path, 'include', 'REFPROP_lib.h'))
 
     version_to_file(root_dir=repo_root_path)
     gitrev_to_file(root_dir=repo_root_path)

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -1064,7 +1064,7 @@ CoolPropDbl AbstractState::calc_second_partial_deriv(parameters Of1, parameters 
 
 #ifdef ENABLE_CATCH
 
-#include "catch.hpp"
+#include <catch2/catch_all.hpp>
 
 TEST_CASE("Check AbstractState", "[AbstractState]") {
     SECTION("bad backend") {

--- a/src/Backends/Cubics/UNIFACLibrary.cpp
+++ b/src/Backends/Cubics/UNIFACLibrary.cpp
@@ -141,7 +141,7 @@ Component UNIFACParameterLibrary::get_component(const std::string& identifier, c
 }; /* namespace UNIFACLibrary */
 
 #if defined(ENABLE_CATCH)
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 
 #    include "UNIFAC.h"
 

--- a/src/Backends/Cubics/VTPRBackend.cpp
+++ b/src/Backends/Cubics/VTPRBackend.cpp
@@ -146,7 +146,7 @@ CoolPropDbl CoolProp::VTPRBackend::calc_fugacity_coefficient(std::size_t i) {
 }
 
 #ifdef ENABLE_CATCH
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 
 #    include "Backends/Cubics/CubicBackend.h"
 

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -6,7 +6,7 @@
 #include "Configuration.h"
 
 #if defined(ENABLE_CATCH)
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 #    include "Backends/Cubics/CubicBackend.h"
 #endif
 

--- a/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
+++ b/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
@@ -5,7 +5,7 @@
 #if defined(ENABLE_CATCH)
 
 #    include "crossplatform_shared_ptr.h"
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 
 #endif
 

--- a/src/Backends/Helmholtz/MixtureDerivatives.cpp
+++ b/src/Backends/Helmholtz/MixtureDerivatives.cpp
@@ -1103,7 +1103,7 @@ CoolPropDbl MixtureDerivatives::d2psir_dxi_dxj(HelmholtzEOSMixtureBackend& HEOS,
 } /* namespace CoolProp */
 
 #ifdef ENABLE_CATCH
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 
 #    include "Backends/Cubics/CubicBackend.h"
 #    include "Backends/Cubics/VTPRBackend.h"
@@ -1294,7 +1294,7 @@ class DerivativeFixture
             numeric = (g(*HEOS_plus_delta, xN) - g(*HEOS_minus_delta, xN)) / (2 * ddelta);
         }
         CAPTURE(name);
-        CAPTURE(analytic)
+        CAPTURE(analytic);
         CAPTURE(numeric);
         CAPTURE(xN);
         double error = mix_deriv_err_func(numeric, analytic);
@@ -1321,7 +1321,7 @@ class DerivativeFixture
             }
             CAPTURE(name);
             CAPTURE(i);
-            CAPTURE(analytic)
+            CAPTURE(analytic);
             CAPTURE(numeric);
             CAPTURE(xN);
             double error = mix_deriv_err_func(numeric, analytic);
@@ -1346,7 +1346,7 @@ class DerivativeFixture
 
             CAPTURE(name);
             CAPTURE(i);
-            CAPTURE(analytic)
+            CAPTURE(analytic);
             CAPTURE(numeric);
             CAPTURE(xN);
             double error = mix_deriv_err_func(numeric, analytic);
@@ -1370,7 +1370,7 @@ class DerivativeFixture
                 CAPTURE(name);
                 CAPTURE(i);
                 CAPTURE(j);
-                CAPTURE(analytic)
+                CAPTURE(analytic);
                 CAPTURE(numeric);
                 CAPTURE(xN);
                 double error = mix_deriv_err_func(numeric, analytic);
@@ -1394,7 +1394,7 @@ class DerivativeFixture
                 CAPTURE(name);
                 CAPTURE(i);
                 CAPTURE(j);
-                CAPTURE(analytic)
+                CAPTURE(analytic);
                 CAPTURE(numeric);
                 CAPTURE(xN);
                 double error = mix_deriv_err_func(numeric, analytic);
@@ -1417,7 +1417,7 @@ class DerivativeFixture
                     CAPTURE(name);
                     CAPTURE(i);
                     CAPTURE(j);
-                    CAPTURE(analytic)
+                    CAPTURE(analytic);
                     CAPTURE(numeric);
                     CAPTURE(xN);
                     double error = mix_deriv_err_func(numeric, analytic);
@@ -1443,7 +1443,7 @@ class DerivativeFixture
                     CAPTURE(i);
                     CAPTURE(j);
                     CAPTURE(k);
-                    CAPTURE(analytic)
+                    CAPTURE(analytic);
                     CAPTURE(numeric);
                     CAPTURE(xN);
                     double error = mix_deriv_err_func(numeric, analytic);

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -864,7 +864,7 @@ CoolPropDbl sign(CoolPropDbl x) {
 void SaturationSolvers::saturation_T_pure_Maxwell(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl T, saturation_T_pure_Akasaka_options& options) {
 
     /*
-    This function implements the method of 
+    This function implements the method of
 
     Ancillary equations are used to get a sensible starting point
     */
@@ -2025,7 +2025,7 @@ void SaturationSolvers::PTflash_twophase::build_arrays() {
 } /* namespace CoolProp*/
 
 #if defined(ENABLE_CATCH)
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 
 TEST_CASE("Check the PT flash calculation for two-phase inputs", "[PTflash_twophase]") {
     shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "Propane&Ethane"));

--- a/src/Backends/Incompressible/IncompressibleBackend.cpp
+++ b/src/Backends/Incompressible/IncompressibleBackend.cpp
@@ -575,7 +575,7 @@ double IncompressibleBackend::calc_dhdpatTx(double T, double rho, double drhodTa
 #ifdef ENABLE_CATCH
 #    include <math.h>
 #    include <iostream>
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 
 #    include "TestObjects.h"
 

--- a/src/Backends/Incompressible/IncompressibleFluid.cpp
+++ b/src/Backends/Incompressible/IncompressibleFluid.cpp
@@ -438,7 +438,7 @@ bool IncompressibleFluid::checkX(double x) {
 #ifdef ENABLE_CATCH
 #    include <math.h>
 #    include <iostream>
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 #    include "TestObjects.h"
 
 Eigen::MatrixXd makeMatrix(const std::vector<double>& coefficients) {

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -2129,7 +2129,7 @@ void REFPROP_SETREF(char hrf[3], int ixflag, double x0[1], double& h0, double& s
 
 #ifdef ENABLE_CATCH
 #    include "CoolProp.h"
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 
 TEST_CASE("Check REFPROP and CoolProp values agree", "[REFPROP]") {
     SECTION("Saturation densities agree within 0.5% at T/Tc = 0.9") {

--- a/src/Backends/Tabular/TabularBackends.cpp
+++ b/src/Backends/Tabular/TabularBackends.cpp
@@ -25,7 +25,7 @@ static CoolProp::TabularDataLibrary library;
 namespace CoolProp {
 
 /**
- * @brief 
+ * @brief
  * @param table
  * @param path_to_tables
  * @param filename
@@ -1468,7 +1468,7 @@ void CoolProp::TabularDataSet::build_coeffs(SinglePhaseGriddedTableData& table, 
 }
 
 #    if defined(ENABLE_CATCH)
-#        include "catch.hpp"
+#        include <catch2/catch_all.hpp>
 
 // Defined global so we only load once
 static shared_ptr<CoolProp::AbstractState> ASHEOS, ASTTSE, ASBICUBIC;

--- a/src/Backends/Tabular/TabularBackends.h
+++ b/src/Backends/Tabular/TabularBackends.h
@@ -15,22 +15,26 @@
  * See http://stackoverflow.com/a/148610
  * See http://stackoverflow.com/questions/147267/easy-way-to-use-variables-of-enum-types-as-string-in-c#202511
  */
-#define LIST_OF_MATRICES                                                                                                                   \
-    X(T)                                                                                                                                   \
-    X(p) X(rhomolar) X(hmolar) X(smolar) X(umolar) X(dTdx) X(dTdy) X(dpdx) X(dpdy) X(drhomolardx) X(drhomolardy) X(dhmolardx) X(dhmolardy) \
-      X(dsmolardx) X(dsmolardy) X(dumolardx) X(dumolardy) X(d2Tdx2) X(d2Tdxdy) X(d2Tdy2) X(d2pdx2) X(d2pdxdy) X(d2pdy2) X(d2rhomolardx2)   \
-        X(d2rhomolardxdy) X(d2rhomolardy2) X(d2hmolardx2) X(d2hmolardxdy) X(d2hmolardy2) X(d2smolardx2) X(d2smolardxdy) X(d2smolardy2)     \
-          X(d2umolardx2) X(d2umolardxdy) X(d2umolardy2) X(visc) X(cond)
+#define LIST_OF_MATRICES                                                                                                                            \
+    X(T)                                                                                                                                            \
+    X(p)                                                                                                                                            \
+    X(rhomolar)                                                                                                                                     \
+    X(hmolar) X(smolar) X(umolar) X(dTdx) X(dTdy) X(dpdx) X(dpdy) X(drhomolardx) X(drhomolardy) X(dhmolardx) X(dhmolardy) X(dsmolardx) X(dsmolardy) \
+      X(dumolardx) X(dumolardy) X(d2Tdx2) X(d2Tdxdy) X(d2Tdy2) X(d2pdx2) X(d2pdxdy) X(d2pdy2) X(d2rhomolardx2) X(d2rhomolardxdy) X(d2rhomolardy2)   \
+        X(d2hmolardx2) X(d2hmolardxdy) X(d2hmolardy2) X(d2smolardx2) X(d2smolardxdy) X(d2smolardy2) X(d2umolardx2) X(d2umolardxdy) X(d2umolardy2)   \
+          X(visc) X(cond)
 
 /** ***MAGIC WARNING***!! X Macros in use
  * See http://stackoverflow.com/a/148610
  * See http://stackoverflow.com/questions/147267/easy-way-to-use-variables-of-enum-types-as-string-in-c#202511
  */
-#define LIST_OF_SATURATION_VECTORS                                                                                                             \
-    X(TL)                                                                                                                                      \
-    X(pL) X(logpL) X(hmolarL) X(smolarL) X(umolarL) X(rhomolarL) X(logrhomolarL) X(viscL) X(condL) X(logviscL) X(TV) X(pV) X(logpV) X(hmolarV) \
-      X(smolarV) X(umolarV) X(rhomolarV) X(logrhomolarV) X(viscV) X(condV) X(logviscV) X(cpmolarV) X(cpmolarL) X(cvmolarV) X(cvmolarL)         \
-        X(speed_soundL) X(speed_soundV)
+#define LIST_OF_SATURATION_VECTORS                                                                                                          \
+    X(TL)                                                                                                                                   \
+    X(pL)                                                                                                                                   \
+    X(logpL)                                                                                                                                \
+    X(hmolarL) X(smolarL) X(umolarL) X(rhomolarL) X(logrhomolarL) X(viscL) X(condL) X(logviscL) X(TV) X(pV) X(logpV) X(hmolarV) X(smolarV)  \
+      X(umolarV) X(rhomolarV) X(logrhomolarV) X(viscV) X(condV) X(logviscV) X(cpmolarV) X(cpmolarL) X(cvmolarV) X(cvmolarL) X(speed_soundL) \
+        X(speed_soundV)
 
 namespace CoolProp {
 

--- a/src/CPstrings.cpp
+++ b/src/CPstrings.cpp
@@ -54,7 +54,7 @@ std::string format(const char* fmt, ...) {
 #if defined(ENABLE_CATCH)
 
 #    include "crossplatform_shared_ptr.h"
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 #    include "CoolPropTools.h"
 #    include "CoolProp.h"
 

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -49,7 +49,7 @@
 #include "Backends/PCSAFT/PCSAFTLibrary.h"
 
 #if defined(ENABLE_CATCH)
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 #endif
 
 namespace CoolProp {

--- a/src/DataStructures.cpp
+++ b/src/DataStructures.cpp
@@ -743,7 +743,7 @@ std::string get_backend_string(backends backend) {
 } /* namespace CoolProp */
 
 #ifdef ENABLE_CATCH
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 #    include <sstream>
 
 TEST_CASE("Check that all parameters are described", "") {

--- a/src/Helmholtz.cpp
+++ b/src/Helmholtz.cpp
@@ -1340,7 +1340,7 @@ IdealHelmholtzEnthalpyEntropyOffset EnthalpyEntropyOffset;
 
 #ifdef ENABLE_CATCH
 #    include <math.h>
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 #    include "crossplatform_shared_ptr.h"
 
 class HelmholtzConsistencyFixture

--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -2179,7 +2179,7 @@ double IceProps(const char* Name, double T, double p) {
 
 #ifdef ENABLE_CATCH
 #    include <math.h>
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 
 TEST_CASE("Check HA Virials from Table A.2.1", "[RP1485]") {
     SECTION("B_aa") {

--- a/src/MatrixMath.cpp
+++ b/src/MatrixMath.cpp
@@ -15,7 +15,7 @@ namespace CoolProp {}; /* namespace CoolProp */
 #ifdef ENABLE_CATCH
 #    include <math.h>
 #    include <iostream>
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 
 TEST_CASE("Internal consistency checks and example use cases for MatrixMath.h", "[MatrixMath]") {
     bool PRINT = false;

--- a/src/ODEIntegrators.cpp
+++ b/src/ODEIntegrators.cpp
@@ -165,7 +165,7 @@ bool ODEIntegrators::AdaptiveRK54(AbstractODEIntegrator& ode, double tstart, dou
 }
 
 #if defined(ENABLE_CATCH)
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 
 TEST_CASE("Integrate y'=y", "[ODEIntegrator]") {
     class SimpleODEIntegrator : public ODEIntegrators::AbstractODEIntegrator

--- a/src/PolyMath.cpp
+++ b/src/PolyMath.cpp
@@ -930,7 +930,7 @@ double Poly2DFracIntResidual::deriv(double target) {
 #ifdef ENABLE_CATCH
 #    include <math.h>
 #    include <iostream>
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 
 TEST_CASE("Internal consistency checks and example use cases for PolyMath.cpp", "[PolyMath]") {
     bool PRINT = false;

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -11,7 +11,7 @@
 #if defined(ENABLE_CATCH)
 
 #    include "crossplatform_shared_ptr.h"
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 #    include "CoolPropTools.h"
 #    include "CoolProp.h"
 

--- a/src/Tests/Tests.cpp
+++ b/src/Tests/Tests.cpp
@@ -8,8 +8,7 @@ Catch clashing
 #include "time.h"
 
 #if defined ENABLE_CATCH
-#    define CATCH_CONFIG_RUNNER
-#    include "catch.hpp"
+#    include <catch2/catch_all.hpp>
 
 static Catch::Session session;  // There must be exactly one instance
 

--- a/src/Tests/catch_always_return_success.cxx
+++ b/src/Tests/catch_always_return_success.cxx
@@ -4,7 +4,7 @@
 // number of failing catch tests
 
 #define CATCH_CONFIG_RUNNER
-#include "catch.hpp"
+#include <catch2/catch_all.hpp>
 #include <iostream>
 
 int main(int argc, char* argv[]) {

--- a/src/Tests/test_main.cxx
+++ b/src/Tests/test_main.cxx
@@ -1,5 +1,0 @@
-#ifdef ENABLE_CATCH
-#    define CATCH_CONFIG_MAIN
-#    include "catch.hpp"
-
-#endif /* ENABLE_CATCH */


### PR DESCRIPTION

### Description of the Change

Bump Catch to Catch 2.x
register catch2 tests as `ctest`

Note: this build upon the `cpp_review` branch, so review https://github.com/CoolProp/CoolProp/pull/2104 or look at https://github.com/jmarrec/CoolProp/compare/cpp_review...catch2 for a clean diff

### Benefits

More modernizing

### Possible Drawbacks

none.

### Verification Process

Ran the Catch2 tests

### Applicable Issues


