### PR TITLE
ci: add .pre-commit-config.yaml with clang-format hook (CoolProp-2uw.3)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+# Pre-commit hooks for CoolProp.
+#
+# Install:
+#   pip install pre-commit
+#   pre-commit install
+#
+# Run manually against staged files:
+#   pre-commit run
+# Or against the whole repo (slow):
+#   pre-commit run --all-files
+#
+# Skip the hooks for a single commit (e.g. WIP):
+#   git commit --no-verify
+#
+# Uninstall (fully revert pre-commit from this clone):
+#   pre-commit uninstall      # removes .git/hooks/pre-commit
+#   pre-commit clean          # optional: clears cached hook environments
+#   pip uninstall pre-commit  # optional: remove the package itself
+#
+# The clang-format hook mirrors .github/workflows/dev_clangformat.yml — same
+# clang-format version (18.1.3, matches the Ubuntu image in CI). Pinning
+# matters: different clang-format versions produce different output and
+# unpinned hooks break reproducibility across contributors.
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.3
+    hooks:
+      - id: clang-format
+        types_or: [c, c++]
+        exclude: ^externals/


### PR DESCRIPTION
## Summary
Tier 1.3 of the C++ code-quality epic (`CoolProp-2uw`). Lets contributors catch clang-format violations before pushing.

Mirrors the CI check in `.github/workflows/dev_clangformat.yml` — same clang-format version (18.1.3, matching the Ubuntu image in CI). Pinning matters: different clang-format versions produce different output and unpinned hooks break reproducibility across contributors.

## Setup (one-time)
\`\`\`bash
pip install pre-commit
pre-commit install
\`\`\`

After that, pre-commit auto-runs `clang-format` on staged C/C++ files at every commit. Manual runs: `pre-commit run` (staged) or `pre-commit run --all-files` (everything, slow).

## Test plan
- [ ] Install pre-commit, stage a deliberate formatting violation in src/, commit → fails with clang-format diff
- [ ] Stage correctly-formatted code → passes
- [ ] `pre-commit run --all-files` against current master surfaces the same violations CI does (e.g., `src/Tests/CoolProp-Tests.cpp`)

## Related
- #2786 — switches `dev_clangformat.yml` to PR-only (`CoolProp-2uw.1`)
- Future: `CoolProp-2uw.6` will extend this config with a clang-tidy hook (depends on `CoolProp-2uw.7` for compile_commands.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)