### PR TITLE
Update fmt submodule to 10.0.0

### DIFF
--- a/include/CPstrings.h
+++ b/include/CPstrings.h
@@ -74,17 +74,16 @@ inline bool endswith(const std::string& s1, const std::string& s2) {
 #if defined(NO_FMTLIB)
 // Missing string formatting function, this old guy is needed for ancient gcc compilers on PowerPC for VxWorks
 inline std::string format(const char* fmt, ...);
+#elif FMT_VERSION >= 50000
+template <typename... Args>
+inline std::string format(const char* format_str, const Args&... args) {
+    return fmt::sprintf(format_str, args...);
+}
 #else
-// Missing std::string formatting function - provided by the fmtlib library
 inline std::string format(const char* format, fmt::ArgList args) {
     return fmt::sprintf(format, args);
 }
 FMT_VARIADIC(std::string, format, const char*)
-// For latest FMTLIB
-/*template <typename... Args>
-    inline std::string format(const char *format_str, const Args & ... args) {
-        return fmt::sprintf(format_str, args);
-    }*/
 #endif
 
 // Missing string split - like in Python

--- a/include/CoolPropFluid.h
+++ b/include/CoolPropFluid.h
@@ -562,5 +562,19 @@ class CoolPropFluid
     };
 };
 
+#if !defined(NO_FMTLIB) && FMT_VERSION >= 90000
+static int format_as(ViscosityDiluteVariables::ViscosityDiluteType type) {
+    return fmt::underlying(type);
+}
+
+static int format_as(TransportPropertyData::ViscosityHardcodedEnum viscosity) {
+    return fmt::underlying(viscosity);
+}
+
+static int format_as(TransportPropertyData::ConductivityHardcodedEnum conductivity) {
+    return fmt::underlying(conductivity);
+}
+#endif
+
 } /* namespace CoolProp */
 #endif /* COOLPROPFLUID_H_ */

--- a/include/DataStructures.h
+++ b/include/DataStructures.h
@@ -473,5 +473,40 @@ void extract_backend_families(std::string backend_string, backend_families& f1, 
 void extract_backend_families_string(std::string backend_string, backend_families& f1, std::string& f2);
 std::string get_backend_string(backends backend);
 
+#if !defined(NO_FMTLIB) && FMT_VERSION >= 90000
+/// Allows enums to be formatted
+static int format_as(parameters parameter) {
+    return fmt::underlying(parameter);
+}
+
+static int format_as(phases phase) {
+    return fmt::underlying(phase);
+}
+
+static int format_as(schemes scheme) {
+    return fmt::underlying(scheme);
+}
+
+static int format_as(composition_types type) {
+    return fmt::underlying(type);
+}
+
+static int format_as(fluid_types type) {
+    return fmt::underlying(type);
+}
+
+static int format_as(input_pairs pair) {
+    return fmt::underlying(pair);
+}
+
+static int format_as(backend_families family) {
+    return fmt::underlying(family);
+}
+
+static int format_as(backends backend) {
+    return fmt::underlying(backend);
+}
+#endif
+
 } /* namespace CoolProp */
 #endif /* DATASTRUCTURES_H_ */

--- a/include/IncompressibleFluid.h
+++ b/include/IncompressibleFluid.h
@@ -44,6 +44,12 @@ struct IncompressibleData
     };
 };
 
+#if !defined(NO_FMTLIB) && FMT_VERSION >= 90000
+static int format_as(IncompressibleData::IncompressibleTypeEnum type) {
+    return fmt::underlying(type);
+}
+#endif
+
 /// A property provider for incompressible solutions and pure fluids
 /**
 This fluid instance is populated using an entry from a JSON file

--- a/src/Backends/Helmholtz/VLERoutines.h
+++ b/src/Backends/Helmholtz/VLERoutines.h
@@ -97,6 +97,12 @@ struct saturation_PHSU_pure_options
     }
 };
 
+#if !defined(NO_FMTLIB) && FMT_VERSION >= 90000
+static int format_as(saturation_PHSU_pure_options::specified_variable_options option) {
+    return fmt::underlying(option);
+}
+#endif
+
 void saturation_PHSU_pure(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl specified_value, saturation_PHSU_pure_options& options);
 
 /* \brief This is a backup saturation_p solver for the case where the Newton solver cannot approach closely enough the solution

--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -76,6 +76,12 @@ enum givens
     GIVEN_ISENTROPIC_EXPONENT
 };
 
+#if !defined(NO_FMTLIB) && FMT_VERSION >= 90000
+int format_as(givens given) {
+    return fmt::underlying(given);
+}
+#endif
+
 void _HAPropsSI_inputs(double p, const std::vector<givens>& input_keys, const std::vector<double>& input_vals, double& T, double& psi_w);
 double _HAPropsSI_outputs(givens OuputType, double p, double T, double psi_w);
 double MoleFractionWater(double, double, int, double);


### PR DESCRIPTION
### Requirements

* Fill out this template to the extent possible so that this PR can be reviewed in a timely manner.
* Replace the bracketed text below with your own.
* All new code requires tests to ensure against regressions.

### Description of the Change

With the recent breaking changes made with fmt, it is no longer possible to build CoolProp using the latest release of fmt (10.0.0).

The main issue is that enums no longer get automatically converted to int, even when using `sprintf` and the `%d` specifier explicitly.

To resolve this issue, every enum that is used in a format call needs to have a `format_as` overload **in the same namespace**. This feature is only available since fmt 9.0.0, hence the `FMT_VERSION >= 90000` guard.

As suggested, the module was also updated to the latest version.

### Benefits

Support newer versions of fmt, without dropping support for older versions.

### Possible Drawbacks

There is sort of a pattern that cannot be abstracted away with a template (to my knowledge) and that is repeated for every enum:
```cpp
int format_as(TheEnum foo) { return fmt::underlying(foo) }
```

Updating the fmt submodule beyond 4.x raises the minimum to  GCC 4.8, Clang 3.4, and MSVC 19.0 (2015). This change is not strictly necessary so it can be reverted if needed.

### Verification Process

Admittedly, I am not a CoolProp user, so the only testing that was done was ensuring the project successfully built with a newer version of fmt.

### Applicable Issues

Fixes #2251 
