### PR TITLE
Addition of EoS JSON of R1336mzz(E) from Akasaka-IJT-2023

### DIFF
--- a/CoolPropBibTeXLibrary.bib
+++ b/CoolPropBibTeXLibrary.bib
@@ -104,6 +104,18 @@
   Timestamp                = {2013.04.10}
 }
 
+@Article{Akasaka-IJT-2023,
+  Title                    = {{A Helmholtz Energy Equation of State for trans-1,1,1,4,4,4-Hexafluoro-2-butene [R-1336mzz(E)]}},
+  Author                   = {Ryo Akasaka and Marcia L. Huber and Luke Simoni and Eric W. Lemmon},
+  Journal                  = {International Journal of Thermophysics},
+  Year                     = {2023},
+  Pages                    = {1003-1013},
+  Volume                   = {44},
+
+  Doi                      = {10.1007/s10765-022-03143-5},
+  Timestamp                = {2023.10.24}
+}
+
 @Article{Akasaka-JPCRD-2015-R245fa,
   Title                    = {{A Fundamental Equation of State for 1,1,1,3,3-Pentafluoropropane (R-245fa)}},
   Author                   = {Ryo Akasaka and Yong Zhou and Eric W. Lemmon},

--- a/dev/fluids/R1336mzz(E).json
+++ b/dev/fluids/R1336mzz(E).json
@@ -67,7 +67,7 @@
   "EOS": [
     {
       "BibTeX_CP0": "",
-      "BibTeX_EOS": "XXX-X-XXXX",
+      "BibTeX_EOS": "Akasaka-IJT-2023",
       "STATES": {
         "reducing": {
           "T": 403.53,

--- a/dev/fluids/R1336mzz(E).json
+++ b/dev/fluids/R1336mzz(E).json
@@ -88,7 +88,7 @@
           "hmolar_units": "J/mol",
           "p": 649.2750000000001,
           "p_units": "Pa",
-          "rhomolar": 9999999999999999,
+          "rhomolar": 5681.7471741845075,
           "rhomolar_units": "mol/m^3",
           "smolar": 99999999999999999999,
           "smolar_units": "J/mol/K"
@@ -100,7 +100,7 @@
           "hmolar_units": "J/mol",
           "p": 649.2750000000001,
           "p_units": "Pa",
-          "rhomolar": 99999999999999,
+          "rhomolar": 1e-10,
           "rhomolar_units": "mol/m^3",
           "smolar": 9999999999999999999,
           "smolar_units": "J/mol/K"
@@ -309,7 +309,7 @@
       "hmolar_units": "J/mol",
       "p": 649.2750000000001,
       "p_units": "Pa",
-      "rhomolar": 9999999999999999,
+      "rhomolar": 5681.7471741845075,
       "rhomolar_units": "mol/m^3",
       "smolar": 99999999999999999999,
       "smolar_units": "J/mol/K"
@@ -321,7 +321,7 @@
       "hmolar_units": "J/mol",
       "p": 649.2750000000001,
       "p_units": "Pa",
-      "rhomolar": 99999999999999,
+      "rhomolar": 1e-10,
       "rhomolar_units": "mol/m^3",
       "smolar": 9999999999999999999,
       "smolar_units": "J/mol/K"

--- a/dev/fluids/R1336mzz(E).json
+++ b/dev/fluids/R1336mzz(E).json
@@ -1,0 +1,330 @@
+{
+  "ANCILLARIES": {
+    "pS": {
+      "T_r": 403.53,
+      "Tmax": 403.53,
+      "Tmin": 0.0,
+      "description": "P=Pc*EXP[SUM(Ni*Theta^ti)*Tc/T]",
+      "n": [
+        -8.2611,
+        3.9076,
+        -3.9675,
+        -6.1565
+      ],
+      "reducing_value": 2779000.0,
+      "t": [
+        1.0,
+        1.5,
+        1.88,
+        4.47
+      ],
+      "type": "pL",
+      "using_tau_r": true
+    },
+    "rhoL": {
+      "T_r": 403.53,
+      "Tmax": 403.53,
+      "Tmin": 0.0,
+      "description": "D=Dc*[1+SUM(Ni*Theta^ti)]",
+      "n": [
+        2.1958,
+        6.4706,
+        -13.191,
+        7.7906
+      ],
+      "reducing_value": 3129.0,
+      "t": [
+        0.347,
+        1.42,
+        1.82,
+        2.232
+      ],
+      "type": "rhoLnoexp",
+      "using_tau_r": false
+    },
+    "rhoV": {
+      "T_r": 403.53,
+      "Tmax": 403.53,
+      "Tmin": 0.0,
+      "description": "D=Dc*EXP[SUM(Ni*Theta^ti)]",
+      "n": [
+        -3.1511,
+        -9.2173,
+        -32.976,
+        -86.791
+      ],
+      "reducing_value": 3129.0,
+      "t": [
+        0.387,
+        1.34,
+        3.77,
+        7.85
+      ],
+      "type": "rhoV",
+      "using_tau_r": false
+    }
+  },
+  "EOS": [
+    {
+      "BibTeX_CP0": "",
+      "BibTeX_EOS": "XXX-X-XXXX",
+      "STATES": {
+        "reducing": {
+          "T": 403.53,
+          "T_units": "K",
+          "hmolar": -99999999999,
+          "hmolar_units": "J/mol",
+          "p": 2779000.0,
+          "p_units": "Pa",
+          "rhomolar": 3129.0,
+          "rhomolar_units": "mol/m^3",
+          "smolar": 999999999999999,
+          "smolar_units": "J/mol/K"
+        },
+        "sat_min_liquid": {
+          "T": 200.15,
+          "T_units": "K",
+          "hmolar": -999999999999,
+          "hmolar_units": "J/mol",
+          "p": 649.2750000000001,
+          "p_units": "Pa",
+          "rhomolar": 9999999999999999,
+          "rhomolar_units": "mol/m^3",
+          "smolar": 99999999999999999999,
+          "smolar_units": "J/mol/K"
+        },
+        "sat_min_vapor": {
+          "T": 200.15,
+          "T_units": "K",
+          "hmolar": 9999999999999,
+          "hmolar_units": "J/mol",
+          "p": 649.2750000000001,
+          "p_units": "Pa",
+          "rhomolar": 99999999999999,
+          "rhomolar_units": "mol/m^3",
+          "smolar": 9999999999999999999,
+          "smolar_units": "J/mol/K"
+        }
+      },
+      "T_max": 410.0,
+      "T_max_units": "K",
+      "Ttriple": 200.15,
+      "Ttriple_units": "K",
+      "acentric": 0.413,
+      "acentric_units": "-",
+      "alpha0": [
+        {
+          "a1": 0.0,
+          "a2": 0.0,
+          "type": "IdealGasHelmholtzLead"
+        },
+        {
+          "a": 3.0,
+          "type": "IdealGasHelmholtzLogTau"
+        },
+        {
+          "n": [
+            -17.583859885194016,
+            11.524417012948918
+          ],
+          "t": [
+            0.0,
+            1.0
+          ],
+          "type": "IdealGasHelmholtzPower"
+        },
+        {
+          "n": [
+            15.891,
+            14.143
+          ],
+          "t": [
+            1.3629717740936238,
+            8.609025351275
+          ],
+          "type": "IdealGasHelmholtzPlanckEinstein"
+        }
+      ],
+      "alphar": [
+        {
+          "d": [
+            4.0,
+            1.0,
+            1.0,
+            2.0,
+            3.0,
+            1.0,
+            3.0,
+            2.0,
+            2.0,
+            7.0
+          ],
+          "l": [
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            2.0,
+            2.0,
+            1.0,
+            2.0,
+            1.0
+          ],
+          "n": [
+            0.08297005,
+            1.1213658,
+            -2.0279038680756,
+            -0.3486706213113,
+            0.13227952,
+            -1.3751844,
+            -1.3939029,
+            0.11190839,
+            -0.90635088,
+            -0.050014594
+          ],
+          "t": [
+            1.0,
+            0.117,
+            1.0,
+            1.0,
+            0.413,
+            2.44,
+            2.51,
+            0.535,
+            1.927,
+            1.186
+          ],
+          "type": "ResidualHelmholtzPower"
+        },
+        {
+          "beta": [
+            1.237,
+            0.384,
+            1.24,
+            0.46,
+            1.326
+          ],
+          "d": [
+            1.0,
+            1.0,
+            3.0,
+            2.0,
+            2.0
+          ],
+          "epsilon": [
+            1.23,
+            0.751,
+            0.522,
+            0.32,
+            1.22
+          ],
+          "eta": [
+            1.234,
+            1.34,
+            1.13,
+            1.15,
+            1.3
+          ],
+          "gamma": [
+            1.21,
+            2.0,
+            1.216,
+            2.27,
+            1.26
+          ],
+          "n": [
+            1.7953748,
+            2.0579712,
+            -1.0433081,
+            -1.2459808,
+            -0.49712249
+          ],
+          "t": [
+            0.876,
+            1.23,
+            0.875,
+            0.5181,
+            0.86
+          ],
+          "type": "ResidualHelmholtzGaussian"
+        }
+      ],
+      "gas_constant": 8.314462618,
+      "gas_constant_units": "J/mol/K",
+      "molar_mass": 0.1640491,
+      "molar_mass_units": "kg/mol",
+      "p_max": 5700000.0,
+      "p_max_units": "Pa",
+      "pseudo_pure": false
+    }
+  ],
+  "INFO": {
+    "2DPNG_URL": "http://www.chemspider.com/ImagesHandler.ashx?id=-1",
+    "ALIASES": [
+      "(E)-1,1,1,4,4,4-HEXAFLUORO-2-BUTENE",
+      "r1336mzz(e)",
+      "R1336mzz(E)",
+      "(E)-1,1,1,4,4,4-Hexafluoro-2-butene",
+      "R1336MZZ(E)",
+      "(e)-1,1,1,4,4,4-hexafluoro-2-butene"
+    ],
+    "CAS": "66711-86-2",
+    "CHEMSPIDER_ID": -1,
+    "ENVIRONMENTAL": {
+      "ASHRAE34": "A1",
+      "FH": 0,
+      "GWP100": 1.0,
+      "GWP20": 0.0,
+      "GWP500": 0.0,
+      "HH": 0,
+      "Name": "R1336MZZE",
+      "ODP": 0.0,
+      "PH": 1e+30
+    },
+    "FORMULA": "C_{4}H_{2}F_{6}",
+    "INCHI_KEY": "NLOLSXYRJFEOTA-OWOJBTEDSA-N",
+    "INCHI_STRING": "InChI=1S/C4H2F6/c5-3(6,7)1-2-4(8,9)10/h1-2H/b2-1+",
+    "NAME": "R1336MZZE",
+    "REFPROP_NAME": "R1336MZZE",
+    "SMILES": "?"
+  },
+  "STATES": {
+    "critical": {
+      "T": 403.53,
+      "T_units": "K",
+      "hmolar": -99999999999,
+      "hmolar_units": "J/mol",
+      "p": 2779000.0,
+      "p_units": "Pa",
+      "rhomolar": 3129.0,
+      "rhomolar_units": "mol/m^3",
+      "smolar": 999999999999999,
+      "smolar_units": "J/mol/K"
+    },
+    "triple_liquid": {
+      "T": 200.15,
+      "T_units": "K",
+      "hmolar": -999999999999,
+      "hmolar_units": "J/mol",
+      "p": 649.2750000000001,
+      "p_units": "Pa",
+      "rhomolar": 9999999999999999,
+      "rhomolar_units": "mol/m^3",
+      "smolar": 99999999999999999999,
+      "smolar_units": "J/mol/K"
+    },
+    "triple_vapor": {
+      "T": 200.15,
+      "T_units": "K",
+      "hmolar": 9999999999999,
+      "hmolar_units": "J/mol",
+      "p": 649.2750000000001,
+      "p_units": "Pa",
+      "rhomolar": 99999999999999,
+      "rhomolar_units": "mol/m^3",
+      "smolar": 9999999999999999999,
+      "smolar_units": "J/mol/K"
+    }
+  }
+}


### PR DESCRIPTION
As requested in Issues #2127 and #2307, this pull request aims to add R1336mzz(E) to the list of fluids of CoolProp.

I added the JSON file of the supplementary information zip-file from Akasaka-IJT-2023 (https://doi.org/10.1007/s10765-022-03143-5) in the fluids directory. Then i created the corresponding BibTeX entry and referenced it in the JSON file at parameter "BibTeX_EOS".

Please let me know, if there is anything else to do in order to complete the addition of R1336mzz(E).
