### PR TITLE
ci(codeql): run on PRs + master, bump to v3 actions (CoolProp-2uw.9)

### DIFF
--- a/.github/workflows/dev_codeql.yml
+++ b/.github/workflows/dev_codeql.yml
@@ -2,13 +2,11 @@ name: Development CodeQL
 
 on:
   push:
-    branches: [ 'dev_checks' ]
-  #  branches: [ 'master', 'main', 'develop', 'dev_checks' ]
-  #  tags: [ 'v*' ]
-  #pull_request:
-  #  branches: [ 'master', 'main', 'develop' ]
+    branches: [ 'master' ]
+  pull_request:
+    branches: [ 'master', 'main', 'develop' ]
   schedule:
-    - cron: '15 8 * * 0,4' # Run twice a week
+    - cron: '15 8 * * 0,4' # Run twice a week as a fallback
 
 jobs:
   analyze:
@@ -26,24 +24,22 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
           
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-          
-          
+
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
-
       - name: Autobuild Python
         if: ${{ matrix.language == 'python' }}
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       
       - name: Configure CPP
@@ -61,6 +57,6 @@ jobs:
 
       
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
Tier 3.2 of the C++ code-quality epic (`CoolProp-2uw`). CodeQL has been triggering only on `push` to `dev_checks` (effectively off for active development) plus a 2× weekly schedule. With `queries: +security-and-quality` on cpp + python, this is meaningful coverage that should run on actual PRs.

## Trigger changes
- `push: master` (was: `dev_checks`)
- `pull_request: master / main / develop` (was: commented out)
- `schedule: 2× weekly` retained as fallback

## Action version bumps
The v2 versions of CodeQL actions are deprecated (Node 16 → 20 transition). All bumped to current:
- `actions/checkout@v3 → v4`
- `actions/setup-python@v4 → v5`
- `github/codeql-action/init@v2 → v3`
- `github/codeql-action/autobuild@v2 → v3`
- `github/codeql-action/analyze@v2 → v3`

## Test plan
- [ ] Workflow runs on this PR (cpp + python matrix)
- [ ] No deprecation warnings in the run log
- [ ] Findings (if any) appear in the repo Security tab once merged

## Related
- #2786 (`2uw.1`), #2788 (`2uw.3`), #2789 (`2uw.7`), #2791 (`2uw.2`), #2792 (`2uw.8`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)