### PR TITLE
Use temperature dependent hard sphere diameter for ion term in ePC-SAFT

### DIFF
--- a/src/Backends/PCSAFT/PCSAFTBackend.cpp
+++ b/src/Backends/PCSAFT/PCSAFTBackend.cpp
@@ -252,8 +252,7 @@ CoolPropDbl PCSAFTBackend::calc_alphar(void) {
     if (ion_term) {
         for (int i = 0; i < ncomp; i++) {
             if (components[i].getZ() != 0) {
-                d[i] =
-                  components[i].getSigma() * (1 - 0.12);  // for ions the diameter is assumed to be temperature independent (see Held et al. 2014)
+                d[i] = components[i].getSigma() * (1 - 0.12);  // for ions the diameter is assumed to be temperature independent (see Held et al. 2014)
             }
         }
     }
@@ -500,9 +499,9 @@ CoolPropDbl PCSAFTBackend::calc_alphar(void) {
             vector<double> sigma_k(ncomp);
             summ = 0.;
             for (int i = 0; i < ncomp; i++) {
-                chi[i] = 3 / pow(kappa * components[i].getSigma(), 3)
-                         * (1.5 + log(1 + kappa * components[i].getSigma()) - 2 * (1 + kappa * components[i].getSigma())
-                            + 0.5 * pow(1 + kappa * components[i].getSigma(), 2));
+                chi[i] = 3 / pow(kappa * d[i], 3)
+                         * (1.5 + log(1 + kappa * d[i]) - 2 * (1 + kappa * d[i])
+                            + 0.5 * pow(1 + kappa * d[i], 2));
                 summ += mole_fractions[i] * q[i] * q[i] * chi[i] * kappa;
             }
 
@@ -524,8 +523,7 @@ CoolPropDbl PCSAFTBackend::calc_dadt(void) {
     if (ion_term) {
         for (int i = 0; i < ncomp; i++) {
             if (components[i].getZ() != 0) {
-                d[i] =
-                  components[i].getSigma() * (1 - 0.12);  // for ions the diameter is assumed to be temperature independent (see Held et al. 2014)
+                d[i] = components[i].getSigma() * (1 - 0.12);  // for ions the diameter is assumed to be temperature independent (see Held et al. 2014)
                 dd_dt[i] = 0.;
             }
         }
@@ -824,10 +822,10 @@ CoolPropDbl PCSAFTBackend::calc_dadt(void) {
             vector<double> dchikap_dk(ncomp);
             summ = 0.;
             for (int i = 0; i < ncomp; i++) {
-                chi[i] = 3 / pow(kappa * components[i].getSigma(), 3)
-                         * (1.5 + log(1 + kappa * components[i].getSigma()) - 2 * (1 + kappa * components[i].getSigma())
-                            + 0.5 * pow(1 + kappa * components[i].getSigma(), 2));
-                dchikap_dk[i] = -2 * chi[i] + 3 / (1 + kappa * components[i].getSigma());
+                chi[i] = 3 / pow(kappa * d[i], 3)
+                         * (1.5 + log(1 + kappa * d[i]) - 2 * (1 + kappa * d[i])
+                            + 0.5 * pow(1 + kappa * d[i], 2));
+                dchikap_dk[i] = -2 * chi[i] + 3 / (1 + kappa * d[i]);
                 summ += mole_fractions[i] * components[i].getZ() * components[i].getZ();
             }
             dkappa_dt = -0.5 * den * E_CHRG * E_CHRG / kb / _T / _T / (dielc * perm_vac) * summ / kappa;
@@ -869,8 +867,7 @@ vector<CoolPropDbl> PCSAFTBackend::calc_fugacity_coefficients(void) {
     if (ion_term) {
         for (int i = 0; i < ncomp; i++) {
             if (components[i].getZ() != 0) {
-                d[i] =
-                  components[i].getSigma() * (1 - 0.12);  // for ions the diameter is assumed to be temperature independent (see Held et al. 2014)
+                d[i] = components[i].getSigma() * (1 - 0.12);  // for ions the diameter is assumed to be temperature independent (see Held et al. 2014)
             }
         }
     }
@@ -1314,10 +1311,10 @@ vector<CoolPropDbl> PCSAFTBackend::calc_fugacity_coefficients(void) {
             double summ1 = 0.;
             double summ2 = 0.;
             for (int i = 0; i < ncomp; i++) {
-                chi[i] = 3 / pow(kappa * components[i].getSigma(), 3)
-                         * (1.5 + log(1 + kappa * components[i].getSigma()) - 2 * (1 + kappa * components[i].getSigma())
-                            + 0.5 * pow(1 + kappa * components[i].getSigma(), 2));
-                sigma_k[i] = -2 * chi[i] + 3 / (1 + kappa * components[i].getSigma());
+                chi[i] = 3 / pow(kappa * d[i], 3)
+                         * (1.5 + log(1 + kappa * d[i]) - 2 * (1 + kappa * d[i])
+                            + 0.5 * pow(1 + kappa * d[i], 2));
+                sigma_k[i] = -2 * chi[i] + 3 / (1 + kappa * d[i]);
                 summ1 += q[i] * q[i] * mole_fractions[i] * sigma_k[i];
                 summ2 += mole_fractions[i] * q[i] * q[i];
             }
@@ -1357,8 +1354,7 @@ CoolPropDbl PCSAFTBackend::calc_compressibility_factor(void) {
     if (ion_term) {
         for (int i = 0; i < ncomp; i++) {
             if (components[i].getZ() != 0) {
-                d[i] =
-                  components[i].getSigma() * (1 - 0.12);  // for ions the diameter is assumed to be temperature independent (see Held et al. 2014)
+                d[i] = components[i].getSigma() * (1 - 0.12);  // for ions the diameter is assumed to be temperature independent (see Held et al. 2014)
             }
         }
     }
@@ -1667,10 +1663,10 @@ CoolPropDbl PCSAFTBackend::calc_compressibility_factor(void) {
             double chi, sigma_k;
             summ = 0.;
             for (int i = 0; i < ncomp; i++) {
-                chi = 3 / pow(kappa * components[i].getSigma(), 3)
-                      * (1.5 + log(1 + kappa * components[i].getSigma()) - 2 * (1 + kappa * components[i].getSigma())
-                         + 0.5 * pow(1 + kappa * components[i].getSigma(), 2));
-                sigma_k = -2 * chi + 3 / (1 + kappa * components[i].getSigma());
+                chi = 3 / pow(kappa * d[i], 3)
+                      * (1.5 + log(1 + kappa * d[i]) - 2 * (1 + kappa * d[i])
+                         + 0.5 * pow(1 + kappa * d[i], 2));
+                sigma_k = -2 * chi + 3 / (1 + kappa * d[i]);
                 summ += q[i] * q[i] * mole_fractions[i] * sigma_k;
             }
             Zion = -1 * kappa / 24. / PI / kb / _T / (dielc * perm_vac) * summ;

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -1995,7 +1995,7 @@ TEST_CASE("Check the PC-SAFT pressure function", "[pcsaft_pressure]") {
     p_calc = CoolProp::PropsSI("P", "T", 298.15, "Dmolar", 9368.903838750752, "PCSAFT::METHANOL[0.055]&CYCLOHEXANE[0.945]");
     CHECK(abs((p_calc/p) - 1) < 1e-5);
 
-    p_calc = CoolProp::PropsSI("P", "T", 298.15, "Dmolar", 55740.15826463244, "PCSAFT::Na+[0.010579869455908]&Cl-[0.010579869455908]&WATER[0.978840261088184]");
+    p_calc = CoolProp::PropsSI("P", "T", 298.15, "Dmolar", 55757.07260200306, "PCSAFT::Na+[0.010579869455908]&Cl-[0.010579869455908]&WATER[0.978840261088184]");
     CHECK(abs((p_calc/p) - 1) < 1e-5);
 
     p = CoolProp::PropsSI("P", "T", 100., "Q", 0, "PCSAFT::PROPANE");


### PR DESCRIPTION
### Description of the Change

The ion term in the PC-SAFT code was updated to use the temperature dependent hard sphere diameter (d) instead of sigma. This is a fix for issue [2338](https://github.com/CoolProp/CoolProp/issues/2338).

### Benefits

Fixes the ePC-SAFT model so it give correct results.

### Possible Drawbacks

There's always the chance a mistake was introduced.

### Verification Process

I ran the Catch tests before and after making changes. The test results were exactly the same and all PC-SAFT tests passed.

### Applicable Issues

``Closes #2338``
