### PR TITLE
Topic 2142

### DIFF
--- a/dev/fluids/R1233zd(E).json
+++ b/dev/fluids/R1233zd(E).json
@@ -1,27 +1,5 @@
 {
   "ANCILLARIES": {
-    "hL": {
-      "A": [
-        -59081.90149961518,
-        -56.71632899355515,
-        3.4601929994947436,
-        -0.022382015166099334,
-        7.983388457665615e-05,
-        -1.6902202857616328e-07,
-        1.9661600933963034e-10,
-        -9.735546908737005e-14
-      ],
-      "B": [
-        1,
-        -0.0022550755060008
-      ],
-      "Tmax": 439.5,
-      "Tmin": 195.15,
-      "_note": "coefficients are in increasing order; input in K, output in J/mol; value is enthalpy minus hs_anchor enthalpy",
-      "max_abs_error": 271.53420989192637,
-      "max_abs_error_units": "J/mol",
-      "type": "rational_polynomial"
-    },
     "hLV": {
       "A": [
         -5135.181894492507,

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -1553,7 +1553,7 @@ void FlashRoutines::HSU_P_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
                         if (saturation_called) {
                             Tmin = HEOS.SatV->T();
                         } else {
-                            Tmin = HEOS._TVanc.pt() + 0.01;
+                            Tmin = HEOS._TVanc.pt() - 0.01;
                         }
                     }
                     break;

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -1562,7 +1562,7 @@ void FlashRoutines::HSU_P_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
                     if (saturation_called) {
                         Tmax = HEOS.SatL->T();
                     } else {
-                        Tmax = HEOS._TLanc.pt();
+                        Tmax = HEOS._TLanc.pt() + 0.01;
                     }
 
                     // Sometimes the minimum pressure for the melting line is a bit above the triple point pressure


### PR DESCRIPTION
### Description of the Change

Correct issues that lead to poor performance of R1233zd(E) near the saturation line. This closes issue #2142. The steps taken to do so are:

1) Remove the poorly performing hL ancillary.
2) Add a 0.01K cushion to the `T_max` that is acquired from an ancillary. 
3) Reverse the 0.01K cushion on `T_min` the is produced by an ancillary.

While item 3 was not part of the original investigation, it might prevent future issues. 

### Benefits

R1233zd(E) now performs as expected near the saturation curve. The adjustments to `T_max` and `T_min` may also assist other fluids near the saturation curve under HSU_P inputs. 

### Possible Drawbacks

The lack of an ancillary may slow calculations with R1233zd(E). Furthermore, no robust investigation into the other ancillary functions has been carried out. Future work should attempt to refit the hL ancillary for R1233zd(E) and investigate the other ancillary functions to ensure that they are accurate. 

### Verification Process

The test case from #2142 was run and expected results were returned. 

```
#include "CoolProp.h"
#include <stdio.h>
int main()
{
    printf("%f\n",CoolProp::PropsSI("T", "P", 136730, "H", 260000.00, "R1233zd(E)"));
    printf("%f\n",CoolProp::PropsSI("T", "P", 136730, "H", 263277.27, "R1233zd(E)"));
    printf("%f\n",CoolProp::PropsSI("T", "P", 136730, "H", 263277.35, "R1233zd(E)"));
    printf("%f\n",CoolProp::PropsSI("T", "P", 136730, "H", 268000.00, "R1233zd(E)"));
    printf("%f\n",CoolProp::PropsSI("T", "P", 136730, "H", 275000.00, "R1233zd(E)"));
    printf("%f\n",CoolProp::PropsSI("T", "P", 136730, "H", 293000.00, "R1233zd(E)"));
    printf("%f\n",CoolProp::PropsSI("T", "P", 136730, "H", 300000.00, "R1233zd(E)"));
    return 0;
}
```

### Applicable Issues

Closes #2142 
