### PR TITLE
Simplify CoolProp python bindings cibuildwheel

### DIFF
--- a/.github/workflows/python_cibuildwheel.yml
+++ b/.github/workflows/python_cibuildwheel.yml
@@ -12,35 +12,21 @@ on:
 jobs:
 
   python_bindings:
-    name: Build wheel for ${{ matrix.os }}
+    name: py${{ matrix.python-version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-2019, macos-latest]
-        include:
-          # Window 64 bit
-          # Note: windows-2019 is needed for older Python versions:
-          # https://github.com/scikit-learn/scikit-learn/issues/22530
-          - os: windows-2019
-            archs: 'AMD64,x86'
-
-          # Linux 64 bit manylinux2014
-          - os: ubuntu-latest
-            archs: 'x86_64,aarch64'
-
-            # MacOS x86_64
-          - os: macos-latest
-            archs: 'x86_64,arm64'
-
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [36, 37, 38, 39, 310]
 
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: 3.9.x
@@ -49,18 +35,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install requests packaging cibuildwheel
-
-#    - name: Setup Deps
-#      shell: bash
-#      run: |
-#        if [ "$RUNNER_OS" == "Windows" ]; then
-#          # C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
-#          MSVC_DIR=$(cmd.exe /c "vswhere -products * -requires Microsoft.Component.MSBuild -property installationPath -latest")
-#          echo "Latest is: $MSVC_DIR"
-#          echo "MSVC_DIR=$MSVC_DIR" >> $GITHUB_ENV
-#          # add folder containing vcvarsall.bat
-#          echo "$MSVC_DIR\VC\Auxiliary\Build" >> $GITHUB_PATH
-#        fi
 
     - name: Figure out the TestPyPi/PyPi Version
       shell: bash
@@ -76,6 +50,7 @@ jobs:
         MACOSX_DEPLOYMENT_TARGET: 10.9
         CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9 SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
         CIBW_BEFORE_BUILD: pip install setuptools wheel Cython requests jinja2 pyyaml
+        CIBW_BUILD: cp${{ matrix.python-version }}-*
         CIBW_ARCHS_MACOS: 'x86_64,arm64'
         CIBW_ARCHS_WINDOWS: 'AMD64,x86'
         CIBW_ARCHS_LINUX: 'x86_64,aarch64'

--- a/.github/workflows/python_cibuildwheel.yml
+++ b/.github/workflows/python_cibuildwheel.yml
@@ -50,6 +50,7 @@ jobs:
         MACOSX_DEPLOYMENT_TARGET: 10.9
         CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9 SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
         CIBW_BEFORE_BUILD: pip install setuptools wheel Cython requests jinja2 pyyaml
+        CIBW_ENVIRONMENT_LINUX: COOLPROP_CMAKE=default,64
         CIBW_BUILD: cp${{ matrix.python-version }}-*
         CIBW_ARCHS_MACOS: 'x86_64,arm64'
         CIBW_ARCHS_WINDOWS: 'AMD64,x86'

--- a/.github/workflows/python_cibuildwheel.yml
+++ b/.github/workflows/python_cibuildwheel.yml
@@ -53,7 +53,7 @@ jobs:
         CIBW_BUILD: cp${{ matrix.python-version }}-*
         CIBW_ARCHS_MACOS: 'x86_64,arm64'
         CIBW_ARCHS_WINDOWS: 'AMD64,x86'
-        CIBW_ARCHS_LINUX: 'x86_64,aarch64'
+        CIBW_ARCHS_LINUX: 'x86_64'   # aarch64 is having issues launching the docker correctly
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_MANYLINUX_I686_IMAGE: manylinux2014
         CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014

--- a/.github/workflows/python_cibuildwheel.yml
+++ b/.github/workflows/python_cibuildwheel.yml
@@ -12,137 +12,28 @@ on:
 jobs:
 
   python_bindings:
-    name: Build wheel for cp${{ matrix.python }}-${{ matrix.platform_id }}-${{ matrix.manylinux_image }}
+    name: Build wheel for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allow_failure }}
     strategy:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-2019, macos-latest]
         include:
           # Window 64 bit
           # Note: windows-2019 is needed for older Python versions:
           # https://github.com/scikit-learn/scikit-learn/issues/22530
           - os: windows-2019
-            python: 37
-            bitness: 64
-            platform_id: win_amd64
-            cmake_compiler: vc16
-            arch: x64
-            allow_failure: false
-          - os: windows-2019
-            python: 38
-            bitness: 64
-            platform_id: win_amd64
-            cmake_compiler: vc16
-            arch: x64
-            allow_failure: false
-          - os: windows-latest
-            python: 39
-            bitness: 64
-            cmake_compiler: vc17
-            platform_id: win_amd64
-            arch: x64
-            allow_failure: false
-          - os: windows-latest
-            python: 310
-            bitness: 64
-            platform_id: win_amd64
-            cmake_compiler: vc17
-            arch: x64
-            allow_failure: false
-
-          # Window 32 bit
-          - os: windows-2019
-            python: 38
-            bitness: 32
-            platform_id: win32
-            cmake_compiler: vc16
-            arch: x86
-            allow_failure: true
-          - os: windows-latest
-            python: 39
-            bitness: 32
-            platform_id: win32
-            cmake_compiler: vc17
-            arch: x86
-            allow_failure: true
+            archs: 'AMD64,x86'
 
           # Linux 64 bit manylinux2014
           - os: ubuntu-latest
-            python: 37
-            bitness: 64
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-            cmake_compiler: default
-            allow_failure: false
-          - os: ubuntu-latest
-            python: 38
-            bitness: 64
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-            cmake_compiler: default
-            allow_failure: false
-          - os: ubuntu-latest
-            python: 39
-            bitness: 64
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-            cmake_compiler: default
-            allow_failure: false
-          - os: ubuntu-latest
-            python: 310
-            bitness: 64
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-            cmake_compiler: default
-            allow_failure: false
+            archs: 'x86_64,aarch64'
 
-          # MacOS x86_64
+            # MacOS x86_64
           - os: macos-latest
-            bitness: 64
-            python: 37
-            platform_id: macosx_x86_64
-            cmake_compiler: default
-            allow_failure: false
-          - os: macos-latest
-            bitness: 64
-            python: 38
-            platform_id: macosx_x86_64
-            cmake_compiler: default
-            allow_failure: false
-          - os: macos-latest
-            bitness: 64
-            python: 39
-            platform_id: macosx_x86_64
-            cmake_compiler: default
-            allow_failure: false
-          - os: macos-latest
-            bitness: 64
-            python: 310
-            platform_id: macosx_x86_64
-            cmake_compiler: default
-            allow_failure: false
+            archs: 'x86_64,arm64'
 
-          # MacOS arm64
-          - os: macos-latest
-            bitness: 64
-            python: 38
-            platform_id: macosx_arm64
-            cmake_compiler: default
-            allow_failure: false
-          - os: macos-latest
-            bitness: 64
-            python: 39
-            platform_id: macosx_arm64
-            cmake_compiler: default
-            allow_failure: false
-          - os: macos-latest
-            bitness: 64
-            python: 310
-            platform_id: macosx_arm64
-            cmake_compiler: default
-            allow_failure: false
 
     steps:
     - uses: actions/checkout@v3
@@ -157,28 +48,19 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install requests packaging
+        python -m pip install requests packaging cibuildwheel
 
-    - name: Setup Deps
-      shell: bash
-      run: |
-        if [ "$RUNNER_OS" == "Windows" ]; then
-          # C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
-          MSVC_DIR=$(cmd.exe /c "vswhere -products * -requires Microsoft.Component.MSBuild -property installationPath -latest")
-          echo "Latest is: $MSVC_DIR"
-          echo "MSVC_DIR=$MSVC_DIR" >> $GITHUB_ENV
-          # add folder containing vcvarsall.bat
-          echo "$MSVC_DIR\VC\Auxiliary\Build" >> $GITHUB_PATH
-        fi
-
-        if [ "${{ matrix.platform_id }}" == "win32" ]; then
-          echo "Not setting COOLPROP_CMAKE"
-        else
-          COOLPROP_CMAKE=${{ matrix.cmake_compiler }},${{ matrix.bitness }}
-          echo "COOLPROP_CMAKE=$COOLPROP_CMAKE"
-          echo "COOLPROP_CMAKE=$COOLPROP_CMAKE" >> $GITHUB_ENV
-        fi
-
+#    - name: Setup Deps
+#      shell: bash
+#      run: |
+#        if [ "$RUNNER_OS" == "Windows" ]; then
+#          # C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
+#          MSVC_DIR=$(cmd.exe /c "vswhere -products * -requires Microsoft.Component.MSBuild -property installationPath -latest")
+#          echo "Latest is: $MSVC_DIR"
+#          echo "MSVC_DIR=$MSVC_DIR" >> $GITHUB_ENV
+#          # add folder containing vcvarsall.bat
+#          echo "$MSVC_DIR\VC\Auxiliary\Build" >> $GITHUB_PATH
+#        fi
 
     - name: Figure out the TestPyPi/PyPi Version
       shell: bash
@@ -191,22 +73,21 @@ jobs:
 
     - name: Build and test wheels
       env:
-        COOLPROP_CMAKE: ${{ matrix.cmake_compiler}},${{ matrix.bitness }}
-        CIBW_ENVIRONMENT: COOLPROP_CMAKE=${{ env.COOLPROP_CMAKE }}
         MACOSX_DEPLOYMENT_TARGET: 10.9
         CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9 SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
         CIBW_BEFORE_BUILD: pip install setuptools wheel Cython requests jinja2 pyyaml
-        CIBW_BEFORE_ALL_WINDOWS: call vcvarsall.bat ${{ matrix.arch }}
-        CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
-        CIBW_ARCHS: all
-        CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
-        CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.manylinux_image }}
+        CIBW_ARCHS_MACOS: 'x86_64,arm64'
+        CIBW_ARCHS_WINDOWS: 'AMD64,x86'
+        CIBW_ARCHS_LINUX: 'x86_64,aarch64'
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+        CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+        CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+        CIBW_SKIP: "*musllinux* pp* *-manylinux_i686"
         CIBW_TEST_SKIP: "*-macosx_arm64"
         # CIBW_TEST_COMMAND: python -c 'from CoolProp.CoolProp import get_global_param_string; print("CoolProp gitrevision:", get_global_param_string("gitrevision"))'
         CIBW_BUILD_VERBOSITY: 1
 
       run: |
-        python -m pip install cibuildwheel
         python -m cibuildwheel --output-dir wheelhouse ./wrappers/Python
 
     - name: Store artifacts


### PR DESCRIPTION
I'm opening this because I've done the legwork and we discussed it on a couple of occasions already.

Pros:
* It's less verbose and therefore perhaps simpler to read.

Cons:
* It's slower (about 16minutes versus 8minutes in the current setup)
    * Primarily because one runner will build both x86_64 and win32 for eg
    * because it doesn't use the COOLPROP_CMAKE (which will build the shared library bit in parallel with `-j $(nproc)`)
* I'm pretty sure there is something quite wrong with the linux configs... the whl ends up being 43 MB versus 6MB in the current cibuildwheel setup (and 2MB on mac, 1.7 on windows...), I don't know why. (nor am I interested in figuring it out)
    * **edit**: fixed by putting back COOLPROP_CMAKE for linux

I'm not really in favor of making this "simplification" (edit: now the binary size is fixed, it's a matter of taste)

**edit2:** actually this solves the arm64 while my minimum fix didn't... so that makes me a lot more enclined to swallow the small runtime cost. I would now recommend we go with this one @ibell 