### PR TITLE
Improvements in the  critical region for subcritical pressures for P+{H,S,U}

### DIFF
--- a/include/Solvers.h
+++ b/include/Solvers.h
@@ -21,6 +21,7 @@ class FuncWrapper1D
     std::string errstring;
     Dictionary options;
     int iter;
+    int verbosity = 0;
     FuncWrapper1D() : errcode(0), errstring(""), iter(0) {};
     virtual ~FuncWrapper1D(){};
     virtual double call(double) = 0;

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -1587,7 +1587,7 @@ void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend& HE
             // to converge for any continuous function, and take the optimal step among bisection
             // and higher-order methods
             resid.iter = 0;
-            std::size_t max_iter = 100;
+            boost::math::uintmax_t max_iter = 100;
             
             auto f = [&resid](const double T){ return resid.call(T); };
             // Want 44 bits to be correct, tolerance is 2^(1-bits) ::

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -1576,7 +1576,7 @@ void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend& HE
     double rhomolarstart = (err_Tmin < err_Tmax) ? rhomolar_Tmin : rhomolar_Tmax;
 
     try {
-        // First try to use Halley's method (including two derivatives) starting at the limit with the smaller deviation
+        // First try to use Halley's method (including two derivatives) starting at the limit with the smaller residual
         if (get_debug_level() > 0){
             resid.verbosity = 1;
         }
@@ -1593,7 +1593,7 @@ void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend& HE
                 resid.verbosity = 1;
             }
             resid.iter = 0;
-            std::vector<double> x0 = {Tmax, rhomolarstart};
+            std::vector<double> x0 = {Tstart, rhomolarstart};
             NDNewtonRaphson_Jacobian(&solver_resid2d, x0, 1e-12, 20, 1.0);
             if (!is_in_closed_range(Tmin, Tmax, static_cast<CoolPropDbl>(solver_resid2d.HEOS->T())) || solver_resid2d.HEOS->phase() != phase) {
                 throw ValueError("2D Newton method was unable to find a solution in HSU_P_flash_singlephase_Brent");


### PR DESCRIPTION
See #2594

The proximate reason for the problems is that dp/drho|T is VERY sensitive parameter in the critical region, and goes into derivatives of internal energy (and h, s too). The routine is restructured to first start with Halley method, then 2D Newton, then Brent. The first two steps check whether the value is feasible

### Benefits

Fixes the issue, hopefully it doesn't create other problems, could be an issue if the Tmin calcs fail

### Possible Drawbacks

Changes to flash routines are always dangerous!

### Applicable Issues

See #2594