### PR TITLE
Added second_partial_deriv and  first_two_phase_deriv

### DIFF
--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -463,6 +463,37 @@ EXPORT_CODE double CONVENTION AbstractState_first_partial_deriv(const long handl
                                                                 char* message_buffer, const long buffer_length);
 
 /**
+    * @brief Calculate the second partial derivative in homogeneous phases from the AbstractState using integer values for the desired parameters
+    * @param handle The integer handle for the state class stored in memory
+    * @param Of1 The parameter of which the derivative is being taken
+    * @param Wrt1 The parameter that the derivative is taken with respect to in the first derivative 
+    * @param Constant1 The parameter that is held constant in the first derivative 
+    * @param Wrt2 The parameter that the derivative is taken with respect to in the second derivative 
+    * @param Constant2 The parameter that is held constant in the second derivative 
+    * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+    * @param message_buffer A buffer for the error code
+    * @param buffer_length The length of the buffer for the error code
+    * @return
+    */
+
+EXPORT_CODE double CONVENTION AbstractState_second_partial_deriv(const long handle, const long Of1, const long Wrt1, const long Constant1,
+                                                                 const long Wrt2, const long Constant2, long* errcode, char* message_buffer,
+                                                                 const long buffer_length);
+/**
+    * @brief Calculate the first partial derivative in homogeneous phases from the AbstractState using integer values for the desired parameters
+    * @param handle The integer handle for the state class stored in memory
+    * @param Of The parameter of which the derivative is being taken
+    * @param Wrt The derivative with with respect to this parameter
+    * @param Constant The parameter that is not affected by the derivative
+    * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+    * @param message_buffer A buffer for the error code
+    * @param buffer_length The length of the buffer for the error code
+    * @return
+    */
+EXPORT_CODE double CONVENTION AbstractState_first_two_phase_deriv(const long handle, const long Of, const long Wrt, const long Constant,
+                                                                  long* errcode, char* message_buffer, const long buffer_length);
+
+/**
     * @brief Update the state of the AbstractState and get an output value five common outputs (temperature, pressure, molar density, molar enthalpy and molar entropy)
     * @brief from the AbstractState using pointers as inputs and output to allow array computation.
     * @param handle The integer handle for the state class stored in memory

--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -476,9 +476,44 @@ EXPORT_CODE double CONVENTION AbstractState_first_partial_deriv(const long handl
     * @return
     */
 
+EXPORT_CODE double CONVENTION AbstractState_second_two_phase_deriv(const long handle, const long Of1, const long Wrt1, const long Constant1,
+                                                                 const long Wrt2, const long Constant2, long* errcode, char* message_buffer,
+                                                                 const long buffer_length);
+/**
+    * @brief Calculate the second partial derivative int two-phase region from the AbstractState using integer values for the desired parameters
+    * @param handle The integer handle for the state class stored in memory
+    * @param Of1 The parameter of which the derivative is being taken
+    * @param Wrt1 The parameter that the derivative is taken with respect to in the first derivative 
+    * @param Constant1 The parameter that is held constant in the first derivative 
+    * @param Wrt2 The parameter that the derivative is taken with respect to in the second derivative 
+    * @param Constant2 The parameter that is held constant in the second derivative 
+    * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+    * @param message_buffer A buffer for the error code
+    * @param buffer_length The length of the buffer for the error code
+    * @return
+    */
+
 EXPORT_CODE double CONVENTION AbstractState_second_partial_deriv(const long handle, const long Of1, const long Wrt1, const long Constant1,
                                                                  const long Wrt2, const long Constant2, long* errcode, char* message_buffer,
                                                                  const long buffer_length);
+
+/**
+    * @brief Calculate the first partial derivative in two-phase region with Spline - Approach from the AbstractState using integer values for the desired parameters
+    Spline Approach "Methods to Increase the Robustness of Finite-Volume FlowModels in Thermodynamic Systems: Sylvain Quoilin, Ian Bell, Adriano Desideri, Pierre Dewallef and Vincent Lemort"
+    * @param handle The integer handle for the state class stored in memory
+    * @x_end constant parameter for defining range of the spline, (usually 0.1 is used, 0..1 is possible)
+    * @param Of The parameter of which the derivative is being taken
+    * @param Wrt The derivative with with respect to this parameter
+    * @param Constant The parameter that is not affected by the derivative
+    * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+    * @param message_buffer A buffer for the error code
+    * @param buffer_length The length of the buffer for the error code
+    * @return
+    */
+
+
+EXPORT_CODE double CONVENTION AbstractState_first_two_phase_deriv_splined(const long handle, const long Of, const long Wrt, const long Constant,
+                                                                  const double x_end,long* errcode, char* message_buffer, const long buffer_length);
 /**
     * @brief Calculate the first partial derivative in homogeneous phases from the AbstractState using integer values for the desired parameters
     * @param handle The integer handle for the state class stored in memory
@@ -490,9 +525,9 @@ EXPORT_CODE double CONVENTION AbstractState_second_partial_deriv(const long hand
     * @param buffer_length The length of the buffer for the error code
     * @return
     */
+
 EXPORT_CODE double CONVENTION AbstractState_first_two_phase_deriv(const long handle, const long Of, const long Wrt, const long Constant,
                                                                   long* errcode, char* message_buffer, const long buffer_length);
-
 /**
     * @brief Update the state of the AbstractState and get an output value five common outputs (temperature, pressure, molar density, molar enthalpy and molar entropy)
     * @brief from the AbstractState using pointers as inputs and output to allow array computation.

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -707,6 +707,21 @@ EXPORT_CODE double CONVENTION AbstractState_second_partial_deriv(const long hand
     return _HUGE;
 }
 
+EXPORT_CODE double CONVENTION AbstractState_second_two_phase_deriv(const long handle, const long Of1, const long Wrt1, const long Constant1,
+                                                                 const long Wrt2, const long Constant2, long* errcode, char* message_buffer,
+                                                                 const long buffer_length) {
+    *errcode = 0;
+    try {
+        shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
+        return AS->second_two_phase_deriv(static_cast<CoolProp::parameters>(Of1), static_cast<CoolProp::parameters>(Wrt1),
+                                        static_cast<CoolProp::parameters>(Constant1), static_cast<CoolProp::parameters>(Wrt2),
+                                        static_cast<CoolProp::parameters>(Constant2));
+    } catch (...) {
+        HandleException(errcode, message_buffer, buffer_length);
+    }
+    return _HUGE;
+}
+
 EXPORT_CODE double CONVENTION AbstractState_first_two_phase_deriv(const long handle, const long Of, const long Wrt, const long Constant,
                                                                   long* errcode, char* message_buffer, const long buffer_length) {
     *errcode = 0;
@@ -719,6 +734,21 @@ EXPORT_CODE double CONVENTION AbstractState_first_two_phase_deriv(const long han
     }
     return _HUGE;
 }
+
+EXPORT_CODE double CONVENTION AbstractState_first_two_phase_deriv_splined(const long handle, const long Of, const long Wrt, const long Constant,
+                                                                          const double x_end, long* errcode, char* message_buffer,
+                                                                          const long buffer_length) {
+    *errcode = 0;
+    try {
+        shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
+        return AS->first_two_phase_deriv_splined(static_cast<CoolProp::parameters>(Of), static_cast<CoolProp::parameters>(Wrt),
+                                                 static_cast<CoolProp::parameters>(Constant), x_end);
+    } catch (...) {
+        HandleException(errcode, message_buffer, buffer_length);
+    }
+    return _HUGE;
+}
+
 
 EXPORT_CODE void CONVENTION AbstractState_update_and_common_out(const long handle, const long input_pair, const double* value1, const double* value2,
                                                                 const long length, double* T, double* p, double* rhomolar, double* hmolar,

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -692,6 +692,34 @@ EXPORT_CODE double CONVENTION AbstractState_first_partial_deriv(const long handl
     return _HUGE;
 }
 
+EXPORT_CODE double CONVENTION AbstractState_second_partial_deriv(const long handle, const long Of1, const long Wrt1, const long Constant1,
+                                                                 const long Wrt2, const long Constant2, long* errcode, char* message_buffer,
+                                                                 const long buffer_length) {
+    *errcode = 0;
+    try {
+        shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
+        return AS->second_partial_deriv(static_cast<CoolProp::parameters>(Of1), static_cast<CoolProp::parameters>(Wrt1),
+                                        static_cast<CoolProp::parameters>(Constant1), static_cast<CoolProp::parameters>(Wrt2),
+                                        static_cast<CoolProp::parameters>(Constant2));
+    } catch (...) {
+        HandleException(errcode, message_buffer, buffer_length);
+    }
+    return _HUGE;
+}
+
+EXPORT_CODE double CONVENTION AbstractState_first_two_phase_deriv(const long handle, const long Of, const long Wrt, const long Constant,
+                                                                  long* errcode, char* message_buffer, const long buffer_length) {
+    *errcode = 0;
+    try {
+        shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
+        return AS->first_two_phase_deriv(static_cast<CoolProp::parameters>(Of), static_cast<CoolProp::parameters>(Wrt),
+                                         static_cast<CoolProp::parameters>(Constant));
+    } catch (...) {
+        HandleException(errcode, message_buffer, buffer_length);
+    }
+    return _HUGE;
+}
+
 EXPORT_CODE void CONVENTION AbstractState_update_and_common_out(const long handle, const long input_pair, const double* value1, const double* value2,
                                                                 const long length, double* T, double* p, double* rhomolar, double* hmolar,
                                                                 double* smolar, long* errcode, char* message_buffer, const long buffer_length) {

--- a/src/CoolPropLib.def
+++ b/src/CoolPropLib.def
@@ -10,6 +10,8 @@ EXPORTS
   AbstractState_update = _AbstractState_update@36
   AbstractState_first_saturation_deriv = _AbstractState_first_saturation_deriv@24
   AbstractState_first_partial_deriv = _AbstractState_first_partial_deriv@28
+  AbstractState_second_partial_deriv = _AbstractState_second_partial_deriv@28
+  AbstractState_first_two_phase_deriv= _AbstractState_first_two_phase_deriv@28 
   AbstractState_specify_phase = _AbstractState_specify_phase@20
   AbstractState_unspecify_phase = _AbstractState_unspecify_phase@16
   AbstractState_update_and_1_out = _AbstractState_update_and_1_out@40

--- a/src/CoolPropLib.def
+++ b/src/CoolPropLib.def
@@ -11,7 +11,9 @@ EXPORTS
   AbstractState_first_saturation_deriv = _AbstractState_first_saturation_deriv@24
   AbstractState_first_partial_deriv = _AbstractState_first_partial_deriv@28
   AbstractState_second_partial_deriv = _AbstractState_second_partial_deriv@28
-  AbstractState_first_two_phase_deriv= _AbstractState_first_two_phase_deriv@28 
+  AbstractState_second_two_phase_deriv = _AbstractState_second_two_phase_deriv@28
+  AbstractState_first_two_phase_deriv= _AbstractState_first_two_phase_deriv@28
+  AbstractState_first_two_phase_deriv_splined= _AbstractState_first_two_phase_deriv_splined@28 
   AbstractState_specify_phase = _AbstractState_specify_phase@20
   AbstractState_unspecify_phase = _AbstractState_unspecify_phase@16
   AbstractState_update_and_1_out = _AbstractState_update_and_1_out@40


### PR DESCRIPTION
### Description of the Change

Files Modified: CoolPropLib.cpp, CoolPropLib.h,  CoolPropLib.def

Changes:
* Added AbstratState_second_partial_deriv Function:
        Location: Added in CoolPropLib.cpp
        Description: The AbstratState_second_partial_deriv function calculates the second partial derivative and is already implemented in AbstractState.cpp so I only had to implement it to the CoolPropLib.

* Added AbstractState_first_two_phase_deriv Function:
        Location: Added in CoolPropLib.cpp
        Description: The first_two_phase_deriv function calculates the first derivative in a two-phase region of a thermodynamic and is already implemented in AbstractState.cpp so I only had to implement it to the CoolPropLib.

* Header File Updates:
        File: CoolPropLib.h
        Changes: Added functions and docstrings for second_partial_deriv and first_two_phase_deriv.

* Export Definitions:
        File: CoolPropLib.def
        Changes: Included the new function names to the list of exports to make them accessible when using the DLL.


### Benefits


* Starting now, the already implemented functions AbstractState_second_partial_deriv and AbstractState_first_two_phase_deriv are usable in the DLL. 

### Possible Drawbacks

Due to the fact, that I only linked existing and already tested functions to CoolProp.dll I don't aspect any drawbacks. 
* For AbstractState_second_partial_deriv:

    Drawbacks: Not known.

*  For AbstractState_first_two_phase_deriv:

    Drawbacks: Likely to work only with HEOS Backend, not with REFPROP Backend. 

### Verification Process

I used a self builded Wrapper in C++ to query data from CoolProp and compared the results to Coolprop using Python.  
If more Information are needed, feel free to contact me. 

### Applicable Issues
The Issues, could be closed if this PR is accepted. 
https://github.com/CoolProp/CoolProp/issues/2226 
