### PR TITLE
Add bound-check to setter and getter functions

### DIFF
--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -543,6 +543,16 @@ CoolPropDbl CoolProp::AbstractCubicBackend::calc_molar_mass(void) {
 
 void CoolProp::AbstractCubicBackend::set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter,
                                                                    const double value) {
+    // bound-check indices
+    if (i < 0 || i >= N) {
+        if (j < 0 || j >= N) {
+            throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N-1));
+        } else {
+            throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N-1));
+        }
+    } else if (j < 0 || j >= N) {
+        throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N-1));
+    }
     if (parameter == "kij" || parameter == "k_ij") {
         get_cubic()->set_kij(i, j, value);
     } else {
@@ -553,6 +563,16 @@ void CoolProp::AbstractCubicBackend::set_binary_interaction_double(const std::si
     }
 };
 double CoolProp::AbstractCubicBackend::get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter) {
+    // bound-check indices
+    if (i < 0 || i >= N) {
+        if (j < 0 || j >= N) {
+            throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N-1));
+        } else {
+            throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N-1));
+        }
+    } else if (j < 0 || j >= N) {
+        throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N-1));
+    }
     if (parameter == "kij" || parameter == "k_ij") {
         return get_cubic()->get_kij(i, j);
     } else {
@@ -592,6 +612,10 @@ void CoolProp::AbstractCubicBackend::copy_internals(AbstractCubicBackend& donor)
 
 void CoolProp::AbstractCubicBackend::set_cubic_alpha_C(const size_t i, const std::string& parameter, const double c1, const double c2,
                                                        const double c3) {
+    // bound-check indices
+    if (i < 0 || i >= N) {
+        throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N-1));
+    } 
     if (parameter == "MC" || parameter == "mc" || parameter == "Mathias-Copeman") {
         get_cubic()->set_C_MC(i, c1, c2, c3);
     } else if (parameter == "TWU" || parameter == "Twu" || parameter == "twu") {
@@ -606,6 +630,10 @@ void CoolProp::AbstractCubicBackend::set_cubic_alpha_C(const size_t i, const std
 }
 
 void CoolProp::AbstractCubicBackend::set_fluid_parameter_double(const size_t i, const std::string& parameter, const double value) {
+    // bound-check indices
+    if (i < 0 || i >= N) {
+        throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N-1));
+    } 
     // Set the volume translation parrameter, currently applied to the whole fluid, not to components.
     if (parameter == "c" || parameter == "cm" || parameter == "c_m") {
         get_cubic()->set_cm(value);
@@ -624,6 +652,10 @@ void CoolProp::AbstractCubicBackend::set_fluid_parameter_double(const size_t i, 
     }
 }
 double CoolProp::AbstractCubicBackend::get_fluid_parameter_double(const size_t i, const std::string& parameter) {
+    // bound-check indices
+    if (i < 0 || i >= N) {
+        throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N-1));
+    } 
     // Get the volume translation parrameter, currently applied to the whole fluid, not to components.
     if (parameter == "c" || parameter == "cm" || parameter == "c_m") {
         return get_cubic()->get_cm();

--- a/src/Backends/Cubics/VTPRBackend.cpp
+++ b/src/Backends/Cubics/VTPRBackend.cpp
@@ -104,6 +104,16 @@ CoolPropDbl CoolProp::VTPRBackend::calc_molar_mass(void) {
 
 void CoolProp::VTPRBackend::set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter,
                                                           const double value) {
+    // bound-check indices
+    if (i < 0 || i >= N) {
+        if (j < 0 || j >= N) {
+            throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N-1));
+        } else {
+            throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N-1));
+        }
+    } else if (j < 0 || j >= N) {
+        throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N-1));
+    }    
     cubic->set_interaction_parameter(i, j, parameter, value);
     for (std::vector<shared_ptr<HelmholtzEOSMixtureBackend>>::iterator it = linked_states.begin(); it != linked_states.end(); ++it) {
         (*it)->set_binary_interaction_double(i, j, parameter, value);
@@ -115,6 +125,16 @@ void CoolProp::VTPRBackend::set_Q_k(const size_t sgi, const double value) {
 };
 
 double CoolProp::VTPRBackend::get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter) {
+    // bound-check indices
+    if (i < 0 || i >= N) {
+        if (j < 0 || j >= N) {
+            throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N-1));
+        } else {
+            throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N-1));
+        }
+    } else if (j < 0 || j >= N) {
+        throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N-1));
+    }    
     return cubic->get_interaction_parameter(i, j, parameter);
 };
 

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -261,6 +261,16 @@ std::string HelmholtzEOSMixtureBackend::fluid_param_string(const std::string& Pa
 }
 
 void HelmholtzEOSMixtureBackend::apply_simple_mixing_rule(std::size_t i, std::size_t j, const std::string& model) {
+    // bound-check indices
+    if (i < 0 || i >= N) {
+        if (j < 0 || j >= N) {
+            throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N-1));
+        } else {
+            throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N-1));
+        }
+    } else if (j < 0 || j >= N) {
+        throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N-1));
+    }
     if (model == "linear") {
         double Tc1 = get_fluid_constant(i, iT_critical), Tc2 = get_fluid_constant(j, iT_critical);
         double gammaT = 0.5 * (Tc1 + Tc2) / sqrt(Tc1 * Tc2);
@@ -282,6 +292,16 @@ void HelmholtzEOSMixtureBackend::apply_simple_mixing_rule(std::size_t i, std::si
 /// Set binary mixture floating point parameter for this instance
 void HelmholtzEOSMixtureBackend::set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter,
                                                                const double value) {
+    // bound-check indices
+    if (i < 0 || i >= N) {
+        if (j < 0 || j >= N) {
+            throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N-1));
+        } else {
+            throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N-1));
+        }
+    } else if (j < 0 || j >= N) {
+        throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N-1));
+    }
     if (parameter == "Fij") {
         residual_helmholtz->Excess.F[i][j] = value;
         residual_helmholtz->Excess.F[j][i] = value;
@@ -295,6 +315,16 @@ void HelmholtzEOSMixtureBackend::set_binary_interaction_double(const std::size_t
 };
 /// Get binary mixture floating point parameter for this instance
 double HelmholtzEOSMixtureBackend::get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter) {
+    // bound-check indices
+    if (i < 0 || i >= N) {
+        if (j < 0 || j >= N) {
+            throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N-1));
+        } else {
+            throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N-1));
+        }
+    } else if (j < 0 || j >= N) {
+        throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N-1));
+    }
     if (parameter == "Fij") {
         return residual_helmholtz->Excess.F[i][j];
     } else {
@@ -308,6 +338,16 @@ double HelmholtzEOSMixtureBackend::get_binary_interaction_double(const std::size
 /// Set binary mixture floating point parameter for this instance
 void HelmholtzEOSMixtureBackend::set_binary_interaction_string(const std::size_t i, const std::size_t j, const std::string& parameter,
                                                                const std::string& value) {
+    // bound-check indices
+    if (i < 0 || i >= N) {
+        if (j < 0 || j >= N) {
+            throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N-1));
+        } else {
+            throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N-1));
+        }
+    } else if (j < 0 || j >= N) {
+        throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N-1));
+    }
     if (parameter == "function") {
         residual_helmholtz->Excess.DepartureFunctionMatrix[i][j].reset(get_departure_function(value));
         residual_helmholtz->Excess.DepartureFunctionMatrix[j][i].reset(get_departure_function(value));

--- a/src/Backends/Helmholtz/ReducingFunctions.h
+++ b/src/Backends/Helmholtz/ReducingFunctions.h
@@ -187,6 +187,16 @@ class GERG2008ReducingFunction : public ReducingFunction
 
     /// Set all beta and gamma values in one shot
     void set_binary_interaction_double(const std::size_t i, const std::size_t j, double betaT, double gammaT, double betaV, double gammaV) {
+        // bound-check indices
+        if (i < 0 || i >= N) {
+            if (j < 0 || j >= N) {
+                throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N-1));
+            } else {
+                throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N-1));
+            }
+        } else if (j < 0 || j >= N) {
+            throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N-1));
+        }
         beta_T[i][j] = betaT;
         beta_T[j][i] = 1 / betaT;
         gamma_T[i][j] = gammaT;
@@ -199,6 +209,16 @@ class GERG2008ReducingFunction : public ReducingFunction
 
     /// Set a parameter
     virtual void set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter, double value) {
+        // bound-check indices
+        if (i < 0 || i >= N) {
+            if (j < 0 || j >= N) {
+                throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N-1));
+            } else {
+                throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N-1));
+            }
+        } else if (j < 0 || j >= N) {
+            throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N-1));
+        }
         if (parameter == "betaT") {
             beta_T[i][j] = value;
             beta_T[j][i] = 1 / value;

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -548,7 +548,16 @@ std::string REFPROPMixtureBackend::get_binary_interaction_string(const std::stri
 /// Set binary mixture string value
 void REFPROPMixtureBackend::set_binary_interaction_string(const std::size_t i, const std::size_t j, const std::string& parameter,
                                                           const std::string& value) {
-
+    // bound-check indices
+    if (i < 0 || i >= Ncomp) {
+        if (j < 0 || j >= Ncomp) {
+            throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, Ncomp-1));
+        } else {
+            throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, Ncomp-1));
+        }
+    } else if (j < 0 || j >= Ncomp) {
+        throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, Ncomp-1));
+    }
     int icomp = static_cast<int>(i) + 1, jcomp = static_cast<int>(j) + 1, ierr = 0L;
     char hmodij[4], hfmix[255], hbinp[255], hfij[255], hmxrul[255];
     double fij[6];
@@ -574,6 +583,16 @@ void REFPROPMixtureBackend::set_binary_interaction_string(const std::size_t i, c
 /// Set binary mixture string parameter (EXPERT USE ONLY!!!)
 void REFPROPMixtureBackend::set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter,
                                                           const double value) {
+    // bound-check indices
+    if (i < 0 || i >= Ncomp) {
+        if (j < 0 || j >= Ncomp) {
+            throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, Ncomp-1));
+        } else {
+            throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, Ncomp-1));
+        }
+    } else if (j < 0 || j >= Ncomp) {
+        throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, Ncomp-1));
+    }
     int icomp = static_cast<int>(i) + 1, jcomp = static_cast<int>(j) + 1, ierr = 0L;
     char hmodij[4], hfmix[255], hbinp[255], hfij[255], hmxrul[255];
     double fij[6];
@@ -609,6 +628,16 @@ void REFPROPMixtureBackend::set_binary_interaction_double(const std::size_t i, c
 
 /// Get binary mixture double value (EXPERT USE ONLY!!!)
 double REFPROPMixtureBackend::get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter) {
+    // bound-check indices
+    if (i < 0 || i >= Ncomp) {
+        if (j < 0 || j >= Ncomp) {
+            throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, Ncomp-1));
+        } else {
+            throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, Ncomp-1));
+        }
+    } else if (j < 0 || j >= Ncomp) {
+        throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, Ncomp-1));
+    }
     int icomp = static_cast<int>(i) + 1, jcomp = static_cast<int>(j) + 1;
     char hmodij[4], hfmix[255], hbinp[255], hfij[255], hmxrul[255];
     double fij[6];


### PR DESCRIPTION
### Description of the Change

Bound-checks were added to setter and getter functions:

   - set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string &parameter, const double value)
  -  set_binary_interaction_string(const std::size_t i, const std::size_t j, const std::string &parameter, const std::string &value)
 -   get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string &parameter)
-    apply_simple_mixing_rule(std::size_t i, std::size_t j, const std::string &model)
  -  set_cubic_alpha_C(const size_t i, const std::string &parameter, const double c1, const double c2, const double c3)
 -   set_fluid_parameter_double(const size_t i, const std::string &parameter, const double value)
-    get_fluid_parameter_double(const size_t i, const std::string &parameter)


### Benefits

Instead of a crash due to accessing indices out of bounds of vectors, an error message is generated.

### Possible Drawbacks

None

### Verification Process

Bound-check was verified for set_fluid_parameter_double and set_cubic_alpha_C in PR backend using Mathematica wrapper (modified). Same code should work for all other cases. 
Could not verify REFPROP functions, code must be checked!

![grafik](https://user-images.githubusercontent.com/84069190/160780892-bcabb888-0e89-4a9d-8795-c28a720e8155.png)


### Applicable Issues

Closes #2102
