### PR TITLE
Update REFPROPMixtureBackend.cpp

### DIFF
--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -343,6 +343,9 @@ void REFPROPMixtureBackend::set_REFPROP_fluids(const std::vector<std::string>& f
             strcpy(mix, _components_joined_raw);
 
             SETMIXdll(mix, hmx_bnc, reference_state, &N, component_string, &(x[0]), &ierr, herr, 255, 255, 3, 10000, 255);
+            int ixflag = 2;
+            double h0 = 0, s0 = 0, t0 = 0, p0 = 0;
+            SETREFdll(reference_state, &ixflag, &(x[0]), &h0, &s0, &t0, &p0, &ierr, herr, 3, 255);
             if (static_cast<int>(ierr) <= 0) {
                 this->Ncomp = N;
                 mole_fractions.resize(ncmax);


### PR DESCRIPTION
Coolprop library does not implement the function call setrefdll from Refprop. As a result, there are discrepancies between the calculation results of Refprop and Coolprop when computing predefined mixture MIX models, primarily in terms of standard state deviations (which affect enthalpy values and related quantities).

Coolprop does provide a method to set the standard state, which can be set to DEF. However, the default value of DEF in Coolprop still differs from the calculation results of Refprop.

### Requirements

* Fill out this template to the extent possible so that this PR can be reviewed in a timely manner.
* Replace the bracketed text below with your own.
* All new code requires tests to ensure against regressions.

### Description of the Change

Based on the previously mentioned issue (https://github.com/CoolProp/CoolProp/issues/2239),
Coolprop library does not implement the function call setrefdll from Refprop. As a result, there are discrepancies between the calculation results of Refprop and Coolprop when computing predefined mixture MIX models, primarily in terms of standard state deviations (which affect enthalpy values and related quantities).
Coolprop does provide a method to set the standard state, which can be set to DEF. However, the default value of DEF in Coolprop still differs from the calculation results of Refprop.


### Benefits

[ The modified code now includes the call to setrefdll from refprop, resulting in the same calculations as those set in refprop when computing predefined mixtures. ]

### Possible Drawbacks

[The original user's calculations for predefined mixtures will be affected by the changes, but only when using the REFPROP backend. This will primarily impact variables such as enthalpy values. ]

### Verification Process

[ *What process did you follow to verify that your change has the desired effects?*
I only verified R410A.MIX  and did not conduct extensive testing, but I believe the impact should be minimal and feasible.




### Applicable Issues
Closes #2239 
 
