### PR TITLE
AbstractState functions for CoolPropLib

### DIFF
--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -354,6 +354,21 @@ EXPORT_CODE void CONVENTION AbstractState_set_fractions(const long handle, const
 EXPORT_CODE void CONVENTION AbstractState_get_mole_fractions(const long handle, double* fractions, const long maxN, long* N, long* errcode,
                                                              char* message_buffer, const long buffer_length);
 /**
+     * @brief Get the molar fractions for the AbstractState and the desired saturated State
+     * @param handle The integer handle for the state class stored in memory
+     * @param saturated_state The string specifying the state (liquid or gas)
+     * @param fractions The array of fractions
+     * @param maxN The length of the buffer for the fractions
+     * @param N number of fluids
+     * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+     * @param message_buffer A buffer for the error code
+     * @param buffer_length The length of the buffer for the error code
+     * @return 
+     */
+EXPORT_CODE void CONVENTION AbstractState_get_mole_fractions_satState(const long handle, const char* saturated_state, double* fractions,
+                                                                      const long maxN, long* N, long* errcode, char* message_buffer,
+                                                                      const long buffer_length);
+/**
      * @brief Update the state of the AbstractState
      * @param handle The integer handle for the state class stored in memory
      * @param input_pair The integer value for the input pair obtained from XXXXXXXXXXXXXXXX
@@ -559,12 +574,15 @@ EXPORT_CODE void CONVENTION AbstractState_build_phase_envelope(const long handle
      * @brief Get data from the phase envelope for the given mixture composition
      * @param handle The integer handle for the state class stored in memory
      * @param length The number of elements stored in the arrays (both inputs and outputs MUST be the same length)
+     * @param maxComponents The number of fluid components for which memory is allocated
      * @param T The pointer to the array of temperature (K)
      * @param p The pointer to the array of pressure (Pa)
      * @param rhomolar_vap The pointer to the array of molar density for vapor phase (m^3/mol)
      * @param rhomolar_liq The pointer to the array of molar density for liquid phase (m^3/mol)
      * @param x The compositions of the "liquid" phase (WARNING: buffer should be Ncomp*Npoints in length, at a minimum, but there is no way to check buffer length at runtime)
      * @param y The compositions of the "vapor" phase (WARNING: buffer should be Ncomp*Npoints in length, at a minimum, but there is no way to check buffer length at runtime)
+     * @param actual_length The number of elements actually stored in the arrays
+     * @param actual_components The number of fluid components actually stored in the arrays
      * @param errcode The errorcode that is returned (0 = no error, !0 = error)
      * @param message_buffer A buffer for the error code
      * @param buffer_length The length of the buffer for the error code
@@ -572,8 +590,9 @@ EXPORT_CODE void CONVENTION AbstractState_build_phase_envelope(const long handle
      *
      * @note If there is an error in an update call for one of the inputs, no change in the output array will be made
      */
-EXPORT_CODE void CONVENTION AbstractState_get_phase_envelope_data(const long handle, const long length, double* T, double* p, double* rhomolar_vap,
-                                                                  double* rhomolar_liq, double* x, double* y, long* errcode, char* message_buffer,
+EXPORT_CODE void CONVENTION AbstractState_get_phase_envelope_data(const long handle, const long length, const long maxComponents, double* T,
+                                                                  double* p, double* rhomolar_vap, double* rhomolar_liq, double* x, double* y,
+                                                                  long* actual_length, long* actual_components, long* errcode, char* message_buffer,
                                                                   const long buffer_length);
 
 /**
@@ -620,6 +639,38 @@ EXPORT_CODE void CONVENTION AbstractState_get_spinodal_data(const long handle, c
      */
 EXPORT_CODE void CONVENTION AbstractState_all_critical_points(const long handle, const long length, double* T, double* p, double* rhomolar,
                                                               long* stable, long* errcode, char* message_buffer, const long buffer_length);
+/**
+     * @brief Get an output value from the AbstractState using an integer value for the desired output value and desired saturated State
+     * @param handle The integer handle for the state class stored in memory
+     * @param saturated_state The string specifying the state (liquid or gas)
+     * @param param The integer value for the parameter you want
+     * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+     * @param message_buffer A buffer for the error code
+     * @param buffer_length The length of the buffer for the error code
+     * @return
+     */
+EXPORT_CODE double CONVENTION AbstractState_keyed_output_satState(const long handle, const char* saturated_state, const long param, long* errcode,
+                                                                  char* message_buffer, const long buffer_length);
+/**
+     * @brief Return the name of the backend used in the AbstractState
+     * @param handle The integer handle for the state class stored in memory
+     * @param backend The char pointer the name is written to
+     * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+     * @param message_buffer A buffer for the error code
+     * @param buffer_length The length of the buffer for the error code
+     * @return
+     */
+EXPORT_CODE void CONVENTION AbstractState_backend_name(const long handle, char* backend, long* errcode, char* message_buffer,
+                                                       const long buffer_length);
+/** 
+     * \brief Add fluids as a JSON-formatted string
+     * @param backend The backend to which these should be added; e.g. "HEOS", "SRK", "PR"
+     * @param fluidstring The JSON-formatted string
+     * @return
+     *
+     */
+EXPORT_CODE void CONVENTION add_fluids_as_JSON(const char* backend, const char* fluidstring, long* errcode, char* message_buffer,
+                                               const long buffer_length);
 
 // *************************************************************************************
 // *************************************************************************************

--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -574,6 +574,27 @@ EXPORT_CODE void CONVENTION AbstractState_build_phase_envelope(const long handle
      * @brief Get data from the phase envelope for the given mixture composition
      * @param handle The integer handle for the state class stored in memory
      * @param length The number of elements stored in the arrays (both inputs and outputs MUST be the same length)
+     * @param T The pointer to the array of temperature (K)
+     * @param p The pointer to the array of pressure (Pa)
+     * @param rhomolar_vap The pointer to the array of molar density for vapor phase (m^3/mol)
+     * @param rhomolar_liq The pointer to the array of molar density for liquid phase (m^3/mol)
+     * @param x The compositions of the "liquid" phase (WARNING: buffer should be Ncomp*Npoints in length, at a minimum, but there is no way to check buffer length at runtime)
+     * @param y The compositions of the "vapor" phase (WARNING: buffer should be Ncomp*Npoints in length, at a minimum, but there is no way to check buffer length at runtime)
+     * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+     * @param message_buffer A buffer for the error code
+     * @param buffer_length The length of the buffer for the error code
+     * @return
+     *
+     * @note If there is an error in an update call for one of the inputs, no change in the output array will be made
+     */
+EXPORT_CODE void CONVENTION AbstractState_get_phase_envelope_data(const long handle, const long length, double* T, double* p, double* rhomolar_vap,
+                                                                  double* rhomolar_liq, double* x, double* y, long* errcode, char* message_buffer,
+                                                                  const long buffer_length);
+
+/**
+     * @brief Get data from the phase envelope for the given mixture composition
+     * @param handle The integer handle for the state class stored in memory
+     * @param length The number of elements stored in the arrays (both inputs and outputs MUST be the same length)
      * @param maxComponents The number of fluid components for which memory is allocated
      * @param T The pointer to the array of temperature (K)
      * @param p The pointer to the array of pressure (Pa)

--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -611,7 +611,7 @@ EXPORT_CODE void CONVENTION AbstractState_get_phase_envelope_data(const long han
      *
      * @note If there is an error in an update call for one of the inputs, no change in the output array will be made
      */
-EXPORT_CODE void CONVENTION AbstractState_get_phase_envelope_data(const long handle, const long length, const long maxComponents, double* T,
+EXPORT_CODE void CONVENTION AbstractState_get_phase_envelope_data_checkedMemory(const long handle, const long length, const long maxComponents, double* T,
                                                                   double* p, double* rhomolar_vap, double* rhomolar_liq, double* x, double* y,
                                                                   long* actual_length, long* actual_components, long* errcode, char* message_buffer,
                                                                   const long buffer_length);

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -593,8 +593,9 @@ EXPORT_CODE void CONVENTION AbstractState_get_mole_fractions_satState(const long
         }
         *N = _fractions.size();
         if (*N <= maxN) {
-            for (int i = 0; i < *N; i++)
+            for (int i = 0; i < *N; i++) {
                 fractions[i] = _fractions[i];
+            }
         } else {
             throw CoolProp::ValueError(format("Length of array [%d] is greater than allocated buffer length [%d]", *N, maxN));
         }
@@ -922,8 +923,13 @@ EXPORT_CODE void CONVENTION AbstractState_backend_name(const long handle, char* 
 
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
-        strcpy(backend, AS->backend_name().c_str());
-
+        std::string backendstring = AS->backend_name();
+        if (backendstring.size() < static_cast<std::size_t>(buffer_length)) {
+            strcpy(backend, backendstring.c_str());
+        } else {
+            throw CoolProp::ValueError(format("Length of string [%d] is greater than allocated buffer length [%d]", backendstring.size(),
+                                              static_cast<std::size_t>(buffer_length)));
+        }
     } catch (...) {
         HandleException(errcode, message_buffer, buffer_length);
     }

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -577,10 +577,11 @@ EXPORT_CODE void CONVENTION AbstractState_get_mole_fractions_satState(const long
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         std::vector<double> _fractions;
         double quality = AS->Q();
+        std::string string_state(saturated_state);
         if (0 <= quality && quality <= 1) {
-            if (strcmp("liquid", saturated_state) == 0) {
+            if (string_state == "liquid") {
                 _fractions = AS->mole_fractions_liquid();
-            } else if (strcmp("gas", saturated_state) == 0) {
+            } else if (string_state == "gas") {
                 _fractions = AS->mole_fractions_vapor();
             } else {
                 throw CoolProp::ValueError(
@@ -897,10 +898,11 @@ EXPORT_CODE double CONVENTION AbstractState_keyed_output_satState(const long han
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         double quality = AS->Q();
+        std::string string_state(saturated_state);
         if (0 <= quality && quality <= 1) {
-            if (strcmp("liquid", saturated_state) == 0) {
+            if (string_state == "liquid") {
                 return AS->saturated_liquid_keyed_output(static_cast<CoolProp::parameters>(param));
-            } else if (strcmp("gas", saturated_state) == 0) {
+            } else if (string_state == "gas") {
                 return AS->saturated_vapor_keyed_output(static_cast<CoolProp::parameters>(param));
             } else {
                 throw CoolProp::ValueError(

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -778,6 +778,33 @@ EXPORT_CODE void CONVENTION AbstractState_build_phase_envelope(const long handle
     }
 }
 
+EXPORT_CODE void CONVENTION AbstractState_get_phase_envelope_data(const long handle, const long length, double* T, double* p, double* rhomolar_vap,
+                                                                  double* rhomolar_liq, double* x, double* y, long* errcode, char* message_buffer,
+                                                                  const long buffer_length) {
+    *errcode = 0;
+    try {
+        shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
+        CoolProp::PhaseEnvelopeData pe = AS->get_phase_envelope_data();
+        if (pe.T.size() > static_cast<std::size_t>(length)) {
+            throw CoolProp::ValueError(format("Length of phase envelope vectors [%d] is greater than allocated buffer length [%d]",
+                                              static_cast<int>(pe.T.size()), static_cast<int>(length)));
+        }
+        std::size_t N = pe.x.size();
+        for (std::size_t i = 0; i < pe.T.size(); i++) {
+            *(T + i) = pe.T[i];
+            *(p + i) = pe.p[i];
+            *(rhomolar_vap + i) = pe.rhomolar_vap[i];
+            *(rhomolar_liq + i) = pe.rhomolar_liq[i];
+            for (std::size_t j = 0; j < N; ++j) {
+                *(x + i * N + j) = pe.x[j][i];
+                *(y + i * N + j) = pe.y[j][i];
+            }
+        }
+    } catch (...) {
+        HandleException(errcode, message_buffer, buffer_length);
+    }
+}
+
 EXPORT_CODE void CONVENTION AbstractState_get_phase_envelope_data(const long handle, const long length, const long maxComponents, double* T,
                                                                   double* p, double* rhomolar_vap, double* rhomolar_liq, double* x, double* y,
                                                                   long* actual_length, long* actual_components, long* errcode, char* message_buffer,

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -805,7 +805,7 @@ EXPORT_CODE void CONVENTION AbstractState_get_phase_envelope_data(const long han
     }
 }
 
-EXPORT_CODE void CONVENTION AbstractState_get_phase_envelope_data(const long handle, const long length, const long maxComponents, double* T,
+EXPORT_CODE void CONVENTION AbstractState_get_phase_envelope_data_checkedMemory(const long handle, const long length, const long maxComponents, double* T,
                                                                   double* p, double* rhomolar_vap, double* rhomolar_liq, double* x, double* y,
                                                                   long* actual_length, long* actual_components, long* errcode, char* message_buffer,
                                                                   const long buffer_length) {


### PR DESCRIPTION
### Description of the Change

AbstractState_get_mole_fractions_satState returns mole fractions for saturated "liquid" or "gas" phases
AbstractState_keyed_output_satState returns keyed output for saturated "liquid" or "gas" phases
AbstractState_backend_name returns the backend name for an AbstractState
add_fluids_as_JSON can be called from the High-Level.

Changes to AbstractState_get_phase_envelope_data

### Benefits

Adds functionality to the High-Level-Interface.

AbstractState_get_phase_envelope_data returns the actual length of the array and throws an error should there not be enough memory allocated.

### Possible Drawbacks

Changes to AbstractState_get_phase_envelope_data might imply refactoring of wrappers (could only find it in Julia wrapper)

### Verification Process

Functions were tested using the Mathematica wrapper, see PR #2085

### Applicable Issues

Based on PR #2133 and #2134 
