### PR TITLE
build(cmake): add format and format-check targets (CoolProp-2uw.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2219,3 +2219,40 @@ endif()
 #include_directories("${CMAKE_CURRENT_SOURCE_DIR}/CoolProp")
 #FILE(GLOB coolprop_files "${CMAKE_CURRENT_SOURCE_DIR}/CoolProp/*.cpp")
 #add_library(coolprop STATIC ${coolprop_files})
+
+# clang-format developer targets (CoolProp-2uw.2)
+# Whole-tree mode over src/ + include/, mirroring dev/ci/clang-format.sh's
+# fallback path. Re-run cmake after adding new files for them to be picked up.
+# Excludes:
+#   - include/*_JSON.h, include/cubic_fluids_schema_JSON.h — auto-generated from
+#     dev/fluids/ JSON, contain raw-string literals up to 60 MB; reformatting
+#     them is wasteful and will be overwritten on the next regeneration.
+#   - include/gitrevision.h — auto-generated.
+#   - include/miniz.h — vendored copy of upstream miniz; format upstream, not us.
+find_program(CLANG_FORMAT_EXE NAMES clang-format-18 clang-format)
+if(CLANG_FORMAT_EXE)
+  file(GLOB_RECURSE COOLPROP_FORMAT_FILES
+       LIST_DIRECTORIES false
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/*.c"
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/*.h"
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/*.hpp"
+       "${CMAKE_CURRENT_SOURCE_DIR}/include/*.c"
+       "${CMAKE_CURRENT_SOURCE_DIR}/include/*.cpp"
+       "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h"
+       "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp")
+  list(FILTER COOLPROP_FORMAT_FILES EXCLUDE REGEX
+       "/include/(.*_JSON.*|gitrevision|miniz)\\.h$")
+  add_custom_target(format
+                    COMMAND ${CLANG_FORMAT_EXE} -style=file -fallback-style=none
+                            -i ${COOLPROP_FORMAT_FILES}
+                    COMMENT "clang-format -i over src/ and include/ (${CLANG_FORMAT_EXE})"
+                    VERBATIM)
+  add_custom_target(format-check
+                    COMMAND ${CLANG_FORMAT_EXE} -style=file -fallback-style=none
+                            --dry-run --Werror ${COOLPROP_FORMAT_FILES}
+                    COMMENT "clang-format dry-run check over src/ and include/ (${CLANG_FORMAT_EXE})"
+                    VERBATIM)
+else()
+  message(STATUS "clang-format not found; 'format' and 'format-check' targets disabled")
+endif()


### PR DESCRIPTION
## Summary
Tier 1.2 of the C++ code-quality epic (`CoolProp-2uw`). Adds developer-facing CMake targets so contributors can format the codebase from a build directory:

\`\`\`bash
cmake --build build --target format        # apply clang-format -i in place
cmake --build build --target format-check  # dry-run, fail on violations
\`\`\`

Mirrors `dev/ci/clang-format.sh`'s whole-tree fallback over `src/` and `include/`. CI logic stays unchanged.

## Excludes (deliberate)
- `include/*_JSON*.h` (e.g. `all_fluids_JSON.h` at 60 MB) — auto-generated raw-string-literal headers, regenerated from `dev/fluids/`. Reformatting them is wasteful and will be undone on next regen.
- `include/gitrevision.h` — auto-generated.
- `include/miniz.h` — vendored upstream copy.

## Verification (macOS arm64, clang-format 18.1.x)
- `format-check` correctly flags `src/Tests/CoolProp-Tests.cpp` (the violation master has been red on)
- `format-check` is read-only (`--dry-run --Werror`)
- `format` applies fixes in place; tightened scope means it doesn't touch the giant JSON headers anymore (an earlier version of the glob did)
- Surfaces the broader legacy formatting backlog in `include/PolyMath.h`, `include/superancillary/*.h`, etc. — `CoolProp-2uw.12` (Tier 4.1, one-shot reformat) will clean those up

## Test plan
- [ ] `cmake -G Ninja -B build -S .` configures cleanly with clang-format on PATH
- [ ] `cmake --build build --target format-check` exits non-zero on current master (legacy violations)
- [ ] `cmake --build build --target format` modifies the same files `dev/ci/clang-format.sh HEAD master` would (after staging changes)
- [ ] When `clang-format` is missing, configure still succeeds with a STATUS message saying targets are disabled

## Related
- #2786 — `CoolProp-2uw.1` PR-only clang-format trigger
- #2788 — `CoolProp-2uw.3` pre-commit clang-format hook
- #2789 — `CoolProp-2uw.7` always-export compile_commands.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)