### PR TITLE
Improvements to mixture pair management

### DIFF
--- a/Web/fluid_properties/Mixtures.rst
+++ b/Web/fluid_properties/Mixtures.rst
@@ -34,8 +34,6 @@ The two schemes available are
 * ``linear`` - :math:`T_r` and :math:`v_r` are a linear function of molar composition between the two pure fluid values
 * ``Lorentz-Berthelot`` - all interaction parameters are 1.0
 
-Note that if  ``apply_simple_mixing_rule`` is called first in a programme before any property calculation function, the interaction parameter library is initialized with just the binary mixture that was specified, and other binary mixtures will raise an error. To augment the built-in database, call a property calculation function before calling ``apply_simple_mixing_rule``.
-
 Here is a sample of using this in python:
 
 .. ipython::

--- a/include/DataStructures.h
+++ b/include/DataStructures.h
@@ -428,6 +428,9 @@ const std::string& get_input_pair_long_desc(input_pairs pair);
 /// Split an input pair into parameters for the two parts that form the pair
 void split_input_pair(input_pairs pair, parameters& p1, parameters& p2);
 
+extern void apply_simple_mixing_rule(const std::string& identifier1, const std::string& identifier2, const std::string& rule);
+extern void set_interaction_parameters(const std::string& string_data);
+
 extern std::string get_mixture_binary_pair_data(const std::string& CAS1, const std::string& CAS2, const std::string& param);
 extern void set_mixture_binary_pair_data(const std::string& CAS1, const std::string& CAS2, const std::string& param, const double val);
 extern std::string get_mixture_binary_pair_pcsaft(const std::string& CAS1, const std::string& CAS2, const std::string& param);

--- a/src/Backends/Helmholtz/MixtureParameters.cpp
+++ b/src/Backends/Helmholtz/MixtureParameters.cpp
@@ -88,10 +88,7 @@ class MixtureBinaryPairLibrary
 
    public:
     std::map<std::vector<std::string>, std::vector<Dictionary>>& binary_pair_map() {
-        // Set the default departure functions if none have been provided yet
-        if (m_binary_pair_map.size() == 0) {
-            load_defaults();
-        }
+        load_defaults_if_needed();
         return m_binary_pair_map;
     };
 
@@ -103,6 +100,12 @@ class MixtureBinaryPairLibrary
             throw ValueError("Unable to parse binary interaction function string");
         }
         load_from_JSON(doc);
+    }
+
+    void load_defaults_if_needed() {
+        if (m_binary_pair_map.size() == 0) {
+            load_defaults();
+        }
     }
 
     // Load the defaults that come from the JSON-encoded string compiled into library
@@ -284,11 +287,10 @@ class MixtureBinaryPairLibrary
 };
 // The modifiable parameter library
 static MixtureBinaryPairLibrary mixturebinarypairlibrary;
-// A fixed parameter library containing the default values
-static MixtureBinaryPairLibrary mixturebinarypairlibrary_default;
 
 /// Add a simple mixing rule
 void apply_simple_mixing_rule(const std::string& identifier1, const std::string& identifier2, const std::string& rule) {
+    mixturebinarypairlibrary.load_defaults_if_needed();
     mixturebinarypairlibrary.add_simple_mixing_rule(identifier1, identifier2, rule);
 }
 
@@ -410,10 +412,7 @@ class MixtureDepartureFunctionsLibrary
 
    public:
     std::map<std::string, Dictionary>& departure_function_map() {
-        // Set the default departure functions if none have been provided yet
-        if (m_departure_function_map.size() == 0) {
-            load_defaults();
-        }
+        load_defaults_if_needed();
         return m_departure_function_map;
     };
 
@@ -505,6 +504,11 @@ class MixtureDepartureFunctionsLibrary
                 throw ValueError(format("Name of departure function [%s] is already loaded. Current departure function names are: %s", name.c_str(),
                                         strjoin(names, ",").c_str()));
             }
+        }
+    }
+    void load_defaults_if_needed() {
+        if (m_departure_function_map.size() == 0) {
+            load_defaults();
         }
     }
     // Load the defaults that come from the JSON-encoded string compiled into library


### PR DESCRIPTION
### Description of the Change

This PR makes two changes to improve mixture pair management:

* `apply_simple_mixing_rule` and `set_interaction_parameters` were exposed in the CoolProp Python library but not its C++ library.
* Previously, calling `apply_simple_mixing_rule` could break the default mixing rules, if the mixing rules hadn't already been initialized. This has caused confusion and bugs in the past; see #1874 and https://github.com/CoolProp/CoolProp/issues/2082#issuecomment-1024954744.

I also removed the unused `mixturebinarypairlibrary_default` static variable.

### Benefits

More complete and consistent interfaces across CoolProp's supported language bindings, and less error-prone usage of mixture pair support.

### Possible Drawbacks

Minimal increase in API surface and an extra runtime check

### Verification Process

We've been running this in an internal fork of CoolProp for a couple of years with no issues.

### Applicable Issues

#1874 
