### PR TITLE
Alternative to splined two-phase derivative using smoothstep function

### DIFF
--- a/CoolPropBibTeXLibrary.bib
+++ b/CoolPropBibTeXLibrary.bib
@@ -2190,6 +2190,19 @@
   Timestamp                = {2013.03.30}
 }
 
+@Article{Quoilin-E-2014,
+  Title                    = {{Methods to Increase the Robustness of Finite-Volume Flow Models in Thermodynamic Systems}},
+  Author                   = {Quoilin, Sylvain and Bell, Ian and Desideri, Adriano and Dewallef, Pierre and Lemort, Vincent},
+  Journal                  = {Energies},
+  Year                     = {2014},
+  Number                   = {3},
+  Pages                    = {1621--1640},
+  Volume                   = {7},
+
+  Doi                      = {10.3390/en7031621}
+  Issn                     = {1996-1073},
+}
+
 @Article{Reeves-JCP-1964,
   Title                    = {{Melting Curves of Pressure Transmitting Fluids}},
   Author                   = {Larry E. Reeves and Gene J. Scott and Stanley E. Babb Jr.},

--- a/Web/coolprop/LowLevelAPI.rst
+++ b/Web/coolprop/LowLevelAPI.rst
@@ -207,7 +207,7 @@ For more information, see the docs: :cpapi:`CoolProp::AbstractState::first_parti
 Two-Phase and Saturation Derivatives
 ------------------------------------
 
-The two-phase derivatives of Thorade :cite:`Thorade-EES-2013` are implemented in the :cpapi:`CoolProp::AbstractState::first_two_phase_deriv` function, and derivatives along the saturation curve in the functions :cpapi:`CoolProp::AbstractState::first_saturation_deriv` and :cpapi:`CoolProp::AbstractState::second_saturation_deriv`.  Here are some examples of using these functions:
+The two-phase derivatives of Thorade :cite:`Thorade-EES-2013` are implemented in the :cpapi:`CoolProp::AbstractState::first_two_phase_deriv` function, and derivatives along the saturation curve in the functions :cpapi:`CoolProp::AbstractState::first_saturation_deriv` and :cpapi:`CoolProp::AbstractState::second_saturation_deriv`. The functions `CoolProp::AbstractState::first_two_phase_deriv_splined` and `CoolProp::AbstractState::first_two_phase_deriv_smoothed` return two-phase derivatives after smoothing out discontinuities at saturated states using splines :cite:`Quoilin-E-2014` and smoothstep functions, respectively. Here are some examples of using these functions:
     
 .. ipython::
 
@@ -235,6 +235,9 @@ The two-phase derivatives of Thorade :cite:`Thorade-EES-2013` are implemented in
     # The d(Dmass)/d(Hmass)|P two-phase derivative using splines
     In [0]: HEOS.first_two_phase_deriv_splined(CoolProp.iDmass, CoolProp.iHmass, CoolProp.iP, 0.3)
     
+    # The d(Dmass)/d(Hmass)|P two-phase derivative using smoothstep functions
+    In [0]: HEOS.first_two_phase_deriv_smoothed(CoolProp.iDmass, CoolProp.iHmass, CoolProp.iP, CoolProp.iQ, 0.3, 0.0)
+
 An example of plotting these derivatives is here:
 
 .. plot::
@@ -259,7 +262,15 @@ An example of plotting these derivatives is here:
         y.append(AS.first_partial_deriv(CoolProp.iDmass, CoolProp.iHmass, CoolProp.iP))
     plt.plot(x, y, label = 'Subcooled')
 
-    # Two-phase derivatives (normal and splined)
+    # Two-phase derivatives (smoothed)
+    x, y1 = [], []
+    for Q in np.linspace(0, 0.3, 1000):
+        AS.update(CoolProp.PQ_INPUTS, 101325, Q)
+        x.append(AS.Q())
+        y1.append(AS.first_two_phase_deriv_smoothed(CoolProp.iDmass, CoolProp.iHmass, CoolProp.iP, CoolProp.iQ, 0.3, 0.0))
+    plt.plot(x, y1, label = 'Two-phase (smoothed)')
+
+    # Two-phase derivatives (splined)
     x, y1 = [], []
     for Q in np.linspace(0, 0.3, 1000):
         AS.update(CoolProp.PQ_INPUTS, 101325, Q)
@@ -267,7 +278,7 @@ An example of plotting these derivatives is here:
         y1.append(AS.first_two_phase_deriv_splined(CoolProp.iDmass, CoolProp.iHmass, CoolProp.iP, 0.3))
     plt.plot(x, y1, label = 'Two-phase (splined)')
 
-    # Two-phase derivatives (normal and splined)
+    # Two-phase derivatives (normal)
     x, y1 = [], []
     for Q in np.linspace(0.0, 0.6, 1000):
         AS.update(CoolProp.PQ_INPUTS, 101325, Q)

--- a/include/AbstractState.h
+++ b/include/AbstractState.h
@@ -629,6 +629,9 @@ class AbstractState
     virtual CoolPropDbl calc_first_two_phase_deriv_splined(parameters Of, parameters Wrt, parameters Constant, CoolPropDbl x_end) {
         throw NotImplementedError("calc_first_two_phase_deriv_splined is not implemented for this backend");
     };
+    virtual CoolPropDbl calc_first_two_phase_deriv_smoothed(parameters Of, parameters Wrt, parameters Constant, parameters sWrt, CoolPropDbl Lsmooth, CoolPropDbl Vsmooth) {
+        throw NotImplementedError("calc_first_two_phase_deriv_smoothed is not implemented for this backend");
+    };
 
     virtual CoolPropDbl calc_saturated_liquid_keyed_output(parameters key) {
         throw NotImplementedError("calc_saturated_liquid_keyed_output is not implemented for this backend");
@@ -1376,6 +1379,27 @@ class AbstractState
     */
     double first_two_phase_deriv_splined(parameters Of, parameters Wrt, parameters Constant, double x_end) {
         return calc_first_two_phase_deriv_splined(Of, Wrt, Constant, x_end);
+    };
+
+    /**
+    * @brief Calculate the first "two-phase" derivative as described by Thorade and Sadaat, EAS, 2013
+    *
+    * Implementing the algorithms and ideas of:
+    * Matthis Thorade, Ali Saadat, "Partial derivatives of thermodynamic state properties for dynamic simulation",
+    * Environmental Earth Sciences, December 2013, Volume 70, Issue 8, pp 3497-3503
+    *
+    * Discontinuities in first derivatives at saturation lines are smoothed using smoothstep function
+    *
+    * @param Of The parameter to be derived
+    * @param Wrt The parameter that the derivative is taken with respect to
+    * @param Constant The parameter that is held constant
+    * @param sWrt The parameter that smoothing is done with respect to
+    * @param Lsmooth Smoothing amount in the interval [0.0, 1.0] at saturated liquid line
+    * @param Vsmooth Smoothing amount in the interval [0.0, 1.0] at saturated vapour line
+    * @return
+    */
+    double first_two_phase_deriv_smoothed(parameters Of, parameters Wrt, parameters Constant, parameters sWrt, double Lsmooth, double Vsmooth) {
+        return calc_first_two_phase_deriv_smoothed(Of, Wrt, Constant, sWrt, Lsmooth, Vsmooth);
     };
 
     // ----------------------------------------

--- a/include/CPnumerics.h
+++ b/include/CPnumerics.h
@@ -472,6 +472,7 @@ void MatInv_2(double A[2][2], double B[2][2]);
 double root_sum_square(const std::vector<double>& x);
 double interp1d(const std::vector<double>* x, const std::vector<double>* y, double x0);
 double powInt(double x, int y);
+double smoothstep(double t, double lo, double hi);
 
 template <class T>
 T POW2(T x) {

--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -523,6 +523,25 @@ EXPORT_CODE double CONVENTION AbstractState_second_partial_deriv(const long hand
 EXPORT_CODE double CONVENTION AbstractState_first_two_phase_deriv_splined(const long handle, const long Of, const long Wrt, const long Constant,
                                                                   const double x_end,long* errcode, char* message_buffer, const long buffer_length);
 /**
+    * @brief Calculate the first partial derivative in two-phase region with smoothing from the AbstractState using integer values for the desired parameters
+      Discontinuities in first derivatives at saturation lines are smoothed using smoothstep function
+    * @param handle The integer handle for the state class stored in memory
+    * @x_end constant parameter for defining range of the spline, (usually 0.1 is used, 0..1 is possible)
+    * @param Of The parameter of which the derivative is being taken
+    * @param Wrt The derivative is with respect to this parameter
+    * @param Constant The parameter that is not affected by the derivative
+    * @param sWrt The parameter that smoothing is done with respect to
+    * @param Lsmooth Smoothing amount in the interval [0.0, 1.0] at saturated liquid line
+    * @param Vsmooth Smoothing amount in the interval [0.0, 1.0] at saturated vapour line
+    * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+    * @param message_buffer A buffer for the error code
+    * @param buffer_length The length of the buffer for the error code
+    * @return
+    */
+EXPORT_CODE double CONVENTION AbstractState_first_two_phase_deriv_smoothed(const long handle, const long Of, const long Wrt, const long Constant, const long sWrt,
+                                                                           const double Lsmooth, const double Vsmooth, long* errcode, char* message_buffer,
+                                                                           const long buffer_length);
+/**
     * @brief Calculate the first partial derivative in homogeneous phases from the AbstractState using integer values for the desired parameters
     * @param handle The integer handle for the state class stored in memory
     * @param Of The parameter of which the derivative is being taken

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -3440,6 +3440,76 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_first_two_phase_deriv_splined(param
     return _HUGE;
 }
 
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_first_two_phase_deriv_smoothed(parameters Of, parameters Wrt, parameters Constant,
+                                                                            parameters sWrt, CoolPropDbl Lsmooth, CoolPropDbl Vsmooth) {
+    // Limits of smoothing amount
+    const CoolPropDbl SMIN = 0.0;
+    const CoolPropDbl SMAX = 1.0;
+
+    if (_phase != iphase_twophase) throw ValueError("state is not two-phase");
+    if ((Lsmooth < SMIN) || (Lsmooth > SMAX))
+        throw CoolProp::OutOfRangeError(format("Input smoothing amount at saturated liquid line [Lsmooth] must be between [%f] and [%f]", SMIN, SMAX));
+    if ((Vsmooth < SMIN) || (Vsmooth > SMAX))
+        throw CoolProp::OutOfRangeError(format("Input smoothing amount at saturated vapour line [Vsmooth] must be between [%f] and [%f]", SMIN, SMAX));
+    if ((Lsmooth + Vsmooth) > SMAX)
+        throw CoolProp::OutOfRangeError(format("Sum of input smoothing amounts [Lsmooth + Vsmooth] must be less than or equal to [%f]", SMAX));
+    if (!this->SatL || !this->SatV)
+        throw ValueError("saturation properties are needed for calc_first_two_phase_deriv_smoothed");
+
+    // Limits of parameter for smoothing function
+    const CoolPropDbl XMIN = 0.0;
+    const CoolPropDbl XMAX = 1.0;
+
+    // Parameter for smoothing function
+    CoolPropDbl x = 0.0;
+    // Vapor quality is not available from saturation properties; therefore the conditional statement.
+    if (sWrt == iQ) x = _Q;
+    else {
+        // Values of fluid state parameter with respect to which smoothing is applied
+        // Value at current state
+        CoolPropDbl sWrtCurrentValue = keyed_output(sWrt);
+        // Value at saturated liquid state
+        CoolPropDbl sWrtSatLValue = SatL->keyed_output(sWrt);
+        // Value at saturated vapour state
+        CoolPropDbl sWrtSatVValue = SatV->keyed_output(sWrt);
+        // The following reduces to vapour quality for properties like iHmolar, iHmass, iSmolar etc.
+        // But not in cases of iDmolar and iDmass
+        x = (sWrtCurrentValue - sWrtSatLValue) / (sWrtSatVValue - sWrtSatLValue);
+    }
+    // Clamp
+    x = (x < XMIN) ? XMIN : (x > XMAX) ? XMAX : x;
+
+    // Interval limits without smoothing
+    CoolPropDbl nsxmin = XMIN + Lsmooth;
+    CoolPropDbl nsxmax = XMAX - Vsmooth;
+
+    // Two-phase derivative
+    CoolPropDbl dOf_dWrt_C2p = first_two_phase_deriv(Of, Wrt, Constant);
+
+    // Values outside smoothed regions
+    if (!((x < nsxmin) || (x > nsxmax))) return dOf_dWrt_C2p; 
+
+    // Derivative value for extended single phase
+    CoolPropDbl dOf_dWrt_C1p = 0.0;
+    // Smoothing factor
+    CoolPropDbl s = 0.0;
+
+    // Near saturated liquid state
+    if (x < nsxmin) {
+        dOf_dWrt_C1p = SatL->first_partial_deriv(Of, Wrt, Constant);
+        s = smoothstep(x, XMIN, nsxmin);
+    }
+    // Near saturated vapour state
+    if (x > nsxmax) {
+        dOf_dWrt_C1p = SatV->first_partial_deriv(Of, Wrt, Constant);
+        s = smoothstep(x, XMAX, nsxmax);
+    }
+
+    // Smoothed derivative
+    CoolPropDbl dOf_dWrt_C = (1.0 - s) * dOf_dWrt_C1p + s * dOf_dWrt_C2p;
+    return dOf_dWrt_C;
+}
+
 CoolProp::CriticalState HelmholtzEOSMixtureBackend::calc_critical_point(double rho0, double T0) {
     class Resid : public FuncWrapperND
     {

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
@@ -226,6 +226,7 @@ class HelmholtzEOSMixtureBackend : public AbstractState
     CoolPropDbl calc_first_two_phase_deriv(parameters Of, parameters Wrt, parameters Constant);
     CoolPropDbl calc_second_two_phase_deriv(parameters Of, parameters Wrt1, parameters Constant1, parameters Wrt2, parameters Constant2);
     CoolPropDbl calc_first_two_phase_deriv_splined(parameters Of, parameters Wrt, parameters Constant, CoolPropDbl x_end);
+    CoolPropDbl calc_first_two_phase_deriv_smoothed(parameters Of, parameters Wrt, parameters Constant, parameters sWrt, CoolPropDbl Lsmooth, CoolPropDbl Vsmooth);
 
     CriticalState calc_critical_point(double rho0, double T0);
     /// An overload to make the compiler (clang in this case) happy

--- a/src/CPnumerics.cpp
+++ b/src/CPnumerics.cpp
@@ -200,3 +200,14 @@ bool SplineClass::add_derivative_constraint(double x, double dydx) {
 double SplineClass::evaluate(double x) {
     return a * x * x * x + b * x * x + c * x + d;
 }
+
+double smoothstep(double t, double lo, double hi) {
+    // Scale
+    double xs = (t - lo) / (hi - lo);
+    // Clamp to [0.0, 1.0]
+    double x = (xs < 0.0) ? 0.0 : (xs > 1.0) ? 1.0 : xs;
+    // Smoothstep function (3rd-order)
+    double y = x * x * (3.0 - 2.0 * x);
+    return y;
+}
+

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -754,6 +754,19 @@ EXPORT_CODE double CONVENTION AbstractState_first_two_phase_deriv_splined(const 
     return _HUGE;
 }
 
+EXPORT_CODE double CONVENTION AbstractState_first_two_phase_deriv_smoothed(const long handle, const long Of, const long Wrt, const long Constant,
+                                                                           const long sWrt, const double Lsmooth, const double Vsmooth, long* errcode,
+                                                                           char* message_buffer, const long buffer_length) {
+    *errcode = 0;
+    try {
+        shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
+        return AS->first_two_phase_deriv_smoothed(static_cast<CoolProp::parameters>(Of), static_cast<CoolProp::parameters>(Wrt),
+                                                  static_cast<CoolProp::parameters>(Constant), static_cast<CoolProp::parameters>(sWrt), Lsmooth, Vsmooth);
+    } catch (...) {
+        HandleException(errcode, message_buffer, buffer_length);
+    }
+    return _HUGE;
+}
 
 EXPORT_CODE void CONVENTION AbstractState_update_and_common_out(const long handle, const long input_pair, const double* value1, const double* value2,
                                                                 const long length, double* T, double* p, double* rhomolar, double* hmolar,

--- a/wrappers/Python/CoolProp/AbstractState.pxd
+++ b/wrappers/Python/CoolProp/AbstractState.pxd
@@ -187,6 +187,7 @@ cdef class AbstractState:
     cpdef double first_two_phase_deriv(self, constants_header.parameters Of, constants_header.parameters Wrt, constants_header.parameters Constant) except *
     cpdef double second_two_phase_deriv(self, constants_header.parameters Of, constants_header.parameters Wrt1, constants_header.parameters Constant1, constants_header.parameters Wrt2, constants_header.parameters Constant2) except *
     cpdef double first_two_phase_deriv_splined(self ,constants_header.parameters Of, constants_header.parameters Wrt, constants_header.parameters Constant, double x_end) except *
+    cpdef double first_two_phase_deriv_smoothed(self, constants_header.parameters Of, constants_header.parameters Wrt, constants_header.parameters Constant, constants_header.parameters sWrt, double Lsmooth, double Vsmooth) except *
 
     cpdef double melting_line(self, int, int, double) except *
     cpdef bool has_melting_line(self) except *

--- a/wrappers/Python/CoolProp/AbstractState.pyx
+++ b/wrappers/Python/CoolProp/AbstractState.pyx
@@ -463,6 +463,9 @@ cdef class AbstractState:
     cpdef double first_two_phase_deriv_splined(self, constants_header.parameters Of, constants_header.parameters Wrt, constants_header.parameters Constant, double x_end) except *:
         """ Get the first two-phase derivative using splines - wrapper of C++ function :cpapi:`CoolProp::AbstractState::first_two_phase_deriv_splined` """
         return self.thisptr.first_two_phase_deriv_splined(Of, Wrt, Constant, x_end)
+    cpdef double first_two_phase_deriv_smoothed(self, constants_header.parameters Of, constants_header.parameters Wrt, constants_header.parameters Constant, constants_header.parameters sWrt, double Lsmooth, double Vsmooth) except *:
+        """ Get the first two-phase derivative using smoothstep function - wrapper of C++ function :cpapi:`CoolProp::AbstractState::first_two_phase_deriv_smoothed` """
+        return self.thisptr.first_two_phase_deriv_smoothed(Of, Wrt, Constant, sWrt, Lsmooth, Vsmooth)
 
     ## ----------------------------------------
     ##        Ancillary curves

--- a/wrappers/Python/CoolProp/cAbstractState.pxd
+++ b/wrappers/Python/CoolProp/cAbstractState.pxd
@@ -186,6 +186,7 @@ cdef extern from "AbstractState.h" namespace "CoolProp":
         double first_two_phase_deriv(constants_header.parameters Of, constants_header.parameters Wrt, constants_header.parameters Constant) except+ValueError
         double second_two_phase_deriv(constants_header.parameters Of, constants_header.parameters Wrt1, constants_header.parameters Constant1, constants_header.parameters Wrt2, constants_header.parameters Constant2) except+ValueError
         double first_two_phase_deriv_splined(constants_header.parameters Of, constants_header.parameters Wrt, constants_header.parameters Constant, double x_end) except+ValueError
+        double first_two_phase_deriv_smoothed(constants_header.parameters Of, constants_header.parameters Wrt, constants_header.parameters Constant, constants_header.parameters sWrt, double Lsmooth, double Vsmooth) except+ValueError
         void true_critical_point(double &T, double &rho) except +ValueError
 
         double melting_line(int,int,double) except+ValueError


### PR DESCRIPTION
### Description of the Change

An alternative to the abstract state method  `first_two_phase_deriv_splined`, for a continuous transition between `first_partial_deriv` and `first_two_phase_deriv` using smoothstep functions.

Discussion: #2456 

### Benefits

Another option to smooth out discontinuities in derivatives at both saturated states.

### Possible Drawbacks

None, so far.

### Verification Process

**Comparison** in discussion: #2456

### Applicable Issues

None
