### PR TITLE
Skip REFPROP tests when not available during CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@
 /include/pcsaft_fluids_schema_JSON.h
 /include/version.h
 /include/catch.hpp
+/install_root/
 /build*/
 /dev/hashes.json
 /include/cpversion.h

--- a/include/CoolProp.h
+++ b/include/CoolProp.h
@@ -191,5 +191,8 @@ std::string extract_fractions(const std::string& fluid_string, std::vector<doubl
 /// @param Phase The enumerated phase index to be looked up
 std::string phase_lookup_string(phases Phase);
 
+/// A function to skip tests that require REFPROPMixtureBackend in environments where it is not supported (e.g., CI builds on GitHub)
+void Skip_if_No_REFPROP();
+
 } /* namespace CoolProp */
 #endif

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -1044,8 +1044,17 @@ TEST_CASE("Check AbstractState", "[AbstractState]") {
     SECTION("good backend - incomp") {
         CHECK_NOTHROW(shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("INCOMP", "DEB")));
     }
+    // SECTION("good backend - REFPROP") {
+    //     CHECK_NOTHROW(shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("REFPROP", "Water")));
+    // }
+    // Code below lets the test suite continue with REFPROP isn't present while still reporting a visile warning from CATCH2
     SECTION("good backend - REFPROP") {
-        CHECK_NOTHROW(shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("REFPROP", "Water")));
+        try {
+            auto s = shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("REFPROP", "Water"));
+            CHECK(s);  // assert we got a non-null pointer when REFPROP is present
+        } catch (const std::exception& e) {
+            WARN(std::string("REFPROP backend unavailable. All tests requiring REFPROP will be skipped.");
+        }
     }
 }
 

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -1051,9 +1051,10 @@ TEST_CASE("Check AbstractState", "[AbstractState]") {
     SECTION("good backend - REFPROP") {
         try {
             auto s = shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("REFPROP", "Water"));
-            CHECK(s);  // assert we got a non-null pointer when REFPROP is present
-        } catch (const std::exception& e) {
-            WARN(std::string("REFPROP backend unavailable. All tests requiring REFPROP will be skipped.");
+            CHECK_(s);  // assert we got a non-null pointer when REFPROP is present
+        }
+        catch (const std::exception& e) {
+            WARN(std::string("REFPROP backend unavailable. All tests requiring REFPROP will be skipped."));
         }
     }
 }

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -1051,7 +1051,7 @@ TEST_CASE("Check AbstractState", "[AbstractState]") {
     SECTION("good backend - REFPROP") {
         try {
             auto s = shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("REFPROP", "Water"));
-            CHECK_(s);  // assert we got a non-null pointer when REFPROP is present
+            CHECK(s);  // assert we got a non-null pointer when REFPROP is present
         }
         catch (const std::exception& e) {
             WARN(std::string("REFPROP backend unavailable. All tests requiring REFPROP will be skipped."));

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -2224,9 +2224,7 @@ void REFPROP_SETREF(char hrf[3], int ixflag, double x0[1], double& h0, double& s
 #    include <catch2/catch_all.hpp>
 
 TEST_CASE("Check REFPROP and CoolProp values agree", "[REFPROP]") {
-    if (!CoolProp::REFPROPMixtureBackend::REFPROP_supported()) {
-        SKIP("REFPROP backend not available in this environment");
-    }
+    CoolProp::Skip_if_No_REFPROP();
 
     SECTION("Saturation densities agree within 0.5% at T/Tc = 0.9") {
         std::vector<std::string> ss = strsplit(CoolProp::get_global_param_string("FluidsList"), ',');
@@ -2343,9 +2341,7 @@ TEST_CASE("Check REFPROP and CoolProp values agree", "[REFPROP]") {
 }
 
 TEST_CASE("Check trivial inputs for REFPROP work", "[REFPROP_trivial]") {
-    if (!CoolProp::REFPROPMixtureBackend::REFPROP_supported()) {
-        SKIP("REFPROP backend not available in this environment");
-    }
+    CoolProp::Skip_if_No_REFPROP();
 
     const int num_inputs = 6;
     std::string inputs[num_inputs] = {"T_triple", "T_critical", "p_critical", "molar_mass", "rhomolar_critical", "rhomass_critical"};
@@ -2365,9 +2361,7 @@ TEST_CASE("Check trivial inputs for REFPROP work", "[REFPROP_trivial]") {
 }
 
 TEST_CASE("Check PHI0 derivatives", "[REFPROP_PHI0]") {
-    if (!CoolProp::REFPROPMixtureBackend::REFPROP_supported()) {
-        SKIP("REFPROP backend not available in this environment");
-    }
+    CoolProp::Skip_if_No_REFPROP();
 
     const int num_inputs = 3;
     std::string inputs[num_inputs] = {"DALPHA0_DDELTA_CONSTTAU", "D2ALPHA0_DDELTA2_CONSTTAU", "D3ALPHA0_DDELTA3_CONSTTAU"};

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -2224,6 +2224,10 @@ void REFPROP_SETREF(char hrf[3], int ixflag, double x0[1], double& h0, double& s
 #    include <catch2/catch_all.hpp>
 
 TEST_CASE("Check REFPROP and CoolProp values agree", "[REFPROP]") {
+    if (!CoolProp::REFPROPMixtureBackend::REFPROP_supported()) {
+        SKIP("REFPROP backend not available in this environment");
+    }
+
     SECTION("Saturation densities agree within 0.5% at T/Tc = 0.9") {
         std::vector<std::string> ss = strsplit(CoolProp::get_global_param_string("FluidsList"), ',');
 
@@ -2339,6 +2343,10 @@ TEST_CASE("Check REFPROP and CoolProp values agree", "[REFPROP]") {
 }
 
 TEST_CASE("Check trivial inputs for REFPROP work", "[REFPROP_trivial]") {
+    if (!CoolProp::REFPROPMixtureBackend::REFPROP_supported()) {
+        SKIP("REFPROP backend not available in this environment");
+    }
+
     const int num_inputs = 6;
     std::string inputs[num_inputs] = {"T_triple", "T_critical", "p_critical", "molar_mass", "rhomolar_critical", "rhomass_critical"};
     for (int i = 0; i < num_inputs; ++i) {
@@ -2357,6 +2365,9 @@ TEST_CASE("Check trivial inputs for REFPROP work", "[REFPROP_trivial]") {
 }
 
 TEST_CASE("Check PHI0 derivatives", "[REFPROP_PHI0]") {
+    if (!CoolProp::REFPROPMixtureBackend::REFPROP_supported()) {
+        SKIP("REFPROP backend not available in this environment");
+    }
 
     const int num_inputs = 3;
     std::string inputs[num_inputs] = {"DALPHA0_DDELTA_CONSTTAU", "D2ALPHA0_DDELTA2_CONSTTAU", "D3ALPHA0_DDELTA3_CONSTTAU"};

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -675,7 +675,17 @@ bool add_fluids_as_JSON(const std::string& backend, const std::string& fluidstri
     }
 }
 
+// Simple function to check if REFPROPMixtureBackend is supported in this environment, so that we can skip
+// tests that require it in environments where it is not supported (e.g., CI builds on GitHub)
+void Skip_if_No_REFPROP() {
 #if defined(ENABLE_CATCH)
+    if (!CoolProp::REFPROPMixtureBackend::REFPROP_supported()) SKIP("Skipping: REFPROP not supported in this environment.");
+#endif
+    // Otherwise, in non-testing environments, this is a no-op.
+}
+
+#if defined(ENABLE_CATCH)
+
 TEST_CASE("Check inputs to PropsSI", "[PropsSI]") {
     SECTION("Single state, single output") {
         CHECK(ValidNumber(CoolProp::PropsSI("T", "P", 101325, "Q", 0, "Water")));
@@ -705,15 +715,11 @@ TEST_CASE("Check inputs to PropsSI", "[PropsSI]") {
         CHECK(ValidNumber(CoolProp::PropsSI("T", "P", 101325, "Q", 0, "R410A.mix")));
     };
     SECTION("Single state, single output, predefined mixture from REFPROP") {
-        if (!CoolProp::REFPROPMixtureBackend::REFPROP_supported()) {
-            SKIP("REFPROPMixtureBackend is supported in this environment, so skipping REFPROP PropsSI test.");
-        }
+        Skip_if_No_REFPROP();
         CHECK(ValidNumber(CoolProp::PropsSI("T", "P", 101325, "Q", 0, "REFPROP::R410A.MIX")));
     };
     SECTION("Single state, single output, bad predefined mixture from REFPROP") {
-        if (!CoolProp::REFPROPMixtureBackend::REFPROP_supported()) {
-            SKIP("REFPROPMixtureBackend is supported in this environment, so skipping REFPROP PropsSI test.");
-        }
+        Skip_if_No_REFPROP();
         CHECK(!ValidNumber(CoolProp::PropsSI("T", "P", 101325, "Q", 0, "REFPROP::RRRRRR.mix")));
     };
     SECTION("Predefined mixture") {

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -705,9 +705,15 @@ TEST_CASE("Check inputs to PropsSI", "[PropsSI]") {
         CHECK(ValidNumber(CoolProp::PropsSI("T", "P", 101325, "Q", 0, "R410A.mix")));
     };
     SECTION("Single state, single output, predefined mixture from REFPROP") {
+        if (!CoolProp::REFPROPMixtureBackend::REFPROP_supported()) {
+            SKIP("REFPROPMixtureBackend is supported in this environment, so skipping REFPROP PropsSI test.");
+        }
         CHECK(ValidNumber(CoolProp::PropsSI("T", "P", 101325, "Q", 0, "REFPROP::R410A.MIX")));
     };
     SECTION("Single state, single output, bad predefined mixture from REFPROP") {
+        if (!CoolProp::REFPROPMixtureBackend::REFPROP_supported()) {
+            SKIP("REFPROPMixtureBackend is supported in this environment, so skipping REFPROP PropsSI test.");
+        }
         CHECK(!ValidNumber(CoolProp::PropsSI("T", "P", 101325, "Q", 0, "REFPROP::RRRRRR.mix")));
     };
     SECTION("Predefined mixture") {

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -1329,7 +1329,7 @@ TEST_CASE("Humid air auxiliary functions: physical validity and monotonicity",
 
 TEST_CASE("Test consistency between Gernert models in CoolProp and Gernert models in REFPROP", "[Gernert]") {
     // See https://groups.google.com/forum/?fromgroups#!topic/catch-forum/mRBKqtTrITU
-    if (!_REFPROP_supported) {
+    if (!REFPROPMixtureBackend::REFPROP_supported()) {
         SKIP("REFPROP backend not available in this environment. Skipping Gernert test.");
     }
     std::string mixes[] = {"CO2[0.7]&Argon[0.3]", "CO2[0.7]&Water[0.3]", "CO2[0.7]&Nitrogen[0.3]"};
@@ -1808,7 +1808,7 @@ TEST_CASE("Test second partial derivatives", "[derivatives]") {
 }
 
 // Helper function to check if REFPROP is available. If not, we skip the test cases that require REFPROP
-// Might not be needed.  See if we can use REFPROPMixtureBackend::_REFPROP_supported instead, but this is
+// Might not be needed.  See if we can use REFPROPMixtureBackend::REFPROP_supported() instead, but this is
 // a more direct test of whether REFPROPMixtureBackend can actually call REFPROPMixtureBackend::REFPROPMixtureBackend()
 // without throwing an exception
 namespace {
@@ -1824,7 +1824,7 @@ namespace {
 
 
 TEST_CASE("REFPROP names for coolprop fluids", "[REFPROPName]") {
-    if (!_REFPROP_supported) {
+    if (!REFPROPMixtureBackend::REFPROP_supported()) {
         SKIP("REFPROP backend not available in this environment");
     }
 
@@ -1845,7 +1845,7 @@ TEST_CASE("REFPROP names for coolprop fluids", "[REFPROPName]") {
     }
 }
 TEST_CASE("Backwards compatibility for REFPROP v4 fluid name convention", "[REFPROP_backwards_compatibility]") {
-    if (!_REFPROP_supported) {
+    if (!REFPROPMixtureBackend::REFPROP_supported()) {
         SKIP("REFPROP backend not available in this environment");
     }
 
@@ -3105,7 +3105,7 @@ TEST_CASE("CoolProp.jl tests", "[2598]") {
 }
 
 TEST_CASE("Check methanol EOS matches REFPROP 10", "[2538]") {
-    if (!is_refprop_available()) {
+    if (!REFPROPMixtureBackend::REFPROP_supported()) {
         SKIP("REFPROP backend not available in this environment");
     }
 
@@ -3323,6 +3323,9 @@ TEST_CASE_METHOD(SuperAncillaryOnFixture, "Check throws for R410A", "[superanc]"
 }
 
 TEST_CASE_METHOD(SuperAncillaryOnFixture, "Check throws for REFPROP", "[superanc]") {
+    if (!REFPROPMixtureBackend::REFPROP_supported()) {
+        SKIP("REFPROP backend not available in this environment");
+    }
     shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("REFPROP", "WATER"));
     CHECK_THROWS(AS->update_QT_pure_superanc(1.0, 300.0));
 }
@@ -3474,6 +3477,10 @@ std::vector<std::tuple<double, double, double, double>> MSA22values = {
 };
 
 TEST_CASE("Ideal gas thermodynamic properties", "[2589]") {
+    if (!CoolProp::REFPROPMixtureBackend::REFPROP_supported()) {
+        SKIP("REFPROPMixtureBackend is supported in this environment, so skipping ideal gas test");
+    }
+
     shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "Air"));
     shared_ptr<CoolProp::AbstractState> RP(CoolProp::AbstractState::factory("REFPROP", "Air"));
 

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -1329,9 +1329,8 @@ TEST_CASE("Humid air auxiliary functions: physical validity and monotonicity",
 
 TEST_CASE("Test consistency between Gernert models in CoolProp and Gernert models in REFPROP", "[Gernert]") {
     // See https://groups.google.com/forum/?fromgroups#!topic/catch-forum/mRBKqtTrITU
-    if (!REFPROPMixtureBackend::REFPROP_supported()) {
-        SKIP("REFPROP backend not available in this environment. Skipping Gernert test.");
-    }
+    Skip_if_No_REFPROP();  // Skip this test if REFPROPMixture backend is not available
+
     std::string mixes[] = {"CO2[0.7]&Argon[0.3]", "CO2[0.7]&Water[0.3]", "CO2[0.7]&Nitrogen[0.3]"};
     for (int i = 0; i < 3; ++i) {
         const char* ykey = mixes[i].c_str();
@@ -1808,9 +1807,7 @@ TEST_CASE("Test second partial derivatives", "[derivatives]") {
 }
 
 TEST_CASE("REFPROP names for coolprop fluids", "[REFPROPName]") {
-    if (!REFPROPMixtureBackend::REFPROP_supported()) {
-        SKIP("REFPROP backend not available in this environment");
-    }
+    Skip_if_No_REFPROP();  // Skip this test if REFPROPMixture backend is not available
 
     std::vector<std::string> fluids = strsplit(CoolProp::get_global_param_string("fluids_list"), ',');
     for (std::size_t i = 0; i < fluids.size(); ++i) {
@@ -1829,9 +1826,7 @@ TEST_CASE("REFPROP names for coolprop fluids", "[REFPROPName]") {
     }
 }
 TEST_CASE("Backwards compatibility for REFPROP v4 fluid name convention", "[REFPROP_backwards_compatibility]") {
-    if (!REFPROPMixtureBackend::REFPROP_supported()) {
-        SKIP("REFPROP backend not available in this environment");
-    }
+    Skip_if_No_REFPROP();  // Skip this test if REFPROPMixture backend is not available
 
     SECTION("REFPROP-", "") {
         double val = Props1SI("REFPROP-Water", "Tcrit");
@@ -3089,9 +3084,7 @@ TEST_CASE("CoolProp.jl tests", "[2598]") {
 }
 
 TEST_CASE("Check methanol EOS matches REFPROP 10", "[2538]") {
-    if (!REFPROPMixtureBackend::REFPROP_supported()) {
-        SKIP("REFPROP backend not available in this environment");
-    }
+    Skip_if_No_REFPROP();  // Skip this test if REFPROPMixture backend is not available
 
     auto TNBP_RP = PropsSI("T", "P", 101325, "Q", 0, "REFPROP::METHANOL");
     auto TNBP_CP = PropsSI("T", "P", 101325, "Q", 0, "HEOS::METHANOL");
@@ -3307,9 +3300,7 @@ TEST_CASE_METHOD(SuperAncillaryOnFixture, "Check throws for R410A", "[superanc]"
 }
 
 TEST_CASE_METHOD(SuperAncillaryOnFixture, "Check throws for REFPROP", "[superanc]") {
-    if (!REFPROPMixtureBackend::REFPROP_supported()) {
-        SKIP("REFPROP backend not available in this environment");
-    }
+    Skip_if_No_REFPROP();  // Skip this test if REFPROPMixture backend is not available
     shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("REFPROP", "WATER"));
     CHECK_THROWS(AS->update_QT_pure_superanc(1.0, 300.0));
 }
@@ -3461,9 +3452,7 @@ std::vector<std::tuple<double, double, double, double>> MSA22values = {
 };
 
 TEST_CASE("Ideal gas thermodynamic properties", "[2589]") {
-    if (!CoolProp::REFPROPMixtureBackend::REFPROP_supported()) {
-        SKIP("REFPROPMixtureBackend is supported in this environment, so skipping ideal gas test");
-    }
+    Skip_if_No_REFPROP();  // Skip this test if REFPROPMixture backend is not available
 
     shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "Air"));
     shared_ptr<CoolProp::AbstractState> RP(CoolProp::AbstractState::factory("REFPROP", "Air"));

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -1807,22 +1807,6 @@ TEST_CASE("Test second partial derivatives", "[derivatives]") {
     }
 }
 
-// Helper function to check if REFPROP is available. If not, we skip the test cases that require REFPROP
-// Might not be needed.  See if we can use REFPROPMixtureBackend::REFPROP_supported() instead, but this is
-// a more direct test of whether REFPROPMixtureBackend can actually call REFPROPMixtureBackend::REFPROPMixtureBackend()
-// without throwing an exception
-namespace {
-    bool is_refprop_available() {
-        try {
-            double val = Props1SI("REFPROP::Nitrogen", "molemass");
-            return ValidNumber(val);
-        } catch (...) {
-            return false;
-        }
-    }
-}
-
-
 TEST_CASE("REFPROP names for coolprop fluids", "[REFPROPName]") {
     if (!REFPROPMixtureBackend::REFPROP_supported()) {
         SKIP("REFPROP backend not available in this environment");

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -1329,6 +1329,9 @@ TEST_CASE("Humid air auxiliary functions: physical validity and monotonicity",
 
 TEST_CASE("Test consistency between Gernert models in CoolProp and Gernert models in REFPROP", "[Gernert]") {
     // See https://groups.google.com/forum/?fromgroups#!topic/catch-forum/mRBKqtTrITU
+    if (!_REFPROP_supported) {
+        SKIP("REFPROP backend not available in this environment. Skipping Gernert test.");
+    }
     std::string mixes[] = {"CO2[0.7]&Argon[0.3]", "CO2[0.7]&Water[0.3]", "CO2[0.7]&Nitrogen[0.3]"};
     for (int i = 0; i < 3; ++i) {
         const char* ykey = mixes[i].c_str();
@@ -1805,6 +1808,9 @@ TEST_CASE("Test second partial derivatives", "[derivatives]") {
 }
 
 // Helper function to check if REFPROP is available. If not, we skip the test cases that require REFPROP
+// Might not be needed.  See if we can use REFPROPMixtureBackend::_REFPROP_supported instead, but this is
+// a more direct test of whether REFPROPMixtureBackend can actually call REFPROPMixtureBackend::REFPROPMixtureBackend()
+// without throwing an exception
 namespace {
     bool is_refprop_available() {
         try {
@@ -1818,7 +1824,7 @@ namespace {
 
 
 TEST_CASE("REFPROP names for coolprop fluids", "[REFPROPName]") {
-    if (!is_refprop_available()) {
+    if (!_REFPROP_supported) {
         SKIP("REFPROP backend not available in this environment");
     }
 
@@ -1839,7 +1845,7 @@ TEST_CASE("REFPROP names for coolprop fluids", "[REFPROPName]") {
     }
 }
 TEST_CASE("Backwards compatibility for REFPROP v4 fluid name convention", "[REFPROP_backwards_compatibility]") {
-    if (!is_refprop_available()) {
+    if (!_REFPROP_supported) {
         SKIP("REFPROP backend not available in this environment");
     }
 

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -1804,7 +1804,24 @@ TEST_CASE("Test second partial derivatives", "[derivatives]") {
     }
 }
 
+// Helper function to check if REFPROP is available. If not, we skip the test cases that require REFPROP
+namespace {
+    bool is_refprop_available() {
+        try {
+            double val = Props1SI("REFPROP::Nitrogen", "molemass");
+            return ValidNumber(val);
+        } catch (...) {
+            return false;
+        }
+    }
+}
+
+
 TEST_CASE("REFPROP names for coolprop fluids", "[REFPROPName]") {
+    if (!is_refprop_available()) {
+        SKIP("REFPROP backend not available in this environment");
+    }
+
     std::vector<std::string> fluids = strsplit(CoolProp::get_global_param_string("fluids_list"), ',');
     for (std::size_t i = 0; i < fluids.size(); ++i) {
         std::ostringstream ss1;
@@ -1822,6 +1839,10 @@ TEST_CASE("REFPROP names for coolprop fluids", "[REFPROPName]") {
     }
 }
 TEST_CASE("Backwards compatibility for REFPROP v4 fluid name convention", "[REFPROP_backwards_compatibility]") {
+    if (!is_refprop_available()) {
+        SKIP("REFPROP backend not available in this environment");
+    }
+
     SECTION("REFPROP-", "") {
         double val = Props1SI("REFPROP-Water", "Tcrit");
         std::string err = get_global_param_string("errstring");
@@ -3078,6 +3099,10 @@ TEST_CASE("CoolProp.jl tests", "[2598]") {
 }
 
 TEST_CASE("Check methanol EOS matches REFPROP 10", "[2538]") {
+    if (!is_refprop_available()) {
+        SKIP("REFPROP backend not available in this environment");
+    }
+
     auto TNBP_RP = PropsSI("T", "P", 101325, "Q", 0, "REFPROP::METHANOL");
     auto TNBP_CP = PropsSI("T", "P", 101325, "Q", 0, "HEOS::METHANOL");
     CHECK(TNBP_RP == Catch::Approx(TNBP_CP).epsilon(1e-6));


### PR DESCRIPTION
### Description of the Change

REFPROP Tests still failing during CI from PRs on other branches/forks (see my REFPROP and ASAN failures on #2709).  Apparently #2699 didn't quite do it.  Here's an alternative.

**Solution** approach suggested by GitHub Copilot is to conditionally skip REFPROP-dependent tests when REFPROP is not available. This makes tests robust across different environments even when run outside of GitHub workflows.

**Code Fix** adds a helper function in `CoolProp::` to check REFPROP availability and skip affected tests (_there are ten_) in `CoolProp.cpp`, `REFPROPMixtureBackend.cpp`, and `CoolProp-TESTS.cpp` if REFPROP is unavailable.  If in a non-test environment, the helper function is still available, but is a NoOp.

### Benefits

1. Non-breaking: Tests pass in environments with REFPROP installed
2. Robust: Tests are skipped gracefully when REFPROP is unavailable (common in CI)
3. Maintains PR intent: The PR's code changes are unaffected and other non-REFPROP tests still run.
4. Reduces flakiness: No more failures due to missing dependencies
5. Doesn't rely on the GitHub runners; Users can compile and run the Catch Tests locally, even if they don't have REFPROP, without failures.

### Verification Process

- [x] Verify a fork PR no longer fails on the "Build REFPROP" step (based on this PR).
- [x] Verify a fork PR skips all tests (ASAN & CATCH) that require REFPROP (based on this PR)
- [x] Verify an internal branch PR still runs REFPROP tests (based on recent PRs)
- [x] Verify push to master still runs REFPROP tests (based on recent pushes)
- [ ] Verify Non-Catch compiles are unaffected (Tested Mathcad Prime Wrapper - others tested in CI)

### Applicable Issues

#2694