### PR TITLE
Project names are required to be all lowercase

### DIFF
--- a/wrappers/Python/setup.py
+++ b/wrappers/Python/setup.py
@@ -477,7 +477,7 @@ if __name__ == '__main__':
         ext_modules = cythonize(ext_modules, compiler_directives=cython_directives)
 
     try:
-        setup(name='CoolProp',
+        setup(name='coolprop',
                version=version,  # look above for the definition of version variable - don't modify it here
                author="Ian Bell",
                author_email='ian.h.bell@gmail.com',


### PR DESCRIPTION
Test whether renaming the project in setup.py is enough
 
Based on this PEP: https://peps.python.org/pep-0503/