### PR TITLE
Fix Plots of log-p-h diagrams

### DIFF
--- a/wrappers/Python/CoolProp/Plots/Common.py
+++ b/wrappers/Python/CoolProp/Plots/Common.py
@@ -478,7 +478,7 @@ class IsoLine(Base2DObject):
     VALID_REQ = 5.0 / 100.0
 
     def __init__(self, i_index, x_index, y_index, value=0.0, state=None):
-        super(IsoLine, self).__init__(x_index, y_index, state)
+        super().__init__(x_index, y_index, state)
         self._i_index = _get_index(i_index)
         if value is not None: self.value = value
         else: self._value = None


### PR DESCRIPTION
When i tried to plot log(p)-h-diagrams there always had been an issue in the `common.py` file in line 481. By deleting the `Isoline, self` expression between the clips of super in this line, i could fix this and the plots were generated. So i made this pull request and hope you will fix the master that every coolprop user can make plots again.

