### PR TITLE
fix(docs): regenerate consistency plots when fluids are added

### DIFF
--- a/.github/workflows/docs_docker-run.yml
+++ b/.github/workflows/docs_docker-run.yml
@@ -51,10 +51,13 @@ jobs:
           ./Web/fluid_properties/Incompressibles_volume-based-fluids.csv
           ./Web/fluid_properties/Incompressibles_pure-fluids.csv
           ./Web/scripts/incompressibles_consistency
-        key: cached-props
-        #key: cached-props-${{ github.sha }}
-        #restore-keys: |
-        #  cached-props-
+        # Key depends on the fluid list so adding/removing a fluid invalidates
+        # the cache and triggers a consistency-plot refresh for the new fluid.
+        # The restore-keys fallback still seeds the directory with prior plots
+        # so the incremental Consistency.py only has to regenerate what changed.
+        key: cached-props-${{ hashFiles('dev/fluids/*.json', 'dev/incompressible_liquids/json/*.json') }}
+        restore-keys: |
+          cached-props-
         
     - name: Schedule calculations
       id: schedule_calculation

--- a/Web/scripts/__init__.py
+++ b/Web/scripts/__init__.py
@@ -80,7 +80,7 @@ if sys.platform == "linux":
 elif sys.platform == "darwin":
     add_to_task_list("dev/scripts/examples/OSXRun.py")
     
-add_to_task_list("coolprop.tabular.speed.py")    
+add_to_task_list("coolprop.tabular.speed.py")
 add_to_task_list("fluid_properties.phase_envelope.py")
 add_to_task_list("fluid_properties.PurePseudoPure.py")
 add_to_task_list("fluid_properties.Mixtures.py")
@@ -90,11 +90,14 @@ add_to_task_list("coolprop.parametric_table.py")
 add_to_task_list("coolprop.configuration.py")
 add_to_task_list("logo_2014.py")
 add_to_task_list("fluid_properties.REFPROPcomparison.py")
+# Consistency.py is incremental: it skips fluids whose PNG already exists, so a
+# cache-restored run is a cheap no-op while new fluids still get their plots.
+add_to_task_list("fluid_properties.Consistency.py")
 
 # The expensive tasks that are fired when full_rebuild is True
 if full_rebuild:
     print("Adding the computationally expensive scripts to the task list.")
-    add_to_task_list("fluid_properties.Consistency.py")
+    os.environ["COOLPROP_FORCE_CONSISTENCY"] = "1"
     add_to_task_list("fluid_properties.Incompressibles.sh")
 
 # Run all the files in the task list

--- a/Web/scripts/fluid_properties.Consistency.py
+++ b/Web/scripts/fluid_properties.Consistency.py
@@ -25,7 +25,13 @@ del ff
 if not os.path.exists(plots_path):
     os.makedirs(plots_path)
 
+force = os.environ.get('COOLPROP_FORCE_CONSISTENCY', '').lower() in ('1', 'true', 'yes')
+
 for fluid in CoolProp.__fluids__:
+    png_path = os.path.join(plots_path, fluid + '.png')
+    if os.path.exists(png_path) and not force:
+        print('fluid:', fluid, '- plot already exists, skipping (set COOLPROP_FORCE_CONSISTENCY=1 to regenerate)')
+        continue
     print('fluid:', fluid)
     file_string = template.format(fluid=fluid)
     file_path = os.path.join(plots_path, fluid + '.py')


### PR DESCRIPTION
## Summary
- Fixes #2755 (dead link at `.../Chlorine.html#consistency-plots`).
- Root cause: `docs_docker-run.yml` cached `Consistencyplots/` under a static key (`cached-props`), so fluids added after the cache was first populated (Chlorine in ee1e5416) never had plots generated — the expensive `Consistency.py` step was gated behind `full_rebuild`, and the stale cache was restored on every build.
- Now `Consistency.py` is incremental (skips fluids whose PNG exists) and always runs, and the cache key hashes the fluid JSON lists so adding a fluid invalidates the exact-key match and triggers incremental regeneration seeded from the previous cache via `restore-keys`.

## Changes
- `Web/scripts/fluid_properties.Consistency.py`: skip fluids whose PNG already exists unless `COOLPROP_FORCE_CONSISTENCY=1`.
- `Web/scripts/__init__.py`: move `Consistency.py` into the always-run task list; `full_rebuild=True` exports `COOLPROP_FORCE_CONSISTENCY=1` to preserve the regenerate-all semantics.
- `.github/workflows/docs_docker-run.yml`: cache key → `cached-props-${{ hashFiles('dev/fluids/*.json', 'dev/incompressible_liquids/json/*.json') }}` with `cached-props-` restore-key.

## Test plan
- [ ] Trigger `Documentation builds (HTML)` workflow on this branch and confirm Chlorine's PNG lands in `Web/fluid_properties/fluids/Consistencyplots/`.
- [ ] Confirm a subsequent run is a cheap no-op (cache hits the new exact key; Consistency.py skips all fluids).
- [ ] After merge, verify `https://coolprop.github.io/devdocs/fluid_properties/fluids/Chlorine.html#consistency-plots` renders a plot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)