### PR TITLE
fix(cmake): Update FindMathematica dependency to latest version

### DIFF
--- a/Web/coolprop/wrappers/Mathematica/index.rst
+++ b/Web/coolprop/wrappers/Mathematica/index.rst
@@ -6,15 +6,9 @@ Mathematica Wrapper
 
 Pre-compiled Binaries
 =====================
-Pre-compiled binaries can be downloaded from :sfdownloads:`Mathematica`, which come from :sfnightly:`the nightly snapshots <Mathematica>`.
-
-Place the shared library for your platform (windows: CoolProp.dll, OSX: CoolProp.dylib, linux: CoolProp.so) in the directory that you can obtain from Mathematica::
-
-    FileNameJoin[{$BaseDirectory, "SystemFiles", "LibraryResources", $SystemID}]
-
-If this directory doesn't yet exist, create it. At the command prompt, you should be able to call ``FindLibrary["CoolProp"]``
-
-There is a small example file ``example.nb`` that demonstrates how to call the functions in the DLL which can be downloaded from :sfdownloads:`Mathematica`
+Pre-compiled binaries are no longer uploaded to the  :sfdownloads:`latest Release` on SourceForge or :sfnightly:`the nightly snapshots <Mathematica>`.  This is because:
+- Usage is one of the lowest of all the wrappers supported by CoolProp with few active developers
+- The wrapper should really be built by the user for their specific version of Wolfram Mathematica on their system.  Major and minor updates to Mathematica are just too frequent to keep up with. 
 
 User-Compiled Binaries
 ======================
@@ -22,6 +16,8 @@ User-Compiled Binaries
 Common Requirements
 -------------------
 Compilation of the Mathematica wrapper requires a few :ref:`common wrapper pre-requisites <wrapper_common_prereqs>`
+
+A version of Wolfram Mathematica (v13.0 or higher) or Wolfram Engine
 
 Linux and OSX
 ^^^^^^^^^^^^^
@@ -56,9 +52,9 @@ You need to just slightly modify the building procedure
     A: Building using Visual Studio::
 
         # Build the makefile using CMake
-        cmake .. -DCOOLPROP_MATHEMATICA_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -G "Visual Studio 10 2010 Win64"
+        cmake .. -DCOOLPROP_MATHEMATICA_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -G "Visual Studio 17 2022" -A x64"
         
-    If you have a different version of Visual Studio installed, replace the generator name in the ``-G`` argument
+    If you have a different version of Visual Studio installed, replace the generator name in the ``-G`` argument.  Note that the DLL must be 64-bit by using the ``-A x64`` option at the end.  Prior to VS 2017, this "bitness" was embedded in the ``-G`` argument.
         
     B: Building using MinGW::
 
@@ -69,3 +65,19 @@ You need to just slightly modify the building procedure
     
     # Make the shared library
     cmake --build . --config Release
+
+Install and Verify
+==================
+Place the shared library for your platform (Windows: ``CoolProp.dll``, OSX: ``CoolProp.dylib``, Linux: ``CoolProp.so``) in the directory that you can obtain from Mathematica::
+
+    FileNameJoin[{$BaseDirectory, "SystemFiles", "LibraryResources", $SystemID}]
+
+If this directory doesn't yet exist, create it. At the command prompt, you should be able to call ``FindLibrary["CoolProp"]``
+
+There is a small example file ``example.nb`` in the CoolProp repository under ``\CoolProp\wrappers\Mathematica`` that demonstrates how to call the functions in the installed DLL.
+
+Future Work
+===========
+As of Wolfram Mathematica 14.0, the Wolfram Language has the ability to make API calls *directly to the CoolProp shared library*.  This can be done from a Wolfram Language ``paclet`` that obviates the need for compiling a C++ wrapper and can be handled solely through Mathematica's **Paclet Manager**.  This means that the wrapper can be built with automation scripts by any user for any version of Mathematica greater than v14.0.
+
+We welcome any Wolfram Language users to take this on and contribute to the CoolProp project.

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -94,7 +94,7 @@ if(COOLPROP_MATHEMATICA_MODULE)
   CPMAddPackage(
     NAME FindMathematica
     GIT_REPOSITORY https://github.com/sakra/FindMathematica
-    GIT_TAG        99d8c95eed1a517f4a06511ea40b2cee6477a8c1
+    GIT_TAG        4.2.0
     DOWNLOAD_ONLY  YES
   )
 endif()


### PR DESCRIPTION
### Description of the Change

Keep [FindMathematica](https://github.com/sakra/FindMathematica) package up to date.
- Change package `GIT_TAG` from a specific SHA to `master` so that it will always pull the most recent version when generating the build system with the CPM.
- Update Mathematica wrapper page (`reST` file) for accuracy (binaries no longer available on SourceForge) and updated build steps for compiler versions in this decade.

### Benefits

Users won't have to constantly keep updating the CPM dependencies file to keep this package up to date for:
1. Minimum CMake version supported
2. Supported versions of Wolfram Mathematica family of products

### Possible Drawbacks

While there is a possibility of automatically incorporating a regression from [FindMathematica](https://github.com/sakra/FindMathematica), it is extremely improbable that it will have any impact on CoolProp for several reasons:
1. It is only needed by users who want to build the Mathematica wrapper and does not impact CoolProp code.
2. With the new CPM ( #2728 ), [FindMathematica](https://github.com/sakra/FindMathematica) is no longer included as a submodule in the CoolProp repository.

Additionally, all of the commits to [FindMathematica](https://github.com/sakra/FindMathematica) over the last decade have consisted of:
- Updates to the lowest supported version of CMake
- Updates to the latest Mathematica release version
- Updates to Wolfram product name changes and variations for Mathematica, Desktop Mathematica, Wolfram Engine, WolframNB, etc.
- Updates to logic for finding the actual Wolfram products in MaxOS, OSX, etc., which can be fairly dynamic.
- Updates to the manual and README files.

All of these are rather innocuous to CoolProp and worthy of being kept dynamically up to date without any maintenance from the CoolProp community.

### Verification Process

- Verified that the CPM dependency specification `GIT_TAG    master` actually pulls the latest [FindMathematica](https://github.com/sakra/FindMathematica) commit and successfully generates the build environment with CMake.
- Verified that the Mathematica wrapper is built, installs per the instructions on the updated Mathematica web page, and successfully runs in Mathematica 14.3 (latest).

### Applicable Issues

Closes #2740 
