### PR TITLE
Verify that mole fractions are set before using them

### DIFF
--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -483,6 +483,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_gas_constant(void) {
         } else {
             // mass fraction weighted average of the components
             double summer = 0;
+            verify_mole_fractions_set();
             for (unsigned int i = 0; i < components.size(); ++i) {
                 summer += mole_fractions[i] * components[i].gas_constant();
             }
@@ -492,6 +493,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_gas_constant(void) {
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_molar_mass(void) {
     double summer = 0;
+    verify_mole_fractions_set();
     for (unsigned int i = 0; i < components.size(); ++i) {
         summer += mole_fractions[i] * components[i].molar_mass();
     }
@@ -660,6 +662,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity(void) {
     } else {
         set_warning_string("Mixture model for viscosity is highly approximate");
         CoolPropDbl summer = 0;
+        verify_mole_fractions_set();
         for (std::size_t i = 0; i < mole_fractions.size(); ++i) {
             shared_ptr<HelmholtzEOSBackend> HEOS(new HelmholtzEOSBackend(components[i]));
             HEOS->update(DmolarT_INPUTS, _rhomolar, _T);
@@ -893,6 +896,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_conductivity(void) {
     } else {
         set_warning_string("Mixture model for conductivity is highly approximate");
         CoolPropDbl summer = 0;
+        verify_mole_fractions_set();
         for (std::size_t i = 0; i < mole_fractions.size(); ++i) {
             shared_ptr<HelmholtzEOSBackend> HEOS(new HelmholtzEOSBackend(components[i]));
             HEOS->update(DmolarT_INPUTS, _rhomolar, _T);
@@ -925,6 +929,7 @@ void HelmholtzEOSMixtureBackend::calc_conformal_state(const std::string& referen
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_Ttriple(void) {
     double summer = 0;
+    verify_mole_fractions_set();
     for (unsigned int i = 0; i < components.size(); ++i) {
         summer += mole_fractions[i] * components[i].EOS().Ttriple;
     }
@@ -932,6 +937,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_Ttriple(void) {
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_p_triple(void) {
     double summer = 0;
+    verify_mole_fractions_set();
     for (unsigned int i = 0; i < components.size(); ++i) {
         summer += mole_fractions[i] * components[i].EOS().ptriple;
     }
@@ -1116,6 +1122,7 @@ void HelmholtzEOSMixtureBackend::calc_pmin_sat(CoolPropDbl& pmin_satL, CoolPropD
 
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_Tmax(void) {
     double summer = 0;
+    verify_mole_fractions_set();
     for (unsigned int i = 0; i < components.size(); ++i) {
         summer += mole_fractions[i] * components[i].EOS().limits.Tmax;
     }
@@ -1123,6 +1130,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_Tmax(void) {
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_Tmin(void) {
     double summer = 0;
+    verify_mole_fractions_set();
     for (unsigned int i = 0; i < components.size(); ++i) {
         summer += mole_fractions[i] * components[i].EOS().limits.Tmin;
     }
@@ -1130,6 +1138,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_Tmin(void) {
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_pmax(void) {
     double summer = 0;
+    verify_mole_fractions_set();
     for (unsigned int i = 0; i < components.size(); ++i) {
         summer += mole_fractions[i] * components[i].EOS().limits.pmax;
     }
@@ -2521,6 +2530,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::solver_rho_Tp(CoolPropDbl T, CoolPropDbl
 CoolPropDbl HelmholtzEOSMixtureBackend::solver_rho_Tp_SRK(CoolPropDbl T, CoolPropDbl p, phases phase) {
     CoolPropDbl rhomolar, R_u = gas_constant(), a = 0, b = 0, k_ij = 0;
 
+    verify_mole_fractions_set();
     for (std::size_t i = 0; i < components.size(); ++i) {
         CoolPropDbl Tci = components[i].EOS().reduce.T, pci = components[i].EOS().reduce.p, acentric_i = components[i].EOS().acentric;
         CoolPropDbl m_i = 0.480 + 1.574 * acentric_i - 0.176 * pow(acentric_i, 2);
@@ -2870,6 +2880,7 @@ void HelmholtzEOSMixtureBackend::calc_excess_properties(void) {
     _gibbsmolar_excess = this->gibbsmolar(), _smolar_excess = this->smolar(), _hmolar_excess = this->hmolar();
     _umolar_excess = this->umolar();
     _volumemolar_excess = 1 / this->rhomolar();
+    verify_mole_fractions_set();
     for (std::size_t i = 0; i < components.size(); ++i) {
         transient_pure_state.reset(new HelmholtzEOSBackend(components[i].name));
         transient_pure_state->update(PT_INPUTS, p(), T());
@@ -2916,6 +2927,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_fugacity(std::size_t i) {
     return MixtureDerivatives::fugacity_i(*this, i, xN_flag);
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_chemical_potential(std::size_t i) {
+    verify_mole_fractions_set();
     x_N_dependency_flag xN_flag = XN_DEPENDENT;
     double Tci = get_fluid_constant(i, iT_critical);
     double rhoci = get_fluid_constant(i, irhomolar_critical);

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
@@ -54,6 +54,13 @@ class HelmholtzEOSMixtureBackend : public AbstractState
             linked_states.push_back(transient_pure_state);
         }
     };
+    // Verify that the mole fractions are set. Throw an exception if they are not.
+    virtual bool verify_mole_fractions_set(){
+        if (mole_fractions.size() != components.size()){
+            throw CoolProp::ValueError("mole fractions are not set for all components");
+        }
+        return true;
+    }
 
     std::vector<CoolPropFluid> components;      ///< The components that are in use
     bool is_pure_or_pseudopure;                 ///< A flag for whether the substance is a pure or pseudo-pure fluid (true) or a mixture (false)


### PR DESCRIPTION
### Description of the Change

Add a check for mole fractions being set before attempting to use them.

### Benefits

Prevents hard crash in Python module. 

Currently, if mole fractions are not set, then there is an exception thrown in the vector's out of bounds check (`"vector subscript out of range"`). In the created Python module, there is no handling for this, so the code just crashes. We now check for the mole fraction size before using and throw a CoolProp::ValueError. This is recognized by the Python module and allows for Python side exception handling. 

### Possible Drawbacks

* I may have missed a usage of the mole fractions and this issue may reappear somewhere in the future. 
* It is awkward to have the check called at all places where mole fractions are used. It would be more elegant to place the check at a higher level so that future modifications do no need to manually include this check. However, I am not sure if there are alternative code paths that lead to the mole fractions, so I put the check close to the actual usage. 

### Verification Process
The test from #2205 was executed:
``` python
import CoolProp.CoolProp as CP
AS = CP.AbstractState("HEOS", "R134a&R1234YF")
AS.trivial_keyed_output(CP.iT_min)
```

Now, an exception is thrown.
```
>>> import CoolProp.CoolProp as CP
>>> AS = CP.AbstractState("HEOS", "R134a&R1234YF")
>>> AS.trivial_keyed_output(CP.iT_min)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "CoolProp\AbstractState.pyx", line 227, in CoolProp.CoolProp.AbstractState.trivial_keyed_output
  File "CoolProp\AbstractState.pyx", line 229, in CoolProp.CoolProp.AbstractState.trivial_keyed_output
ValueError: mole fractions are not set for all components
```

This can be handled if desired:
``` python
try:
    AS.trivial_keyed_output(CP.iT_min)
except Exception as e:
    print("Handle this:", e)
```


### Applicable Issues

Closes #2205 
