### PR TITLE
Mathematica wrapper web page .rst touchups [skip ci]

### DIFF
--- a/Web/coolprop/wrappers/MathCAD/MathcadPrime.rst
+++ b/Web/coolprop/wrappers/MathCAD/MathcadPrime.rst
@@ -55,7 +55,7 @@ To Build
              -DCMAKE_VERBOSE_MAKEFILE=ON  
   
 .. note::   
-   Mathcad Varsion: Use your version of Mathcad Prime in place of **"10.0.0.0"** (with `7.0.0.0` or later)
+   Mathcad Version: Use your version of Mathcad Prime in place of **"10.0.0.0"** (with `7.0.0.0` or later)
 
 .. note::
    Compiler Bitness: Mathcad Prime is 64-bit, so the `-A x64` option is necessary in the Visual Studio string for VS2017 or later.  

--- a/Web/coolprop/wrappers/Mathematica/index.rst
+++ b/Web/coolprop/wrappers/Mathematica/index.rst
@@ -7,8 +7,8 @@ Mathematica Wrapper
 Pre-compiled Binaries
 =====================
 Pre-compiled binaries are no longer uploaded to the  :sfdownloads:`latest Release` on SourceForge or :sfnightly:`the nightly snapshots <Mathematica>`.  This is because:
-- Usage is one of the lowest of all the wrappers supported by CoolProp with few active developers
-- The wrapper should really be built by the user for their specific version of Wolfram Mathematica on their system.  Major and minor updates to Mathematica are just too frequent to keep up with. 
+* Usage is one of the lowest of all the wrappers supported by CoolProp with few active developers
+* The wrapper should really be built by the user for their specific version of Wolfram Mathematica on their system.  Major and minor updates to Mathematica are just too frequent to keep up with. 
 
 User-Compiled Binaries
 ======================
@@ -54,7 +54,8 @@ You need to just slightly modify the building procedure
         # Build the makefile using CMake
         cmake .. -DCOOLPROP_MATHEMATICA_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -G "Visual Studio 17 2022" -A x64"
         
-    If you have a different version of Visual Studio installed, replace the generator name in the ``-G`` argument.  Note that the DLL must be 64-bit by using the ``-A x64`` option at the end.  Prior to VS 2017, this "bitness" was embedded in the ``-G`` argument.
+.. note::   
+    If you have a different version of Visual Studio installed, replace the generator name in the ``-G`` argument.  Note that the DLL must be 64-bit by using the ``-A x64`` option at the end.  Prior to VS 2017, this "bitness" was embedded in the ``-G`` argument using the format **-G "Visual Studio 14 2015 Win64"** and will not use the ``-A`` option.
         
     B: Building using MinGW::
 


### PR DESCRIPTION
### Description of the Change

Fixing some rst formatting on the Mathematica page.

### Benefits

Was using markdown bullet formatting.
Put VS compiler notes in a `Note:` section per the Mathcad page.