### PR TITLE
ci: add IWYU report job as warning-only artifact (CoolProp-2uw.11)

### DIFF
--- a/.github/workflows/dev_iwyu.yml
+++ b/.github/workflows/dev_iwyu.yml
@@ -1,0 +1,58 @@
+name: Development include-what-you-use
+
+# Warning-only — IWYU is high-noise and its suggestions need per-file
+# judgment, so this workflow uploads the full report as an artifact and
+# never fails a PR. The intent is to surface signal contributors can
+# triage incrementally, not to gate.
+#
+# How: IWYU is wired into CMakeLists.txt via the COOLPROP_IWYU option
+# (see src/Backends and the find_program(iwyu_path ...) blocks). When
+# enabled, CMake sets CXX_INCLUDE_WHAT_YOU_USE on the Main target and
+# the build output IS the IWYU report.
+
+on:
+  pull_request:
+    branches: [ 'master', 'main', 'develop' ]
+  push:
+    branches: [ 'master' ]
+  schedule:
+    - cron: '15 8 * * 0'  # weekly Sunday fallback
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install include-what-you-use
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y iwyu ninja-build
+          include-what-you-use --version || true
+
+      - name: Configure with COOLPROP_IWYU
+        run: |
+          cmake -G Ninja \
+            -DCOOLPROP_IWYU=ON \
+            -DCOOLPROP_MY_MAIN=dev/ci/main.cpp \
+            -B ${{ github.workspace }}/build \
+            -S .
+
+      - name: Build (produces IWYU report)
+        continue-on-error: true
+        shell: bash
+        run: |
+          cmake --build ${{ github.workspace }}/build --config Release \
+            2>&1 | tee iwyu.log
+          # IWYU's exit codes don't follow build conventions; protect against
+          # tee swallowing a non-zero pipefail.
+          echo "iwyu.log size: $(wc -l < iwyu.log) lines"
+
+      - name: Upload IWYU report as artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: CoolProp-${{ github.sha }}-iwyu
+          path: iwyu.log
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
Tier 3.4 of the C++ code-quality epic (`CoolProp-2uw`). `include-what-you-use` is already wired into `CMakeLists.txt` via the `COOLPROP_IWYU` opt-in (see the `find_program(iwyu_path ...)` blocks for `Main` and `CatchTestRunner`). This workflow runs the IWYU build on every PR and uploads the full report as a downloadable artifact — depends on `compile_commands.json` from #2789 (already merged).

## Warning-only
- `continue-on-error: true` on the build step
- `if: always()` on the upload
- Never blocks a PR

IWYU output is noisy and its suggestions need per-file judgment, so the artifact gives contributors and AI agents the data without forcing per-PR triage. We can tighten later once we've seen what the volume looks like.

## Trigger model
- `pull_request` (master / main / develop)
- `push: master`
- Weekly Sunday schedule fallback
- `workflow_dispatch`

## Test plan
- [ ] PR runs surface a downloadable `iwyu.log` artifact
- [ ] PR check stays green even if IWYU's exit is nonzero (continue-on-error)
- [ ] `cmake -DCOOLPROP_IWYU=ON ...` configures cleanly with `apt install iwyu`

## Related
- Sibling PRs already merged from `CoolProp-2uw`: #2786, #2789, #2791, #2792, #2793, #2794, #2788
- Open: #2795 (pin bump), #2796 (docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)