### PR TITLE
Fix set_Tp_limits TypeError 

### DIFF
--- a/wrappers/Python/CoolProp/Plots/Common.py
+++ b/wrappers/Python/CoolProp/Plots/Common.py
@@ -889,7 +889,7 @@ consider replacing it with \"_get_sat_bounds\".",
         dim = self._system[CoolProp.iP]
         limits[2] = dim.to_SI(limits[2])
         limits[3] = dim.to_SI(limits[3])
-        self.limits = limits
+        self.limits = tuple(limits)
 
     def get_Tp_limits(self):
         """Get the limits for the graphs in temperature and pressure, based on


### PR DESCRIPTION
### Description of the Change
 This should solve the issue #2289 by setting the limits in the set_Tp_limits method as tuple and  not as list. 

### Verification Process
Tested with:

```python
from CoolProp.Plots import PropertyPlot
plot = PropertyPlot('Water', 'hs', tp_limits = 'ORC')
my_limits=[10, 800, 0.1, 40]
plot.set_Tp_limits(my_limits)
plot.calc_isolines()
plot.show()
```
Screenshot: 
<img width="699" height="689" alt="grafik" src="https://github.com/user-attachments/assets/61911588-0a93-49d3-9811-b65bdca5d4e9" />

### Applicable Issues
Closes #2289 