### PR TITLE
Change links from Google group to GitHub discussions

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -16,7 +16,7 @@ It was originally developed by Ian Bell, at the time a post-doc at the Universit
 
 * The documentation is available for the `latest release <http://www.coolprop.org>`_ and the `development version <http://www.coolprop.org/dev>`_  
 
-* For any kind of question regarding CoolProp and its usage, you can ask the `CoolProp user group <https://goo.gl/Pa7FBT>`_ 
+* For any kind of question regarding CoolProp and its usage, you can ask the `CoolProp Discussions <https://github.com/CoolProp/CoolProp/discussions>`_
 
 * ... you might also find answers in our `FAQ <https://github.com/CoolProp/CoolProp/blob/master/FAQ.md>`_ 
 

--- a/Web/index.rst
+++ b/Web/index.rst
@@ -49,7 +49,7 @@ See more examples of PropsSI usage at :ref:`High-Level interface <high_level_api
 Help
 ----
 
-* (**General Discussion**) Email the `Google group <https://groups.google.com/d/forum/coolprop-users>`_
+* (**General Discussion**) Create a new discussion at `Github CoolProp Discussions <https://github.com/CoolProp/CoolProp/discussions>`_
 * (**Bugs, feature requests**) File a `Github issue <https://github.com/CoolProp/CoolProp/issues>`_
 * `Docs for v4 of CoolProp <http://www.coolprop.org/v4/>`_
 * `Docs for development version of CoolProp <http://www.coolprop.org/dev/>`_


### PR DESCRIPTION
As discussed here:
https://groups.google.com/g/coolprop-users/c/l_aY4vTT58Q


### Description of the Change

Change links in readme and docs to point to github discussions.

### Benefits

I think the github discussions has a better format to discuss programming questions, it is easier to read, and we have options such as choosing the right answer, upvote etc. which are similar to stackoverflow.

Additionally, we would have all content (issues + discussions) in only one place, making it easier to search things.

It would also make it easier to reference things, for example, issues that could be open based on discussions.
