### PR TITLE
App name change: CuadernoDeProblemas -> pSolver, Update index.rst

### DIFF
--- a/Web/index.rst
+++ b/Web/index.rst
@@ -69,7 +69,7 @@ Projects Using CoolProp
 * `T-Props <https://play.google.com/store/apps/details?id=com.innoversetech.tprops>`_
 * `PropiedadesDeFluidos <https://personal.us.es/jfc/PropiedadesDeFluidos/descripcion/>`_ (FluidProperties)
 * `CoolPropJavascriptDemo <https://github.com/dvd101x/CoolPropJavascriptDemo>`_
-* `CuadernoDeProblemas <https://personal.us.es/jfc/CuadernoDeProblemas/>`_ (ProblemNotebook)
+* `pSolver <https://personal.us.es/jfc/pSolver/docs/index.html>`_
 
 Main Developers
 ---------------


### PR DESCRIPTION
We have changed the name of the app

CuadernoDeProblemas -> pSolver.

pSolver can be used on English and Spanish



### Description of the Change

Updating the reference to the app

### Benefits

Update the links

### Possible Drawbacks

None

### Verification Process

New links verified

