### PR TITLE
Python 3.13 and replace distutils with setuptools PEP 632 – Deprecate distutils

### DIFF
--- a/.github/workflows/python_buildwheels.yml
+++ b/.github/workflows/python_buildwheels.yml
@@ -84,12 +84,6 @@ jobs:
         arch: [x86_64, arm64, universal2]
         exclude:
           - os: macos
-            arch: arm64
-            python-version: 36
-          - os: macos
-            arch: arm64
-            python-version: 37
-          - os: macos
             arch: universal2 # is redundant
     uses: ./.github/workflows/python_cibuildwheel.yml
     with:

--- a/.github/workflows/python_buildwheels.yml
+++ b/.github/workflows/python_buildwheels.yml
@@ -68,15 +68,6 @@ jobs:
         exclude:
           - os: windows
             arch: ARM64 # creates problems with msgpack-c
-          - os: windows
-            arch: ARM64
-            python-version: 36
-          - os: windows
-            arch: ARM64
-            python-version: 37
-          - os: windows
-            arch: ARM64
-            python-version: 38
     uses: ./.github/workflows/python_cibuildwheel.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/python_buildwheels.yml
+++ b/.github/workflows/python_buildwheels.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: 3.13.x
         
     - name: Install dependencies
-      run: pip install setuptools wheel Cython requests jinja2 pyyaml
+      run: pip install setuptools wheel Cython requests jinja2 pyyaml packaging
         
     - name: Build package, sdist
       working-directory: ./wrappers/Python/pypi

--- a/.github/workflows/python_buildwheels.yml
+++ b/.github/workflows/python_buildwheels.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12.x
+        python-version: 3.13.x
         
     - name: Install dependencies
       run: pip install setuptools wheel Cython requests jinja2 pyyaml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        python-version: [38, 39, 310, 311, 312]
+        python-version: [38, 39, 310, 311, 312, 313]
         arch: [i686, x86_64, aarch64, ppc64le, s390x]
         exclude:
           - os: ubuntu
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows]
-        python-version: [38, 39, 310, 311, 312]
+        python-version: [38, 39, 310, 311, 312, 313]
         arch: [AMD64, x86, ARM64]
         exclude:
           - os: windows
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos]
-        python-version: [38, 39, 310, 311, 312]
+        python-version: [38, 39, 310, 311, 312, 313]
         arch: [x86_64, arm64, universal2]
         exclude:
           - os: macos
@@ -125,7 +125,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12.x
+        python-version: 3.13.x
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/python_cibuildwheel.yml
+++ b/.github/workflows/python_cibuildwheel.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12.x
+        python-version: 3.13.x
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/python_cibuildwheel.yml
+++ b/.github/workflows/python_cibuildwheel.yml
@@ -49,7 +49,7 @@ jobs:
         platforms: all
         
     - name: Build and test wheels
-      uses: pypa/cibuildwheel@v2.17.0
+      uses: pypa/cibuildwheel@v2.21.3
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.9
         CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.9 SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk

--- a/.github/workflows/release_all_files.yml
+++ b/.github/workflows/release_all_files.yml
@@ -83,6 +83,7 @@ jobs:
     # Doesn't work through the matrix calls to release_get_artifact above and no output results for troubleshooting. 
     uses: ./.github/workflows/mathcad_builder.yml
     # Stores artifact under binaries-MathcadPrime consistent with the other builds
+    secrets: inherit
 
 
   prepare_sources:

--- a/.github/workflows/release_all_files.yml
+++ b/.github/workflows/release_all_files.yml
@@ -75,8 +75,16 @@ jobs:
     with:
       branch: ${{ needs.set_vars.outputs.branch }}
       workflow: ${{ matrix.workflow }}
-      
-      
+
+
+  prepare_mathcad:
+    needs: [set_vars]
+    # Call the mathcad_builder workflow here direclty
+    # Doesn't work through the matrix calls to release_get_artifact above and no output results for troubleshooting. 
+    uses: ./.github/workflows/mathcad_builder.yml
+    # Stores artifact under binaries-MathcadPrime consistent with the other builds
+
+
   prepare_sources:
     needs: [set_vars]
     name: Prepare the source code
@@ -110,7 +118,7 @@ jobs:
 
 
   deploy_files:
-    needs: [set_vars, collect_binaries, prepare_sources]
+    needs: [set_vars, collect_binaries, prepare_mathcad, prepare_sources]
     name: Deploy collected files
     runs-on: ubuntu-latest
     steps:  

--- a/wrappers/Python/setup.py
+++ b/wrappers/Python/setup.py
@@ -350,7 +350,7 @@ if __name__ == '__main__':
             """ Metaclass for overwriting compilation flags """
 
             def set_shared_ptr_flags(self):
-                from setuptools import CompileErro
+                from setuptools import CompileError
 
                 if sys.platform.startswith('win') and sys.version_info <= (3, 0):
                     # Hardcode for windows for python 2.7...

--- a/wrappers/Python/setup.py
+++ b/wrappers/Python/setup.py
@@ -1,8 +1,8 @@
 from __future__ import print_function
 import platform
 import subprocess, shutil, os, sys, glob, tempfile
-from distutils.version import LooseVersion
-from distutils.sysconfig import get_config_var
+from packaging.version import Version
+from sysconfig import get_config_var
 from setuptools.command.build_ext import build_ext
 from multiprocessing import cpu_count
 
@@ -57,13 +57,13 @@ if __name__ == '__main__':
     # libstdc++ which forces is to manipulate the minimum OSX target
     # version when compiling the Cython extensions.
     if sys.platform == 'darwin':
-        osx_target = LooseVersion(get_config_var('MACOSX_DEPLOYMENT_TARGET'))
-        osx_compiler = LooseVersion('0.0')
-        osx_version = LooseVersion('0.0')
+        osx_target = Version(get_config_var('MACOSX_DEPLOYMENT_TARGET'))
+        osx_compiler = Version('0.0')
+        osx_version = Version('0.0')
         FORCE_TARGET = None
         USE_OSX_VERSION = False
         if USE_OSX_VERSION:
-            osx_version = LooseVersion(platform.mac_ver()[0])
+            osx_version = Version(platform.mac_ver()[0])
             print("OSX build detected, targetting {0} on {1}.".format(osx_target, osx_version))
         else:
             import subprocess
@@ -74,7 +74,7 @@ if __name__ == '__main__':
                 except AttributeError: pass
                 line = line.strip()
                 try:
-                    osx_compiler = LooseVersion(line)
+                    osx_compiler = Version(line)
                     if osx_compiler > "1.0" and osx_compiler < "100.0": break
                 except BaseException as be:
                     print('Error getting OSX compile version: ', str(be))
@@ -226,7 +226,7 @@ if __name__ == '__main__':
             raise ValueError('cmake_compiler [' + cmake_compiler + '] is invalid')
 
         # if 'darwin' in sys.platform:
-        #    current_system = LooseVersion(platform.mac_ver()[0])
+        #    current_system = Version(platform.mac_ver()[0])
         #    print("OSX build detected for system {0}".format(current_system))
         #    #if current_system >= '10.9':
         #    #    cmake_config_args += ["-DDARWIN_USE_LIBCPP=ON"]
@@ -288,7 +288,7 @@ if __name__ == '__main__':
             raise ImportError("Cython not found, please install it.  You can do a pip install Cython")
 
         # Handle different Cython versions
-        cython_version = LooseVersion(Cython.__version__)
+        cython_version = str(Version (Cython.__version__))
         print('Cython version: ', cython_version)
 
         if cython_version < '0.20':
@@ -350,7 +350,7 @@ if __name__ == '__main__':
             """ Metaclass for overwriting compilation flags """
 
             def set_shared_ptr_flags(self):
-                from distutils.errors import CompileError
+                from setuptools import CompileErro
 
                 if sys.platform.startswith('win') and sys.version_info <= (3, 0):
                     # Hardcode for windows for python 2.7...
@@ -391,9 +391,8 @@ if __name__ == '__main__':
     if USE_CYTHON:
         print('Cython will be used; cy_ext is ' + cy_ext)
         import Cython.Compiler
-        from Cython.Distutils.extension import Extension
+        from setuptools.extension import Extension
         from Cython.Build import cythonize
-        from Cython.Distutils import build_ext
 
         # setup_kwargs['cmdclass'] = dict(build_ext=get_shared_ptr_setter(build_ext))
 

--- a/wrappers/Python/setup.py
+++ b/wrappers/Python/setup.py
@@ -288,7 +288,7 @@ if __name__ == '__main__':
             raise ImportError("Cython not found, please install it.  You can do a pip install Cython")
 
         # Handle different Cython versions
-        cython_version = str(Version (Cython.__version__))
+        cython_version = str(Version(Cython.__version__))
         print('Cython version: ', cython_version)
 
         if cython_version < '0.20':


### PR DESCRIPTION
### Description of the Change

Updated setup.py, python_cibuildwheel.yml, and python_buildwheels.yml

setup.py
- Replaced distutils as per PEP 632 with setuptools and packaging

python_cibuildwheel.yml
- Added the module packaging to the dependencies
- Added 313 to the list of python versions
- Replaced python-version: 3.12.x with python-version: 3.13.x
- Removed some redundant lines of codes related to version specifically excluded architecture (for example ARM64 windows python 36) since these architectures are generically already excluded and/or the python version is no longer supported.

python_buildwheels.yml
- Replaced pypa/cibuildwheel@v2.17.0 with pypa/cibuildwheel@v2.21.3
- Replaced python-version: 3.12.x with python-version: 3.13.x

### Benefits

Python 3.13 should now be supported

### Possible Drawbacks

There is still an error left-over related to Testing Catch2 which was still unsolved in the previous pull request. #2432 

### Verification Process

Tested with pull request #2432 

### Applicable Issues

Closes #2430
