### PR TITLE
Disable profiling by default with flag to enable

### DIFF
--- a/wrappers/Python/setup.py
+++ b/wrappers/Python/setup.py
@@ -307,7 +307,7 @@ if __name__ == '__main__':
             _profiling_enabled = False
             raise ImportError('Your version of Cython (%s) must be >= 0.20 .  Please update your version of cython' % (cython_version,))
         else:
-            _profiling_enabled = True
+            _profiling_enabled = os.environ.get('COOLPROP_PROFILE', None) is not None
 
         cython_directives = dict(
             profile=_profiling_enabled,


### PR DESCRIPTION
Fixes issue #2612 by turning off cython profiling in build unless explicitly set via an environment flag

This is a fairly speculative/illustrative PR, I don't know the upstream ramifications of disabling this, nor where to document this new environment variable flag in the documentation.

### Description of the Change

Based on this issue https://github.com/CoolProp/CoolProp/issues/2612 this change turns off the cython profiling support by default which clashes with the debugpy debugger in python 3.13. 

### Benefits

* debugpy Debugging works in python 3.13
* Presumably it could also improve performance, although I haven't any data around that

### Possible Drawbacks

I have a limited understand of the python build process of this library and no idea if anything upstream depends on the profiling

### Verification Process

I cloned the repo locally and built our application pointing at it via `uv add /Dev/CoolProp` debugging then worked as intended.      

### Applicable Issues

Closes #2612
See https://github.com/aio-libs/frozenlist/pull/660 on another library for a similar fix for this issue https://github.com/microsoft/vscode-python-debugger/issues/723 
They reported a 50% performance speed up in production wheels, so potentially some large improvements here too.