### PR TITLE
Corrected rho_ice route by replacing g_ice with dg_dp_Ice in Ice.cpp

### DIFF
--- a/src/Ice.cpp
+++ b/src/Ice.cpp
@@ -127,7 +127,7 @@ double h_Ice(double T, double p) {
 double rho_Ice(double T, double p) {
 #ifndef __powerpc__
     // Returned value is in units of kg/m3
-    return 1 / g_Ice(T, p);
+    return 1 / dg_dp_Ice(T, p);
 #else
     return 1e99;
 #endif


### PR DESCRIPTION
### Requirements


### Description of the Change

Email reply from Dr Bell.
"""
Yes, I think you are right. From the IAPWS release:

 

I think I overlooked the p subscript when I was implementing that, now more than a decade ago! Can you please file a pull request fixing it?  I wonder how nobody noticed before.


================================================================================
Dear Dr Bell,
 
I came across the density of ice function in CoolProp as follows. (https://coolprop.dreamhosters.com/binaries/sphinx/_static/doxygen/html/_ice_8cpp_source.html)
 
 
double rho_Ice(double T, double p)
{
     #ifndef __powerpc__
         // Returned value is in units of kg/m3
         return 1/g_Ice(T,p);
     #else
         return 1e99;
     #endif
}
 
Shouldn’t it be dg_dp_Ice instead of g_ice?
 
I confirmed with vmolar and get the same value as rho_ice using dg_dp_ice.
 
Thanks. 
"""

### Benefits

Used the correct formula for the density of ice.

### Possible Drawbacks

The code becomes theoretically correct.

### Verification Process

Verified with
1. the model described in the original paper (The International Association for the Properties of Water and Steam
Doorwerth, The Netherlands September 2009, Revised Release on the Equation of State 2006 for H2O Ice Ih)
2. Independently checked the value of rho using the specific volume at different temperatures.
3. The routines gave the same values.
4. The change involved the simple replacement of the already implemented functions. Thus, there is no regression.

Corrected rho_ice route by replacing g_ice with dg_dp_Ice in Ice.cpp. 

I didn't compile it. 

Please see the above for the email exchange with Dr. Bell.

### Applicable Issues
NA
