### PR TITLE
Topic-2200: Correct typo in n-Hexane rhoV auxilliary

### DIFF
--- a/dev/fluids/n-Hexane.json
+++ b/dev/fluids/n-Hexane.json
@@ -96,7 +96,7 @@
       "T_r": 507.82,
       "Tmax": 507.82,
       "Tmin": 177.83,
-      "description": "rho'' = rhoc*exp(Tc/T*sum(n_i*theta^t_i))",
+      "description": "rho'' = rhoc*exp(sum(n_i*theta^t_i))",
       "max_abserror_percentage": 1.0104195769602642,
       "n": [
         -3.4056,
@@ -116,7 +116,7 @@
         30.0
       ],
       "type": "rhoV",
-      "using_tau_r": true
+      "using_tau_r": false
     },
     "sL": {
       "A": [


### PR DESCRIPTION
The rhoV auxiliary for n-Hexane had accidentally been set to use reduced tau. This commit fixes the typo. This prevents bad guesses for a number of property evaluations which use saturated states. See also https://github.com/usnistgov/teqp/commit/7de5755594f0c3ba201a9ecd368be5dd0543d7a7 .

### Description of the Change

Correct a typo in the rhoV auxiliary for n-Hexane. The value had been accidentally set improperly. This was discovered during investigation of issue #2200.

### Benefits

n-Hexane now gets better guesses when calculating saturated states and has fewer crashes.

### Possible Drawbacks

I have only performed testing for the specific state point mentioned in #2200 (see below). There may be other side effects that have not been tested for explicitly. 

### Verification Process

I ran the following C++ code from #2200. Before this fix, it caused an uncaught ValueError to be raised. It now returns the expected value. 

```C++
// Test issue #2200
#include "CoolProp.h"
#include "AbstractState.h"
#include <iostream>
#include <memory>
int main()
{
    std::shared_ptr<CoolProp::AbstractState> AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Hexane"));
    AS->update(CoolProp::PQ_INPUTS, 6065, 0);
    std::cout << AS->T() << std::endl;
    return 0;
}
```


### Applicable Issues

Closes #2200