### PR TITLE
Make AbstractStateLibrary class thread-safe

### DIFF
--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -500,12 +500,10 @@ class AbstractStateLibrary
 };
 static AbstractStateLibrary handle_manager;
 
-std::mutex AS_mutex;
 EXPORT_CODE long CONVENTION AbstractState_factory(const char* backend, const char* fluids, long* errcode, char* message_buffer,
                                                   const long buffer_length) {
     *errcode = 0;
     try {
-        std::lock_guard<std::mutex> guard(AS_mutex);
         shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory(backend, fluids));
         return handle_manager.add(AS);
     } catch (...) {

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -19,6 +19,7 @@
 #include "Backends/Helmholtz/MixtureParameters.h"
 
 #include <string.h>
+#include <mutex>
 
 void str2buf(const std::string& str, char* buf, int n) {
     if (str.size() < static_cast<unsigned int>(n))
@@ -470,21 +471,25 @@ class AbstractStateLibrary
    private:
     std::map<std::size_t, shared_ptr<CoolProp::AbstractState>> ASlibrary;
     long next_handle;
+    std::mutex ASLib_mutex;
 
    public:
     AbstractStateLibrary() : next_handle(0){};
     long add(shared_ptr<CoolProp::AbstractState> AS) {
+        std::lock_guard<std::mutex> guard(ASLib_mutex);
         ASlibrary.insert(std::pair<std::size_t, shared_ptr<CoolProp::AbstractState>>(this->next_handle, AS));
         this->next_handle++;
         return next_handle - 1;
     }
     void remove(long handle) {
+        std::lock_guard<std::mutex> guard(ASLib_mutex);
         std::size_t count_removed = ASlibrary.erase(handle);
         if (count_removed != 1) {
             throw CoolProp::HandleError("could not free handle");
         }
     }
     shared_ptr<CoolProp::AbstractState>& get(long handle) {
+        std::lock_guard<std::mutex> guard(ASLib_mutex);
         std::map<std::size_t, shared_ptr<CoolProp::AbstractState>>::iterator it = ASlibrary.find(handle);
         if (it != ASlibrary.end()) {
             return it->second;
@@ -495,10 +500,12 @@ class AbstractStateLibrary
 };
 static AbstractStateLibrary handle_manager;
 
+std::mutex AS_mutex;
 EXPORT_CODE long CONVENTION AbstractState_factory(const char* backend, const char* fluids, long* errcode, char* message_buffer,
                                                   const long buffer_length) {
     *errcode = 0;
     try {
+        std::lock_guard<std::mutex> guard(AS_mutex);
         shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory(backend, fluids));
         return handle_manager.add(AS);
     } catch (...) {


### PR DESCRIPTION
### Description of the Change

Attempt to make calls to `AbstractStateLibrary` class thread-safe. Not so familiar with multi-threading so, there might be a better solution. No changes have been made to `AbstractState` class and if I understand correctly, methods like `AbstractState::update()` are prone to data races.

### Benefits

Handles to `AbstractState` objects can be obtained within parallel loops using `Threads.@threads` macro when working with Julia wrapper.

### Possible Drawbacks

None known so far

### Verification Process

**Test file** : Julia source `test-CP.jl`

```julia
# load CoolProp library
pathCoolProp = "CoolProp"
(pathCoolProp in Base.DL_LOAD_PATH) || push!(Base.DL_LOAD_PATH, pathCoolProp)
(pathCoolProp in LOAD_PATH) || push!(LOAD_PATH, pathCoolProp)

import CoolProp as CP

function geteos(name::AbstractString, backend::AbstractString="HEOS")
    handle = CP.AbstractState_factory(backend, name)
end

function freeeos(handle::Integer)
    handle = CP.AbstractState_free(handle)
end

function getproperty(handle::Integer, density::Real, pressure::Real)
    # state update without data-races in AbstractState.update()
    # handles are accessed only by a single thread
    CP.AbstractState_update(handle, "DmassP_INPUTS", density, pressure)
    CP.AbstractState_keyed_output(handle, CP.get_param_index("Hmass"))
end

function test(size::Integer, repititions::Integer)
    fluidname = "Water"
    density = collect(LinRange(100, 900, size))
    pressure = collect(LinRange(5e+04, 1e+05, size))
    # store for fluid handles
    handlesST = Vector{Int64}(undef, size) 
    handlesMT = similar(handlesST)
    # store for property values
    propertiesST = Vector{Float64}(undef, size) 
    propertiesMT = similar(propertiesST)
    # get handles
    for _ in 1:repititions
        # single-threaded
        for i in 1:size
            handle = geteos(fluidname)
            handlesST[i] = handle
        end
        propertiesST .= getproperty.(handlesST, density, pressure)
        # multi-threaded
        Threads.@threads for i in 1:size
            handle = geteos(fluidname)
            handlesMT[i] = handle
        end
        propertiesMT .= getproperty.(handlesMT, density, pressure)
        # verify
        @assert propertiesST == propertiesMT
	# free handles
	freeeos.(handlesST)
	freeeos.(handlesMT)
    end
    "OK"
end

# run test
test(1000, 100)
```

**Output**:

*Before*

```bash
$ julia -t auto
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.8.5 (2023-01-08)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> include("test-CP.jl")
ERROR: LoadError: CoolProp: HandleError: could not get handle
Stacktrace:
  [1] error(::String, ::String)
    @ Base ./error.jl:44
  [2] raise(errcode::Base.RefValue{Int64}, message_buffer::Vector{UInt8})
    @ CoolProp /tmp/test-CP/CoolProp/CoolProp.jl:678
  [3] AbstractState_update(handle::Int64, input_pair::Int64, value1::Float64, value2::Float64)
    @ CoolProp /tmp/test-CP/CoolProp/CoolProp.jl:782
  [4] AbstractState_update
    @ /tmp/test-CP/CoolProp/CoolProp.jl:787 [inlined]
  [5] getproperty
    @ /tmp/test-CP/test-CP.jl:18 [inlined]
  [6] _broadcast_getindex_evalf
    @ ./broadcast.jl:670 [inlined]
  [7] _broadcast_getindex
    @ ./broadcast.jl:643 [inlined]
  [8] getindex
    @ ./broadcast.jl:597 [inlined]
  [9] macro expansion
    @ ./broadcast.jl:961 [inlined]
 [10] macro expansion
    @ ./simdloop.jl:77 [inlined]
 [11] copyto!
    @ ./broadcast.jl:960 [inlined]
 [12] copyto!
    @ ./broadcast.jl:913 [inlined]
 [13] materialize!
    @ ./broadcast.jl:871 [inlined]
 [14] materialize!
    @ ./broadcast.jl:868 [inlined]
 [15] test(size::Int64, repititions::Int64)
    @ Main /tmp/test-CP/test-CP.jl:45
 [16] top-level scope
    @ /tmp/test-CP/test-CP.jl:55
 [17] include(fname::String)
    @ Base.MainInclude ./client.jl:476
 [18] top-level scope
    @ REPL[1]:1
in expression starting at /tmp/test-CP/test-CP.jl:55

julia> 
```

(Next `include` resulted in segmentation fault)

*After*

```bash
$ julia -t auto
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.8.5 (2023-01-08)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> include("test-CP.jl")
"OK"

julia> 
```

(A second `include` resulted in `"OK"`)

### Applicable Issues

None
