### PR TITLE
Bump fmtlib to 11.1.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,12 @@ list(APPEND APP_INCLUDE_DIRS
      "${CMAKE_CURRENT_SOURCE_DIR}/externals/fmtlib/include")
 list(APPEND APP_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/externals/fmtlib"
 )# should be deprecated
+
+if (MSVC)
+  # fmtlib requires that the utf-8 support be compiled in
+  # TODO: add the fmt target from fmtlib directly which does this 
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /utf-8")
+endif()
 list(APPEND APP_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include")
 list(APPEND APP_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/src")
 

--- a/wrappers/Python/setup.py
+++ b/wrappers/Python/setup.py
@@ -443,6 +443,10 @@ if __name__ == '__main__':
         common_args.update(dict(
             extra_compile_args=["-std=c++11"]
         ))
+    if sys.platform == 'win32':
+        common_args.update(dict(
+            extra_compile_args=["/utf-8"]
+        ))
 
     if USE_CYTHON:
         common_args.update(dict(cython_c_in_temp=True,


### PR DESCRIPTION
Required addition of unicode support

Squashes copious warnings in MSVC