### PR TITLE
Fix bug introduced by 443a2fd

### DIFF
--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -597,7 +597,7 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend& HEOS, C
     // reset the phase for the next update.
     SatL->specify_phase(iphase_liquid);
     SatV->specify_phase(iphase_gas);
-    if (error > 1e-8){
+    if (error > 1e-8 && max_abs_value(v) > 1e-9){
         throw SolutionError(format("saturation_PHSU_pure solver was good, but went bad. Current error is %Lg", error));
     }
 }


### PR DESCRIPTION

### Description of the Change
Commit 443a2fd added some extra checks for convergence in the Helmholtz PHSU flash routines. However, its checking was more aggressive than the original routine. This caused the routine to raise an exception on several values that had previously been deemed acceptable. This trickled down to cause the TTSE tables to be filled with empty values, making them less robust.

This commit allows for a solution to be acceptable if the change is small between iterations as was originally intended.


### Benefits

The docs now build properly. 

### Possible Drawbacks

None known. However we should ensure that the tests pass acceptably. 

### Verification Process

I manually ran `Web/scripts/coolprop.tabular.speed.py`  with the updated code and with the current master branch. Using master causes a crash - this was what was causing the docs the fail to build in the github pipeline. Running with this new commit causes `coolprop.tabular.speed.py` to run to completion.

### Applicable Issues

Closes #2349 
