### PR TITLE
fix: repair clang-format CI for fork PRs and push events

### DIFF
--- a/.github/workflows/dev_clangformat.yml
+++ b/.github/workflows/dev_clangformat.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0   # Fetch all history (especially branches)
 
@@ -21,13 +21,26 @@ jobs:
       shell: bash
       run: |
           echo "GITHUB_REF=$GITHUB_REF GITHUB_BASE_REF=$GITHUB_BASE_REF GITHUB_HEAD_REF=$GITHUB_HEAD_REF"
-          git fetch --all
           clang-format --version
-          ./dev/ci/clang-format.sh remotes/origin/$GITHUB_HEAD_REF remotes/origin/$GITHUB_BASE_REF
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            # Use SHAs directly so this works for both fork PRs and local-branch PRs.
+            # remotes/origin/<branch> is unreliable for fork PRs because the fork's
+            # branch is not fetched into origin.
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            HEAD_SHA="${{ github.sha }}"
+            echo "Comparing HEAD $HEAD_SHA against base $BASE_SHA"
+            ./dev/ci/clang-format.sh "$HEAD_SHA" "$BASE_SHA"
+          else
+            # Push event: GITHUB_HEAD_REF/BASE_REF are empty, so use before/after SHAs.
+            BEFORE_SHA="${{ github.event.before }}"
+            AFTER_SHA="${{ github.sha }}"
+            echo "Comparing push $AFTER_SHA against before $BEFORE_SHA"
+            ./dev/ci/clang-format.sh "$AFTER_SHA" "$BEFORE_SHA"
+          fi
 
     - name: Upload clang-format patch as artifact
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
           name: CoolProp-${{ github.sha }}-clang_format.patch
           path: clang_format.patch


### PR DESCRIPTION
## Summary

Fixes #2724 — the `dev_clangformat` workflow was silently passing on the majority of PRs.

- **Fork PRs**: replaced `remotes/origin/$GITHUB_HEAD_REF` / `remotes/origin/$GITHUB_BASE_REF` with commit SHAs from the GitHub Actions context (`github.event.pull_request.base.sha` and `github.sha`). The fork's branch is never fetched into `origin`, so the old ref always resolved to nothing and `git diff` reported 0 changed files.
- **Push events**: `GITHUB_HEAD_REF` and `GITHUB_BASE_REF` are only populated for `pull_request` events, not `push`. The fix detects the event type and uses `github.event.before` / `github.sha` for push events.
- **Action versions**: bumped `actions/checkout` v3 → v6 and `actions/upload-artifact` v4 → v7 (both at latest stable).
- **Removed** redundant `git fetch --all` (not needed since `fetch-depth: 0` already fetches everything and we now use SHAs).

## Test plan

- [x] Open a PR from a fork branch and confirm the workflow now correctly identifies changed `.cpp`/`.h` files
- [ ] Verify a push to `master`/`develop` runs the diff against `github.event.before`
- [x] Confirm a correctly-formatted PR still passes (exit 0)
- [x] Confirm a poorly-formatted PR fails and uploads the patch artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)