### PR TITLE
ci(coverity): schedule-only + dump JSON defects (CoolProp-2uw.10, closes #2717)

### DIFF
--- a/.github/workflows/dev_coverity.yml
+++ b/.github/workflows/dev_coverity.yml
@@ -1,21 +1,28 @@
 name: Development Coverity scan
 
+# Schedule-only by design (CoolProp-2uw.10).
+#
+# Coverity Scan's free tier has weekly run-rate limits tied to project size.
+# CoolProp (~937 KLOC) is in Coverity's "large project" bucket — roughly
+# 7-14 submissions per week. Triggering on every PR would blow the quota
+# and lock us out. workflow_dispatch is the manual escape hatch.
+#
+# If per-PR coverage becomes important, switch to a label-gated trigger
+# (e.g. only run when a `run-coverity` label is added) so contributors
+# opt-in selectively rather than spending quota on every push.
+
 on:
-  push:
-    branches: [ 'dev_checks' ]
-  #  branches: [ 'master', 'main', 'develop', 'dev_checks' ]
-  #  tags: [ 'v*' ]
-  #pull_request:
-  #  branches: [ 'master', 'main', 'develop' ]
   schedule:
     - cron: '15 8 * * 0,4' # Run twice a week
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      
+      - uses: actions/checkout@v4
+
+
       - name: Configure build
         run: cmake
                  -DCOOLPROP_MY_MAIN=dev/ci/main.cpp
@@ -27,3 +34,34 @@ jobs:
           email: ${{ secrets.COVERITY_SCAN_EMAIL }}
           token: ${{ secrets.COVERITY_SCAN_TOKEN }}
           command: cmake --build ${{github.workspace}}/build --config Release
+
+      # Run cov-analyze locally on the same cov-int/ tree that was uploaded.
+      # The vapier action downloads the full Coverity Build Tool tarball
+      # (cov-analysis/), which ships cov-analyze + cov-format-errors alongside
+      # cov-build. The web UI is hard for humans (and AI agents) to scrape; a
+      # JSON artifact gives us a stable machine-readable defect list. Closes
+      # #2717.
+      - name: Analyze cov-int and dump JSON defects
+        if: ${{ always() }}
+        continue-on-error: true
+        shell: bash
+        working-directory: ${{ github.workspace }}
+        run: |
+          export PATH="${PWD}/cov-analysis/bin:${PATH}"
+          cov-analyze --dir cov-int --all 2>&1 | tee cov-analyze.log
+          cov-format-errors --dir cov-int \
+            --json-output-v9 coverity-defects.json
+          cov-format-errors --dir cov-int --emacs-style 2>&1 \
+            | tee coverity-defects.txt | head -200 || true
+
+      - name: Upload Coverity artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: CoolProp-${{ github.sha }}-coverity
+          path: |
+            coverity-defects.json
+            coverity-defects.txt
+            cov-analyze.log
+            cov-int.tgz
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
Tier 3.3 of the C++ code-quality epic (`CoolProp-2uw`). Two changes in one workflow:

### 1. Schedule-only trigger, documented (CoolProp-2uw.10)
Coverity Scan's free tier has weekly submission limits tied to project size. CoolProp (~937 KLOC) is in the "large project" bucket — roughly **7-14 submissions/week**. PR-triggered would blow the quota, so schedule-only is the right default.

- Drop `push: dev_checks` (was firing in addition to schedule, doubling submissions and obscuring intent).
- Add `workflow_dispatch` for on-demand manual runs.
- Top-of-file comment explains the rationale and points at the label-gated alternative if per-PR coverage ever becomes important.
- `actions/checkout@v3 → v4`.

### 2. Dump Coverity defects JSON as artifact (closes #2717)
The Coverity Scan web UI is hard for humans and AI agents to scrape. This adds a workflow artifact with machine-readable defect output.

How: the upstream `vapier/coverity-scan-action` already downloads the full Coverity Build Tool tarball, which ships `cov-analyze` and `cov-format-errors` alongside `cov-build`. After the action finishes (cov-build + submit), run those tools locally on `cov-int/` to produce defects JSON.

Artifact bundle: `coverity-defects.json` (json-output-v9, machine-readable) + `coverity-defects.txt` (human-readable, emacs-style) + `cov-analyze.log` + `cov-int.tgz` (the submitted tarball, for re-running analysis).

`continue-on-error: true` so a flaky analyze step never fails the workflow.

> **Note:** local checker set may differ from server-side analysis in the web UI (Coverity Scan's cloud may run additional or paid checkers), but the JSON gives downstream consumers a stable shape to parse.

## Test plan
- [ ] Manually `workflow_dispatch` → completes with the artifact attached
- [ ] `coverity-defects.json` parses as valid JSON
- [ ] `coverity-defects.txt` is human-readable
- [ ] PR check stays green even if cov-analyze produces defects
- [ ] Next scheduled run (Sun 08:15 UTC) submits as expected

## Related
- Closes #2717
- Sibling PRs from `CoolProp-2uw`: #2786 (`2uw.1`), #2788 (`2uw.3`), #2789 (`2uw.7`), #2791 (`2uw.2`), #2792 (`2uw.8`), #2793 (`2uw.9`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)