### PR TITLE
fix(build): default CPM_SOURCE_CACHE to enable incremental builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Web/fluid_properties/fluids/molecule_sdf/
 .version
 
 /bld*
+/.cpm_cache/
 
 /dev/VS2010
 

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,6 +1,11 @@
 # Dependencies for CoolProp managed via CPM.cmake
-# Set CPM_SOURCE_CACHE in your environment (e.g. ~/.cache/CPM) to share the
-# download cache across git worktrees and build directories.
+# CPM_SOURCE_CACHE can be overridden via environment variable (e.g. ~/.cache/CPM)
+# to share the download cache across git worktrees and build directories.
+# Without a stable cache location, FetchContent re-runs on every cmake configure,
+# touching header timestamps and forcing a complete C++ rebuild each time.
+if(NOT DEFINED CPM_SOURCE_CACHE AND "$ENV{CPM_SOURCE_CACHE}" STREQUAL "")
+  set(CPM_SOURCE_CACHE "${CMAKE_CURRENT_LIST_DIR}/../.cpm_cache" CACHE PATH "CPM source cache")
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/CPM.cmake")
 


### PR DESCRIPTION
## Summary

- Without `CPM_SOURCE_CACHE`, CPM calls `FetchContent_Populate` on every cmake configure (new session), which triggers ExternalProject's git fetch/checkout and updates file timestamps in `_deps/<name>-src/` (Eigen, fmt, rapidjson, etc.)
- These updated header timestamps cause a complete C++ recompile on every `uv build` even with no source changes
- Fix defaults `CPM_SOURCE_CACHE` to `.cpm_cache/` in the repo root; users can still override via the `CPM_SOURCE_CACHE` env var (e.g. `~/.cache/CPM` to share across worktrees)

## Test plan

- [ ] Run `uv build` twice with no source changes — second build should be incremental (no C++ recompilation)
- [ ] Verify `.cpm_cache/` is populated after first build
- [ ] Verify `CPM_SOURCE_CACHE` env var still overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)