### PR TITLE
Add Windows Instructions and example for Fluent Wrapper

### DIFF
--- a/wrappers/Fluent/Example_windows_UDF.cpp
+++ b/wrappers/Fluent/Example_windows_UDF.cpp
@@ -1,0 +1,50 @@
+#include "udf.h"
+#include "CoolPropLib.h"
+#include <string>
+
+#pragma comment(lib, "C:\\XX\\XX\\CoolProp.lib") 
+
+// User settings
+static const std::string FLUID_NAME = "R134a";
+
+DEFINE_ON_DEMAND(test)
+{
+    double PropResult = PropsSI("T", "P", 101325, "Q", 0, "Water");
+    Message0("Saturation temperature of Water at 1 atm = %g K\n", PropResult);    
+}
+
+// Density via CoolProp
+DEFINE_PROPERTY(rho_coolprop, cell, thread)
+{
+    real P = C_P(cell, thread);
+    real H = C_H(cell, thread);
+    double rho = PropsSI("VISCOSITY",
+                         "P",    static_cast<double>(P),
+                         "Hmass",static_cast<double>(H),
+                         FLUID_NAME.c_str());
+    return static_cast<real>(rho);
+}
+
+// Viscosity via CoolProp
+DEFINE_PROPERTY(mu_coolprop, cell, thread)
+{
+    real P = C_P(cell, thread);
+    real H = C_H(cell, thread);
+    double mu = PropsSI("VISCOSITY",
+                        "P",    static_cast<double>(P),
+                        "Hmass",static_cast<double>(H),
+                        FLUID_NAME.c_str());
+    return static_cast<real>(mu);
+}
+
+// Thermal conductivity via CoolProp
+DEFINE_PROPERTY(k_coolprop, cell, thread)
+{
+    real P = C_P(cell, thread);
+    real H = C_H(cell, thread);
+    double k = PropsSI("CONDUCTIVITY",
+                       "P",    static_cast<double>(P),
+                       "Hmass",static_cast<double>(H),
+                       FLUID_NAME.c_str());
+    return static_cast<real>(k);
+}

--- a/wrappers/Fluent/README.rst
+++ b/wrappers/Fluent/README.rst
@@ -21,17 +21,21 @@ Windows
    f. Select the version you would like to use in your code; most likely, you will need the *64bit* version
    g. Download *CoolProp.dll* and *CoolProp.lib* files
 
-2. Place the three files (*CoolProp.dll*, *CoolProp.lib*, and *CoolPropLib.h*) in the same folder as your working folder.
+2. Place the three files (*CoolProp.dll*, *CoolProp.lib*, and *CoolPropLib.h*) in your Flunet working folder.
 
-3. Select *User-Defined* tab -> *Functions* -> *Compiled*
+3. Launch Fluent using Fluent Startup window. Make Sure to select the Working Folder is the same as step 2
 
-4. Using the window, include your UDF source file as .cpp; You can find an example UDF file in this folder named *Example_windows_UDF.cpp*
+4. Select *User-Defined* tab -> *Functions* -> *Compiled*
+
+5. Using the window, include your UDF source file as .cpp; You can find an example UDF file in this folder named *Example_windows_UDF.cpp*
    a. Make sure the UDF cpp file has "*#include "CoolPropLib.h*"
-   b. Make sure the UDF cpp file has "*#pragma comment(lib, "XX//XX//CoolProp.lib")*" which includes the CoolProp lib file into the compilation process. Make sure that the path of *CoolProp.lib* is the correct **absolute** path
+   b. Make sure the UDF cpp file has "*#pragma comment(lib, "XX//XX//CoolProp.lib")*" which includes the CoolProp lib file into the compilation process. 
+	i. Make sure that the path of *CoolProp.lib* is the correct **absolute** path
+	ii. use "//" for path instead of "\"
 
-5. Using the window, include *CoolPropLib.h* file you downloaded eariler in the *Header Files* section
-6. Build the UDF DLL, then load it
-7. Test functionality through *User-Defined* tab -> *Excute on Demand* -> select *test::libudf* -> Click Execute
+6. Using the window, include *CoolPropLib.h* file you downloaded eariler in the *Header Files* section
+7. Build the UDF DLL, then load it
+8. Test functionality through *User-Defined* tab -> *Excute on Demand* -> select *test::libudf* -> Click Execute
 
 Linux
 ------------

--- a/wrappers/Fluent/README.rst
+++ b/wrappers/Fluent/README.rst
@@ -3,21 +3,48 @@ CoolProp wrapper for FLUENT
 
 Contributors
 ------------
-Primary CoolProp Developer: Ian Bell, University of Liege, Belgium (ian.h.bell@gmail.com)
-FLUENT experts: Joris Degroote and Iva Papes, University of Gent, Belgium
-Others Contributors : Frederic Sonnino, AREVA company (frederic.sonnino1@areva.com)
-Second release: October , 2017
+- Primary CoolProp Developer: Ian Bell, University of Liege, Belgium (ian.h.bell@gmail.com)
+- FLUENT experts: Joris Degroote and Iva Papes, University of Gent, Belgium
+- Other Contributors: 
+   - Frederic Sonnino, AREVA company (frederic.sonnino1@areva.com)
+   - Omar Zaki, University of Illinois at Urbana-Champaign (Omarz2@illinois.edu)
+
+Windows
+---------------
+1. Download CoolProp Shared Library (https://sourceforge.net/projects/coolprop/files/CoolProp/)
+   
+   a. Open the Link above
+   b. Select the CoolProp version you wish to use
+   c. Open *shared_library* Folder
+   d. Download the file *CoolPropLib.h*
+   e. Open *Windows* Folder
+   f. Select the version you would like to use in your code; most likely, you will need the *64bit* version
+   g. Download *CoolProp.dll* and *CoolProp.lib* files
+
+2. Place the three files (*CoolProp.dll*, *CoolProp.lib*, and *CoolPropLib.h*) in the same folder as your working folder.
+
+3. Select *User-Defined* tab -> *Functions* -> *Compiled*
+
+4. Using the window, include your UDF source file as .cpp; You can find an example UDF file in this folder named *Example_windows_UDF.cpp*
+   a. Make sure the UDF cpp file has "*#include "CoolPropLib.h*"
+   b. Make sure the UDF cpp file has "*#pragma comment(lib, "XX//XX//CoolProp.lib")*" which includes the CoolProp lib file into the compilation process. Make sure that the path of *CoolProp.lib* is the correct **absolute** path
+
+5. Using the window, include *CoolPropLib.h* file you downloaded eariler in the *Header Files* section
+6. Build the UDF DLL, then load it
+7. Test functionality through *User-Defined* tab -> *Excute on Demand* -> select *test::libudf* -> Click Execute
+
+Linux
+------------
 
 Requirements
-------------
-A linux version of FLUENT
-g++
-python 2.7
-cmake >2.8
+~~~~~~~~~~~~
+* A linux version of FLUENT
+* g++
+* python 2.7
+* cmake >2.8
 
 To Build
---------
-
+~~~~~~~~~~~~
 Let us call the main directory where the Fluent case and the fluent wrapper is (coolprop/wrappers/Fluent) as CUSTOM_DIRECTORY.
 
 1. Make sure you are in the CUSTOM_DIRECTORY

--- a/wrappers/Fluent/README.rst
+++ b/wrappers/Fluent/README.rst
@@ -11,6 +11,8 @@ Contributors
 
 Windows
 ---------------
+Using the shared library method can result in some limitation of functionality and some issues with linking DLL to the compiler. Compiling static library and using it is guranteed to work more robustly, but requires more work and compiling the static library yourself using the same compiler used for the UDF later.
+
 1. Download CoolProp Shared Library (https://sourceforge.net/projects/coolprop/files/CoolProp/)
    
    a. Open the Link above
@@ -22,17 +24,15 @@ Windows
    g. Download *CoolProp.dll* and *CoolProp.lib* files
 
 2. Place the three files (*CoolProp.dll*, *CoolProp.lib*, and *CoolPropLib.h*) in your Flunet working folder.
-
 3. Launch Fluent using Fluent Startup window. Make Sure to select the Working Folder is the same as step 2
-
 4. Select *User-Defined* tab -> *Functions* -> *Compiled*
-
 5. Using the window, include your UDF source file as .cpp; You can find an example UDF file in this folder named *Example_windows_UDF.cpp*
+
    a. Make sure the UDF cpp file has "*#include "CoolPropLib.h*"
-   b. Make sure the UDF cpp file has "*#pragma comment(lib, "XX//XX//CoolProp.lib")*" which includes the CoolProp lib file into the compilation process. 
+   b. Make sure the UDF cpp file has "*#pragma comment(lib, "XX//XX//CoolProp.lib")*" which includes the CoolProp lib file into the compilation process.
+
 	i. Make sure that the path of *CoolProp.lib* is the correct **absolute** path
 	ii. use "//" for path instead of "\"
-
 6. Using the window, include *CoolPropLib.h* file you downloaded eariler in the *Header Files* section
 7. Build the UDF DLL, then load it
 8. Test functionality through *User-Defined* tab -> *Excute on Demand* -> select *test::libudf* -> Click Execute


### PR DESCRIPTION
### Description of the Change

I added how to use the wrapper for Windows through the shared library. There might be a better way using the static library, but I believe this method works for 99% of use cases.

### Benefits

There was no guide for how to use CoolProp with Fluent in Windows anywhere

### Verification Process

Worked with both Fluent internal compiler and VS compiler
