### PR TITLE
CI add InnoSetup

### DIFF
--- a/.github/workflows/windows_installer.yml
+++ b/.github/workflows/windows_installer.yml
@@ -26,6 +26,12 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install requests packaging
 
+    # See: https://github.com/actions/runner-images/issues/12464
+    - name: Install Inno Setup
+      shell: powershell
+      run: |
+        choco install innosetup -y
+
     - name: Extract CoolProp version from CMakeLists.txt
       shell: bash
       run: |


### PR DESCRIPTION
Dropped in Windows server 2025 image; see https://github.com/actions/runner-images/issues/12464

