### PR TITLE
ci: add manual-stage clang-tidy pre-commit hook (CoolProp-2uw.6)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,9 @@
 # Or against the whole repo (slow):
 #   pre-commit run --all-files
 #
+# Run the clang-tidy hook (manual-only; see notes below):
+#   pre-commit run --hook-stage manual --all-files clang-tidy
+#
 # Skip the hooks for a single commit (e.g. WIP):
 #   git commit --no-verify
 #
@@ -17,11 +20,12 @@
 #   pre-commit clean          # optional: clears cached hook environments
 #   pip uninstall pre-commit  # optional: remove the package itself
 #
-# Pinned to the latest clang-format 18.x patch (18.1.8). The Ubuntu image in
-# CI ships 18.1.3, but 18.x patches are bug-fix-only with no formatting-rule
-# changes, so hook output is identical to what CI emits. Pinning matters:
-# different MAJOR versions produce different output and unpinned hooks break
+# clang-format pin: latest 18.x patch (18.1.8). The Ubuntu image in CI ships
+# 18.1.3, but 18.x patches are bug-fix-only with no formatting-rule changes,
+# so hook output is identical to what CI emits. Pinning matters: different
+# MAJOR versions produce different output and unpinned hooks break
 # reproducibility across contributors.
+
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v18.1.8
@@ -29,3 +33,32 @@ repos:
       - id: clang-format
         types_or: [c, c++]
         exclude: ^externals/
+
+  # clang-tidy hook (CoolProp-2uw.6).
+  #
+  # Manual stage: clang-tidy on the CoolProp codebase is too slow to run on
+  # every commit (single-file runs can be tens of seconds with the strict
+  # .clang-tidy config). Invoke before pushing instead:
+  #
+  #   pre-commit run --hook-stage manual --all-files clang-tidy
+  #
+  # Or per a list of files:
+  #
+  #   pre-commit run --hook-stage manual --files src/CPstrings.cpp clang-tidy
+  #
+  # The wrapper at dev/ci/run-clang-tidy-staged.sh skips gracefully if
+  # clang-tidy is not installed or compile_commands.json doesn't exist (no
+  # build dir yet). Configure cmake once before invoking:
+  #
+  #   cmake -G Ninja -B build -S .
+  #
+  # Override the build dir via COOLPROP_BUILD_DIR=<path>.
+  - repo: local
+    hooks:
+      - id: clang-tidy
+        name: clang-tidy (manual; needs build/compile_commands.json)
+        entry: dev/ci/run-clang-tidy-staged.sh
+        language: script
+        types_or: [c, c++]
+        exclude: ^(externals/|include/(.*_JSON.*|gitrevision|miniz)\.h$)
+        stages: [manual]

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -97,6 +97,30 @@ headers use.
 
 CI runs on Ubuntu where this issue doesn't apply.
 
+### Running clang-tidy locally
+
+Once `build/compile_commands.json` exists, the manual-stage pre-commit
+hook runs clang-tidy with the strict repo `.clang-tidy` config:
+
+```bash
+pre-commit run --hook-stage manual --all-files clang-tidy
+# or per file:
+pre-commit run --hook-stage manual --files src/CPstrings.cpp clang-tidy
+```
+
+It's manual-stage because clang-tidy on the CoolProp codebase is too slow
+to run on every commit (single-file runs can be tens of seconds with the
+full check set). Invoke it before pushing instead.
+
+The hook auto-skips with a warning when clang-tidy isn't installed or no
+`build/` directory exists. Override the build dir via
+`COOLPROP_BUILD_DIR=<path>` if you have multiple build trees.
+
+The CI counterpart (`.github/workflows/dev_clangtidy.yml`) runs
+`clang-tidy-diff.py` on PR-touched lines only; the local hook runs
+clang-tidy on whole files, so local output is a strict superset of what
+CI surfaces.
+
 ---
 
 ## Other CI tooling (warning-only)
@@ -123,6 +147,4 @@ they exist to surface signal, not to gate.
 These will land as the `CoolProp-2uw` epic progresses; cross-references
 will be added here as each lands:
 
-- clang-tidy diff-only PR check (Tier 2.1, `CoolProp-2uw.5`)
-- IWYU report artifact (Tier 3.4, `CoolProp-2uw.11`)
 - `.git-blame-ignore-revs` for the one-shot reformat (Tier 4.1, `CoolProp-2uw.12`)

--- a/dev/ci/run-clang-tidy-staged.sh
+++ b/dev/ci/run-clang-tidy-staged.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Wrapper for the pre-commit clang-tidy hook (CoolProp-2uw.6).
+#
+# Skips gracefully when:
+#   - clang-tidy is not on PATH (contributor without LLVM installed)
+#   - $COOLPROP_BUILD_DIR/compile_commands.json is missing (no build/ yet)
+#
+# Otherwise runs `clang-tidy -p $BUILD_DIR <files>` and inherits all check
+# selection + WarningsAsErrors from the repo-root .clang-tidy config.
+#
+# Override the build directory:
+#   COOLPROP_BUILD_DIR=build_debug pre-commit run --hook-stage manual clang-tidy
+
+set -euo pipefail
+
+BUILD_DIR="${COOLPROP_BUILD_DIR:-build}"
+COMPDB="$BUILD_DIR/compile_commands.json"
+
+if ! command -v clang-tidy >/dev/null 2>&1; then
+  echo "warning: clang-tidy not on PATH; skipping (install LLVM 18+ for parity with CI)" >&2
+  exit 0
+fi
+
+if [ ! -f "$COMPDB" ]; then
+  echo "warning: $COMPDB not found; skipping clang-tidy" >&2
+  echo "         configure cmake first: cmake -G Ninja -B $BUILD_DIR -S ." >&2
+  echo "         (or set COOLPROP_BUILD_DIR=<path> to point at your existing build dir)" >&2
+  exit 0
+fi
+
+exec clang-tidy -p "$BUILD_DIR" "$@"


### PR DESCRIPTION
## Summary
Tier 2.2 of the C++ code-quality epic (`CoolProp-2uw`). Local pre-commit complement to the clang-tidy-diff CI workflow (`CoolProp-2uw.5` / #2798). Drives `clang-tidy` with the strict repo-root `.clang-tidy` config (`WarningsAsErrors: '*'`) so contributors see the same checks CI runs.

## Why manual-stage (not on every commit)
clang-tidy on the CoolProp codebase is too slow to run on every commit — single-file runs can take tens of seconds with the full check set, and a typical PR touches 1–3 backend files. Invoke before pushing instead:

```bash
pre-commit run --hook-stage manual --all-files clang-tidy
# or per file:
pre-commit run --hook-stage manual --files src/CPstrings.cpp clang-tidy
```

Auto-on-commit would be punishing on a 937 KLOC codebase. This matches the rollout pattern of the `format-check` CMake target — opt-in, not background.

## Graceful fallbacks
The wrapper at `dev/ci/run-clang-tidy-staged.sh` exits 0 with a warning when:
- `clang-tidy` is not on `PATH` (contributor without LLVM installed) ✓ verified locally
- `$COOLPROP_BUILD_DIR/compile_commands.json` doesn't exist (no `build/` configured yet) ✓ verified locally

Default `$COOLPROP_BUILD_DIR` is `build`. Override for multi-build-tree workflows:

```bash
COOLPROP_BUILD_DIR=build_debug pre-commit run --hook-stage manual --all-files clang-tidy
```

## Excludes
Same pattern as the CMake `format` target and clang-tidy-diff CI:
- `externals/` (vendored)
- `include/*_JSON*.h` (auto-generated raw-string-literal headers)
- `include/gitrevision.h` (auto-generated)
- `include/miniz.h` (vendored)

## Files
- `.pre-commit-config.yaml` — adds the `local` clang-tidy hook stanza
- `dev/ci/run-clang-tidy-staged.sh` — wrapper script (executable)
- `dev/ci/README.md` — adds a "Running clang-tidy locally" section under the compile_commands.json subsection

## Test plan
- [x] No `clang-tidy` on `PATH` → wrapper exits 0 with skip message
- [x] No `compile_commands.json` → wrapper exits 0 with skip message
- [ ] After `cmake -G Ninja -B build -S .`, `pre-commit run --hook-stage manual --files src/CPstrings.cpp clang-tidy` produces the same diagnostics as `clang-tidy -p build src/CPstrings.cpp`

## Related
- Sibling PR for the CI side: #2798 (`CoolProp-2uw.5`, clang-tidy-diff workflow) — already merged
- Depends on #2789 (compile_commands.json always-on) — already merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)