### PR TITLE
New C Interface Functions

### DIFF
--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -801,4 +801,11 @@ EXPORT_CODE double CONVENTION Props(const char* Output, const char Name1, double
     */
 EXPORT_CODE double CONVENTION Props1(const char* FluidName, const char* Output);
 
+EXPORT_CODE void CONVENTION AbstractState_fluid_param_string(const long handle, const char*const param, char *return_buffer, const long return_buffer_length, long *errcode, char *message_buffer, const long buffer_length);
+EXPORT_CODE long long CONVENTION AbstractState_phase(const long handle, long *errcode, char *message_buffer, const long buffer_length);
+EXPORT_CODE double CONVENTION AbstractState_saturated_liquid_keyed_output(const long handle, const long param, long *errcode, char *message_buffer, const long buffer_length);
+EXPORT_CODE double CONVENTION AbstractState_saturated_vapor_keyed_output(const long handle, const long param, long *errcode, char *message_buffer, const long buffer_length);
+EXPORT_CODE int CONVENTION C_is_valid_fluid_string(const char* const fluidName);
+EXPORT_CODE int CONVENTION C_extract_backend(const char* const fluid_string, char* backend, const long backend_length, char* fluid, const long fluid_length);
+
 #endif

--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -801,11 +801,11 @@ EXPORT_CODE double CONVENTION Props(const char* Output, const char Name1, double
     */
 EXPORT_CODE double CONVENTION Props1(const char* FluidName, const char* Output);
 
-EXPORT_CODE void CONVENTION AbstractState_fluid_param_string(const long handle, const char*const param, char *return_buffer, const long return_buffer_length, long *errcode, char *message_buffer, const long buffer_length);
-EXPORT_CODE long long CONVENTION AbstractState_phase(const long handle, long *errcode, char *message_buffer, const long buffer_length);
+EXPORT_CODE void CONVENTION AbstractState_fluid_param_string(const long handle, const char* param, char *return_buffer, const long return_buffer_length, long *errcode, char *message_buffer, const long buffer_length);
+EXPORT_CODE int CONVENTION AbstractState_phase(const long handle, long *errcode, char *message_buffer, const long buffer_length);
 EXPORT_CODE double CONVENTION AbstractState_saturated_liquid_keyed_output(const long handle, const long param, long *errcode, char *message_buffer, const long buffer_length);
 EXPORT_CODE double CONVENTION AbstractState_saturated_vapor_keyed_output(const long handle, const long param, long *errcode, char *message_buffer, const long buffer_length);
-EXPORT_CODE int CONVENTION C_is_valid_fluid_string(const char* const fluidName);
-EXPORT_CODE int CONVENTION C_extract_backend(const char* const fluid_string, char* backend, const long backend_length, char* fluid, const long fluid_length);
+EXPORT_CODE int CONVENTION C_is_valid_fluid_string(const char* fluidName);
+EXPORT_CODE int CONVENTION C_extract_backend(const char* fluid_string, char* backend, const long backend_length, char* fluid, const long fluid_length);
 
 #endif

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -1029,7 +1029,7 @@ EXPORT_CODE void CONVENTION add_fluids_as_JSON(const char* backend, const char* 
 }
 
 
-EXPORT_CODE long long CONVENTION AbstractState_phase(const long handle, long *errcode, char *message_buffer, const long buffer_length) {
+EXPORT_CODE int CONVENTION AbstractState_phase(const long handle, long *errcode, char *message_buffer, const long buffer_length) {
     *errcode = 0;
     try {
         shared_ptr<CoolProp::AbstractState> &AS = handle_manager.get(handle);
@@ -1041,7 +1041,7 @@ EXPORT_CODE long long CONVENTION AbstractState_phase(const long handle, long *er
     return -1;
 }
 
-EXPORT_CODE void CONVENTION AbstractState_fluid_param_string(const long handle, const char*const param, char *return_buffer, const long return_buffer_length, long *errcode, char *message_buffer, const long buffer_length) {
+EXPORT_CODE void CONVENTION AbstractState_fluid_param_string(const long handle, const char* param, char *return_buffer, const long return_buffer_length, long *errcode, char *message_buffer, const long buffer_length) {
     *errcode = 0;
     try {
         shared_ptr<CoolProp::AbstractState> &AS = handle_manager.get(handle);
@@ -1082,12 +1082,12 @@ EXPORT_CODE double CONVENTION AbstractState_saturated_vapor_keyed_output(const l
     return _HUGE;
 }
 
-EXPORT_CODE int CONVENTION C_is_valid_fluid_string(const char* const fluidName)
+EXPORT_CODE int CONVENTION C_is_valid_fluid_string(const char* fluidName)
 {
     return CoolProp::is_valid_fluid_string(fluidName);
 }
 
-EXPORT_CODE int CONVENTION C_extract_backend(const char* const fluid_string, char* backend, const long backend_length, char* fluid, const long fluid_length)
+EXPORT_CODE int CONVENTION C_extract_backend(const char* fluid_string, char* backend, const long backend_length, char* fluid, const long fluid_length)
 {
     std::string _fluid, _backend;
     CoolProp::extract_backend(fluid_string, _backend, _fluid);

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -1027,3 +1027,81 @@ EXPORT_CODE void CONVENTION add_fluids_as_JSON(const char* backend, const char* 
         HandleException(errcode, message_buffer, buffer_length);
     }
 }
+
+
+EXPORT_CODE long long CONVENTION AbstractState_phase(const long handle, long *errcode, char *message_buffer, const long buffer_length) {
+    *errcode = 0;
+    try {
+        shared_ptr<CoolProp::AbstractState> &AS = handle_manager.get(handle);
+        return AS->phase();
+    }
+    catch (...) {
+        HandleException(errcode, message_buffer, buffer_length);
+    }
+    return -1;
+}
+
+EXPORT_CODE void CONVENTION AbstractState_fluid_param_string(const long handle, const char*const param, char *return_buffer, const long return_buffer_length, long *errcode, char *message_buffer, const long buffer_length) {
+    *errcode = 0;
+    try {
+        shared_ptr<CoolProp::AbstractState> &AS = handle_manager.get(handle);
+        std::string temp = AS->fluid_param_string(param);
+        if (temp.size() < static_cast<std::size_t>(return_buffer_length)) {
+            strcpy(return_buffer, temp.c_str());
+        }
+        else {
+            *errcode = 2;
+        }
+    }
+    catch (...) {
+        HandleException(errcode, message_buffer, buffer_length);
+    }
+}
+EXPORT_CODE double CONVENTION AbstractState_saturated_liquid_keyed_output(const long handle, const long param, long *errcode, char *message_buffer, const long buffer_length)
+{
+    *errcode = 0;
+    try{
+        shared_ptr<CoolProp::AbstractState> &AS = handle_manager.get(handle);
+        return AS->saturated_liquid_keyed_output(static_cast<CoolProp::parameters>(param));
+    }
+    catch (...) {
+		HandleException(errcode, message_buffer, buffer_length);
+	}
+    return _HUGE;
+}
+EXPORT_CODE double CONVENTION AbstractState_saturated_vapor_keyed_output(const long handle, const long param, long *errcode, char *message_buffer, const long buffer_length)
+{
+    *errcode = 0;
+    try{
+        shared_ptr<CoolProp::AbstractState> &AS = handle_manager.get(handle);
+        return AS->saturated_vapor_keyed_output(static_cast<CoolProp::parameters>(param));
+    }
+    catch (...) {
+		HandleException(errcode, message_buffer, buffer_length);
+	}
+    return _HUGE;
+}
+
+EXPORT_CODE int CONVENTION C_is_valid_fluid_string(const char* const fluidName)
+{
+    return CoolProp::is_valid_fluid_string(fluidName);
+}
+
+EXPORT_CODE int CONVENTION C_extract_backend(const char* const fluid_string, char* backend, const long backend_length, char* fluid, const long fluid_length)
+{
+    std::string _fluid, _backend;
+    CoolProp::extract_backend(fluid_string, _backend, _fluid);
+    if (_backend.size() < static_cast<std::size_t>(backend_length)) {
+        strcpy(backend, _backend.c_str());
+    }
+    else {
+        return -1;
+    }
+    if (_fluid.size() < static_cast<std::size_t>(fluid_length)) {
+        strcpy(fluid, _fluid.c_str());
+    }
+    else {
+        return -1;
+    }
+    return 0;
+}


### PR DESCRIPTION
### Description of the Change

A few new C interface functions have been added. They enable accessing some information which is currently not available in the C interface. I guess they were just missing.
I did not yet add docstrings to the headers. I didn't know where to copy the descriptions from (as it surely exists somewhere in the library).

### Benefits

A more complete C interface?

### Possible Drawbacks

Future maintenance?

### Verification Process

We already use this interface in the TILMedia library. So, the interface is ready to use. However, not all failure cases (try/catch) are tested. The interface functions have been duplicated and modified from existing functions in the same file, to meet the same requirements.
