### PR TITLE
Possible fix for failing python_cibuildwheel due to cpdef deprication in Cython

### DIFF
--- a/.github/workflows/python_cibuildwheel.yml
+++ b/.github/workflows/python_cibuildwheel.yml
@@ -53,7 +53,8 @@ jobs:
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.9
         CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9 SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
-        CIBW_BEFORE_BUILD: pip install setuptools wheel Cython requests jinja2 pyyaml
+        CIBW_BEFORE_BUILD: >
+         pip install setuptools wheel "Cython<=3.0" requests jinja2 pyyaml
         CIBW_ENVIRONMENT_LINUX: COOLPROP_CMAKE=default,NATIVE
         CIBW_BUILD: cp${{ inputs.python-version }}-*
         CIBW_ARCHS_MACOS: ${{ inputs.arch }} # x86_64 arm64 # universal2 is redundant

--- a/CoolPropBibTeXLibrary.bib
+++ b/CoolPropBibTeXLibrary.bib
@@ -3267,4 +3267,14 @@
 	author = {M. L. Huber and E. A. Sykioti and M. J. Assael and  R. A. Perkins},
 }
 
+@article{Laesecke-JPCRD-2017-CO2,
+	title = {{Reference Correlation for the Viscosity of Carbon Dioxide}},
+	volume = {46},
+	doi = {10.1063/1.4977429},
+	number = {1},
+	journal = {Journal of Physical and Chemical Reference Data},
+	author = {A. Laesecke and C. D. Muzny},
+	year = {2017},
+}
+
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/dev/fluids/CarbonDioxide.json
+++ b/dev/fluids/CarbonDioxide.json
@@ -680,96 +680,41 @@
       }
     },
     "viscosity": {
-      "BibTeX": "Fenghour-JPCRD-1998",
-      "_note": "sigma set to 1 nm in since sigma wrapped into constant in equation in Fenghour",
+      "BibTeX": "Laesecke-JPCRD-2017-CO2",
       "dilute": {
-        "C": 1.5178953643112785e-07,
-        "_note": "Leading coefficient was back calculated from 1.00697e-6/(44.0098)**0.5 (using sigma = 1 nm)",
-        "a": [
-          0.235156,
-          -0.491266,
-          0.05211155,
-          0.05347906,
-          -0.01537102
-        ],
-        "molar_mass": 0.0440098,
-        "molar_mass_units": "kg/mol",
-        "t": [
-          0,
-          1,
-          2,
-          3,
-          4
-        ],
-        "type": "collision_integral"
+        "hardcoded": "CarbonDioxideLaeseckeJPCRD2017"
       },
-      "epsilon_over_k": 251.196,
+      "initial_density": {
+        "type": "Rainwater-Friend",
+        "b": [
+          -19.572881,
+          219.73999,
+          -1015.3226,
+          2471.0125,
+          -3375.1717,
+          2491.6597,
+          -787.26086,
+          14.085455,
+          -0.34664158
+        ],
+        "t": [
+          0.0,
+          -0.25,
+          -0.5,
+          -0.75,
+          -1.0,
+          -1.25,
+          -1.5,
+          -2.5,
+          -5.5
+        ]
+      },
+      "epsilon_over_k": 200.760,
       "epsilon_over_k_units": "K",
       "higher_order": {
-        "T_reduce": 304.1282,
-        "T_reduce_units": "K",
-        "_note": "All of the coefficients for higher order viscosity contribution were converted to be in terms of delta and tau",
-        "a": [
-          1.9036541208525784e-06,
-          1.57384720473354e-05,
-          1.4207809578440784e-07,
-          6.79058431241662e-08,
-          -3.0732988514867565e-08
-        ],
-        "d1": [
-          1,
-          2,
-          6,
-          8,
-          8
-        ],
-        "d2": [
-          1
-        ],
-        "f": [
-          0
-        ],
-        "g": [
-          1
-        ],
-        "gamma": [
-          0,
-          0,
-          0,
-          0,
-          0
-        ],
-        "h": [
-          0
-        ],
-        "l": [
-          1,
-          1,
-          1,
-          1,
-          0
-        ],
-        "p": [
-          1
-        ],
-        "q": [
-          0
-        ],
-        "rhomolar_reduce": 10624.9,
-        "rhomolar_reduce_units": "mol/m^3",
-        "t1": [
-          0,
-          0,
-          3,
-          0,
-          1
-        ],
-        "t2": [
-          0
-        ],
-        "type": "modified_Batschinski_Hildebrand"
+        "hardcoded": "CarbonDioxideLaeseckeJPCRD2017"
       },
-      "sigma_eta": 1e-09,
+      "sigma_eta": 0.378421e-09,
       "sigma_eta_units": "m"
     }
   }

--- a/include/CoolPropFluid.h
+++ b/include/CoolPropFluid.h
@@ -246,6 +246,7 @@ struct ViscosityDiluteVariables
         VISCOSITY_DILUTE_KINETIC_THEORY,                      ///< Use \ref TransportRoutines::viscosity_dilute_kinetic_theory
         VISCOSITY_DILUTE_ETHANE,                              ///< Use \ref TransportRoutines::viscosity_dilute_ethane
         VISCOSITY_DILUTE_CYCLOHEXANE,                         ///< Use \ref TransportRoutines::viscosity_dilute_cyclohexane
+        VISCOSITY_DILUTE_CO2_LAESECKE_JPCRD_2017,             ///< Use \ref TransportRoutines::viscosity_dilute_CO2_LaeseckeJPCRD2017
         VISCOSITY_DILUTE_POWERS_OF_T,                         ///< Use \ref TransportRoutines::viscosity_dilute_powers_of_T
         VISCOSITY_DILUTE_POWERS_OF_TR,                        ///< Use \ref TransportRoutines::viscosity_dilute_powers_of_Tr
         VISCOSITY_DILUTE_NOT_SET
@@ -309,6 +310,7 @@ struct ViscosityHigherOrderVariables
         VISCOSITY_HIGHER_ORDER_ETHANE,                 ///< Use \ref TransportRoutines::viscosity_ethane_higher_order_hardcoded
         VISCOSITY_HIGHER_ORDER_BENZENE,                ///< Use \ref TransportRoutines::viscosity_benzene_higher_order_hardcoded
         VISCOSITY_HIGHER_ORDER_TOLUENE,                ///< Use \ref TransportRoutines::viscosity_toluene_higher_order_hardcoded
+        VISCOSITY_HIGHER_ORDER_CO2_LAESECKE_JPCRD_2017,///< Use \ref TransportRoutines::viscosity_CO2_higher_order_hardcoded_LaeseckeJPCRD2017
         VISCOSITY_HIGHER_ORDER_FRICTION_THEORY,        ///< Use \ref TransportRoutines::viscosity_higher_order_friction_theory
         VISCOSITY_HIGHER_ORDER_NOT_SET
     };

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.h
@@ -446,6 +446,9 @@ class JSONFluidLibrary
             } else if (!target.compare("Cyclohexane")) {
                 fluid.transport.viscosity_dilute.type = CoolProp::ViscosityDiluteVariables::VISCOSITY_DILUTE_CYCLOHEXANE;
                 return;
+            } else if (!target.compare("CarbonDioxideLaeseckeJPCRD2017")) {
+                fluid.transport.viscosity_dilute.type = CoolProp::ViscosityDiluteVariables::VISCOSITY_DILUTE_CO2_LAESECKE_JPCRD_2017;
+                return;
             } else {
                 throw ValueError(format("hardcoded dilute viscosity [%s] is not understood for fluid %s", target.c_str(), fluid.name.c_str()));
             }
@@ -551,6 +554,9 @@ class JSONFluidLibrary
                 return;
             } else if (!target.compare("Benzene")) {
                 fluid.transport.viscosity_higher_order.type = CoolProp::ViscosityHigherOrderVariables::VISCOSITY_HIGHER_ORDER_BENZENE;
+                return;
+            } else if (!target.compare("CarbonDioxideLaeseckeJPCRD2017")) {
+                fluid.transport.viscosity_higher_order.type = CoolProp::ViscosityHigherOrderVariables::VISCOSITY_HIGHER_ORDER_CO2_LAESECKE_JPCRD_2017;
                 return;
             } else {
                 throw ValueError(

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -584,6 +584,9 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity_dilute(void) {
             case ViscosityDiluteVariables::VISCOSITY_DILUTE_CYCLOHEXANE:
                 eta_dilute = TransportRoutines::viscosity_dilute_cyclohexane(*this);
                 break;
+            case ViscosityDiluteVariables::VISCOSITY_DILUTE_CO2_LAESECKE_JPCRD_2017:
+                eta_dilute = TransportRoutines::viscosity_dilute_CO2_LaeseckeJPCRD2017(*this);
+                break;
             default:
                 throw ValueError(
                   format("dilute viscosity type [%d] is invalid for fluid %s", components[0].transport.viscosity_dilute.type, name().c_str()));
@@ -603,7 +606,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity_background(CoolPropDbl et
         case ViscosityInitialDensityVariables::VISCOSITY_INITIAL_DENSITY_RAINWATER_FRIEND: {
             CoolPropDbl B_eta_initial = TransportRoutines::viscosity_initial_density_dependence_Rainwater_Friend(*this);
             CoolPropDbl rho = rhomolar();
-            initial_density = eta_dilute * B_eta_initial * rho;
+            initial_density = eta_dilute * B_eta_initial * rho; //TODO: Check units once AMTG
             break;
         }
         case ViscosityInitialDensityVariables::VISCOSITY_INITIAL_DENSITY_EMPIRICAL: {
@@ -640,6 +643,9 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity_background(CoolPropDbl et
             break;
         case ViscosityHigherOrderVariables::VISCOSITY_HIGHER_ORDER_BENZENE:
             residual = TransportRoutines::viscosity_benzene_higher_order_hardcoded(*this);
+            break;
+        case ViscosityHigherOrderVariables::VISCOSITY_HIGHER_ORDER_CO2_LAESECKE_JPCRD_2017:
+            residual = TransportRoutines::viscosity_CO2_higher_order_hardcoded_LaeseckeJPCRD2017(*this);
             break;
         default:
             throw ValueError(

--- a/src/Backends/Helmholtz/TransportRoutines.cpp
+++ b/src/Backends/Helmholtz/TransportRoutines.cpp
@@ -340,6 +340,17 @@ CoolPropDbl TransportRoutines::viscosity_heptane_higher_order_hardcoded(Helmholt
               + c[4] * rhor / (c[5] + c[6] * Tr + c[7] * rhor + rhor * rhor + c[8] * rhor * Tr));
 }
 
+CoolPropDbl TransportRoutines::viscosity_CO2_higher_order_hardcoded_LaeseckeJPCRD2017(HelmholtzEOSMixtureBackend& HEOS) {
+    double c1 = 0.360603235428487, c2 = 0.121550806591497, gamma = 8.06282737481277;
+    double Tt = HEOS.Ttriple(), rho_tL = 1178.53;
+    double Tr = HEOS.T() / Tt, rhor = HEOS.rhomass() / rho_tL;
+    // Eq. (9) from Laesecke, JPCRD, 2017
+    double eta_tL = pow(rho_tL, 2.0/3.0) * sqrt(HEOS.gas_constant() * Tt) / (pow(HEOS.molar_mass(), 1.0/6.0) * 84446887.43579945);
+    // Eq. (8) from Laesecke, JPCRD, 2017
+    double residual = eta_tL * (c1 * Tr * pow(rhor, 3) + (pow(rhor, 2) + pow(rhor, gamma)) / (Tr - c2));
+    return residual;
+}
+
 CoolPropDbl TransportRoutines::viscosity_higher_order_friction_theory(HelmholtzEOSMixtureBackend& HEOS) {
     if (HEOS.is_pure_or_pseudopure) {
         CoolProp::ViscosityFrictionTheoryData& F = HEOS.components[0].transport.viscosity_higher_order.friction_theory;
@@ -581,6 +592,21 @@ CoolPropDbl TransportRoutines::viscosity_dilute_cyclohexane(HelmholtzEOSMixtureB
     CoolPropDbl S_eta = exp(-1.5093 + 364.87 / T - 39537 / pow(T, 2));  //[nm^2]
     return 0.19592 * sqrt(T) / S_eta / 1e6;                             //[Pa-s]
 }
+
+CoolPropDbl TransportRoutines::viscosity_dilute_CO2_LaeseckeJPCRD2017(HelmholtzEOSMixtureBackend& HEOS) {
+    // From Laesecke, JPRCD, 2016
+    double eta0, eta1, DELTAetar, den, Bstar;
+    double T = HEOS.T();
+
+    double a[] = {
+        1749.354893188350, -369.069300007128, 5423856.34887691, -2.21283852168356, -269503.247933569, 73145.021531826, 5.34368649509278};
+    
+    // Eq. (4) from Laesecke, JPRCD, 2016
+    den = a[0] + a[1] * pow(T, 1.0/6.0) + a[2] * exp(a[3] * pow(T, 1.0/3.0)) + (a[4] + a[5] * pow(T, 1.0/3.0)) / exp(pow(T, 1.0 / 3.0)) + a[6] * sqrt(T);
+    eta0 = 0.0010055 * sqrt(T) / den;  // [Pa-s]
+    return eta0;
+}
+
 CoolPropDbl TransportRoutines::viscosity_ethane_higher_order_hardcoded(HelmholtzEOSMixtureBackend& HEOS) {
     double r[] = {0, 1, 1, 2, 2, 2, 3, 3, 4, 4, 1, 1};
     double s[] = {0, 0, 1, 0, 1, 1.5, 0, 2, 0, 1, 0, 1};

--- a/src/Backends/Helmholtz/TransportRoutines.h
+++ b/src/Backends/Helmholtz/TransportRoutines.h
@@ -105,6 +105,8 @@ class TransportRoutines
 
     static CoolPropDbl viscosity_dilute_ethane(HelmholtzEOSMixtureBackend& HEOS);
     static CoolPropDbl viscosity_dilute_cyclohexane(HelmholtzEOSMixtureBackend& HEOS);
+    static CoolPropDbl viscosity_dilute_CO2_LaeseckeJPCRD2017(HelmholtzEOSMixtureBackend& HEOS);
+
 
     /** \brief Viscosity hardcoded for Methanol
      *
@@ -126,6 +128,7 @@ class TransportRoutines
     static CoolPropDbl viscosity_benzene_higher_order_hardcoded(HelmholtzEOSMixtureBackend& HEOS);
     static CoolPropDbl viscosity_hexane_higher_order_hardcoded(HelmholtzEOSMixtureBackend& HEOS);
     static CoolPropDbl viscosity_heptane_higher_order_hardcoded(HelmholtzEOSMixtureBackend& HEOS);
+    static CoolPropDbl viscosity_CO2_higher_order_hardcoded_LaeseckeJPCRD2017(HelmholtzEOSMixtureBackend& HEOS);
 
     /**
      * @brief Higher-order viscosity term from friction theory of Sergio Quinones-Cisneros


### PR DESCRIPTION
This may fix the broken python_cibuildwheel which works with older version of Cython.