### PR TITLE
New functions for CoolPropLib

### DIFF
--- a/include/CoolProp.h
+++ b/include/CoolProp.h
@@ -26,6 +26,14 @@ namespace CoolProp {
 /// @param FluidName The fluid name
 /// @param Output The output parameter, one of "Tcrit","D","H",etc.
 double Props1SI(std::string FluidName, std::string Output);
+/**
+     * @brief  Get a matrix of outputs that do not depend on the thermodynamic state - this is a convenience function that does the call PropsSImulti(Outputs, "", {0}, "", {0}, backend, fluids, fractions)
+     * @param Outputs A vector of strings for the output parameters
+     * @param backend The string representation of the backend (HEOS, REFPROP, INCOMP, etc.)
+     * @param fluids The fluid name(s)
+     * @param fractions The fractions (molar, mass, volume, etc.) of the components
+     */     
+std::vector<std::vector<double>> Props1SImulti(const std::vector<std::string>& Outputs, const std::string& backend, const std::vector<std::string>& fluids, const std::vector<double>& fractions);
 /// Return a value that depends on the thermodynamic state
 /// @param Output The output parameter, one of "T","D","H",etc.
 /// @param Name1 The first state variable name, one of "T","D","H",etc.

--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -82,6 +82,15 @@ inline void __assert(const char* error) {
      * \note If there is an error, a huge value will be returned, you can get the error message by doing something like get_global_param_string("errstring",output)
      */
 EXPORT_CODE double CONVENTION Props1SI(const char* FluidName, const char* Output);
+
+/**
+     *\overload
+     *\sa \ref CoolProp::Props1SImulti(const std::vector<std::string>& Outputs, const std::string& backend, const std::vector<std::string>& fluids, const std::vector<double>& fractions)
+     *
+     * \note If there is an error, a huge value will be returned, you can get the error message by doing something like get_global_param_string("errstring",output)
+     */
+EXPORT_CODE void CONVENTION Props1SImulti(const char* Outputs, char* backend, const char* FluidNames, const double* fractions,
+                                          const long length_fractions, double* result, long* resdim1);
 /**
      *\overload
      *\sa \ref CoolProp::PropsSI(const std::string &, const std::string &, double, const std::string &, double, const std::string&)
@@ -89,7 +98,31 @@ EXPORT_CODE double CONVENTION Props1SI(const char* FluidName, const char* Output
      * \note If there is an error, a huge value will be returned, you can get the error message by doing something like get_global_param_string("errstring",output)
      */
 EXPORT_CODE double CONVENTION PropsSI(const char* Output, const char* Name1, double Prop1, const char* Name2, double Prop2, const char* Ref);
-
+/**
+     *\overload
+     *\sa \ref CoolProp::PropsSImulti(const std::vector<std::string>& Outputs, const std::string& Name1, const std::vector<double>& Prop1,
+                                              const std::string& Name2, const std::vector<double>& Prop2, const std::string& backend,
+                                              const std::vector<std::string>& fluids, const std::vector<double>& fractions)
+     *
+     * @param Outputs Delimited string separated by LIST_STRING_DELIMITER for the output parameters
+     * @param Name1 The name of the first input variable
+     * @param Prop1 A vector of the first input values 
+     * @param size_Prop1 Size of Prop1 double*
+     * @param Name2 The name of the second input variable
+     * @param Prop2 A vector of the second input values 
+     * @param size_Prop2 Size of Prop2 double*
+     * @param backend 	The string representation of the backend (HEOS, REFPROP, INCOMP, etc.) 
+     * @param FluidNames  Delimited string separated by LIST_STRING_DELIMITER for the fluid name(s)
+     * @param fractions The fractions (molar, mass, volume, etc.) of the components
+     * @param length_fractions Size of fractions double*
+     * @param result Allocated memory for result vector
+     * @param resdim1 result vector dimension 1 pointer, to check allocated space and return actual result size
+     * @param resdim2 result vector dimension 2 pointer, to check allocated space and return actual result size
+     * \note If there is an error, an empty vector will be returned, you can get the error message by doing something like get_global_param_string("errstring",output)
+     */
+EXPORT_CODE void CONVENTION PropsSImulti(const char* Outputs, const char* Name1, double* Prop1, const long size_Prop1, const char* Name2,
+                                         double* Prop2, const long size_Prop2, char* backend, const char* FluidNames, const double* fractions,
+                                         const long length_fractions, double* result, long* resdim1, long* resdim2);
 /**
      *\overload
      *\sa \ref CoolProp::PhaseSI(const std::string &, double, const std::string &, double, const std::string&)

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -834,6 +834,15 @@ double Props1SI(std::string FluidName, std::string Output) {
         return val1;
     }
 }
+
+std::vector<std::vector<double>> Props1SImulti(const std::vector<std::string>& Outputs, const std::string& backend, const std::vector<std::string>& fluids, const std::vector<double>& fractions) {
+    std::vector<double> zero_vector(1, 0.);
+    std::vector<std::vector<double>> val1 = PropsSImulti(Outputs, "", zero_vector, "", zero_vector, backend, fluids, fractions);
+    // error handling is done in PropsSImulti, val1 will be an empty vector if an error occured
+    return val1;
+}
+
+
 #if defined(ENABLE_CATCH)
 TEST_CASE("Check inputs to Props1SI", "[Props1SI],[PropsSI]") {
     SECTION("Good fluid, good parameter") {


### PR DESCRIPTION
Props1SImulti new function in CoolProp and Props1SImulti and PropsSImulti to CoolPropLib

### Description of the Change

Function Props1SImulti was added to CoolProp. It is the Props1SI function but with multiple outputs possible, comparable to PropsSImulti.
Props1SImulti and PropsSImulti were added to CoolPropLib

### Benefits

Enables the user to acces multiple non-thermodynamic-state-dependend fluid properties at once.

### Possible Drawbacks

None

### Verification Process

Functions were tested using the Mathematica wrapper, see PR #2085 
