### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1493,6 +1493,7 @@ if(COOLPROP_JAVA_MODULE)
   include_directories(${JAVA_INCLUDE_PATH})
   include_directories(${JAVA_INCLUDE_PATH}/win32)
   include_directories(${JAVA_INCLUDE_PATH}/linux)
+  include_directories(${JAVA_INCLUDE_PATH}/darwin)
 
   set(I_FILE "${CMAKE_CURRENT_SOURCE_DIR}/src/CoolProp.i")
 


### PR DESCRIPTION
Fix compilation for Java wrapper on MacOS. Java wrappers will not compile as the machine dependent java native headers cannot be found on the normal Java classpath (they are in an OS-dependent subdirectory).

### Description of the Change

Simple addition to CMakeLists to add a directory for MacOS machine dependent java native headers (jni_md.h). This allows compilation of the wrapped native library for use with Java on Macintosh machines. Note that this is very similar to directory includes that are already in the CMakeLists file for the Windows and Linux machine dependent subdirectories. The MacOS directory simply appears to be missing.

### Benefits

Developers using the CoolProp library to write applications in Java for multiple target OS, and who need to perform a custom compilation (for example to define a specific package other than the default package) can now compile and run on Windows, Linux and MacOS. For anything other than a trivial application, the ability to define a custom package (for example org.coolprop) is important as modular Java applications will struggle to include libraries in the default package.

### Possible Drawbacks

Addition of single line to CMakeLists.txt, should not affect any other compilation. Confirmed that after the addition, Windows compilation of the Java wrappers still works.

### Verification Process

Had colleague run the compilation on his Macbook Air and he shared the logs with me. I have then included the libCoolProp.jnilib into my application and distributed this back to him. We confirmed that the application is able to run and execute the portions of code that rely on CoolProp on MacOS, meaning that the MacOS native library has been recognised and properly wrapped by the SWIG wrappers (which incidentally were generated on a Windows machine -- although they should be identical to those generated by the MacOS compilation).

End result after running `cmake --build .` is:

```
[100%] Linking CXX shared module libCoolProp.jnilib
7-Zip [64] 17.05 : Copyright (c) 1999-2021 Igor Pavlov : 2017-08-28
p7zip Version 17.05 (locale=utf8,Utf16=on,HugeFiles=on,64 bits,8 CPUs LE)
Scanning the drive:
38 files, 184434 bytes (181 KiB)
Creating archive: /Users/SBN/applications/CoolProp/build-macos/platformindependent.7z
Items to compress: 38
Files read from disk: 38
Archive size: 15022 bytes (15 KiB)
Everything is Ok
[100%] Built target CoolProp
```

### Applicable Issues

Use ``Closes #2346``.
