### PR TITLE
Fix HEOS fugacity for mixtures in the two-phase region

### DIFF
--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -2919,16 +2919,17 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_fugacity_coefficient(std::size_t i)
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_fugacity(std::size_t i) {
     x_N_dependency_flag xN_flag = XN_DEPENDENT;
+    CoolPropDbl localFug;
     if (isTwoPhase()) {
         if (!this->SatL || !this->SatV) throw ValueError(format("The saturation properties are needed for the two-phase properties"));
         if (std::abs(_Q) < DBL_EPSILON) {
-            _hmolar = SatL->fugacity(i);
+            localFug = SatL->fugacity(i);
         } else if (std::abs(_Q - 1) < DBL_EPSILON) {
-            _hmolar = SatV->fugacity(i);
+            localFug = SatV->fugacity(i);
         } else {
-            _hmolar = _Q * SatV->fugacity(i) + (1 - _Q) * SatL->fugacity(i);
+            localFug = _Q * SatV->fugacity(i) + (1 - _Q) * SatL->fugacity(i);
         }
-        return static_cast<CoolPropDbl>(_hmolar);
+        return static_cast<CoolPropDbl>(localFug);
     } else if (isHomogeneousPhase()) {
         return MixtureDerivatives::fugacity_i(*this, i, xN_flag);
     } else {

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -2919,7 +2919,21 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_fugacity_coefficient(std::size_t i)
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_fugacity(std::size_t i) {
     x_N_dependency_flag xN_flag = XN_DEPENDENT;
-    return MixtureDerivatives::fugacity_i(*this, i, xN_flag);
+    if (isTwoPhase()) {
+        if (!this->SatL || !this->SatV) throw ValueError(format("The saturation properties are needed for the two-phase properties"));
+        if (std::abs(_Q) < DBL_EPSILON) {
+            _hmolar = SatL->fugacity(i);
+        } else if (std::abs(_Q - 1) < DBL_EPSILON) {
+            _hmolar = SatV->fugacity(i);
+        } else {
+            _hmolar = _Q * SatV->fugacity(i) + (1 - _Q) * SatL->fugacity(i);
+        }
+        return static_cast<CoolPropDbl>(_hmolar);
+    } else if (isHomogeneousPhase()) {
+        return MixtureDerivatives::fugacity_i(*this, i, xN_flag);
+    } else {
+        throw ValueError(format("phase is invalid in calc_fugacity"));
+    }
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_chemical_potential(std::size_t i) {
     x_N_dependency_flag xN_flag = XN_DEPENDENT;


### PR DESCRIPTION
### Description of the Change

I noticed that when calculating the fugacity for mixtures in Peng-Robinson EoS the results did not quite made sense. Since the fugacity of a component in the mixture must be the same in liquid and gas, I checked the saturation states which both had the same fugacity but different from the overall state. As I am not quite sure the two-phase region is currently appropriately handled in this case, I suggest this PR which returns the sat-state fugacity. It now returns the weighted sum of both sat-states, which is of course equal to the single sat-states (should I just decide on liquid or gas?).

### Benefits

Get better fugacity values for two-phase region

### Possible Drawbacks

/

### Verification Process

Tested before and after change fugacity values for AbstractStates: EoS "HEOS" and "PR":
 - components: "Methane&Ethane&Propane"
 - fractions: (0.25, 0.25, 0.5)
 - PQ inputs: p = 500000, q = 0.5
 - get molar fractions for sat states -> update State appropriately
 - compare differences in fugacities for overall, gas and liquid state
 
![grafik](https://github.com/CoolProp/CoolProp/assets/84069190/85866ecf-ad1f-4b6f-bdb3-0b01251a4b8e)

after the changes, overall and gas/liquid returned the same values
