### PR TITLE
Fix mac cibuildwheel

### DIFF
--- a/dev/extract_version.py
+++ b/dev/extract_version.py
@@ -73,7 +73,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     current_v = parse_cmake_version_info()
     if args.cmake_only:
-        print(current_v)
+        print(current_v, end="")
         exit(0)
 
     current_v = version.Version(current_v)


### PR DESCRIPTION
I think I know why mac is failing, it's because of the newline char... testing it out. Worse case scenario, I'll make the replacement in python instead of using sed in bash

example failed run: https://github.com/CoolProp/CoolProp/runs/5784053724?check_suite_focus=true