### PR TITLE
fix(cmake): change CACHE LIST to CACHE STRING for app sources and include dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,10 +345,10 @@ set(SWIG_DEPENDENCIES
 
 set(COOLPROP_APP_SOURCES
     ${APP_SOURCES}
-    CACHE LIST "List of CPP sources needed for CoolProp")
+    CACHE STRING "List of CPP sources needed for CoolProp")
 set(COOLPROP_INCLUDE_DIRECTORIES
     ${APP_INCLUDE_DIRS}
-    CACHE LIST "List of include directories needed for CoolProp")
+    CACHE STRING "List of include directories needed for CoolProp")
 
 #######################################
 #         REQUIRED MODULES            #


### PR DESCRIPTION
## Summary

- Fixes `COOLPROP_APP_SOURCES` and `COOLPROP_INCLUDE_DIRECTORIES` cache variable types from `LIST` to `STRING` in `CMakeLists.txt`
- CMake has no `LIST` cache type — it was silently coercing to `STRING` and emitting a warning on every configure invocation (at least on Windows, as reported by @henningjp in #2728)

Addresses the review comment: https://github.com/CoolProp/CoolProp/pull/2728#discussion_r3104420850

## Test plan
- [ ] Configure CMake on Windows and verify no `LIST` cache type warning is emitted
- [ ] Verify CMake configures cleanly on Linux/macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)