### PR TITLE
Provide better feedback for bad DQ inputs

### DIFF
--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -269,7 +269,8 @@ void FlashRoutines::DQ_flash(HelmholtzEOSMixtureBackend& HEOS) {
             HEOS._Q = Q;
             HEOS._phase = iphase_twophase;
         } catch (ValueError e) {
-            if (rhomolar >= HEOS.rhomolar_critical() && Q > 0 && Q < 1){
+            const double eps = 1e-12; // small tolerance to allow for slop in iterative calculations
+            if (rhomolar >= HEOS.rhomolar_critical() && Q > (0 + eps) && Q < (1 - eps)){
                 throw CoolProp::OutOfRangeError(format("DQ inputs are not defined for density above critical density (%g)", HEOS.rhomolar_critical()).c_str());
             } else {
                 throw;

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -269,7 +269,7 @@ void FlashRoutines::DQ_flash(HelmholtzEOSMixtureBackend& HEOS) {
             HEOS._Q = Q;
             HEOS._phase = iphase_twophase;
         } catch (ValueError e) {
-            if (rhomolar >= HEOS.rhomolar_critical()){
+            if (rhomolar >= HEOS.rhomolar_critical() && Q > 0 && Q < 1){
                 throw CoolProp::OutOfRangeError(format("DQ inputs are not defined for density above critical density (%g)", HEOS.rhomolar_critical()).c_str());
             } else {
                 throw;

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -262,7 +262,7 @@ void FlashRoutines::DQ_flash(HelmholtzEOSMixtureBackend& HEOS) {
         double Q = HEOS._Q;
         const double eps = 1e-12; // small tolerance to allow for slop in iterative calculations
         if (rhomolar >= (HEOS.rhomolar_critical() + eps) && Q > (0 + eps)){
-            throw CoolProp::OutOfRangeError(format("DQ inputs are not defined for density above critical density (%g)", HEOS.rhomolar_critical()).c_str());
+            throw CoolProp::OutOfRangeError(format("DQ inputs are not defined for density (%g) above critical density (%g) and Q>0", rhomolar, HEOS.rhomolar_critical()).c_str());
         }
         DQ_flash_residual resid(HEOS, rhomolar, Q);
         Brent(resid, Tmin, Tmax, DBL_EPSILON, 1e-10, 100);


### PR DESCRIPTION
### Description of the Change

DQ is poorly defined (not unique) for densities above critical density. Provide the user better feedback when they try to do this, but do not give them a non-unique answer that might give them trouble later. This PR provides the user more direct feedback warning them about this, but does not try to guess at one of the non unique solutions.

#### A bit more about DQ
The HEOS defines properties in terms of density (D) and temperature (T). If we provide a DQ input pair, the first thing that the solver attempts to do is to find the associated temperature. However, above the critical density, temperature is not a function of density and therefore no unique state exists. 

For all (most?) fluids, DQ inputs are not unique for densities above the critical density. Take for example the following plots of R134a, water, hydrogen, and propane.
![r134](https://user-images.githubusercontent.com/95806012/209880989-ed8639d2-e792-4d20-b8fc-69b72238af9c.png)
![water](https://user-images.githubusercontent.com/95806012/209880998-72aba4d2-10cc-4c17-a0a9-917ac8286fb0.png)
![hydrogen](https://user-images.githubusercontent.com/95806012/209881003-bae2a1c8-e263-4c41-9691-4aa4e95a78df.png)
![propane](https://user-images.githubusercontent.com/95806012/209881006-f7af6214-a435-4306-886e-b4e57c33d51a.png)

Things become a bit clearer if we plot it on a linear scale (water for remaining plots). Note that the curves are curves of constant quality. The orange curve is 5% quality and it is clear that it does not pass the vertical line test. Therefore, we can see that temperature is not a function of density for a given quality. 
![linear_quality](https://user-images.githubusercontent.com/95806012/209881035-b19db5a7-3ca8-4fe5-955a-887e5750d563.png)

To put it another way, the solver can calculate quality for a given DT pair. We know D, so we iterate on T until we find the quality that we want. Plotted below is Q for D=450 and a range of temperatures. If we want to find the temperature for which the quality is 0.05, there is no unique solution. This lack of a solution is why the current version of the code typically crashes due to Brent failing to bracket. 
![solver_issue](https://user-images.githubusercontent.com/95806012/209881173-dc9f87a0-b5b3-48e0-aa6f-6576a4eb4236.png)

### Benefits

Provide the user more robust feedback so that they can make a decision about how to handle their thermodynamic state. E.g., they may choose to build their own solver, ignore the error, or recognize that they need a new method. 

### Possible Drawbacks

This does not actual prevent an exception from being thrown, but simply adds additional text helping explain to the user what went wrong. 

### Verification Process
I wrote a quick code the proves out of range inputs and gets the new error text as expected. Because we are not changing much, more robust regression is not needed. 

```
#include "CoolProp.h"
#include "AbstractState.h"
#include <iostream>
#include <memory>

int main(){
    std::shared_ptr<CoolProp::AbstractState> AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "water"));
    double rho = 450;
    double q = 0.05;
    try{
        AS->update(CoolProp::DmassQ_INPUTS, rho, q);
        std::cout << AS->T() <<std::endl;
    } catch (CoolProp::CoolPropBaseError e){
        std::cout << e.what() << std::endl;
    }
    return 0;
}
```

### Applicable Issues

No issue, but resolves the discussion from PR #2173 .
