### PR TITLE
Add a method for getting the fluid_param string length

### DIFF
--- a/include/CoolPropLib.h
+++ b/include/CoolPropLib.h
@@ -163,6 +163,13 @@ EXPORT_CODE long CONVENTION get_parameter_information_string(const char* key, ch
      * @returns error_code 1 = Ok 0 = error
      */
 EXPORT_CODE long CONVENTION get_fluid_param_string(const char* fluid, const char* param, char* Output, int n);
+/**
+     * @param fluid Null-terminated string with the fluid name
+     * @param param Null-terminated string with the parameter of interest
+     *
+     * @returns length of string object to be returned from get_fluid_param_string
+     */
+EXPORT_CODE long CONVENTION get_fluid_param_string_len(const char* fluid, const char* param);
 /** \brief Set configuration string
     * @param key The key to configure
     * @param val The value to set to the key

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -25,7 +25,7 @@ void str2buf(const std::string& str, char* buf, int n) {
     if (str.size() < static_cast<unsigned int>(n))
         strcpy(buf, str.c_str());
     else
-        throw CoolProp::ValueError("Buffer size is too small");
+        throw CoolProp::ValueError("Buffer is too small; must be at least " + std::to_string(str.size()) + " characters in size");
 }
 void HandleException(long* errcode, char* message_buffer, const long buffer_length) {
     try {
@@ -401,6 +401,17 @@ EXPORT_CODE long CONVENTION get_fluid_param_string(const char* fluid, const char
         CoolProp::set_error_string("Undefined error");
     }
     return 0;
+}
+EXPORT_CODE long CONVENTION get_fluid_param_string_len(const char* fluid, const char* param) {
+    try {
+        std::string s = CoolProp::get_fluid_param_string(std::string(fluid), std::string(param));
+        return s.size();
+    } catch (std::exception& e) {
+        CoolProp::set_error_string(e.what());
+    } catch (...) {
+        CoolProp::set_error_string("Undefined error");
+    }
+    return -1;
 }
 EXPORT_CODE void CONVENTION set_config_string(const char* key, const char* val) {
     try {


### PR DESCRIPTION
Also update the error message

### Benefits

Adds a method to the public API to allow the required buffer size to be queried

### Applicable Issues

Closes #2541 
