### PR TITLE
docs(index): auto-generate pure fluid count on landing page

### DIFF
--- a/Web/conf.py
+++ b/Web/conf.py
@@ -41,6 +41,7 @@ def _download(url, dest):
 
 import CoolProp
 ver = CoolProp.__version__
+num_pure_fluids = len(CoolProp.__fluids__)
 # The short X.Y version.
 version = ver.rsplit('.', 1)[0]
 # The full version, including alpha/beta/rc tags.
@@ -155,6 +156,11 @@ templates_path = ['_templates']
 
 # The suffix of source filenames.
 source_suffix = {'.rst': 'restructuredtext'}
+
+# Substitutions available in every .rst file (auto-generated from CoolProp)
+rst_prolog = """
+.. |num_pure_fluids| replace:: {num_pure_fluids}
+""".format(num_pure_fluids=num_pure_fluids)
 
 # The encoding of source files.
 source_encoding = 'utf-8'

--- a/Web/index.rst
+++ b/Web/index.rst
@@ -12,7 +12,7 @@ What is CoolProp?
 
 CoolProp is a C++ library that implements:
 
-* :ref:`Pure and pseudo-pure fluid equations of state and transport properties for 122 components <list_of_fluids>`
+* :ref:`Pure and pseudo-pure fluid equations of state and transport properties <list_of_fluids>` for |num_pure_fluids| components
 * :ref:`Mixture properties using high-accuracy Helmholtz energy formulations <mixtures>`
 * :ref:`Correlations of properties of incompressible fluids and brines <Pure>`
 * :ref:`Computationally efficient tabular interpolation <tabular_interpolation>`


### PR DESCRIPTION
## Summary
- Fixes #2756 — the landing page claimed "122 components" but there are now 125 pure fluids in CoolProp.
- Adds `num_pure_fluids = len(CoolProp.__fluids__)` in `Web/conf.py` and exposes it to RST via an `rst_prolog` substitution (`|num_pure_fluids|`), so the count updates automatically as fluids are added or removed.
- Restructures the `:ref:` in `Web/index.rst` so the substitution sits outside the role target text (RST substitutions don't resolve inside role content).

## Test plan
- [x] Built a minimal Sphinx project that mirrors the new `rst_prolog` + `:ref:` structure; the landing line renders as *"Pure and pseudo-pure fluid equations of state and transport properties for 125 components"* with the link targeting `list_of_fluids`.
- [ ] Full `Web/` Sphinx build on CI once merged, to confirm no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)