### PR TITLE
Install cmake config files for CoolÜrop library [2144]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,6 +538,7 @@ if(COOLPROP_OBJECT_LIBRARY
     endif(MSVC)
     install(
       TARGETS CoolProp
+      EXPORT CoolProp-targets
       DESTINATION
         static_library/${CMAKE_SYSTEM_NAME}/${BITNESS}bit_${CMAKE_CXX_COMPILER_ID}_${CMAKE_CXX_COMPILER_VERSION}
     )
@@ -549,6 +550,7 @@ if(COOLPROP_OBJECT_LIBRARY
     add_library(CoolProp SHARED ${APP_SOURCES} ${COOLPROP_LIBRARY_EXPORTS})
     install(
       TARGETS CoolProp
+      EXPORT CoolProp-targets
       DESTINATION shared_library/${CMAKE_SYSTEM_NAME}/${BITNESS}bit${CONVENTION}
     )
     install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_HEADER}
@@ -592,6 +594,12 @@ if(COOLPROP_OBJECT_LIBRARY
 
   if(NOT COOLPROP_OBJECT_LIBRARY)
     target_link_libraries(CoolProp PRIVATE ${CMAKE_DL_LIBS})
+
+    # install exports
+    install (
+        EXPORT CoolProp-targets
+        DESTINATION lib/cmake/CoolProp)
+
   endif()
 
   # For windows systems, bug workaround for Eigen
@@ -629,7 +637,9 @@ if(COOLPROP_OBJECT_LIBRARY
   #
   if(CMAKE_VERSION VERSION_GREATER 3.0)
     # Add target include directories for easy linking with other applications
-    target_include_directories(CoolProp PUBLIC ${APP_INCLUDE_DIRS})
+    # TODO: check: CoolProp.h does not include any other dirs, but apps
+    # might not only use CoolProp.h but also the C++ API
+    target_include_directories(CoolProp PRIVATE ${APP_INCLUDE_DIRS})
   endif()
 
   # Set the bitness

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,10 +555,7 @@ if(COOLPROP_OBJECT_LIBRARY
       DESTINATION shared_library/${CMAKE_SYSTEM_NAME}/${BITNESS}bit${CONVENTION}
     )
     set(CoolPropLibDestination "shared_library")
-    set_property(
-      TARGET CoolPropLib
-      APPEND_STRING
-      PROPERTY COMPILE_FLAGS " -DCOOLPROP_LIB")
+    target_compile_definitions(CoolPropLib PUBLIC COOLPROP_LIB)
     # Now all the compiler specific settings for Visual Studio
     if(MSVC)
       # Add postfix for debugging

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.0)
 
 project(CoolProp)
-set(CoolPropVersion "6.4.2dev")
 
 include(CheckIncludeFileCXX)
 
@@ -596,6 +595,11 @@ if(COOLPROP_OBJECT_LIBRARY
   if(NOT COOLPROP_OBJECT_LIBRARY)
     target_link_libraries(CoolPropLib PRIVATE ${CMAKE_DL_LIBS})
 
+    file(GENERATE
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/CoolProp-config.cmake"
+      INPUT  "${PROJECT_SOURCE_DIR}/dev/cmake/Modules/CoolProp-config.cmake.in"
+    )
+
     set(COOLPROP_CMAKE_DIR "lib/cmake/CoolProp")
 
     # install the public header file
@@ -615,13 +619,13 @@ if(COOLPROP_OBJECT_LIBRARY
     include(CMakePackageConfigHelpers)
     write_basic_package_version_file(
       "${CMAKE_CURRENT_BINARY_DIR}/CoolProp-config-version.cmake"
-      VERSION ${CoolPropVersion}
+      VERSION ${COOLPROP_VERSION}
       COMPATIBILITY AnyNewerVersion
     )
 
     install (
         FILES ${CMAKE_CURRENT_BINARY_DIR}/CoolProp-config-version.cmake
-        # ${CMAKE_CURRENT_BINARY_DIR}/CoolProp-config.cmake
+               ${CMAKE_CURRENT_BINARY_DIR}/CoolProp-config.cmake
         DESTINATION ${COOLPROP_CMAKE_DIR})
 
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -591,7 +591,7 @@ if(COOLPROP_OBJECT_LIBRARY
   set_target_properties(CoolProp PROPERTIES OUTPUT_NAME ${LIB_NAME})
 
   if(NOT COOLPROP_OBJECT_LIBRARY)
-    target_link_libraries(CoolProp ${CMAKE_DL_LIBS})
+    target_link_libraries(CoolProp PRIVATE ${CMAKE_DL_LIBS})
   endif()
 
   # For windows systems, bug workaround for Eigen

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,8 +545,7 @@ if(COOLPROP_OBJECT_LIBRARY
       DESTINATION
         static_library/${CMAKE_SYSTEM_NAME}/${BITNESS}bit_${CMAKE_CXX_COMPILER_ID}_${CMAKE_CXX_COMPILER_VERSION}
     )
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_HEADER}
-            DESTINATION static_library)
+    set(CoolPropLibDestination "static_library")
   elseif(COOLPROP_SHARED_LIBRARY)
     list(APPEND APP_SOURCES
          "${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_SOURCE}")
@@ -556,8 +555,7 @@ if(COOLPROP_OBJECT_LIBRARY
       EXPORT CoolProp-targets
       DESTINATION shared_library/${CMAKE_SYSTEM_NAME}/${BITNESS}bit${CONVENTION}
     )
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_HEADER}
-            DESTINATION shared_library)
+    set(CoolPropLibDestination "shared_library")
     set_property(
       TARGET CoolPropLib
       APPEND_STRING
@@ -599,6 +597,15 @@ if(COOLPROP_OBJECT_LIBRARY
     target_link_libraries(CoolPropLib PRIVATE ${CMAKE_DL_LIBS})
 
     set(COOLPROP_CMAKE_DIR "lib/cmake/CoolProp")
+
+    # install the public header file
+    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_HEADER}
+            DESTINATION ${CoolPropLibDestination})
+
+    # link header file to library
+    target_include_directories(CoolPropLib PUBLIC
+        $<INSTALL_INTERFACE:${CoolPropLibDestination}>
+    )
 
     # install exports
     install (

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,23 +521,23 @@ if(COOLPROP_OBJECT_LIBRARY
   set(LIB_NAME ${COOLPROP_LIBRARY_NAME})
   # Object, static or shared?
   if(COOLPROP_OBJECT_LIBRARY)
-    add_library(CoolProp OBJECT ${APP_SOURCES})
+    add_library(CoolPropLib OBJECT ${APP_SOURCES})
     set(COOLPROP_LIBRARY_SOURCE "")
     set(COOLPROP_LIBRARY_HEADER "")
   elseif(COOLPROP_STATIC_LIBRARY)
     list(APPEND APP_SOURCES
          "${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_SOURCE}")
-    add_library(CoolProp STATIC ${APP_SOURCES} ${COOLPROP_LIBRARY_EXPORTS})
+    add_library(CoolPropLib STATIC ${APP_SOURCES} ${COOLPROP_LIBRARY_EXPORTS})
     if(MSVC)
       # Add postfix for debugging
-      set_property(TARGET CoolProp PROPERTY DEBUG_POSTFIX d)
-      set_property(TARGET CoolProp PROPERTY RELEASE_POSTFIX)
+      set_property(TARGET CoolPropLib PROPERTY DEBUG_POSTFIX d)
+      set_property(TARGET CoolPropLib PROPERTY RELEASE_POSTFIX)
       modify_msvc_flags("/MD")
 
       # Note that the default is not used if ${COOLPROP_MSVC_REL} or ${COOLPROP_MSVC_DBG} is set
     endif(MSVC)
     install(
-      TARGETS CoolProp
+      TARGETS CoolPropLib
       EXPORT CoolProp-targets
       DESTINATION
         static_library/${CMAKE_SYSTEM_NAME}/${BITNESS}bit_${CMAKE_CXX_COMPILER_ID}_${CMAKE_CXX_COMPILER_VERSION}
@@ -547,32 +547,32 @@ if(COOLPROP_OBJECT_LIBRARY
   elseif(COOLPROP_SHARED_LIBRARY)
     list(APPEND APP_SOURCES
          "${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_SOURCE}")
-    add_library(CoolProp SHARED ${APP_SOURCES} ${COOLPROP_LIBRARY_EXPORTS})
+    add_library(CoolPropLib SHARED ${APP_SOURCES} ${COOLPROP_LIBRARY_EXPORTS})
     install(
-      TARGETS CoolProp
+      TARGETS CoolPropLib
       EXPORT CoolProp-targets
       DESTINATION shared_library/${CMAKE_SYSTEM_NAME}/${BITNESS}bit${CONVENTION}
     )
     install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_HEADER}
             DESTINATION shared_library)
     set_property(
-      TARGET CoolProp
+      TARGET CoolPropLib
       APPEND_STRING
       PROPERTY COMPILE_FLAGS " -DCOOLPROP_LIB")
     # Now all the compiler specific settings for Visual Studio
     if(MSVC)
       # Add postfix for debugging
-      set_property(TARGET CoolProp PROPERTY DEBUG_POSTFIX d)
-      set_property(TARGET CoolProp PROPERTY RELEASE_POSTFIX)
+      set_property(TARGET CoolPropLib PROPERTY DEBUG_POSTFIX d)
+      set_property(TARGET CoolPropLib PROPERTY RELEASE_POSTFIX)
       # No lib prefix for the shared library
-      set_property(TARGET CoolProp PROPERTY PREFIX "")
+      set_property(TARGET CoolPropLib PROPERTY PREFIX "")
       modify_msvc_flags("/MT")
 
       # Note that the default is not used if ${COOLPROP_MSVC_REL} or ${COOLPROP_MSVC_DBG} is set
       add_custom_command(
-        TARGET CoolProp
+        TARGET CoolPropLib
         POST_BUILD
-        COMMAND dumpbin /EXPORTS $<TARGET_FILE:CoolProp> >
+        COMMAND dumpbin /EXPORTS $<TARGET_FILE:CoolPropLib> >
                 ${CMAKE_CURRENT_BINARY_DIR}/exports.txt)
       install(
         FILES ${CMAKE_CURRENT_BINARY_DIR}/exports.txt
@@ -581,8 +581,8 @@ if(COOLPROP_OBJECT_LIBRARY
     endif()
     # For Linux
     if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
-      set_property(TARGET CoolProp PROPERTY VERSION ${COOLPROP_VERSION})
-      set_property(TARGET CoolProp PROPERTY SOVERSION
+      set_property(TARGET CoolPropLib PROPERTY VERSION ${COOLPROP_VERSION})
+      set_property(TARGET CoolPropLib PROPERTY SOVERSION
                                                ${COOLPROP_VERSION_MAJOR})
     endif()
   else()
@@ -590,10 +590,10 @@ if(COOLPROP_OBJECT_LIBRARY
   endif()
 
   # rename coolprop library to user-specified name
-  set_target_properties(CoolProp PROPERTIES OUTPUT_NAME ${LIB_NAME})
+  set_target_properties(CoolPropLib PROPERTIES OUTPUT_NAME ${LIB_NAME})
 
   if(NOT COOLPROP_OBJECT_LIBRARY)
-    target_link_libraries(CoolProp PRIVATE ${CMAKE_DL_LIBS})
+    target_link_libraries(CoolPropLib PRIVATE ${CMAKE_DL_LIBS})
 
     # install exports
     install (
@@ -606,7 +606,7 @@ if(COOLPROP_OBJECT_LIBRARY
   if(MSVC90)
     message(STATUS "EIGEN WORKAROUND ACTIVE!!")
     set_property(
-      TARGET CoolProp
+      TARGET CoolPropLib
       APPEND_STRING
       PROPERTY COMPILE_FLAGS " -DEIGEN_DONT_VECTORIZE")
   endif()
@@ -615,12 +615,12 @@ if(COOLPROP_OBJECT_LIBRARY
   if("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
     if(DEFINED OSX_COMPILE_FLAGS)
       set_target_properties(
-        CoolProp PROPERTIES APPEND_STRING PROPERTY COMPILE_FLAGS
+        CoolPropLib PROPERTIES APPEND_STRING PROPERTY COMPILE_FLAGS
                                                       "${OSX_COMPILE_FLAGS}")
     endif(DEFINED OSX_COMPILE_FLAGS)
     if(DEFINED OSX_COMPILE_FLAGS)
       set_target_properties(
-        CoolProp PROPERTIES APPEND_STRING PROPERTY LINK_FLAGS
+        CoolPropLib PROPERTIES APPEND_STRING PROPERTY LINK_FLAGS
                                                       "${OSX_LINK_FLAGS}")
     endif(DEFINED OSX_COMPILE_FLAGS)
   endif()
@@ -628,18 +628,18 @@ if(COOLPROP_OBJECT_LIBRARY
   # Name mangling settings
   if(COOLPROP_EXTERNC_LIBRARY)
     set_property(
-      TARGET CoolProp
+      TARGET CoolPropLib
       APPEND_STRING
       PROPERTY COMPILE_FLAGS " -DEXTERNC")
   endif()
   ### All options are set, we are building a library ###
-  add_dependencies(CoolProp generate_headers)
+  add_dependencies(CoolPropLib generate_headers)
   #
   if(CMAKE_VERSION VERSION_GREATER 3.0)
     # Add target include directories for easy linking with other applications
     # TODO: check: CoolProp.h does not include any other dirs, but apps
     # might not only use CoolProp.h but also the C++ API
-    target_include_directories(CoolProp PRIVATE ${APP_INCLUDE_DIRS})
+    target_include_directories(CoolPropLib PRIVATE ${APP_INCLUDE_DIRS})
   endif()
 
   # Set the bitness
@@ -647,11 +647,11 @@ if(COOLPROP_OBJECT_LIBRARY
     if(NOT "${BITNESS}" STREQUAL "NATIVE")
       message(STATUS "Setting bitness flag -m${BITNESS}")
       set_property(
-        TARGET CoolProp
+        TARGET CoolPropLib
         APPEND_STRING
         PROPERTY COMPILE_FLAGS " -m${BITNESS}")
       set_property(
-        TARGET CoolProp
+        TARGET CoolPropLib
         APPEND_STRING
         PROPERTY LINK_FLAGS " -m${BITNESS}")
     endif()
@@ -661,7 +661,7 @@ if(COOLPROP_OBJECT_LIBRARY
   if(COOLPROP_FPIC)
     message(STATUS "Setting bitness flag -m${BITNESS}")
     set_property(
-      TARGET CoolProp
+      TARGET CoolPropLib
       APPEND_STRING
       PROPERTY COMPILE_FLAGS " -fPIC")
   endif()
@@ -671,7 +671,7 @@ if(COOLPROP_OBJECT_LIBRARY
     #MESSAGE(STATUS "Skipping unknown calling convention.")
   else()
     set_property(
-      TARGET CoolProp
+      TARGET CoolPropLib
       APPEND_STRING
       PROPERTY COMPILE_FLAGS " -DCONVENTION=${CONVENTION}")
   endif()
@@ -689,12 +689,12 @@ if(COOLPROP_OBJECT_LIBRARY
   #
   get_property(
     tmpVar
-    TARGET CoolProp
+    TARGET CoolPropLib
     PROPERTY COMPILE_FLAGS)
   message(STATUS "COMPILE_FLAGS: ${tmpVar}")
   get_property(
     tmpVar
-    TARGET CoolProp
+    TARGET CoolPropLib
     PROPERTY LINK_FLAGS)
   message(STATUS "LINK_FLAGS: ${tmpVar}")
   #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,23 +521,23 @@ if(COOLPROP_OBJECT_LIBRARY
   set(LIB_NAME ${COOLPROP_LIBRARY_NAME})
   # Object, static or shared?
   if(COOLPROP_OBJECT_LIBRARY)
-    add_library(${LIB_NAME} OBJECT ${APP_SOURCES})
+    add_library(CoolProp OBJECT ${APP_SOURCES})
     set(COOLPROP_LIBRARY_SOURCE "")
     set(COOLPROP_LIBRARY_HEADER "")
   elseif(COOLPROP_STATIC_LIBRARY)
     list(APPEND APP_SOURCES
          "${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_SOURCE}")
-    add_library(${LIB_NAME} STATIC ${APP_SOURCES} ${COOLPROP_LIBRARY_EXPORTS})
+    add_library(CoolProp STATIC ${APP_SOURCES} ${COOLPROP_LIBRARY_EXPORTS})
     if(MSVC)
       # Add postfix for debugging
-      set_property(TARGET ${LIB_NAME} PROPERTY DEBUG_POSTFIX d)
-      set_property(TARGET ${LIB_NAME} PROPERTY RELEASE_POSTFIX)
+      set_property(TARGET CoolProp PROPERTY DEBUG_POSTFIX d)
+      set_property(TARGET CoolProp PROPERTY RELEASE_POSTFIX)
       modify_msvc_flags("/MD")
 
       # Note that the default is not used if ${COOLPROP_MSVC_REL} or ${COOLPROP_MSVC_DBG} is set
     endif(MSVC)
     install(
-      TARGETS ${LIB_NAME}
+      TARGETS CoolProp
       DESTINATION
         static_library/${CMAKE_SYSTEM_NAME}/${BITNESS}bit_${CMAKE_CXX_COMPILER_ID}_${CMAKE_CXX_COMPILER_VERSION}
     )
@@ -546,31 +546,31 @@ if(COOLPROP_OBJECT_LIBRARY
   elseif(COOLPROP_SHARED_LIBRARY)
     list(APPEND APP_SOURCES
          "${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_SOURCE}")
-    add_library(${LIB_NAME} SHARED ${APP_SOURCES} ${COOLPROP_LIBRARY_EXPORTS})
+    add_library(CoolProp SHARED ${APP_SOURCES} ${COOLPROP_LIBRARY_EXPORTS})
     install(
-      TARGETS ${LIB_NAME}
+      TARGETS CoolProp
       DESTINATION shared_library/${CMAKE_SYSTEM_NAME}/${BITNESS}bit${CONVENTION}
     )
     install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_HEADER}
             DESTINATION shared_library)
     set_property(
-      TARGET ${LIB_NAME}
+      TARGET CoolProp
       APPEND_STRING
       PROPERTY COMPILE_FLAGS " -DCOOLPROP_LIB")
     # Now all the compiler specific settings for Visual Studio
     if(MSVC)
       # Add postfix for debugging
-      set_property(TARGET ${LIB_NAME} PROPERTY DEBUG_POSTFIX d)
-      set_property(TARGET ${LIB_NAME} PROPERTY RELEASE_POSTFIX)
+      set_property(TARGET CoolProp PROPERTY DEBUG_POSTFIX d)
+      set_property(TARGET CoolProp PROPERTY RELEASE_POSTFIX)
       # No lib prefix for the shared library
-      set_property(TARGET ${LIB_NAME} PROPERTY PREFIX "")
+      set_property(TARGET CoolProp PROPERTY PREFIX "")
       modify_msvc_flags("/MT")
 
       # Note that the default is not used if ${COOLPROP_MSVC_REL} or ${COOLPROP_MSVC_DBG} is set
       add_custom_command(
-        TARGET ${LIB_NAME}
+        TARGET CoolProp
         POST_BUILD
-        COMMAND dumpbin /EXPORTS $<TARGET_FILE:${LIB_NAME}> >
+        COMMAND dumpbin /EXPORTS $<TARGET_FILE:CoolProp> >
                 ${CMAKE_CURRENT_BINARY_DIR}/exports.txt)
       install(
         FILES ${CMAKE_CURRENT_BINARY_DIR}/exports.txt
@@ -579,23 +579,26 @@ if(COOLPROP_OBJECT_LIBRARY
     endif()
     # For Linux
     if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
-      set_property(TARGET ${LIB_NAME} PROPERTY VERSION ${COOLPROP_VERSION})
-      set_property(TARGET ${LIB_NAME} PROPERTY SOVERSION
+      set_property(TARGET CoolProp PROPERTY VERSION ${COOLPROP_VERSION})
+      set_property(TARGET CoolProp PROPERTY SOVERSION
                                                ${COOLPROP_VERSION_MAJOR})
     endif()
   else()
     message(FATAL_ERROR "You have to build a static or shared library.")
   endif()
 
+  # rename coolprop library to user-specified name
+  set_target_properties(CoolProp PROPERTIES OUTPUT_NAME ${LIB_NAME})
+
   if(NOT COOLPROP_OBJECT_LIBRARY)
-    target_link_libraries(${LIB_NAME} ${CMAKE_DL_LIBS})
+    target_link_libraries(CoolProp ${CMAKE_DL_LIBS})
   endif()
 
   # For windows systems, bug workaround for Eigen
   if(MSVC90)
     message(STATUS "EIGEN WORKAROUND ACTIVE!!")
     set_property(
-      TARGET ${LIB_NAME}
+      TARGET CoolProp
       APPEND_STRING
       PROPERTY COMPILE_FLAGS " -DEIGEN_DONT_VECTORIZE")
   endif()
@@ -604,12 +607,12 @@ if(COOLPROP_OBJECT_LIBRARY
   if("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
     if(DEFINED OSX_COMPILE_FLAGS)
       set_target_properties(
-        ${LIB_NAME} PROPERTIES APPEND_STRING PROPERTY COMPILE_FLAGS
+        CoolProp PROPERTIES APPEND_STRING PROPERTY COMPILE_FLAGS
                                                       "${OSX_COMPILE_FLAGS}")
     endif(DEFINED OSX_COMPILE_FLAGS)
     if(DEFINED OSX_COMPILE_FLAGS)
       set_target_properties(
-        ${LIB_NAME} PROPERTIES APPEND_STRING PROPERTY LINK_FLAGS
+        CoolProp PROPERTIES APPEND_STRING PROPERTY LINK_FLAGS
                                                       "${OSX_LINK_FLAGS}")
     endif(DEFINED OSX_COMPILE_FLAGS)
   endif()
@@ -617,16 +620,16 @@ if(COOLPROP_OBJECT_LIBRARY
   # Name mangling settings
   if(COOLPROP_EXTERNC_LIBRARY)
     set_property(
-      TARGET ${LIB_NAME}
+      TARGET CoolProp
       APPEND_STRING
       PROPERTY COMPILE_FLAGS " -DEXTERNC")
   endif()
   ### All options are set, we are building a library ###
-  add_dependencies(${LIB_NAME} generate_headers)
+  add_dependencies(CoolProp generate_headers)
   #
   if(CMAKE_VERSION VERSION_GREATER 3.0)
     # Add target include directories for easy linking with other applications
-    target_include_directories(${LIB_NAME} PUBLIC ${APP_INCLUDE_DIRS})
+    target_include_directories(CoolProp PUBLIC ${APP_INCLUDE_DIRS})
   endif()
 
   # Set the bitness
@@ -634,11 +637,11 @@ if(COOLPROP_OBJECT_LIBRARY
     if(NOT "${BITNESS}" STREQUAL "NATIVE")
       message(STATUS "Setting bitness flag -m${BITNESS}")
       set_property(
-        TARGET ${LIB_NAME}
+        TARGET CoolProp
         APPEND_STRING
         PROPERTY COMPILE_FLAGS " -m${BITNESS}")
       set_property(
-        TARGET ${LIB_NAME}
+        TARGET CoolProp
         APPEND_STRING
         PROPERTY LINK_FLAGS " -m${BITNESS}")
     endif()
@@ -648,7 +651,7 @@ if(COOLPROP_OBJECT_LIBRARY
   if(COOLPROP_FPIC)
     message(STATUS "Setting bitness flag -m${BITNESS}")
     set_property(
-      TARGET ${LIB_NAME}
+      TARGET CoolProp
       APPEND_STRING
       PROPERTY COMPILE_FLAGS " -fPIC")
   endif()
@@ -658,7 +661,7 @@ if(COOLPROP_OBJECT_LIBRARY
     #MESSAGE(STATUS "Skipping unknown calling convention.")
   else()
     set_property(
-      TARGET ${LIB_NAME}
+      TARGET CoolProp
       APPEND_STRING
       PROPERTY COMPILE_FLAGS " -DCONVENTION=${CONVENTION}")
   endif()
@@ -676,12 +679,12 @@ if(COOLPROP_OBJECT_LIBRARY
   #
   get_property(
     tmpVar
-    TARGET ${LIB_NAME}
+    TARGET CoolProp
     PROPERTY COMPILE_FLAGS)
   message(STATUS "COMPILE_FLAGS: ${tmpVar}")
   get_property(
     tmpVar
-    TARGET ${LIB_NAME}
+    TARGET CoolProp
     PROPERTY LINK_FLAGS)
   message(STATUS "LINK_FLAGS: ${tmpVar}")
   #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 2.8.11)
 
+project(CoolProp)
+set(CoolPropVersion "6.4.2dev")
+
 include(CheckIncludeFileCXX)
 
 if(DEFINED COOLPROP_INSTALL_PREFIX)
@@ -595,10 +598,24 @@ if(COOLPROP_OBJECT_LIBRARY
   if(NOT COOLPROP_OBJECT_LIBRARY)
     target_link_libraries(CoolPropLib PRIVATE ${CMAKE_DL_LIBS})
 
+    set(COOLPROP_CMAKE_DIR "lib/cmake/CoolProp")
+
     # install exports
     install (
         EXPORT CoolProp-targets
-        DESTINATION lib/cmake/CoolProp)
+        DESTINATION ${COOLPROP_CMAKE_DIR})
+
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file(
+      "${CMAKE_CURRENT_BINARY_DIR}/CoolProp-config-version.cmake"
+      VERSION ${CoolPropVersion}
+      COMPATIBILITY AnyNewerVersion
+    )
+
+    install (
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/CoolProp-config-version.cmake
+        # ${CMAKE_CURRENT_BINARY_DIR}/CoolProp-config.cmake
+        DESTINATION ${COOLPROP_CMAKE_DIR})
 
   endif()
 

--- a/dev/cmake/Modules/CoolProp-config.cmake.in
+++ b/dev/cmake/Modules/CoolProp-config.cmake.in
@@ -1,0 +1,19 @@
+# Config file for the CoolProp package
+#
+# This package exports the "CoolPropLib" target
+# which should be used to link against it
+#  
+# For backwards compatibility, it also defines the following variables
+#  CoolProp_INCLUDE_DIRS - include directory for CoolProp
+#  CoolProp_LIBRARIES    - libraries to link against
+
+# Load the cmake targets, if not already done
+if(NOT TARGET CoolPropLib)
+  include("${CMAKE_CURRENT_LIST_DIR}/CoolProp-targets.cmake")
+endif()
+
+ 
+# For backwards compatibility, we set these variables pointing 
+# to the coolprop library and include paths
+set(CoolProp_LIBRARIES CoolPropLib)
+get_target_property(CoolProp_INCLUDE_DIRS CoolPropLib INTERFACE_INCLUDE_DIRECTORIES)


### PR DESCRIPTION
### Description of the Change

This PR adds proper cmake config scripts to CoolProp. It installs cmake config files, which enables a user to use the CoolProp library as follows

```cmake
find_package(CoolProp REQUIRED)

add_executable(CoolPropTest main.cpp)
target_link_libraries(CoolPropTest PRIVATE CoolPropLib)
```

The user does not need to fiddle with include paths, library names or compiler switches. Everything is stored in the following config files, which are installed by the `install` target (excerpt from `make install`):
 - Installing: C:/src/3rdparty/CoolProp/install_root/lib/cmake/CoolProp/CoolProp-targets.cmake
 - Installing: C:/src/3rdparty/CoolProp/install_root/lib/cmake/CoolProp/CoolProp-targets-release.cmake
 - Installing: C:/src/3rdparty/CoolProp/install_root/lib/cmake/CoolProp/CoolProp-config-version.cmake
 - Installing: C:/src/3rdparty/CoolProp/install_root/lib/cmake/CoolProp/CoolProp-config.cmake

More information on the specific files and their use can be found here: https://cmake.org/cmake/help/latest/guide/importing-exporting/index.html


### Benefits

There are multiple benefits:
 - Proper find_package support for coolprop to be used from 3-rd party software
 - All specifics, like library name (specified during coolprop build), compile switches, include paths are handled by the config files: i.e. no compile time switches for the user required
 - Supports the typical cmake workflow

### Possible Drawbacks

The CoolProp libarary target is now fixed to `CoolPropLib`. From the users perspective, this is a good thing: the user simply needs to link against CoolPropLib, independent on the actually used library name.

The generated library file names can still be renamed in the CoolProp build by the user and are by default still "CoolProp". This is however an internal change that might interfere in the whole build process.

I tested building also the snippets, which worked fine though. I suggest building all interfaces (matlab, octave, java ...) to check, whether the renaming introduces any problems.

### Verification Process

I built coolprop both as a "shared" and "static" library and used a small test build to check the functionality.

I attached the check build cmake project here: 
[CoolPropTest.tar.gz](https://github.com/CoolProp/CoolProp/files/9232943/CoolPropTest.tar.gz)

I did not try to build all language interfaces though.

The check build project can be built like the following:

```bash
 cmake -G Ninja .. -DCMAKE_PREFIX_PATH=c:\src\3rdparty\CoolProp\install_root\
 cmake --build .
```


### Applicable Issues

Closes #2144
