### PR TITLE
build(cmake): always export compile_commands.json (CoolProp-2uw.7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.14)
 
+# Always export compile_commands.json for clang-tidy, IWYU, and editor LSPs
+# (CoolProp-2uw.7). Honored by Makefile and Ninja generators; harmless on others.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 include(CheckIncludeFileCXX)
 
 # Dependency management via CPM.cmake (replaces git submodules).

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -1,0 +1,46 @@
+# CoolProp CI scripts and contributor tooling
+
+This directory holds CI helper scripts and contributor-facing tooling docs.
+The full code-quality workflow doc lives elsewhere (CoolProp-2uw.4); this file
+covers the pieces that CI directly depends on.
+
+## compile_commands.json
+
+`clang-tidy`, `include-what-you-use`, and most editor LSP integrations need a
+JSON compilation database. CoolProp configures `CMAKE_EXPORT_COMPILE_COMMANDS`
+ON unconditionally (CMakeLists.txt), so any cmake configure produces it:
+
+```bash
+cmake -G Ninja -B build -S .            # Ninja or Makefile generator
+ls build/compile_commands.json          # 90+ entries covering src/
+```
+
+### macOS contributors
+
+The Homebrew `llvm@18` and `llvm` packages ship `clang-tidy`, but they don't
+know about the Xcode SDK that Apple's `/usr/bin/c++` links against. If
+`clang-tidy` reports `'iterator' file not found` or `__builtin_clzg`-style
+errors against system headers, point it at the Xcode sysroot:
+
+```bash
+SDK=$(xcrun --show-sdk-path)
+clang-tidy -p build --extra-arg=--sysroot=$SDK src/CPstrings.cpp
+```
+
+clang-tidy 19+ is recommended on macOS — earlier versions don't recognize new
+libc++ builtins (`__builtin_clzg`, `__builtin_ctzg`) that Apple's libc++
+headers use.
+
+CI runs on Ubuntu where this issue doesn't apply.
+
+## clang-format
+
+`clang-format.sh` runs `clang-format -i` over C/C++ files changed between two
+git refs. Used by `.github/workflows/dev_clangformat.yml` and runnable
+locally:
+
+```bash
+./dev/ci/clang-format.sh HEAD master   # format files staged + committed vs master
+```
+
+Pinned version: clang-format 18.1.x (matches the Ubuntu image in CI).


### PR DESCRIPTION
## Summary
Tier 2.3 of the C++ code-quality epic (`CoolProp-2uw`). Sets `CMAKE_EXPORT_COMPILE_COMMANDS ON` unconditionally in `CMakeLists.txt` so any cmake configure produces `compile_commands.json` automatically. Unblocks:
- `CoolProp-2uw.5` (clang-tidy-diff CI workflow)
- `CoolProp-2uw.6` (clang-tidy pre-commit hook)
- `CoolProp-2uw.11` (IWYU report job)
- `CoolProp-2uw.13` (safe `clang-tidy --fix` passes)

Plus editor LSP integrations (clangd, ccls).

## Verification
Tested locally with the Ninja generator on macOS arm64:
- Fresh `cmake -G Ninja -B build_tidy -S .` (no explicit export flag) produces `build_tidy/compile_commands.json`
- 97 entries covering `src/`
- `clang-tidy -p build_tidy src/CPstrings.cpp` runs and surfaces real `.clang-tidy` warnings (e.g., `readability-isolate-declaration`, `misc-include-cleaner`)

## New: `dev/ci/README.md`
Documents the contributor build invocation. Includes a macOS sysroot caveat — the Homebrew `llvm@18`/`llvm` packages ship `clang-tidy` but don't see Apple's Xcode SDK by default. Workaround:
\`\`\`bash
SDK=\$(xcrun --show-sdk-path)
clang-tidy -p build --extra-arg=--sysroot=\$SDK src/...
\`\`\`
CI runs on Ubuntu where this issue doesn't apply.

## Test plan
- [ ] CI builds remain green (no semantic build change — just adds a JSON file output)
- [ ] After merge, `cmake -B build -S .` produces `build/compile_commands.json` with no extra flags
- [ ] `clang-tidy -p build src/<file>.cpp` consumes it without unresolved-include errors on Linux

## Related
- #2786 — `CoolProp-2uw.1` PR-only clang-format trigger
- #2788 — `CoolProp-2uw.3` pre-commit clang-format hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)