### PR TITLE
Some Refactoring of the Mathcad Wrapper for code succinctness and readability

### DIFF
--- a/wrappers/MathCAD/CoolPropMathcad.cpp
+++ b/wrappers/MathCAD/CoolPropMathcad.cpp
@@ -2,6 +2,7 @@
 //
 
 #include <string>
+#include <cstring>
 // #include <sstream>
 
 #ifndef NOMINMAX  // Kill windows' horrible min() and max() macros
@@ -26,13 +27,15 @@ extern void apply_simple_mixing_rule(const std::string& identifier1, const std::
 
 enum EC
 {
-    MUST_BE_REAL = 1,
+    MUST_BE_REAL = 1,  // Mathcad Error Codes       v
     INSUFFICIENT_MEMORY,
-    INTERRUPTED,  // Mathcad Error Codes
-    BAD_FLUID,
+    INTERRUPTED,
+    //---------------------------------------------------
+    BAD_FLUID,        // CoolProp Error Codes from here v
+    BAD_MIXTURE,
     BAD_IF97_FLUID,
     BAD_PARAMETER,
-    BAD_PHASE,  // CoolProp Error Codes
+    BAD_PHASE,
     ONLY_ONE_PHASE_SPEC,
     BAD_REF,
     NON_TRIVIAL,
@@ -49,6 +52,7 @@ enum EC
     TP_SATURATION,
     HA_INPUTS,
     BAD_BINARY_PAIR,
+    MISSING_BINARY_PAIR,
     BAD_RULE,
     PAIR_EXISTS,
     UNKNOWN,
@@ -56,14 +60,13 @@ enum EC
 };  // Dummy Code for Error Count
 
 // table of error messages
-// if user function never returns an
-// error -- you do not need to create this
-// table
+// As of Mathcad Prime 10, these are now actually returned as Custom Error: messages
 char* CPErrorMessageTable[NUMBER_OF_ERRORS] = {"Interrupted",
                                                "Insufficient Memory",
                                                "Argument must be real",
                                                "Invalid Fluid String",
-                                               "IF97 Backend supports pure water only",
+                                               "Invalid predefined mixture or Binary Interaction Parameters Missing",
+                                               "IF97 Backend supports pure \"Water\" only",
                                                "Invalid Parameter String",
                                                "Invalid Phase String",
                                                "Only one input key phase specification allowed",
@@ -82,10 +85,33 @@ char* CPErrorMessageTable[NUMBER_OF_ERRORS] = {"Interrupted",
                                                "Temperature-Pressure inputs in 2-phase region; use TQ or PQ",
                                                "At least one of the inputs must be [T], [R], [W], or [Tdp]",
                                                "Could not match binary pair",
+                                               "Missing at least one set of binary interaction parameters. Use get_global_param_string(\"errstring\") for more info.",
                                                "Mixing rule must be \"linear\" or \"Lorentz-Berthelot\".",
                                                "Specified binary pair already exists.",
-                                               "ERROR: Use get_global_param_string(\"errstring\") for more info",
+                                               "CoolProp Issue: Use get_global_param_string(\"errstring\") for more info.",
                                                "Error Count - Not Used"};
+
+// Helper: allocate Mathcad string and copy contents
+static char* AllocMathcadString(const std::string& s)
+{
+    // Must use MathcadAllocate(size) so Mathcad can track and release the memory properly.
+    char* c = MathcadAllocate(static_cast<int>(s.size()) + 1);
+    if (c != nullptr) {
+        // copy s into c, this process avoids the const-cast type which would result from instead
+        // converting the string using s.c_str()
+        // memcpy is fine for this because std::string in C++11+ is contiguous
+        std::memcpy(c, s.data(), s.size());
+        c[s.size()] = '\0';
+    }
+    return c;
+}
+
+// Helper: check that a complex scalar input is Real and return proper Mathcad error
+static inline LRESULT CheckRealOrError(LPCCOMPLEXSCALAR val, int position)
+{
+    if (val->imag != 0.0) return MAKELRESULT(MUST_BE_REAL, position);
+    return 0;
+}
 
 // this code executes the user function CP_get_global_param_string, which is a wrapper for
 // the CoolProp.get_global_param_string() function, used to get a global string parameter from CoolProp
@@ -105,12 +131,8 @@ LRESULT CP_get_global_param_string(LPMCSTRING ParamValue,  // output (value of p
             return MAKELRESULT(UNKNOWN, 1);
     }
 
-    // Must use MathcadAllocate(size) so Mathcad can track and release
-    char* c = MathcadAllocate(static_cast<int>(s.size()) + 1);  // create a c-string (pointer) c with the same size as s
-    // copy s into c, this process avoids the const-cast type which would result from instead
-    // converting the string using s.c_str()
-    std::copy(s.begin(), s.end(), c);
-    c[s.size()] = '\0';
+    // Must use MathcadAllocate(size) so Mathcad can track and release, using Helper routine above
+    char* c = AllocMathcadString(s);
     // assign the string to the function's output parameter
     ParamValue->str = c;
 
@@ -140,12 +162,8 @@ LRESULT CP_get_fluid_param_string(LPMCSTRING ParamValue,  // output (value of pa
             return MAKELRESULT(UNKNOWN, 1);
     }
 
-    // Must use MathcadAllocate(size) so Mathcad can track and release
-    char* c = MathcadAllocate(static_cast<int>(s.size()) + 1);  // create a c-string (pointer) c with the same size as s
-    // copy s into c, this process avoids the const-cast type which would result from instead
-    // converting the string using s.c_str()
-    std::copy(s.begin(), s.end(), c);
-    c[s.size()] = '\0';
+    // Must use MathcadAllocate(size) so Mathcad can track and release, using Helper routine above
+    char* c = AllocMathcadString(s);
     // assign the string to the function's output parameter
     ParamValue->str = c;
 
@@ -157,7 +175,7 @@ LRESULT CP_get_fluid_param_string(LPMCSTRING ParamValue,  // output (value of pa
 // the CoolProp.set_reference_stateS() function, used to set the H/S reference states
 // based on a standard state string of "IIR", "ASHRAE", "NBP", or "DEF".
 LRESULT CP_set_reference_state(LPCOMPLEXSCALAR Conf,   // output (dummy value)
-                               LPCMCSTRING FluidName,  // name of fluidr (string) to retrieve
+                               LPCMCSTRING FluidName,  // name of fluid (string) to retrieve
                                LPCMCSTRING StateStr)   // name of standard state (string) to set
 {
     // Invoke the set_reference_stateS() function, no result from this void function.
@@ -166,12 +184,17 @@ LRESULT CP_set_reference_state(LPCOMPLEXSCALAR Conf,   // output (dummy value)
     } catch (const CoolProp::ValueError& e) {
         std::string emsg(e.what());
         CoolProp::set_error_string(emsg);
-        if (emsg.find("key") != std::string::npos)
+
+        // Normalize the error message to lowercase to simplify substring checks and
+        // avoid repeating checks for different capitalizations.
+        std::string emsg_l = emsg;
+        std::transform(emsg_l.begin(), emsg_l.end(), emsg_l.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+        if (emsg_l.find("key") != std::string::npos)
             return MAKELRESULT(BAD_FLUID, 1);
-        else if ((emsg.find("Cannot use") != std::string::npos) || (emsg.find("Temperature to QT_flash") != std::string::npos))
+        else if ((emsg_l.find("cannot use") != std::string::npos) || (emsg_l.find("temperature to qt_flash") != std::string::npos))
             return MAKELRESULT(BAD_REF, 2);
-        else if ((emsg.find("reference state") != std::string::npos) || (emsg.find("Reference state") != std::string::npos)
-                 || (emsg.find("Reference State") != std::string::npos))
+        else if (emsg_l.find("reference state") != std::string::npos)
             return MAKELRESULT(BAD_PARAMETER, 2);
         else
             return MAKELRESULT(UNKNOWN, 1);
@@ -184,6 +207,45 @@ LRESULT CP_set_reference_state(LPCOMPLEXSCALAR Conf,   // output (dummy value)
     return 0;
 }
 
+  // Helper: centralize text-matching logic for Props1SI error handling
+  static LRESULT HandleProps1SIError(const std::string& emsg, const std::string& FluidString, const std::string& PropNameBrackets)
+  {
+    auto contains = [&](const char* s) { return emsg.find(s) != std::string::npos; };
+    unsigned int errPos = 0;  // Temp variable to hold the position of the error argument for returning to Mathcad, if needed
+      // Check for "valid fluid" error first, since it is the most common error and can have multiple causes
+      // that require parsing the error message to determine the specific error type and position.
+    if (contains("valid fluid")) {
+        if (contains("Neither input")) {
+            if (contains("REFPROP")) {  // REFPROP or REFPROP Fluid not found
+                errPos = (FluidString.find("REFPROP") != std::string::npos) ? 1u : 2u;
+                return MAKELRESULT(BAD_FLUID, errPos);
+            }
+            if (contains("IF97")) {  // Something other than "Water" was used to IF97
+                errPos = (FluidString.find("IF97") != std::string::npos) ? 1u : 2u;
+                return MAKELRESULT(BAD_IF97_FLUID, errPos);
+            }
+            std::string fluid_l = lower(FluidString);
+            if (fluid_l.find(".mix") != std::string::npos) return MAKELRESULT(BAD_MIXTURE, 1);  // Mixture string error position 1
+            std::string prop_l = lower(PropNameBrackets);
+            if (prop_l.find(".mix") != std::string::npos) return MAKELRESULT(BAD_MIXTURE, 2);  // Mixture string error position 2
+            return MAKELRESULT(BAD_FLUID, 1);
+        } else {  // "Both inputs"
+            return MAKELRESULT(BAD_PARAMETER, 2);
+        }
+    }
+    // Check for "invalid parameter" errors next...
+    if (contains("Unable to use")) {
+        errPos = (emsg.find(PropNameBrackets) != std::string::npos) ? 2u : 1u;
+        if (contains("Output string is invalid")) return MAKELRESULT(BAD_PARAMETER, errPos);
+        if (contains("non-trivial")) return MAKELRESULT(NON_TRIVIAL, errPos);
+        if (contains("No outputs")) return MAKELRESULT(NOT_AVAIL, errPos);
+        return MAKELRESULT(UNKNOWN, errPos);
+    }
+    //
+    return MAKELRESULT(UNKNOWN, 1);
+}
+
+
 // this code executes the user function CP_Props1SI, which is a wrapper for
 // the CoolProp.PropsSI() function, used to simply extract a
 // fluid-specific parameter that is not dependent on the state
@@ -191,7 +253,6 @@ LRESULT CP_Props1SI(LPCOMPLEXSCALAR Prop,  // pointer to the result
                     LPCMCSTRING Fluid,     // string with a valid CoolProp fluid name
                     LPCMCSTRING PropName)  // a fluid property
 {
-    unsigned int errPos;
     std::string PropNameBrackets(PropName->str);
     PropNameBrackets = "[" + PropNameBrackets + "]";
     std::string FluidString = Fluid->str;
@@ -205,48 +266,56 @@ LRESULT CP_Props1SI(LPCOMPLEXSCALAR Prop,  // pointer to the result
     if (!ValidNumber(Prop->real)) {
         std::string emsg = CoolProp::get_global_param_string("errstring");
         CoolProp::set_error_string(emsg);  // reset error string so Mathcad can retrieve it
-        if (emsg.find("valid fluid") != std::string::npos) {
-            if (emsg.find("Neither input") != std::string::npos) {
-                if (emsg.find("REFPROP") != std::string::npos) {
-                    // Fluid can be in either parameter location, find out which.
-                    // It will be in brackets in the error message.
-                    if (FluidString.find("REFPROP") != std::string::npos)
-                        errPos = 1;  // [REFPROP::???] is in Fluid->str, i.e. position 1
-                    else
-                        errPos = 2;  // [REFPROP::???] is in PropName->str, i.e. position 2
-                    return MAKELRESULT(BAD_FLUID, errPos);
-                } else if (emsg.find("IF97") != std::string::npos) {
-                    if (FluidString.find("IF97") != std::string::npos)
-                        errPos = 1;  // [IF97::???] is in Fluid->str, i.e. position 1
-                    else
-                        errPos = 2;  // [IF97::???] is in PropName-str, i.e. position 2
-                    return MAKELRESULT(BAD_IF97_FLUID, errPos);
-                } else
-                    return MAKELRESULT(BAD_FLUID, 1);
-            } else  //  "Both inputs"
-                return MAKELRESULT(BAD_PARAMETER, 2);
-        } else if (emsg.find("Unable to use") != std::string::npos) {
-            // PropName can be in either parameter location, find out which.
-            // It will be in brackets in the error message.
-            if (emsg.find(PropNameBrackets) != std::string::npos)
-                errPos = 2;  // [PropName] is in error message, i.e. position 2
-            else
-                errPos = 1;  // [Fluid] variable is in error message, i.e. position 1
-            // Now determine specific error type
-            if (emsg.find("Output string is invalid") != std::string::npos)
-                return MAKELRESULT(BAD_PARAMETER, errPos);
-            else if (emsg.find("non-trivial") != std::string::npos)
-                return MAKELRESULT(NON_TRIVIAL, errPos);
-            else if (emsg.find("No outputs") != std::string::npos)
-                return MAKELRESULT(NOT_AVAIL, errPos);
-            else
-                return MAKELRESULT(UNKNOWN, errPos);
-        } else
-            return MAKELRESULT(UNKNOWN, 1);
+        return HandleProps1SIError(emsg, FluidString, PropNameBrackets);
     }
 
     // normal return
     return 0;
+}
+
+// Helper: centralize text-matching logic for PropsSI error handling
+static LRESULT HandlePropsSIError(const std::string& emsg, const std::string& Prop1Name, CoolProp::parameters& key1)
+{
+    auto contains = [&](const char* s) { return emsg.find(s) != std::string::npos; };
+    unsigned int errPos = 0;
+
+    if (contains("Input pair variable is invalid")) {
+        errPos = !is_valid_parameter(Prop1Name, key1) ? 2u : 4u;
+        return MAKELRESULT(BAD_PARAMETER, errPos);
+    }
+    if (contains("Input Name1")) return MAKELRESULT(BAD_PARAMETER, 2);
+    if (contains("Input Name2")) return MAKELRESULT(BAD_PARAMETER, 4);
+    if (contains("Phase can only be specified on one")) return MAKELRESULT(ONLY_ONE_PHASE_SPEC, 4);
+    if (contains("valid phase")) {
+        errPos = !is_valid_parameter(Prop1Name, key1) ? 2u : 4u;
+        return MAKELRESULT(BAD_PHASE, errPos);
+    }
+    if (contains("This pair of inputs")) return MAKELRESULT(BAD_INPUT_PAIR, 2);
+    if (contains("Input vapor quality")) return (Prop1Name == "Q") ? MAKELRESULT(BAD_QUAL, 3) : MAKELRESULT(BAD_QUAL, 5);
+    if (contains("Output string is invalid")) return MAKELRESULT(BAD_PARAMETER, 1);
+    if (contains("not valid in two phase region")) return MAKELRESULT(TWO_PHASE, 1);
+    if (contains("only defined within the two-phase")) return MAKELRESULT(NON_TWO_PHASE, 1);
+    if (contains("not implemented")) return MAKELRESULT(NOT_AVAIL, 1);
+
+    if (contains("Initialize failed")) {
+        if (contains("Could not match the binary pair")) return MAKELRESULT(MISSING_BINARY_PAIR, 6);
+        if (contains("REFPROP")) {
+            if (contains("cannot use")) return MAKELRESULT(NO_REFPROP, 6);
+            return MAKELRESULT(BAD_FLUID, 6);
+        }
+        if (contains("IF97")) return MAKELRESULT(BAD_IF97_FLUID, 6);
+        return MAKELRESULT(BAD_FLUID, 6);
+    }
+
+    if (contains("Temperature")) return (Prop1Name == "T") ? MAKELRESULT(T_OUT_OF_RANGE, 3) : MAKELRESULT(T_OUT_OF_RANGE, 5);
+    if (contains("Saturation pressure")) return (Prop1Name == "P") ? MAKELRESULT(TP_SATURATION, 3) : MAKELRESULT(TP_SATURATION, 5);
+    if (contains("Pressure")) return (Prop1Name == "P") ? MAKELRESULT(P_OUT_OF_RANGE, 3) : MAKELRESULT(P_OUT_OF_RANGE, 5);
+    if (contains("Enthalpy") || contains("solution because Hmolar"))
+        return ((Prop1Name == "H") || (Prop1Name == "Hmolar")) ? MAKELRESULT(H_OUT_OF_RANGE, 3) : MAKELRESULT(H_OUT_OF_RANGE, 5);
+    if (contains("Entropy") || contains("solution because Smolar"))
+        return ((Prop1Name == "S") || (Prop1Name == "Smolar")) ? MAKELRESULT(S_OUT_OF_RANGE, 3) : MAKELRESULT(S_OUT_OF_RANGE, 5);
+
+    return MAKELRESULT(UNKNOWN, 1);
 }
 
 // this code executes the user function CP_PropsSI, which is a wrapper for
@@ -259,17 +328,19 @@ LRESULT CP_PropsSI(LPCOMPLEXSCALAR Prop,         // pointer to the result
                    LPCCOMPLEXSCALAR InputProp2,  // CoolProp InputProp2
                    LPCMCSTRING FluidName)        // CoolProp Fluid
 {
-    unsigned int errPos;
+    // unsigned int errPos = 0;
     std::string Prop1Name(InputName1->str);
     std::string Prop2Name(InputName2->str);
     std::string FluidString = FluidName->str;
     CoolProp::parameters key1;
 
     // check that the first scalar argument is real
-    if (InputProp1->imag != 0.0) return MAKELRESULT(MUST_BE_REAL, 3);  // if not, display "Argument must be real" under scalar argument
+    LRESULT r = CheckRealOrError(InputProp1, 3);
+    if (r) return r;
 
     // check that the second scalar argument is real
-    if (InputProp2->imag != 0.0) return MAKELRESULT(MUST_BE_REAL, 5);  // if not, display "Argument must be real" under scalar argument
+    r = CheckRealOrError(InputProp2, 5);
+    if (r) return r;
 
     // pass the arguments to the CoolProp.Props() function
     Prop->real = CoolProp::PropsSI(OutputName->str, InputName1->str, InputProp1->real, InputName2->str, InputProp2->real, FluidName->str);
@@ -280,76 +351,7 @@ LRESULT CP_PropsSI(LPCOMPLEXSCALAR Prop,         // pointer to the result
     if (!ValidNumber(Prop->real)) {
         std::string emsg = CoolProp::get_global_param_string("errstring");
         CoolProp::set_error_string(emsg);  // reset error string so Mathcad can retrieve it
-        if (emsg.find("Input pair variable is invalid") != std::string::npos) {
-            if (!is_valid_parameter(Prop1Name, key1))
-                errPos = 2;  // First input parameter string; position 2.
-            else             // must be the second input parameter that's bad
-                errPos = 4;  // Second input parameter string; position 4.
-            return MAKELRESULT(BAD_PARAMETER, errPos);
-        } else if (emsg.find("Input Name1") != std::string::npos) {
-            return MAKELRESULT(BAD_PARAMETER, 2);  // first position input parameter
-        } else if (emsg.find("Input Name2") != std::string::npos) {
-            return MAKELRESULT(BAD_PARAMETER, 4);  // second position input parameter
-        } else if (emsg.find("Phase can only be specified on one") != std::string::npos) {
-            return MAKELRESULT(ONLY_ONE_PHASE_SPEC, 4);  // second position parameter
-        } else if (emsg.find("valid phase") != std::string::npos) {
-            if (!is_valid_parameter(Prop1Name, key1))
-                errPos = 2;                         // First input parameter string; position 2.
-            else                                    // must be the second input parameter that's bad
-                errPos = 4;                         // Second input parameter string; position 4.
-            return MAKELRESULT(BAD_PHASE, errPos);  // second position parameter
-        } else if (emsg.find("This pair of inputs") != std::string::npos) {
-            return MAKELRESULT(BAD_INPUT_PAIR, 2);  // second position parameter
-        } else if (emsg.find("Input vapor quality") != std::string::npos) {
-            if (Prop1Name == "Q")
-                return MAKELRESULT(BAD_QUAL, 3);  // First value position
-            else
-                return MAKELRESULT(BAD_QUAL, 5);  // Second value position
-        } else if (emsg.find("Output string is invalid") != std::string::npos) {
-            return MAKELRESULT(BAD_PARAMETER, 1);  // first position parameter
-        } else if (emsg.find("not valid in two phase region") != std::string::npos) {
-            return MAKELRESULT(TWO_PHASE, 1);  // first position parameter
-        } else if (emsg.find("only defined within the two-phase") != std::string::npos) {
-            return MAKELRESULT(NON_TWO_PHASE, 1);  // first position parameter
-        } else if (emsg.find("not implemented") != std::string::npos) {
-            return MAKELRESULT(NOT_AVAIL, 1);  // first position parameter
-        } else if (emsg.find("Initialize failed") != std::string::npos) {
-            if (emsg.find("REFPROP") != std::string::npos) {
-                if (emsg.find("cannot use") != std::string::npos)
-                    return MAKELRESULT(NO_REFPROP, 6);
-                else
-                    return MAKELRESULT(BAD_FLUID, 6);
-            } else if (emsg.find("IF97") != std::string::npos) {
-                return MAKELRESULT(BAD_IF97_FLUID, 6);
-            } else
-                return MAKELRESULT(BAD_FLUID, 6);
-        } else if (emsg.find("Temperature") != std::string::npos) {
-            if (Prop1Name == "T")
-                return MAKELRESULT(T_OUT_OF_RANGE, 3);  // First value position
-            else
-                return MAKELRESULT(T_OUT_OF_RANGE, 5);  // Second value position
-        } else if (emsg.find("Saturation pressure") != std::string::npos) {
-            if (Prop1Name == "P")
-                return MAKELRESULT(TP_SATURATION, 3);  // First value position
-            else
-                return MAKELRESULT(TP_SATURATION, 5);  // Second value position
-        } else if (emsg.find("Pressure") != std::string::npos) {
-            if (Prop1Name == "P")
-                return MAKELRESULT(P_OUT_OF_RANGE, 3);  // First value position
-            else
-                return MAKELRESULT(P_OUT_OF_RANGE, 5);  // Second value position
-        } else if ((emsg.find("Enthalpy") != std::string::npos) || (emsg.find("solution because Hmolar") != std::string::npos)) {
-            if ((Prop1Name == "H") || (Prop1Name == "Hmolar"))
-                return MAKELRESULT(H_OUT_OF_RANGE, 3);  // First value position
-            else
-                return MAKELRESULT(H_OUT_OF_RANGE, 5);  // Second value position
-        } else if ((emsg.find("Entropy") != std::string::npos) || (emsg.find("solution because Smolar") != std::string::npos)) {
-            if ((Prop1Name == "S") || (Prop1Name == "Smolar"))
-                return MAKELRESULT(S_OUT_OF_RANGE, 3);  // First value position
-            else
-                return MAKELRESULT(S_OUT_OF_RANGE, 5);  // Second value position
-        } else
-            return MAKELRESULT(UNKNOWN, 1);
+        return HandlePropsSIError(emsg, Prop1Name, key1);
     }
     // normal return
     return 0;
@@ -366,7 +368,7 @@ LRESULT CP_HAPropsSI(LPCOMPLEXSCALAR Prop,         // pointer to the result
                      LPCMCSTRING InputName3,       // CoolProp InputName3
                      LPCCOMPLEXSCALAR InputProp3)  // CoolProp InputProp3
 {
-    unsigned int errPos;
+    unsigned int errPos = 0;
     std::string OutName(OutputName->str);
     OutName = "[" + OutName + "]";
     std::string Prop1Name(InputName1->str);
@@ -376,14 +378,15 @@ LRESULT CP_HAPropsSI(LPCOMPLEXSCALAR Prop,         // pointer to the result
     std::string Prop3Name(InputName3->str);
     Prop3Name = "[" + Prop3Name + "]";
 
-    // check that the first scalar argument is real
-    if (InputProp1->imag != 0.0) return MAKELRESULT(MUST_BE_REAL, 3);  // if not, display "must be real" under scalar argument
+    // check that the 3 scalar arguments are real or throw error using inline helper function above
+    LRESULT r = CheckRealOrError(InputProp1, 3);
+    if (r) return r;
 
-    // check that the second scalar argument is real
-    if (InputProp2->imag != 0.0) return MAKELRESULT(MUST_BE_REAL, 5);  // if not, display "must be real" under scalar argument
+    r = CheckRealOrError(InputProp2, 5);
+    if (r) return r;
 
-    // check that the third scalar argument is real
-    if (InputProp3->imag != 0.0) return MAKELRESULT(MUST_BE_REAL, 7);  // if not, display "must be real" under scalar argument
+    r = CheckRealOrError(InputProp3, 7);
+    if (r) return r;
 
     // pass the arguments to the HumidAirProp.HAProps() function
     Prop->real =
@@ -396,7 +399,7 @@ LRESULT CP_HAPropsSI(LPCOMPLEXSCALAR Prop,         // pointer to the result
         std::string emsg = CoolProp::get_global_param_string("errstring");
         CoolProp::set_error_string(emsg);  // reset error string so Mathcad can retrieve it
 
-        errPos = 0;
+        unsigned int errPos = 0;
         if (emsg.find(OutName) != std::string::npos)
             errPos = 1;
         else if (emsg.find(Prop1Name) != std::string::npos)
@@ -423,7 +426,7 @@ LRESULT CP_HAPropsSI(LPCOMPLEXSCALAR Prop,         // pointer to the result
 // the CoolProp.get_mixture_binary_pair_data() function, used to get the requested binary pair
 // interaction parameter (always returned as a string).
 LRESULT CP_get_mixture_binary_pair_data(LPMCSTRING Value,  // output string (string contains value of parameter)
-                                        LPCMCSTRING CAS1,  // FIrst component
+                                        LPCMCSTRING CAS1,  // First component
                                         LPCMCSTRING CAS2,  // Second component
                                         LPCMCSTRING Key)   // name of the binary pair parameter (string) to retrieve
 {
@@ -442,12 +445,8 @@ LRESULT CP_get_mixture_binary_pair_data(LPMCSTRING Value,  // output string (str
             return MAKELRESULT(UNKNOWN, 1);
     }
 
-    // Must use MathcadAllocate(size) so Mathcad can track and release
-    char* c = MathcadAllocate(static_cast<int>(s.size()) + 1);  // create a c-string (pointer) c with the same size as s
-    // copy s into c, this process avoids the const-cast type which would result from instead
-    // converting the string using s.c_str()
-    std::copy(s.begin(), s.end(), c);
-    c[s.size()] = '\0';
+    // Must use MathcadAllocate(size) so Mathcad can track and release, using Helper routine above
+    char* c = AllocMathcadString(s);
     // assign the string to the function's output parameter
     Value->str = c;
 
@@ -487,11 +486,7 @@ LRESULT CP_apply_simple_mixing_rule(LPMCSTRING Msg,    // output string (verific
     }
 
     // Must use MathcadAllocate(size) so Mathcad can track and release
-    char* c = MathcadAllocate(static_cast<int>(s.size()) + 1);  // create a c-string (pointer) c with the same size as s
-    // copy s into c, this process avoids the const-cast type which would result from instead
-    // converting the string using s.c_str()
-    std::copy(s.begin(), s.end(), c);
-    c[s.size()] = '\0';
+    char* c = AllocMathcadString(s);
     // assign the string to the function's output parameter
     Msg->str = c;
 
@@ -512,7 +507,8 @@ LRESULT CP_set_mixture_binary_pair_data(LPMCSTRING Msg,          // output strin
     s.append(" parameter set.");
 
     // check that the first scalar argument is real
-    if (Value->imag != 0.0) return MAKELRESULT(MUST_BE_REAL, 4);  // if not, display "must be real" under scalar argument
+    LRESULT r = CheckRealOrError(Value, 4);
+    if (r) return r;
 
     // Invoke the std::string form of get_global_param_string() function, save result to a new string s
     try {
@@ -532,11 +528,7 @@ LRESULT CP_set_mixture_binary_pair_data(LPMCSTRING Msg,          // output strin
     }
 
     // Must use MathcadAllocate(size) so Mathcad can track and release
-    char* c = MathcadAllocate(static_cast<int>(s.size()) + 1);  // create a c-string (pointer) c with the same size as s
-    // copy s into c, this process avoids the const-cast type which would result from instead
-    // converting the string using s.c_str()
-    std::copy(s.begin(), s.end(), c);
-    c[s.size()] = '\0';
+    char* c = AllocMathcadString(s);
     // assign the string to the function's output parameter
     Msg->str = c;
 
@@ -546,95 +538,95 @@ LRESULT CP_set_mixture_binary_pair_data(LPMCSTRING Msg,          // output strin
 
 // fill out a FUNCTIONINFO structure with the information needed for registering the function with Mathcad
 FUNCTIONINFO PropsParam = {
-  "get_global_param_string",                                 // Name by which MathCAD will recognize the function
+  "get_global_param_string",                                 // Name by which Mathcad will recognize the function
   "Name of the parameter to retrieve",                       // Description of input parameters
   "Returns the value of the requested CoolProps parameter",  // description of the function for the Insert Function dialog box
   (LPCFUNCTION)CP_get_global_param_string,                   // Pointer to the function code.
-  MC_STRING,                                                 // Returns a MathCAD string
+  MC_STRING,                                                 // Returns a Mathcad string
   1,                                                         // Number of arguments
   {MC_STRING}                                                // Argument types
 };
 
 // fill out a FUNCTIONINFO structure with the information needed for registering the function with Mathcad
 FUNCTIONINFO FluidParam = {
-  "get_fluid_param_string",                                  // Name by which MathCAD will recognize the function
+  "get_fluid_param_string",                                  // Name by which Mathcad will recognize the function
   "Fluid, Name of the parameter to retrieve",                // Description of input parameters
   "Returns the value of the requested CoolProps parameter",  // description of the function for the Insert Function dialog box
   (LPCFUNCTION)CP_get_fluid_param_string,                    // Pointer to the function code.
-  MC_STRING,                                                 // Returns a MathCAD string
+  MC_STRING,                                                 // Returns a Mathcad string
   2,                                                         // Number of arguments
   {MC_STRING, MC_STRING}                                     // Argument types
 };
 
 // fill out a FUNCTIONINFO structure with the information needed for registering the function with Mathcad
 FUNCTIONINFO RefState = {
-  "set_reference_state",                                           // Name by which MathCAD will recognize the function
+  "set_reference_state",                                           // Name by which Mathcad will recognize the function
   "Fluid, Reference State String",                                 // Description of input parameters
   "Sets the reference state to either IIR, ASHRAE, NBP, or DEF.",  // description of the function for the Insert Function dialog box
   (LPCFUNCTION)CP_set_reference_state,                             // Pointer to the function code.
-  COMPLEX_SCALAR,                                                  // Returns a MathCAD complex scalar
+  COMPLEX_SCALAR,                                                  // Returns a Mathcad complex scalar
   2,                                                               // Number of arguments
   {MC_STRING, MC_STRING}                                           // Argument types
 };
 
 // fill out a FUNCTIONINFO structure with the information needed for registering the function with Mathcad
 FUNCTIONINFO Props1SI = {
-  "Props1SI",                                                                                     // Name by which MathCAD will recognize the function
+  "Props1SI",                                                                                     // Name by which Mathcad will recognize the function
   "Fluid, Property Name",                                                                         // Description of input parameters
   "Returns a fluid-specific parameter, where the parameter is not dependent on the fluid state",  // Description of the function for the Insert Function dialog box
   (LPCFUNCTION)CP_Props1SI,                                                                       // Pointer to the function code.
-  COMPLEX_SCALAR,                                                                                 // Returns a MathCAD complex scalar
+  COMPLEX_SCALAR,                                                                                 // Returns a Mathcad complex scalar
   2,                                                                                              // Number of arguments
   {MC_STRING, MC_STRING}                                                                          // Argument types
 };
 
 // fill out a FUNCTIONINFO structure with the information needed for registering the function with Mathcad
 FUNCTIONINFO PropsSI = {
-  "PropsSI",                                                                                  // Name by which MathCAD will recognize the function
+  "PropsSI",                                                                                  // Name by which Mathcad will recognize the function
   "Output Name, Input Name 1, Input Property 1, Input Name 2, Input Property 2, Fluid Name",  // Description of input parameters
   "Returns a fluid-specific parameter, where the parameter is dependent on the fluid state",  // Description of the function for the Insert Function dialog box
   (LPCFUNCTION)CP_PropsSI,                                                                    // Pointer to the function code.
-  COMPLEX_SCALAR,                                                                             // Returns a MathCAD complex scalar
+  COMPLEX_SCALAR,                                                                             // Returns a Mathcad complex scalar
   6,                                                                                          // Number of arguments
   {MC_STRING, MC_STRING, COMPLEX_SCALAR, MC_STRING, COMPLEX_SCALAR, MC_STRING}                // Argument types
 };
 
 FUNCTIONINFO HAPropsSI = {
-  "HAPropsSI",  // Name by which MathCAD will recognize the function
+  "HAPropsSI",  // Name by which Mathcad will recognize the function
   "Output Name, Input Name 1, Input Property 1, Input Name 2, Input Property 2, Input Name 3, Input Property 3",  // Description of input parameters
   "Returns a parameter of humid air, where the parameter is dependent on the fluid state",  // Description of the function for the Insert Function dialog box
   (LPCFUNCTION)CP_HAPropsSI,                                                                // Pointer to the function code.
-  COMPLEX_SCALAR,                                                                           // Returns a MathCAD complex scalar
+  COMPLEX_SCALAR,                                                                           // Returns a Mathcad complex scalar
   7,                                                                                        // Number of arguments
   {MC_STRING, MC_STRING, COMPLEX_SCALAR, MC_STRING, COMPLEX_SCALAR, MC_STRING, COMPLEX_SCALAR}  // Argument types
 };
 
 FUNCTIONINFO GetMixtureData = {
-  "get_mixture_binary_pair_data",                            // Name by which MathCAD will recognize the function
+  "get_mixture_binary_pair_data",                            // Name by which Mathcad will recognize the function
   "CAS 1, CAS 2, Name of the parameter to retrieve",         // Description of input parameters
   "Returns the value of the requested CoolProps parameter",  // description of the function for the Insert Function dialog box
   (LPCFUNCTION)CP_get_mixture_binary_pair_data,              // Pointer to the function code.
-  MC_STRING,                                                 // Returns a MathCAD string
+  MC_STRING,                                                 // Returns a Mathcad string
   3,                                                         // Number of arguments
   {MC_STRING, MC_STRING, MC_STRING}                          // Argument types
 };
 
 FUNCTIONINFO ApplyMixingRule = {
-  "apply_simple_mixing_rule",                   // Name by which MathCAD will recognize the function
+  "apply_simple_mixing_rule",                   // Name by which Mathcad will recognize the function
   "CAS 1, CAS 2, Mixing Rule",                  // Description of input parameters
   "Sets a simple mixing rule for binary pair",  // description of the function for the Insert Function dialog box
   (LPCFUNCTION)CP_apply_simple_mixing_rule,     // Pointer to the function code.
-  MC_STRING,                                    // Returns a MathCAD string
+  MC_STRING,                                    // Returns a Mathcad string
   3,                                            // Number of arguments
   {MC_STRING, MC_STRING, MC_STRING}             // Argument types
 };
 
 FUNCTIONINFO SetMixtureData = {
-  "set_mixture_binary_pair_data",                             // Name by which MathCAD will recognize the function
+  "set_mixture_binary_pair_data",                             // Name by which Mathcad will recognize the function
   "CAS 1, CAS 2, Parameter Name, Parameter value",            // Description of input parameters
   "Sets the value of the specified binary mixing parameter",  // description of the function for the Insert Function dialog box
   (LPCFUNCTION)CP_set_mixture_binary_pair_data,               // Pointer to the function code.
-  MC_STRING,                                                  // Returns a MathCAD string
+  MC_STRING,                                                  // Returns a Mathcad string
   4,                                                          // Number of arguments
   {MC_STRING, MC_STRING, MC_STRING, COMPLEX_SCALAR}           // Argument types
 };
@@ -642,7 +634,7 @@ FUNCTIONINFO SetMixtureData = {
 // ************************************************************************************
 // DLL entry point code.
 // ************************************************************************************
-// The _CRT_INIT function is needed if you are using Microsoft's 32 bit compiler
+// The _CRT_INIT function is needed if you are using Microsoft's WIN32 compiler
 #ifdef _WIN32
 extern "C" BOOL WINAPI _CRT_INIT(HINSTANCE hinstDLL, DWORD dwReason, LPVOID lpReserved);
 #endif
@@ -651,20 +643,14 @@ extern "C" BOOL WINAPI DllEntryPoint(HINSTANCE hDLL, DWORD dwReason, LPVOID lpRe
     switch (dwReason) {
         case DLL_PROCESS_ATTACH:
             //
-            // DLL is attaching to the address space of
-            // the current process.
+            // DLL is attaching to the address space of the current process.
             //
             if (!_CRT_INIT(hDLL, dwReason, lpReserved)) return FALSE;
 
-            // register the error message table
-            // Note, that if your function never returns
-            // an error -- you do not need to
-            // register an error message table
+            // Register the error message table
             if (!CreateUserErrorMessageTable(hDLL, NUMBER_OF_ERRORS, CPErrorMessageTable)) break;
 
-            // and if the errors register OK
-            // go ahead and
-            // register user function
+            // ...and if the errors register OK, go ahead and register user function
             CreateUserFunction(hDLL, &PropsParam);
             CreateUserFunction(hDLL, &FluidParam);
             CreateUserFunction(hDLL, &RefState);


### PR DESCRIPTION
### Description of the Change

Some refactorization of the Mathcad wrapper code:
* Helper functions added to reduce code duplication and improve readability.
* Helper functions added to improve readability and succinctness of error trapping from PropsSI and Props1SI
* Added error handling for specific pre-defined mixture cases in PropsSI and Props1SI wrapper.
* Some commenting and comment touchups.

### Benefits

1. Removed code redundancy
2. Improved succinctness and readability
3. Improved maintainability
4. Added clearer Mathcad error messages for missing BIPs on pre-defined mixtures

### Possible Drawbacks

None.  No computational changes intended or observed.

### Verification Process

Mathcad Prime verification file (``wrappers\MathCAD\Prime\CoolPropFluidProperties.mcdx``) showed no regressions.  
Specific testing of trapped error output in Mathcad interface demonstrated intended behavior:
<img width="796" height="281" alt="image" src="https://github.com/user-attachments/assets/bc04ba32-5767-4bcf-ba6a-b9f297ea0484" />


### Applicable Issues

None.
