### PR TITLE
Fix failing python_cibuildwheel workflows

### DIFF
--- a/.github/workflows/python_cibuildwheel.yml
+++ b/.github/workflows/python_cibuildwheel.yml
@@ -53,7 +53,8 @@ jobs:
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.9
         CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9 SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
-        CIBW_BEFORE_BUILD: pip install setuptools wheel Cython requests jinja2 pyyaml
+        CIBW_BEFORE_BUILD: >
+         pip install setuptools wheel "Cython<=3.0" requests jinja2 pyyaml
         CIBW_ENVIRONMENT_LINUX: COOLPROP_CMAKE=default,NATIVE
         CIBW_BUILD: cp${{ inputs.python-version }}-*
         CIBW_ARCHS_MACOS: ${{ inputs.arch }} # x86_64 arm64 # universal2 is redundant


### PR DESCRIPTION
This may fix the failing python_cibuildwheel workflows.
Changed to older Cython version to fix `cpdef` deprication.