### PR TITLE
Prevent crashes near critical density due to saturation calc

### DIFF
--- a/include/Solvers.h
+++ b/include/Solvers.h
@@ -73,6 +73,7 @@ class FuncWrapperND
 double Brent(FuncWrapper1D* f, double a, double b, double macheps, double t, int maxiter);
 double Secant(FuncWrapper1D* f, double x0, double dx, double ftol, int maxiter);
 double BoundedSecant(FuncWrapper1D* f, double x0, double xmin, double xmax, double dx, double ftol, int maxiter);
+double ExtrapolatingSecant(FuncWrapper1D* f, double x0, double dx, double ftol, int maxiter);
 double Newton(FuncWrapper1DWithDeriv* f, double x0, double ftol, int maxiter);
 double Halley(FuncWrapper1DWithTwoDerivs* f, double x0, double ftol, int maxiter, double xtol_rel = 1e-12);
 double Householder4(FuncWrapper1DWithThreeDerivs* f, double x0, double ftol, int maxiter, double xtol_rel = 1e-12);
@@ -84,7 +85,11 @@ inline double Brent(FuncWrapper1D& f, double a, double b, double macheps, double
 inline double Secant(FuncWrapper1D& f, double x0, double dx, double ftol, int maxiter) {
     return Secant(&f, x0, dx, ftol, maxiter);
 }
-inline double BoundedSecant(FuncWrapper1D& f, double x0, double xmin, double xmax, double dx, double ftol, int maxiter) {
+
+inline double ExtrapolatingSecant(FuncWrapper1D& f, double x0, double dx, double ftol, int maxiter){
+    return ExtrapolatingSecant(&f, x0, dx, ftol, maxiter);
+}
+inline double BoundedSecant(FuncWrapper1D& f, double x0, double xmin, double xmax, double dx, double ftol, int maxiter){
     return BoundedSecant(&f, x0, xmin, xmax, dx, ftol, maxiter);
 }
 inline double Newton(FuncWrapper1DWithDeriv& f, double x0, double ftol, int maxiter) {

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -1136,7 +1136,7 @@ void FlashRoutines::HSU_D_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
             SaturationSolvers::saturation_D_pure_options optionsD;
             optionsD.omega = 1;
             optionsD.use_logdelta = false;
-            int saturation_solver_iterations = 200;
+            optionsD.max_iterations = 200;
             for (int i_try = 0; i_try < 7; i_try++)
             {
                 try
@@ -1144,14 +1144,14 @@ void FlashRoutines::HSU_D_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
                     if (HEOS._rhomolar > HEOS._crit.rhomolar)
                     {
                         optionsD.imposed_rho = SaturationSolvers::saturation_D_pure_options::IMPOSED_RHOL;
-                        SaturationSolvers::saturation_D_pure(HEOS, HEOS._rhomolar, optionsD, saturation_solver_iterations);
+                        SaturationSolvers::saturation_D_pure(HEOS, HEOS._rhomolar, optionsD);
                         // SatL and SatV have the saturation values
                         Sat = HEOS.SatL;
                     }
                     else
                     {
                         optionsD.imposed_rho = SaturationSolvers::saturation_D_pure_options::IMPOSED_RHOV;
-                        SaturationSolvers::saturation_D_pure(HEOS, HEOS._rhomolar, optionsD, saturation_solver_iterations);
+                        SaturationSolvers::saturation_D_pure(HEOS, HEOS._rhomolar, optionsD);
                         // SatL and SatV have the saturation values
                         Sat = HEOS.SatV;
                     }
@@ -1160,7 +1160,7 @@ void FlashRoutines::HSU_D_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
                 catch(CoolPropBaseError)
                 {
                     optionsD.omega /= 2;
-                    saturation_solver_iterations *= 2;
+                    optionsD.max_iterations *= 2;
                     if (i_try >= 6){throw;}
                 }
             }

--- a/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
+++ b/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
@@ -98,7 +98,7 @@ double SaturationAncillaryFunction::invert(double value, double min_bound, doubl
         // because then you get (negative number)^(double) which is undefined.
         return Brent(resid, min_bound, max_bound, DBL_EPSILON, 1e-10, 100);
     } catch (...) {
-        return Secant(resid, max_bound, -0.01, 1e-12, 100);
+        return ExtrapolatingSecant(resid,max_bound, -0.01, 1e-12, 100);
     }
 }
 

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -555,7 +555,7 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend& HEOS, C
         }
     } while (error > 1e-9);
 }
-void SaturationSolvers::saturation_D_pure(HelmholtzEOSMixtureBackend &HEOS, CoolPropDbl rhomolar, saturation_D_pure_options &options, int max_iterations=200)
+void SaturationSolvers::saturation_D_pure(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl rhomolar, saturation_D_pure_options& options)
 {
     /*
     This function is inspired by the method of Akasaka:
@@ -695,8 +695,8 @@ void SaturationSolvers::saturation_D_pure(HelmholtzEOSMixtureBackend &HEOS, Cool
         if (T < 0) {
             throw SolutionError(format("saturation_D_pure solver T < 0"));
         }
-        if (iter > max_iterations){
-            throw SolutionError(format("saturation_D_pure solver did not converge after %d iterations with rho: %g mol/m^3",max_iterations,rhomolar));
+        if (iter > options.max_iterations){
+            throw SolutionError(format("saturation_D_pure solver did not converge after %d iterations with rho: %g mol/m^3",options.max_iterations,rhomolar));
         }
     } while (error > 1e-9);
     CoolPropDbl p_error_limit = 1e-3;

--- a/src/Backends/Helmholtz/VLERoutines.h
+++ b/src/Backends/Helmholtz/VLERoutines.h
@@ -31,7 +31,8 @@ struct saturation_D_pure_options
       use_logdelta;    ///< True to use partials with respect to log(delta) rather than delta
     CoolPropDbl omega, rhoL, rhoV, pL, pV;
     int imposed_rho;
-    saturation_D_pure_options() : use_guesses(false), rhoL(_HUGE), rhoV(_HUGE), pL(_HUGE), pV(_HUGE), imposed_rho(0) {
+    int max_iterations;
+    saturation_D_pure_options() : use_guesses(false), rhoL(_HUGE), rhoV(_HUGE), pL(_HUGE), pV(_HUGE), imposed_rho(0), max_iterations(200) {
         use_logdelta = true;
         omega = 1.0;
     }  // Defaults
@@ -66,7 +67,7 @@ static CoolPropDbl Wilson_lnK_factor(const HelmholtzEOSMixtureBackend& HEOS, Coo
     return log(pci / p) + 5.373 * (1 + omegai) * (1 - Tci / T);
 };
 
-void saturation_D_pure(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl rhomolar, saturation_D_pure_options& options, int max_iter);
+void saturation_D_pure(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl rhomolar, saturation_D_pure_options& options);
 void saturation_T_pure(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl T, saturation_T_pure_options& options);
 void saturation_T_pure_Akasaka(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl T, saturation_T_pure_Akasaka_options& options);
 void saturation_T_pure_Maxwell(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl T, saturation_T_pure_Akasaka_options& options);
@@ -95,9 +96,7 @@ struct saturation_PHSU_pure_options
         omega = 1.0;
     }
 };
-/**
 
-    */
 void saturation_PHSU_pure(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl specified_value, saturation_PHSU_pure_options& options);
 
 /* \brief This is a backup saturation_p solver for the case where the Newton solver cannot approach closely enough the solution

--- a/src/Backends/Helmholtz/VLERoutines.h
+++ b/src/Backends/Helmholtz/VLERoutines.h
@@ -66,13 +66,11 @@ static CoolPropDbl Wilson_lnK_factor(const HelmholtzEOSMixtureBackend& HEOS, Coo
     return log(pci / p) + 5.373 * (1 + omegai) * (1 - Tci / T);
 };
 
-void saturation_D_pure(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl rhomolar, saturation_D_pure_options& options);
+void saturation_D_pure(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl rhomolar, saturation_D_pure_options& options, int max_iter);
 void saturation_T_pure(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl T, saturation_T_pure_options& options);
 void saturation_T_pure_Akasaka(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl T, saturation_T_pure_Akasaka_options& options);
 void saturation_T_pure_Maxwell(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl T, saturation_T_pure_Akasaka_options& options);
 
-/**
-    */
 struct saturation_PHSU_pure_options
 {
     enum specified_variable_options


### PR DESCRIPTION
### Description of the Change

When updating an HEOS abstract state from density and energy, crashes (`ValueError` thrown) can occur when the density is very near the critical density. This PR fixes this behavior and prevents the exception.

`HSU_D_flash` is called when updating with D and U (as well as other combinations). As one of the first steps in the flash routine, the saturation points are determined at the given density (`saturation_D_pure`). However, when near the critical density, instabilities in the solver routines cause an exception. This PR utilizes a few strategies to prevent this:

- When inverting the ancillary curve, if the density is outside of the ancillary curve's domain, extrapolate in the secant solver. 
- When using the 2D Newton solver within `saturation_D_pure`, prevent the calculation of a negative temperature or density by dynamically changing omega (underrelaxation factor). I.e., check what the new values would be and if they were going to be negative, set the omega value to instead cause a bisection. 
- Wrap the calls to `saturation_D_pure` in a try block and repeat the solution with a smaller starting omega value (and more allowed iterations) a few times in an attempt to get even better stability. Cases that were already solving fine will require no further computation. 

The "hole" in the results is illustrated in the attached image (colormap of temperature).

### Benefits

Currently, CoolProp will fail for many fluids when updating from density/energy when the density is near the critical density. Updates from density/energy are a fairly common method in thermal hydraulic code development and crossing the isochor of the critical density is not uncommon. Prior to this PR, CoolProp would throw an exception, usually leading to a crash of the user's program. This allows the solver to continue without impacting calculations at other parts of the domain. 

### Possible Drawbacks

I foresee two potential drawbacks:

- Because of the underrelaxation factor, certain flash calculation could now take significantly (1000x or more) longer. However, this should only occur for cases which previous would have thrown an exception. In most cases, a slower solution is better than a faster failure. 
- Extrapolating the ancillary curves may cause poor guesses for further solution, but a poor guess is better than no guess. 

### Verification Process

I evaluated several thousand density/energy combinations near the critical point for both hydrogen and helium (see c++ code below). In almost all cases, rather than throwing an exception, a good value was created. A few points fail in the Brent solver. These failures are due to a two-phase state where the temperature is within 0.01 of the critical temperature because HSU_D_flash_twophase applies a 0.01 bracket limit to the temperature. I have not removed this for fear of causing bracketing issues in other parts of the code. 

Furthermore, when linked to another code, the code produces good, expected results - both near and removed from the critical point.  This indicates that there is likely no regression failure. 

### Applicable Issues
Closes #2154 

### Test code
```
/*
This program demonstrates how the topic-2154 PR fixes failures of HSU_D
(update from DU) when density is near the critical density for certain fluids.
*/
#pragma once
#include "CoolProp.h"
#include "AbstractState.h"

#include <iostream>
#include <memory>
#include <vector>

std::vector <double> linspace(double start, double stop, int num_pts){
    std::vector<double> vals (num_pts);
    for (int ii=0; ii < num_pts; ii++){
        vals.at(ii) = start + (stop - start) * double(ii) / double(num_pts-1);
    }
    return vals;
}

void test_range(std::shared_ptr<CoolProp::AbstractState> state)
{
    double density = state->rhomass_critical();
    double tcrit = state->T_critical();
    state->update(CoolProp::DmassT_INPUTS, density, tcrit);
    double energy = state->umass();
    state->update(CoolProp::DmassUmass_INPUTS, density, energy);
    std::vector<double> density_vals = linspace(density*0.75, density*1.5, 5000);
    std::vector<double> energy_vals = linspace(energy*0.5, energy*10., 200);
    for (double ee: energy_vals){
        for (double d : density_vals){
            try{
                state->update(CoolProp::DmassUmass_INPUTS, d, ee);
            }
            catch(CoolProp::ValueError e){
                std::cout << "BAD rho=" << d << " e=" << ee << " error=" << e.what() << std::endl;
            }
            catch(CoolProp::CoolPropBaseError e){
                std::cout << "BAD rho=" << d << " e=" << ee << " error=" << e.what() << std::endl;
            }
        }
    }
}

int main()
{
    std::cout << " === Test Helium ===" << std::endl;
    std::shared_ptr<CoolProp::AbstractState> helium = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Helium"));
    test_range(helium);

    std::cout << " === Test Hydrogen ===" << std::endl;
    std::shared_ptr<CoolProp::AbstractState> hydrogen = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Hydrogen"));
    test_range(hydrogen);

    std::cout << " == Test was successful if you saw no 'BAD' output" << "\n";
    std::cout << " == Brent failures are due to 2-phase temperature within 0.01K of critical (HSU_D_flash_twophase)" << std::endl;
    return EXIT_SUCCESS;
}
```
### Sample Plot
![bad_range](https://user-images.githubusercontent.com/95806012/195164941-2dd2a6f2-59af-40c3-8268-97c62a360dfd.png)
