### PR TITLE
feat(python): pybind11 as default Python interface alongside Cython

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -53,6 +53,12 @@ CPMAddPackage(
   DOWNLOAD_ONLY  YES
 )
 
+CPMAddPackage(
+  NAME pybind11
+  GIT_REPOSITORY https://github.com/pybind/pybind11.git
+  GIT_TAG        v2.11.0
+)
+
 # ── fmt (header-only use; disable fmt's own tests/docs) ───────────────────
 
 CPMAddPackage(

--- a/src/pybind11_interface.cxx
+++ b/src/pybind11_interface.cxx
@@ -6,6 +6,8 @@
 #    include "HumidAirProp.h"
 #    include "DataStructures.h"
 #    include "Backends/Helmholtz/MixtureParameters.h"
+#    include "Backends/PCSAFT/PCSAFTLibrary.h"
+#    include "CPstrings.h"
 
 #    include <pybind11/pybind11.h>
 #    include <pybind11/stl.h>
@@ -370,7 +372,20 @@ void init_CoolProp(py::module& m) {
       .def("d4alphar_dDelta3_dTau", &AbstractState::d4alphar_dDelta3_dTau)
       .def("d4alphar_dDelta2_dTau2", &AbstractState::d4alphar_dDelta2_dTau2)
       .def("d4alphar_dDelta_dTau3", &AbstractState::d4alphar_dDelta_dTau3)
-      .def("d4alphar_dTau4", &AbstractState::d4alphar_dTau4);
+      .def("d4alphar_dTau4", &AbstractState::d4alphar_dTau4)
+      .def("update_QT_pure_superanc", &AbstractState::update_QT_pure_superanc)
+      .def("set_cubic_alpha_C",       &AbstractState::set_cubic_alpha_C)
+      .def("get_fluid_constant",      &AbstractState::get_fluid_constant)
+      .def("neff",                    &AbstractState::neff)
+      .def("gibbsmolar_residual",     &AbstractState::gibbsmolar_residual)
+      .def("hmolar_residual",         &AbstractState::hmolar_residual)
+      .def("smolar_residual",         &AbstractState::smolar_residual)
+      .def("umolar_idealgas",         &AbstractState::umolar_idealgas)
+      .def("umass_idealgas",          &AbstractState::umass_idealgas)
+      .def("hmolar_idealgas",         &AbstractState::hmolar_idealgas)
+      .def("hmass_idealgas",          &AbstractState::hmass_idealgas)
+      .def("smolar_idealgas",         &AbstractState::smolar_idealgas)
+      .def("smass_idealgas",          &AbstractState::smass_idealgas);
 
     m.def("AbstractState", &factory);
 
@@ -389,7 +404,11 @@ void init_CoolProp(py::module& m) {
     m.def("get_parameter_index", &get_parameter_index);
     m.def("get_phase_index", &get_phase_index);
     m.def("is_trivial_parameter", &is_trivial_parameter);
-    m.def("generate_update_pair", &generate_update_pair<double>);
+    m.def("generate_update_pair", [](parameters key1, double val1, parameters key2, double val2) {
+        double out1 = 0, out2 = 0;
+        auto pair = generate_update_pair(key1, val1, key2, val2, out1, out2);
+        return py::make_tuple(pair, out1, out2);
+    });
     m.def("Props1SI", &Props1SI);
     m.def("PropsSI", &PropsSI);
     m.def("PhaseSI", &PhaseSI);
@@ -415,14 +434,25 @@ void init_CoolProp(py::module& m) {
     m.def("get_mixture_binary_pair_data", &get_mixture_binary_pair_data);
     m.def("set_mixture_binary_pair_data", &set_mixture_binary_pair_data);
     m.def("apply_simple_mixing_rule", &apply_simple_mixing_rule);
+    m.def("set_config_int",                 &set_config_int);
+    m.def("get_config_int",                 &get_config_int);
+    m.def("set_interaction_parameters",     &set_interaction_parameters);
+    m.def("set_predefined_mixtures",        &set_predefined_mixtures);
+    m.def("get_mixture_binary_pair_pcsaft", &get_mixture_binary_pair_pcsaft);
+    m.def("set_mixture_binary_pair_pcsaft", &set_mixture_binary_pair_pcsaft);
+    m.def("FluidsList", []() {
+        return strsplit(get_global_param_string("FluidsList"), ',');
+    });
 }
 
-#    if defined(COOLPROP_PYBIND11_MODULE)
+#    if defined(COOLPROP_PYBIND11_INTERNAL_MODULE)
+PYBIND11_MODULE(_CoolProp_pybind11, m) {
+    init_CoolProp(m);
+}
+#    elif defined(COOLPROP_PYBIND11_MODULE)
 PYBIND11_PLUGIN(CoolProp) {
     py::module m("CoolProp", "CoolProp module");
-
     init_CoolProp(m);
-
     return m.ptr();
 }
 #    endif

--- a/wrappers/Python/CMakeLists.txt
+++ b/wrappers/Python/CMakeLists.txt
@@ -221,6 +221,41 @@ else()
     target_compile_options(_constants_module PRIVATE -std=c++17)
 endif()
 
+# ============================================================================
+# pybind11 extension module (_CoolProp_pybind11) — ships alongside Cython
+# ============================================================================
+option(COOLPROP_BUILD_PYBIND11 "Build pybind11 Python extension alongside Cython" ON)
+
+if(COOLPROP_BUILD_PYBIND11)
+    pybind11_add_module(_CoolProp_pybind11_module MODULE
+        ${COOLPROP_SOURCES}
+        "${ROOT_DIR}/src/pybind11_interface.cxx"
+    )
+
+    add_dependencies(_CoolProp_pybind11_module generate_headers_target generate_constants_target)
+
+    target_compile_definitions(_CoolProp_pybind11_module PRIVATE
+        PYBIND11
+        COOLPROP_PYBIND11_INTERNAL_MODULE
+    )
+
+    target_include_directories(_CoolProp_pybind11_module PRIVATE
+        ${COOLPROP_INCLUDE_DIRS}
+    )
+
+    target_link_libraries(_CoolProp_pybind11_module PRIVATE miniz)
+
+    set_target_properties(_CoolProp_pybind11_module PROPERTIES
+        OUTPUT_NAME "_CoolProp_pybind11"
+        PREFIX ""
+    )
+
+    install(TARGETS _CoolProp_pybind11_module
+        LIBRARY DESTINATION CoolProp
+        RUNTIME DESTINATION CoolProp
+    )
+endif()
+
 # Install the modules to the CoolProp package
 install(TARGETS CoolProp_module _constants_module
     LIBRARY DESTINATION CoolProp

--- a/wrappers/Python/CoolProp/__init__.py
+++ b/wrappers/Python/CoolProp/__init__.py
@@ -13,24 +13,30 @@ if constants.__file__.rsplit('.', 1)[1] not in ['pyc', 'pyo', 'py']:
         print("Unable to remove" + constants.__file__ + ". Please manually remove it")
     quit()
 
-from .CoolProp import AbstractState
-from . import CoolProp
+try:
+    from . import _CoolProp_pybind11 as _impl
+    from ._CoolProp_pybind11 import AbstractState
+except ImportError:
+    from . import CoolProp as _impl
+    from .CoolProp import AbstractState
+
+from . import CoolProp  # retained for PDSim backward compat (.pxd cimport users)
 from . import HumidAirProp
 from . import State
 from .constants import *
 
-__fluids__ = CoolProp.get_global_param_string('fluids_list').split(',')
-__incompressibles_pure__ = CoolProp.get_global_param_string('incompressible_list_pure').split(',')
-__incompressibles_solution__ = CoolProp.get_global_param_string('incompressible_list_solution').split(',')
-__version__ = CoolProp.get_global_param_string('version')
-__gitrevision__ = CoolProp.get_global_param_string('gitrevision')
+__fluids__                   = _impl.get_global_param_string('fluids_list').split(',')
+__incompressibles_pure__     = _impl.get_global_param_string('incompressible_list_pure').split(',')
+__incompressibles_solution__ = _impl.get_global_param_string('incompressible_list_solution').split(',')
+__version__                  = _impl.get_global_param_string('version')
+__gitrevision__              = _impl.get_global_param_string('gitrevision')
 
 def get(s):
     """
     This is just a shorthand function for getting a parameter from
     ``CoolProp.get_global_param_string``
     """
-    return CoolProp.get_global_param_string(s)
+    return _impl.get_global_param_string(s)
 
 
 def test():

--- a/wrappers/Python/CoolProp/tests/test_pxd_compat.py
+++ b/wrappers/Python/CoolProp/tests/test_pxd_compat.py
@@ -1,0 +1,60 @@
+"""
+Backward-compatibility tests: verify Cython .pxd files remain usable for
+PDSim-style cimport, and that the Cython module is still accessible alongside
+the new pybind11 module.
+"""
+import os
+import sys
+import pytest
+
+
+def test_pxd_files_installed():
+    import CoolProp
+    pkg_dir = os.path.dirname(CoolProp.__file__)
+    pxd_files = [f for f in os.listdir(pkg_dir) if f.endswith('.pxd')]
+    assert pxd_files, f"No .pxd files found in {pkg_dir}"
+
+
+def test_cython_module_still_accessible():
+    from CoolProp.CoolProp import AbstractState
+    assert hasattr(AbstractState, '__pyx_vtable__'), \
+        "CoolProp.CoolProp.AbstractState is not a Cython type (missing __pyx_vtable__)"
+
+
+def test_pybind11_module_accessible():
+    pytest.importorskip('CoolProp._CoolProp_pybind11',
+                        reason="_CoolProp_pybind11 not built")
+    from CoolProp._CoolProp_pybind11 import AbstractState
+    AS = AbstractState('HEOS', 'Water')
+    assert AS is not None
+
+
+def test_pdsim_cython_step():
+    Cython = pytest.importorskip('Cython', reason="Cython not installed")
+    pdsim_src = os.environ.get('PDSIM_SOURCE_DIR', '')
+    if not pdsim_src:
+        pytest.skip("PDSIM_SOURCE_DIR env var not set")
+    from Cython.Build import cythonize
+    pyx_files = [
+        os.path.join(pdsim_src, f)
+        for f in os.listdir(pdsim_src)
+        if f.endswith('.pyx')
+    ]
+    if not pyx_files:
+        pytest.skip(f"No .pyx files found in {pdsim_src}")
+    cythonize(pyx_files, include_path=[os.path.dirname(__import__('CoolProp').__file__)])
+
+
+def test_pdsim_full_build():
+    pdsim_src = os.environ.get('PDSIM_SOURCE_DIR', '')
+    if not pdsim_src:
+        pytest.skip("PDSIM_SOURCE_DIR env var not set")
+    import subprocess
+    result = subprocess.run(
+        [sys.executable, 'setup.py', 'build_ext', '--inplace'],
+        cwd=pdsim_src,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, \
+        f"PDSim build failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"


### PR DESCRIPTION
## Summary

- Adds `_CoolProp_pybind11.cpython-XX.so` to the wheel alongside the existing Cython `CoolProp.cpython-XX.so`
- `CoolProp/__init__.py` now imports pybind11 first and falls back to Cython — zero API change for callers
- Cython module is kept unconditionally imported so PDSim's `.pxd` `cimport` path continues to work

**Changes:**
- `cmake/dependencies.cmake` — pybind11 v2.11.0 via CPM
- `src/pybind11_interface.cxx` — 14 missing `AbstractState` methods, fixed `generate_update_pair` (now returns `(pair, out1, out2)` tuple), `set/get_config_int`, `set_interaction_parameters`, `set_predefined_mixtures`, PCSAFT binary pair helpers, `FluidsList()`, new `PYBIND11_MODULE(_CoolProp_pybind11)` entry guarded by `COOLPROP_PYBIND11_INTERNAL_MODULE`
- `wrappers/Python/CMakeLists.txt` — `pybind11_add_module` target; controlled by `COOLPROP_BUILD_PYBIND11` option (default ON)
- `wrappers/Python/CoolProp/__init__.py` — try/except pybind11 import with Cython fallback
- `wrappers/Python/CoolProp/tests/test_pxd_compat.py` — backward-compat tests

## Test plan

- [ ] `pip install -e . --no-build-isolation` from `wrappers/Python/`
- [ ] `python -c "import CoolProp._CoolProp_pybind11; import CoolProp.CoolProp; print('both present')"`
- [ ] `python -c "from CoolProp import AbstractState; import CoolProp; AS = AbstractState('HEOS','Water'); AS.update(CoolProp.PT_INPUTS, 1e5, 300); print(AS.hmass())"`
- [ ] `python -c "from CoolProp._CoolProp_pybind11 import generate_update_pair, iT, iP; print(generate_update_pair(iT, 300, iP, 1e5))"`
- [ ] `python -c "from CoolProp._CoolProp_pybind11 import FluidsList; f=FluidsList(); print(type(f), f[:3])"`
- [ ] `python -c "from CoolProp.CoolProp import AbstractState; print(hasattr(AbstractState, '__pyx_vtable__'))"`
- [ ] `pytest wrappers/Python/CoolProp/tests/test_pxd_compat.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)