### PR TITLE
fix(ci): skip REFPROP build for fork PRs where secrets are unavailable

### DIFF
--- a/.github/workflows/dev_asan.yml
+++ b/.github/workflows/dev_asan.yml
@@ -15,6 +15,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
       - name: Build REFPROP
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         shell: bash
         run: |
           set -x

--- a/.github/workflows/test_catch2.yml
+++ b/.github/workflows/test_catch2.yml
@@ -24,6 +24,7 @@ jobs:
         submodules: recursive
 
     - name: Build REFPROP
+      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       shell: bash
       run: |
         set -x


### PR DESCRIPTION
## Summary
- Adds a conditional to the "Build REFPROP" step in `test_catch2.yml` and `dev_asan.yml` so it is skipped when triggered by a PR from a fork
- Fork PRs don't have access to `REFPROP_GPG_PASSPHRASE`, causing the gpg decrypt to fail and the entire job to error
- Non-REFPROP build and tests still run for fork contributors; REFPROP tests continue to run on internal branch PRs and pushes to master

## Test plan
- [ ] Verify a fork PR no longer fails on the "Build REFPROP" step
- [ ] Verify an internal branch PR still runs REFPROP tests
- [ ] Verify push to master still runs REFPROP tests

Fixes #2694

🤖 Generated with [Claude Code](https://claude.com/claude-code)