### PR TITLE
Enable COOLPROP_REFPROP_PATH environment variable

### DIFF
--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -126,6 +126,9 @@ std::string get_REFPROP_fluid_path_prefix() {
 #endif
 }
 std::string get_REFPROP_mixtures_path_prefix() {
+    if (get_envvar("COOLPROP_REFPROP_ROOT")){
+        return "";
+    }
     std::string rpPath = refpropPath;
     // Allow the user to specify an alternative REFPROP path by configuration value
     std::string alt_refprop_path = CoolProp::get_config_string(ALTERNATIVE_REFPROP_PATH);

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -87,6 +87,9 @@ std::optional<std::string> get_envvar(const char* var){
 
 /// Find either FLUIDS or fluids folder relative to the root path provided; return the path
 std::string get_casesensitive_fluids(const std::string& root) {
+    if (get_envvar("COOLPROP_REFPROP_ROOT")){
+        return "";
+    }
     std::string joined = join_path(root, "fluids");
     if (path_exists(joined)) {
         return joined;


### PR DESCRIPTION
### Description of the Change

The ``COOLPROP_REFPROP_ROOT`` environment variable can now be set in the operating system which is used when CoolProp needs to load REFPROP. If it is not used, the normal, but not recommended approach can still be used, as this environment variable "wins".  After the shared library of REFPORP gets loaded, the SETPATHdll function is used, so absolute paths should no longer be used with the REFPROP backend.

To support custom REFPROP use, it is recommended to copy REFPROP folders to local location and 

### Benefits

Much better integration with REFPROP

### Applicable Issues

Closes #2501 
