### PR TITLE
Add set_cubic_alpha_C function to python wrapper

### DIFF
--- a/wrappers/Python/CoolProp/AbstractState.pxd
+++ b/wrappers/Python/CoolProp/AbstractState.pxd
@@ -62,6 +62,7 @@ cdef class AbstractState:
     cpdef backend_name(self)
     cpdef fluid_names(self)
     cpdef fluid_param_string(self, string key)
+    cpdef set_cubic_alpha_C(self, size_t i, string parameter, double c1, double c2, double c3)
     cpdef set_fluid_parameter_double(self, size_t i, string parameter, double value)
     cpdef double get_fluid_parameter_double(self, size_t i, string parameter) except *
     cpdef change_EOS(self, size_t, string)

--- a/wrappers/Python/CoolProp/AbstractState.pyx
+++ b/wrappers/Python/CoolProp/AbstractState.pyx
@@ -91,6 +91,10 @@ cdef class AbstractState:
         """ Get a string interaction parameter - wrapper of c++ function :cpapi:`CoolProp::AbstractState::get_binary_interaction_string` """
         return self.thisptr.get_binary_interaction_string(CAS1, CAS2, parameter)
 
+    cpdef set_cubic_alpha_C(self, size_t i, string parameter, double c1, double c2, double c3):
+        """ Set alpha function (MC or Twu) and fluid specific parameters - wrapper of c++ function :cpapi:`CoolProp::AbstractCubicBackend::set_cubic_alpha_C` """
+        self.thisptr.set_cubic_alpha_C(i, parameter, c1, c2, c3)
+
     cpdef set_fluid_parameter_double(self, size_t i, string parameter, double val):
         """ Set a fluid parameter that is a double-precision number - wrapper of c++ function :cpapi:`CoolProp::AbstractState::set_fluid_parameter_double` """
         self.thisptr.set_fluid_parameter_double(i, parameter, val)

--- a/wrappers/Python/CoolProp/cAbstractState.pxd
+++ b/wrappers/Python/CoolProp/cAbstractState.pxd
@@ -66,6 +66,7 @@ cdef extern from "AbstractState.h" namespace "CoolProp":
         string backend_name() except +ValueError
         vector[string] fluid_names() except +ValueError
         string fluid_param_string(const string &) except +ValueError
+        void set_cubic_alpha_C(const size_t, const string&, const double, const double, const double) except +ValueError
         void set_fluid_parameter_double(const size_t, const string&, const double) except +ValueError
         double get_fluid_parameter_double(const size_t, const string&) except +ValueError
 


### PR DESCRIPTION

### Description of the Change

The C++-function set_cubic_alpha_C seems to be missing from the python wrapper, so I added it.

### Benefits

The function set_cubic_alpha_C will be available in python, allowing the user to change the alpha function of cubic equations of state to Twu or MC and set the fluid specific parameters c1, c2 and c3.

### Possible Drawbacks

None.

### Verification Process

I compared the density calculation of PR with and without the Twu alpha function for a mixture of methane and ethane. The calculated densities differ, as expected, and match those that I get when using CoolProp with the Mathematica wrapper where the set_cubic_alpha_C function is already implemented.
I can do a more "formal" test and post the code if you wish, but since I only added an existing C++ function to the python wrapper I feel like this should be enough.

### Applicable Issues

No open issue that I am aware of.
