### PR TITLE
Include stdbool for C interface

### DIFF
--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -59,6 +59,10 @@
 #    endif
 #endif
 
+#ifndef __cplusplus
+#    include <stdbool.h>
+#endif
+
 // Hack for PowerPC compilation to only use extern "C"
 #if defined(__powerpc__) || defined(EXTERNC)
 #    undef EXPORT_CODE

--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -60,7 +60,11 @@
 #endif
 
 #ifndef __cplusplus
-#    include <stdbool.h>
+#    if defined(__STDC_VERSION__)
+#        if (__STDC_VERSION__ >= 199901L)
+#            include <stdbool.h>
+#        endif
+#    endif
 #endif
 
 // Hack for PowerPC compilation to only use extern "C"


### PR DESCRIPTION
### Description of the Change

Conditionally include `stdbool.h` when including `CoolPropLib.h` from C. 

### Benefits

`stdbool.h` will not need to be included before `CoolPropLib.h` in C programs. This conforms to the [include what you use](https://google.github.io/styleguide/cppguide.html#Include_What_You_Use) rule from the style guide.

### Possible Drawbacks

None I can think of.

### Verification Process

- Compiled a C99 program including `CoolPropLib.h` without including `stdbool.h` beforehand.
- Still compiles with C89 when using typedef for bool