### PR TITLE
add PCSAFT page in docs

### DIFF
--- a/CoolPropBibTeXLibrary.bib
+++ b/CoolPropBibTeXLibrary.bib
@@ -618,6 +618,19 @@
   Timestamp                = {2013.04.08}
 }
 
+@Article{Fuchs-IECR-2006,
+	Title = {{Solubility of Amino Acids:  Influence of the pH value and the Addition of Alcoholic Cosolvents on Aqueous Solubility}},
+	Volume = {45},
+	Url = {https://doi.org/10.1021/ie0602097},
+	Doi = {10.1021/ie0602097},
+	Number = {19},
+	Journal = {Industrial \& Engineering Chemistry Research},
+	Author = {Fuchs, Dominik and Fischer, Jan and Tumakaka, Feelly and Sadowski, Gabriele},
+	Month = {sep},
+	Year = {2006},
+	Pages = {6578--6584},
+}
+
 @Article{Gao-JCED-2016,
   Title                    = {{A Helmholtz Energy Equation of State for Sulfur Dioxide}},
   Author                   = {Kehui Gao and Jiangtao Wu and Penggang Zhang and Eric W. Lemmon},
@@ -707,6 +720,45 @@
   Publisher                = {Elsevier}
 }
 
+@Article{Ghosh-FPE-2003,
+	Title = {Gas solubility in hydrocarbons—a SAFT-based approach},
+	Volume = {209},
+	Url = {https://www.sciencedirect.com/science/article/pii/S037838120300147X},
+	Doi = {10.1016/S0378-3812(03)00147-X},
+	Number = {2},
+	Journal = {Fluid Phase Equilibria},
+	Author = {Ghosh, Auleen and Chapman, Walter G and French, Ray N},
+	Month = jul,
+	Year = {2003},
+	Pages = {229--243},
+}
+
+@Article{Gross-IECR-2001,
+	Title = {{Perturbed-Chain SAFT:  An Equation of State Based on a Perturbation Theory for Chain Molecules}},
+	Volume = {40},
+	Url = {https://doi.org/10.1021/ie0003887},
+	Doi = {10.1021/ie0003887},
+	Number = {4},
+	Journal = {Industrial \& Engineering Chemistry Research},
+	Author = {Gross, Joachim and Sadowski, Gabriele},
+	Month = {feb},
+	Year = {2001},
+	Pages = {1244--1260},
+}
+
+@Article{Gross-IECR-2002,
+	Title = {{Application of the Perturbed-Chain SAFT Equation of State to Associating Systems}},
+	Volume = {41},
+	Url = {https://doi.org/10.1021/ie010954d},
+	Doi = {10.1021/ie010954d},
+	Number = {22},
+	Journal = {Industrial \& Engineering Chemistry Research},
+	Author = {Gross, Joachim and Sadowski, Gabriele},
+	Month = {oct},
+	year = {2002},
+	pages = {5510--5515},
+}
+
 @Article{Guder-JPCRD-2009,
   Title                    = {{A Reference Equation of State for the Thermodynamic Properties of Sulfur Hexafluoride SF6 for Temperatures from the Melting Line to 625 K and Pressures up to 150 MPa}},
   Author                   = {C. Guder and W. Wagner},
@@ -758,6 +810,19 @@
   Doi                      = {10.1016/S0140-7007(97)00044-3},
   Owner                    = {Belli},
   Timestamp                = {2013.04.08}
+}
+
+@Article{Held-CERD-2014,
+	Title = {{ePC-SAFT revised}},
+	Volume = {92},
+	Url = {https://www.sciencedirect.com/science/article/pii/S0263876214002469},
+	Doi = {10.1016/j.cherd.2014.05.017},
+	Number = {12},
+	Journal = {Chemical Engineering Research and Design},
+	Author = {Held, Christoph and Reschke, Thomas and Mohammad, Sultan and Luza, Armando and Sadowski, Gabriele},
+	Month = {dec},
+	Year = {2014},
+	Pages = {2884--2897},
 }
 
 @Article{Herrig-JPCRD-2019,
@@ -1114,6 +1179,19 @@
   Doi                      = {10.1016/S0140-7007(96)00073-4},
   Owner                    = {Belli},
   Timestamp                = {2014.12.06}
+}
+
+@Article{Kleiner-JPCC-2007,
+	Title = {{Modeling of Polar Systems Using PCP-SAFT:  An Approach to Account for Induced-Association Interactions}},
+	Volume = {111},
+	Url = {https://doi.org/10.1021/jp072640v},
+	Doi = {10.1021/jp072640v},
+	Number = {43},
+	Journal = {The Journal of Physical Chemistry C},
+	Author = {Kleiner, Matthias and Sadowski, Gabriele},
+	Month = {nov},
+	Year = {2007},
+	Pages = {15544--15553},
 }
 
 @Article{Kondou-IJR-2015,

--- a/Web/coolprop/PCSAFT.rst
+++ b/Web/coolprop/PCSAFT.rst
@@ -1,0 +1,74 @@
+.. _pcsaft_backend:
+
+************************
+PC-SAFT Equations of State
+************************
+
+.. contents:: :depth: 2
+
+Introduction
+============
+
+CoolProp (as of version 6.4) includes the PC-SAFT equation of state. The PC-SAFT equation of state was originally proposed in 2001 by `Gross and Sadowski <>`. In addition to the hard chain and dispersion terms, the PC-SAFT backend in CoolProp also includes terms for associating, polar, and electrolyte compounds. For the polar term the formulation given by `Gross and Vrabec (2006) <>` was used, and this is sometimes called PCP-SAFT. For electrolyte compounds the equations presented by `Held et al. (2014) <>` were used, and this version of the equation of state is sometimes called electrolyte PC-SAFT (ePC-SAFT).
+
+Caveats
+-------
+
+.. warning:: NOT ALL PROPERTIES ARE AVAILABLE AS INPUTS/OUTPUTS
+
+Only a limited subset of properties are available currently. You can do:
+
+* Flash calculations with TP, PQ, DT, QT inputs
+* Calculation of some mixture flashes
+
+.. warning:: The flash algorithm for the PC-SAFT backend is not yet as robust as for other backends. For some conditions it may fail to find the correct solution.
+
+Pure Fluids
+===========
+
+Usage
+-----
+
+Similar to other backends in CoolProp, in the :ref:`high-level interface <high_level_api>`, all that you have to do to evaluate properties using the PC-SAFT equation of state is to change the backend name.
+
+.. ipython::
+
+    In [0]: import CoolProp.CoolProp as CP
+
+    # The multi-parameter Helmholtz backend
+    In [0]: CP.PropsSI("T","P",101325,"Q",0,"HEOS::Propane")
+
+    # PC-SAFT
+    In [0]: CP.PropsSI("T","P",101325,"Q",0,"PCSAFT::Propane")
+
+The same holds for the :ref:`low-level interface <low_level_api>`:
+
+.. ipython::
+
+    In [0]: import CoolProp.CoolProp as CP
+
+    In [0]: AS = CP.AbstractState("PCSAFT", "Propane"); AS.update(CP.QT_INPUTS, 0, 300); print(AS.p())
+
+The PC-SAFT equation of state is available for more than 100 fluids for which parameter were available in the literature.
+
+Mixtures
+========
+
+Interaction Parameters
+----------------------
+
+For mixtures, PC-SAFT generally uses a binary interaction parameter between pairs of fluids. CoolProp does have some of these parameters for the PC-SAFT EOS, and it is possible to add more yourself.
+
+.. ipython::
+
+    In [0]: import CoolProp.CoolProp as CP
+
+    In [0]: CAS_water = CP.get_fluid_param_string("WATER","CAS")
+
+    In [0]: CAS_aacid = "64-19-7"
+
+    In [0]: CP.set_mixture_binary_pair_pcsaft(CAS_water, CAS_aacid, "kij", -0.127)
+
+    In [0]: T = CP.PropsSI("T", "P", 72915.92217342, "Q", 0, "PCSAFT::WATER[0.2691800943]&ACETIC ACID[0.7308199057]")
+
+    In [0]: print(T)

--- a/Web/coolprop/index.rst
+++ b/Web/coolprop/index.rst
@@ -14,5 +14,6 @@ This section includes information about the CoolProp software, listings of input
     Configuration.rst
     REFPROP.rst
     Cubics.rst
+    PCSAFT.rst
     examples.rst
     changelog.rst

--- a/Web/index.rst
+++ b/Web/index.rst
@@ -20,6 +20,7 @@ CoolProp is a C++ library that implements:
 * :ref:`User-friendly interface around the full capabilities of NIST REFPROP <REFPROP>`
 * :ref:`Fast IAPWS-IF97 (Industrial Formulation) for Water/Steam <IF97>`
 * :ref:`Cubic equations of state (SRK, PR) <cubic_backend>`
+* :ref:`PC-SAFT equation of state <pcsaft_backend>`
 
 Environments Supported
 ----------------------
@@ -83,7 +84,7 @@ Please be so kind and cite our work in your publication: :ref:`Citation informat
 Supporters
 ----------
 
-\ 
+\
 
 .. image:: _static/logo_labothap.png
    :height: 100px
@@ -117,9 +118,9 @@ Supporters
    :height: 50px
    :alt: IPU Refrigeration and Energy Technology
    :target: https://www.ipu.dk
-   
+
 
 License Information
 -------------------
 
-CoolProp has flexible licensing terms and you can use it for commercial projects and academic work free of charge. Have a look at the actual `license <https://github.com/CoolProp/CoolProp/blob/master/LICENSE>`_, if you are in doubt. 
+CoolProp has flexible licensing terms and you can use it for commercial projects and academic work free of charge. Have a look at the actual `license <https://github.com/CoolProp/CoolProp/blob/master/LICENSE>`_, if you are in doubt.

--- a/dev/pcsaft/all_pcsaft_fluids.json
+++ b/dev/pcsaft/all_pcsaft_fluids.json
@@ -12,7 +12,7 @@
     "molemass": 0.016043,
     "molemass_units": "kg/mol",
     "name": "METHANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "74-84-0",
@@ -27,7 +27,7 @@
     "molemass": 0.03007,
     "molemass_units": "kg/mol",
     "name": "ETHANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "74-98-6",
@@ -42,7 +42,7 @@
     "molemass": 0.044096,
     "molemass_units": "kg/mol",
     "name": "PROPANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "106-97-8",
@@ -58,7 +58,7 @@
     "molemass": 0.055123,
     "molemass_units": "kg/mol",
     "name": "N-BUTANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "109-66-0",
@@ -74,7 +74,7 @@
     "molemass": 0.072146,
     "molemass_units": "kg/mol",
     "name": "N-PENTANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "110-54-3",
@@ -90,7 +90,7 @@
     "molemass": 0.086177,
     "molemass_units": "kg/mol",
     "name": "N-HEXANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "142-82-5",
@@ -106,7 +106,7 @@
     "molemass": 0.100203,
     "molemass_units": "kg/mol",
     "name": "N-HEPTANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "111-65-9",
@@ -122,7 +122,7 @@
     "molemass": 0.114231,
     "molemass_units": "kg/mol",
     "name": "N-OCTANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "111-84-2",
@@ -138,7 +138,7 @@
     "molemass": 0.12825,
     "molemass_units": "kg/mol",
     "name": "N-NONANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "124-18-5",
@@ -154,7 +154,7 @@
     "molemass": 0.142285,
     "molemass_units": "kg/mol",
     "name": "N-DECANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "1120-21-4",
@@ -170,7 +170,7 @@
     "molemass": 0.156312,
     "molemass_units": "kg/mol",
     "name": "N-UNDECANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "112-40-3",
@@ -186,7 +186,7 @@
     "molemass": 0.170338,
     "molemass_units": "kg/mol",
     "name": "N-DODECANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "629-50-5",
@@ -202,7 +202,7 @@
     "molemass": 0.184365,
     "molemass_units": "kg/mol",
     "name": "N-TRIDECANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "629-59-4",
@@ -218,7 +218,7 @@
     "molemass": 0.198392,
     "molemass_units": "kg/mol",
     "name": "N-TETRADECANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "629-62-9",
@@ -234,7 +234,7 @@
     "molemass": 0.212419,
     "molemass_units": "kg/mol",
     "name": "N-PENTADECANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "544-76-3",
@@ -250,7 +250,7 @@
     "molemass": 0.226446,
     "molemass_units": "kg/mol",
     "name": "N-HEXADECANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "629-78-7",
@@ -266,7 +266,7 @@
     "molemass": 0.240473,
     "molemass_units": "kg/mol",
     "name": "N-HEPTADECANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "593-45-3",
@@ -282,7 +282,7 @@
     "molemass": 0.2545,
     "molemass_units": "kg/mol",
     "name": "N-OCTADECANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "629-92-5",
@@ -298,7 +298,7 @@
     "molemass": 0.268527,
     "molemass_units": "kg/mol",
     "name": "N-NONADECANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "112-95-8",
@@ -314,7 +314,7 @@
     "molemass": 0.282553,
     "molemass_units": "kg/mol",
     "name": "N-EICOSANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "75-28-5",
@@ -330,7 +330,7 @@
     "molemass": 0.058123,
     "molemass_units": "kg/mol",
     "name": "ISOBUTANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "78-78-4",
@@ -346,7 +346,7 @@
     "molemass": 0.07215,
     "molemass_units": "kg/mol",
     "name": "ISOPENTANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "463-82-1",
@@ -362,7 +362,7 @@
     "molemass": 0.07215,
     "molemass_units": "kg/mol",
     "name": "NEOPENTANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "107-83-5",
@@ -378,7 +378,7 @@
     "molemass": 0.086177,
     "molemass_units": "kg/mol",
     "name": "2-METHYLPENTANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "75-83-2",
@@ -394,7 +394,7 @@
     "molemass": 0.086177,
     "molemass_units": "kg/mol",
     "name": "2,2-DIMETHYLBUTANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "79-29-8",
@@ -410,7 +410,7 @@
     "molemass": 0.086177,
     "molemass_units": "kg/mol",
     "name": "2,3-DIMETHYLBUTANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "96-14-0",
@@ -425,7 +425,7 @@
     "molemass": 0.086177,
     "molemass_units": "kg/mol",
     "name": "3-METHYLPENTANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "591-76-4",
@@ -440,7 +440,7 @@
     "molemass": 0.100204,
     "molemass_units": "kg/mol",
     "name": "2-METHYLHEXANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "287-92-3",
@@ -455,7 +455,7 @@
     "molemass": 0.07013,
     "molemass_units": "kg/mol",
     "name": "CYCLOPENTANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "110-82-7",
@@ -470,7 +470,7 @@
     "molemass": 0.084147,
     "molemass_units": "kg/mol",
     "name": "CYCLOHEXANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "96-37-7",
@@ -485,7 +485,7 @@
     "molemass": 0.084156,
     "molemass_units": "kg/mol",
     "name": "METHYLCYCLOPENTANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "108-87-2",
@@ -500,7 +500,7 @@
     "molemass": 0.098182,
     "molemass_units": "kg/mol",
     "name": "METHYLCYCLOHEXANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "1640-89-7",
@@ -515,7 +515,7 @@
     "molemass": 0.098182,
     "molemass_units": "kg/mol",
     "name": "ETHYLCYCLOPENTANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "1678-91-7",
@@ -530,7 +530,7 @@
     "molemass": 0.112215,
     "molemass_units": "kg/mol",
     "name": "ETHYLCYCLOHEXANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "74-85-1",
@@ -546,7 +546,7 @@
     "molemass": 0.02805,
     "molemass_units": "kg/mol",
     "name": "ETHYLENE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "115-07-1",
@@ -562,7 +562,7 @@
     "molemass": 0.042081,
     "molemass_units": "kg/mol",
     "name": "PROPYLENE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "106-98-9",
@@ -579,7 +579,7 @@
     "molemass": 0.05610631999999999,
     "molemass_units": "kg/mol",
     "name": "1-BUTENE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "109-67-1",
@@ -594,7 +594,7 @@
     "molemass": 0.070134,
     "molemass_units": "kg/mol",
     "name": "1-PENTENE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "592-41-6",
@@ -609,7 +609,7 @@
     "molemass": 0.084616,
     "molemass_units": "kg/mol",
     "name": "1-HEXENE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "592-76-7",
@@ -624,7 +624,7 @@
     "molemass": 0.0981861,
     "molemass_units": "kg/mol",
     "name": "1-HEPTENE",
-    "BibTeX": "Ghosh-2003"
+    "BibTeX": "Ghosh-FPE-2003"
   },
   {
     "CAS": "111-66-0",
@@ -639,7 +639,7 @@
     "molemass": 0.112215,
     "molemass_units": "kg/mol",
     "name": "1-OCTENE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "124-11-8",
@@ -654,7 +654,7 @@
     "molemass": 0.126243,
     "molemass_units": "kg/mol",
     "name": "1-NONENE",
-    "BibTeX": "Ghosh-2003"
+    "BibTeX": "Ghosh-FPE-2003"
   },
   {
     "CAS": "872-05-9",
@@ -669,7 +669,7 @@
     "molemass": 0.140266,
     "molemass_units": "kg/mol",
     "name": "1-DECENE",
-    "BibTeX": "Ghosh-2003"
+    "BibTeX": "Ghosh-FPE-2003"
   },
   {
     "CAS": "112-41-4",
@@ -684,7 +684,7 @@
     "molemass": 0.168319,
     "molemass_units": "kg/mol",
     "name": "1-DODECENE",
-    "BibTeX": "Ghosh-2003"
+    "BibTeX": "Ghosh-FPE-2003"
   },
   {
     "CAS": "1120-36-1",
@@ -699,7 +699,7 @@
     "molemass": 0.196378,
     "molemass_units": "kg/mol",
     "name": "1-TETRADECENE",
-    "BibTeX": "Ghosh-2003"
+    "BibTeX": "Ghosh-FPE-2003"
   },
   {
     "CAS": "629-73-2",
@@ -714,7 +714,7 @@
     "molemass": 0.224432,
     "molemass_units": "kg/mol",
     "name": "1-HEXADECENE",
-    "BibTeX": "Ghosh-2003"
+    "BibTeX": "Ghosh-FPE-2003"
   },
   {
     "CAS": "142-29-0",
@@ -729,7 +729,7 @@
     "molemass": 0.068114,
     "molemass_units": "kg/mol",
     "name": "CYCLOPENTENE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "71-43-2",
@@ -744,7 +744,7 @@
     "molemass": 0.078114,
     "molemass_units": "kg/mol",
     "name": "BENZENE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "108-88-3",
@@ -760,7 +760,7 @@
     "molemass": 0.092141,
     "molemass_units": "kg/mol",
     "name": "TOLUENE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "100-41-4",
@@ -775,7 +775,7 @@
     "molemass": 0.106167,
     "molemass_units": "kg/mol",
     "name": "ETHYLBENZENE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "108-38-3",
@@ -791,7 +791,7 @@
     "molemass": 0.106167,
     "molemass_units": "kg/mol",
     "name": "M-XYLENE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "95-47-6",
@@ -807,7 +807,7 @@
     "molemass": 0.106167,
     "molemass_units": "kg/mol",
     "name": "O-XYLENE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "106-42-3",
@@ -823,7 +823,7 @@
     "molemass": 0.106167,
     "molemass_units": "kg/mol",
     "name": "P-XYLENE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "103-65-1",
@@ -838,7 +838,7 @@
     "molemass": 0.120194,
     "molemass_units": "kg/mol",
     "name": "N-PROPYLBENZENE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "119-64-2",
@@ -854,7 +854,7 @@
     "molemass": 0.132205,
     "molemass_units": "kg/mol",
     "name": "TETRALIN",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "104-51-8",
@@ -869,7 +869,7 @@
     "molemass": 0.134221,
     "molemass_units": "kg/mol",
     "name": "N-BUTYLBENZENE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "92-52-4",
@@ -884,7 +884,7 @@
     "molemass": 0.154211,
     "molemass_units": "kg/mol",
     "name": "BIPHENYL",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "630-08-0",
@@ -899,7 +899,7 @@
     "molemass": 0.02801,
     "molemass_units": "kg/mol",
     "name": "CARBON MONOXIDE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "7727-37-9",
@@ -914,7 +914,7 @@
     "molemass": 0.02801,
     "molemass_units": "kg/mol",
     "name": "NITROGEN",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "7440-37-1",
@@ -929,7 +929,7 @@
     "molemass": 0.039948,
     "molemass_units": "kg/mol",
     "name": "ARGON",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "124-38-9",
@@ -944,7 +944,7 @@
     "molemass": 0.04401,
     "molemass_units": "kg/mol",
     "name": "CARBON DIOXIDE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "7446-09-5",
@@ -959,7 +959,7 @@
     "molemass": 0.064065,
     "molemass_units": "kg/mol",
     "name": "SULFUR DIOXIDE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "1333-74-0",
@@ -974,7 +974,7 @@
     "molemass": 0.00201588,
     "molemass_units": "kg/mol",
     "name": "HYDROGEN",
-    "BibTeX": "Ghosh-2003"
+    "BibTeX": "Ghosh-FPE-2003"
   },
   {
     "CAS": "7782-50-5",
@@ -989,7 +989,7 @@
     "molemass": 0.070905,
     "molemass_units": "kg/mol",
     "name": "CHLORINE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "75-15-0",
@@ -1004,7 +1004,7 @@
     "molemass": 0.076143,
     "molemass_units": "kg/mol",
     "name": "CARBON DISULFIDE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "75-00-3",
@@ -1019,7 +1019,7 @@
     "molemass": 0.064514,
     "molemass_units": "kg/mol",
     "name": "CHLOROETHANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "75-29-6",
@@ -1034,7 +1034,7 @@
     "molemass": 0.078541,
     "molemass_units": "kg/mol",
     "name": "2-CHLOROPROPANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "109-69-3",
@@ -1049,7 +1049,7 @@
     "molemass": 0.092568,
     "molemass_units": "kg/mol",
     "name": "1-CHLOROBUTANE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "108-90-7",
@@ -1064,7 +1064,7 @@
     "molemass": 0.112558,
     "molemass_units": "kg/mol",
     "name": "CHLOROBENZENE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "108-86-1",
@@ -1079,7 +1079,7 @@
     "molemass": 0.15701,
     "molemass_units": "kg/mol",
     "name": "BROMOBENZENE",
-    "BibTeX": "Gross-2001"
+    "BibTeX": "Gross-IECR-2001"
   },
   {
     "CAS": "67-56-1",
@@ -1101,7 +1101,7 @@
     "molemass": 0.032042,
     "molemass_units": "kg/mol",
     "name": "METHANOL",
-    "BibTeX": "Gross-2002"
+    "BibTeX": "Gross-IECR-2002"
   },
   {
     "CAS": "64-17-5",
@@ -1123,7 +1123,7 @@
     "molemass": 0.046069,
     "molemass_units": "kg/mol",
     "name": "ETHANOL",
-    "BibTeX": "Gross-2002"
+    "BibTeX": "Gross-IECR-2002"
   },
   {
     "CAS": "71-23-8",
@@ -1145,7 +1145,7 @@
     "molemass": 0.060096,
     "molemass_units": "kg/mol",
     "name": "1-PROPANOL",
-    "BibTeX": "Gross-2002"
+    "BibTeX": "Gross-IECR-2002"
   },
   {
     "CAS": "71-36-3",
@@ -1167,7 +1167,7 @@
     "molemass": 0.074123,
     "molemass_units": "kg/mol",
     "name": "1-BUTANOL",
-    "BibTeX": "Gross-2002"
+    "BibTeX": "Gross-IECR-2002"
   },
   {
     "CAS": "71-41-0",
@@ -1189,7 +1189,7 @@
     "molemass": 0.08815,
     "molemass_units": "kg/mol",
     "name": "1-PENTANOL",
-    "BibTeX": "Gross-2002"
+    "BibTeX": "Gross-IECR-2002"
   },
   {
     "CAS": "111-27-3",
@@ -1211,7 +1211,7 @@
     "molemass": 0.102177,
     "molemass_units": "kg/mol",
     "name": "1-HEXANOL",
-    "BibTeX": "Gross-2002"
+    "BibTeX": "Gross-IECR-2002"
   },
   {
     "CAS": "111-70-6",
@@ -1233,7 +1233,7 @@
     "molemass": 0.116203,
     "molemass_units": "kg/mol",
     "name": "1-HEPTANOL",
-    "BibTeX": "Gross-2002"
+    "BibTeX": "Gross-IECR-2002"
   },
   {
     "CAS": "111-87-5",
@@ -1255,7 +1255,7 @@
     "molemass": 0.13023,
     "molemass_units": "kg/mol",
     "name": "1-OCTANOL",
-    "BibTeX": "Gross-2002"
+    "BibTeX": "Gross-IECR-2002"
   },
   {
     "CAS": "143-08-8",
@@ -1277,7 +1277,7 @@
     "molemass": 0.144257,
     "molemass_units": "kg/mol",
     "name": "1-NONANOL",
-    "BibTeX": "Gross-2002"
+    "BibTeX": "Gross-IECR-2002"
   },
   {
     "CAS": "67-63-0",
@@ -1300,7 +1300,7 @@
     "molemass": 0.060096,
     "molemass_units": "kg/mol",
     "name": "2-PROPANOL",
-    "BibTeX": "Gross-2002"
+    "BibTeX": "Gross-IECR-2002"
   },
   {
     "CAS": "75-85-4",
@@ -1322,7 +1322,7 @@
     "molemass": 0.08815,
     "molemass_units": "kg/mol",
     "name": "2-METHYL-2-BUTANOL",
-    "BibTeX": "Gross-2002"
+    "BibTeX": "Gross-IECR-2002"
   },
   {
     "CAS": "74-89-5",
@@ -1344,7 +1344,7 @@
     "molemass": 0.03106,
     "molemass_units": "kg/mol",
     "name": "METHYLAMINE",
-    "BibTeX": "Gross-2002"
+    "BibTeX": "Gross-IECR-2002"
   },
   {
     "CAS": "75-04-7",
@@ -1366,7 +1366,7 @@
     "molemass": 0.04509,
     "molemass_units": "kg/mol",
     "name": "ETHYLAMINE",
-    "BibTeX": "Gross-2002"
+    "BibTeX": "Gross-IECR-2002"
   },
   {
     "CAS": "107-10-8",
@@ -1388,7 +1388,7 @@
     "molemass": 0.05911,
     "molemass_units": "kg/mol",
     "name": "1-PROPYLAMINE",
-    "BibTeX": "Gross-2002"
+    "BibTeX": "Gross-IECR-2002"
   },
   {
     "CAS": "75-31-0",
@@ -1410,7 +1410,7 @@
     "molemass": 0.05911,
     "molemass_units": "kg/mol",
     "name": "2-PROPYLAMINE",
-    "BibTeX": "Gross-2002"
+    "BibTeX": "Gross-IECR-2002"
   },
   {
     "CAS": "62-53-3",
@@ -1432,7 +1432,7 @@
     "molemass": 0.09313,
     "molemass_units": "kg/mol",
     "name": "ANILINE",
-    "BibTeX": "Gross-2002"
+    "BibTeX": "Gross-IECR-2002"
   },
   {
     "CAS": "7732-18-5",
@@ -1456,7 +1456,7 @@
     "molemass": 0.01801528,
     "molemass_units": "kg/mol",
     "name": "WATER",
-    "BibTeX": "Fuchs-2006"
+    "BibTeX": "Fuchs-IECR-2006"
   },
   {
     "CAS": "13968-08-6",
@@ -1473,7 +1473,7 @@
     "molemass": 0.0190232,
     "molemass_units": "kg/mol",
     "name": "H3O+",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "17341-24-1",
@@ -1489,7 +1489,7 @@
     "molemass": 0.006941,
     "molemass_units": "kg/mol",
     "name": "Li+",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "17341-25-2",
@@ -1505,7 +1505,7 @@
     "molemass": 0.02299,
     "molemass_units": "kg/mol",
     "name": "Na+",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "24203-36-9",
@@ -1521,7 +1521,7 @@
     "molemass": 0.039098,
     "molemass_units": "kg/mol",
     "name": "K+",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "18459-37-5",
@@ -1537,7 +1537,7 @@
     "molemass": 0.132905,
     "molemass_units": "kg/mol",
     "name": "Cs+",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "14798-03-9",
@@ -1554,7 +1554,7 @@
     "molemass": 0.018039,
     "molemass_units": "kg/mol",
     "name": "NH4+",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "16984-48-8",
@@ -1571,7 +1571,7 @@
     "molemass": 0.018998,
     "molemass_units": "kg/mol",
     "name": "F-",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "16887-00-6",
@@ -1588,7 +1588,7 @@
     "molemass": 0.03545,
     "molemass_units": "kg/mol",
     "name": "Cl-",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "24959-67-9",
@@ -1605,7 +1605,7 @@
     "molemass": 0.079904,
     "molemass_units": "kg/mol",
     "name": "Br-",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "20461-54-5",
@@ -1621,7 +1621,7 @@
     "molemass": 0.126904,
     "molemass_units": "kg/mol",
     "name": "I-",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "14797-55-8",
@@ -1637,7 +1637,7 @@
     "molemass": 0.062004,
     "molemass_units": "kg/mol",
     "name": "NO3-",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "14280-30-9",
@@ -1653,7 +1653,7 @@
     "molemass": 0.017007,
     "molemass_units": "kg/mol",
     "name": "OH-",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "14797-73-0",
@@ -1669,7 +1669,7 @@
     "molemass": 0.099446,
     "molemass_units": "kg/mol",
     "name": "ClO4-",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "71-52-3",
@@ -1685,7 +1685,7 @@
     "molemass": 0.061016,
     "molemass_units": "kg/mol",
     "name": "HCO3-",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "14066-20-7",
@@ -1701,7 +1701,7 @@
     "molemass": 0.096986,
     "molemass_units": "kg/mol",
     "name": "H2PO4-",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "71-47-6",
@@ -1718,7 +1718,7 @@
     "molemass": 0.045017,
     "molemass_units": "kg/mol",
     "name": "CHO2-",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "71-50-1",
@@ -1735,7 +1735,7 @@
     "molemass": 0.059044,
     "molemass_units": "kg/mol",
     "name": "C2H3O2-",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "22537-22-0",
@@ -1751,7 +1751,7 @@
     "molemass": 0.024305,
     "molemass_units": "kg/mol",
     "name": "Mg2+",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "14127-61-8",
@@ -1767,7 +1767,7 @@
     "molemass": 0.040078,
     "molemass_units": "kg/mol",
     "name": "Ca2+",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "15158-11-9",
@@ -1783,7 +1783,7 @@
     "molemass": 0.063546,
     "molemass_units": "kg/mol",
     "name": "Cu2+",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "23713-49-7",
@@ -1799,7 +1799,7 @@
     "molemass": 0.06538,
     "molemass_units": "kg/mol",
     "name": "Zn2+",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "14808-79-8",
@@ -1815,7 +1815,7 @@
     "molemass": 0.096056,
     "molemass_units": "kg/mol",
     "name": "SO42-",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "14383-50-7",
@@ -1831,7 +1831,7 @@
     "molemass": 0.112117,
     "molemass_units": "kg/mol",
     "name": "S2O32-",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "3812-32-6",
@@ -1847,7 +1847,7 @@
     "molemass": 0.060008,
     "molemass_units": "kg/mol",
     "name": "CO32-",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "14066-19-4",
@@ -1863,7 +1863,7 @@
     "molemass": 0.095978,
     "molemass_units": "kg/mol",
     "name": "HPO42-",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "14265-44-2",
@@ -1879,7 +1879,7 @@
     "molemass": 0.09497,
     "molemass_units": "kg/mol",
     "name": "PO43-",
-    "BibTeX": "Held-2014"
+    "BibTeX": "Held-CERD-2014"
   },
   {
     "CAS": "115-10-6",
@@ -1897,7 +1897,7 @@
     "molemass": 0.046069000000000006,
     "molemass_units": "kg/mol",
     "name": "DIMETHYL ETHER",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "60-29-7",
@@ -1915,7 +1915,7 @@
     "molemass": 0.07412300000000001,
     "molemass_units": "kg/mol",
     "name": "DIETHYL ETHER",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "111-43-3",
@@ -1933,7 +1933,7 @@
     "molemass": 0.102177,
     "molemass_units": "kg/mol",
     "name": "DI-N-PROPYL ETHER",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "142-96-1",
@@ -1951,7 +1951,7 @@
     "molemass": 0.13022999999999998,
     "molemass_units": "kg/mol",
     "name": "DI-N-BUTYL ETHER",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "693-65-2",
@@ -1969,7 +1969,7 @@
     "molemass": 0.15828,
     "molemass_units": "kg/mol",
     "name": "DI-N-PENTYL ETHER",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "540-67-0",
@@ -1987,7 +1987,7 @@
     "molemass": 0.0601,
     "molemass_units": "kg/mol",
     "name": "METHYL ETHYL ETHER",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "557-17-5",
@@ -2005,7 +2005,7 @@
     "molemass": 0.07412300000000001,
     "molemass_units": "kg/mol",
     "name": "METHYL N-PROPYL ETHER",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "628-28-4",
@@ -2023,7 +2023,7 @@
     "molemass": 0.08815,
     "molemass_units": "kg/mol",
     "name": "METHYL N-BUTYL ETHER",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "628-80-8",
@@ -2041,7 +2041,7 @@
     "molemass": 0.102177,
     "molemass_units": "kg/mol",
     "name": "METHYL N-PENTYL ETHER",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "628-32-0",
@@ -2059,7 +2059,7 @@
     "molemass": 0.08815,
     "molemass_units": "kg/mol",
     "name": "ETHYL N-PROPYL ETHER",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "108-20-3",
@@ -2077,7 +2077,7 @@
     "molemass": 0.102176,
     "molemass_units": "kg/mol",
     "name": "DIISOPROPYL ETHER",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "109-87-5",
@@ -2095,7 +2095,7 @@
     "molemass": 0.076095,
     "molemass_units": "kg/mol",
     "name": "DIMETHOXYMETHANE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "110-71-4",
@@ -2113,7 +2113,7 @@
     "molemass": 0.090122,
     "molemass_units": "kg/mol",
     "name": "1,2-DIMETHOXYETHANE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "629-14-1",
@@ -2131,7 +2131,7 @@
     "molemass": 0.118176,
     "molemass_units": "kg/mol",
     "name": "1,2-DIETHOXYETHANE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "75-56-9",
@@ -2149,7 +2149,7 @@
     "molemass": 0.05808,
     "molemass_units": "kg/mol",
     "name": "1,2-PROPYLENE OXIDE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "503-30-0",
@@ -2167,7 +2167,7 @@
     "molemass": 0.05808,
     "molemass_units": "kg/mol",
     "name": "1,3-PROPYLENE OXIDE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "106-88-7",
@@ -2185,7 +2185,7 @@
     "molemass": 0.072107,
     "molemass_units": "kg/mol",
     "name": "1,2-BUTENE OXIDE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "109-99-9",
@@ -2203,7 +2203,7 @@
     "molemass": 0.072107,
     "molemass_units": "kg/mol",
     "name": "TETRAHYDROFURAN",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "107-31-3",
@@ -2221,7 +2221,7 @@
     "molemass": 0.060052,
     "molemass_units": "kg/mol",
     "name": "METHYL FORMATE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "109-94-4",
@@ -2239,7 +2239,7 @@
     "molemass": 0.07407899999999999,
     "molemass_units": "kg/mol",
     "name": "ETHYL FORMATE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "110-74-7",
@@ -2257,7 +2257,7 @@
     "molemass": 0.08810599999999999,
     "molemass_units": "kg/mol",
     "name": "PROPYL FORMATE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "592-84-7",
@@ -2275,7 +2275,7 @@
     "molemass": 0.102133,
     "molemass_units": "kg/mol",
     "name": "BUTYL FORMATE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "79-20-9",
@@ -2293,7 +2293,7 @@
     "molemass": 0.07407899999999999,
     "molemass_units": "kg/mol",
     "name": "METHYL ACETATE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "141-78-6",
@@ -2311,7 +2311,7 @@
     "molemass": 0.08810599999999999,
     "molemass_units": "kg/mol",
     "name": "ETHYL ACETATE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "109-60-4",
@@ -2329,7 +2329,7 @@
     "molemass": 0.102133,
     "molemass_units": "kg/mol",
     "name": "PROPYL ACETATE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "554-12-01",
@@ -2347,7 +2347,7 @@
     "molemass": 0.08810599999999999,
     "molemass_units": "kg/mol",
     "name": "METHYL PROPANOATE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "105-37-3",
@@ -2365,7 +2365,7 @@
     "molemass": 0.102133,
     "molemass_units": "kg/mol",
     "name": "ETHYL PROPANOATE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "106-36-5",
@@ -2383,7 +2383,7 @@
     "molemass": 0.11616,
     "molemass_units": "kg/mol",
     "name": "PROPYL PROPANOATE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "623-42-7",
@@ -2401,7 +2401,7 @@
     "molemass": 0.102133,
     "molemass_units": "kg/mol",
     "name": "METHYL BUTANOATE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "96-33-3",
@@ -2419,7 +2419,7 @@
     "molemass": 0.08609,
     "molemass_units": "kg/mol",
     "name": "METHYL ACRYLATE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "140-88-5",
@@ -2437,7 +2437,7 @@
     "molemass": 0.100117,
     "molemass_units": "kg/mol",
     "name": "ETHYL ACRYLATE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "25281-48-5",
@@ -2455,7 +2455,7 @@
     "molemass": 0.100117,
     "molemass_units": "kg/mol",
     "name": "MMA",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "97-63-2",
@@ -2473,7 +2473,7 @@
     "molemass": 0.11414400000000001,
     "molemass_units": "kg/mol",
     "name": "ETHYL METHACRYLATE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "50-00-0",
@@ -2491,7 +2491,7 @@
     "molemass": 0.030026,
     "molemass_units": "kg/mol",
     "name": "FORMALDEHYDE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "123-38-6",
@@ -2509,7 +2509,7 @@
     "molemass": 0.05808,
     "molemass_units": "kg/mol",
     "name": "PROPANAL",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "123-72-8",
@@ -2527,7 +2527,7 @@
     "molemass": 0.0721066,
     "molemass_units": "kg/mol",
     "name": "BUTANAL",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "98-01-01",
@@ -2545,7 +2545,7 @@
     "molemass": 0.096086,
     "molemass_units": "kg/mol",
     "name": "FURFURAL",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "67-64-1",
@@ -2563,7 +2563,7 @@
     "molemass": 0.05808,
     "molemass_units": "kg/mol",
     "name": "ACETONE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "78-93-3",
@@ -2581,7 +2581,7 @@
     "molemass": 0.072107,
     "molemass_units": "kg/mol",
     "name": "2-BUTANONE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "107-87-9",
@@ -2599,7 +2599,7 @@
     "molemass": 0.086134,
     "molemass_units": "kg/mol",
     "name": "2-PENTANONE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "96-22-0",
@@ -2617,7 +2617,7 @@
     "molemass": 0.086134,
     "molemass_units": "kg/mol",
     "name": "3-PENTANONE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "591-78-6",
@@ -2635,7 +2635,7 @@
     "molemass": 0.10016,
     "molemass_units": "kg/mol",
     "name": "2-HEXANONE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "589-38-8",
@@ -2653,7 +2653,7 @@
     "molemass": 0.10016,
     "molemass_units": "kg/mol",
     "name": "3-HEXANONE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "110-43-0",
@@ -2671,7 +2671,7 @@
     "molemass": 0.11419,
     "molemass_units": "kg/mol",
     "name": "2-HEPTANONE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "123-19-3",
@@ -2689,7 +2689,7 @@
     "molemass": 0.11419,
     "molemass_units": "kg/mol",
     "name": "4-HEPTANONE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "111-13-7",
@@ -2707,7 +2707,7 @@
     "molemass": 0.12888,
     "molemass_units": "kg/mol",
     "name": "2-OCTANONE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "106-68-3",
@@ -2725,7 +2725,7 @@
     "molemass": 0.12888,
     "molemass_units": "kg/mol",
     "name": "3-OCTANONE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "821-55-6",
@@ -2743,7 +2743,7 @@
     "molemass": 0.14224,
     "molemass_units": "kg/mol",
     "name": "2-NONANONE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "502-56-7",
@@ -2761,7 +2761,7 @@
     "molemass": 0.14224,
     "molemass_units": "kg/mol",
     "name": "5-NONANONE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "112-12-9",
@@ -2779,7 +2779,7 @@
     "molemass": 0.1703,
     "molemass_units": "kg/mol",
     "name": "2-UNDECANONE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "927-49-1",
@@ -2797,7 +2797,7 @@
     "molemass": 0.1703,
     "molemass_units": "kg/mol",
     "name": "6-UNDECANONE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "593-08-8",
@@ -2815,7 +2815,7 @@
     "molemass": 0.19835,
     "molemass_units": "kg/mol",
     "name": "2-TRIDECANONE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "68-12-2",
@@ -2833,7 +2833,7 @@
     "molemass": 0.07309,
     "molemass_units": "kg/mol",
     "name": "DIMETHYLFORMAMIDE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "67-68-5",
@@ -2851,7 +2851,7 @@
     "molemass": 0.07812999999999999,
     "molemass_units": "kg/mol",
     "name": "DIMETHYL SULFOXIDE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "75-05-8",
@@ -2869,7 +2869,7 @@
     "molemass": 0.041052,
     "molemass_units": "kg/mol",
     "name": "ACETONITRILE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "107-13-1",
@@ -2887,7 +2887,7 @@
     "molemass": 0.053,
     "molemass_units": "kg/mol",
     "name": "ACRYLONITRILE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "107-12-0",
@@ -2905,7 +2905,7 @@
     "molemass": 0.055079,
     "molemass_units": "kg/mol",
     "name": "PROPIONITRILE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "109-74-0",
@@ -2923,7 +2923,7 @@
     "molemass": 0.06911,
     "molemass_units": "kg/mol",
     "name": "BUTYRONITRILE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "75-52-5",
@@ -2941,7 +2941,7 @@
     "molemass": 0.06104,
     "molemass_units": "kg/mol",
     "name": "NITROMETHANE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "79-24-3",
@@ -2959,7 +2959,7 @@
     "molemass": 0.075067,
     "molemass_units": "kg/mol",
     "name": "NITROETHANE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "74-87-3",
@@ -2977,7 +2977,7 @@
     "molemass": 0.050488,
     "molemass_units": "kg/mol",
     "name": "CHLOROMETHANE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "75-09-2",
@@ -2995,7 +2995,7 @@
     "molemass": 0.08493200000000001,
     "molemass_units": "kg/mol",
     "name": "DICHLOROMETHANE",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "67-66-3",
@@ -3013,7 +3013,7 @@
     "molemass": 0.119377,
     "molemass_units": "kg/mol",
     "name": "CHLOROFORM",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "75-45-6",
@@ -3031,7 +3031,7 @@
     "molemass": 0.086468,
     "molemass_units": "kg/mol",
     "name": "R22",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "811-97-2",
@@ -3049,7 +3049,7 @@
     "molemass": 0.10203,
     "molemass_units": "kg/mol",
     "name": "R134A",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "354-33-6",
@@ -3067,7 +3067,7 @@
     "molemass": 0.12002,
     "molemass_units": "kg/mol",
     "name": "R125",
-    "BibTeX": "Kleiner-2007"
+    "BibTeX": "Kleiner-JPCC-2007"
   },
   {
     "CAS": "64-19-7",
@@ -3090,6 +3090,6 @@
     "molemass": 0.060052,
     "molemass_units": "kg/mol",
     "name": "ACETIC ACID",
-    "BibTeX": "Gross-2002"
+    "BibTeX": "Gross-IECR-2002"
   }
 ]

--- a/dev/pcsaft/mixture_binary_pairs_pcsaft.json
+++ b/dev/pcsaft/mixture_binary_pairs_pcsaft.json
@@ -1,6 +1,6 @@
 [
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "74-82-8",
     "CAS2": "106-97-8",
     "Name1": "METHANE",
@@ -8,7 +8,7 @@
     "kij": 0.022
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "74-82-8",
     "CAS2": "110-54-3",
     "Name1": "METHANE",
@@ -16,7 +16,7 @@
     "kij": 0.021
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "74-82-8",
     "CAS2": "142-82-5",
     "Name1": "METHANE",
@@ -24,7 +24,7 @@
     "kij": 0.016
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "74-82-8",
     "CAS2": "124-18-5",
     "Name1": "METHANE",
@@ -32,7 +32,7 @@
     "kij": 0.056
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "74-82-8",
     "CAS2": "75-28-5",
     "Name1": "METHANE",
@@ -40,7 +40,7 @@
     "kij": 0.028
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "74-82-8",
     "CAS2": "110-82-7",
     "Name1": "METHANE",
@@ -48,7 +48,7 @@
     "kij": 0.045
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "74-82-8",
     "CAS2": "71-43-2",
     "Name1": "METHANE",
@@ -56,7 +56,7 @@
     "kij": 0.037
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "74-82-8",
     "CAS2": "108-88-3",
     "Name1": "METHANE",
@@ -64,7 +64,7 @@
     "kij": 0.052
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "74-82-8",
     "CAS2": "119-64-2",
     "Name1": "METHANE",
@@ -72,7 +72,7 @@
     "kij": 0.075
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "74-82-8",
     "CAS2": "108-38-3",
     "Name1": "METHANE",
@@ -80,7 +80,7 @@
     "kij": 0.045
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "7727-37-9",
     "CAS2": "74-85-1",
     "Name1": "NITROGEN",
@@ -88,7 +88,7 @@
     "kij": 0.075
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "7727-37-9",
     "CAS2": "110-54-3",
     "Name1": "NITROGEN",
@@ -96,7 +96,7 @@
     "kij": 0.119
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "74-85-1",
     "CAS2": "142-82-5",
     "Name1": "ETHYLENE",
@@ -104,7 +104,7 @@
     "kij": 0.018
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "74-85-1",
     "CAS2": "115-07-1",
     "Name1": "ETHYLENE",
@@ -112,7 +112,7 @@
     "kij": -0.001
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "74-98-6",
     "CAS2": "106-97-8",
     "Name1": "PROPANE",
@@ -120,7 +120,7 @@
     "kij": 0.003
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "115-07-1",
     "CAS2": "75-28-5",
     "Name1": "PROPYLENE",
@@ -128,7 +128,7 @@
     "kij": -0.006
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "109-66-0",
     "CAS2": "142-82-5",
     "Name1": "N-PENTANE",
@@ -136,7 +136,7 @@
     "kij": 0.011
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "124-38-9",
     "CAS2": "74-82-8",
     "Name1": "CARBON DIOXIDE",
@@ -144,7 +144,7 @@
     "kij": 0.065
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "124-38-9",
     "CAS2": "74-98-6",
     "Name1": "CARBON DIOXIDE",
@@ -152,7 +152,7 @@
     "kij": 0.109
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "124-38-9",
     "CAS2": "106-97-8",
     "Name1": "CARBON DIOXIDE",
@@ -160,7 +160,7 @@
     "kij": 0.120
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "124-38-9",
     "CAS2": "109-66-0",
     "Name1": "CARBON DIOXIDE",
@@ -168,7 +168,7 @@
     "kij": 0.143
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "124-38-9",
     "CAS2": "142-82-5",
     "Name1": "CARBON DIOXIDE",
@@ -176,7 +176,7 @@
     "kij": 0.129
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "124-38-9",
     "CAS2": "108-87-2",
     "Name1": "CARBON DIOXIDE",
@@ -184,7 +184,7 @@
     "kij": 0.144
   },
   {
-    "BibTeX": "Ghosh-2003",
+    "BibTeX": "Ghosh-FPE-2003",
     "CAS1": "74-82-8",
     "CAS2": "112-40-3",
     "Name1": "METHANE",
@@ -192,7 +192,7 @@
     "kij": 0.025
   },
   {
-    "BibTeX": "Ghosh-2003",
+    "BibTeX": "Ghosh-FPE-2003",
     "CAS1": "74-84-0",
     "CAS2": "112-40-3",
     "Name1": "ETHANE",
@@ -200,7 +200,7 @@
     "kij": 0.020
   },
   {
-    "BibTeX": "Ghosh-2003",
+    "BibTeX": "Ghosh-FPE-2003",
     "CAS1": "74-84-0",
     "CAS2": "111-65-9",
     "Name1": "ETHANE",
@@ -208,7 +208,7 @@
     "kij": 0.020
   },
   {
-    "BibTeX": "Ghosh-2003",
+    "BibTeX": "Ghosh-FPE-2003",
     "CAS1": "630-08-0",
     "CAS2": "111-65-9",
     "Name1": "CARBON MONOXIDE",
@@ -216,7 +216,7 @@
     "kij": 0.125
   },
   {
-    "BibTeX": "Ghosh-2003",
+    "BibTeX": "Ghosh-FPE-2003",
     "CAS1": "630-08-0",
     "CAS2": "112-40-3",
     "Name1": "CARBON MONOXIDE",
@@ -224,7 +224,7 @@
     "kij": 0.125
   },
   {
-    "BibTeX": "Ghosh-2003",
+    "BibTeX": "Ghosh-FPE-2003",
     "CAS1": "1333-74-0",
     "CAS2": "544-76-3",
     "Name1": "HYDROGEN",
@@ -232,7 +232,7 @@
     "kij": 0.0
   },
   {
-    "BibTeX": "Ghosh-2003",
+    "BibTeX": "Ghosh-FPE-2003",
     "CAS1": "1333-74-0",
     "CAS2": "592-76-7",
     "Name1": "HYDROGEN",
@@ -240,7 +240,7 @@
     "kij": 0.0
   },
   {
-    "BibTeX": "Ghosh-2003",
+    "BibTeX": "Ghosh-FPE-2003",
     "CAS1": "1333-74-0",
     "CAS2": "111-66-0",
     "Name1": "HYDROGEN",
@@ -248,7 +248,7 @@
     "kij": 0.0
   },
   {
-    "BibTeX": "Gross-2002",
+    "BibTeX": "Gross-IECR-2002",
     "CAS1": "67-56-1",
     "CAS2": "110-82-7",
     "Name1": "METHANOL",
@@ -256,7 +256,7 @@
     "kij": 0.051
   },
   {
-    "BibTeX": "Gross-2002",
+    "BibTeX": "Gross-IECR-2002",
     "CAS1": "67-56-1",
     "CAS2": "111-87-5",
     "Name1": "METHANOL",
@@ -264,7 +264,7 @@
     "kij": 0.020
   },
   {
-    "BibTeX": "Gross-2002",
+    "BibTeX": "Gross-IECR-2002",
     "CAS1": "64-17-5",
     "CAS2": "106-97-8",
     "Name1": "ETHANOL",
@@ -272,7 +272,7 @@
     "kij": 0.028
   },
   {
-    "BibTeX": "Gross-2002",
+    "BibTeX": "Gross-IECR-2002",
     "CAS1": "71-23-8",
     "CAS2": "71-43-2",
     "Name1": "1-PROPANOL",
@@ -280,7 +280,7 @@
     "kij": 0.020
   },
   {
-    "BibTeX": "Gross-2002",
+    "BibTeX": "Gross-IECR-2002",
     "CAS1": "71-23-8",
     "CAS2": "100-41-4",
     "Name1": "1-PROPANOL",
@@ -288,7 +288,7 @@
     "kij": 0.023
   },
   {
-    "BibTeX": "Gross-2002",
+    "BibTeX": "Gross-IECR-2002",
     "CAS1": "67-63-0",
     "CAS2": "71-43-2",
     "Name1": "2-PROPANOL",
@@ -296,7 +296,7 @@
     "kij": 0.021
   },
   {
-    "BibTeX": "Gross-2002",
+    "BibTeX": "Gross-IECR-2002",
     "CAS1": "71-36-3",
     "CAS2": "106-97-8",
     "Name1": "1-BUTANOL",
@@ -304,7 +304,7 @@
     "kij": 0.015
   },
   {
-    "BibTeX": "Gross-2002",
+    "BibTeX": "Gross-IECR-2002",
     "CAS1": "71-41-0",
     "CAS2": "71-43-2",
     "Name1": "1-PENTANOL",
@@ -312,7 +312,7 @@
     "kij": 0.0135
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "14265-44-2",
     "Name1": "WATER",
@@ -320,7 +320,7 @@
     "kij": -0.25
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "14066-19-4",
     "Name1": "WATER",
@@ -328,7 +328,7 @@
     "kij": 0.25
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "3812-32-6",
     "Name1": "WATER",
@@ -336,7 +336,7 @@
     "kij": -0.25
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "14383-50-7",
     "Name1": "WATER",
@@ -344,7 +344,7 @@
     "kij": 0.25
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "14808-79-8",
     "Name1": "WATER",
@@ -352,7 +352,7 @@
     "kij": 0.25
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "23713-49-7",
     "Name1": "WATER",
@@ -360,7 +360,7 @@
     "kij": -0.25
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "15158-11-9",
     "Name1": "WATER",
@@ -368,7 +368,7 @@
     "kij": 0.25
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "14127-61-8",
     "Name1": "WATER",
@@ -376,7 +376,7 @@
     "kij": 0.0041
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "22537-22-0",
     "Name1": "WATER",
@@ -384,7 +384,7 @@
     "kij": -0.25
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "71-50-1",
     "Name1": "WATER",
@@ -392,7 +392,7 @@
     "kij": -0.23
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "71-47-6",
     "Name1": "WATER",
@@ -400,7 +400,7 @@
     "kij": -0.23
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "14066-20-7",
     "Name1": "WATER",
@@ -408,7 +408,7 @@
     "kij": 0.25
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "71-52-3",
     "Name1": "WATER",
@@ -416,7 +416,7 @@
     "kij": 0.00
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "14797-73-0",
     "Name1": "WATER",
@@ -424,7 +424,7 @@
     "kij": -0.25
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "14280-30-9",
     "Name1": "WATER",
@@ -432,7 +432,7 @@
     "kij": -0.25
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "14797-55-8",
     "Name1": "WATER",
@@ -440,7 +440,7 @@
     "kij": 0.098
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "20461-54-5",
     "Name1": "WATER",
@@ -448,7 +448,7 @@
     "kij": -0.25
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "24959-67-9",
     "Name1": "WATER",
@@ -456,7 +456,7 @@
     "kij": -0.25
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "16887-00-6",
     "Name1": "WATER",
@@ -464,7 +464,7 @@
     "kij": -0.25
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "16984-48-8",
     "Name1": "WATER",
@@ -472,7 +472,7 @@
     "kij": -0.25
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "14798-03-9",
     "Name1": "WATER",
@@ -480,7 +480,7 @@
     "kij": 0.064
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "18459-37-5",
     "Name1": "WATER",
@@ -488,7 +488,7 @@
     "kij": 0.081
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "24203-36-9",
     "Name1": "WATER",
@@ -497,7 +497,7 @@
     "kijT": -0.004012
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "17341-25-2",
     "Name1": "WATER",
@@ -506,7 +506,7 @@
     "kijT": -0.007981
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "17341-24-1",
     "Name1": "WATER",
@@ -514,7 +514,7 @@
     "kij": -0.25
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "7732-18-5",
     "CAS2": "13968-08-6",
     "Name1": "WATER",
@@ -522,7 +522,7 @@
     "kij": 0.25
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "13968-08-6",
     "CAS2": "16887-00-6",
     "Name1": "H3O+",
@@ -530,7 +530,7 @@
     "kij": 0.654
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "13968-08-6",
     "CAS2": "24959-67-9",
     "Name1": "H3O+",
@@ -538,7 +538,7 @@
     "kij": 0.645
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "13968-08-6",
     "CAS2": "20461-54-5",
     "Name1": "H3O+",
@@ -546,7 +546,7 @@
     "kij": 0.497
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "13968-08-6",
     "CAS2": "14797-73-0",
     "Name1": "H3O+",
@@ -554,7 +554,7 @@
     "kij": 0.861
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-24-1",
     "CAS2": "16887-00-6",
     "Name1": "Li+",
@@ -562,7 +562,7 @@
     "kij": 0.669
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-24-1",
     "CAS2": "24959-67-9",
     "Name1": "Li+",
@@ -570,7 +570,7 @@
     "kij": 0.591
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-24-1",
     "CAS2": "20461-54-5",
     "Name1": "Li+",
@@ -578,7 +578,7 @@
     "kij": 0.002
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-24-1",
     "CAS2": "14797-73-0",
     "Name1": "Li+",
@@ -586,7 +586,7 @@
     "kij": 0.406
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-24-1",
     "CAS2": "14797-55-8",
     "Name1": "Li+",
@@ -594,7 +594,7 @@
     "kij": 0.364
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-24-1",
     "CAS2": "71-50-1",
     "Name1": "Li+",
@@ -602,7 +602,7 @@
     "kij": -0.998
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-24-1",
     "CAS2": "14280-30-9",
     "Name1": "Li+",
@@ -610,7 +610,7 @@
     "kij": -0.566
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-24-1",
     "CAS2": "14808-79-8",
     "Name1": "Li+",
@@ -618,7 +618,7 @@
     "kij": -0.952
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-25-2",
     "CAS2": "16984-48-8",
     "Name1": "Na+",
@@ -626,7 +626,7 @@
     "kij": 0.665
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-25-2",
     "CAS2": "16887-00-6",
     "Name1": "Na+",
@@ -634,7 +634,7 @@
     "kij": 0.317
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-25-2",
     "CAS2": "24959-67-9",
     "Name1": "Na+",
@@ -642,7 +642,7 @@
     "kij": 0.290
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-25-2",
     "CAS2": "20461-54-5",
     "Name1": "Na+",
@@ -650,7 +650,7 @@
     "kij": 0.018
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-25-2",
     "CAS2": "14797-73-0",
     "Name1": "Na+",
@@ -658,7 +658,7 @@
     "kij": -0.118
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-25-2",
     "CAS2": "14797-55-8",
     "Name1": "Na+",
@@ -666,7 +666,7 @@
     "kij": -0.300
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-25-2",
     "CAS2": "14066-20-7",
     "Name1": "Na+",
@@ -674,7 +674,7 @@
     "kij": -0.071
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-25-2",
     "CAS2": "14066-19-4",
     "Name1": "Na+",
@@ -682,7 +682,7 @@
     "kij": -1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-25-2",
     "CAS2": "14265-44-2",
     "Name1": "Na+",
@@ -690,7 +690,7 @@
     "kij": -1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-25-2",
     "CAS2": "71-50-1",
     "Name1": "Na+",
@@ -698,7 +698,7 @@
     "kij": 0.246
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-25-2",
     "CAS2": "71-47-6",
     "Name1": "Na+",
@@ -706,7 +706,7 @@
     "kij": -0.370
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-25-2",
     "CAS2": "14280-30-9",
     "Name1": "Na+",
@@ -714,7 +714,7 @@
     "kij": 0.649
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-25-2",
     "CAS2": "14808-79-8",
     "Name1": "Na+",
@@ -722,7 +722,7 @@
     "kij": -1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-25-2",
     "CAS2": "3812-32-6",
     "Name1": "Na+",
@@ -730,7 +730,7 @@
     "kij": -1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-25-2",
     "CAS2": "71-52-3",
     "Name1": "Na+",
@@ -738,7 +738,7 @@
     "kij": -0.514
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "17341-25-2",
     "CAS2": "14383-50-7",
     "Name1": "Na+",
@@ -746,7 +746,7 @@
     "kij": 0.184
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "24203-36-9",
     "CAS2": "16984-48-8",
     "Name1": "K+",
@@ -754,7 +754,7 @@
     "kij": 1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "24203-36-9",
     "CAS2": "16887-00-6",
     "Name1": "K+",
@@ -762,7 +762,7 @@
     "kij": 0.064
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "24203-36-9",
     "CAS2": "24959-67-9",
     "Name1": "K+",
@@ -770,7 +770,7 @@
     "kij": -0.102
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "24203-36-9",
     "CAS2": "20461-54-5",
     "Name1": "K+",
@@ -778,7 +778,7 @@
     "kij": -0.312
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "24203-36-9",
     "CAS2": "14797-55-8",
     "Name1": "K+",
@@ -786,7 +786,7 @@
     "kij": -0.585
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "24203-36-9",
     "CAS2": "14066-20-7",
     "Name1": "K+",
@@ -794,7 +794,7 @@
     "kij": 0.018
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "24203-36-9",
     "CAS2": "14066-19-4",
     "Name1": "K+",
@@ -802,7 +802,7 @@
     "kij": 1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "24203-36-9",
     "CAS2": "14265-44-2",
     "Name1": "K+",
@@ -810,7 +810,7 @@
     "kij": 1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "24203-36-9",
     "CAS2": "71-50-1",
     "Name1": "K+",
@@ -818,7 +818,7 @@
     "kij": 1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "24203-36-9",
     "CAS2": "71-47-6",
     "Name1": "K+",
@@ -826,7 +826,7 @@
     "kij": 0.340
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "24203-36-9",
     "CAS2": "14280-30-9",
     "Name1": "K+",
@@ -834,7 +834,7 @@
     "kij": 1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "24203-36-9",
     "CAS2": "14808-79-8",
     "Name1": "K+",
@@ -842,7 +842,7 @@
     "kij": 1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "24203-36-9",
     "CAS2": "3812-32-6",
     "Name1": "K+",
@@ -850,7 +850,7 @@
     "kij": 1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "24203-36-9",
     "CAS2": "71-52-3",
     "Name1": "K+",
@@ -858,7 +858,7 @@
     "kij": -0.476
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "18459-37-5",
     "CAS2": "16984-48-8",
     "Name1": "Cs+",
@@ -866,7 +866,7 @@
     "kij": 1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "18459-37-5",
     "CAS2": "16887-00-6",
     "Name1": "Cs+",
@@ -874,7 +874,7 @@
     "kij": -0.417
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "18459-37-5",
     "CAS2": "24959-67-9",
     "Name1": "Cs+",
@@ -882,7 +882,7 @@
     "kij": -0.670
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "18459-37-5",
     "CAS2": "20461-54-5",
     "Name1": "Cs+",
@@ -890,7 +890,7 @@
     "kij": -1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "18459-37-5",
     "CAS2": "14797-55-8",
     "Name1": "Cs+",
@@ -898,7 +898,7 @@
     "kij": -0.855
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "18459-37-5",
     "CAS2": "71-50-1",
     "Name1": "Cs+",
@@ -906,7 +906,7 @@
     "kij": 0.785
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "18459-37-5",
     "CAS2": "14280-30-9",
     "Name1": "Cs+",
@@ -914,7 +914,7 @@
     "kij": 0.564
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "18459-37-5",
     "CAS2": "14808-79-8",
     "Name1": "Cs+",
@@ -922,7 +922,7 @@
     "kij": -1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "14798-03-9",
     "CAS2": "16887-00-6",
     "Name1": "NH4+",
@@ -930,7 +930,7 @@
     "kij": -0.566
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "14798-03-9",
     "CAS2": "24959-67-9",
     "Name1": "NH4++",
@@ -938,7 +938,7 @@
     "kij": -0.639
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "14798-03-9",
     "CAS2": "20461-54-5",
     "Name1": "NH4+",
@@ -946,7 +946,7 @@
     "kij": -0.787
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "14798-03-9",
     "CAS2": "14797-73-0",
     "Name1": "NH4+",
@@ -954,7 +954,7 @@
     "kij": -1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "14798-03-9",
     "CAS2": "14797-55-8",
     "Name1": "NH4+",
@@ -962,7 +962,7 @@
     "kij": -0.419
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "14798-03-9",
     "CAS2": "14066-20-7",
     "Name1": "NH4+",
@@ -970,7 +970,7 @@
     "kij": -1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "14798-03-9",
     "CAS2": "14066-19-4",
     "Name1": "NH4+",
@@ -978,7 +978,7 @@
     "kij": -0.556
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "14798-03-9",
     "CAS2": "14808-79-8",
     "Name1": "NH4+",
@@ -986,7 +986,7 @@
     "kij": -1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "22537-22-0",
     "CAS2": "16887-00-6",
     "Name1": "Mg2+",
@@ -994,7 +994,7 @@
     "kij": 0.817
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "22537-22-0",
     "CAS2": "24959-67-9",
     "Name1": "Mg2++",
@@ -1002,7 +1002,7 @@
     "kij": 0.752
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "22537-22-0",
     "CAS2": "20461-54-5",
     "Name1": "Mg2+",
@@ -1010,7 +1010,7 @@
     "kij": 0.317
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "22537-22-0",
     "CAS2": "14797-73-0",
     "Name1": "Mg2+",
@@ -1018,7 +1018,7 @@
     "kij": 0.122
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "22537-22-0",
     "CAS2": "14797-55-8",
     "Name1": "Mg2+",
@@ -1026,7 +1026,7 @@
     "kij": 0.285
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "22537-22-0",
     "CAS2": "14808-79-8",
     "Name1": "Mg2+",
@@ -1034,7 +1034,7 @@
     "kij": -1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "14127-61-8",
     "CAS2": "16887-00-6",
     "Name1": "Ca2+",
@@ -1042,7 +1042,7 @@
     "kij": 1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "14127-61-8",
     "CAS2": "24959-67-9",
     "Name1": "Ca2+",
@@ -1050,7 +1050,7 @@
     "kij": 0.993
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "14127-61-8",
     "CAS2": "20461-54-5",
     "Name1": "Ca2+",
@@ -1058,7 +1058,7 @@
     "kij": 0.229
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "14127-61-8",
     "CAS2": "14797-73-0",
     "Name1": "Ca2+",
@@ -1066,7 +1066,7 @@
     "kij": 0.674
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "14127-61-8",
     "CAS2": "14797-55-8",
     "Name1": "Ca2+",
@@ -1074,7 +1074,7 @@
     "kij": -0.101
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "14127-61-8",
     "CAS2": "14808-79-8",
     "Name1": "Ca2+",
@@ -1082,7 +1082,7 @@
     "kij": -0.908
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "15158-11-9",
     "CAS2": "16887-00-6",
     "Name1": "Cu2+",
@@ -1090,7 +1090,7 @@
     "kij": -0.216
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "15158-11-9",
     "CAS2": "14808-79-8",
     "Name1": "Cu2+",
@@ -1098,7 +1098,7 @@
     "kij": -1.000
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "23713-49-7",
     "CAS2": "16887-00-6",
     "Name1": "Zn2+",
@@ -1106,7 +1106,7 @@
     "kij": -0.705
   },
   {
-    "BibTeX": "Held-2014",
+    "BibTeX": "Held-CERD-2014",
     "CAS1": "23713-49-7",
     "CAS2": "14808-79-8",
     "Name1": "Zn2+",
@@ -1114,7 +1114,7 @@
     "kij": -0.446
   },
   {
-    "BibTeX": "Gross-2001",
+    "BibTeX": "Gross-IECR-2001",
     "CAS1": "74-82-8",
     "CAS2": "109-66-0",
     "Name1": "METHANE",


### PR DESCRIPTION
### Description of the Change

I added a page in the docs for the PC-SAFT equation of state. I also added the references for the PC-SAFT fluid parameters to the BibTeX file.
