### PR TITLE
Google Apps Scipts function and python flask api.

### DIFF
--- a/wrappers/GoogleAppsScript/Code.js
+++ b/wrappers/GoogleAppsScript/Code.js
@@ -1,0 +1,72 @@
+function PropsSI(output,property_1,value_1,property_2,value_2,fluid, opt_url) {
+
+  /* This function fetches the state property for a fluid from the web api
+
+  Args:
+  output: str, name of the output property
+  property_1: str, name of the first input property
+  value_1: float, value of the first input property
+  property_2: str, name of the second input property
+  value_2: float, value of the second input property
+  fluid: str, name of the fluid
+  opt_url: str optional, url of the web api
+
+  Returns:
+  float, value of the state property
+  
+  */
+
+  if (opt_url==null) {
+    var baseUrl = "https://qnikil7.pythonanywhere.com"
+  } else {
+    var baseUrl = opt_url
+  }
+  
+  functionName = "PropsSI"
+
+  var requestString = baseUrl + '/' + functionName + '/' + output + '/' + property_1 + '/' + value_1 + '/' + property_2 + '/' + value_2 + '/' + fluid ;
+
+  var response = UrlFetchApp.fetch(requestString, {muteHttpExceptions: true});
+
+  var responseData = JSON.parse(response.getContentText());
+
+  return responseData;
+  
+}
+
+function HAPropsSI(output,property_1,value_1,property_2,value_2, property_3,value_3, opt_url) {
+
+  /* This function fetches the humid air state property from the web api
+
+  Args:
+  output: str, name of the output property
+  property_1: str, name of the first input property
+  value_1: float, value of the first input property
+  property_2: str, name of the second input property
+  value_2: float, value of the second input property
+  property_3: str, name of the third input property
+  value_3: float, value of the third input property
+  opt_url: str optional, url of the web api
+
+  Returns:
+  float, value of the state property
+
+  */
+
+  if (opt_url==null) {
+    var baseUrl = "https://qnikil7.pythonanywhere.com"
+  } else {
+    var baseUrl = opt_url
+  }
+  
+  functionName = "HAPropsSI"
+
+  var requestString = baseUrl + '/' + functionName + '/' + output + '/' + property_1 + '/' + value_1 + '/' + property_2 + '/' + value_2 + '/' + property_3 + '/' + value_3 ;
+
+  var response = UrlFetchApp.fetch(requestString, {muteHttpExceptions: true});
+
+  var responseData = JSON.parse(response.getContentText());
+
+  return responseData;
+  
+}

--- a/wrappers/GoogleAppsScript/README.md
+++ b/wrappers/GoogleAppsScript/README.md
@@ -1,0 +1,5 @@
+# Google appscript addin for CoolProp
+
+A web application created using in python using flask is hosted (currently for testing in Python Anywhere), the google Apps script calls this using an api.
+
+Google sheet [link](https://docs.google.com/spreadsheets/d/1vU6Hx7oFZxdVOvrh6zusoLPGNxDD-TWY5mbbEt8bUOU/edit#gid=0) to test the function. 

--- a/wrappers/GoogleAppsScript/flaskapi.py
+++ b/wrappers/GoogleAppsScript/flaskapi.py
@@ -1,0 +1,27 @@
+from flask import Flask
+from flask_restful import Api, Resource
+import CoolProp as cp
+
+app = Flask(__name__)
+api = Api(app)
+
+class PropsSI(Resource):
+    def get(self, output, property_1, value_1, property_2, value_2,  fluid):
+        output_value = cp.CoolProp.PropsSI(output, property_1, float(value_1), property_2, float(value_2), fluid)
+        return output_value
+
+class HAPropsSI(Resource):
+    def get(self, output, property_1, value_1, property_2, value_2, property_3, value_3):
+        output_value = cp.HumidAirProp.HAPropsSI(output, property_1, float(value_1), property_2, float(value_2), property_3, float(value_3))
+        return output_value
+    
+@app.route('/')
+def index():
+    return 'CoolProp API'
+
+api.add_resource(PropsSI, '/PropsSI/<output>/<property_1>/<value_1>/<property_2>/<value_2>/<fluid>')
+api.add_resource(HAPropsSI, '/HAPropsSI/<output>/<property_1>/<value_1>/<property_2>/<value_2>/<property_3>/<value_3>')
+
+if __name__ == '__main__':
+    app.run()
+    

--- a/wrappers/GoogleAppsScript/test_api.py
+++ b/wrappers/GoogleAppsScript/test_api.py
@@ -1,0 +1,50 @@
+import requests
+
+# local url
+# base_url = "http://127.0.0.1:5000"
+
+base_url = "https://qnikil7.pythonanywhere.com"
+
+# Test PropsSI
+function = 'PropsSI'
+output = 'D'
+property_1 = 'T'
+value_1 = 298.15
+property_2 = 'P'
+value_2 = 100e5
+fluid = 'CO2'
+
+string = base_url + '/' + function + '/' + output + '/' + property_1 + '/' + str(value_1) + '/' + property_2 + '/' + str(value_2) + '/' + fluid
+
+response = requests.get(string)
+
+print(response.json())
+
+"""
+Density of carbon dioxide at 100 bar and 25C
+PropsSI('D', 'T', 298.15, 'P', 100e5, 'CO2')
+Out[3]: 817.6273812375758
+"""
+
+# Test HAPropsSI
+function = 'HAPropsSI'
+output = 'H'
+property_1 = 'T'
+value_1 = 298.15
+property_2 = 'P'
+value_2 = 101325
+property_3 = 'R'
+value_3 = 0.5
+
+string = base_url + '/' + function + '/' + output + '/' + property_1 + '/' + str(value_1) + '/' + property_2 + '/' + str(value_2) + '/' + property_3 + '/' + str(value_3)
+
+response = requests.get(string)
+
+print(response.json())
+
+"""
+Enthalpy (J per kg dry air) as a function of temperature, pressure,
+   and relative humidity at STP
+h = HAPropsSI('H','T',298.15,'P',101325,'R',0.5); print(h)
+Out[4]: 50423.45039107799
+"""


### PR DESCRIPTION
### Description of the Change

Coolprop for google sheets.

I wanted to use coolprop in google sheets and wasn't able to find a way to call shared libraries in google sheet. So this is an alternate approach.

I have created a web app in python using flask which which is called through an api from google sheets using GET. I have hosted this currently in python anywhere. Link for [google sheet.](https://docs.google.com/spreadsheets/d/1vU6Hx7oFZxdVOvrh6zusoLPGNxDD-TWY5mbbEt8bUOU/edit#gid=0)

Currently I have added only PropsSI and HAPropsSI functions.

### Benefits

Use CoolProp in google sheets.

### Possible Drawbacks

Sometimes the functions are slow to load.

### Verification Process

- There is a google sheet that demonstrates the functionality.
- The google sheets have the https links to get the values.
- test_api script to verify the values.

### Applicable Issues

- Probably calling a shared library using Apps Script (If possible) would be preferred.
- If there is interest in this, probably hosting it somewhere and creating an addin in google workspace.
- Also I selected python flask based on ease of use but may not be the most efficient.