### PR TITLE
Robust hsu D flash method

### DIFF
--- a/include/Ancillaries.h
+++ b/include/Ancillaries.h
@@ -9,6 +9,15 @@
 
 namespace CoolProp {
 
+struct SaturationAncillaryFunction_invert_options
+{
+    double min_bound = -1;
+    double max_bound = -1;
+    int max_iter = 200;
+    double omega = 1.;
+    bool best_guess = false;
+};
+
 /**
 The surface tension correlation class uses correlations for the surface tension that are all
 of the form
@@ -137,7 +146,7 @@ class SaturationAncillaryFunction
     /// @param min_bound (optional) The minimum value for T; ignored if < 0
     /// @param max_bound (optional) The maximum value for T; ignored if < 0
     /// @returns T The temperature in K
-    double invert(double value, double min_bound = -1, double max_bound = -1);
+    double invert(double value, SaturationAncillaryFunction_invert_options options = SaturationAncillaryFunction_invert_options()) ;
 
     /// Get the minimum temperature in K
     double get_Tmin(void) {

--- a/include/Solvers.h
+++ b/include/Solvers.h
@@ -73,7 +73,7 @@ class FuncWrapperND
 double Brent(FuncWrapper1D* f, double a, double b, double macheps, double t, int maxiter);
 double Secant(FuncWrapper1D* f, double x0, double dx, double ftol, int maxiter);
 double BoundedSecant(FuncWrapper1D* f, double x0, double xmin, double xmax, double dx, double ftol, int maxiter);
-double ExtrapolatingSecant(FuncWrapper1D* f, double x0, double dx, double ftol, int maxiter);
+double ExtrapolatingSecant(FuncWrapper1D* f, double x0, double dx, double ftol, int maxiter, bool best_guess);
 double Newton(FuncWrapper1DWithDeriv* f, double x0, double ftol, int maxiter);
 double Halley(FuncWrapper1DWithTwoDerivs* f, double x0, double ftol, int maxiter, double xtol_rel = 1e-12);
 double Householder4(FuncWrapper1DWithThreeDerivs* f, double x0, double ftol, int maxiter, double xtol_rel = 1e-12);
@@ -86,8 +86,8 @@ inline double Secant(FuncWrapper1D& f, double x0, double dx, double ftol, int ma
     return Secant(&f, x0, dx, ftol, maxiter);
 }
 
-inline double ExtrapolatingSecant(FuncWrapper1D& f, double x0, double dx, double ftol, int maxiter){
-    return ExtrapolatingSecant(&f, x0, dx, ftol, maxiter);
+inline double ExtrapolatingSecant(FuncWrapper1D& f, double x0, double dx, double ftol, int maxiter, bool best_guess){
+    return ExtrapolatingSecant(&f, x0, dx, ftol, maxiter, best_guess);
 }
 inline double BoundedSecant(FuncWrapper1D& f, double x0, double xmin, double xmax, double dx, double ftol, int maxiter){
     return BoundedSecant(&f, x0, xmin, xmax, dx, ftol, maxiter);

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -1161,6 +1161,7 @@ void FlashRoutines::HSU_D_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
                 {
                     optionsD.omega /= 2;
                     optionsD.max_iterations *= 2;
+                    if (i_try == 5){optionsD.best_guess = true;}
                     if (i_try >= 6){throw;}
                 }
             }

--- a/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
+++ b/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
@@ -102,7 +102,10 @@ double SaturationAncillaryFunction::invert(double value,
         // because then you get (negative number)^(double) which is undefined.
         return Brent(resid, min_bound, max_bound, DBL_EPSILON, 1e-10, options.max_iter);
     } catch (...) {
-        return ExtrapolatingSecant(resid,max_bound, -0.01, 1e-12, options.max_iter, options.best_guess);
+        double T = ExtrapolatingSecant(resid,max_bound, -0.01, 1e-12, options.max_iter, options.best_guess);
+        T = std::max(min_bound, T);
+        T = std::min(max_bound, T);
+        return T;
     }
 }
 

--- a/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
+++ b/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
@@ -103,8 +103,6 @@ double SaturationAncillaryFunction::invert(double value,
         return Brent(resid, min_bound, max_bound, DBL_EPSILON, 1e-10, options.max_iter);
     } catch (...) {
         double T = ExtrapolatingSecant(resid,max_bound, -0.01, 1e-12, options.max_iter, options.best_guess);
-        T = std::max(min_bound, T);
-        T = std::min(max_bound, T);
         return T;
     }
 }

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -246,11 +246,15 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend& HEOS, C
                 // Ancillary is deltas = s - hs_anchor.s
                 // First try a conventional call
                 try {
-                    SaturationAncillaryFunction_invert_options options = {Tmin, Tmax};
+                    SaturationAncillaryFunction_invert_options options;
+                    options.min_bound = Tmin;
+                    options.max_bound = Tmax;
                     T = anc.invert(specified_value - hs_anchor.smolar, options);
                 } catch (...) {
                     try {
-                        SaturationAncillaryFunction_invert_options options = {Tmin - 3, Tmax + 3};
+                        SaturationAncillaryFunction_invert_options options;
+                        options.min_bound = Tmin - 3;
+                        options.max_bound = Tmax + 3;
                         T = anc.invert(specified_value - hs_anchor.smolar, options);
                     } catch (...) {
                         double vmin = anc.evaluate(Tmin);
@@ -584,7 +588,10 @@ void SaturationSolvers::saturation_D_pure(HelmholtzEOSMixtureBackend& HEOS, Cool
         if (options.imposed_rho == saturation_D_pure_options::IMPOSED_RHOL) {
             // Invert liquid density ancillary to get temperature
             // TODO: fit inverse ancillaries too
-            SaturationAncillaryFunction_invert_options inv_options = {-1, -1, options.max_iterations, options.omega, options.best_guess};
+            SaturationAncillaryFunction_invert_options inv_options;
+            inv_options.max_iter = options.max_iterations;
+            inv_options.omega = options.omega;
+            inv_options.best_guess = options.best_guess;
             T = HEOS.get_components()[0].ancillaries.rhoL.invert(rhomolar, inv_options);
             if (inv_options.min_bound < 0) {
                 inv_options.min_bound = HEOS.get_components()[0].ancillaries.rhoL.get_Tmin() - 0.01;

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -586,6 +586,15 @@ void SaturationSolvers::saturation_D_pure(HelmholtzEOSMixtureBackend& HEOS, Cool
             // TODO: fit inverse ancillaries too
             SaturationAncillaryFunction_invert_options inv_options = {-1, -1, options.max_iterations, options.omega, options.best_guess};
             T = HEOS.get_components()[0].ancillaries.rhoL.invert(rhomolar, inv_options);
+            if (inv_options.min_bound < 0) {
+                inv_options.min_bound = HEOS.get_components()[0].ancillaries.rhoL.get_Tmin() - 0.01;
+            }
+            if (inv_options.max_bound < 0) {
+                inv_options.max_bound = HEOS.get_components()[0].ancillaries.rhoL.get_Tmax();
+            }
+            if (T >= inv_options.max_bound){
+                T = (inv_options.max_bound + inv_options.min_bound) / 2.;
+            }
             rhoV = HEOS.get_components()[0].ancillaries.rhoV.evaluate(T);
             rhoL = rhomolar;
         } else if (options.imposed_rho == saturation_D_pure_options::IMPOSED_RHOV) {

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -246,10 +246,12 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend& HEOS, C
                 // Ancillary is deltas = s - hs_anchor.s
                 // First try a conventional call
                 try {
-                    T = anc.invert(specified_value - hs_anchor.smolar, Tmin, Tmax);
+                    SaturationAncillaryFunction_invert_options options = {Tmin, Tmax};
+                    T = anc.invert(specified_value - hs_anchor.smolar, options);
                 } catch (...) {
                     try {
-                        T = anc.invert(specified_value - hs_anchor.smolar, Tmin - 3, Tmax + 3);
+                        SaturationAncillaryFunction_invert_options options = {Tmin - 3, Tmax + 3};
+                        T = anc.invert(specified_value - hs_anchor.smolar, options);
                     } catch (...) {
                         double vmin = anc.evaluate(Tmin);
                         double vmax = anc.evaluate(Tmax);
@@ -582,7 +584,8 @@ void SaturationSolvers::saturation_D_pure(HelmholtzEOSMixtureBackend& HEOS, Cool
         if (options.imposed_rho == saturation_D_pure_options::IMPOSED_RHOL) {
             // Invert liquid density ancillary to get temperature
             // TODO: fit inverse ancillaries too
-            T = HEOS.get_components()[0].ancillaries.rhoL.invert(rhomolar);
+            SaturationAncillaryFunction_invert_options inv_options = {-1, -1, options.max_iterations, options.omega, options.best_guess};
+            T = HEOS.get_components()[0].ancillaries.rhoL.invert(rhomolar, inv_options);
             rhoV = HEOS.get_components()[0].ancillaries.rhoV.evaluate(T);
             rhoL = rhomolar;
         } else if (options.imposed_rho == saturation_D_pure_options::IMPOSED_RHOV) {

--- a/src/Backends/Helmholtz/VLERoutines.h
+++ b/src/Backends/Helmholtz/VLERoutines.h
@@ -32,9 +32,11 @@ struct saturation_D_pure_options
     CoolPropDbl omega, rhoL, rhoV, pL, pV;
     int imposed_rho;
     int max_iterations;
+    bool best_guess;
     saturation_D_pure_options() : use_guesses(false), rhoL(_HUGE), rhoV(_HUGE), pL(_HUGE), pV(_HUGE), imposed_rho(0), max_iterations(200) {
         use_logdelta = true;
         omega = 1.0;
+        best_guess = false;
     }  // Defaults
 };
 

--- a/src/Solvers.cpp
+++ b/src/Solvers.cpp
@@ -409,9 +409,10 @@ Note that this is different than the Secant function because if something goes o
 @param dx The initial amount that is added to x in order to build the numerical derivative
 @param tol The absolute value of the tolerance accepted for the objective function
 @param maxiter Maximum number of iterations
+@param best_guess If true, return your best guess at the end of the iteration process
 @returns If no errors are found, the solution, otherwise the value _HUGE, the value for infinity
 */
-double ExtrapolatingSecant(FuncWrapper1D* f, double x0, double dx, double tol, int maxiter)
+double ExtrapolatingSecant(FuncWrapper1D* f, double x0, double dx, double tol, int maxiter, bool best_guess)
 {
     #if defined(COOLPROP_DEEP_DEBUG)
     static std::vector<double> xlog, flog;
@@ -467,6 +468,7 @@ double ExtrapolatingSecant(FuncWrapper1D* f, double x0, double dx, double tol, i
         if (f->iter>maxiter)
         {
             f->errstring=std::string("reached maximum number of iterations");
+            if (best_guess) { return x2-omega*y1/(y1-y0)*(x2-x1); }
             throw SolutionError(format("Secant reached maximum number of iterations"));
         }
         f->iter += 1;


### PR DESCRIPTION
### Description of the Change

Providing inputs to CoolProp of D and U (or any of HSU) is usually stable, but sometimes can cause annoying issues. This is noted in issues #1965 and #2157 (as well as some of my personal projects). This PR attempts to solve these issues once and for all as an extension to the work done in PR #2173. This is done in 3 main changes:

* Add additional checks and attempts at solving the ancillary equations. Adds more damping attempts and a way to force a guess.
* Add limits to the extrapolated ancillary guesses. If the ancillary becomes very flat near the edges (e.g., near the triple point or critical point), it might not have a solution, but the extrapolated guess could be very far off. We limit the extrapolated guess so that the Akshasa solver can at least attempt something. 
* If all else fails, we give up on finding the saturation curve, and apply a Brent method directly to find T by iterating H/S/U. We do not know the phase, but at least we have everything else. 

### Benefits

We should now always get a solution for D_HSU inputs. 

### Possible Drawbacks

It is possible that one of our fallbacks does not provide the user with a phase, instead setting it to iphase_unknown. 

The fallback solver can be slow because of needing a ton of Brent iterations, after already doing thousands of other iterations trying to find the saturation curve (which is now allowed to go to many of thousands of evaluations). However, a slow solution is almost always better than no solution. 

### Verification Process

I ran large sweeps of inputs to ensure that no errors were observed. I also integrated the results with another code and it seems to behave acceptably. I made custom test codes for issues #1965 and #2157. See the attached C++ code. 

[coolPropTester.zip](https://github.com/CoolProp/CoolProp/files/10314853/coolPropTester.zip)

### Applicable Issues

Closes #1965
Closes #2157 
