### PR TITLE
Minimal fix for arm64 python bindings

### DIFF
--- a/.github/workflows/python_cibuildwheel.yml
+++ b/.github/workflows/python_cibuildwheel.yml
@@ -172,7 +172,9 @@ jobs:
         fi
 
         if [ "${{ matrix.platform_id }}" == "win32" ]; then
-          echo "Not setting COOLPROP_CMAKE"
+          echo "Not setting COOLPROP_CMAKE for win32 (fails to build)"
+        elif [ "${{ matrix.platform_id }}" == "macosx_arm64" ]; then
+          echo "Not setting COOLPROP_CMAKE for arm64 (fails to install)"
         else
           COOLPROP_CMAKE=${{ matrix.cmake_compiler }},${{ matrix.bitness }}
           echo "COOLPROP_CMAKE=$COOLPROP_CMAKE"


### PR DESCRIPTION
cf comment on https://github.com/CoolProp/CoolProp/pull/2122#issuecomment-1097273453 where I identified the fix

Edit: after downloading the artifact from https://github.com/CoolProp/CoolProp/actions/runs/2157826275 it does not work

```shell
$ pip install ./CoolProp-6.4.2.post1-cp39-cp39-macosx_11_0_arm64.whl --force-reinstall
Processing ./CoolProp-6.4.2.post1-cp39-cp39-macosx_11_0_arm64.whl
Installing collected packages: CoolProp
  Attempting uninstall: CoolProp
    Found existing installation: CoolProp 6.4.2.post1
    Uninstalling CoolProp-6.4.2.post1:
      Successfully uninstalled CoolProp-6.4.2.post1
Successfully installed CoolProp-6.4.2.post1

$python -c 'from CoolProp.CoolProp import get_global_param_string; print("CoolProp gitrevision:", get_global_param_string("gitrevision"))'

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/julien/Virtualenvs/py39/lib/python3.9/site-packages/CoolProp/__init__.py", line 16, in <module>
    from .CoolProp import AbstractState
ImportError: dlopen(/Users/julien/Virtualenvs/py39/lib/python3.9/site-packages/CoolProp/CoolProp.cpython-39-darwin.so, 0x0002): symbol not found in flat namespace '__Z5PropsPKccdcdS0_'