### PR TITLE
Update the Release Workflow for upload/downlaod-artifact@v4 [skip ci]

### DIFF
--- a/.github/workflows/release_all_files.yml
+++ b/.github/workflows/release_all_files.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Store artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: binaries
+        name: binaries-source
         path: binaries
         retention-days: 1
 
@@ -116,9 +116,14 @@ jobs:
     steps:  
     
     - name: Download binaries
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
-        name: binaries
+        # Get all unique artifacts starting with "binaries-" per the pattern
+        # per requirements of actions/download-artifact@v4
+        pattern: binaries-*
+        # Allow multiple artifacts matching the patter to be merged
+        # into the same binaries directory.
+        merge-multiple: true
         path: binaries
         
     - name: Create info files

--- a/.github/workflows/release_get_artifact.yml
+++ b/.github/workflows/release_get_artifact.yml
@@ -84,7 +84,11 @@ jobs:
       - name: Store artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: binaries
+          # Create individual artifacts for each workflow
+          # These will be combined later in release_all_files
+          # suffix will have a "." character embeded, but may be ok;
+          # otherwise we can strip it off the workflow string.
+          name: binaries-${{ inputs.workflow }}
           path: binaries
           retention-days: 1
       


### PR DESCRIPTION
### Description of the Change

Simple updates to workflows:
- release_all_files.yaml
- release_get_artifacts.yaml  

to create uniquely named artifacts from sub-workflows and then merge them on download for deployment.

### Benefits

Should fix the nightly builds, which are currently failing after updating to upload/download-artifact@v4.  This version requires artifacts from each workflow to be uniquely named.  This patch implements that change with a workflow suffix on each artifact and then downloads them all according to pattern "binaries-*" and merges them into the same directory for deployment.

NOTE: It is not necessary to upload a new, single artifact with the merged files.

### Possible Drawbacks

None.  No impact on the code; only the nightly builds (which are currently failing).  Skipping CI workflows as this change does not impact them, only the nightly build workflows.

### Verification Process

Because of repository secret files and permissions issues.

### Applicable Issues

#2394
