### PR TITLE
Bypass Mathcad builder on pushes and PRs

### DIFF
--- a/.github/workflows/mathcad_builder.yml
+++ b/.github/workflows/mathcad_builder.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
 
+    if: github.event_name != 'push' && github.event_name != 'pull_request'
+
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
### Description of the Change

Mathcad builder is failing due to permissions issues on accessing repository secrets to get required build libraries from PTC.

The only reason the Mathcad builder exists is to provide a binary on the scheduled nightly builds.  It is not necessary to check the Mathcad wrapper every time a change is made to CoolProp.  So, the following line in the build job skips the build if this is a push (direct commit) or a Pull Request to the repository.

```
        if: github.event_name != 'push' && github.event_name != 'pull_request'
```

I believe this will allow the script to run when called directly (a 'workflow_call' event) from the nightly build script and the nightly binary file will still be built.

### Benefits

Removes Mathcad Build failures from standard pushes and PRs

### Possible Drawbacks

The only drawback would be if a change is made to names of the CoolProp API functions that the Mathcad wrapper calls, breaking the wrapper.  This is a low probability change and would still be caught by the nightly build.

### Verification Process

This will get verified with the push, I hope, and when the next nightly build runs.
Edit: Checks successfully skipped during this PR's CI checks.  Should get called successfully tonight by nightly build.

### Applicable Issues

Affects issue #2394, but does not close as there are still other items failing.
