### PR TITLE
Fix HAPropsSI T_db from T_wb + low RelHum failing for narrow pressure band (issue #2690)

### DIFF
--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -354,12 +354,14 @@ static double Brent_HAProps_T(givens OutputKey, double p, givens In1Name, double
             T_min_valid = ValidNumber(r_min);
         }
     }
-    // We will do a secant call if the values at T_min and T_max have the same sign
+    // We will do a bounded secant call if the values at T_min and T_max have the same sign.
+    // Using BoundedSecant (instead of unbounded Secant) prevents the solver from wandering
+    // above T_max toward T_sat where WetbulbTemperature becomes singular (issue #2690).
     if (r_min * r_max > 0) {
         if (std::abs(r_min) < std::abs(r_max)) {
-            T = CoolProp::Secant(BSR, T_min, 0.01 * T_min, 1e-7, 50);
+            T = CoolProp::BoundedSecant(BSR, T_min, T_min, T_max, 0.01 * T_min, 1e-7, 50);
         } else {
-            T = CoolProp::Secant(BSR, T_max, -0.01 * T_max, 1e-7, 50);
+            T = CoolProp::BoundedSecant(BSR, T_max, T_min, T_max, -0.01 * T_max, 1e-7, 50);
         }
     } else {
         double mach_eps = 1e-15, tol = 1e-10;
@@ -1297,10 +1299,13 @@ double WetbulbTemperature(double T, double p, double psi_w) {
 
     double return_val;
     try {
-        return_val = Brent(WBS, Tmax + 1, 100, DBL_EPSILON, 1e-12, 50);
+        // Upper bound is Tmax (= T_db for T_db < Tsat, else Tsat).
+        // Using Tmax+1 would evaluate WBS at T_sat when T_db = T_sat-1, causing
+        // p_s_wb >= p and division-by-zero in the humidity ratio calculation (issue #2690).
+        return_val = Brent(WBS, Tmax, 100, DBL_EPSILON, 1e-12, 50);
 
         // Solution obtained is out of range (T>Tmax)
-        if (return_val > Tmax + 1) {
+        if (return_val > Tmax) {
             throw CoolProp::ValueError();
         }
     } catch (...) {
@@ -1721,7 +1726,14 @@ void _HAPropsSI_inputs(double p, const std::vector<givens>& input_keys, const st
                     throw CoolProp::ValueError("For dry air, dewpoint is an invalid input variable\n");
                 }
             } else {
-                T_max = CoolProp::PropsSI("T", "P", p, "Q", 0, "Water") - 1;
+                Water->update(CoolProp::PQ_INPUTS, p, 0);
+                T_max = Water->T() - 1;
+                // For wetbulb or enthalpy secondary inputs, the solution T_db may exceed T_sat(P)
+                // when the air is very dry (low RelHum). WetbulbTemperature handles T_db > T_sat
+                // correctly via its fallback solver, so allow T_max up to 640 K (issue #2690).
+                if (SecondaryInputKey == GIVEN_TWB || SecondaryInputKey == GIVEN_ENTHALPY) {
+                    T_max = 640;
+                }
             }
         }
         // Minimum drybulb temperature is the drybulb temperature corresponding to saturated air for the humidity ratio

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -883,6 +883,32 @@ TEST_CASE("HAPropsSI two-water-content inputs that uniquely determine dry-bulb t
     }
 }
 
+TEST_CASE("HAPropsSI T_db from T_wb + very-low RelHum over a range of pressures (issue #2690)", "[humid_air][2690]") {
+    // For very dry air (RelHum << 1) the solution T_db can exceed T_sat(P), which is
+    // physically valid: WetbulbTemperature() handles T_db > T_sat via its fallback solver.
+    // The bug: a narrow pressure band (~90190–91160 Pa) threw ValueError("temperature (inf)
+    // outside range of validity") while adjacent pressures silently returned wrong values.
+    // Fix: (1) inner Brent upper bound Tmax instead of Tmax+1 (avoids P_s == P singularity),
+    //      (2) outer T_max extended to 640 K for T_wb/enthalpy secondary inputs.
+    const double T_wb = 303.15;   // 30 °C wet-bulb
+    const double RH   = 1e-5;    // effectively dry air
+
+    // Pressures that previously threw (narrow failing band) plus neighbouring values
+    double pressures[] = {90000, 90190, 90500, 91000, 91024, 91160, 91200, 92000, 95000, 101325};
+    for (double p : pressures) {
+        SECTION(std::string("P = ") + std::to_string(static_cast<int>(p)) + " Pa") {
+            double T_db = HumidAir::HAPropsSI("T_db", "T_wb", T_wb, "RelHum", RH, "P", p);
+            REQUIRE(ValidNumber(T_db));
+            CHECK(T_db > T_wb);  // dry-bulb must exceed wet-bulb
+
+            // Round-trip: T_wb computed from the found T_db must match the input
+            double T_wb_check = HumidAir::HAPropsSI("T_wb", "T_db", T_db, "RelHum", RH, "P", p);
+            CHECK(ValidNumber(T_wb_check));
+            CHECK(std::abs(T_wb_check - T_wb) < 1e-6);
+        }
+    }
+}
+
 TEST_CASE("Test consistency between Gernert models in CoolProp and Gernert models in REFPROP", "[Gernert]") {
     // See https://groups.google.com/forum/?fromgroups#!topic/catch-forum/mRBKqtTrITU
     std::string mixes[] = {"CO2[0.7]&Argon[0.3]", "CO2[0.7]&Water[0.3]", "CO2[0.7]&Nitrogen[0.3]"};


### PR DESCRIPTION
## Summary

- **Root cause 1**: `WetbulbTemperature`'s inner `Brent(WBS, Tmax+1, 100)` evaluated `WBS` at `T_sat(P)` where `P_s == P`, causing division-by-zero (`W_s_wb = ∞`) for dry-bulb temperatures just below `T_sat`. Changed upper bound to `Tmax` (not `Tmax+1`).
- **Root cause 2**: For very dry air at sub-atmospheric pressures, the solution `T_db` can legitimately exceed `T_sat(P)` (e.g. `T_db ≈ 377 K > T_sat(90500 Pa) ≈ 370 K`). The outer solver's `T_max = T_sat(P) - 1` excluded the solution entirely. Extended `T_max` to 640 K when the secondary input is `T_wb` or enthalpy — matching the existing behaviour for the `RelHum < 1e-10` case, and safe because `WetbulbTemperature` already handles `T_db > T_sat` via its fallback solver.
- **Minor fix**: Replace `CoolProp::PropsSI("T","P",p,"Q",0,"Water")` with the already-instantiated `Water` singleton, consistent with the rest of `HumidAirProp.cpp`.

## Test plan

- [ ] New Catch test `[humid_air][2690]` covers 10 pressures including the previously-failing 90190–91160 Pa band; verifies `ValidNumber(T_db)`, `T_db > T_wb`, and round-trip error < 1e-6 K
- [ ] Existing `[2670]` and `[humid_air]` tests still pass (51 assertions, 2 test cases)
- [ ] Results are physically consistent: as P decreases, the required T_db increases smoothly

Closes #2690

🤖 Generated with [Claude Code](https://claude.com/claude-code)