### PR TITLE
Fix libreoffice_builder

### DIFF
--- a/.github/workflows/libreoffice_builder.yml
+++ b/.github/workflows/libreoffice_builder.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 
     - name: Install dependencies
       shell: bash
       # use backports to get libreoffice > 7.3 on ubuntu-lastest (22.04)
-      run: sudo apt-get install -y -t $(lsb_release -cs)-backports libreoffice-dev
+      run: sudo apt-get update -y && sudo apt-get install -y -t $(lsb_release -cs)-backports libreoffice-dev
 
     - name: Configure CMake
       shell: bash


### PR DESCRIPTION
### Description of the Change

Fix build action for LibreOffice extension.

- Run apt-get update to sync package index files before installing libreoffice as a build dependency. This fixes failing builds due to download errors of outdated packages.
- Update to actions/checkout@v4 as v3 uses deprecated Node.js version.


### Benefits

Build action will run again.

### Possible Drawbacks

None

### Verification Process

Tested the updated build workflow on GitHub. It works fine without any errors or warnings.


### Applicable Issues

Fixes the issue seen by @henningjp at https://github.com/CoolProp/CoolProp/commit/214a6147dfbd57600fdc728b0bfd1a291fb11db9#comments