### PR TITLE
fix: thread-safe lazy initialization of fluid libraries

### DIFF
--- a/src/Backends/Cubics/CubicsLibrary.cpp
+++ b/src/Backends/Cubics/CubicsLibrary.cpp
@@ -20,14 +20,45 @@ class CubicsLibraryClass
     /// Map from index of fluid to a string
     std::map<std::string, std::string> JSONstring_map;
     bool empty;  // Is empty
+
+    /// Schema-validate then parse a JSON blob and merge into this instance.
+    /// Used by the constructor (avoids recursing through the global singleton)
+    /// and by the free `add_fluids_as_JSON()` (operates on get_library()).
+    void _add_fluids_from_JSON_string(const std::string_view& JSON) {
+        std::string errstr;
+        cpjson::schema_validation_code val_code = cpjson::validate_schema(cubic_fluids_schema_JSON, JSON, errstr);
+        if (val_code == cpjson::SCHEMA_VALIDATION_OK) {
+            rapidjson::Document dd;
+            dd.Parse<0>(JSON.data(), JSON.size());
+            if (dd.HasParseError()) {
+                throw ValueError("Cubics JSON is not valid JSON");
+            } else {
+                try {
+                    this->add_many(dd);
+                } catch (std::exception& /* e */) {
+                    throw ValueError(format("Unable to load cubics library with error: %s", errstr.c_str()));
+                }
+            }
+        } else {
+            throw ValueError(format("Unable to validate cubics library against schema with error: %s", errstr.c_str()));
+        }
+    }
+
    public:
     CubicsLibraryClass() : empty(true) {
-        // This JSON formatted string comes from the all_cubics_JSON.h header which is a C++-escaped version of the JSON file
-        add_fluids_as_JSON(all_cubics_JSON);
+        // Populate via the private member to avoid recursing through
+        // get_library() while the singleton is still being built.
+        _add_fluids_from_JSON_string(all_cubics_JSON);
     };
     bool is_empty() {
         return empty;
     };
+
+    /// Public wrapper used by the free `add_fluids_as_JSON()` after construction.
+    void add_fluids_from_JSON_string(const std::string_view& JSON) {
+        _add_fluids_from_JSON_string(JSON);
+    }
+
     int add_many(rapidjson::Value& listing) {
         int counter = 0;
         for (rapidjson::Value::ValueIterator itr = listing.Begin(); itr != listing.End(); ++itr) {
@@ -138,42 +169,31 @@ class CubicsLibraryClass
         return strjoin(out, ",");
     }
 };
-static CubicsLibraryClass library;
+/// Function-local static (Meyers singleton). C++11 guarantees the
+/// constructor runs exactly once even under concurrent first calls. The
+/// previous namespace-scope `static CubicsLibraryClass library;` relied on
+/// single-threaded static init, which is fragile across translation-unit
+/// init order and dynamic-library load contexts (gh-2787).
+static CubicsLibraryClass& get_library() {
+    static CubicsLibraryClass library;
+    return library;
+}
 
 void add_fluids_as_JSON(const std::string_view& JSON) {
-    // First we validate the json string against the schema;
-    std::string errstr;
-    cpjson::schema_validation_code val_code = cpjson::validate_schema(cubic_fluids_schema_JSON, JSON, errstr);
-    // Then we check the validation code
-    if (val_code == cpjson::SCHEMA_VALIDATION_OK) {
-        rapidjson::Document dd;
-
-        dd.Parse<0>(JSON.data(), JSON.size());
-        if (dd.HasParseError()) {
-            throw ValueError("Cubics JSON is not valid JSON");
-        } else {
-            try {
-                library.add_many(dd);
-            } catch (std::exception& /* e */) {
-                throw ValueError(format("Unable to load cubics library with error: %s", errstr.c_str()));
-            }
-        }
-    } else {
-        throw ValueError(format("Unable to validate cubics library against schema with error: %s", errstr.c_str()));
-    }
+    get_library().add_fluids_from_JSON_string(JSON);
 }
 std::string get_fluid_as_JSONstring(const std::string& identifier) {
-    return library.get_JSONstring(identifier);
+    return get_library().get_JSONstring(identifier);
 }
 
 CubicLibrary::CubicsValues get_cubic_values(const std::string& identifier) {
-    return library.get(identifier);
+    return get_library().get(identifier);
 }
 std::string_view get_cubic_fluids_schema() {
     return cubic_fluids_schema_JSON;
 }
 std::string get_cubic_fluids_list() {
-    return library.get_fluids_list();
+    return get_library().get_fluids_list();
 }
 
 }  // namespace CubicLibrary

--- a/src/Backends/Cubics/CubicsLibrary.cpp
+++ b/src/Backends/Cubics/CubicsLibrary.cpp
@@ -21,44 +21,11 @@ class CubicsLibraryClass
     std::map<std::string, std::string> JSONstring_map;
     bool empty;  // Is empty
 
-    /// Schema-validate then parse a JSON blob and merge into this instance.
-    /// Used by the constructor (avoids recursing through the global singleton)
-    /// and by the free `add_fluids_as_JSON()` (operates on get_library()).
-    void _add_fluids_from_JSON_string(const std::string_view& JSON) {
-        std::string errstr;
-        cpjson::schema_validation_code val_code = cpjson::validate_schema(cubic_fluids_schema_JSON, JSON, errstr);
-        if (val_code == cpjson::SCHEMA_VALIDATION_OK) {
-            rapidjson::Document dd;
-            dd.Parse<0>(JSON.data(), JSON.size());
-            if (dd.HasParseError()) {
-                throw ValueError("Cubics JSON is not valid JSON");
-            } else {
-                try {
-                    this->add_many(dd);
-                } catch (std::exception& /* e */) {
-                    throw ValueError(format("Unable to load cubics library with error: %s", errstr.c_str()));
-                }
-            }
-        } else {
-            throw ValueError(format("Unable to validate cubics library against schema with error: %s", errstr.c_str()));
-        }
-    }
-
    public:
-    CubicsLibraryClass() : empty(true) {
-        // Populate via the private member to avoid recursing through
-        // get_library() while the singleton is still being built.
-        _add_fluids_from_JSON_string(all_cubics_JSON);
-    };
+    CubicsLibraryClass();
     bool is_empty() {
         return empty;
     };
-
-    /// Public wrapper used by the free `add_fluids_as_JSON()` after construction.
-    void add_fluids_from_JSON_string(const std::string_view& JSON) {
-        _add_fluids_from_JSON_string(JSON);
-    }
-
     int add_many(rapidjson::Value& listing) {
         int counter = 0;
         for (rapidjson::Value::ValueIterator itr = listing.Begin(); itr != listing.End(); ++itr) {
@@ -169,6 +136,37 @@ class CubicsLibraryClass
         return strjoin(out, ",");
     }
 };
+namespace {
+/// Schema-validate a JSON blob and merge it into the given library instance.
+/// File-private so the constructor can populate `*this` without going through
+/// the get_library() singleton (which would recurse into its own constructor).
+void add_fluids_from_JSON_string(CubicsLibraryClass& dest, const std::string_view& JSON) {
+    std::string errstr;
+    cpjson::schema_validation_code val_code = cpjson::validate_schema(cubic_fluids_schema_JSON, JSON, errstr);
+    if (val_code == cpjson::SCHEMA_VALIDATION_OK) {
+        rapidjson::Document dd;
+        dd.Parse<0>(JSON.data(), JSON.size());
+        if (dd.HasParseError()) {
+            throw ValueError("Cubics JSON is not valid JSON");
+        } else {
+            try {
+                dest.add_many(dd);
+            } catch (std::exception& /* e */) {
+                throw ValueError(format("Unable to load cubics library with error: %s", errstr.c_str()));
+            }
+        }
+    } else {
+        throw ValueError(format("Unable to validate cubics library against schema with error: %s", errstr.c_str()));
+    }
+}
+}  // anonymous namespace
+
+CubicsLibraryClass::CubicsLibraryClass() : empty(true) {
+    // Populate via the file-private helper so the constructor does NOT recurse
+    // through get_library() while the singleton is still being built.
+    add_fluids_from_JSON_string(*this, all_cubics_JSON);
+}
+
 /// Function-local static (Meyers singleton). C++11 guarantees the
 /// constructor runs exactly once even under concurrent first calls. The
 /// previous namespace-scope `static CubicsLibraryClass library;` relied on
@@ -180,7 +178,7 @@ static CubicsLibraryClass& get_library() {
 }
 
 void add_fluids_as_JSON(const std::string_view& JSON) {
-    get_library().add_fluids_from_JSON_string(JSON);
+    add_fluids_from_JSON_string(get_library(), JSON);
 }
 std::string get_fluid_as_JSONstring(const std::string& identifier) {
     return get_library().get_JSONstring(identifier);

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
@@ -1,6 +1,8 @@
 
 #include "FluidLibrary.h"
 
+#include <mutex>
+
 #include "Backends/Helmholtz/HelmholtzEOSBackend.h"
 #include "miniz.h"
 
@@ -24,6 +26,22 @@ INCBIN(all_fluids_JSON_z, "all_fluids.json.z");
 namespace CoolProp {
 
 static JSONFluidLibrary library;
+
+void load();
+
+// Thread-safe lazy initialization of the global fluid library. The
+// previous `if (library.is_empty()) load();` pattern races when multiple
+// threads hit a cold cache simultaneously — multiple threads see the
+// library empty, all call load() concurrently, and the resulting
+// concurrent inserts into string_to_index_map / fluid_map leave the
+// library partially populated (gh-2787). std::call_once ensures load()
+// runs exactly once even under concurrent first calls; if load() throws,
+// the flag is left unset and the next call will retry.
+static std::once_flag library_load_flag;
+
+static void ensure_library_loaded() {
+    std::call_once(library_load_flag, &load);
+}
 
 void load() {
     std::vector<unsigned char> outbuffer(gall_fluids_JSON_zSize * 7);
@@ -115,9 +133,7 @@ void JSONFluidLibrary::set_fluid_enthalpy_entropy_offset(const std::string& flui
 void JSONFluidLibrary::add_many(const std::string& JSON_string) {
 
     // First load all the baseline fluids
-    if (library.is_empty()) {
-        load();
-    }
+    ensure_library_loaded();
 
     // Then, load the fluids we would like to add
     rapidjson::Document doc;
@@ -357,37 +373,27 @@ void JSONFluidLibrary::add_one(rapidjson::Value& fluid_json) {
 };
 
 JSONFluidLibrary& get_library(void) {
-    if (library.is_empty()) {
-        load();
-    }
+    ensure_library_loaded();
     return library;
 }
 
 CoolPropFluid get_fluid(const std::string& fluid_string) {
-    if (library.is_empty()) {
-        load();
-    }
+    ensure_library_loaded();
     return library.get(fluid_string);
 }
 
 std::string get_fluid_as_JSONstring(const std::string& identifier) {
-    if (library.is_empty()) {
-        load();
-    }
+    ensure_library_loaded();
     return library.get_JSONstring(identifier);
 }
 
 std::string get_fluid_list(void) {
-    if (library.is_empty()) {
-        load();
-    }
+    ensure_library_loaded();
     return library.get_fluid_list();
 };
 
 void set_fluid_enthalpy_entropy_offset(const std::string& fluid, double delta_a1, double delta_a2, const std::string& ref) {
-    if (library.is_empty()) {
-        load();
-    }
+    ensure_library_loaded();
     library.set_fluid_enthalpy_entropy_offset(fluid, delta_a1, delta_a2, ref);
 }
 

--- a/src/Backends/Helmholtz/MixtureParameters.cpp
+++ b/src/Backends/Helmholtz/MixtureParameters.cpp
@@ -4,6 +4,8 @@
 #include "mixture_binary_pairs_JSON.h"         // Creates the variable mixture_binary_pairs_JSON
 #include "predefined_mixtures_JSON.h"          // Makes a std::string variable called predefined_mixtures_JSON
 
+#include <mutex>
+
 namespace CoolProp {
 
 /** \brief A library of predefined mixtures
@@ -84,6 +86,10 @@ class MixtureBinaryPairLibrary
    private:
     /// Map from sorted pair of CAS numbers to reducing parameter map.  The reducing parameter map is a map from key (string) to value (double)
     std::map<std::vector<std::string>, std::vector<Dictionary>> m_binary_pair_map;
+    /// Guards single-threaded population of m_binary_pair_map. Without it,
+    /// concurrent first calls to binary_pair_map() race in load_defaults()
+    /// (gh-2787).
+    std::once_flag m_load_flag;
 
    public:
     std::map<std::vector<std::string>, std::vector<Dictionary>>& binary_pair_map() {
@@ -102,9 +108,7 @@ class MixtureBinaryPairLibrary
     }
 
     void load_defaults_if_needed() {
-        if (m_binary_pair_map.size() == 0) {
-            load_defaults();
-        }
+        std::call_once(m_load_flag, [this] { load_defaults(); });
     }
 
     // Load the defaults that come from the JSON-encoded string compiled into library
@@ -407,6 +411,8 @@ class MixtureDepartureFunctionsLibrary
    private:
     /// Map from sorted pair of CAS numbers to departure term dictionary.
     std::map<std::string, Dictionary> m_departure_function_map;
+    /// Guards single-threaded population of m_departure_function_map.
+    std::once_flag m_load_flag;
 
    public:
     std::map<std::string, Dictionary>& departure_function_map() {
@@ -504,9 +510,7 @@ class MixtureDepartureFunctionsLibrary
         }
     }
     void load_defaults_if_needed() {
-        if (m_departure_function_map.size() == 0) {
-            load_defaults();
-        }
+        std::call_once(m_load_flag, [this] { load_defaults(); });
     }
     // Load the defaults that come from the JSON-encoded string compiled into library
     // as the variable mixture_departure_functions_JSON

--- a/src/Backends/Incompressible/IncompressibleLibrary.cpp
+++ b/src/Backends/Incompressible/IncompressibleLibrary.cpp
@@ -5,6 +5,8 @@
 #include "rapidjson_include.h"
 #include "all_incompressibles_JSON.h"  // Makes a std::string variable called all_incompressibles_JSON
 
+#include <mutex>
+
 namespace CoolProp {
 
 ///// Class to access Lithium-Bromide solutions
@@ -539,6 +541,16 @@ IncompressibleFluid& JSONIncompressibleLibrary::get(std::size_t key) {
 
 static JSONIncompressibleLibrary library;
 
+void load_incompressible_library();
+
+// Thread-safe lazy initialization — see FluidLibrary.cpp for the same pattern
+// and rationale (gh-2787).
+static std::once_flag library_load_flag;
+
+static void ensure_library_loaded() {
+    std::call_once(library_load_flag, &load_incompressible_library);
+}
+
 void load_incompressible_library() {
     rapidjson::Document dd;
     // This json formatted string comes from the all_incompressibles_JSON.h header which is a C++-escaped version of the JSON file
@@ -557,29 +569,21 @@ void load_incompressible_library() {
 }
 
 JSONIncompressibleLibrary& get_incompressible_library(void) {
-    if (library.is_empty()) {
-        load_incompressible_library();
-    }
+    ensure_library_loaded();
     return library;
 }
 
 IncompressibleFluid& get_incompressible_fluid(const std::string& fluid_string) {
-    if (library.is_empty()) {
-        load_incompressible_library();
-    }
+    ensure_library_loaded();
     return library.get(fluid_string);
 }
 
 std::string get_incompressible_list_pure(void) {
-    if (library.is_empty()) {
-        load_incompressible_library();
-    }
+    ensure_library_loaded();
     return library.get_incompressible_list_pure();
 };
 std::string get_incompressible_list_solution(void) {
-    if (library.is_empty()) {
-        load_incompressible_library();
-    }
+    ensure_library_loaded();
     return library.get_incompressible_list_solution();
 };
 

--- a/src/Backends/PCSAFT/PCSAFTLibrary.cpp
+++ b/src/Backends/PCSAFT/PCSAFTLibrary.cpp
@@ -23,15 +23,20 @@ void set_mixture_binary_pair_pcsaft(const std::string& CAS1, const std::string& 
 
 namespace PCSAFTLibrary {
 
-static PCSAFTLibraryClass library;
-
 PCSAFTLibraryClass& get_library(void) {
+    // Function-local static (Meyers singleton): C++11 guarantees the
+    // constructor runs exactly once even under concurrent first calls. The
+    // previous namespace-scope `static PCSAFTLibraryClass library;` relied on
+    // single-threaded static init, which is fragile across translation-unit
+    // init order and dynamic-library load contexts (gh-2787).
+    static PCSAFTLibraryClass library;
     return library;
 }
 
 PCSAFTLibraryClass::PCSAFTLibraryClass() : empty(true) {
-    // This JSON formatted string comes from the all_pcsaft_JSON.h header which is a C++-escaped version of the JSON file
-    add_fluids_as_JSON(all_pcsaft_JSON);
+    // Populate via a private member so the constructor does NOT recurse
+    // through get_library() while the singleton is still being built.
+    _add_fluids_from_JSON_string(all_pcsaft_JSON);
 
     // Then we add the library of binary interaction parameters
     if (m_binary_pair_map.size() == 0) {
@@ -66,7 +71,7 @@ PCSAFTFluid& PCSAFTLibraryClass::get(std::size_t key) {
     }
 };
 
-void add_fluids_as_JSON(const std::string_view& JSON) {
+void PCSAFTLibraryClass::_add_fluids_from_JSON_string(const std::string_view& JSON) {
     // First we validate the json string against the schema;
     std::string errstr;
     cpjson::schema_validation_code val_code = cpjson::validate_schema(pcsaft_fluids_schema_JSON, JSON, errstr);
@@ -80,7 +85,7 @@ void add_fluids_as_JSON(const std::string_view& JSON) {
             throw ValueError("Unable to load all_pcsaft_JSON.json");
         } else {
             try {
-                library.add_many(dd);
+                this->add_many(dd);
             } catch (std::exception& e) {
                 std::cout << e.what() << std::endl;
             }
@@ -90,6 +95,10 @@ void add_fluids_as_JSON(const std::string_view& JSON) {
             throw ValueError(format("Unable to load PC-SAFT library with error: %s", errstr.c_str()));
         }
     }
+}
+
+void add_fluids_as_JSON(const std::string_view& JSON) {
+    get_library().add_fluids_from_JSON_string(JSON);
 }
 
 int PCSAFTLibraryClass::add_many(rapidjson::Value& listing) {

--- a/src/Backends/PCSAFT/PCSAFTLibrary.cpp
+++ b/src/Backends/PCSAFT/PCSAFTLibrary.cpp
@@ -23,6 +23,33 @@ void set_mixture_binary_pair_pcsaft(const std::string& CAS1, const std::string& 
 
 namespace PCSAFTLibrary {
 
+namespace {
+/// Schema-validate a JSON blob and merge it into the given library instance.
+/// File-private so the constructor can populate `*this` without going through
+/// the get_library() singleton (which would recurse into its own constructor).
+void add_fluids_from_JSON_string(PCSAFTLibraryClass& dest, const std::string_view& JSON) {
+    std::string errstr;
+    cpjson::schema_validation_code val_code = cpjson::validate_schema(pcsaft_fluids_schema_JSON, JSON, errstr);
+    if (val_code == cpjson::SCHEMA_VALIDATION_OK) {
+        rapidjson::Document dd;
+        dd.Parse<0>(JSON.data(), JSON.size());
+        if (dd.HasParseError()) {
+            throw ValueError("Unable to load all_pcsaft_JSON.json");
+        } else {
+            try {
+                dest.add_many(dd);
+            } catch (std::exception& e) {
+                std::cout << e.what() << std::endl;
+            }
+        }
+    } else {
+        if (get_debug_level() > 0) {
+            throw ValueError(format("Unable to load PC-SAFT library with error: %s", errstr.c_str()));
+        }
+    }
+}
+}  // anonymous namespace
+
 PCSAFTLibraryClass& get_library(void) {
     // Function-local static (Meyers singleton): C++11 guarantees the
     // constructor runs exactly once even under concurrent first calls. The
@@ -34,9 +61,9 @@ PCSAFTLibraryClass& get_library(void) {
 }
 
 PCSAFTLibraryClass::PCSAFTLibraryClass() : empty(true) {
-    // Populate via a private member so the constructor does NOT recurse
+    // Populate via the file-private helper so the constructor does NOT recurse
     // through get_library() while the singleton is still being built.
-    _add_fluids_from_JSON_string(all_pcsaft_JSON);
+    add_fluids_from_JSON_string(*this, all_pcsaft_JSON);
 
     // Then we add the library of binary interaction parameters
     if (m_binary_pair_map.size() == 0) {
@@ -71,34 +98,8 @@ PCSAFTFluid& PCSAFTLibraryClass::get(std::size_t key) {
     }
 };
 
-void PCSAFTLibraryClass::_add_fluids_from_JSON_string(const std::string_view& JSON) {
-    // First we validate the json string against the schema;
-    std::string errstr;
-    cpjson::schema_validation_code val_code = cpjson::validate_schema(pcsaft_fluids_schema_JSON, JSON, errstr);
-    // Then we check the validation code
-
-    if (val_code == cpjson::SCHEMA_VALIDATION_OK) {
-        rapidjson::Document dd;
-
-        dd.Parse<0>(JSON.data(), JSON.size());
-        if (dd.HasParseError()) {
-            throw ValueError("Unable to load all_pcsaft_JSON.json");
-        } else {
-            try {
-                this->add_many(dd);
-            } catch (std::exception& e) {
-                std::cout << e.what() << std::endl;
-            }
-        }
-    } else {
-        if (get_debug_level() > 0) {
-            throw ValueError(format("Unable to load PC-SAFT library with error: %s", errstr.c_str()));
-        }
-    }
-}
-
 void add_fluids_as_JSON(const std::string_view& JSON) {
-    get_library().add_fluids_from_JSON_string(JSON);
+    add_fluids_from_JSON_string(get_library(), JSON);
 }
 
 int PCSAFTLibraryClass::add_many(rapidjson::Value& listing) {

--- a/src/Backends/PCSAFT/PCSAFTLibrary.h
+++ b/src/Backends/PCSAFT/PCSAFTLibrary.h
@@ -28,18 +28,8 @@ class PCSAFTLibraryClass
     void load_from_JSON(rapidjson::Document& doc);
     void load_from_string(const std::string_view& str);
 
-    /// Schema-validate then parse a JSON blob and merge into this instance.
-    /// Called from the constructor to avoid recursing through the global
-    /// singleton during its own construction.
-    void _add_fluids_from_JSON_string(const std::string_view& JSON);
-
    public:
     PCSAFTLibraryClass();
-
-    /// Public wrapper used by the free `add_fluids_as_JSON()` after construction.
-    void add_fluids_from_JSON_string(const std::string_view& JSON) {
-        _add_fluids_from_JSON_string(JSON);
-    }
 
     bool is_empty() {
         return empty;

--- a/src/Backends/PCSAFT/PCSAFTLibrary.h
+++ b/src/Backends/PCSAFT/PCSAFTLibrary.h
@@ -28,8 +28,18 @@ class PCSAFTLibraryClass
     void load_from_JSON(rapidjson::Document& doc);
     void load_from_string(const std::string_view& str);
 
+    /// Schema-validate then parse a JSON blob and merge into this instance.
+    /// Called from the constructor to avoid recursing through the global
+    /// singleton during its own construction.
+    void _add_fluids_from_JSON_string(const std::string_view& JSON);
+
    public:
     PCSAFTLibraryClass();
+
+    /// Public wrapper used by the free `add_fluids_as_JSON()` after construction.
+    void add_fluids_from_JSON_string(const std::string_view& JSON) {
+        _add_fluids_from_JSON_string(JSON);
+    }
 
     bool is_empty() {
         return empty;

--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -5,6 +5,7 @@
 #endif
 
 #include <memory>
+#include <mutex>
 using std::shared_ptr;
 
 #include "HumidAirProp.h"
@@ -87,15 +88,17 @@ double _HAPropsSI_outputs(givens OuputType, double p, double T, double psi_w);
 double MoleFractionWater(double, double, int, double);
 
 void check_fluid_instantiation() {
-    if (!Water.get()) {
+    // Lazy init of the Water/Air backends needs to be thread-safe — without
+    // std::call_once, two threads concurrently entering HAPropsSI on a cold
+    // cache both observed null and both reset the shared_ptr, with the late
+    // assignment destroying the in-flight backend the other thread was using
+    // (gh-2787).
+    static std::once_flag flag;
+    std::call_once(flag, [] {
         Water.reset(new CoolProp::HelmholtzEOSBackend("Water"));
-    }
-    if (!WaterIF97.get()) {
         WaterIF97.reset(CoolProp::AbstractState::factory("IF97", "Water"));
-    }
-    if (!Air.get()) {
         Air.reset(new CoolProp::HelmholtzEOSBackend("Air"));
-    }
+    });
 };
 
 static double epsilon = 0.621945, R_bar = 8.314472;


### PR DESCRIPTION
Closes #2787.

## Summary

Five global singletons in CoolProp lazy-load JSON-encoded data on first access without synchronization. Multiple threads concurrently hitting a cold cache all see the singleton empty, all run the `load()` path, and the resulting concurrent inserts into the underlying `std::map` / `std::vector` race.

The visible symptom is a partially populated library — `FluidsList` comes back as `"D4,D4,D4,D4,R125"` or `"IsoButene,IsoButene,IsoButene,IsoButene"`, and any subsequent `get("Water")` (etc.) fails with `key [Water] was not found in string_to_index_map in JSONFluidLibrary`. Triggers reliably from cargo's default-parallel test runner in `wrappers/GUI/src-tauri/` on macOS (Apple Silicon) and ubuntu-22.04; full repro in #2787.

## Fix

Wraps each lazy-init path in `std::call_once` with a local `std::once_flag`:

- `src/Backends/Helmholtz/Fluids/FluidLibrary.cpp` — file-scope flag covering `get_library`, `get_fluid`, `get_fluid_as_JSONstring`, `get_fluid_list`, `set_fluid_enthalpy_entropy_offset`, and the public `add_many(string)` overload. Six `if (library.is_empty()) load();` sites collapsed into a single `ensure_library_loaded()` helper.
- `src/Backends/Incompressible/IncompressibleLibrary.cpp` — same shape, four accessors.
- `src/Backends/Helmholtz/MixtureParameters.cpp` — `MixtureBinaryPairLibrary` and `MixtureDepartureFunctionsLibrary` each get a per-instance `std::once_flag` member that their existing `load_defaults_if_needed()` now routes through.
- `src/HumidAirProp.cpp` — `check_fluid_instantiation()` now runs the `Water` / `WaterIF97` / `Air` shared_ptr resets inside `std::call_once`. Without it two threads observed null, both reset the shared_ptr, and the late assignment destroyed the in-flight backend the other thread was using.

`std::call_once` retries on exception, so the previous retry-on-failed-load behavior is preserved (a parse error in `load()` leaves the flag unset and the next caller tries again).

## Verification

Cargo's default-parallel test runner against the new GUI Rust binary in `wrappers/GUI/src-tauri/` went from **5 passed; 12 failed** to **17 passed; 0 failed**. The `--test-threads=1` workaround currently in `.github/workflows/gui_builder.yml` (not on master yet) becomes unnecessary once this lands.

## Out of scope (follow-ups)

The audit found two more thread-safety issues that warrant separate PRs:

- Static-init-time races in `PCSAFTLibrary` / `CubicsLibrary` constructors — populate the map in the constructor, technically safe in single-threaded static-init but fragile in dynamic-library contexts.
- Concurrent `TabularDataLibrary::data` map insertion in `src/Backends/Tabular/TabularBackends.cpp` — different pattern (map insert race rather than singleton-init race), needs a per-key mutex.

## Test plan

- [x] Local: `cargo test --release` (default parallel) on macOS arm64 — 17 passed.
- [ ] CI: Catch2 / library_shared / Python cibuildwheel suites stay green.