### PR TITLE
Support plotting in C++

### DIFF
--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -102,6 +102,18 @@ public:
     double value_at(CoolProp::parameters key, double xvalue, double yvalue, CoolProp::phases phase = CoolProp::phases::iphase_not_imposed) const;
 
 private:
+    struct Range2D
+    {
+        union
+        {
+            Range x, T;
+        };
+        union
+        {
+            Range y, p;
+        };
+    };
+
     std::string fluid_name;
     CoolProp::input_pairs axis_pair;
     bool swap_axis_inputs_for_update;
@@ -111,7 +123,7 @@ private:
 
     Range get_sat_bounds(CoolProp::parameters key);
     void get_Tp_limits(double& T_lo, double& T_hi, double& P_lo, double& P_hi);
-    std::vector<double> get_axis_limits(CoolProp::parameters xkey = CoolProp::parameters::iundefined_parameter, CoolProp::parameters ykey = CoolProp::parameters::iundefined_parameter, bool autoscale = true);
+    Range2D get_axis_limits(CoolProp::parameters xkey = CoolProp::parameters::iundefined_parameter, CoolProp::parameters ykey = CoolProp::parameters::iundefined_parameter, bool autoscale = true);
 };
 
 } /* namespace Plot */

--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -2,9 +2,7 @@
 #define COOLPROPPLOT_H_
 
 #include "AbstractState.h"
-#include "CPnumerics.h"
 #include <vector>
-#include <map>
 
 namespace CoolProp {
 namespace Plot {
@@ -21,32 +19,6 @@ struct Range
 };
 
 namespace Detail {
-
-const double NaN = std::numeric_limits<double>::quiet_NaN();
-
-enum IsolineSupported
-{
-    No = 0,
-    Yes = 1,
-    Flipped = 2
-};
-
- const int TS = CoolProp::iT * 10 + CoolProp::iSmass;
- const int PH = CoolProp::iP * 10 + CoolProp::iHmass;
- const int HS = CoolProp::iHmass * 10 + CoolProp::iSmass;
- const int PS = CoolProp::iP * 10 + CoolProp::iSmass;
- const int PD = CoolProp::iP * 10 + CoolProp::iDmass;
- const int TD = CoolProp::iT * 10 + CoolProp::iDmass;
- const int PT = CoolProp::iP * 10 + CoolProp::iT;
-
- const std::map<CoolProp::parameters, std::map<int, IsolineSupported>> xy_switch = {
-    {CoolProp::iDmass, {{TS, Flipped}, {PH, Flipped}, {HS, Yes    }, {PS, Flipped}, {PD, No     }, {TD, No     }, {PT, Yes    }}},
-    {CoolProp::iHmass, {{TS, Yes    }, {PH, No     }, {HS, No     }, {PS, Flipped}, {PD, Flipped}, {TD, Yes    }, {PT, Yes    }}},
-    {CoolProp::iP,     {{TS, Yes    }, {PH, No     }, {HS, Yes    }, {PS, No     }, {PD, No     }, {TD, Yes    }, {PT, No     }}},
-    {CoolProp::iSmass, {{TS, No     }, {PH, Flipped}, {HS, No     }, {PS, No     }, {PD, Flipped}, {TD, Yes    }, {PT, Flipped}}},
-    {CoolProp::iT,     {{TS, No     }, {PH, Flipped}, {HS, Yes    }, {PS, Yes    }, {PD, Yes    }, {TD, No     }, {PT, No     }}},
-    {CoolProp::iQ,     {{TS, Flipped}, {PH, Flipped}, {HS, Flipped}, {PS, Flipped}, {PD, Flipped}, {TD, Flipped}, {PT, Yes    }}}
-};
 
 Scale default_scale(CoolProp::parameters key);
 std::shared_ptr<CoolProp::AbstractState> process_fluid_state(const std::string& fluid_ref);

--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -68,12 +68,18 @@ enum class TPLimits
 class PropertyPlot
 {
    public:
-    CoolProp::parameters xkey;
-    CoolProp::parameters ykey;
-    Scale xscale;
-    Scale yscale;
-    Range xrange;
-    Range yrange;
+    struct Axis
+    {
+        Scale scale;
+        union
+        {
+            Range range;
+            struct
+            {
+                double min, max;
+            };
+        };
+    } xaxis, yaxis;
 
     PropertyPlot(const std::string& fluid_name, CoolProp::parameters ykey, CoolProp::parameters xkey, CoolProp::Plot::TPLimits tp_limits = CoolProp::Plot::TPLimits::Def);
 
@@ -95,6 +101,8 @@ class PropertyPlot
         };
     };
 
+    CoolProp::parameters xkey_;
+    CoolProp::parameters ykey_;
     CoolProp::input_pairs axis_pair_;
     bool swap_axis_inputs_for_update_;
     std::shared_ptr<CoolProp::AbstractState> state_;

--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -71,7 +71,7 @@ private:
 
     Isoline(CoolProp::parameters key, CoolProp::parameters xkey, CoolProp::parameters ykey, double value, const std::shared_ptr<CoolProp::AbstractState>& state);
 
-    Range get_sat_bounds(CoolProp::parameters key);
+    Range get_sat_bounds(CoolProp::parameters key) const;
     void calc_sat_range(int count);
     void update_pair(int& ipos, int& xpos, int& ypos, int& pair);
     void calc_range(std::vector<double>& xvals, std::vector<double>& yvals);

--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -63,11 +63,11 @@ public:
     double value;
 
 private:
-    std::shared_ptr<CoolProp::AbstractState> state;
-    std::shared_ptr<CoolProp::AbstractState> critical_state;
-    CoolProp::parameters xkey;
-    CoolProp::parameters ykey;
-    CoolProp::parameters key;
+    std::shared_ptr<CoolProp::AbstractState> state_;
+    std::shared_ptr<CoolProp::AbstractState> critical_state_;
+    CoolProp::parameters xkey_;
+    CoolProp::parameters ykey_;
+    CoolProp::parameters key_;
 
     Isoline(CoolProp::parameters key, CoolProp::parameters xkey, CoolProp::parameters ykey, double value, const std::shared_ptr<CoolProp::AbstractState>& state);
 
@@ -114,11 +114,10 @@ private:
         };
     };
 
-    std::string fluid_name;
-    CoolProp::input_pairs axis_pair;
-    bool swap_axis_inputs_for_update;
-    std::shared_ptr<CoolProp::AbstractState> state;
-    std::shared_ptr<CoolProp::AbstractState> critical_state;
+    CoolProp::input_pairs axis_pair_;
+    bool swap_axis_inputs_for_update_;
+    std::shared_ptr<CoolProp::AbstractState> state_;
+    std::shared_ptr<CoolProp::AbstractState> critical_state_;
     Range2D Tp_limits_;
 
     Range get_sat_bounds(CoolProp::parameters key) const;

--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -56,14 +56,14 @@ inline std::shared_ptr<CoolProp::AbstractState> get_critical_point(const std::sh
 
 class Isoline
 {
-public:
+   public:
     std::vector<double> x;
     std::vector<double> y;
     double value;
 
     size_t size() const { return x.size(); };
 
-private:
+   private:
     std::shared_ptr<CoolProp::AbstractState> state_;
     std::shared_ptr<CoolProp::AbstractState> critical_state_;
     CoolProp::parameters xkey_;
@@ -95,7 +95,7 @@ enum class TPLimits
 
 class PropertyPlot
 {
-public:
+   public:
     CoolProp::parameters xkey;
     CoolProp::parameters ykey;
     Scale xscale;
@@ -110,7 +110,7 @@ public:
     std::vector<CoolProp::parameters> supported_isoline_keys() const;
     double value_at(CoolProp::parameters key, double xvalue, double yvalue, CoolProp::phases phase = CoolProp::phases::iphase_not_imposed) const;
 
-private:
+   private:
     struct Range2D
     {
         union
@@ -138,8 +138,3 @@ private:
 } /* namespace CoolProp */
 
 #endif /* COOLPROPPLOT_H_ */
-
-
-
-
-

--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -67,7 +67,7 @@ inline Scale default_scale(CoolProp::parameters key)
 namespace Detail
 {
 
-inline std::shared_ptr<CoolProp::AbstractState> process_fluid_state(std::string fluid_ref)
+inline std::shared_ptr<CoolProp::AbstractState> process_fluid_state(const std::string& fluid_ref)
 {
     std::string backend;
     std::string fluids;
@@ -378,13 +378,17 @@ class PropertyPlot
 public:
     CoolProp::parameters xkey;
     CoolProp::parameters ykey;
+    Scale axis_x_scale;
+    Scale axis_y_scale;
+    Range axis_x_range;
+    Range axis_y_range;
 
-    PropertyPlot(const std::string& fluid_name, CoolProp::parameters ykey, CoolProp::parameters xkey, std::string tp_limits)
+    PropertyPlot(const std::string& fluid_name, CoolProp::parameters ykey, CoolProp::parameters xkey, const std::string& tp_limits)
         : fluid_name(fluid_name),
           xkey(xkey),
           ykey(ykey),
-          axis_x_scale_(default_scale(xkey)),
-          axis_y_scale_(default_scale(ykey))
+          axis_x_scale(default_scale(xkey)),
+          axis_y_scale(default_scale(ykey))
     {
         this->state = Detail::process_fluid_state(fluid_name);
         this->critical_state = Detail::get_critical_point(state);
@@ -425,8 +429,8 @@ public:
 
     IsoLines calc_isolines(CoolProp::parameters key, const std::vector<double>& values, int points)
     {
-        std::vector<double> xvals = Detail::generate_values_in_range(axis_x_scale_, axis_x_limits.min, axis_x_limits.max, points);
-        std::vector<double> yvals = Detail::generate_values_in_range(axis_y_scale_, axis_y_limits.min, axis_y_limits.max, points);
+        std::vector<double> xvals = Detail::generate_values_in_range(axis_x_scale, axis_x_range.min, axis_x_range.max, points);
+        std::vector<double> yvals = Detail::generate_values_in_range(axis_y_scale, axis_y_range.min, axis_y_range.max, points);
 
         IsoLines lines;
         for (double val : values)
@@ -451,42 +455,6 @@ public:
                 keys.push_back(it->first);
         }
         return keys;
-    }
-
-    void set_axis_y_scale(Scale scale)
-    {
-        axis_y_scale_ = scale;
-    }
-    Scale axis_y_scale() const
-    {
-        return axis_y_scale_;
-    }
-
-    void set_axis_x_scale(Scale scale)
-    {
-        axis_x_scale_ = scale;
-    }
-    Scale axis_x_scale() const
-    {
-        return axis_x_scale_;
-    }
-
-    void set_axis_x_range(Range limits)
-    {
-        axis_x_limits = limits;
-    }
-    void set_axis_y_range(Range limits)
-    {
-        axis_y_limits = limits;
-    }
-
-    Range axis_x_range() const
-    {
-        return axis_x_limits; // TODO: just remove this function
-    }
-    Range axis_y_range() const
-    {
-        return axis_y_limits;
     }
 
     // for value under cursor
@@ -521,16 +489,11 @@ public:
 
 private:
     std::string fluid_name;
-    std::string graph_type;
     CoolProp::input_pairs axis_pair;
     bool swap_axis_inputs_for_update;
     std::shared_ptr<CoolProp::AbstractState> state;
     std::shared_ptr<CoolProp::AbstractState> critical_state;
     std::vector<double> limits;
-    Range axis_x_limits;
-    Range axis_y_limits;
-    Scale axis_x_scale_;
-    Scale axis_y_scale_;
 
     Range get_sat_bounds(CoolProp::parameters key)
     {
@@ -626,19 +589,19 @@ private:
             }
             if (xkey == this->xkey)
             {
-                axis_x_limits.min = limits[0];
-                axis_x_limits.max = limits[1];
+                axis_x_range.min = limits[0];
+                axis_x_range.max = limits[1];
             }
             if (ykey == this->ykey)
             {
-                axis_y_limits.min = limits[2];
-                axis_y_limits.max = limits[3];
+                axis_y_range.min = limits[2];
+                axis_y_range.max = limits[3];
             }
             return limits;
         }
         else
         {
-            return {axis_x_limits.min, axis_x_limits.max, axis_y_limits.min, axis_y_limits.max};
+            return {axis_x_range.min, axis_x_range.max, axis_y_range.min, axis_y_range.max};
         }
     }
 };

--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -66,20 +66,20 @@ inline std::shared_ptr<CoolProp::AbstractState> process_fluid_state(std::string 
     return std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory(backend, fluids));
 }
 
-inline std::vector<double> generate_ranges(Scale scale, double start, double end, int num)
+inline std::vector<double> generate_values_in_range(Scale scale, double start, double end, int count)
 {
     if (scale == Scale::Log)
-        return logspace(start, end, num);
+        return logspace(start, end, count);
     else
-        return linspace(start, end, num);
+        return linspace(start, end, count);
 }
 
-inline std::vector<double> generate_ranges(CoolProp::parameters type, double start, double end, int num)
+inline std::vector<double> generate_values_in_range(CoolProp::parameters type, double start, double end, int count)
 {
-    return generate_ranges(default_scale(type), start, end, num);
+    return generate_values_in_range(default_scale(type), start, end, count);
 }
 
-inline std::shared_ptr<CoolProp::AbstractState> get_critical_point(std::shared_ptr<CoolProp::AbstractState> state)
+inline std::shared_ptr<CoolProp::AbstractState> get_critical_point(const std::shared_ptr<CoolProp::AbstractState>& state)
 {
     CoolProp::CriticalState crit_state;
     crit_state.T = Detail::NaN;
@@ -432,8 +432,8 @@ public:
 
     IsoLines calc_isolines(CoolProp::parameters iso_index, const std::vector<double>& iso_values, int points)
     {
-        std::vector<double> ixrange = Detail::generate_ranges(axis_x_scale_, axis_x_limits.min, axis_x_limits.max, points);
-        std::vector<double> iyrange = Detail::generate_ranges(axis_y_scale_, axis_y_limits.min, axis_y_limits.max, points);
+        std::vector<double> ixrange = Detail::generate_values_in_range(axis_x_scale_, axis_x_limits.min, axis_x_limits.max, points);
+        std::vector<double> iyrange = Detail::generate_values_in_range(axis_y_scale_, axis_y_limits.min, axis_y_limits.max, points);
 
         IsoLines lines;
         for (double iso_value : iso_values)

--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -96,7 +96,7 @@ public:
 
     PropertyPlot(const std::string& fluid_name, CoolProp::parameters ykey, CoolProp::parameters xkey, const std::string& tp_limits);
 
-    Range isoline_range(CoolProp::parameters key);
+    Range isoline_range(CoolProp::parameters key) const;
     Isolines calc_isolines(CoolProp::parameters key, const std::vector<double>& values, int points) const;
     std::vector<CoolProp::parameters> supported_isoline_keys() const;
     double value_at(CoolProp::parameters key, double xvalue, double yvalue, CoolProp::phases phase = CoolProp::phases::iphase_not_imposed) const;
@@ -119,11 +119,11 @@ private:
     bool swap_axis_inputs_for_update;
     std::shared_ptr<CoolProp::AbstractState> state;
     std::shared_ptr<CoolProp::AbstractState> critical_state;
-    std::vector<double> limits;
+    Range2D Tp_limits_;
 
-    Range get_sat_bounds(CoolProp::parameters key);
-    void get_Tp_limits(double& T_lo, double& T_hi, double& P_lo, double& P_hi);
-    Range2D get_axis_limits(CoolProp::parameters xkey = CoolProp::parameters::iundefined_parameter, CoolProp::parameters ykey = CoolProp::parameters::iundefined_parameter, bool autoscale = true);
+    Range get_sat_bounds(CoolProp::parameters key) const;
+    Range2D get_Tp_limits() const;
+    Range2D get_axis_limits(CoolProp::parameters xkey = CoolProp::parameters::iundefined_parameter, CoolProp::parameters ykey = CoolProp::parameters::iundefined_parameter, bool autoscale = true) const;
 };
 
 } /* namespace Plot */

--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -26,13 +26,21 @@ inline std::shared_ptr<CoolProp::AbstractState> get_critical_point(const std::sh
 
 } /* namespace Detail */
 
+/**
+A class representing a single isoline, returned by ``PropertyPlot::calc_isolines`` method. ``Isoline::x`` and ``Isoline::y`` members contain the x, y coordinates of points on the isoline in SI units of the x and y axis (respectively) of the queried PropertyPlot, and ``Isoline::value`` contains the value of the isoline in SI units.
+
+Either ``x[i]`` or ``y[i]`` may be NaN if the isoline is not defined at that point, and should be treated as a discontinuity in the isoline.
+*/
 class Isoline
 {
    public:
-    std::vector<double> x;
-    std::vector<double> y;
-    double value;
+    std::vector<double> x; ///< x positions of the isoline, in SI unit of the x axis of the queried ``PropertyPlot``. May contain NaN values.
+    std::vector<double> y; ///< y positions of the isoline, in SI unit of the y axis of the queried ``PropertyPlot``. May contain NaN values.
+    double value;          ///< Value of the isoline in SI units.
 
+    /**
+         @brief Convenience method to get the number of points in the isoline. ``size() = x.size() = y.size()``.
+         */
     size_t size() const { return x.size(); };
 
    private:
@@ -54,7 +62,21 @@ class Isoline
 
 using Isolines = std::vector<Isoline>;
 
+/**
+     @brief Generate a list of ``count`` equally (linearly or logarithmically) spaced values in a given ``range``.
+
+     @param scale The spacing of the values
+     @param range The minimum and maximum values of generated list of values (inclusive)
+     @param count The number of values to generate
+     */
 std::vector<double> generate_values_in_range(Scale scale, const Range& range, int count);
+/**
+     @brief Generate a list of ``count`` equally spaced values in a given ``range``, spaced either linearly or logarithmically based on the parameter type.
+
+     @param type The parameter type to generate values for (usually one of the supported isoline keys, e.g. ``CoolProp::iP`` or ``CoolProp::iT``)
+     @param range The minimum and maximum values of generated list of values (inclusive)
+     @param count The number of values to generate
+     */
 std::vector<double> generate_values_in_range(CoolProp::parameters type, const Range& range, int count);
 
 enum class TPLimits
@@ -65,6 +87,30 @@ enum class TPLimits
     Orc
 };
 
+/**
+A class representing a property plot of a fluid. Used to generate isolines of a given parameter over a given pair of parameters. The code is a C++ reimplementation of the Python CoolProp.Plots.PropertyPlot class, with the actual drawing of the calculated values of the plot left to the user.
+
+Supported plots: "p-h", "T-s", "h-s", "p-s", "p-rho", "T-rho", and "p-T".
+
+Example usage for generating a log p-h plot for R134a with temperature isolines (for more examples, see the tests at the bottom of ``src/CoolPropPlot.cpp``):
+\code{.cpp}
+    // Create a plot object for R134a with pressure on the y axis and enthalpy on the x axis
+    CoolProp::Plot::PropertyPlot plot("HEOS::R134a", CoolProp::iP, CoolProp::iHmass);
+    // print the axis properties:
+    std::cout << "x axis: h, " << (plot.xaxis.scale == CoolProp::Plot::Scale::Lin ? "lin" : "log") << ", limits [" << plot.xaxis.min << ", " << plot.xaxis.max << "] J/kg" << "\n";
+    std::cout << "y axis: p, " << (plot.yaxis.scale == CoolProp::Plot::Scale::Lin ? "lin" : "log") << ", limits [" << plot.yaxis.min << ", " << plot.yaxis.max << "] Pa" << "\n";
+
+    // Generate 5 isolines for temperature in K on this plot, 100 points per isoline
+    std::vector<double> t_values = CoolProp::Plot::generate_values_in_range(CoolProp::iT, plot.isoline_range(CoolProp::iT), 5);
+    CoolProp::Plot::Isolines t_isolines = plot.calc_isolines(CoolProp::iT, t_values, 100);
+
+    // print the first temperature isoline:
+    std::cout << "T: " << t_isolines[0].value << " K\n";
+    for (int i = 0; i < t_isolines[0].size(); ++i) {
+        std::cout << "h: " << t_isolines[0].x[i] << " J/kg, p: " << t_isolines[0].y[i] << " Pa\n";
+    }
+\endcode
+*/
 class PropertyPlot
 {
    public:
@@ -79,13 +125,43 @@ class PropertyPlot
                 double min, max;
             };
         };
-    } xaxis, yaxis;
+    } xaxis,  ///< The (non-modifiable) properties of the x axis of the plot
+      yaxis;  ///< The (non-modifiable) properties of the y axis of the plot
 
+    /**
+         @brief Construct a PropertyPlot object for a given fluid and a pair of parameters to plot.
+
+         @param fluid_name The name of the fluid to plot (e.g. "HEOS::R134a", or "Water")
+         @param ykey The parameter to plot on the y axis (e.g. for "ph" plots this would be ``CoolProp::iP``, and for "Ts" plots this would be ``CoolProp::iT``)
+         @param xkey The parameter to plot on the x axis (e.g. for "ph" plots this would be ``CoolProp::iHmass``, and for "Ts" plots this would be ``CoolProp::iSmass``)
+         @param tp_limits The temperature and pressure limits of the plot.
+         */
     PropertyPlot(const std::string& fluid_name, CoolProp::parameters ykey, CoolProp::parameters xkey, CoolProp::Plot::TPLimits tp_limits = CoolProp::Plot::TPLimits::Def);
 
+    /**
+         @brief Retrieve a valid range of values (inclusive) for the isoline with the given ``key`` in SI units.
+         */
     Range isoline_range(CoolProp::parameters key) const;
+    /**
+         @brief Calculate the isolines for the given ``key`` at given ``values`` in SI unit.
+
+         @param key The parameter to calculate the isolines for (usually one of the supported isoline keys, e.g. ``CoolProp::iP`` or ``CoolProp::iT``. Full list can be obtained with ``PropertyPlot::supported_isoline_keys()``)
+         @param values The values of the isolines to calculate in SI units
+         @param points The number of points to calculate for each isoline. The larger the number, the smoother the isoline will look
+         */
     Isolines calc_isolines(CoolProp::parameters key, const std::vector<double>& values, int points) const;
+    /**
+         @brief Retrieve a list of supported isoline keys for this plot
+         */
     std::vector<CoolProp::parameters> supported_isoline_keys() const;
+    /**
+         @brief A method for calculating the value of a parameter at a given point in the plot. Useful for "value under cursor" type of queries. Returns NaN if the value is not defined at the given point. Convenience method for ``CoolProp::PropsSI`` based on the configuration of the plot object.
+
+         @param key The parameter to calculate the value for (usually one of the supported isoline keys, e.g. ``CoolProp::iP`` or ``CoolProp::iT``. Full list can be obtained with ``PropertyPlot::supported_isoline_keys()``)
+         @param xvalue The x coordinate of the query point in SI units of the x axis of the plot
+         @param yvalue The y coordinate of the query point in SI units of the y axis of the plot
+         @param phase The phase to impose for the calculation. By default, the phase is not imposed.
+         */
     double value_at(CoolProp::parameters key, double xvalue, double yvalue, CoolProp::phases phase = CoolProp::phases::iphase_not_imposed) const;
 
    private:

--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -611,6 +611,9 @@ public:
         if (x_index == CoolProp::iHmass && y_index == CoolProp::iP) return {CoolProp::iQ, CoolProp::iT, CoolProp::iSmass, CoolProp::iDmass};
         if (x_index == CoolProp::iP && y_index == CoolProp::iHmass) return {CoolProp::iQ, CoolProp::iT, CoolProp::iSmass, CoolProp::iDmass};
 
+        if (x_index == CoolProp::iT && y_index == CoolProp::iSmass) return {CoolProp::iQ, CoolProp::iP, CoolProp::iHmass, CoolProp::iDmass};
+        if (x_index == CoolProp::iSmass && y_index == CoolProp::iT) return {CoolProp::iQ, CoolProp::iP, CoolProp::iHmass, CoolProp::iDmass};
+
         return {};
     }
 

--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -5,7 +5,6 @@
 #include "AbstractState.h"
 #include "CPnumerics.h"
 #include <vector>
-#include <memory>
 #include <map>
 
 namespace CoolProp {

--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -512,7 +512,7 @@ public:
     }
 
     // for value under cursor
-    Detail::Optional<double> value_at(CoolProp::parameters iso_type, double axis_x_value, double axis_y_value, CoolProp::phases phase = CoolProp::phases::iphase_not_imposed)
+    double value_at(CoolProp::parameters iso_type, double axis_x_value, double axis_y_value, CoolProp::phases phase = CoolProp::phases::iphase_not_imposed)
     {
         if (iso_type == x_index) return axis_x_value;
         if (iso_type == y_index) return axis_y_value;
@@ -532,12 +532,12 @@ public:
                 case CoolProp::iSmass: return state->smass();
                 case CoolProp::iUmass: return state->umass();
                 case CoolProp::iQ: return state->Q();
-                default: return {};
+                default: return Detail::NaN;
             }
         }
         catch (...)
         {
-            return {};
+            return Detail::NaN;
         }
     }
 

--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -175,14 +175,14 @@ struct Range
 };
 
 
-class IsoLine
+class Isoline
 {
 public:
     std::vector<double> x;
     std::vector<double> y;
     double value;
 
-    IsoLine(CoolProp::parameters key, CoolProp::parameters xkey, CoolProp::parameters ykey, double value, const std::shared_ptr<CoolProp::AbstractState>& state)
+    Isoline(CoolProp::parameters key, CoolProp::parameters xkey, CoolProp::parameters ykey, double value, const std::shared_ptr<CoolProp::AbstractState>& state)
         : key(key),
           xkey(xkey),
           ykey(ykey),
@@ -365,21 +365,22 @@ private:
     friend class PropertyPlot;
 };
 
-using IsoLines = std::vector<IsoLine>;
+using Isolines = std::vector<Isoline>;
 
 class PropertyPlot
 {
 public:
     CoolProp::parameters xkey;
     CoolProp::parameters ykey;
-    Scale axis_x_scale;
-    Scale axis_y_scale;
-    Range axis_x_range;
-    Range axis_y_range;
+    Scale xscale;
+    Scale yscale;
+    Range xrange;
+    Range yrange;
 
     PropertyPlot(const std::string& fluid_name, CoolProp::parameters ykey, CoolProp::parameters xkey, const std::string& tp_limits);
+
     Range isoline_range(CoolProp::parameters key);
-    IsoLines calc_isolines(CoolProp::parameters key, const std::vector<double>& values, int points) const;
+    Isolines calc_isolines(CoolProp::parameters key, const std::vector<double>& values, int points) const;
     std::vector<CoolProp::parameters> supported_dimensions() const;
     double value_at(CoolProp::parameters key, double axis_x_value, double axis_y_value, CoolProp::phases phase = CoolProp::phases::iphase_not_imposed) const;
 

--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -1,0 +1,827 @@
+#ifndef COOLPROPPLOT_H_
+#define COOLPROPPLOT_H_
+
+#include "CoolProp.h"
+#include "AbstractState.h"
+#include "Backends/REFPROP/REFPROPMixtureBackend.h"
+#include <iostream>
+#include <vector>
+#include <memory>
+#include <unordered_map>
+
+template <typename T>
+struct Optional {
+    Optional(T value) : value(value), has_value_(true) {}
+    Optional() : has_value_(false) {}
+    T operator*() const { return value; }
+    operator bool() const { return has_value_; }
+    bool has_value() const { return has_value_; }
+    T value;
+    bool has_value_;
+};
+
+namespace CoolProp {
+namespace Plot {
+
+
+#define NaN std::numeric_limits<double>::quiet_NaN()
+
+enum class Scale
+{
+    Lin,
+    Log
+};
+
+struct BaseDimension
+{
+    std::string label;
+    std::string symbol;
+    std::string si_unit;
+    Scale scale;
+};
+
+inline BaseDimension dimension_properties(CoolProp::parameters iso_type)
+{
+    switch (iso_type)
+    {
+        case CoolProp::iDmass: return {"Density",                  "d", "kg/m3",  Scale::Log};
+        case CoolProp::iHmass: return {"Specific Enthalpy",        "h", "J/kg",   Scale::Lin};
+        case CoolProp::iP:     return {"Pressure",                 "p", "Pa",     Scale::Log};
+        case CoolProp::iSmass: return {"Specific Entropy",         "s", "J/kg/K", Scale::Lin};
+        case CoolProp::iT:     return {"Temperature",              "T", "K",      Scale::Lin};
+        case CoolProp::iUmass: return {"Specific Internal Energy", "u", "J/kg",   Scale::Lin};
+        case CoolProp::iQ:     return {"Vapour Quality",           "x", "",       Scale::Lin};
+
+        default: return {};
+    }
+}
+
+
+namespace Detail
+{
+
+inline std::shared_ptr<CoolProp::AbstractState> process_fluid_state(std::string fluid_ref)
+{
+    std::string backend;
+    std::string fluids;
+    CoolProp::extract_backend(fluid_ref, backend, fluids);
+    std::vector<double> fractions;
+    fluids = CoolProp::extract_fractions(fluids, fractions);
+
+    return std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory(backend, fluids));
+}
+
+inline std::vector<double> linspace(double start, double end, int num)
+{
+    std::vector<double> linspaced;
+    double delta = (end - start) / (num - 1);
+    for (int i = 0; i < num - 1; ++i)
+    {
+        linspaced.push_back(start + delta * i);
+    }
+    linspaced.push_back(end);
+    return linspaced;
+}
+
+inline std::vector<double> logspace(double start, double end, int num, double base=10.0)
+{
+    std::vector<double> linspaced = linspace(start, end, num);
+    for (int i = 0; i < num; ++i)
+    {
+        linspaced[i] = pow(base, linspaced[i]);
+    }
+    return linspaced;
+}
+
+inline std::vector<double> generate_ranges(Scale scale, double start, double end, int num)
+{
+    if (scale == Scale::Log)
+        return logspace(log2(start), log2(end), num, 2.0);
+    else
+        return linspace(start, end, num);
+}
+
+inline std::vector<double> generate_ranges(CoolProp::parameters type, double start, double end, int num)
+{
+    return generate_ranges(dimension_properties(type).scale, start, end, num);
+}
+
+inline std::shared_ptr<CoolProp::AbstractState> get_critical_point(std::shared_ptr<CoolProp::AbstractState> state)
+{
+    CoolProp::CriticalState crit_state;
+    crit_state.T = NaN;
+    crit_state.p = NaN;
+    crit_state.rhomolar = NaN;
+    crit_state.rhomolar = NaN;
+    crit_state.stable = false;
+    try
+    {
+        crit_state.T = state->T_critical();
+        crit_state.p = state->p_critical();
+        crit_state.rhomolar = state->rhomolar_critical();
+        crit_state.stable = true;
+    }
+    catch (...)
+    {
+        try
+        {
+            for (CoolProp::CriticalState crit_state_tmp: state->all_critical_points())
+            {
+                if (crit_state_tmp.stable && (crit_state_tmp.T > crit_state.T || !std::isfinite(crit_state.T)))
+                {
+                    crit_state.T = crit_state_tmp.T;
+                    crit_state.p = crit_state_tmp.p;
+                    crit_state.rhomolar = crit_state_tmp.rhomolar;
+                    crit_state.stable = crit_state_tmp.stable;
+                }
+            }
+        }
+        catch (...)
+        {
+            throw CoolProp::ValueError("Could not calculate the critical point data.");
+        }
+    }
+
+    std::shared_ptr<CoolProp::AbstractState> new_state(CoolProp::AbstractState::factory(state->backend_name(), state->fluid_names()));
+    std::vector<double> masses = state->get_mass_fractions();
+    if (masses.size() > 1)
+        new_state->set_mass_fractions(masses);
+
+    if (std::isfinite(crit_state.p) && std::isfinite(crit_state.T))
+    {
+        try
+        {
+            new_state->specify_phase(CoolProp::iphase_critical_point);
+            new_state->update(CoolProp::PT_INPUTS, crit_state.p, crit_state.T);
+            return new_state;
+        }
+        catch (...) { }
+        try
+        {
+            new_state->update(CoolProp::PT_INPUTS, crit_state.p, crit_state.T);
+            return new_state;
+        }
+        catch (...) { }
+    }
+
+    if (std::isfinite(crit_state.rhomolar) && std::isfinite(crit_state.T))
+    {
+        try
+        {
+            new_state->specify_phase(CoolProp::iphase_critical_point);
+            new_state->update(CoolProp::DmolarT_INPUTS, crit_state.rhomolar, crit_state.T);
+            return new_state;
+        }
+        catch (...) { }
+        try
+        {
+            new_state->update(CoolProp::DmolarT_INPUTS, crit_state.rhomolar, crit_state.T);
+            return new_state;
+        }
+        catch (...) { }
+    }
+    throw CoolProp::ValueError("Could not calculate the critical point data.");
+    return nullptr;
+}
+
+} // namespace Detail
+
+inline double from_si_value(double value, const std::string& to_unit)
+{
+    // iP
+    if (to_unit == "Pa") return value;
+    if (to_unit == "hPa") return value / 1e2;
+    if (to_unit == "mbar") return value / 1e2;
+    if (to_unit == "psi") return value / 6894.7572931783;
+    if (to_unit == "kPa") return value / 1e3;
+    if (to_unit == "bar") return value / 1e5;
+    if (to_unit == "MPa") return value / 1e6;
+
+    // iT
+    if (to_unit == "K") return value;
+    if (to_unit == "C") return value - 273.15;
+    if (to_unit == "F") return value * 9 / 5 - 459.67;
+
+    // iDmass
+    if (to_unit == "kg/m3") return value;
+    if (to_unit == "g/cm3") return value / 1e3;
+    if (to_unit == "lb/ft3") return value / 16.01846337396;
+
+    // iUmass, iHmass
+    if (to_unit == "J/kg") return value;
+    if (to_unit == "kJ/kg") return value / 1e3;
+    if (to_unit == "MJ/kg") return value / 1e6;
+
+    // iSmass
+    if (to_unit == "J/kgK") return value;
+    if (to_unit == "kJ/kgK") return value / 1e3;
+    if (to_unit == "MJ/kgK") return value / 1e6;
+
+    // iQ
+    if (to_unit == "-") return value;
+    if (to_unit == "%") return value * 100;
+
+    return value;
+}
+
+inline double to_si_value(double value, const std::string& from_unit)
+{
+    // iP
+    if (from_unit == "Pa") return value;
+    if (from_unit == "hPa") return value * 1e2;
+    if (from_unit == "mbar") return value * 1e2;
+    if (from_unit == "psi") return value * 6894.7572931783;
+    if (from_unit == "kPa") return value * 1e3;
+    if (from_unit == "bar") return value * 1e5;
+    if (from_unit == "MPa") return value * 1e6;
+
+    // iT
+    if (from_unit == "K") return value;
+    if (from_unit == "C") return value + 273.15;
+    if (from_unit == "F") return (value + 459.67) * 5 / 9;
+
+    // iDmass
+    if (from_unit == "kg/m3") return value;
+    if (from_unit == "g/cm3") return value * 1e3;
+    if (from_unit == "lb/ft3") return value * 16.01846337396;
+
+    // iUmass, iHmass
+    if (from_unit == "J/kg") return value;
+    if (from_unit == "kJ/kg") return value * 1e3;
+    if (from_unit == "MJ/kg") return value * 1e6;
+
+    // iSmass
+    if (from_unit == "J/kgK") return value;
+    if (from_unit == "kJ/kgK") return value * 1e3;
+    if (from_unit == "MJ/kgK") return value * 1e6;
+
+    // iQ
+    if (from_unit == "-") return value;
+    if (from_unit == "%") return value / 100;
+
+    return value;
+}
+
+inline std::vector<std::string> supported_units(CoolProp::parameters iso_type)
+{
+    switch (iso_type)
+    {
+        case CoolProp::iP: return {"Pa", "hPa", "mbar", "psi", "kPa", "bar", "MPa"};
+        case CoolProp::iT: return {"K", "C", "F"};
+        case CoolProp::iDmass: return {"kg/m3", "g/cm3", "lb/ft3"};
+        case CoolProp::iHmass: return {"J/kg", "kJ/kg", "MJ/kg"};
+        case CoolProp::iSmass: return {"J/kgK", "kJ/kgK", "MJ/kgK"};
+        case CoolProp::iQ: return {"-", "%"};
+        case CoolProp::iUmass: return {"J/kg", "kJ/kg", "MJ/kg"};
+
+        default: return {};
+    }
+}
+
+struct Range
+{
+    double min, max;
+};
+
+
+static std::unordered_map<CoolProp::parameters, std::unordered_map<int, Optional<bool>>> xy_switch;
+
+class IsoLine
+{
+public:
+    std::vector<double> x;
+    std::vector<double> y;
+    double value;
+
+    IsoLine(CoolProp::parameters i_index, CoolProp::parameters x_index, CoolProp::parameters y_index, double value, std::shared_ptr<CoolProp::AbstractState> state)
+    {
+        this->state = state;
+        this->critical_state = Detail::get_critical_point(state);
+        this->i_index = i_index;
+        this->x_index = x_index;
+        this->y_index = y_index;
+        this->value = value;
+    }
+    size_t size() const
+    {
+        return x.size();
+    }
+private:
+    void fill_xy_switch()
+    {
+        static const int TS = CoolProp::iT * 10 + CoolProp::iSmass;
+        static const int PH = CoolProp::iP * 10 + CoolProp::iHmass;
+        static const int HS = CoolProp::iHmass * 10 + CoolProp::iSmass;
+        static const int PS = CoolProp::iP * 10 + CoolProp::iSmass;
+        static const int PD = CoolProp::iP * 10 + CoolProp::iDmass;
+        static const int TD = CoolProp::iT * 10 + CoolProp::iDmass;
+        static const int PT = CoolProp::iP * 10 + CoolProp::iT;
+        static const int PU = CoolProp::iP * 10 + CoolProp::iUmass;
+
+        xy_switch = {
+            {CoolProp::iDmass, {{TS, true }, {PH, true}, {HS, false}, {PS, true }, {PD, {}   }, {TD, {}   }, {PT, false}}},
+            {CoolProp::iHmass, {{TS, false}, {PH, {}  }, {HS, {}   }, {PS, true }, {PD, true }, {TD, false}, {PT, false}}},
+            {CoolProp::iP,     {{TS, false}, {PH, {}  }, {HS, false}, {PS, {}   }, {PD, {}   }, {TD, false}, {PT, {}  }}} ,
+            {CoolProp::iSmass, {{TS, {}   }, {PH, true}, {HS, {}   }, {PS, {}   }, {PD, true }, {TD, false}, {PT, true}}} ,
+            {CoolProp::iT,     {{TS, {}   }, {PH, true}, {HS, false}, {PS, false}, {PD, false}, {TD, {}   }, {PT, {}  }}} ,
+            {CoolProp::iQ,     {{TS, true }, {PH, true}, {HS, true }, {PS, true }, {PD, true }, {TD, true }, {PT, false}}}
+        };
+    }
+
+    std::shared_ptr<CoolProp::AbstractState> state;
+    std::shared_ptr<CoolProp::AbstractState> critical_state;
+    CoolProp::parameters x_index;
+    CoolProp::parameters y_index;
+    CoolProp::parameters i_index;
+
+    Range get_sat_bounds(CoolProp::parameters kind)
+    {
+        double s = 1e-7;
+        double t_small = critical_state->keyed_output(CoolProp::iT) * s;
+        double p_small = critical_state->keyed_output(CoolProp::iP) * s;
+
+        double t_triple = state->trivial_keyed_output(CoolProp::iT_triple);
+        double t_min = state->trivial_keyed_output(CoolProp::iT_min);
+        state->update(CoolProp::QT_INPUTS, 0, std::max(t_triple, t_min) + t_small);
+        double fluid_min, fluid_max;
+        if (kind == CoolProp::iP)
+        {
+            fluid_min = state->keyed_output(CoolProp::iP) + p_small;
+            fluid_max = critical_state->keyed_output(CoolProp::iP) - p_small;
+        }
+        else if (kind == CoolProp::iT)
+        {
+            fluid_min = state->keyed_output(CoolProp::iT) + t_small;
+            fluid_max = critical_state->keyed_output(CoolProp::iT) - t_small;
+        }
+        else
+        {
+            throw CoolProp::ValueError("Invalid kind");
+        }
+        double sat_min = fluid_min;
+        double sat_max = fluid_max;
+        return {sat_min, sat_max};
+    }
+    void calc_sat_range(int num)
+    {
+        double t_lo, t_hi;
+        auto t = get_sat_bounds(CoolProp::iT);
+        t_lo = t.min;
+        t_hi = t.max;
+        std::vector<double> two = ::linspace(t_lo, t_hi, num);
+        std::vector<double> one(two.size(), value);
+        CoolProp::input_pairs input_pair = CoolProp::QT_INPUTS;
+
+        double t_crit = critical_state->keyed_output(CoolProp::iT);
+        double p_crit = critical_state->keyed_output(CoolProp::iP);
+        double x_crit = critical_state->keyed_output(x_index);
+        double y_crit = critical_state->keyed_output(y_index);
+        x.resize(one.size());
+        y.resize(one.size());
+        for (int i = 0; i < one.size(); ++i)
+        {
+            try
+            {
+                state->update(input_pair, one[i], two[i]);
+                x[i] = state->keyed_output(x_index);
+                y[i] = state->keyed_output(y_index);
+            }
+            catch (...)
+            {
+                if (input_pair == CoolProp::QT_INPUTS && abs(two[i] - t_crit) < 1e0 ||
+                    input_pair == CoolProp::PQ_INPUTS && abs(one[i] - p_crit) < 1e2)
+                {
+                    x[i] = x_crit;
+                    y[i] = y_crit;
+                    std::cerr << "ERROR near critical inputs" << std::endl;
+                }
+                else
+                {
+                    x[i] = NaN;
+                    y[i] = NaN;
+                    std::cerr << "ERROR" << std::endl;
+                }
+            }
+        }
+    }
+
+    void update_pair(int& ipos, int& xpos, int& ypos, int& pair)
+    {
+        Optional<bool> should_switch = xy_switch.at(i_index).at(y_index * 10 + x_index);
+        double out1, out2;
+        if (!should_switch)
+            throw CoolProp::ValueError("This isoline cannot be calculated!");
+        else if (*should_switch == false)
+            pair = CoolProp::generate_update_pair(i_index, 0.0, x_index, 1.0, out1, out2);
+        else if (*should_switch == true)
+            pair = CoolProp::generate_update_pair(i_index, 0.0, y_index, 1.0, out1, out2);
+
+        bool should_swap = (out1 != 0.0);
+        if (!(*should_switch) && !should_swap)
+        {
+            ipos = 0;
+            xpos = 1;
+            ypos = 2;
+        }
+        else if (*should_switch && !should_swap)
+        {
+            ipos = 0;
+            xpos = 2;
+            ypos = 1;
+        }
+        else if (!(*should_switch) && should_swap)
+        {
+            ipos = 1;
+            xpos = 0;
+            ypos = 2;
+        }
+        else if (*should_switch && should_swap)
+        {
+            ipos = 1;
+            xpos = 2;
+            ypos = 0;
+        }
+        else
+        {
+            throw CoolProp::ValueError("Check the code, this should not happen!");
+        }
+    }
+
+    void calc_range(std::vector<double>& xvals, std::vector<double>& yvals)
+    {
+        if (i_index == CoolProp::iQ)
+        {
+            calc_sat_range(xvals.size());
+        }
+        else
+        {
+            int ipos, xpos, ypos, pair;
+            update_pair(ipos, xpos, ypos, pair);
+
+            std::vector<double> ivals(xvals.size(), value);
+            std::vector<int> order = {ipos, xpos, ypos};
+            std::vector<CoolProp::parameters> idxs(3);
+            idxs[ipos] = i_index;
+            idxs[xpos] = x_index;
+            idxs[ypos] = y_index;
+            std::vector<std::vector<double>> vals(3);
+            vals[ipos] = ivals;
+            vals[xpos] = xvals;
+            vals[ypos] = yvals;
+
+            // TODO: guesses missing
+
+            for (int i = 0; i < vals[2].size(); ++i)
+            {
+                try
+                {
+                    state->update((CoolProp::input_pairs)pair, vals[0][i], vals[1][i]);
+                    vals[2][i] = state->keyed_output(idxs[2]);
+                }
+                catch (...)
+                {
+                    vals[2][i] = NaN;
+                }
+            }
+
+            for (int i = 0; i < idxs.size(); ++i)
+            {
+                if (idxs[i] == x_index) x = vals[i];
+                if (idxs[i] == y_index) y = vals[i];
+            }
+        }
+    }
+    void convert_units(const std::string& i_unit, const std::string& x_unit, const std::string& y_unit)
+    {
+        for (double& val : x)
+            val = from_si_value(val, x_unit);
+        for (double& val : y)
+            val = from_si_value(val, y_unit);
+        value = from_si_value(value, i_unit);
+    }
+
+    friend class PropertyPlot;
+};
+
+using IsoLines = std::vector<IsoLine>;
+
+class PropertyPlot
+{
+public:
+    CoolProp::parameters x_index;
+    CoolProp::parameters y_index;
+
+    PropertyPlot(std::string fluid_name, CoolProp::parameters y_index, CoolProp::parameters x_index, std::string tp_limits)
+    {
+        this->fluid_name = fluid_name;
+        this->state = Detail::process_fluid_state(fluid_name);
+        this->critical_state = Detail::get_critical_point(state);
+        this->x_index = x_index;
+        this->y_index = y_index;
+        this->axis_x_scale_ = dimension_properties(x_index).scale;
+        this->axis_y_scale_ = dimension_properties(y_index).scale;
+        bool plot_type_is_ts = (y_index == CoolProp::iT && x_index == CoolProp::iSmass);
+        bool plot_type_is_ph = (y_index == CoolProp::iP && x_index == CoolProp::iHmass);
+        if (!plot_type_is_ts && !plot_type_is_ph)
+            throw CoolProp::ValueError("Unsupported parameter pair for axis requested; only Ts and ph are supported");
+        // We are just assuming that all inputs and outputs are in SI units. We
+        // take care of any conversions before calling the library and after
+        // getting the results.
+        int out1, out2;
+        axis_pair = CoolProp::generate_update_pair(x_index, 0, y_index, 1, out1, out2);
+        swap_axis_inputs_for_update = (out1 == 1);
+
+        active_units[CoolProp::iDmass] = "kg/m3";
+        active_units[CoolProp::iHmass] = "J/kg";
+        active_units[CoolProp::iP] =     "Pa";
+        active_units[CoolProp::iSmass] = "J/kg/K";
+        active_units[CoolProp::iT] =     "K";
+        active_units[CoolProp::iUmass] = "J/kg";
+        active_units[CoolProp::iQ] =     "";
+
+        const double HI_FACTOR = 2.25; // Upper default limits: HI_FACTOR*T_crit and HI_FACTOR*p_crit
+        const double LO_FACTOR = 1.01; // Lower default limits: LO_FACTOR*T_triple and LO_FACTOR*p_triple
+        if (tp_limits == "NONE")
+            this->limits = {NaN, NaN, NaN, NaN};
+        else if (tp_limits == "DEF")
+            this->limits = {LO_FACTOR, HI_FACTOR, LO_FACTOR, HI_FACTOR};
+        else if (tp_limits == "ACHP")
+            this->limits = {173.15, 493.15, 0.25e5, HI_FACTOR};
+        else if (tp_limits == "ORC")
+            this->limits = {273.15, 673.15, 0.25e5, HI_FACTOR};
+        else
+            throw CoolProp::ValueError("Invalid tp_limits");
+
+        get_axis_limits();
+    }
+
+    Range isoline_range(CoolProp::parameters iso_index)
+    {
+        std::vector<double> iso_range;
+        if (iso_index == CoolProp::iQ)
+        {
+            return {from_si_value(0., active_units.at(iso_index)),
+                    from_si_value(1., active_units.at(iso_index))};
+        }
+        else
+        {
+            auto limits = get_axis_limits(iso_index, CoolProp::iT);
+            return {from_si_value(limits[0], active_units.at(iso_index)),
+                    from_si_value(limits[1], active_units.at(iso_index))};
+        }
+    }
+
+    IsoLines calc_isolines(CoolProp::parameters iso_index, const std::vector<double>& iso_values, int points)
+    {
+        std::vector<double> ixrange = Detail::generate_ranges(axis_x_scale_, axis_x_limits.min, axis_x_limits.max, points);
+        std::vector<double> iyrange = Detail::generate_ranges(axis_y_scale_, axis_y_limits.min, axis_y_limits.max, points);
+
+        IsoLines lines;
+        for (double iso_value : iso_values)
+        {
+            IsoLine line(iso_index, x_index, y_index, to_si_value(iso_value, active_units.at(iso_index)), state);
+            line.calc_range(ixrange, iyrange);
+            line.convert_units(active_units[iso_index], active_units[x_index], active_units[y_index]);
+            // line.sanitize_data();
+            lines.push_back(line);
+        }
+        return lines;
+    }
+
+    std::vector<CoolProp::parameters> supported_dimensions() const
+    {
+        // taken from PropertyPlot::calc_isolines when called with iso_type='all'
+        std::vector<CoolProp::parameters> result;
+        for (auto it = xy_switch.begin(); it != xy_switch.end(); ++it)
+        {
+            const CoolProp::parameters quantity = it->first;
+            const std::unordered_map<int, Optional<bool>>& supported = it->second;
+            for (int j = 0; j < supported.size(); ++j)
+            {
+                auto supported_xy = supported.find(y_index * 10 + x_index);
+                if (supported_xy != supported.end() && supported_xy->second.has_value())
+                {
+                    result.push_back(quantity);
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
+    void set_dimension_unit(CoolProp::parameters dimension, const std::string& unit)
+    {
+        active_units[dimension] = unit;
+    }
+    std::string dimension_unit(CoolProp::parameters dimension)
+    {
+        return active_units[dimension];
+    }
+
+    void set_axis_y_scale(Scale scale)
+    {
+        axis_y_scale_ = scale;
+    }
+    Scale axis_y_scale() const
+    {
+        return axis_y_scale_;
+    }
+
+    void set_axis_x_scale(Scale scale)
+    {
+        axis_x_scale_ = scale;
+    }
+    Scale axis_x_scale() const
+    {
+        return axis_x_scale_;
+    }
+
+    void set_axis_x_range(Range limits)
+    {
+        axis_x_limits.min = to_si_value(limits.min, active_units.at(x_index));
+        axis_x_limits.max = to_si_value(limits.max, active_units.at(x_index));
+    }
+    void set_axis_y_range(Range limits)
+    {
+        axis_y_limits.min = to_si_value(limits.min, active_units.at(y_index));
+        axis_y_limits.max = to_si_value(limits.max, active_units.at(y_index));
+    }
+
+    Range axis_x_range() const
+    {
+        Range result = axis_x_limits;
+        result.min = from_si_value(result.min, active_units.at(x_index));
+        result.max = from_si_value(result.max, active_units.at(x_index));
+        return result;
+    }
+    Range axis_y_range() const
+    {
+        Range result = axis_y_limits;
+        result.min = from_si_value(result.min, active_units.at(y_index));
+        result.max = from_si_value(result.max, active_units.at(y_index));
+        return result;
+    }
+
+    // for value under cursor
+    Optional<double> value_at(CoolProp::parameters iso_type, double axis_x_value, double axis_y_value, CoolProp::phases phase = CoolProp::phases::iphase_not_imposed)
+    {
+        if (iso_type == x_index) return axis_x_value;
+        if (iso_type == y_index) return axis_y_value;
+
+        try
+        {
+            if (swap_axis_inputs_for_update)
+                std::swap(axis_x_value, axis_y_value);
+            state->specify_phase(phase);
+            state->update(axis_pair, to_si_value(axis_x_value, active_units.at(x_index)), to_si_value(axis_y_value, active_units.at(y_index)));
+            switch (iso_type)
+            {
+                case CoolProp::iT: return from_si_value(state->T(), active_units.at(iso_type));
+                case CoolProp::iP: return from_si_value(state->p(), active_units.at(iso_type));
+                case CoolProp::iDmass: return from_si_value(state->rhomass(), active_units.at(iso_type));
+                case CoolProp::iHmass: return from_si_value(state->hmass(), active_units.at(iso_type));
+                case CoolProp::iSmass: return from_si_value(state->smass(), active_units.at(iso_type));
+                case CoolProp::iUmass: return from_si_value(state->umass(), active_units.at(iso_type));
+                case CoolProp::iQ: return from_si_value(state->Q(), active_units.at(iso_type));
+                default: return {};
+            }
+        }
+        catch (...)
+        {
+            return {};
+        }
+    }
+
+private:
+    std::string fluid_name;
+    std::string graph_type;
+    CoolProp::input_pairs axis_pair;
+    bool swap_axis_inputs_for_update;
+    std::shared_ptr<CoolProp::AbstractState> state;
+    std::shared_ptr<CoolProp::AbstractState> critical_state;
+    std::vector<double> limits;
+    Range axis_x_limits;
+    Range axis_y_limits;
+    Scale axis_x_scale_;
+    Scale axis_y_scale_;
+    std::unordered_map<CoolProp::parameters, std::string> active_units;
+
+    Range get_sat_bounds(CoolProp::parameters kind)
+    {
+        // TODO: duplicated code from IsoLine
+        double s = 1e-7;
+        double t_small = critical_state->keyed_output(CoolProp::iT) * s;
+        double p_small = critical_state->keyed_output(CoolProp::iP) * s;
+
+        double t_triple = state->trivial_keyed_output(CoolProp::iT_triple);
+        double t_min = state->trivial_keyed_output(CoolProp::iT_min);
+        state->update(CoolProp::QT_INPUTS, 0, std::max(t_triple, t_min) + t_small);
+        double fluid_min, fluid_max;
+        if (kind == CoolProp::iP)
+        {
+            fluid_min = state->keyed_output(CoolProp::iP) + p_small;
+            fluid_max = critical_state->keyed_output(CoolProp::iP) - p_small;
+        }
+        else if (kind == CoolProp::iT)
+        {
+            fluid_min = state->keyed_output(CoolProp::iT) + t_small;
+            fluid_max = critical_state->keyed_output(CoolProp::iT) - t_small;
+        }
+        else
+        {
+            throw CoolProp::ValueError("Invalid kind");
+        }
+        double sat_min = fluid_min;
+        double sat_max = fluid_max;
+        return {sat_min, sat_max};
+    }
+
+    void get_Tp_limits(double& T_lo, double& T_hi, double& P_lo, double& P_hi)
+    {
+        T_lo = limits[0];
+        T_hi = limits[1];
+        P_lo = limits[2];
+        P_hi = limits[3];
+
+        double Ts_lo, Ts_hi;
+        auto Ts = get_sat_bounds(CoolProp::iT);
+        Ts_lo = Ts.min;
+        Ts_hi = Ts.max;
+
+        double Ps_lo, Ps_hi;
+        auto Ps = get_sat_bounds(CoolProp::iP);
+        Ps_lo = Ps.min;
+        Ps_hi = Ps.max;
+
+        const double ID_FACTOR = 10.0; // Values below this number are interpreted as factors
+        if (std::isnan(T_lo)) T_lo = 0.0;
+        else if (T_lo < ID_FACTOR) T_lo *= Ts_lo;
+        if (std::isnan(T_hi)) T_hi = 1e6;
+        else if (T_hi < ID_FACTOR) T_hi *= Ts_hi;
+        if (std::isnan(P_lo)) P_lo = 0.0;
+        else if (P_lo < ID_FACTOR) P_lo *= Ps_lo;
+        if (std::isnan(P_hi)) P_hi = 1e10;
+        else if (P_hi < ID_FACTOR) P_hi *= Ps_hi;
+
+        try { T_lo = std::max(T_lo, state->trivial_keyed_output(CoolProp::iT_min)); } catch (...) {}
+        try { T_hi = std::min(T_hi, state->trivial_keyed_output(CoolProp::iT_max)); } catch (...) {}
+        try { P_lo = std::max(P_lo, state->trivial_keyed_output(CoolProp::iP_min)); } catch (...) {}
+        try { P_hi = std::min(P_hi, state->trivial_keyed_output(CoolProp::iP_max)); } catch (...) {}
+    }
+
+    std::vector<double> get_axis_limits(CoolProp::parameters x_index = CoolProp::parameters::iundefined_parameter, CoolProp::parameters y_index = CoolProp::parameters::iundefined_parameter, bool autoscale = true)
+    {
+        if (x_index == CoolProp::parameters::iundefined_parameter) x_index = this->x_index;
+        if (y_index == CoolProp::parameters::iundefined_parameter) y_index = this->y_index;
+
+        if (x_index != this->y_index || y_index != this->y_index || autoscale)
+        {
+            double T_lo, T_hi, P_lo, P_hi;
+            get_Tp_limits(T_lo, T_hi, P_lo, P_hi); // TODO
+            std::vector<double> limits = {std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest(),
+                                          std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest()};
+            for (double T : {T_lo, T_hi})
+            {
+                for (double P : {P_lo, P_hi})
+                {
+                    try
+                    {
+                        state->update(CoolProp::PT_INPUTS, P, T);
+                        double x = state->keyed_output(x_index);
+                        double y = state->keyed_output(y_index);
+                        if (x < limits[0]) limits[0] = x;
+                        if (x > limits[1]) limits[1] = x;
+                        if (y < limits[2]) limits[2] = y;
+                        if (y > limits[3]) limits[3] = y;
+                    }
+                    catch (...) { }
+                }
+            }
+            if (x_index == this->x_index)
+            {
+                axis_x_limits.min = limits[0];
+                axis_x_limits.max = limits[1];
+            }
+            if (y_index == this->y_index)
+            {
+                axis_y_limits.min = limits[2];
+                axis_y_limits.max = limits[3];
+            }
+            return limits;
+        }
+        else
+        {
+            return {axis_x_limits.min, axis_x_limits.max, axis_y_limits.min, axis_y_limits.max};
+        }
+    }
+};
+
+} /* namespace Plot */
+} /* namespace CoolProp */
+
+#endif /* COOLPROPPLOT_H_ */
+
+
+
+
+

--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -1,7 +1,6 @@
 #ifndef COOLPROPPLOT_H_
 #define COOLPROPPLOT_H_
 
-#include "CoolProp.h"
 #include "AbstractState.h"
 #include "CPnumerics.h"
 #include <vector>
@@ -9,6 +8,17 @@
 
 namespace CoolProp {
 namespace Plot {
+
+enum class Scale
+{
+    Lin,
+    Log
+};
+
+struct Range
+{
+    double min, max;
+};
 
 namespace Detail {
 
@@ -21,16 +31,16 @@ enum IsolineSupported
     Flipped = 2
 };
 
-static const int TS = CoolProp::iT * 10 + CoolProp::iSmass;
-static const int PH = CoolProp::iP * 10 + CoolProp::iHmass;
-static const int HS = CoolProp::iHmass * 10 + CoolProp::iSmass;
-static const int PS = CoolProp::iP * 10 + CoolProp::iSmass;
-static const int PD = CoolProp::iP * 10 + CoolProp::iDmass;
-static const int TD = CoolProp::iT * 10 + CoolProp::iDmass;
-static const int PT = CoolProp::iP * 10 + CoolProp::iT;
-static const int PU = CoolProp::iP * 10 + CoolProp::iUmass;
+ const int TS = CoolProp::iT * 10 + CoolProp::iSmass;
+ const int PH = CoolProp::iP * 10 + CoolProp::iHmass;
+ const int HS = CoolProp::iHmass * 10 + CoolProp::iSmass;
+ const int PS = CoolProp::iP * 10 + CoolProp::iSmass;
+ const int PD = CoolProp::iP * 10 + CoolProp::iDmass;
+ const int TD = CoolProp::iT * 10 + CoolProp::iDmass;
+ const int PT = CoolProp::iP * 10 + CoolProp::iT;
+ const int PU = CoolProp::iP * 10 + CoolProp::iUmass;
 
-static std::map<CoolProp::parameters, std::map<int, IsolineSupported>> xy_switch = {
+ const std::map<CoolProp::parameters, std::map<int, IsolineSupported>> xy_switch = {
     {CoolProp::iDmass, {{TS, Flipped}, {PH, Flipped}, {HS, Yes    }, {PS, Flipped}, {PD, No     }, {TD, No     }, {PT, Yes    }}},
     {CoolProp::iHmass, {{TS, Yes    }, {PH, No     }, {HS, No     }, {PS, Flipped}, {PD, Flipped}, {TD, Yes    }, {PT, Yes    }}},
     {CoolProp::iP,     {{TS, Yes    }, {PH, No     }, {HS, Yes    }, {PS, No     }, {PD, No     }, {TD, Yes    }, {PT, No     }}},
@@ -39,141 +49,13 @@ static std::map<CoolProp::parameters, std::map<int, IsolineSupported>> xy_switch
     {CoolProp::iQ,     {{TS, Flipped}, {PH, Flipped}, {HS, Flipped}, {PS, Flipped}, {PD, Flipped}, {TD, Flipped}, {PT, Yes    }}}
 };
 
-}
+Scale default_scale(CoolProp::parameters key);
+std::shared_ptr<CoolProp::AbstractState> process_fluid_state(const std::string& fluid_ref);
+std::vector<double> generate_values_in_range(Scale scale, double start, double end, int count);
+std::vector<double> generate_values_in_range(CoolProp::parameters type, double start, double end, int count);
+inline std::shared_ptr<CoolProp::AbstractState> get_critical_point(const std::shared_ptr<CoolProp::AbstractState>& state);
 
-enum class Scale
-{
-    Lin,
-    Log
-};
-
-namespace Detail {
-
-inline Scale default_scale(CoolProp::parameters key)
-{
-    switch (key)
-    {
-        case CoolProp::iDmass: return Scale::Log;
-        case CoolProp::iHmass: return Scale::Lin;
-        case CoolProp::iP:     return Scale::Log;
-        case CoolProp::iSmass: return Scale::Lin;
-        case CoolProp::iT:     return Scale::Lin;
-        case CoolProp::iUmass: return Scale::Lin;
-        case CoolProp::iQ:     return Scale::Lin;
-
-        default: return Scale::Lin;
-    }
-}
-
-inline std::shared_ptr<CoolProp::AbstractState> process_fluid_state(const std::string& fluid_ref)
-{
-    std::string backend;
-    std::string fluids;
-    CoolProp::extract_backend(fluid_ref, backend, fluids);
-    std::vector<double> fractions;
-    fluids = CoolProp::extract_fractions(fluids, fractions);
-
-    return std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory(backend, fluids));
-}
-
-inline std::vector<double> generate_values_in_range(Scale scale, double start, double end, int count)
-{
-    if (scale == Scale::Log)
-        return logspace(start, end, count);
-    else
-        return linspace(start, end, count);
-}
-
-inline std::vector<double> generate_values_in_range(CoolProp::parameters type, double start, double end, int count)
-{
-    return generate_values_in_range(default_scale(type), start, end, count);
-}
-
-inline std::shared_ptr<CoolProp::AbstractState> get_critical_point(const std::shared_ptr<CoolProp::AbstractState>& state)
-{
-    CoolProp::CriticalState crit_state;
-    crit_state.T = Detail::NaN;
-    crit_state.p = Detail::NaN;
-    crit_state.rhomolar = Detail::NaN;
-    crit_state.rhomolar = Detail::NaN;
-    crit_state.stable = false;
-    try
-    {
-        crit_state.T = state->T_critical();
-        crit_state.p = state->p_critical();
-        crit_state.rhomolar = state->rhomolar_critical();
-        crit_state.stable = true;
-    }
-    catch (...)
-    {
-        try
-        {
-            for (CoolProp::CriticalState crit_state_tmp: state->all_critical_points())
-            {
-                if (crit_state_tmp.stable && (crit_state_tmp.T > crit_state.T || !std::isfinite(crit_state.T)))
-                {
-                    crit_state.T = crit_state_tmp.T;
-                    crit_state.p = crit_state_tmp.p;
-                    crit_state.rhomolar = crit_state_tmp.rhomolar;
-                    crit_state.stable = crit_state_tmp.stable;
-                }
-            }
-        }
-        catch (...)
-        {
-            throw CoolProp::ValueError("Could not calculate the critical point data.");
-        }
-    }
-
-    std::shared_ptr<CoolProp::AbstractState> new_state(CoolProp::AbstractState::factory(state->backend_name(), state->fluid_names()));
-    std::vector<double> masses = state->get_mass_fractions();
-    if (masses.size() > 1)
-        new_state->set_mass_fractions(masses);
-
-    if (std::isfinite(crit_state.p) && std::isfinite(crit_state.T))
-    {
-        try
-        {
-            new_state->specify_phase(CoolProp::iphase_critical_point);
-            new_state->update(CoolProp::PT_INPUTS, crit_state.p, crit_state.T);
-            return new_state;
-        }
-        catch (...) { }
-        try
-        {
-            new_state->update(CoolProp::PT_INPUTS, crit_state.p, crit_state.T);
-            return new_state;
-        }
-        catch (...) { }
-    }
-
-    if (std::isfinite(crit_state.rhomolar) && std::isfinite(crit_state.T))
-    {
-        try
-        {
-            new_state->specify_phase(CoolProp::iphase_critical_point);
-            new_state->update(CoolProp::DmolarT_INPUTS, crit_state.rhomolar, crit_state.T);
-            return new_state;
-        }
-        catch (...) { }
-        try
-        {
-            new_state->update(CoolProp::DmolarT_INPUTS, crit_state.rhomolar, crit_state.T);
-            return new_state;
-        }
-        catch (...) { }
-    }
-    throw CoolProp::ValueError("Could not calculate the critical point data.");
-    return nullptr;
-}
-
-} // namespace Detail
-
-struct Range
-{
-    double min, max;
-};
-
+} /* namespace Detail */
 
 class Isoline
 {
@@ -182,15 +64,8 @@ public:
     std::vector<double> y;
     double value;
 
-    Isoline(CoolProp::parameters key, CoolProp::parameters xkey, CoolProp::parameters ykey, double value, const std::shared_ptr<CoolProp::AbstractState>& state)
-        : key(key),
-          xkey(xkey),
-          ykey(ykey),
-          value(value),
-          state(state)
-    {
-        this->critical_state = Detail::get_critical_point(state);
-    }
+    Isoline(CoolProp::parameters key, CoolProp::parameters xkey, CoolProp::parameters ykey, double value, const std::shared_ptr<CoolProp::AbstractState>& state);
+
 private:
     std::shared_ptr<CoolProp::AbstractState> state;
     std::shared_ptr<CoolProp::AbstractState> critical_state;
@@ -198,169 +73,10 @@ private:
     CoolProp::parameters ykey;
     CoolProp::parameters key;
 
-    Range get_sat_bounds(CoolProp::parameters key)
-    {
-        double s = 1e-7;
-        double t_small = critical_state->keyed_output(CoolProp::iT) * s;
-        double p_small = critical_state->keyed_output(CoolProp::iP) * s;
-
-        double t_triple = state->trivial_keyed_output(CoolProp::iT_triple);
-        double t_min = state->trivial_keyed_output(CoolProp::iT_min);
-        state->update(CoolProp::QT_INPUTS, 0, std::max(t_triple, t_min) + t_small);
-        double fluid_min, fluid_max;
-        if (key == CoolProp::iP)
-        {
-            fluid_min = state->keyed_output(CoolProp::iP) + p_small;
-            fluid_max = critical_state->keyed_output(CoolProp::iP) - p_small;
-        }
-        else if (key == CoolProp::iT)
-        {
-            fluid_min = state->keyed_output(CoolProp::iT) + t_small;
-            fluid_max = critical_state->keyed_output(CoolProp::iT) - t_small;
-        }
-        else
-        {
-            throw CoolProp::ValueError("Invalid key");
-        }
-        double sat_min = fluid_min;
-        double sat_max = fluid_max;
-        return {sat_min, sat_max};
-    }
-    void calc_sat_range(int count)
-    {
-        double t_lo, t_hi;
-        Range t = get_sat_bounds(CoolProp::iT);
-        t_lo = t.min;
-        t_hi = t.max;
-        std::vector<double> two = ::linspace(t_lo, t_hi, count);
-        std::vector<double> one(two.size(), value);
-        CoolProp::input_pairs input_pair = CoolProp::QT_INPUTS;
-
-        double t_crit = critical_state->keyed_output(CoolProp::iT);
-        double p_crit = critical_state->keyed_output(CoolProp::iP);
-        double x_crit = critical_state->keyed_output(xkey);
-        double y_crit = critical_state->keyed_output(ykey);
-        x.resize(one.size());
-        y.resize(one.size());
-        for (int i = 0; i < one.size(); ++i)
-        {
-            try
-            {
-                state->update(input_pair, one[i], two[i]);
-                x[i] = state->keyed_output(xkey);
-                y[i] = state->keyed_output(ykey);
-            }
-            catch (...)
-            {
-                if (input_pair == CoolProp::QT_INPUTS && abs(two[i] - t_crit) < 1e0 ||
-                    input_pair == CoolProp::PQ_INPUTS && abs(one[i] - p_crit) < 1e2)
-                {
-                    x[i] = x_crit;
-                    y[i] = y_crit;
-                    std::cerr << "ERROR near critical inputs" << std::endl;
-                }
-                else
-                {
-                    x[i] = Detail::NaN;
-                    y[i] = Detail::NaN;
-                    std::cerr << "ERROR" << std::endl;
-                }
-            }
-        }
-    }
-
-    void update_pair(int& ipos, int& xpos, int& ypos, int& pair)
-    {
-        Detail::IsolineSupported should_switch = Detail::xy_switch.at(key).at(ykey * 10 + xkey);
-        double out1, out2;
-        switch (should_switch)
-        {
-            case Detail::IsolineSupported::No:
-                throw CoolProp::ValueError("This isoline cannot be calculated!");
-                break;
-            case Detail::IsolineSupported::Yes:
-                pair = CoolProp::generate_update_pair(key, 0.0, xkey, 1.0, out1, out2);
-                break;
-            case Detail::IsolineSupported::Flipped:
-                pair = CoolProp::generate_update_pair(key, 0.0, ykey, 1.0, out1, out2);
-                break;
-        }
-        bool should_swap = (out1 != 0.0);
-
-        if (should_switch == Detail::IsolineSupported::Yes && !should_swap)
-        {
-            ipos = 0;
-            xpos = 1;
-            ypos = 2;
-        }
-        else if (should_switch == Detail::IsolineSupported::Flipped && !should_swap)
-        {
-            ipos = 0;
-            xpos = 2;
-            ypos = 1;
-        }
-        else if (should_switch == Detail::IsolineSupported::Yes && should_swap)
-        {
-            ipos = 1;
-            xpos = 0;
-            ypos = 2;
-        }
-        else if (should_switch == Detail::IsolineSupported::Flipped && should_swap)
-        {
-            ipos = 1;
-            xpos = 2;
-            ypos = 0;
-        }
-        else
-        {
-            throw CoolProp::ValueError("Check the code, this should not happen!");
-        }
-    }
-
-    void calc_range(std::vector<double>& xvals, std::vector<double>& yvals)
-    {
-        if (key == CoolProp::iQ)
-        {
-            calc_sat_range(xvals.size());
-        }
-        else
-        {
-            int ipos, xpos, ypos, pair;
-            update_pair(ipos, xpos, ypos, pair);
-
-            std::vector<double> ivals(xvals.size(), value);
-            std::vector<int> order = {ipos, xpos, ypos};
-            std::vector<CoolProp::parameters> idxs(3);
-            idxs[ipos] = key;
-            idxs[xpos] = xkey;
-            idxs[ypos] = ykey;
-            std::vector<std::vector<double>> vals(3);
-            vals[ipos] = ivals;
-            vals[xpos] = xvals;
-            vals[ypos] = yvals;
-
-            // TODO: guesses missing
-
-            for (int i = 0; i < vals[2].size(); ++i)
-            {
-                try
-                {
-                    state->update((CoolProp::input_pairs)pair, vals[0][i], vals[1][i]);
-                    vals[2][i] = state->keyed_output(idxs[2]);
-                }
-                catch (...)
-                {
-                    vals[2][i] = Detail::NaN;
-                }
-            }
-
-            for (int i = 0; i < idxs.size(); ++i)
-            {
-                if (idxs[i] == xkey) x = vals[i];
-                if (idxs[i] == ykey) y = vals[i];
-            }
-        }
-    }
+    Range get_sat_bounds(CoolProp::parameters key);
+    void calc_sat_range(int count);
+    void update_pair(int& ipos, int& xpos, int& ypos, int& pair);
+    void calc_range(std::vector<double>& xvals, std::vector<double>& yvals);
 
     friend class PropertyPlot;
 };
@@ -381,7 +97,7 @@ public:
 
     Range isoline_range(CoolProp::parameters key);
     Isolines calc_isolines(CoolProp::parameters key, const std::vector<double>& values, int points) const;
-    std::vector<CoolProp::parameters> supported_dimensions() const;
+    std::vector<CoolProp::parameters> supported_isoline_keys() const;
     double value_at(CoolProp::parameters key, double axis_x_value, double axis_y_value, CoolProp::phases phase = CoolProp::phases::iphase_not_imposed) const;
 
 private:

--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -51,8 +51,6 @@ enum IsolineSupported
 
 Scale default_scale(CoolProp::parameters key);
 std::shared_ptr<CoolProp::AbstractState> process_fluid_state(const std::string& fluid_ref);
-std::vector<double> generate_values_in_range(Scale scale, double start, double end, int count);
-std::vector<double> generate_values_in_range(CoolProp::parameters type, double start, double end, int count);
 inline std::shared_ptr<CoolProp::AbstractState> get_critical_point(const std::shared_ptr<CoolProp::AbstractState>& state);
 
 } /* namespace Detail */
@@ -64,14 +62,14 @@ public:
     std::vector<double> y;
     double value;
 
-    Isoline(CoolProp::parameters key, CoolProp::parameters xkey, CoolProp::parameters ykey, double value, const std::shared_ptr<CoolProp::AbstractState>& state);
-
 private:
     std::shared_ptr<CoolProp::AbstractState> state;
     std::shared_ptr<CoolProp::AbstractState> critical_state;
     CoolProp::parameters xkey;
     CoolProp::parameters ykey;
     CoolProp::parameters key;
+
+    Isoline(CoolProp::parameters key, CoolProp::parameters xkey, CoolProp::parameters ykey, double value, const std::shared_ptr<CoolProp::AbstractState>& state);
 
     Range get_sat_bounds(CoolProp::parameters key);
     void calc_sat_range(int count);
@@ -82,6 +80,9 @@ private:
 };
 
 using Isolines = std::vector<Isoline>;
+
+std::vector<double> generate_values_in_range(Scale scale, const Range& range, int count);
+std::vector<double> generate_values_in_range(CoolProp::parameters type, const Range& range, int count);
 
 class PropertyPlot
 {
@@ -98,7 +99,7 @@ public:
     Range isoline_range(CoolProp::parameters key);
     Isolines calc_isolines(CoolProp::parameters key, const std::vector<double>& values, int points) const;
     std::vector<CoolProp::parameters> supported_isoline_keys() const;
-    double value_at(CoolProp::parameters key, double axis_x_value, double axis_y_value, CoolProp::phases phase = CoolProp::phases::iphase_not_imposed) const;
+    double value_at(CoolProp::parameters key, double xvalue, double yvalue, CoolProp::phases phase = CoolProp::phases::iphase_not_imposed) const;
 
 private:
     std::string fluid_name;

--- a/include/CoolPropPlot.h
+++ b/include/CoolPropPlot.h
@@ -38,7 +38,6 @@ enum IsolineSupported
  const int PD = CoolProp::iP * 10 + CoolProp::iDmass;
  const int TD = CoolProp::iT * 10 + CoolProp::iDmass;
  const int PT = CoolProp::iP * 10 + CoolProp::iT;
- const int PU = CoolProp::iP * 10 + CoolProp::iUmass;
 
  const std::map<CoolProp::parameters, std::map<int, IsolineSupported>> xy_switch = {
     {CoolProp::iDmass, {{TS, Flipped}, {PH, Flipped}, {HS, Yes    }, {PS, Flipped}, {PD, No     }, {TD, No     }, {PT, Yes    }}},
@@ -62,6 +61,8 @@ public:
     std::vector<double> y;
     double value;
 
+    size_t size() const { return x.size(); };
+
 private:
     std::shared_ptr<CoolProp::AbstractState> state_;
     std::shared_ptr<CoolProp::AbstractState> critical_state_;
@@ -84,6 +85,14 @@ using Isolines = std::vector<Isoline>;
 std::vector<double> generate_values_in_range(Scale scale, const Range& range, int count);
 std::vector<double> generate_values_in_range(CoolProp::parameters type, const Range& range, int count);
 
+enum class TPLimits
+{
+    None,
+    Def,
+    Achp,
+    Orc
+};
+
 class PropertyPlot
 {
 public:
@@ -94,7 +103,7 @@ public:
     Range xrange;
     Range yrange;
 
-    PropertyPlot(const std::string& fluid_name, CoolProp::parameters ykey, CoolProp::parameters xkey, const std::string& tp_limits);
+    PropertyPlot(const std::string& fluid_name, CoolProp::parameters ykey, CoolProp::parameters xkey, CoolProp::Plot::TPLimits tp_limits = CoolProp::Plot::TPLimits::Def);
 
     Range isoline_range(CoolProp::parameters key) const;
     Isolines calc_isolines(CoolProp::parameters key, const std::vector<double>& values, int points) const;

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -1,0 +1,40 @@
+/*
+ * AbstractState.cpp
+ *
+ *  Created on: 21 Dec 2013
+ *      Author: jowr
+ */
+
+#ifndef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include "CoolPropPlot.h"
+
+namespace CoolProp {
+namespace Plot {
+
+
+} /* namespace Plot */
+} /* namespace CoolProp */
+
+#ifdef ENABLE_CATCH
+#    include <catch2/catch_all.hpp>
+#    include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+
+TEST_CASE("Check CoolPropPlot", "[Plot]") {
+    CHECK(1 == 1);
+}
+TEST_CASE("CoolPropPlot", "[log p-H plot value_at]") {
+    CoolProp::Plot::PropertyPlot plot("R134a", CoolProp::iP, CoolProp::iHmass, "ACHP");
+    plot.set_dimension_unit(plot.y_index, "bar");
+    plot.set_dimension_unit(plot.x_index, "kJ/kg");
+    plot.set_dimension_unit(CoolProp::iQ, "%");
+
+    CHECK(*plot.value_at(CoolProp::iP, 300, 2) == 2);
+    // EXPECT_NEAR(*plot.value_at(CoolProp::iT, 300, 2), 263.07372753976694, 1e-10);
+    // EXPECT_NEAR(*plot.value_at(CoolProp::iQ, 300, 2), 55.044347874344737, 1e-10);
+}
+
+#endif

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -129,34 +129,34 @@ std::vector<double> generate_values_in_range(CoolProp::parameters type, const Ra
 
 
 Isoline::Isoline(CoolProp::parameters key, CoolProp::parameters xkey, CoolProp::parameters ykey, double value, const std::shared_ptr<CoolProp::AbstractState>& state)
-    : key(key),
-      xkey(xkey),
-      ykey(ykey),
+    : key_(key),
+      xkey_(xkey),
+      ykey_(ykey),
       value(value),
-      state(state)
+      state_(state)
 {
-    this->critical_state = Detail::get_critical_point(state);
+    this->critical_state_ = Detail::get_critical_point(state);
 }
 
 Range Isoline::get_sat_bounds(CoolProp::parameters key)
 {
     double s = 1e-7;
-    double t_small = critical_state->keyed_output(CoolProp::iT) * s;
-    double p_small = critical_state->keyed_output(CoolProp::iP) * s;
+    double t_small = critical_state_->keyed_output(CoolProp::iT) * s;
+    double p_small = critical_state_->keyed_output(CoolProp::iP) * s;
 
-    double t_triple = state->trivial_keyed_output(CoolProp::iT_triple);
-    double t_min = state->trivial_keyed_output(CoolProp::iT_min);
-    state->update(CoolProp::QT_INPUTS, 0, std::max(t_triple, t_min) + t_small);
+    double t_triple = state_->trivial_keyed_output(CoolProp::iT_triple);
+    double t_min = state_->trivial_keyed_output(CoolProp::iT_min);
+    state_->update(CoolProp::QT_INPUTS, 0, std::max(t_triple, t_min) + t_small);
     double fluid_min, fluid_max;
     if (key == CoolProp::iP)
     {
-        fluid_min = state->keyed_output(CoolProp::iP) + p_small;
-        fluid_max = critical_state->keyed_output(CoolProp::iP) - p_small;
+        fluid_min = state_->keyed_output(CoolProp::iP) + p_small;
+        fluid_max = critical_state_->keyed_output(CoolProp::iP) - p_small;
     }
     else if (key == CoolProp::iT)
     {
-        fluid_min = state->keyed_output(CoolProp::iT) + t_small;
-        fluid_max = critical_state->keyed_output(CoolProp::iT) - t_small;
+        fluid_min = state_->keyed_output(CoolProp::iT) + t_small;
+        fluid_max = critical_state_->keyed_output(CoolProp::iT) - t_small;
     }
     else
     {
@@ -177,19 +177,19 @@ void Isoline::calc_sat_range(int count)
     std::vector<double> one(two.size(), value);
     CoolProp::input_pairs input_pair = CoolProp::QT_INPUTS;
 
-    double t_crit = critical_state->keyed_output(CoolProp::iT);
-    double p_crit = critical_state->keyed_output(CoolProp::iP);
-    double x_crit = critical_state->keyed_output(xkey);
-    double y_crit = critical_state->keyed_output(ykey);
+    double t_crit = critical_state_->keyed_output(CoolProp::iT);
+    double p_crit = critical_state_->keyed_output(CoolProp::iP);
+    double x_crit = critical_state_->keyed_output(xkey_);
+    double y_crit = critical_state_->keyed_output(ykey_);
     x.resize(one.size());
     y.resize(one.size());
     for (int i = 0; i < one.size(); ++i)
     {
         try
         {
-            state->update(input_pair, one[i], two[i]);
-            x[i] = state->keyed_output(xkey);
-            y[i] = state->keyed_output(ykey);
+            state_->update(input_pair, one[i], two[i]);
+            x[i] = state_->keyed_output(xkey_);
+            y[i] = state_->keyed_output(ykey_);
         }
         catch (...)
         {
@@ -212,7 +212,7 @@ void Isoline::calc_sat_range(int count)
 
 void Isoline::update_pair(int& ipos, int& xpos, int& ypos, int& pair)
 {
-    Detail::IsolineSupported should_switch = Detail::xy_switch.at(key).at(ykey * 10 + xkey);
+    Detail::IsolineSupported should_switch = Detail::xy_switch.at(key_).at(ykey_ * 10 + xkey_);
     double out1, out2;
     switch (should_switch)
     {
@@ -220,10 +220,10 @@ void Isoline::update_pair(int& ipos, int& xpos, int& ypos, int& pair)
             throw CoolProp::ValueError("This isoline cannot be calculated!");
             break;
         case Detail::IsolineSupported::Yes:
-            pair = CoolProp::generate_update_pair(key, 0.0, xkey, 1.0, out1, out2);
+            pair = CoolProp::generate_update_pair(key_, 0.0, xkey_, 1.0, out1, out2);
             break;
         case Detail::IsolineSupported::Flipped:
-            pair = CoolProp::generate_update_pair(key, 0.0, ykey, 1.0, out1, out2);
+            pair = CoolProp::generate_update_pair(key_, 0.0, ykey_, 1.0, out1, out2);
             break;
     }
     bool should_swap = (out1 != 0.0);
@@ -260,7 +260,7 @@ void Isoline::update_pair(int& ipos, int& xpos, int& ypos, int& pair)
 
 void Isoline::calc_range(std::vector<double>& xvals, std::vector<double>& yvals)
 {
-    if (key == CoolProp::iQ)
+    if (key_ == CoolProp::iQ)
     {
         calc_sat_range(xvals.size());
     }
@@ -272,9 +272,9 @@ void Isoline::calc_range(std::vector<double>& xvals, std::vector<double>& yvals)
         std::vector<double> ivals(xvals.size(), value);
         std::vector<int> order = {ipos, xpos, ypos};
         std::vector<CoolProp::parameters> idxs(3);
-        idxs[ipos] = key;
-        idxs[xpos] = xkey;
-        idxs[ypos] = ykey;
+        idxs[ipos] = key_;
+        idxs[xpos] = xkey_;
+        idxs[ypos] = ykey_;
         std::vector<std::vector<double>> vals(3);
         vals[ipos] = ivals;
         vals[xpos] = xvals;
@@ -286,8 +286,8 @@ void Isoline::calc_range(std::vector<double>& xvals, std::vector<double>& yvals)
         {
             try
             {
-                state->update((CoolProp::input_pairs)pair, vals[0][i], vals[1][i]);
-                vals[2][i] = state->keyed_output(idxs[2]);
+                state_->update((CoolProp::input_pairs)pair, vals[0][i], vals[1][i]);
+                vals[2][i] = state_->keyed_output(idxs[2]);
             }
             catch (...)
             {
@@ -297,28 +297,27 @@ void Isoline::calc_range(std::vector<double>& xvals, std::vector<double>& yvals)
 
         for (int i = 0; i < idxs.size(); ++i)
         {
-            if (idxs[i] == xkey) x = vals[i];
-            if (idxs[i] == ykey) y = vals[i];
+            if (idxs[i] == xkey_) x = vals[i];
+            if (idxs[i] == ykey_) y = vals[i];
         }
     }
 }
 
 PropertyPlot::PropertyPlot(const std::string& fluid_name, CoolProp::parameters ykey, CoolProp::parameters xkey, const std::string& tp_limits)
-    : fluid_name(fluid_name),
-      xkey(xkey),
+    : xkey(xkey),
       ykey(ykey),
       xscale(Detail::default_scale(xkey)),
       yscale(Detail::default_scale(ykey))
 {
-    this->state = Detail::process_fluid_state(fluid_name);
-    this->critical_state = Detail::get_critical_point(state);
+    this->state_ = Detail::process_fluid_state(fluid_name);
+    this->critical_state_ = Detail::get_critical_point(state_);
 
     // We are just assuming that all inputs and outputs are in SI units. We
     // take care of any conversions before calling the library and after
     // getting the results.
     int out1, out2;
-    axis_pair = CoolProp::generate_update_pair(xkey, 0, ykey, 1, out1, out2);
-    swap_axis_inputs_for_update = (out1 == 1);
+    axis_pair_ = CoolProp::generate_update_pair(xkey, 0, ykey, 1, out1, out2);
+    swap_axis_inputs_for_update_ = (out1 == 1);
 
     const double HI_FACTOR = 2.25; // Upper default limits: HI_FACTOR*T_crit and HI_FACTOR*p_crit
     const double LO_FACTOR = 1.01; // Lower default limits: LO_FACTOR*T_triple and LO_FACTOR*p_triple
@@ -354,7 +353,7 @@ Isolines PropertyPlot::calc_isolines(CoolProp::parameters key, const std::vector
     Isolines lines;
     for (double val : values)
     {
-        Isoline line(key, xkey, ykey, val, state);
+        Isoline line(key, xkey, ykey, val, state_);
         line.calc_range(xvals, yvals);
         lines.push_back(line);
     }
@@ -382,19 +381,19 @@ double PropertyPlot::value_at(CoolProp::parameters key, double xvalue, double yv
 
     try
     {
-        if (swap_axis_inputs_for_update)
+        if (swap_axis_inputs_for_update_)
             std::swap(xvalue, yvalue);
-        state->specify_phase(phase);
-        state->update(axis_pair, xvalue, yvalue);
+        state_->specify_phase(phase);
+        state_->update(axis_pair_, xvalue, yvalue);
         switch (key)
         {
-            case CoolProp::iT: return state->T();
-            case CoolProp::iP: return state->p();
-            case CoolProp::iDmass: return state->rhomass();
-            case CoolProp::iHmass: return state->hmass();
-            case CoolProp::iSmass: return state->smass();
-            case CoolProp::iUmass: return state->umass();
-            case CoolProp::iQ: return state->Q();
+            case CoolProp::iT: return state_->T();
+            case CoolProp::iP: return state_->p();
+            case CoolProp::iDmass: return state_->rhomass();
+            case CoolProp::iHmass: return state_->hmass();
+            case CoolProp::iSmass: return state_->smass();
+            case CoolProp::iUmass: return state_->umass();
+            case CoolProp::iQ: return state_->Q();
             default: return Detail::NaN;
         }
     }
@@ -408,16 +407,16 @@ Range PropertyPlot::get_sat_bounds(CoolProp::parameters key) const
 {
     // TODO: duplicated code from IsoLine
     double s = 1e-7;
-    double t_small = critical_state->keyed_output(CoolProp::iT) * s;
-    double p_small = critical_state->keyed_output(CoolProp::iP) * s;
+    double t_small = critical_state_->keyed_output(CoolProp::iT) * s;
+    double p_small = critical_state_->keyed_output(CoolProp::iP) * s;
 
-    double t_triple = state->trivial_keyed_output(CoolProp::iT_triple);
-    double t_min = state->trivial_keyed_output(CoolProp::iT_min);
-    state->update(CoolProp::QT_INPUTS, 0, std::max(t_triple, t_min) + t_small);
+    double t_triple = state_->trivial_keyed_output(CoolProp::iT_triple);
+    double t_min = state_->trivial_keyed_output(CoolProp::iT_min);
+    state_->update(CoolProp::QT_INPUTS, 0, std::max(t_triple, t_min) + t_small);
     if (key == CoolProp::iP)
-        return {state->keyed_output(CoolProp::iP) + p_small, critical_state->keyed_output(CoolProp::iP) - p_small};
+        return {state_->keyed_output(CoolProp::iP) + p_small, critical_state_->keyed_output(CoolProp::iP) - p_small};
     else if (key == CoolProp::iT)
-        return {state->keyed_output(CoolProp::iT) + t_small, critical_state->keyed_output(CoolProp::iT) - t_small};
+        return {state_->keyed_output(CoolProp::iT) + t_small, critical_state_->keyed_output(CoolProp::iT) - t_small};
     else
         throw CoolProp::ValueError("Invalid key");
 }
@@ -439,10 +438,10 @@ PropertyPlot::Range2D PropertyPlot::get_Tp_limits() const
     if (std::isnan(p.max)) p.max = 1e10;
     else if (p.max < ID_FACTOR) p.max *= psat.max;
 
-    try { t.min = std::max(t.min, state->trivial_keyed_output(CoolProp::iT_min)); } catch (...) {}
-    try { t.max = std::min(t.max, state->trivial_keyed_output(CoolProp::iT_max)); } catch (...) {}
-    try { p.min = std::max(p.min, state->trivial_keyed_output(CoolProp::iP_min)); } catch (...) {}
-    try { p.max = std::min(p.max, state->trivial_keyed_output(CoolProp::iP_max)); } catch (...) {}
+    try { t.min = std::max(t.min, state_->trivial_keyed_output(CoolProp::iT_min)); } catch (...) {}
+    try { t.max = std::min(t.max, state_->trivial_keyed_output(CoolProp::iT_max)); } catch (...) {}
+    try { p.min = std::max(p.min, state_->trivial_keyed_output(CoolProp::iP_min)); } catch (...) {}
+    try { p.max = std::min(p.max, state_->trivial_keyed_output(CoolProp::iP_max)); } catch (...) {}
     return {t, p};
 }
 
@@ -463,9 +462,9 @@ PropertyPlot::Range2D PropertyPlot::get_axis_limits(CoolProp::parameters xkey, C
             {
                 try
                 {
-                    state->update(CoolProp::PT_INPUTS, p, T);
-                    double x = state->keyed_output(xkey);
-                    double y = state->keyed_output(ykey);
+                    state_->update(CoolProp::PT_INPUTS, p, T);
+                    double x = state_->keyed_output(xkey);
+                    double y = state_->keyed_output(ykey);
                     xrange.min = std::min(xrange.min, x);
                     xrange.max = std::max(xrange.max, x);
                     yrange.min = std::min(yrange.min, y);

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -462,9 +462,9 @@ TEST_CASE("Check that the isolines are the same as from Python", "[Plot]") {
 
     {
         // Q isolines
-        CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iQ);
-        std::vector<double> iso_values = CoolProp::Plot::generate_values_in_range(CoolProp::iQ, iso_range, isoline_count);
-        CoolProp::Plot::Isolines q_isolines = plot.calc_isolines(CoolProp::iQ, iso_values, points_per_isoline);
+        CoolProp::Plot::Range q_range = plot.isoline_range(CoolProp::iQ);
+        std::vector<double> q_values = CoolProp::Plot::generate_values_in_range(CoolProp::iQ, q_range, isoline_count);
+        CoolProp::Plot::Isolines q_isolines = plot.calc_isolines(CoolProp::iQ, q_values, points_per_isoline);
         REQUIRE(q_isolines.size() == isoline_count);
         CHECK_THAT(q_isolines[0].value, WithinAbs(0.0, 1e-10));
         CHECK_THAT(q_isolines[1].value, WithinAbs(0.25, 1e-10));
@@ -485,8 +485,9 @@ TEST_CASE("Check that the isolines are the same as from Python", "[Plot]") {
             {3.89567060e+02, 2.58505756e+04, 2.81105747e+05, 1.31691170e+06, 4.05910826e+06},
             {3.89567060e+02, 2.58505756e+04, 2.81105747e+05, 1.31691170e+06, 4.05910826e+06}
         };
-        for (int i = 0; i < isoline_count; ++i) {
-            for (int j = 0; j < points_per_isoline; ++j) {
+        for (int i = 0; i < q_isolines.size(); ++i) {
+            REQUIRE(q_isolines[i].size() == points_per_isoline);
+            for (int j = 0; j < q_isolines[i].size(); ++j) {
                 CHECK_THAT(q_isolines[i].x[j], WithinRel(expected_x[i][j], 1e-8));
                 CHECK_THAT(q_isolines[i].y[j], WithinRel(expected_y[i][j], 1e-8));
             }
@@ -494,9 +495,9 @@ TEST_CASE("Check that the isolines are the same as from Python", "[Plot]") {
     }
     {
         // T isolines
-        CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iT);
-        std::vector<double> iso_values = CoolProp::Plot::generate_values_in_range(CoolProp::iT, iso_range, isoline_count);
-        CoolProp::Plot::Isolines t_isolines = plot.calc_isolines(CoolProp::iT, iso_values, points_per_isoline);
+        CoolProp::Plot::Range t_range = plot.isoline_range(CoolProp::iT);
+        std::vector<double> t_values = CoolProp::Plot::generate_values_in_range(CoolProp::iT, t_range, isoline_count);
+        CoolProp::Plot::Isolines t_isolines = plot.calc_isolines(CoolProp::iT, t_values, points_per_isoline);
         REQUIRE(t_isolines.size() == isoline_count);
         CHECK_THAT(t_isolines[0].value, WithinAbs(173.15, 1e-10));
         CHECK_THAT(t_isolines[1].value, WithinAbs(243.6125, 1e-10));
@@ -517,8 +518,9 @@ TEST_CASE("Check that the isolines are the same as from Python", "[Plot]") {
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175}
         };
-        for (int i = 0; i < isoline_count; ++i) {
-            for (int j = 0; j < points_per_isoline; ++j) {
+        for (int i = 0; i < t_isolines.size(); ++i) {
+            REQUIRE(t_isolines[i].size() == points_per_isoline);
+            for (int j = 0; j < t_isolines[i].size(); ++j) {
                 CHECK_THAT(t_isolines[i].x[j], WithinRel(expected_x[i][j], 1e-8));
                 CHECK_THAT(t_isolines[i].y[j], WithinRel(expected_y[i][j], 1e-8));
             }
@@ -526,9 +528,9 @@ TEST_CASE("Check that the isolines are the same as from Python", "[Plot]") {
     }
     {
         // S isolines
-        CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iSmass);
-        std::vector<double> iso_values = CoolProp::Plot::generate_values_in_range(CoolProp::iSmass, iso_range, isoline_count);
-        CoolProp::Plot::Isolines s_isolines = plot.calc_isolines(CoolProp::iSmass, iso_values, points_per_isoline);
+        CoolProp::Plot::Range s_range = plot.isoline_range(CoolProp::iSmass);
+        std::vector<double> s_values = CoolProp::Plot::generate_values_in_range(CoolProp::iSmass, s_range, isoline_count);
+        CoolProp::Plot::Isolines s_isolines = plot.calc_isolines(CoolProp::iSmass, s_values, points_per_isoline);
         REQUIRE(s_isolines.size() == isoline_count);
         CHECK_THAT(s_isolines[0].value, WithinAbs(426.0098553415565, 1e-10));
         CHECK_THAT(s_isolines[1].value, WithinAbs(925.2753143522199, 1e-10));
@@ -549,8 +551,9 @@ TEST_CASE("Check that the isolines are the same as from Python", "[Plot]") {
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175}
         };
-        for (int i = 0; i < isoline_count; ++i) {
-            for (int j = 0; j < points_per_isoline; ++j) {
+        for (int i = 0; i < s_isolines.size(); ++i) {
+            REQUIRE(s_isolines[i].size() == points_per_isoline);
+            for (int j = 0; j < s_isolines[i].size(); ++j) {
                 if (std::isnan(s_isolines[i].x[j]))
                     CHECK(std::isnan(expected_x[i][j]));
                 else
@@ -561,9 +564,9 @@ TEST_CASE("Check that the isolines are the same as from Python", "[Plot]") {
     }
     {
         // D isolines
-        CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iDmass);
-        std::vector<double> iso_values = CoolProp::Plot::generate_values_in_range(CoolProp::iDmass, iso_range, isoline_count);
-        CoolProp::Plot::Isolines d_isolines = plot.calc_isolines(CoolProp::iDmass, iso_values, points_per_isoline);
+        CoolProp::Plot::Range d_range = plot.isoline_range(CoolProp::iDmass);
+        std::vector<double> d_values = CoolProp::Plot::generate_values_in_range(CoolProp::iDmass, d_range, isoline_count);
+        CoolProp::Plot::Isolines d_isolines = plot.calc_isolines(CoolProp::iDmass, d_values, points_per_isoline);
         REQUIRE(d_isolines.size() == isoline_count);
         CHECK_THAT(d_isolines[0].value, WithinAbs(0.6749779869915704, 1e-10));
         CHECK_THAT(d_isolines[1].value, WithinAbs(4.704765330619733, 1e-10));
@@ -584,8 +587,9 @@ TEST_CASE("Check that the isolines are the same as from Python", "[Plot]") {
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175}
         };
-        for (int i = 0; i < isoline_count; ++i) {
-            for (int j = 0; j < points_per_isoline; ++j) {
+        for (int i = 0; i < d_isolines.size(); ++i) {
+            REQUIRE(d_isolines[i].size() == points_per_isoline);
+            for (int j = 0; j < d_isolines[i].size(); ++j) {
                 CHECK_THAT(d_isolines[i].x[j], WithinRel(expected_x[i][j], 1e-8));
                 CHECK_THAT(d_isolines[i].y[j], WithinRel(expected_y[i][j], 1e-8));
             }
@@ -618,9 +622,9 @@ TEST_CASE("Basic TS Plot has same output as Python", "[Plot]") {
 
     {
         // Q isolines
-        CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iQ);
-        std::vector<double> iso_values = CoolProp::Plot::generate_values_in_range(CoolProp::iQ, iso_range, isoline_count);
-        CoolProp::Plot::Isolines q_isolines = plot.calc_isolines(CoolProp::iQ, iso_values, points_per_isoline);
+        CoolProp::Plot::Range q_range = plot.isoline_range(CoolProp::iQ);
+        std::vector<double> q_values = CoolProp::Plot::generate_values_in_range(CoolProp::iQ, q_range, isoline_count);
+        CoolProp::Plot::Isolines q_isolines = plot.calc_isolines(CoolProp::iQ, q_values, points_per_isoline);
         REQUIRE(q_isolines.size() == isoline_count);
         CHECK_THAT(q_isolines[0].value, WithinAbs(0.0, 1e-10));
         CHECK_THAT(q_isolines[1].value, WithinAbs(0.25, 1e-10));
@@ -643,8 +647,9 @@ TEST_CASE("Basic TS Plot has same output as Python", "[Plot]") {
             {169.85007484, 220.94004678, 272.03001871, 323.11999064, 374.20996258}
         };
 
-        for(int i = 0; i < isoline_count; i++) {
-            for(int j = 0; j < points_per_isoline; j++) {
+        for(int i = 0; i < q_isolines.size(); i++) {
+            REQUIRE(q_isolines[i].size() == points_per_isoline);
+            for(int j = 0; j < q_isolines[i].size(); j++) {
                 CHECK_THAT(q_isolines[i].x[j], WithinRel(expected_x[i][j], 1e-8));
                 CHECK_THAT(q_isolines[i].y[j], WithinRel(expected_y[i][j], 1e-8));
             }
@@ -653,9 +658,9 @@ TEST_CASE("Basic TS Plot has same output as Python", "[Plot]") {
 
     {
         // P isolines
-        CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iP);
-        std::vector<double> iso_values = CoolProp::Plot::generate_values_in_range(CoolProp::iP, iso_range, isoline_count);
-        CoolProp::Plot::Isolines p_isolines = plot.calc_isolines(CoolProp::iP, iso_values, points_per_isoline);
+        CoolProp::Plot::Range p_range = plot.isoline_range(CoolProp::iP);
+        std::vector<double> p_values = CoolProp::Plot::generate_values_in_range(CoolProp::iP, p_range, isoline_count);
+        CoolProp::Plot::Isolines p_isolines = plot.calc_isolines(CoolProp::iP, p_values, points_per_isoline);
         REQUIRE(p_isolines.size() == isoline_count);
         CHECK_THAT(p_isolines[0].value, WithinAbs(25000.000000000007, 1e-8));
         CHECK_THAT(p_isolines[1].value, WithinAbs(109297.03270763098, 1e-8));
@@ -678,8 +683,9 @@ TEST_CASE("Basic TS Plot has same output as Python", "[Plot]") {
             {173.15, 261.02100275, 371.32673696, 484.42563591, std::nan("")}
         };
 
-        for(int i = 0; i < isoline_count; i++) {
-            for(int j = 0; j < points_per_isoline; j++) {
+        for(int i = 0; i < p_isolines.size(); i++) {
+            REQUIRE(p_isolines[i].size() == points_per_isoline);
+            for(int j = 0; j < p_isolines[i].size(); j++) {
                 if (std::isnan(expected_y[i][j])) {
                     CHECK(std::isnan(p_isolines[i].y[j]));
                 } else {
@@ -692,9 +698,9 @@ TEST_CASE("Basic TS Plot has same output as Python", "[Plot]") {
 
     {
         // H isolines
-        CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iHmass);
-        std::vector<double> iso_values = CoolProp::Plot::generate_values_in_range(CoolProp::iHmass, iso_range, isoline_count);
-        CoolProp::Plot::Isolines h_isolines = plot.calc_isolines(CoolProp::iHmass, iso_values, points_per_isoline);
+        CoolProp::Plot::Range h_range = plot.isoline_range(CoolProp::iHmass);
+        std::vector<double> h_values = CoolProp::Plot::generate_values_in_range(CoolProp::iHmass, h_range, isoline_count);
+        CoolProp::Plot::Isolines h_isolines = plot.calc_isolines(CoolProp::iHmass, h_values, points_per_isoline);
         REQUIRE(h_isolines.size() == isoline_count);
         CHECK_THAT(h_isolines[0].value, WithinAbs(75373.12689908482, 1e-10));
         CHECK_THAT(h_isolines[1].value, WithinAbs(200930.99391811725, 1e-10));
@@ -717,8 +723,9 @@ TEST_CASE("Basic TS Plot has same output as Python", "[Plot]") {
             {241.56832462, 341.66140042, 458.59389239, std::nan(""), 455.0}
         };
 
-        for(int i = 0; i < isoline_count; i++) {
-            for(int j = 0; j < points_per_isoline; j++) {
+        for(int i = 0; i < h_isolines.size(); i++) {
+            REQUIRE(h_isolines[i].size() == points_per_isoline);
+            for(int j = 0; j < h_isolines[i].size(); j++) {
                 if (std::isnan(expected_y[i][j])) {
                     CHECK(std::isnan(h_isolines[i].y[j]));
                 } else {
@@ -731,9 +738,9 @@ TEST_CASE("Basic TS Plot has same output as Python", "[Plot]") {
 
     {
         // D isolines
-        CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iDmass);
-        std::vector<double> iso_values = CoolProp::Plot::generate_values_in_range(CoolProp::iDmass, iso_range, isoline_count);
-        CoolProp::Plot::Isolines d_isolines = plot.calc_isolines(CoolProp::iDmass, iso_values, points_per_isoline);
+        CoolProp::Plot::Range d_range = plot.isoline_range(CoolProp::iDmass);
+        std::vector<double> d_values = CoolProp::Plot::generate_values_in_range(CoolProp::iDmass, d_range, isoline_count);
+        CoolProp::Plot::Isolines d_isolines = plot.calc_isolines(CoolProp::iDmass, d_values, points_per_isoline);
         REQUIRE(d_isolines.size() == isoline_count);
         CHECK_THAT(d_isolines[0].value, WithinAbs(0.6749779869915704, 1e-10));
         CHECK_THAT(d_isolines[1].value, WithinAbs(4.704765330619733, 1e-10));
@@ -756,8 +763,9 @@ TEST_CASE("Basic TS Plot has same output as Python", "[Plot]") {
             {173.15, 243.6125, 314.075, 384.5375, 455.0}
         };
 
-        for(int i = 0; i < isoline_count; i++) {
-            for(int j = 0; j < points_per_isoline; j++) {
+        for(int i = 0; i < d_isolines.size(); i++) {
+            REQUIRE(d_isolines[i].size() == points_per_isoline);
+            for(int j = 0; j < d_isolines[i].size(); j++) {
                 CHECK_THAT(d_isolines[i].x[j], WithinRel(expected_x[i][j], 1e-8));
                 CHECK_THAT(d_isolines[i].y[j], WithinRel(expected_y[i][j], 1e-8));
             }

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Check that the isolines are the same as from Python", "[ph_plot]") {
     {
         // Q isolines
         CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iQ);
-        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iQ, iso_range.min, iso_range.max, isoline_count);
+        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_values_in_range(CoolProp::iQ, iso_range.min, iso_range.max, isoline_count);
         auto isoQ = plot.calc_isolines(CoolProp::iQ, iso_values, points_per_isoline);
         REQUIRE(isoQ.size() == isoline_count);
         CHECK_THAT(isoQ[0].value, WithinAbs(0.0, 1e-10));
@@ -81,7 +81,7 @@ TEST_CASE("Check that the isolines are the same as from Python", "[ph_plot]") {
     {
         // T isolines
         CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iT);
-        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iT, iso_range.min, iso_range.max, isoline_count);
+        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_values_in_range(CoolProp::iT, iso_range.min, iso_range.max, isoline_count);
         auto isoT = plot.calc_isolines(CoolProp::iT, iso_values, points_per_isoline);
         REQUIRE(isoT.size() == isoline_count);
         CHECK_THAT(isoT[0].value, WithinAbs(173.15, 1e-10));
@@ -113,7 +113,7 @@ TEST_CASE("Check that the isolines are the same as from Python", "[ph_plot]") {
     {
         // S isolines
         CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iSmass);
-        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iSmass, iso_range.min, iso_range.max, isoline_count);
+        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_values_in_range(CoolProp::iSmass, iso_range.min, iso_range.max, isoline_count);
         auto isoS = plot.calc_isolines(CoolProp::iSmass, iso_values, points_per_isoline);
         REQUIRE(isoS.size() == isoline_count);
         CHECK_THAT(isoS[0].value, WithinAbs(426.0098553415565, 1e-10));
@@ -148,7 +148,7 @@ TEST_CASE("Check that the isolines are the same as from Python", "[ph_plot]") {
     {
         // D isolines
         CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iDmass);
-        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iDmass, iso_range.min, iso_range.max, isoline_count);
+        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_values_in_range(CoolProp::iDmass, iso_range.min, iso_range.max, isoline_count);
         auto isoD = plot.calc_isolines(CoolProp::iDmass, iso_values, points_per_isoline);
         REQUIRE(isoD.size() == isoline_count);
         CHECK_THAT(isoD[0].value, WithinAbs(0.6749779869915704, 1e-10));
@@ -205,7 +205,7 @@ TEST_CASE("Basic TS Plot has same output as Python", "[ts_plot]") {
     {
         // Q isolines
         CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iQ);
-        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iQ, iso_range.min, iso_range.max, isoline_count);
+        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_values_in_range(CoolProp::iQ, iso_range.min, iso_range.max, isoline_count);
         auto isoQ = plot.calc_isolines(CoolProp::iQ, iso_values, points_per_isoline);
         REQUIRE(isoQ.size() == isoline_count);
         CHECK_THAT(isoQ[0].value, WithinAbs(0.0, 1e-10));
@@ -240,7 +240,7 @@ TEST_CASE("Basic TS Plot has same output as Python", "[ts_plot]") {
     {
         // P isolines
         CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iP);
-        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iP, iso_range.min, iso_range.max, isoline_count);
+        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_values_in_range(CoolProp::iP, iso_range.min, iso_range.max, isoline_count);
         auto isoP = plot.calc_isolines(CoolProp::iP, iso_values, points_per_isoline);
         REQUIRE(isoP.size() == isoline_count);
         CHECK_THAT(isoP[0].value, WithinAbs(25000.000000000007, 1e-8));
@@ -279,7 +279,7 @@ TEST_CASE("Basic TS Plot has same output as Python", "[ts_plot]") {
     {
         // H isolines
         CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iHmass);
-        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iHmass, iso_range.min, iso_range.max, isoline_count);
+        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_values_in_range(CoolProp::iHmass, iso_range.min, iso_range.max, isoline_count);
         auto isoH = plot.calc_isolines(CoolProp::iHmass, iso_values, points_per_isoline);
         REQUIRE(isoH.size() == isoline_count);
         CHECK_THAT(isoH[0].value, WithinAbs(75373.12689908482, 1e-10));
@@ -318,7 +318,7 @@ TEST_CASE("Basic TS Plot has same output as Python", "[ts_plot]") {
     {
         // D isolines
         CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iDmass);
-        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iDmass, iso_range.min, iso_range.max, isoline_count);
+        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_values_in_range(CoolProp::iDmass, iso_range.min, iso_range.max, isoline_count);
         auto isoD = plot.calc_isolines(CoolProp::iDmass, iso_values, points_per_isoline);
         REQUIRE(isoD.size() == isoline_count);
         CHECK_THAT(isoD[0].value, WithinAbs(0.6749779869915704, 1e-10));

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -22,19 +22,172 @@ namespace Plot {
 #    include <catch2/catch_all.hpp>
 #    include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+using Catch::Matchers::WithinAbs;
+using Catch::Matchers::WithinRel;
 
-TEST_CASE("Check CoolPropPlot", "[Plot]") {
-    CHECK(1 == 1);
-}
-TEST_CASE("CoolPropPlot", "[log p-H plot value_at]") {
+TEST_CASE("Check value_at for log p-h plots", "[ph_plot]") {
     CoolProp::Plot::PropertyPlot plot("R134a", CoolProp::iP, CoolProp::iHmass, "ACHP");
-    plot.set_dimension_unit(plot.y_index, "bar");
-    plot.set_dimension_unit(plot.x_index, "kJ/kg");
-    plot.set_dimension_unit(CoolProp::iQ, "%");
 
-    CHECK(*plot.value_at(CoolProp::iP, 300, 2) == 2);
-    // EXPECT_NEAR(*plot.value_at(CoolProp::iT, 300, 2), 263.07372753976694, 1e-10);
-    // EXPECT_NEAR(*plot.value_at(CoolProp::iQ, 300, 2), 55.044347874344737, 1e-10);
+    CHECK_THAT(*plot.value_at(CoolProp::iP, 300000/*Pa*/, 200000/*J/kg*/), WithinAbs(200000, 1e-10));
+    CHECK_THAT(*plot.value_at(CoolProp::iHmass, 300000, 200000), WithinAbs(300000, 1e-10));
+    CHECK_THAT(*plot.value_at(CoolProp::iT, 300000, 200000), WithinAbs(263.07372753976694, 1e-10));
+    CHECK_THAT(*plot.value_at(CoolProp::iQ, 300000, 200000), WithinAbs(0.55044347874344737, 1e-10));
+}
+
+TEST_CASE("Check the output is the same as Python", "[ph_plot]") {
+    CoolProp::Plot::PropertyPlot plot("HEOS::R134a", CoolProp::iP, CoolProp::iHmass, "ACHP");
+    const int isoline_count = 5;
+    const int isoline_points = 5;
+
+    CHECK(plot.x_index == CoolProp::iHmass);
+    CHECK(plot.y_index == CoolProp::iP);
+
+    CHECK(plot.axis_x_scale() == CoolProp::Plot::Scale::Lin);
+    CHECK(plot.axis_y_scale() == CoolProp::Plot::Scale::Log);
+
+    CHECK_THAT(plot.axis_x_range().min, WithinAbs(75373.1, 1));
+    CHECK_THAT(plot.axis_x_range().max, WithinAbs(577605, 1));
+    CHECK_THAT(plot.axis_y_range().min, WithinAbs(25000, 1));
+    CHECK_THAT(plot.axis_y_range().max, WithinAbs(9.133e6, 1));
+
+    auto iso_types = plot.supported_dimensions();
+    REQUIRE(iso_types.size() == 4);
+    CHECK(iso_types[0] == CoolProp::iQ);
+    CHECK(iso_types[1] == CoolProp::iT);
+    CHECK(iso_types[2] == CoolProp::iSmass);
+    CHECK(iso_types[3] == CoolProp::iDmass);
+
+    {
+        // Q isolines
+        CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iQ);
+        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iQ, iso_range.min, iso_range.max, isoline_count);
+        auto isoQ = plot.calc_isolines(CoolProp::iQ, iso_values, isoline_points);
+        REQUIRE(isoQ.size() == isoline_count);
+        CHECK_THAT(isoQ[0].value, WithinAbs(0.0, 1e-10));
+        CHECK_THAT(isoQ[1].value, WithinAbs(0.25, 1e-10));
+        CHECK_THAT(isoQ[2].value, WithinAbs(0.5, 1e-10));
+        CHECK_THAT(isoQ[3].value, WithinAbs(0.75, 1e-10));
+        CHECK_THAT(isoQ[4].value, WithinAbs(1.0, 1e-10));
+        const double expected_x[isoline_count][isoline_points] = {
+            {71455.08256999, 132939.99472497, 198497.0525314, 271576.58908888, 389440.73899019},
+            {137326.83116781, 191267.05172013, 248359.90642508, 309538.95484829, 389511.40516519},
+            {203198.57976564, 249594.1087153, 298222.76031877, 347501.3206077, 389582.0713402},
+            {269070.32836347, 307921.16571046, 348085.61421246, 385463.68636711, 389652.73751521},
+            {334942.07696129, 366248.22270562, 397948.46810615, 423426.05212652, 389723.40369022}
+        };
+        const double expected_y[isoline_count][isoline_points] = {
+            {3.89567060e+02, 2.58505756e+04, 2.81105747e+05, 1.31691170e+06, 4.05910826e+06},
+            {3.89567060e+02, 2.58505756e+04, 2.81105747e+05, 1.31691170e+06, 4.05910826e+06},
+            {3.89567060e+02, 2.58505756e+04, 2.81105747e+05, 1.31691170e+06, 4.05910826e+06},
+            {3.89567060e+02, 2.58505756e+04, 2.81105747e+05, 1.31691170e+06, 4.05910826e+06},
+            {3.89567060e+02, 2.58505756e+04, 2.81105747e+05, 1.31691170e+06, 4.05910826e+06}
+        };
+        for (int i = 0; i < isoline_count; ++i) {
+            for (int j = 0; j < isoline_points; ++j) {
+                CHECK_THAT(isoQ[i].x[j], WithinRel(expected_x[i][j], 1e-8));
+                CHECK_THAT(isoQ[i].y[j], WithinRel(expected_y[i][j], 1e-8));
+            }
+        }
+    }
+    {
+        // T isolines
+        CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iT);
+        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iT, iso_range.min, iso_range.max, isoline_count);
+        auto isoT = plot.calc_isolines(CoolProp::iT, iso_values, isoline_points);
+        REQUIRE(isoT.size() == isoline_count);
+        CHECK_THAT(isoT[0].value, WithinAbs(173.15, 1e-10));
+        CHECK_THAT(isoT[1].value, WithinAbs(243.6125, 1e-10));
+        CHECK_THAT(isoT[2].value, WithinAbs(314.075, 1e-10));
+        CHECK_THAT(isoT[3].value, WithinAbs(384.5375, 1e-10));
+        CHECK_THAT(isoT[4].value, WithinAbs(455.0, 1e-10));
+        const double expected_x[isoline_count][isoline_points] = {
+            {75373.12689908, 75410.99061368, 75576.57734102, 76301.46320034, 79487.71936123},
+            {382785.23058756, 161389.44197265, 161516.21527543, 162076.96181603, 164636.92352411},
+            {439466.64984328, 438148.19040202, 431912.24266074, 257605.32897193, 257512.80690587},
+            {504550.62606561, 503783.53950874, 500331.68636519, 482707.98489058, 366959.25257106},
+            {577604.59497521, 577097.07174302, 574850.21206939, 564444.22079795, 507878.75380996}
+        };
+        const double expected_y[isoline_count][isoline_points] = {
+            {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
+            {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
+            {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
+            {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
+            {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175}
+        };
+        for (int i = 0; i < isoline_count; ++i) {
+            for (int j = 0; j < isoline_points; ++j) {
+                CHECK_THAT(isoT[i].x[j], WithinRel(expected_x[i][j], 1e-8));
+                CHECK_THAT(isoT[i].y[j], WithinRel(expected_y[i][j], 1e-8));
+            }
+        }
+    }
+    {
+        // S isolines
+        CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iSmass);
+        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iSmass, iso_range.min, iso_range.max, isoline_count);
+        auto isoS = plot.calc_isolines(CoolProp::iSmass, iso_values, isoline_points);
+        REQUIRE(isoS.size() == isoline_count);
+        CHECK_THAT(isoS[0].value, WithinAbs(426.0098553415565, 1e-10));
+        CHECK_THAT(isoS[1].value, WithinAbs(925.2753143522199, 1e-10));
+        CHECK_THAT(isoS[2].value, WithinAbs(1424.540773362883, 1e-10));
+        CHECK_THAT(isoS[3].value, WithinAbs(1923.8062323735467, 1e-10));
+        CHECK_THAT(isoS[4].value, WithinAbs(2423.07169138421, 1e-10));
+        const double expected_x[isoline_count][isoline_points] = {
+            {73758.20064883, 73811.34928194, 74043.68191583, 75058.90103546, 79487.71936135},
+            {176257.41124603, 179794.86552304, 180290.38376303, 181487.99233203, 186690.75978367},
+            {286286.21675221, 303984.6485323, 321692.18498473, 335551.56116185, 344087.52152244},
+            {399372.58517377, 433400.13264058, 471964.37092222, 513835.0906295, 555823.55477128},
+            {577604.59497522, 635257.81956317, 698998.52697158, 768744.13132575, std::nan("")}
+        };
+        const double expected_y[isoline_count][isoline_points] = {
+            {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
+            {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
+            {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
+            {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
+            {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175}
+        };
+        for (int i = 0; i < isoline_count; ++i) {
+            for (int j = 0; j < isoline_points; ++j) {
+                if (std::isnan(isoS[i].x[j]))
+                    CHECK(std::isnan(expected_x[i][j]));
+                else
+                    CHECK_THAT(isoS[i].x[j], WithinRel(expected_x[i][j], 1e-8));
+                CHECK_THAT(isoS[i].y[j], WithinRel(expected_y[i][j], 1e-8));
+            }
+        }
+    }
+    {
+        // D isolines
+        CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iDmass);
+        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iDmass, iso_range.min, iso_range.max, isoline_count);
+        auto isoD = plot.calc_isolines(CoolProp::iDmass, iso_values, isoline_points);
+        REQUIRE(isoD.size() == isoline_count);
+        CHECK_THAT(isoD[0].value, WithinAbs(0.6749779869915704, 1e-10));
+        CHECK_THAT(isoD[1].value, WithinAbs(4.704765330619733, 1e-10));
+        CHECK_THAT(isoD[2].value, WithinAbs(32.793390662794806, 1e-10));
+        CHECK_THAT(isoD[3].value, WithinAbs(228.57813208316188, 1e-10));
+        CHECK_THAT(isoD[4].value, WithinAbs(1593.2467308391022, 1e-10));
+        const double expected_x[isoline_count][isoline_points] = {
+            {5.77604595e+05, 3.65397965e+06, 3.84283606e+07, 4.40954815e+08, 5.22494051e+09},
+            {2.02365849e+05, 4.19227802e+05, 1.84512838e+06, 1.78590373e+07, 2.01674048e+08},
+            {1.42114492e+05, 2.04387395e+05, 3.51213643e+05, 1.00846111e+06, 8.12669299e+06},
+            {1.33470419e+05, 1.72415441e+05, 2.35381904e+05, 3.57488786e+05, 6.69475618e+05},
+            {7.05185202e+04, 7.06013993e+04, 7.09637630e+04, 7.25484894e+04, 7.94877194e+04}
+        };
+        const double expected_y[isoline_count][isoline_points] = {
+            {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
+            {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
+            {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
+            {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
+            {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175}
+        };
+        for (int i = 0; i < isoline_count; ++i) {
+            for (int j = 0; j < isoline_points; ++j) {
+                CHECK_THAT(isoD[i].x[j], WithinRel(expected_x[i][j], 1e-8));
+                CHECK_THAT(isoD[i].y[j], WithinRel(expected_y[i][j], 1e-8));
+            }
+        }
+    }
 }
 
 #endif

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -283,7 +283,7 @@ void Isoline::calc_range(std::vector<double>& xvals, std::vector<double>& yvals)
     }
 }
 
-PropertyPlot::PropertyPlot(const std::string& fluid_name, CoolProp::parameters ykey, CoolProp::parameters xkey, const std::string& tp_limits)
+PropertyPlot::PropertyPlot(const std::string& fluid_name, CoolProp::parameters ykey, CoolProp::parameters xkey, TPLimits tp_limits)
     : xkey(xkey),
       ykey(ykey),
       xscale(Detail::default_scale(xkey)),
@@ -301,16 +301,14 @@ PropertyPlot::PropertyPlot(const std::string& fluid_name, CoolProp::parameters y
 
     const double HI_FACTOR = 2.25; // Upper default limits: HI_FACTOR*T_crit and HI_FACTOR*p_crit
     const double LO_FACTOR = 1.01; // Lower default limits: LO_FACTOR*T_triple and LO_FACTOR*p_triple
-    if (tp_limits == "NONE")
-        this->Tp_limits_ = {{Detail::NaN, Detail::NaN}, {Detail::NaN, Detail::NaN}};
-    else if (tp_limits == "DEF")
-        this->Tp_limits_ = {{LO_FACTOR, HI_FACTOR}, {LO_FACTOR, HI_FACTOR}};
-    else if (tp_limits == "ACHP")
-        this->Tp_limits_ = {{173.15, 493.15}, {0.25e5, HI_FACTOR}};
-    else if (tp_limits == "ORC")
-        this->Tp_limits_ = {{273.15, 673.15}, {0.25e5, HI_FACTOR}};
-    else
-        throw CoolProp::ValueError("Invalid tp_limits");
+
+    switch (tp_limits)
+    {
+        case TPLimits::None: this->Tp_limits_ = {{Detail::NaN, Detail::NaN}, {Detail::NaN, Detail::NaN}}; break;
+        case TPLimits::Def:  this->Tp_limits_ = {{LO_FACTOR, HI_FACTOR}, {LO_FACTOR, HI_FACTOR}}; break;
+        case TPLimits::Achp: this->Tp_limits_ = {{173.15, 493.15}, {0.25e5, HI_FACTOR}}; break;
+        case TPLimits::Orc:  this->Tp_limits_ = {{273.15, 673.15}, {0.25e5, HI_FACTOR}}; break;
+    }
 
     Range2D ranges = get_axis_limits();
     xrange = ranges.x;
@@ -471,7 +469,7 @@ using Catch::Matchers::WithinAbs;
 using Catch::Matchers::WithinRel;
 
 TEST_CASE("Check value_at for p-h plots", "[ph_plot]") {
-    CoolProp::Plot::PropertyPlot plot("R134a", CoolProp::iP, CoolProp::iHmass, "ACHP");
+    CoolProp::Plot::PropertyPlot plot("R134a", CoolProp::iP, CoolProp::iHmass, CoolProp::Plot::TPLimits::Achp);
 
     CHECK_THAT(plot.value_at(CoolProp::iP, 300000/*Pa*/, 200000/*J/kg*/), WithinAbs(200000, 1e-10));
     CHECK_THAT(plot.value_at(CoolProp::iHmass, 300000, 200000), WithinAbs(300000, 1e-10));
@@ -480,7 +478,7 @@ TEST_CASE("Check value_at for p-h plots", "[ph_plot]") {
 }
 
 TEST_CASE("Check that the isolines are the same as from Python", "[ph_plot]") {
-    CoolProp::Plot::PropertyPlot plot("HEOS::R134a", CoolProp::iP, CoolProp::iHmass, "ACHP");
+    CoolProp::Plot::PropertyPlot plot("HEOS::R134a", CoolProp::iP, CoolProp::iHmass, CoolProp::Plot::TPLimits::Achp);
     const int isoline_count = 5;
     const int points_per_isoline = 5;
 
@@ -636,7 +634,7 @@ TEST_CASE("Check that the isolines are the same as from Python", "[ph_plot]") {
 }
 
 TEST_CASE("Basic TS Plot has same output as Python", "[ts_plot]") {
-    CoolProp::Plot::PropertyPlot plot("HEOS::R134a", CoolProp::iT, CoolProp::iSmass, "ACHP");
+    CoolProp::Plot::PropertyPlot plot("HEOS::R134a", CoolProp::iT, CoolProp::iSmass, CoolProp::Plot::TPLimits::Achp);
     const int isoline_count = 5;
     const int points_per_isoline = 5;
 

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -1,10 +1,38 @@
 #include "CoolPropPlot.h"
 #include "CoolProp.h"
+#include "CPnumerics.h"
+#include <map>
 
 namespace CoolProp {
 namespace Plot {
 
 namespace Detail {
+
+const double NaN = std::numeric_limits<double>::quiet_NaN();
+
+const int TS = CoolProp::iT * 10 + CoolProp::iSmass;
+const int PH = CoolProp::iP * 10 + CoolProp::iHmass;
+const int HS = CoolProp::iHmass * 10 + CoolProp::iSmass;
+const int PS = CoolProp::iP * 10 + CoolProp::iSmass;
+const int PD = CoolProp::iP * 10 + CoolProp::iDmass;
+const int TD = CoolProp::iT * 10 + CoolProp::iDmass;
+const int PT = CoolProp::iP * 10 + CoolProp::iT;
+
+enum IsolineSupported
+{
+    No = 0,
+    Yes = 1,
+    Flipped = 2
+};
+
+const std::map<CoolProp::parameters, std::map<int, IsolineSupported>> xy_switch = {
+    {CoolProp::iDmass, {{TS, Flipped}, {PH, Flipped}, {HS, Yes    }, {PS, Flipped}, {PD, No     }, {TD, No     }, {PT, Yes    }}},
+    {CoolProp::iHmass, {{TS, Yes    }, {PH, No     }, {HS, No     }, {PS, Flipped}, {PD, Flipped}, {TD, Yes    }, {PT, Yes    }}},
+    {CoolProp::iP,     {{TS, Yes    }, {PH, No     }, {HS, Yes    }, {PS, No     }, {PD, No     }, {TD, Yes    }, {PT, No     }}},
+    {CoolProp::iSmass, {{TS, No     }, {PH, Flipped}, {HS, No     }, {PS, No     }, {PD, Flipped}, {TD, Yes    }, {PT, Flipped}}},
+    {CoolProp::iT,     {{TS, No     }, {PH, Flipped}, {HS, Yes    }, {PS, Yes    }, {PD, Yes    }, {TD, No     }, {PT, No     }}},
+    {CoolProp::iQ,     {{TS, Flipped}, {PH, Flipped}, {HS, Flipped}, {PS, Flipped}, {PD, Flipped}, {TD, Flipped}, {PT, Yes    }}}
+};
 
 Scale default_scale(CoolProp::parameters key) {
     switch (key)

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -17,10 +17,10 @@ using Catch::Matchers::WithinRel;
 TEST_CASE("Check value_at for p-h plots", "[ph_plot]") {
     CoolProp::Plot::PropertyPlot plot("R134a", CoolProp::iP, CoolProp::iHmass, "ACHP");
 
-    CHECK_THAT(*plot.value_at(CoolProp::iP, 300000/*Pa*/, 200000/*J/kg*/), WithinAbs(200000, 1e-10));
-    CHECK_THAT(*plot.value_at(CoolProp::iHmass, 300000, 200000), WithinAbs(300000, 1e-10));
-    CHECK_THAT(*plot.value_at(CoolProp::iT, 300000, 200000), WithinAbs(263.07372753976694, 1e-10));
-    CHECK_THAT(*plot.value_at(CoolProp::iQ, 300000, 200000), WithinAbs(0.55044347874344737, 1e-10));
+    CHECK_THAT(plot.value_at(CoolProp::iP, 300000/*Pa*/, 200000/*J/kg*/), WithinAbs(200000, 1e-10));
+    CHECK_THAT(plot.value_at(CoolProp::iHmass, 300000, 200000), WithinAbs(300000, 1e-10));
+    CHECK_THAT(plot.value_at(CoolProp::iT, 300000, 200000), WithinAbs(263.07372753976694, 1e-10));
+    CHECK_THAT(plot.value_at(CoolProp::iQ, 300000, 200000), WithinAbs(0.55044347874344737, 1e-10));
 }
 
 TEST_CASE("Check that the isolines are the same as from Python", "[ph_plot]") {

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -1,7 +1,306 @@
 #include "CoolPropPlot.h"
+#include "CoolProp.h"
 
 namespace CoolProp {
 namespace Plot {
+
+namespace Detail {
+
+Scale default_scale(CoolProp::parameters key)
+{
+    switch (key)
+    {
+        case CoolProp::iDmass: return Scale::Log;
+        case CoolProp::iHmass: return Scale::Lin;
+        case CoolProp::iP:     return Scale::Log;
+        case CoolProp::iSmass: return Scale::Lin;
+        case CoolProp::iT:     return Scale::Lin;
+        case CoolProp::iUmass: return Scale::Lin;
+        case CoolProp::iQ:     return Scale::Lin;
+
+        default: return Scale::Lin;
+    }
+}
+
+inline std::shared_ptr<CoolProp::AbstractState> process_fluid_state(const std::string& fluid_ref)
+{
+    std::string backend;
+    std::string fluids;
+    CoolProp::extract_backend(fluid_ref, backend, fluids);
+    std::vector<double> fractions;
+    fluids = CoolProp::extract_fractions(fluids, fractions);
+
+    return std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory(backend, fluids));
+}
+
+std::vector<double> generate_values_in_range(Scale scale, double start, double end, int count)
+{
+    if (scale == Scale::Log)
+        return logspace(start, end, count);
+    else
+        return linspace(start, end, count);
+}
+
+std::vector<double> generate_values_in_range(CoolProp::parameters type, double start, double end, int count)
+{
+    return generate_values_in_range(default_scale(type), start, end, count);
+}
+
+std::shared_ptr<CoolProp::AbstractState> get_critical_point(const std::shared_ptr<CoolProp::AbstractState>& state)
+{
+    CoolProp::CriticalState crit_state;
+    crit_state.T = Detail::NaN;
+    crit_state.p = Detail::NaN;
+    crit_state.rhomolar = Detail::NaN;
+    crit_state.rhomolar = Detail::NaN;
+    crit_state.stable = false;
+    try
+    {
+        crit_state.T = state->T_critical();
+        crit_state.p = state->p_critical();
+        crit_state.rhomolar = state->rhomolar_critical();
+        crit_state.stable = true;
+    }
+    catch (...)
+    {
+        try
+        {
+            for (CoolProp::CriticalState crit_state_tmp: state->all_critical_points())
+            {
+                if (crit_state_tmp.stable && (crit_state_tmp.T > crit_state.T || !std::isfinite(crit_state.T)))
+                {
+                    crit_state.T = crit_state_tmp.T;
+                    crit_state.p = crit_state_tmp.p;
+                    crit_state.rhomolar = crit_state_tmp.rhomolar;
+                    crit_state.stable = crit_state_tmp.stable;
+                }
+            }
+        }
+        catch (...)
+        {
+            throw CoolProp::ValueError("Could not calculate the critical point data.");
+        }
+    }
+
+    std::shared_ptr<CoolProp::AbstractState> new_state(CoolProp::AbstractState::factory(state->backend_name(), state->fluid_names()));
+    std::vector<double> masses = state->get_mass_fractions();
+    if (masses.size() > 1)
+        new_state->set_mass_fractions(masses);
+
+    if (std::isfinite(crit_state.p) && std::isfinite(crit_state.T))
+    {
+        try
+        {
+            new_state->specify_phase(CoolProp::iphase_critical_point);
+            new_state->update(CoolProp::PT_INPUTS, crit_state.p, crit_state.T);
+            return new_state;
+        }
+        catch (...) { }
+        try
+        {
+            new_state->update(CoolProp::PT_INPUTS, crit_state.p, crit_state.T);
+            return new_state;
+        }
+        catch (...) { }
+    }
+
+    if (std::isfinite(crit_state.rhomolar) && std::isfinite(crit_state.T))
+    {
+        try
+        {
+            new_state->specify_phase(CoolProp::iphase_critical_point);
+            new_state->update(CoolProp::DmolarT_INPUTS, crit_state.rhomolar, crit_state.T);
+            return new_state;
+        }
+        catch (...) { }
+        try
+        {
+            new_state->update(CoolProp::DmolarT_INPUTS, crit_state.rhomolar, crit_state.T);
+            return new_state;
+        }
+        catch (...) { }
+    }
+    throw CoolProp::ValueError("Could not calculate the critical point data.");
+    return nullptr;
+}
+
+} /* namespace Detail */
+
+
+Isoline::Isoline(CoolProp::parameters key, CoolProp::parameters xkey, CoolProp::parameters ykey, double value, const std::shared_ptr<CoolProp::AbstractState>& state)
+    : key(key),
+      xkey(xkey),
+      ykey(ykey),
+      value(value),
+      state(state)
+{
+    this->critical_state = Detail::get_critical_point(state);
+}
+
+Range Isoline::get_sat_bounds(CoolProp::parameters key)
+{
+    double s = 1e-7;
+    double t_small = critical_state->keyed_output(CoolProp::iT) * s;
+    double p_small = critical_state->keyed_output(CoolProp::iP) * s;
+
+    double t_triple = state->trivial_keyed_output(CoolProp::iT_triple);
+    double t_min = state->trivial_keyed_output(CoolProp::iT_min);
+    state->update(CoolProp::QT_INPUTS, 0, std::max(t_triple, t_min) + t_small);
+    double fluid_min, fluid_max;
+    if (key == CoolProp::iP)
+    {
+        fluid_min = state->keyed_output(CoolProp::iP) + p_small;
+        fluid_max = critical_state->keyed_output(CoolProp::iP) - p_small;
+    }
+    else if (key == CoolProp::iT)
+    {
+        fluid_min = state->keyed_output(CoolProp::iT) + t_small;
+        fluid_max = critical_state->keyed_output(CoolProp::iT) - t_small;
+    }
+    else
+    {
+        throw CoolProp::ValueError("Invalid key");
+    }
+    double sat_min = fluid_min;
+    double sat_max = fluid_max;
+    return {sat_min, sat_max};
+}
+
+void Isoline::calc_sat_range(int count)
+{
+    double t_lo, t_hi;
+    Range t = get_sat_bounds(CoolProp::iT);
+    t_lo = t.min;
+    t_hi = t.max;
+    std::vector<double> two = ::linspace(t_lo, t_hi, count);
+    std::vector<double> one(two.size(), value);
+    CoolProp::input_pairs input_pair = CoolProp::QT_INPUTS;
+
+    double t_crit = critical_state->keyed_output(CoolProp::iT);
+    double p_crit = critical_state->keyed_output(CoolProp::iP);
+    double x_crit = critical_state->keyed_output(xkey);
+    double y_crit = critical_state->keyed_output(ykey);
+    x.resize(one.size());
+    y.resize(one.size());
+    for (int i = 0; i < one.size(); ++i)
+    {
+        try
+        {
+            state->update(input_pair, one[i], two[i]);
+            x[i] = state->keyed_output(xkey);
+            y[i] = state->keyed_output(ykey);
+        }
+        catch (...)
+        {
+            if (input_pair == CoolProp::QT_INPUTS && abs(two[i] - t_crit) < 1e0 ||
+                input_pair == CoolProp::PQ_INPUTS && abs(one[i] - p_crit) < 1e2)
+            {
+                x[i] = x_crit;
+                y[i] = y_crit;
+                std::cerr << "ERROR near critical inputs" << std::endl;
+            }
+            else
+            {
+                x[i] = Detail::NaN;
+                y[i] = Detail::NaN;
+                std::cerr << "ERROR" << std::endl;
+            }
+        }
+    }
+}
+
+void Isoline::update_pair(int& ipos, int& xpos, int& ypos, int& pair)
+{
+    Detail::IsolineSupported should_switch = Detail::xy_switch.at(key).at(ykey * 10 + xkey);
+    double out1, out2;
+    switch (should_switch)
+    {
+        case Detail::IsolineSupported::No:
+            throw CoolProp::ValueError("This isoline cannot be calculated!");
+            break;
+        case Detail::IsolineSupported::Yes:
+            pair = CoolProp::generate_update_pair(key, 0.0, xkey, 1.0, out1, out2);
+            break;
+        case Detail::IsolineSupported::Flipped:
+            pair = CoolProp::generate_update_pair(key, 0.0, ykey, 1.0, out1, out2);
+            break;
+    }
+    bool should_swap = (out1 != 0.0);
+
+    if (should_switch == Detail::IsolineSupported::Yes && !should_swap)
+    {
+        ipos = 0;
+        xpos = 1;
+        ypos = 2;
+    }
+    else if (should_switch == Detail::IsolineSupported::Flipped && !should_swap)
+    {
+        ipos = 0;
+        xpos = 2;
+        ypos = 1;
+    }
+    else if (should_switch == Detail::IsolineSupported::Yes && should_swap)
+    {
+        ipos = 1;
+        xpos = 0;
+        ypos = 2;
+    }
+    else if (should_switch == Detail::IsolineSupported::Flipped && should_swap)
+    {
+        ipos = 1;
+        xpos = 2;
+        ypos = 0;
+    }
+    else
+    {
+        throw CoolProp::ValueError("Check the code, this should not happen!");
+    }
+}
+
+void Isoline::calc_range(std::vector<double>& xvals, std::vector<double>& yvals)
+{
+    if (key == CoolProp::iQ)
+    {
+        calc_sat_range(xvals.size());
+    }
+    else
+    {
+        int ipos, xpos, ypos, pair;
+        update_pair(ipos, xpos, ypos, pair);
+
+        std::vector<double> ivals(xvals.size(), value);
+        std::vector<int> order = {ipos, xpos, ypos};
+        std::vector<CoolProp::parameters> idxs(3);
+        idxs[ipos] = key;
+        idxs[xpos] = xkey;
+        idxs[ypos] = ykey;
+        std::vector<std::vector<double>> vals(3);
+        vals[ipos] = ivals;
+        vals[xpos] = xvals;
+        vals[ypos] = yvals;
+
+        // TODO: guesses missing
+
+        for (int i = 0; i < vals[2].size(); ++i)
+        {
+            try
+            {
+                state->update((CoolProp::input_pairs)pair, vals[0][i], vals[1][i]);
+                vals[2][i] = state->keyed_output(idxs[2]);
+            }
+            catch (...)
+            {
+                vals[2][i] = Detail::NaN;
+            }
+        }
+
+        for (int i = 0; i < idxs.size(); ++i)
+        {
+            if (idxs[i] == xkey) x = vals[i];
+            if (idxs[i] == ykey) y = vals[i];
+        }
+    }
+}
 
 PropertyPlot::PropertyPlot(const std::string& fluid_name, CoolProp::parameters ykey, CoolProp::parameters xkey, const std::string& tp_limits)
     : fluid_name(fluid_name),
@@ -63,7 +362,7 @@ Isolines PropertyPlot::calc_isolines(CoolProp::parameters key, const std::vector
     return lines;
 }
 
-std::vector<CoolProp::parameters> PropertyPlot::supported_dimensions() const
+std::vector<CoolProp::parameters> PropertyPlot::supported_isoline_keys() const
 {
     // taken from PropertyPlot::calc_isolines when called with iso_type='all'
     std::vector<CoolProp::parameters> keys;
@@ -249,7 +548,7 @@ TEST_CASE("Check that the isolines are the same as from Python", "[ph_plot]") {
     CHECK_THAT(plot.yrange.min, WithinAbs(25000, 1));
     CHECK_THAT(plot.yrange.max, WithinAbs(9.133e6, 1));
 
-    std::vector<CoolProp::parameters> iso_types = plot.supported_dimensions();
+    std::vector<CoolProp::parameters> iso_types = plot.supported_isoline_keys();
     REQUIRE(iso_types.size() == 4);
     CHECK(iso_types[0] == CoolProp::iT);
     CHECK(iso_types[1] == CoolProp::iQ);
@@ -405,7 +704,7 @@ TEST_CASE("Basic TS Plot has same output as Python", "[ts_plot]") {
     CHECK_THAT(plot.yrange.min, WithinAbs(173, 1));
     CHECK_THAT(plot.yrange.max, WithinAbs(455, 1));
 
-    std::vector<CoolProp::parameters> iso_types = plot.supported_dimensions();
+    std::vector<CoolProp::parameters> iso_types = plot.supported_isoline_keys();
     REQUIRE(iso_types.size() == 4);
     CHECK(iso_types[0] == CoolProp::iP);
     CHECK(iso_types[1] == CoolProp::iQ);

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -28,16 +28,16 @@ TEST_CASE("Check that the isolines are the same as from Python", "[ph_plot]") {
     const int isoline_count = 5;
     const int points_per_isoline = 5;
 
-    CHECK(plot.x_index == CoolProp::iHmass);
-    CHECK(plot.y_index == CoolProp::iP);
+    CHECK(plot.xkey == CoolProp::iHmass);
+    CHECK(plot.ykey == CoolProp::iP);
 
-    CHECK(plot.axis_x_scale() == CoolProp::Plot::Scale::Lin);
-    CHECK(plot.axis_y_scale() == CoolProp::Plot::Scale::Log);
+    CHECK(plot.axis_x_scale == CoolProp::Plot::Scale::Lin);
+    CHECK(plot.axis_y_scale == CoolProp::Plot::Scale::Log);
 
-    CHECK_THAT(plot.axis_x_range().min, WithinAbs(75373.1, 1));
-    CHECK_THAT(plot.axis_x_range().max, WithinAbs(577605, 1));
-    CHECK_THAT(plot.axis_y_range().min, WithinAbs(25000, 1));
-    CHECK_THAT(plot.axis_y_range().max, WithinAbs(9.133e6, 1));
+    CHECK_THAT(plot.axis_x_range.min, WithinAbs(75373.1, 1));
+    CHECK_THAT(plot.axis_x_range.max, WithinAbs(577605, 1));
+    CHECK_THAT(plot.axis_y_range.min, WithinAbs(25000, 1));
+    CHECK_THAT(plot.axis_y_range.max, WithinAbs(9.133e6, 1));
 
     auto iso_types = plot.supported_dimensions();
     REQUIRE(iso_types.size() == 4);
@@ -184,16 +184,16 @@ TEST_CASE("Basic TS Plot has same output as Python", "[ts_plot]") {
     const int isoline_count = 5;
     const int points_per_isoline = 5;
 
-    CHECK(plot.x_index == CoolProp::iSmass);
-    CHECK(plot.y_index == CoolProp::iT);
+    CHECK(plot.xkey == CoolProp::iSmass);
+    CHECK(plot.ykey == CoolProp::iT);
 
-    CHECK(plot.axis_x_scale() == CoolProp::Plot::Scale::Lin);
-    CHECK(plot.axis_y_scale() == CoolProp::Plot::Scale::Lin);
+    CHECK(plot.axis_x_scale == CoolProp::Plot::Scale::Lin);
+    CHECK(plot.axis_y_scale == CoolProp::Plot::Scale::Lin);
 
-    CHECK_THAT(plot.axis_x_range().min, WithinAbs(426, 1));
-    CHECK_THAT(plot.axis_x_range().max, WithinAbs(2423, 1));
-    CHECK_THAT(plot.axis_y_range().min, WithinAbs(173, 1));
-    CHECK_THAT(plot.axis_y_range().max, WithinAbs(455, 1));
+    CHECK_THAT(plot.axis_x_range.min, WithinAbs(426, 1));
+    CHECK_THAT(plot.axis_x_range.max, WithinAbs(2423, 1));
+    CHECK_THAT(plot.axis_y_range.min, WithinAbs(173, 1));
+    CHECK_THAT(plot.axis_y_range.max, WithinAbs(455, 1));
 
     auto iso_types = plot.supported_dimensions();
     REQUIRE(iso_types.size() == 4);

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -25,7 +25,7 @@ namespace Plot {
 using Catch::Matchers::WithinAbs;
 using Catch::Matchers::WithinRel;
 
-TEST_CASE("Check value_at for log p-h plots", "[ph_plot]") {
+TEST_CASE("Check value_at for p-h plots", "[ph_plot]") {
     CoolProp::Plot::PropertyPlot plot("R134a", CoolProp::iP, CoolProp::iHmass, "ACHP");
 
     CHECK_THAT(*plot.value_at(CoolProp::iP, 300000/*Pa*/, 200000/*J/kg*/), WithinAbs(200000, 1e-10));
@@ -34,10 +34,10 @@ TEST_CASE("Check value_at for log p-h plots", "[ph_plot]") {
     CHECK_THAT(*plot.value_at(CoolProp::iQ, 300000, 200000), WithinAbs(0.55044347874344737, 1e-10));
 }
 
-TEST_CASE("Check the output is the same as Python", "[ph_plot]") {
+TEST_CASE("Check that the isolines are the same as from Python", "[ph_plot]") {
     CoolProp::Plot::PropertyPlot plot("HEOS::R134a", CoolProp::iP, CoolProp::iHmass, "ACHP");
     const int isoline_count = 5;
-    const int isoline_points = 5;
+    const int points_per_isoline = 5;
 
     CHECK(plot.x_index == CoolProp::iHmass);
     CHECK(plot.y_index == CoolProp::iP);
@@ -61,21 +61,21 @@ TEST_CASE("Check the output is the same as Python", "[ph_plot]") {
         // Q isolines
         CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iQ);
         std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iQ, iso_range.min, iso_range.max, isoline_count);
-        auto isoQ = plot.calc_isolines(CoolProp::iQ, iso_values, isoline_points);
+        auto isoQ = plot.calc_isolines(CoolProp::iQ, iso_values, points_per_isoline);
         REQUIRE(isoQ.size() == isoline_count);
         CHECK_THAT(isoQ[0].value, WithinAbs(0.0, 1e-10));
         CHECK_THAT(isoQ[1].value, WithinAbs(0.25, 1e-10));
         CHECK_THAT(isoQ[2].value, WithinAbs(0.5, 1e-10));
         CHECK_THAT(isoQ[3].value, WithinAbs(0.75, 1e-10));
         CHECK_THAT(isoQ[4].value, WithinAbs(1.0, 1e-10));
-        const double expected_x[isoline_count][isoline_points] = {
+        const double expected_x[isoline_count][points_per_isoline] = {
             {71455.08256999, 132939.99472497, 198497.0525314, 271576.58908888, 389440.73899019},
             {137326.83116781, 191267.05172013, 248359.90642508, 309538.95484829, 389511.40516519},
             {203198.57976564, 249594.1087153, 298222.76031877, 347501.3206077, 389582.0713402},
             {269070.32836347, 307921.16571046, 348085.61421246, 385463.68636711, 389652.73751521},
             {334942.07696129, 366248.22270562, 397948.46810615, 423426.05212652, 389723.40369022}
         };
-        const double expected_y[isoline_count][isoline_points] = {
+        const double expected_y[isoline_count][points_per_isoline] = {
             {3.89567060e+02, 2.58505756e+04, 2.81105747e+05, 1.31691170e+06, 4.05910826e+06},
             {3.89567060e+02, 2.58505756e+04, 2.81105747e+05, 1.31691170e+06, 4.05910826e+06},
             {3.89567060e+02, 2.58505756e+04, 2.81105747e+05, 1.31691170e+06, 4.05910826e+06},
@@ -83,7 +83,7 @@ TEST_CASE("Check the output is the same as Python", "[ph_plot]") {
             {3.89567060e+02, 2.58505756e+04, 2.81105747e+05, 1.31691170e+06, 4.05910826e+06}
         };
         for (int i = 0; i < isoline_count; ++i) {
-            for (int j = 0; j < isoline_points; ++j) {
+            for (int j = 0; j < points_per_isoline; ++j) {
                 CHECK_THAT(isoQ[i].x[j], WithinRel(expected_x[i][j], 1e-8));
                 CHECK_THAT(isoQ[i].y[j], WithinRel(expected_y[i][j], 1e-8));
             }
@@ -93,21 +93,21 @@ TEST_CASE("Check the output is the same as Python", "[ph_plot]") {
         // T isolines
         CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iT);
         std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iT, iso_range.min, iso_range.max, isoline_count);
-        auto isoT = plot.calc_isolines(CoolProp::iT, iso_values, isoline_points);
+        auto isoT = plot.calc_isolines(CoolProp::iT, iso_values, points_per_isoline);
         REQUIRE(isoT.size() == isoline_count);
         CHECK_THAT(isoT[0].value, WithinAbs(173.15, 1e-10));
         CHECK_THAT(isoT[1].value, WithinAbs(243.6125, 1e-10));
         CHECK_THAT(isoT[2].value, WithinAbs(314.075, 1e-10));
         CHECK_THAT(isoT[3].value, WithinAbs(384.5375, 1e-10));
         CHECK_THAT(isoT[4].value, WithinAbs(455.0, 1e-10));
-        const double expected_x[isoline_count][isoline_points] = {
+        const double expected_x[isoline_count][points_per_isoline] = {
             {75373.12689908, 75410.99061368, 75576.57734102, 76301.46320034, 79487.71936123},
             {382785.23058756, 161389.44197265, 161516.21527543, 162076.96181603, 164636.92352411},
             {439466.64984328, 438148.19040202, 431912.24266074, 257605.32897193, 257512.80690587},
             {504550.62606561, 503783.53950874, 500331.68636519, 482707.98489058, 366959.25257106},
             {577604.59497521, 577097.07174302, 574850.21206939, 564444.22079795, 507878.75380996}
         };
-        const double expected_y[isoline_count][isoline_points] = {
+        const double expected_y[isoline_count][points_per_isoline] = {
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
@@ -115,7 +115,7 @@ TEST_CASE("Check the output is the same as Python", "[ph_plot]") {
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175}
         };
         for (int i = 0; i < isoline_count; ++i) {
-            for (int j = 0; j < isoline_points; ++j) {
+            for (int j = 0; j < points_per_isoline; ++j) {
                 CHECK_THAT(isoT[i].x[j], WithinRel(expected_x[i][j], 1e-8));
                 CHECK_THAT(isoT[i].y[j], WithinRel(expected_y[i][j], 1e-8));
             }
@@ -125,21 +125,21 @@ TEST_CASE("Check the output is the same as Python", "[ph_plot]") {
         // S isolines
         CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iSmass);
         std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iSmass, iso_range.min, iso_range.max, isoline_count);
-        auto isoS = plot.calc_isolines(CoolProp::iSmass, iso_values, isoline_points);
+        auto isoS = plot.calc_isolines(CoolProp::iSmass, iso_values, points_per_isoline);
         REQUIRE(isoS.size() == isoline_count);
         CHECK_THAT(isoS[0].value, WithinAbs(426.0098553415565, 1e-10));
         CHECK_THAT(isoS[1].value, WithinAbs(925.2753143522199, 1e-10));
         CHECK_THAT(isoS[2].value, WithinAbs(1424.540773362883, 1e-10));
         CHECK_THAT(isoS[3].value, WithinAbs(1923.8062323735467, 1e-10));
         CHECK_THAT(isoS[4].value, WithinAbs(2423.07169138421, 1e-10));
-        const double expected_x[isoline_count][isoline_points] = {
+        const double expected_x[isoline_count][points_per_isoline] = {
             {73758.20064883, 73811.34928194, 74043.68191583, 75058.90103546, 79487.71936135},
             {176257.41124603, 179794.86552304, 180290.38376303, 181487.99233203, 186690.75978367},
             {286286.21675221, 303984.6485323, 321692.18498473, 335551.56116185, 344087.52152244},
             {399372.58517377, 433400.13264058, 471964.37092222, 513835.0906295, 555823.55477128},
             {577604.59497522, 635257.81956317, 698998.52697158, 768744.13132575, std::nan("")}
         };
-        const double expected_y[isoline_count][isoline_points] = {
+        const double expected_y[isoline_count][points_per_isoline] = {
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
@@ -147,7 +147,7 @@ TEST_CASE("Check the output is the same as Python", "[ph_plot]") {
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175}
         };
         for (int i = 0; i < isoline_count; ++i) {
-            for (int j = 0; j < isoline_points; ++j) {
+            for (int j = 0; j < points_per_isoline; ++j) {
                 if (std::isnan(isoS[i].x[j]))
                     CHECK(std::isnan(expected_x[i][j]));
                 else
@@ -160,21 +160,21 @@ TEST_CASE("Check the output is the same as Python", "[ph_plot]") {
         // D isolines
         CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iDmass);
         std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iDmass, iso_range.min, iso_range.max, isoline_count);
-        auto isoD = plot.calc_isolines(CoolProp::iDmass, iso_values, isoline_points);
+        auto isoD = plot.calc_isolines(CoolProp::iDmass, iso_values, points_per_isoline);
         REQUIRE(isoD.size() == isoline_count);
         CHECK_THAT(isoD[0].value, WithinAbs(0.6749779869915704, 1e-10));
         CHECK_THAT(isoD[1].value, WithinAbs(4.704765330619733, 1e-10));
         CHECK_THAT(isoD[2].value, WithinAbs(32.793390662794806, 1e-10));
         CHECK_THAT(isoD[3].value, WithinAbs(228.57813208316188, 1e-10));
         CHECK_THAT(isoD[4].value, WithinAbs(1593.2467308391022, 1e-10));
-        const double expected_x[isoline_count][isoline_points] = {
+        const double expected_x[isoline_count][points_per_isoline] = {
             {5.77604595e+05, 3.65397965e+06, 3.84283606e+07, 4.40954815e+08, 5.22494051e+09},
             {2.02365849e+05, 4.19227802e+05, 1.84512838e+06, 1.78590373e+07, 2.01674048e+08},
             {1.42114492e+05, 2.04387395e+05, 3.51213643e+05, 1.00846111e+06, 8.12669299e+06},
             {1.33470419e+05, 1.72415441e+05, 2.35381904e+05, 3.57488786e+05, 6.69475618e+05},
             {7.05185202e+04, 7.06013993e+04, 7.09637630e+04, 7.25484894e+04, 7.94877194e+04}
         };
-        const double expected_y[isoline_count][isoline_points] = {
+        const double expected_y[isoline_count][points_per_isoline] = {
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175},
@@ -182,7 +182,179 @@ TEST_CASE("Check the output is the same as Python", "[ph_plot]") {
             {25000.0, 109297.03270763, 477833.65434772, 2089032.02192197, 9133000.04909175}
         };
         for (int i = 0; i < isoline_count; ++i) {
-            for (int j = 0; j < isoline_points; ++j) {
+            for (int j = 0; j < points_per_isoline; ++j) {
+                CHECK_THAT(isoD[i].x[j], WithinRel(expected_x[i][j], 1e-8));
+                CHECK_THAT(isoD[i].y[j], WithinRel(expected_y[i][j], 1e-8));
+            }
+        }
+    }
+}
+
+TEST_CASE("Basic TS Plot has same output as Python", "[ts_plot]") {
+    CoolProp::Plot::PropertyPlot plot("HEOS::R134a", CoolProp::iT, CoolProp::iSmass, "ACHP");
+    const int isoline_count = 5;
+    const int points_per_isoline = 5;
+
+    CHECK(plot.x_index == CoolProp::iSmass);
+    CHECK(plot.y_index == CoolProp::iT);
+
+    CHECK(plot.axis_x_scale() == CoolProp::Plot::Scale::Lin);
+    CHECK(plot.axis_y_scale() == CoolProp::Plot::Scale::Lin);
+
+    CHECK_THAT(plot.axis_x_range().min, WithinAbs(426, 1));
+    CHECK_THAT(plot.axis_x_range().max, WithinAbs(2423, 1));
+    CHECK_THAT(plot.axis_y_range().min, WithinAbs(173, 1));
+    CHECK_THAT(plot.axis_y_range().max, WithinAbs(455, 1));
+
+    auto iso_types = plot.supported_dimensions();
+    REQUIRE(iso_types.size() == 4);
+    CHECK(iso_types[0] == CoolProp::iQ);
+    CHECK(iso_types[1] == CoolProp::iP);
+    CHECK(iso_types[2] == CoolProp::iHmass);
+    CHECK(iso_types[3] == CoolProp::iDmass);
+
+    {
+        // Q isolines
+        CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iQ);
+        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iQ, iso_range.min, iso_range.max, isoline_count);
+        auto isoQ = plot.calc_isolines(CoolProp::iQ, iso_values, points_per_isoline);
+        REQUIRE(isoQ.size() == isoline_count);
+        CHECK_THAT(isoQ[0].value, WithinAbs(0.0, 1e-10));
+        CHECK_THAT(isoQ[1].value, WithinAbs(0.25, 1e-10));
+        CHECK_THAT(isoQ[2].value, WithinAbs(0.5, 1e-10));
+        CHECK_THAT(isoQ[3].value, WithinAbs(0.75, 1e-10));
+        CHECK_THAT(isoQ[4].value, WithinAbs(1.0, 1e-10));
+
+        const double expected_x[isoline_count][points_per_isoline] = {
+            {412.61753823, 728.71208313, 994.51958846, 1237.3122956, 1561.56967158},
+            {800.44043827, 992.70703491, 1177.81867482, 1354.79919476, 1561.75851162},
+            {1188.26333832, 1256.70198669, 1361.11776119, 1472.28609393, 1561.94735166},
+            {1576.08623836, 1520.69693847, 1544.41684755, 1589.77299309, 1562.1361917},
+            {1963.9091384, 1784.69189025, 1727.71593392, 1707.25989226, 1562.32503174}
+        };
+        const double expected_y[isoline_count][points_per_isoline] = {
+            {169.85007484, 220.94004678, 272.03001871, 323.11999064, 374.20996258},
+            {169.85007484, 220.94004678, 272.03001871, 323.11999064, 374.20996258},
+            {169.85007484, 220.94004678, 272.03001871, 323.11999064, 374.20996258},
+            {169.85007484, 220.94004678, 272.03001871, 323.11999064, 374.20996258},
+            {169.85007484, 220.94004678, 272.03001871, 323.11999064, 374.20996258}
+        };
+
+        for(int i = 0; i < isoline_count; i++) {
+            for(int j = 0; j < points_per_isoline; j++) {
+                CHECK_THAT(isoQ[i].x[j], WithinRel(expected_x[i][j], 1e-8));
+                CHECK_THAT(isoQ[i].y[j], WithinRel(expected_y[i][j], 1e-8));
+            }
+        }
+    }
+
+    {
+        // P isolines
+        CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iP);
+        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iP, iso_range.min, iso_range.max, isoline_count);
+        auto isoP = plot.calc_isolines(CoolProp::iP, iso_values, points_per_isoline);
+        REQUIRE(isoP.size() == isoline_count);
+        CHECK_THAT(isoP[0].value, WithinAbs(25000.000000000007, 1e-10));
+        CHECK_THAT(isoP[1].value, WithinAbs(109297.03270763098, 1e-10));
+        CHECK_THAT(isoP[2].value, WithinAbs(477833.65434771683, 1e-10));
+        CHECK_THAT(isoP[3].value, WithinAbs(2089032.0219219688, 1e-10));
+        CHECK_THAT(isoP[4].value, WithinAbs(9133000.049091753, 1e-10));
+
+        const double expected_x[isoline_count][points_per_isoline] = {
+            {426.00985534, 925.27531435, 1424.54077336, 1923.80623237, 2423.07169138},
+            {426.00985534, 925.27531435, 1424.54077336, 1923.80623237, 2423.07169138},
+            {426.00985534, 925.27531435, 1424.54077336, 1923.80623237, 2423.07169138},
+            {426.00985534, 925.27531435, 1424.54077336, 1923.80623237, 2423.07169138},
+            {426.00985534, 925.27531435, 1424.54077336, 1923.80623237, 2423.07169138}
+        };
+        const double expected_y[isoline_count][points_per_isoline] = {
+            {171.78612656, 220.38136931, 220.38136931, 265.36250878, 455.0},
+            {171.7989644, 248.7449928, 248.7449928, 308.63364605, 506.38739121},
+            {171.85504128, 258.19575097, 287.47240852, 355.96420961, 560.29233808},
+            {172.09927987, 258.74250558, 342.56046108, 411.32270988, 618.0350615},
+            {173.15, 261.02100275, 371.32673696, 484.42563591, std::nan("")}
+        };
+
+        for(int i = 0; i < isoline_count; i++) {
+            for(int j = 0; j < points_per_isoline; j++) {
+                if (std::isnan(expected_y[i][j])) {
+                    CHECK(std::isnan(isoP[i].y[j]));
+                } else {
+                    CHECK_THAT(isoP[i].x[j], WithinRel(expected_x[i][j], 1e-8));
+                    CHECK_THAT(isoP[i].y[j], WithinRel(expected_y[i][j], 1e-8));
+                }
+            }
+        }
+    }
+
+    {
+        // H isolines
+        CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iHmass);
+        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iHmass, iso_range.min, iso_range.max, isoline_count);
+        auto isoH = plot.calc_isolines(CoolProp::iHmass, iso_values, points_per_isoline);
+        REQUIRE(isoH.size() == isoline_count);
+        CHECK_THAT(isoH[0].value, WithinAbs(75373.12689908482, 1e-10));
+        CHECK_THAT(isoH[1].value, WithinAbs(200930.99391811725, 1e-10));
+        CHECK_THAT(isoH[2].value, WithinAbs(326488.8609371497, 1e-10));
+        CHECK_THAT(isoH[3].value, WithinAbs(452046.72795618215, 1e-10));
+        CHECK_THAT(isoH[4].value, WithinAbs(577604.5949752146, 1e-10));
+
+        const double expected_x[isoline_count][points_per_isoline] = {
+            {426.00985534, 925.27531435, 1424.54077336, 1923.80623237, 2423.07169138},
+            {426.00985534, 925.27531435, 1424.54077336, 1923.80623237, 2423.07169138},
+            {426.00985534, 925.27531435, 1424.54077336, 1923.80623237, 2423.07169138},
+            {426.00985534, 925.27531435, 1424.54077336, 1923.80623237, 2423.07169138},
+            {426.00985534, 925.27531435, 1424.54077336, 1923.80623237, 2423.07169138}
+        };
+        const double expected_y[isoline_count][points_per_isoline] = {
+            {172.17461409, std::nan(""), std::nan(""), std::nan(""), std::nan("")},
+            {196.07460266, 266.63119128, std::nan(""), std::nan(""), std::nan("")},
+            {213.66474036, 299.9847036, 301.72638717, std::nan(""), std::nan("")},
+            {228.4112647, 322.84362137, 426.78791645, 331.52116588, 328.04216753},
+            {241.56832462, 341.66140042, 458.59389239, std::nan(""), 455.0}
+        };
+
+        for(int i = 0; i < isoline_count; i++) {
+            for(int j = 0; j < points_per_isoline; j++) {
+                if (std::isnan(expected_y[i][j])) {
+                    CHECK(std::isnan(isoH[i].y[j]));
+                } else {
+                    CHECK_THAT(isoH[i].x[j], WithinRel(expected_x[i][j], 1e-8));
+                    CHECK_THAT(isoH[i].y[j], WithinRel(expected_y[i][j], 1e-8));
+                }
+            }
+        }
+    }
+
+    {
+        // D isolines
+        CoolProp::Plot::Range iso_range = plot.isoline_range(CoolProp::iDmass);
+        std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iDmass, iso_range.min, iso_range.max, isoline_count);
+        auto isoD = plot.calc_isolines(CoolProp::iDmass, iso_values, points_per_isoline);
+        REQUIRE(isoD.size() == isoline_count);
+        CHECK_THAT(isoD[0].value, WithinAbs(0.6749779869915704, 1e-10));
+        CHECK_THAT(isoD[1].value, WithinAbs(4.704765330619733, 1e-10));
+        CHECK_THAT(isoD[2].value, WithinAbs(32.793390662794806, 1e-10));
+        CHECK_THAT(isoD[3].value, WithinAbs(228.57813208316188, 1e-10));
+        CHECK_THAT(isoD[4].value, WithinAbs(1593.2467308391022, 1e-10));
+
+        const double expected_x[isoline_count][points_per_isoline] = {
+            {524.17387831, 1911.09303198, 2092.95299736, 2262.71394473, 2423.07169138},
+            {448.10309047, 1715.11962047, 1932.46628376, 2103.15612883, 2263.90954344},
+            {437.18945214, 972.48976631, 1758.36242394, 1935.75229847, 2099.20644384},
+            {435.62370654, 865.94698069, 1292.02342121, 1720.27748872, 1899.3816054},
+            {426.00985534, 710.87738683, 946.96900373, 1151.9181105, 1335.56535146}
+        };
+        const double expected_y[isoline_count][points_per_isoline] = {
+            {173.15, 243.6125, 314.075, 384.5375, 455.0},
+            {173.15, 243.6125, 314.075, 384.5375, 455.0},
+            {173.15, 243.6125, 314.075, 384.5375, 455.0},
+            {173.15, 243.6125, 314.075, 384.5375, 455.0},
+            {173.15, 243.6125, 314.075, 384.5375, 455.0}
+        };
+
+        for(int i = 0; i < isoline_count; i++) {
+            for(int j = 0; j < points_per_isoline; j++) {
                 CHECK_THAT(isoD[i].x[j], WithinRel(expected_x[i][j], 1e-8));
                 CHECK_THAT(isoD[i].y[j], WithinRel(expected_y[i][j], 1e-8));
             }

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -1,14 +1,3 @@
-/*
- * AbstractState.cpp
- *
- *  Created on: 21 Dec 2013
- *      Author: jowr
- */
-
-#ifndef _CRT_SECURE_NO_WARNINGS
-#define _CRT_SECURE_NO_WARNINGS
-#endif
-
 #include "CoolPropPlot.h"
 
 namespace CoolProp {

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -41,10 +41,10 @@ TEST_CASE("Check that the isolines are the same as from Python", "[ph_plot]") {
 
     auto iso_types = plot.supported_dimensions();
     REQUIRE(iso_types.size() == 4);
-    CHECK(iso_types[0] == CoolProp::iQ);
-    CHECK(iso_types[1] == CoolProp::iT);
-    CHECK(iso_types[2] == CoolProp::iSmass);
-    CHECK(iso_types[3] == CoolProp::iDmass);
+    CHECK(iso_types[0] == CoolProp::iT);
+    CHECK(iso_types[1] == CoolProp::iQ);
+    CHECK(iso_types[2] == CoolProp::iDmass);
+    CHECK(iso_types[3] == CoolProp::iSmass);
 
     {
         // Q isolines
@@ -197,10 +197,10 @@ TEST_CASE("Basic TS Plot has same output as Python", "[ts_plot]") {
 
     auto iso_types = plot.supported_dimensions();
     REQUIRE(iso_types.size() == 4);
-    CHECK(iso_types[0] == CoolProp::iQ);
-    CHECK(iso_types[1] == CoolProp::iP);
-    CHECK(iso_types[2] == CoolProp::iHmass);
-    CHECK(iso_types[3] == CoolProp::iDmass);
+    CHECK(iso_types[0] == CoolProp::iP);
+    CHECK(iso_types[1] == CoolProp::iQ);
+    CHECK(iso_types[2] == CoolProp::iDmass);
+    CHECK(iso_types[3] == CoolProp::iHmass);
 
     {
         // Q isolines

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -3,6 +3,216 @@
 namespace CoolProp {
 namespace Plot {
 
+PropertyPlot::PropertyPlot(const std::string& fluid_name, CoolProp::parameters ykey, CoolProp::parameters xkey, const std::string& tp_limits)
+    : fluid_name(fluid_name),
+      xkey(xkey),
+      ykey(ykey),
+      axis_x_scale(Detail::default_scale(xkey)),
+      axis_y_scale(Detail::default_scale(ykey))
+{
+    this->state = Detail::process_fluid_state(fluid_name);
+    this->critical_state = Detail::get_critical_point(state);
+
+    // We are just assuming that all inputs and outputs are in SI units. We
+    // take care of any conversions before calling the library and after
+    // getting the results.
+    int out1, out2;
+    axis_pair = CoolProp::generate_update_pair(xkey, 0, ykey, 1, out1, out2);
+    swap_axis_inputs_for_update = (out1 == 1);
+
+    const double HI_FACTOR = 2.25; // Upper default limits: HI_FACTOR*T_crit and HI_FACTOR*p_crit
+    const double LO_FACTOR = 1.01; // Lower default limits: LO_FACTOR*T_triple and LO_FACTOR*p_triple
+    if (tp_limits == "NONE")
+        this->limits = {Detail::NaN, Detail::NaN, Detail::NaN, Detail::NaN};
+    else if (tp_limits == "DEF")
+        this->limits = {LO_FACTOR, HI_FACTOR, LO_FACTOR, HI_FACTOR};
+    else if (tp_limits == "ACHP")
+        this->limits = {173.15, 493.15, 0.25e5, HI_FACTOR};
+    else if (tp_limits == "ORC")
+        this->limits = {273.15, 673.15, 0.25e5, HI_FACTOR};
+    else
+        throw CoolProp::ValueError("Invalid tp_limits");
+
+    get_axis_limits();
+}
+
+Range PropertyPlot::isoline_range(CoolProp::parameters key)
+{
+    if (key == CoolProp::iQ)
+        return {0., 1.};
+    else // TODO: always against iT?
+    {
+        std::vector<double> range = get_axis_limits(key, CoolProp::iT);
+        return {range[0], range[1]};
+    }
+}
+
+IsoLines PropertyPlot::calc_isolines(CoolProp::parameters key, const std::vector<double>& values, int points) const
+{
+    std::vector<double> xvals = Detail::generate_values_in_range(axis_x_scale, axis_x_range.min, axis_x_range.max, points);
+    std::vector<double> yvals = Detail::generate_values_in_range(axis_y_scale, axis_y_range.min, axis_y_range.max, points);
+
+    IsoLines lines;
+    for (double val : values)
+    {
+        IsoLine line(key, xkey, ykey, val, state);
+        line.calc_range(xvals, yvals);
+        // TODO: line.sanitize_data();
+        lines.push_back(line);
+    }
+    return lines;
+}
+
+std::vector<CoolProp::parameters> PropertyPlot::supported_dimensions() const
+{
+    // taken from PropertyPlot::calc_isolines when called with iso_type='all'
+    std::vector<CoolProp::parameters> keys;
+    for (auto it = Detail::xy_switch.begin(); it != Detail::xy_switch.end(); ++it)
+    {
+        const std::map<int, Detail::IsolineSupported>& supported = it->second;
+        auto supported_xy = supported.find(ykey * 10 + xkey);
+        if (supported_xy != supported.end() && supported_xy->second != Detail::IsolineSupported::No)
+            keys.push_back(it->first);
+    }
+    return keys;
+}
+
+double PropertyPlot::value_at(CoolProp::parameters key, double axis_x_value, double axis_y_value, CoolProp::phases phase) const
+{
+    if (key == xkey) return axis_x_value;
+    if (key == ykey) return axis_y_value;
+
+    try
+    {
+        if (swap_axis_inputs_for_update)
+            std::swap(axis_x_value, axis_y_value);
+        state->specify_phase(phase);
+        state->update(axis_pair, axis_x_value, axis_y_value);
+        switch (key)
+        {
+            case CoolProp::iT: return state->T();
+            case CoolProp::iP: return state->p();
+            case CoolProp::iDmass: return state->rhomass();
+            case CoolProp::iHmass: return state->hmass();
+            case CoolProp::iSmass: return state->smass();
+            case CoolProp::iUmass: return state->umass();
+            case CoolProp::iQ: return state->Q();
+            default: return Detail::NaN;
+        }
+    }
+    catch (...)
+    {
+        return Detail::NaN;
+    }
+}
+
+Range PropertyPlot::get_sat_bounds(CoolProp::parameters key)
+{
+    // TODO: duplicated code from IsoLine
+    double s = 1e-7;
+    double t_small = critical_state->keyed_output(CoolProp::iT) * s;
+    double p_small = critical_state->keyed_output(CoolProp::iP) * s;
+
+    double t_triple = state->trivial_keyed_output(CoolProp::iT_triple);
+    double t_min = state->trivial_keyed_output(CoolProp::iT_min);
+    state->update(CoolProp::QT_INPUTS, 0, std::max(t_triple, t_min) + t_small);
+    double fluid_min, fluid_max;
+    if (key == CoolProp::iP)
+    {
+        fluid_min = state->keyed_output(CoolProp::iP) + p_small;
+        fluid_max = critical_state->keyed_output(CoolProp::iP) - p_small;
+    }
+    else if (key == CoolProp::iT)
+    {
+        fluid_min = state->keyed_output(CoolProp::iT) + t_small;
+        fluid_max = critical_state->keyed_output(CoolProp::iT) - t_small;
+    }
+    else
+    {
+        throw CoolProp::ValueError("Invalid key");
+    }
+    return {fluid_min, fluid_max};
+}
+
+void PropertyPlot::get_Tp_limits(double& T_lo, double& T_hi, double& P_lo, double& P_hi)
+{
+    T_lo = limits[0];
+    T_hi = limits[1];
+    P_lo = limits[2];
+    P_hi = limits[3];
+
+    double Ts_lo, Ts_hi;
+    Range Ts = get_sat_bounds(CoolProp::iT);
+    Ts_lo = Ts.min;
+    Ts_hi = Ts.max;
+
+    double Ps_lo, Ps_hi;
+    Range Ps = get_sat_bounds(CoolProp::iP);
+    Ps_lo = Ps.min;
+    Ps_hi = Ps.max;
+
+    const double ID_FACTOR = 10.0; // Values below this number are interpreted as factors
+    if (std::isnan(T_lo)) T_lo = 0.0;
+    else if (T_lo < ID_FACTOR) T_lo *= Ts_lo;
+    if (std::isnan(T_hi)) T_hi = 1e6;
+    else if (T_hi < ID_FACTOR) T_hi *= Ts_hi;
+    if (std::isnan(P_lo)) P_lo = 0.0;
+    else if (P_lo < ID_FACTOR) P_lo *= Ps_lo;
+    if (std::isnan(P_hi)) P_hi = 1e10;
+    else if (P_hi < ID_FACTOR) P_hi *= Ps_hi;
+
+    try { T_lo = std::max(T_lo, state->trivial_keyed_output(CoolProp::iT_min)); } catch (...) {}
+    try { T_hi = std::min(T_hi, state->trivial_keyed_output(CoolProp::iT_max)); } catch (...) {}
+    try { P_lo = std::max(P_lo, state->trivial_keyed_output(CoolProp::iP_min)); } catch (...) {}
+    try { P_hi = std::min(P_hi, state->trivial_keyed_output(CoolProp::iP_max)); } catch (...) {}
+}
+
+std::vector<double> PropertyPlot::get_axis_limits(CoolProp::parameters xkey, CoolProp::parameters ykey, bool autoscale)
+{
+    if (xkey == CoolProp::parameters::iundefined_parameter) xkey = this->xkey;
+    if (ykey == CoolProp::parameters::iundefined_parameter) ykey = this->ykey;
+
+    // TODO: double check comparing xkey against ykey is the same as in python
+    if (xkey != this->ykey || ykey != this->ykey || autoscale)
+    {
+        double T_lo, T_hi, P_lo, P_hi;
+        get_Tp_limits(T_lo, T_hi, P_lo, P_hi); // TODO
+        std::vector<double> limits = {std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest(),
+                                      std::numeric_limits<double>::max(), std::numeric_limits<double>::lowest()};
+        for (double T : {T_lo, T_hi})
+        {
+            for (double P : {P_lo, P_hi})
+            {
+                try
+                {
+                    state->update(CoolProp::PT_INPUTS, P, T);
+                    double x = state->keyed_output(xkey);
+                    double y = state->keyed_output(ykey);
+                    if (x < limits[0]) limits[0] = x;
+                    if (x > limits[1]) limits[1] = x;
+                    if (y < limits[2]) limits[2] = y;
+                    if (y > limits[3]) limits[3] = y;
+                }
+                catch (...) { }
+            }
+        }
+        if (xkey == this->xkey)
+        {
+            axis_x_range.min = limits[0];
+            axis_x_range.max = limits[1];
+        }
+        if (ykey == this->ykey)
+        {
+            axis_y_range.min = limits[2];
+            axis_y_range.max = limits[3];
+        }
+        return limits;
+    }
+    else
+    {
+        return {axis_x_range.min, axis_x_range.max, axis_y_range.min, axis_y_range.max};
+    }
+}
 
 } /* namespace Plot */
 } /* namespace CoolProp */

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -254,11 +254,11 @@ TEST_CASE("Basic TS Plot has same output as Python", "[ts_plot]") {
         std::vector<double> iso_values = CoolProp::Plot::Detail::generate_ranges(CoolProp::iP, iso_range.min, iso_range.max, isoline_count);
         auto isoP = plot.calc_isolines(CoolProp::iP, iso_values, points_per_isoline);
         REQUIRE(isoP.size() == isoline_count);
-        CHECK_THAT(isoP[0].value, WithinAbs(25000.000000000007, 1e-10));
-        CHECK_THAT(isoP[1].value, WithinAbs(109297.03270763098, 1e-10));
-        CHECK_THAT(isoP[2].value, WithinAbs(477833.65434771683, 1e-10));
-        CHECK_THAT(isoP[3].value, WithinAbs(2089032.0219219688, 1e-10));
-        CHECK_THAT(isoP[4].value, WithinAbs(9133000.049091753, 1e-10));
+        CHECK_THAT(isoP[0].value, WithinAbs(25000.000000000007, 1e-8));
+        CHECK_THAT(isoP[1].value, WithinAbs(109297.03270763098, 1e-8));
+        CHECK_THAT(isoP[2].value, WithinAbs(477833.65434771683, 1e-8));
+        CHECK_THAT(isoP[3].value, WithinAbs(2089032.0219219688, 1e-8));
+        CHECK_THAT(isoP[4].value, WithinAbs(9133000.049091753, 1e-8));
 
         const double expected_x[isoline_count][points_per_isoline] = {
             {426.00985534, 925.27531435, 1424.54077336, 1923.80623237, 2423.07169138},


### PR DESCRIPTION
### Description of the Change

This pull request contains a relatively crude rewrite of Python's plotting into C++. The code only takes care of the calculations of the limits and isolines in SI units for different plot types (ph and Ts diagrams are extensively checked but others that are supported in Python have also been tried and seem to work). How the actual drawing is done is left to the end-user.

Usage example can be found in the unit tests at the bottom of `CoolPropPlot.cpp`.

Thank you for creating this really cool library. The code here is a cleaned-up version of what we are using in our fork at Dewesoft for our new Thermodynamics module, and it makes sense to open-source our modifications back into CoolProp as we think they might be generally useful.

### Benefits

It seems like at the moment the only way to really plot with CoolProp is by using the Python library, which is a reasonable choice, but makes it hard to do it from other languages or wherever Python is not supported. This change ads the support for plotting with CoolProp from C++ without other external dependencies, and it should be relatively easy to export the functionality over the C lib so it can potentially be used from any language wrapper.

### Possible Drawbacks

If this is merged there will now exist two competing implementations of "plotting" in CoolProp; one in Python and one in C++. A couple of considerations:
 - Python's implementation is strictly superior and provides a nicer experience for end-user, especially with the unit handling.
 - The C++ implementation _could_ be used as a relatively straight-forward replacement of (some) of the Python plotting's internal code.
 - I would argue that there is benefit to having two implementations, at least for the time being, as the Python one serves as a very nice reference if anything goes wrong.

Out of scope for this request are also:
 - cycle calculations,
 - performance/visualization optimization so that the ranges and scale of x/y axis are taken into account for isoline calculations,
 - C wrapper for this plotting code, and
 - the "guessing" part of the Python library is not implemented.

### Verification Process

The code contains unit tests that compare the output of the C++ code against the raw output of the Python code for ph and Ts diagrams. 
