### PR TITLE
Update CMakeLists.txt to fix Mathcad wrapper check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -788,6 +788,9 @@ if(COOLPROP_PRIME_MODULE)
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/wrappers/MathCAD/CoolPropMathcad.cpp")
   add_library(CoolPropMathcadWrapper SHARED ${APP_SOURCES})
+  if(MSVC)
+      target_compile_options(CoolPropMathcadWrapper PUBLIC "/Zc:__cpluplus")
+  endif()
   include_directories("${COOLPROP_PRIME_ROOT}/Custom Functions")
   target_link_libraries(CoolPropMathcadWrapper
                         "${COOLPROP_PRIME_ROOT}/Custom Functions/mcaduser.lib")


### PR DESCRIPTION
### Description of the Change

Update CMake script to force definition of __cplusplus during build of Mathcad wrapper.  Might fix the code test for this wrapper.

### Benefits

Trying to get the automatic build check to pass.

### Possible Drawbacks

None.  Only impacts the COOLPROP_PRIME_MODULE in the CMake script.

### Verification Process

Works on local system and forces `__cplusplus` to be defined for Visual Studio build.  Triggers the following extern "C" wrapper around the code in the `mcadincl.h` header, which is a standard C-code header file (and library) and seems to be failing.

```cpp
#ifdef __cplusplus
extern "C"
{
#endif // __cplusplus

   [... C code header file...]

#ifdef __cplusplus
}
#endif // __cplusplus
```

It looks like maybe `__cplusplus` is not getting defined by default in the latest version of Visual Studio being used by the checks.  After configuring the project, the `/Zc:__cplusplus' compiler option is confirmed to be set.  Let's see if it fixes the code check.

### Applicable Issues

Might work to fix the failing Mathcad wrapper tests mentioned as failing in #2394 . 
