### PR TITLE
fix(flash): return rhomolar_critical from PT_flash at the critical point (#2738)

### DIFF
--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -89,6 +89,20 @@ void FlashRoutines::PT_flash_mixtures(HelmholtzEOSMixtureBackend& HEOS) {
 }
 void FlashRoutines::PT_flash(HelmholtzEOSMixtureBackend& HEOS) {
     if (HEOS.is_pure_or_pseudopure) {
+        // At the critical point dP/drho -> 0, so solver_rho_Tp is ill-conditioned: a tight
+        // pressure residual does not imply a tight density. Short-circuit when (T, p)
+        // matches the critical point within 1e-10 relative on both axes. See issue #2738.
+        CoolPropDbl Tc = HEOS.T_critical();
+        CoolPropDbl pc = HEOS.p_critical();
+        if (is_in_closed_range(Tc * (1 - 1e-10), Tc * (1 + 1e-10), static_cast<CoolPropDbl>(HEOS._T))
+            && is_in_closed_range(pc * (1 - 1e-10), pc * (1 + 1e-10), static_cast<CoolPropDbl>(HEOS._p))) {
+            HEOS._phase = iphase_critical_point;
+            HEOS._T = Tc;
+            HEOS._p = pc;
+            HEOS._rhomolar = HEOS.rhomolar_critical();
+            HEOS._Q = -1;
+            return;
+        }
         if (HEOS.imposed_phase_index == iphase_not_imposed)  // If no phase index is imposed (see set_components function)
         {
             // At very low temperature (near the triple point temp), the isotherms are VERY steep

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -1500,6 +1500,33 @@ TEST_CASE("Tests for solvers in P,T flash using Water", "[flash],[PT]") {
     }
 }
 
+TEST_CASE("P,T flash at the critical point returns rhomolar_critical", "[flash],[PT],[critical_point],[2738]") {
+    // At the critical point, dP/drho -> 0 so the generic density solver is ill-conditioned.
+    // PT_flash should detect exact-critical inputs and return the tabulated critical density.
+    for (const std::string fluid : {"CarbonDioxide", "Water", "R134a"}) {
+        CAPTURE(fluid);
+        std::shared_ptr<AbstractState> AS(AbstractState::factory("HEOS", fluid));
+        double Tc = AS->T_critical();
+        double pc = AS->p_critical();
+        double rho_c = AS->rhomolar_critical();
+        AS->update(PT_INPUTS, pc, Tc);
+        CHECK(std::abs(AS->rhomolar() - rho_c) / rho_c < 1e-10);
+        CHECK(AS->phase() == iphase_critical_point);
+    }
+    SECTION("Issue #2738 reproducer (high-level API for CO2)") {
+        double Tc = Props1SI("CO2", "Tcrit");
+        double pc = Props1SI("CO2", "Pcrit");
+        double rho_crit = Props1SI("CO2", "rhomass_critical");
+        double rho_pt = PropsSI("Dmass", "T", Tc, "P", pc, "CO2");
+        CAPTURE(Tc);
+        CAPTURE(pc);
+        CAPTURE(rho_crit);
+        CAPTURE(rho_pt);
+        CHECK(ValidNumber(rho_pt));
+        CHECK(std::abs(rho_pt - rho_crit) / rho_crit < 1e-10);
+    }
+}
+
 TEST_CASE("Tests for solvers in P,Y flash using Water", "[flash],[PH],[PS],[PU]") {
     double Ts, y, T2;
     // See https://groups.google.com/forum/?fromgroups#!topic/catch-forum/mRBKqtTrITU


### PR DESCRIPTION
## Summary
- Closes #2738. `PropsSI('Dmass','T',Tcrit,'P',Pcrit,'CO2')` returned 466.207 kg/m³ instead of the true 467.600 kg/m³ because at the critical point dP/dρ → 0 and `solver_rho_Tp` is ill-conditioned (a tight pressure residual does not imply a tight density).
- Add a critical-point short-circuit at the top of `PT_flash` for pure fluids, mirroring the existing guard in `PQ_flash` at `FlashRoutines.cpp:653-661`. Tolerance is 1e-10 relative on both T and p; mixture PT flash is untouched.
- `calc_T_critical`/`calc_p_critical`/`calc_rhomolar_critical` already return superancillary-consistent values, so the (Tc, pc, ρc) triple the guard uses is numerically self-consistent.

## Test plan
- [x] New Catch2 test `"P,T flash at the critical point returns rhomolar_critical"` (tag `[2738]`) — CO2, Water, R134a via `AbstractState`, plus the exact high-level-API reproducer from the issue. Returns `467.59996991048007` kg/m³ after the fix.
- [x] `[flash]` (418 assertions), `[PT]` (22), `[critical_point]` (8), `[sat_T_to_Tc]` (1309), `[triple_point]` (716), `[2545]` (1) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)