### PR TITLE
Add fugacity functions needed for compatability with `CoolProp.jl` pkg

### DIFF
--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -369,6 +369,38 @@ EXPORT_CODE void CONVENTION AbstractState_get_mole_fractions_satState(const long
                                                                       const long maxN, long* N, long* errcode, char* message_buffer,
                                                                       const long buffer_length);
 /**
+     * @brief Return the fugacity of the i-th component of the mixture.
+     * @param handle The integer handle for the state class stored in memory
+     * @param i i-th component of the mixture
+     * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+     * @param message_buffer A buffer for the error code
+     * @param buffer_length The length of the buffer for the error code
+     * @return 
+     */
+EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+                                                         const long buffer_length);
+/**
+     * @brief Return the fugacity coefficient of the i-th component of the mixture.
+     * @param handle The integer handle for the state class stored in memory
+     * @param i i-th component of the mixture
+     * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+     * @param message_buffer A buffer for the error code
+     * @param buffer_length The length of the buffer for the error code
+     * @return 
+     */
+EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+                                                                      const long buffer_length);
+// TODO: update once the AbstractState_get_fugacity_coefficients function is verified to be correct
+// /**
+//      * @brief Return a vector of the fugacity coefficients for all components in the mixture.
+//      * @param handle The integer handle for the state class stored in memory
+//      * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+//      * @param message_buffer A buffer for the error code
+//      * @param buffer_length The length of the buffer for the error code
+//      * @return 
+//      */
+// EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficients(const long handle, long* errcode, char* message_buffer, const long buffer_length);
+/**
      * @brief Update the state of the AbstractState
      * @param handle The integer handle for the state class stored in memory
      * @param input_pair The integer value for the input pair obtained from XXXXXXXXXXXXXXXX

--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -377,7 +377,7 @@ EXPORT_CODE void CONVENTION AbstractState_get_mole_fractions_satState(const long
      * @param buffer_length The length of the buffer for the error code
      * @return 
      */
-EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, const long i, long* errcode, char* message_buffer,
                                                          const long buffer_length);
 /**
      * @brief Return the fugacity coefficient of the i-th component of the mixture.
@@ -388,18 +388,8 @@ EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, cons
      * @param buffer_length The length of the buffer for the error code
      * @return 
      */
-EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long handle, const long i, long* errcode, char* message_buffer,
                                                                       const long buffer_length);
-// TODO: update once the AbstractState_get_fugacity_coefficients function is verified to be correct
-// /**
-//      * @brief Return a vector of the fugacity coefficients for all components in the mixture.
-//      * @param handle The integer handle for the state class stored in memory
-//      * @param errcode The errorcode that is returned (0 = no error, !0 = error)
-//      * @param message_buffer A buffer for the error code
-//      * @param buffer_length The length of the buffer for the error code
-//      * @return 
-//      */
-// EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficients(const long handle, long* errcode, char* message_buffer, const long buffer_length);
 /**
      * @brief Update the state of the AbstractState
      * @param handle The integer handle for the state class stored in memory

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -604,8 +604,7 @@ EXPORT_CODE void CONVENTION AbstractState_get_mole_fractions_satState(const long
         HandleException(errcode, message_buffer, buffer_length);
     }
 }
-// TODO: verify this is correct
-EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, const long i, long* errcode, char* message_buffer,
                                                          const long buffer_length) {
     *errcode = 0;
     try {
@@ -616,8 +615,7 @@ EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, cons
     }
     return _HUGE;
 }
-// TODO: verify this is correct
-EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long handle, const long i, long* errcode, char* message_buffer,
                                                                     const long buffer_length) {
     *errcode = 0;
     try {
@@ -628,19 +626,6 @@ EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long 
     }
     return _HUGE;
 }
-// TODO: verify this is correct
-// Am I returning vectors correctly??
-// EXPORT_CODE vector<std::double> CONVENTION AbstractState_get_fugacity_coefficients(const long handle, const std::size_t i, long* errcode, char* message_buffer,
-//                                                                     const long buffer_length) {
-//     *errcode = 0;
-//     try {
-//         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
-//         return AS->fugacity_coefficients(i);
-//     } catch (...) {
-//         HandleException(errcode, message_buffer, buffer_length);
-//     }
-//     return _HUGE;
-// }
 EXPORT_CODE void CONVENTION AbstractState_update(const long handle, const long input_pair, const double value1, const double value2, long* errcode,
                                                  char* message_buffer, const long buffer_length) {
     *errcode = 0;

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -604,6 +604,43 @@ EXPORT_CODE void CONVENTION AbstractState_get_mole_fractions_satState(const long
         HandleException(errcode, message_buffer, buffer_length);
     }
 }
+// TODO: verify this is correct
+EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+                                                         const long buffer_length) {
+    *errcode = 0;
+    try {
+        shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
+        return AS->fugacity(i);
+    } catch (...) {
+        HandleException(errcode, message_buffer, buffer_length);
+    }
+    return _HUGE;
+}
+// TODO: verify this is correct
+EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+                                                                    const long buffer_length) {
+    *errcode = 0;
+    try {
+        shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
+        return AS->fugacity_coefficient(i);
+    } catch (...) {
+        HandleException(errcode, message_buffer, buffer_length);
+    }
+    return _HUGE;
+}
+// TODO: verify this is correct
+// Am I returning vectors correctly??
+// EXPORT_CODE vector<std::double> CONVENTION AbstractState_get_fugacity_coefficients(const long handle, const std::size_t i, long* errcode, char* message_buffer,
+//                                                                     const long buffer_length) {
+//     *errcode = 0;
+//     try {
+//         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
+//         return AS->fugacity_coefficients(i);
+//     } catch (...) {
+//         HandleException(errcode, message_buffer, buffer_length);
+//     }
+//     return _HUGE;
+// }
 EXPORT_CODE void CONVENTION AbstractState_update(const long handle, const long input_pair, const double value1, const double value2, long* errcode,
                                                  char* message_buffer, const long buffer_length) {
     *errcode = 0;

--- a/src/CoolPropLib.def
+++ b/src/CoolPropLib.def
@@ -15,6 +15,8 @@ EXPORTS
   AbstractState_update_and_1_out = _AbstractState_update_and_1_out@40
   AbstractState_update_and_5_out = _AbstractState_update_and_5_out@56
   AbstractState_update_and_common_out = _AbstractState_update_and_common_out@52
+  AbstractState_get_fugacity = _AbstractState_get_fugacity@20
+  AbstractState_get_fugacity_coefficient = _AbstractState_get_fugacity_coefficient@20
   F2K = _F2K@8
   HAProps = _HAProps@40
   HAPropsSI = _HAPropsSI@40

--- a/src/CoolPropLib.def
+++ b/src/CoolPropLib.def
@@ -15,8 +15,6 @@ EXPORTS
   AbstractState_update_and_1_out = _AbstractState_update_and_1_out@40
   AbstractState_update_and_5_out = _AbstractState_update_and_5_out@56
   AbstractState_update_and_common_out = _AbstractState_update_and_common_out@52
-  AbstractState_get_fugacity = _AbstractState_get_fugacity@20
-  AbstractState_get_fugacity_coefficient = _AbstractState_get_fugacity_coefficient@20
   F2K = _F2K@8
   HAProps = _HAProps@40
   HAPropsSI = _HAPropsSI@40


### PR DESCRIPTION
### Description of the Change

Fugacity lookups `get_fugacity`, `get_fugacity_coefficient`, and `get_fugacity_coefficients` cannot be wrapped with Julia functions as they currently are in this repo. This is in effort to enable using `CoolProp.jl` to return fugacity which is currently  a missing feature (an issue was created [here](https://github.com/CoolProp/CoolProp.jl/issues/31) in `CoolProp.jl`). 

### Benefits

Allows fugacity calls to be wrapped with Julia code directly in `CoolProp.jl`. We have found that using low-level Julia-wrapper commands is approximately 10x faster than using `Pycall` within Julia to call CoolProp low-level commands. This is a surmountable benefit when incorporating CoolProp calls with iterative numerical models of fluid systems within the Julia language that require fugacity lookups.

### Possible Drawbacks

Unsure of any possible drawbacks.

### Verification Process

TODO: 
- [x] test that the C++ package works
- [ ] test that the envisioned CoolProp.jl Julia wrapper functions work properly with the new C++ code

### Applicable Issues

Closes #2284 

