### PR TITLE
fix(cubics): replace rounded SRK/PR Omega coefficients with exact values

### DIFF
--- a/src/Backends/Cubics/GeneralizedCubic.cpp
+++ b/src/Backends/Cubics/GeneralizedCubic.cpp
@@ -634,13 +634,13 @@ double AbstractCubic::d3_alphar_dxidxjdxk(double tau, double delta, const std::v
 }
 
 double SRK::a0_ii(std::size_t i) {
-    // Values from Soave, 1972 (Equilibrium constants from a ..)
-    double a = 0.42747 * R_u * R_u * Tc[i] * Tc[i] / pc[i];
+    // Exact value: 1/(9*(2^(1/3)-1)); see Bell and Deiters, IECR, 2021
+    double a = 0.42748023335403414043900347952220 * R_u * R_u * Tc[i] * Tc[i] / pc[i];
     return a;
 }
 double SRK::b0_ii(std::size_t i) {
-    // Values from Soave, 1972 (Equilibrium constants from a ..)
-    double b = 0.08664 * R_u * Tc[i] / pc[i];
+    // Exact value: (2^(1/3)-1)/3; see Bell and Deiters, IECR, 2021
+    double b = 0.08664034999649577215890158147700 * R_u * Tc[i] / pc[i];
     return b;
 }
 double SRK::m_ii(std::size_t i) {
@@ -651,11 +651,13 @@ double SRK::m_ii(std::size_t i) {
 }
 
 double PengRobinson::a0_ii(std::size_t i) {
-    double a = 0.45724 * R_u * R_u * Tc[i] * Tc[i] / pc[i];
+    // Exact value; see Bell and Deiters, IECR, 2021
+    double a = 0.45723552892138218938000849856422 * R_u * R_u * Tc[i] * Tc[i] / pc[i];
     return a;
 }
 double PengRobinson::b0_ii(std::size_t i) {
-    double b = 0.07780 * R_u * Tc[i] / pc[i];
+    // Exact value; see Bell and Deiters, IECR, 2021
+    double b = 0.07779607390388455972148597969400 * R_u * Tc[i] / pc[i];
     return b;
 }
 double PengRobinson::m_ii(std::size_t i) {

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -2650,7 +2650,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::SRK_covolume() {
         // Get the parameters for the cubic EOS
         CoolPropDbl Tc = get_fluid_constant(i, iT_critical), pc = get_fluid_constant(i, iP_critical);
         CoolPropDbl R = 8.3144598;
-        b += mole_fractions[i] * 0.08664 * R * Tc / pc;
+        b += mole_fractions[i] * 0.08664034999649577215890158147700 * R * Tc / pc;
     }
     return b;
 }
@@ -2843,16 +2843,16 @@ CoolPropDbl HelmholtzEOSMixtureBackend::solver_rho_Tp_SRK(CoolPropDbl T, CoolPro
     for (std::size_t i = 0; i < components.size(); ++i) {
         CoolPropDbl Tci = components[i].EOS().reduce.T, pci = components[i].EOS().reduce.p, acentric_i = components[i].EOS().acentric;
         CoolPropDbl m_i = 0.480 + 1.574 * acentric_i - 0.176 * pow(acentric_i, 2);
-        CoolPropDbl b_i = 0.08664 * R_u * Tci / pci;
+        CoolPropDbl b_i = 0.08664034999649577215890158147700 * R_u * Tci / pci;
         b += mole_fractions[i] * b_i;
 
-        CoolPropDbl a_i = 0.42747 * pow(R_u * Tci, 2) / pci * pow(1 + m_i * (1 - sqrt(T / Tci)), 2);
+        CoolPropDbl a_i = 0.42748023335403414043900347952220 * pow(R_u * Tci, 2) / pci * pow(1 + m_i * (1 - sqrt(T / Tci)), 2);
 
         for (std::size_t j = 0; j < components.size(); ++j) {
             CoolPropDbl Tcj = components[j].EOS().reduce.T, pcj = components[j].EOS().reduce.p, acentric_j = components[j].EOS().acentric;
             CoolPropDbl m_j = 0.480 + 1.574 * acentric_j - 0.176 * pow(acentric_j, 2);
 
-            CoolPropDbl a_j = 0.42747 * pow(R_u * Tcj, 2) / pcj * pow(1 + m_j * (1 - sqrt(T / Tcj)), 2);
+            CoolPropDbl a_j = 0.42748023335403414043900347952220 * pow(R_u * Tcj, 2) / pcj * pow(1 + m_j * (1 - sqrt(T / Tcj)), 2);
 
             k_ij = 0;
             //if (i == j){


### PR DESCRIPTION
## Summary

- Replaces the truncated/rounded Ωa and Ωb constants for SRK and Peng-Robinson with the full-precision analytical values from Bell & Deiters, *Ind. Eng. Chem. Res.* 2021 (https://tsapps.nist.gov/publication/get_pdf.cfm?pub_id=931868)
- Updated in both `GeneralizedCubic.cpp` (the canonical cubic backend) and `HelmholtzEOSMixtureBackend.cpp` (the SRK covolume and solver helpers)

| EOS | Constant | Old (rounded) | New (exact) |
|-----|----------|--------------|-------------|
| SRK | Ωa | 0.42747 | 0.42748023335403414... = 1/(9(∛2−1)) |
| SRK | Ωb | 0.08664 | 0.08664034999649577... = (∛2−1)/3 |
| PR  | Ωa | 0.45724 | 0.45723552892138218... |
| PR  | Ωb | 0.07780 | 0.07779607390388455... |

Closes #2742

## Test plan

- [ ] Verify existing cubic EOS tests still pass
- [ ] Spot-check saturation properties for a representative fluid (e.g. propane) with SRK and PR — values should shift by ~0.001% or less, consistent with the coefficient correction magnitude

🤖 Generated with [Claude Code](https://claude.com/claude-code)