### PR TITLE
ci: skip CI on beads-only commits via shared commit-msg hook

### DIFF
--- a/.beads-hooks/README.md
+++ b/.beads-hooks/README.md
@@ -1,0 +1,36 @@
+# Shared git hooks
+
+This directory holds tracked git hooks for the CoolProp repository.
+
+To enable them, run once per local clone:
+
+```sh
+git config core.hooksPath .beads-hooks
+```
+
+After that, every commit/push runs the hooks below.
+
+## Installed hooks
+
+- **prepare-commit-msg, pre-commit, pre-push, post-merge, post-checkout** — beads
+  integration shims (managed by `bd hooks install --shared`). They auto-export
+  `.beads/issues.jsonl` and trigger bd's audit/sync logic on commit/push/pull.
+  See https://github.com/steveyegge/beads/.
+
+- **commit-msg** — auto-appends `[skip ci]` to a commit message when the only
+  staged paths are under `.beads/`. GitHub Actions skips workflows when the
+  commit message contains a `[skip ci]` (or `[ci skip]`, etc.) marker, so a
+  beads-only sync commit no longer triggers the ~11 workflows that fire on
+  every push to master. Mixed commits (beads + code) are unaffected.
+
+## Updating the beads shims
+
+If a future `bd` version updates its hook shims, re-run:
+
+```sh
+bd hooks install --shared --force
+```
+
+That regenerates the bd-managed sections inside the existing files; everything
+outside the `BEGIN BEADS INTEGRATION` markers (including the `commit-msg` hook
+above) is preserved.

--- a/.beads-hooks/commit-msg
+++ b/.beads-hooks/commit-msg
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+# Auto-append [skip ci] to commit messages whose entire change set lives
+# under .beads/ (issue-tracker syncs). GitHub Actions skips workflows when
+# the commit message contains [skip ci], so beads-only commits don't burn
+# CI minutes across the ~11 workflows in this repo that fire on every push.
+#
+# Triggers on:
+#   - any commit whose staged paths are all under `.beads/`
+# Skips itself if the message already contains a skip-ci token.
+#
+# This hook is intentionally outside any bd-managed section so `bd hooks
+# install` won't touch it.
+
+msg_file=$1
+[ -z "$msg_file" ] && exit 0
+[ -f "$msg_file" ] || exit 0
+
+# Already has a skip-ci marker — leave it alone.
+if grep -qE '\[(skip ci|ci skip|no ci|skip actions|actions skip)\]' "$msg_file"; then
+  exit 0
+fi
+
+# What's staged? If git diff returns nothing, fall back to the working tree
+# (handles `git commit -a` flows where files aren't pre-staged).
+staged=$(git diff --cached --name-only --diff-filter=ACMRTD 2>/dev/null)
+if [ -z "$staged" ]; then
+  staged=$(git diff --name-only --diff-filter=ACMRTD HEAD 2>/dev/null)
+fi
+[ -z "$staged" ] && exit 0
+
+# Bail out the moment we see anything outside .beads/.
+if printf '%s\n' "$staged" | grep -qv '^\.beads/'; then
+  exit 0
+fi
+
+# Append the marker on a fresh line, separated from the existing message.
+printf '\n[skip ci]\n' >> "$msg_file"

--- a/.beads-hooks/post-checkout
+++ b/.beads-hooks/post-checkout
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-checkout "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'post-checkout' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run post-checkout "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-checkout'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads-hooks/post-merge
+++ b/.beads-hooks/post-merge
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run post-merge "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-merge'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads-hooks/pre-commit
+++ b/.beads-hooks/pre-commit
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-commit'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads-hooks/pre-push
+++ b/.beads-hooks/pre-push
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-push "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'pre-push' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run pre-push "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-push'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---

--- a/.beads-hooks/prepare-commit-msg
+++ b/.beads-hooks/prepare-commit-msg
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'prepare-commit-msg' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'prepare-commit-msg'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.0.3 ---


### PR DESCRIPTION
## Summary

- Adds `.beads-hooks/` as a tracked git-hooks directory containing both the five bd-managed shims (from `bd hooks install --shared`) and a new `commit-msg` hook.
- The `commit-msg` hook auto-appends `[skip ci]` to commit messages when every staged path lives under `.beads/`. GitHub Actions skips workflows whose commit message carries that marker, so issue-tracker syncs no longer trigger the ~11 workflows that currently fire on every push (Library shared, Catch2, ASan, devdocs, Mathcad, LibreOffice, JS, Python cibuildwheel, Clang Format, Windows installer, Docker docs).
- Mixed commits (beads + code) are untouched — the marker is only injected when nothing else is staged.
- Documented in `.beads-hooks/README.md`. Contributors enable per local clone with `git config core.hooksPath .beads-hooks`.

## Test plan

- [ ] Run `git config core.hooksPath .beads-hooks` on a local clone.
- [ ] Make a beads-only change (e.g. `bd note CoolProp-X "..."` then commit) — verify `git log -1` shows `[skip ci]` appended.
- [ ] Push to a topic branch and confirm no workflow runs are queued for that commit.
- [ ] Make a mixed commit (beads + a real code file) — verify the marker is **not** appended and CI runs normally.