### PR TITLE
Fix base temperature and composition problems for incompressible fluids

### DIFF
--- a/dev/Tickets/2295.py
+++ b/dev/Tickets/2295.py
@@ -1,0 +1,29 @@
+import CoolProp as CP
+
+
+p = 1e6
+for fluid in ["PHE", "Water", "TVP1", "DowQ"]:
+    CP.CoolProp.set_debug_level(0)
+
+    state = CP.AbstractState("INCOMP", fluid)
+
+    Tmax = state.trivial_keyed_output(CP.iT_max)
+    Tmin = state.trivial_keyed_output(CP.iT_min)
+    Tbase = (Tmax + Tmin) *  0.5
+
+    state.update(CP.PT_INPUTS, p, Tbase + 1e-6)
+    h_hi = state.hmass()
+    state.update(CP.PT_INPUTS, p, Tbase - 1e-6)
+    h_lo = state.hmass()
+
+    state.update(CP.PT_INPUTS, p, Tbase)
+    try:
+        print(state.hmass(), " vs ", (h_hi + h_lo) * 0.5)
+    except ValueError as e:
+        msg = (
+            "Exactly the middle between maximum and minimum temperature does "
+            f"not work for {fluid}."
+        )
+        print(msg)
+
+        print(str(e))

--- a/dev/Tickets/2295.py
+++ b/dev/Tickets/2295.py
@@ -13,17 +13,20 @@ for fluid in ["PHE", "Water", "TVP1", "DowQ"]:
 
     state.update(CP.PT_INPUTS, p, Tbase + 1e-6)
     h_hi = state.hmass()
+    s_hi = state.smass()
     state.update(CP.PT_INPUTS, p, Tbase - 1e-6)
     h_lo = state.hmass()
+    s_lo = state.smass()
 
     state.update(CP.PT_INPUTS, p, Tbase)
     try:
-        print(state.hmass(), " vs ", (h_hi + h_lo) * 0.5)
+        print(state.hmass(), "J/kg   vs", (h_hi + h_lo) * 0.5, "J/kg")
+        print(state.smass(), "J/kg/K vs", (s_hi + s_lo) * 0.5, "J/kg/K")
     except ValueError as e:
-        msg = (
-            "Exactly the middle between maximum and minimum temperature does "
-            f"not work for {fluid}."
-        )
-        print(msg)
-
+        # msg = (
+        #     "Exactly the middle between maximum and minimum temperature does "
+        #     f"not work for {fluid}."
+        # )
+        # print(msg)
         print(str(e))
+        print((h_hi + h_lo) * 0.5, "J/kg and", (s_hi + s_lo) * 0.5, "J/kg/K")

--- a/src/Backends/Incompressible/IncompressibleFluid.cpp
+++ b/src/Backends/Incompressible/IncompressibleFluid.cpp
@@ -7,7 +7,8 @@
 #include "PolyMath.h"
 #include <Eigen/Core>
 
-const double INCOMP_EPSILON = DBL_EPSILON * 100.0;
+constexpr double INCOMP_EPSILON = DBL_EPSILON * 100.0;
+constexpr double INCOMP_DELTA = INCOMP_EPSILON * 10.0;
 
 namespace CoolProp {
 
@@ -50,8 +51,8 @@ double IncompressibleFluid::baseExponential(IncompressibleData data, double y, d
     }
     // ... now we know that we are in the danger zone
     // step away from the zero-crossing
-    x_lo -= DBL_EPSILON;
-    x_hi += DBL_EPSILON;
+    x_lo -= INCOMP_DELTA;
+    x_hi += INCOMP_DELTA;
     const double f_lo = fnc(x_lo);
     const double f_hi = fnc(x_hi);
     // Linearize around the zero-crossing
@@ -77,8 +78,8 @@ double IncompressibleFluid::baseLogexponential(IncompressibleData data, double y
     }
     // ... now we know that we are in the danger zone
     // step away from the zero-crossing
-    x_lo -= DBL_EPSILON;
-    x_hi += DBL_EPSILON;
+    x_lo -= INCOMP_DELTA;
+    x_hi += INCOMP_DELTA;
     const double f_lo = fnc(x_lo);
     const double f_hi = fnc(x_hi);
     // Linearize around the zero-crossing

--- a/src/Backends/Incompressible/IncompressibleFluid.cpp
+++ b/src/Backends/Incompressible/IncompressibleFluid.cpp
@@ -7,6 +7,8 @@
 #include "PolyMath.h"
 #include <Eigen/Core>
 
+const double INCOMP_EPSILON = DBL_EPSILON * 100.0;
+
 namespace CoolProp {
 
 /// A thermophysical property provider for all properties
@@ -34,18 +36,54 @@ bool IncompressibleFluid::is_pure() {
 double IncompressibleFluid::baseExponential(IncompressibleData data, double y, double ybase) {
     Eigen::VectorXd coeffs = makeVector(data.coeffs);
     size_t r = coeffs.rows(), c = coeffs.cols();
-    if (strict && (r != 3 || c != 1))
+    if (strict && (r != 3 || c != 1)) {
         throw ValueError(format("%s (%d): You have to provide a 3,1 matrix of coefficients, not  (%d,%d).", __FILE__, __LINE__, r, c));
-    return exp((double)(coeffs[0] / ((y - ybase) + coeffs[1]) - coeffs[2]));
+    }
+
+    // Guard the function against zero denominators in exp((double)(coeffs[0] / ((y - ybase) + coeffs[1]) - coeffs[2]))
+    auto fnc = [&](double x) { return exp((double)(coeffs[0] / (x) - coeffs[2])); } ;
+    double x_den = (y - ybase) + coeffs[1];
+    double x_lo = -INCOMP_EPSILON;
+    double x_hi = +INCOMP_EPSILON;
+    if (x_den < x_lo || x_den > x_hi) {
+        return fnc(x_den);
+    }
+    // ... now we know that we are in the danger zone
+    // step away from the zero-crossing
+    x_lo -= DBL_EPSILON;
+    x_hi += DBL_EPSILON;
+    const double f_lo = fnc(x_lo);
+    const double f_hi = fnc(x_hi);
+    // Linearize around the zero-crossing
+    const double m = (f_hi - f_lo) / (x_hi - x_lo);
+    return m * (x_den - x_lo) + f_lo;
 }
+
 /// Base exponential function with logarithmic term
 double IncompressibleFluid::baseLogexponential(IncompressibleData data, double y, double ybase) {
     Eigen::VectorXd coeffs = makeVector(data.coeffs);
     size_t r = coeffs.rows(), c = coeffs.cols();
-    if (strict && (r != 3 || c != 1))
+    if (strict && (r != 3 || c != 1)) {
         throw ValueError(format("%s (%d): You have to provide a 3,1 matrix of coefficients, not  (%d,%d).", __FILE__, __LINE__, r, c));
-    return exp(
-      (double)(log((double)(1.0 / ((y - ybase) + coeffs[0]) + 1.0 / ((y - ybase) + coeffs[0]) / ((y - ybase) + coeffs[0]))) * coeffs[1] + coeffs[2]));
+    }
+
+    // Guard the function against zero denominators in exp((double)(log((double)(1.0 / ((y - ybase) + coeffs[0]) + 1.0 / ((y - ybase) + coeffs[0]) / ((y - ybase) + coeffs[0]))) * coeffs[1] + coeffs[2]))
+    auto fnc = [&](double x) { return exp((double)(log((double)(1.0 / (x) + 1.0 / (x) / (x))) * coeffs[1] + coeffs[2])); } ;
+    double x_den = (y - ybase) + coeffs[0];
+    double x_lo = -INCOMP_EPSILON;
+    double x_hi = +INCOMP_EPSILON;
+    if (x_den < x_lo || x_den > x_hi) {
+        return fnc(x_den);
+    }
+    // ... now we know that we are in the danger zone
+    // step away from the zero-crossing
+    x_lo -= DBL_EPSILON;
+    x_hi += DBL_EPSILON;
+    const double f_lo = fnc(x_lo);
+    const double f_hi = fnc(x_hi);
+    // Linearize around the zero-crossing
+    const double m = (f_hi - f_lo) / (x_hi - x_lo);
+    return m * (x_den - x_lo) + f_lo;    
 }
 
 double IncompressibleFluid::basePolyOffset(IncompressibleData data, double y, double z) {

--- a/src/Backends/Incompressible/IncompressibleFluid.cpp
+++ b/src/Backends/Incompressible/IncompressibleFluid.cpp
@@ -56,8 +56,7 @@ double IncompressibleFluid::baseExponential(IncompressibleData data, double y, d
     const double f_lo = fnc(x_lo);
     const double f_hi = fnc(x_hi);
     // Linearize around the zero-crossing
-    const double m = (f_hi - f_lo) / (x_hi - x_lo);
-    return m * (x_den - x_lo) + f_lo;
+    return (f_hi - f_lo) / (x_hi - x_lo) * (x_den - x_lo) + f_lo;
 }
 
 /// Base exponential function with logarithmic term
@@ -83,8 +82,7 @@ double IncompressibleFluid::baseLogexponential(IncompressibleData data, double y
     const double f_lo = fnc(x_lo);
     const double f_hi = fnc(x_hi);
     // Linearize around the zero-crossing
-    const double m = (f_hi - f_lo) / (x_hi - x_lo);
-    return m * (x_den - x_lo) + f_lo;    
+    return (f_hi - f_lo) / (x_hi - x_lo) * (x_den - x_lo) + f_lo;
 }
 
 double IncompressibleFluid::basePolyOffset(IncompressibleData data, double y, double z) {

--- a/src/PolyMath.cpp
+++ b/src/PolyMath.cpp
@@ -471,8 +471,7 @@ double Polynomial2DFrac::evaluate(const Eigen::MatrixXd& coefficients, const dou
         const double x_hi = x_base + CPPOLY_DELTA;
         const double y_lo = evaluate(coefficients, x_lo, firstExponent, x_base);
         const double y_hi = evaluate(coefficients, x_hi, firstExponent, x_base);
-        const double m = (y_hi - y_lo)/(x_hi - x_lo);
-        return y_lo + m*(x_in - x_lo);
+        return (y_hi - y_lo)/(x_hi - x_lo) * (x_in - x_lo) + y_lo;
     }
 
     Eigen::MatrixXd tmpCoeffs(coefficients);
@@ -517,22 +516,20 @@ double Polynomial2DFrac::evaluate(const Eigen::MatrixXd& coefficients, const dou
     if ((x_exp < 0) && (std::abs(x_in - x_base) < CPPOLY_EPSILON)) {
         // throw ValueError(format("%s (%d): A fraction cannot be evaluated with zero as denominator, x_in-x_base=%f ", __FILE__, __LINE__, x_in - x_base));
         if (this->do_debug()) std::cout << "Interpolating in x-direction for base " << x_base << " and input " << x_in << std::endl;
-        double x_lo = x_base - CPPOLY_DELTA;
-        double x_hi = x_base + CPPOLY_DELTA;
-        double z_lo = evaluate(coefficients, x_lo, y_in, x_exp, y_exp, x_base, y_base);
-        double z_hi = evaluate(coefficients, x_hi, y_in, x_exp, y_exp, x_base, y_base);
-        double dzdx = (z_hi - z_lo)/(x_hi - x_lo);
-        return z_lo + dzdx*(x_in - x_lo);
+        const double x_lo = x_base - CPPOLY_DELTA;
+        const double x_hi = x_base + CPPOLY_DELTA;
+        const double z_lo = evaluate(coefficients, x_lo, y_in, x_exp, y_exp, x_base, y_base);
+        const double z_hi = evaluate(coefficients, x_hi, y_in, x_exp, y_exp, x_base, y_base);
+        return (z_hi - z_lo)/(x_hi - x_lo) * (x_in - x_lo) + z_lo;
     }
     if ((y_exp < 0) && (std::abs(y_in - y_base) < CPPOLY_EPSILON)) {
         // throw ValueError(format("%s (%d): A fraction cannot be evaluated with zero as denominator, y_in-y_base=%f ", __FILE__, __LINE__, y_in - y_base));
         if (this->do_debug()) std::cout << "Interpolating in y-direction for base " << y_base << " and input " << y_in << std::endl;
-        double y_lo = y_base - CPPOLY_DELTA;
-        double y_hi = y_base + CPPOLY_DELTA;
-        double z_lo = evaluate(coefficients, x_in, y_lo, x_exp, y_exp, x_base, y_base);
-        double z_hi = evaluate(coefficients, x_in, y_hi, x_exp, y_exp, x_base, y_base);
-        double dzdy = (z_hi - z_lo)/(y_hi - y_lo);
-        return z_lo + dzdy*(y_in - y_lo);
+        const double y_lo = y_base - CPPOLY_DELTA;
+        const double y_hi = y_base + CPPOLY_DELTA;
+        const double z_lo = evaluate(coefficients, x_in, y_lo, x_exp, y_exp, x_base, y_base);
+        const double z_hi = evaluate(coefficients, x_in, y_hi, x_exp, y_exp, x_base, y_base);
+        return (z_hi - z_lo)/(y_hi - y_lo) * (y_in - y_lo) + z_lo;
     }
 
     Eigen::MatrixXd tmpCoeffs(coefficients);

--- a/src/PolyMath.cpp
+++ b/src/PolyMath.cpp
@@ -17,7 +17,8 @@
 
 namespace CoolProp {
 
-const double CPPOLY_EPSILON = DBL_EPSILON * 100.0;
+constexpr double CPPOLY_EPSILON = DBL_EPSILON * 100.0;
+constexpr double CPPOLY_DELTA = CPPOLY_EPSILON * 10.0;
 
 /// Basic checks for coefficient vectors.
 /** Starts with only the first coefficient dimension
@@ -466,8 +467,8 @@ double Polynomial2DFrac::evaluate(const Eigen::MatrixXd& coefficients, const dou
     }
     if ((firstExponent < 0) && (std::abs(x_in - x_base) < CPPOLY_EPSILON)) {
         //throw ValueError(format("%s (%d): A fraction cannot be evaluated with zero as denominator, x_in-x_base=%f ", __FILE__, __LINE__, x_in - x_base));
-        const double x_lo = x_base - 1.001*CPPOLY_EPSILON;
-        const double x_hi = x_base + 1.001*CPPOLY_EPSILON;
+        const double x_lo = x_base - CPPOLY_DELTA;
+        const double x_hi = x_base + CPPOLY_DELTA;
         const double y_lo = evaluate(coefficients, x_lo, firstExponent, x_base);
         const double y_hi = evaluate(coefficients, x_hi, firstExponent, x_base);
         const double m = (y_hi - y_lo)/(x_hi - x_lo);
@@ -515,8 +516,9 @@ double Polynomial2DFrac::evaluate(const Eigen::MatrixXd& coefficients, const dou
                                   const double& x_base, const double& y_base) {
     if ((x_exp < 0) && (std::abs(x_in - x_base) < CPPOLY_EPSILON)) {
         // throw ValueError(format("%s (%d): A fraction cannot be evaluated with zero as denominator, x_in-x_base=%f ", __FILE__, __LINE__, x_in - x_base));
-        double x_lo = x_base - 1.001*CPPOLY_EPSILON;
-        double x_hi = x_base + 1.001*CPPOLY_EPSILON;
+        if (this->do_debug()) std::cout << "Interpolating in x-direction for base " << x_base << " and input " << x_in << std::endl;
+        double x_lo = x_base - CPPOLY_DELTA;
+        double x_hi = x_base + CPPOLY_DELTA;
         double z_lo = evaluate(coefficients, x_lo, y_in, x_exp, y_exp, x_base, y_base);
         double z_hi = evaluate(coefficients, x_hi, y_in, x_exp, y_exp, x_base, y_base);
         double dzdx = (z_hi - z_lo)/(x_hi - x_lo);
@@ -524,8 +526,9 @@ double Polynomial2DFrac::evaluate(const Eigen::MatrixXd& coefficients, const dou
     }
     if ((y_exp < 0) && (std::abs(y_in - y_base) < CPPOLY_EPSILON)) {
         // throw ValueError(format("%s (%d): A fraction cannot be evaluated with zero as denominator, y_in-y_base=%f ", __FILE__, __LINE__, y_in - y_base));
-        double y_lo = y_base - 1.001*CPPOLY_EPSILON;
-        double y_hi = y_base + 1.001*CPPOLY_EPSILON;
+        if (this->do_debug()) std::cout << "Interpolating in y-direction for base " << y_base << " and input " << y_in << std::endl;
+        double y_lo = y_base - CPPOLY_DELTA;
+        double y_hi = y_base + CPPOLY_DELTA;
         double z_lo = evaluate(coefficients, x_in, y_lo, x_exp, y_exp, x_base, y_base);
         double z_hi = evaluate(coefficients, x_in, y_hi, x_exp, y_exp, x_base, y_base);
         double dzdy = (z_hi - z_lo)/(y_hi - y_lo);

--- a/src/PolyMath.cpp
+++ b/src/PolyMath.cpp
@@ -17,6 +17,8 @@
 
 namespace CoolProp {
 
+const double CPPOLY_EPSILON = DBL_EPSILON * 100.0;
+
 /// Basic checks for coefficient vectors.
 /** Starts with only the first coefficient dimension
  *  and checks the matrix size against the parameters rows and columns.
@@ -462,9 +464,14 @@ double Polynomial2DFrac::evaluate(const Eigen::MatrixXd& coefficients, const dou
         throw ValueError(format("%s (%d): You have a 2D coefficient matrix (%d,%d), please use the 2D functions. ", __FILE__, __LINE__,
                                 coefficients.rows(), coefficients.cols()));
     }
-    if ((firstExponent < 0) && (std::abs(x_in - x_base) < DBL_EPSILON)) {
-        throw ValueError(
-          format("%s (%d): A fraction cannot be evaluated with zero as denominator, x_in-x_base=%f ", __FILE__, __LINE__, x_in - x_base));
+    if ((firstExponent < 0) && (std::abs(x_in - x_base) < CPPOLY_EPSILON)) {
+        //throw ValueError(format("%s (%d): A fraction cannot be evaluated with zero as denominator, x_in-x_base=%f ", __FILE__, __LINE__, x_in - x_base));
+        const double x_lo = x_base - 1.001*CPPOLY_EPSILON;
+        const double x_hi = x_base + 1.001*CPPOLY_EPSILON;
+        const double y_lo = evaluate(coefficients, x_lo, firstExponent, x_base);
+        const double y_hi = evaluate(coefficients, x_hi, firstExponent, x_base);
+        const double m = (y_hi - y_lo)/(x_hi - x_lo);
+        return y_lo + m*(x_in - x_lo);
     }
 
     Eigen::MatrixXd tmpCoeffs(coefficients);
@@ -506,13 +513,23 @@ double Polynomial2DFrac::evaluate(const Eigen::MatrixXd& coefficients, const dou
 /// @param y_base double value that represents the base value for a centred fit in the 2nd dimension
 double Polynomial2DFrac::evaluate(const Eigen::MatrixXd& coefficients, const double& x_in, const double& y_in, const int& x_exp, const int& y_exp,
                                   const double& x_base, const double& y_base) {
-    if ((x_exp < 0) && (std::abs(x_in - x_base) < DBL_EPSILON)) {
-        throw ValueError(
-          format("%s (%d): A fraction cannot be evaluated with zero as denominator, x_in-x_base=%f ", __FILE__, __LINE__, x_in - x_base));
+    if ((x_exp < 0) && (std::abs(x_in - x_base) < CPPOLY_EPSILON)) {
+        // throw ValueError(format("%s (%d): A fraction cannot be evaluated with zero as denominator, x_in-x_base=%f ", __FILE__, __LINE__, x_in - x_base));
+        double x_lo = x_base - 1.001*CPPOLY_EPSILON;
+        double x_hi = x_base + 1.001*CPPOLY_EPSILON;
+        double z_lo = evaluate(coefficients, x_lo, y_in, x_exp, y_exp, x_base, y_base);
+        double z_hi = evaluate(coefficients, x_hi, y_in, x_exp, y_exp, x_base, y_base);
+        double dzdx = (z_hi - z_lo)/(x_hi - x_lo);
+        return z_lo + dzdx*(x_in - x_lo);
     }
-    if ((y_exp < 0) && (std::abs(y_in - y_base) < DBL_EPSILON)) {
-        throw ValueError(
-          format("%s (%d): A fraction cannot be evaluated with zero as denominator, y_in-y_base=%f ", __FILE__, __LINE__, y_in - y_base));
+    if ((y_exp < 0) && (std::abs(y_in - y_base) < CPPOLY_EPSILON)) {
+        // throw ValueError(format("%s (%d): A fraction cannot be evaluated with zero as denominator, y_in-y_base=%f ", __FILE__, __LINE__, y_in - y_base));
+        double y_lo = y_base - 1.001*CPPOLY_EPSILON;
+        double y_hi = y_base + 1.001*CPPOLY_EPSILON;
+        double z_lo = evaluate(coefficients, x_in, y_lo, x_exp, y_exp, x_base, y_base);
+        double z_hi = evaluate(coefficients, x_in, y_hi, x_exp, y_exp, x_base, y_base);
+        double dzdy = (z_hi - z_lo)/(y_hi - y_lo);
+        return z_lo + dzdy*(y_in - y_lo);
     }
 
     Eigen::MatrixXd tmpCoeffs(coefficients);


### PR DESCRIPTION
### Description of the Change

The base input values of incompressible fluids can cause a division by zero when calculating properties at this particular temperature or composition.

### Benefits

No more exceptions when calculating at base temperature or composition.

### Verification Process

Have a look at `dev\Tickets\2295.py`: 

```shell
python .\dev\Tickets\2295.py
Exactly the middle between maximum and minimum temperature does not work for PHE.
..\..\src\PolyMath.cpp (511): A fraction cannot be evaluated with zero as denominator, x_in-x_base=0.000000
Exactly the middle between maximum and minimum temperature does not work for Water.
..\..\src\PolyMath.cpp (511): A fraction cannot be evaluated with zero as denominator, x_in-x_base=0.000000
Exactly the middle between maximum and minimum temperature does not work for TVP1.
..\..\src\PolyMath.cpp (511): A fraction cannot be evaluated with zero as denominator, x_in-x_base=0.000000
Exactly the middle between maximum and minimum temperature does not work for DowQ.
..\..\src\PolyMath.cpp (511): A fraction cannot be evaluated with zero as denominator, x_in-x_base=0.000000
```

```shell
python .\dev\Tickets\2295.py
311263.76559865545  vs  311263.76559865545
334848.0345431278  vs  334848.03454312787
334017.96888476453  vs  334017.96888476453
267970.81788517773  vs  267970.8178851777
```

### Applicable Issues

Closes #2295 
