### PR TITLE
ci(clang-tidy): document informational-by-design

### DIFF
--- a/.github/workflows/dev_clangtidy.yml
+++ b/.github/workflows/dev_clangtidy.yml
@@ -1,15 +1,17 @@
-name: Development clang-tidy (diff-only)
+name: Development clang-tidy (diff-only, informational)
 
-# Runs clang-tidy on lines changed in the PR via clang-tidy-diff.py.
-# This avoids drowning PR authors in the legacy 937KLOC warning backlog
-# while enforcing the strict .clang-tidy config (WarningsAsErrors: '*')
-# on new code.
+# Runs clang-tidy on lines changed in the PR via clang-tidy-diff.py and
+# uploads the report as an artifact. Informational by design: never gates
+# a PR. Empirical noise survey on representative src/ files (Solvers.cpp,
+# CPstrings.cpp, HelmholtzEOSMixtureBackend.cpp) showed the strict
+# .clang-tidy config (WarningsAsErrors: '*') would surface a high-volume
+# cascade — mostly misc-include-cleaner / misc-const-correctness /
+# readability-isolate-declaration noise — on virtually every PR touching
+# src/, before any meaningful bug-finding signal could be acted on.
 #
-# ROLLOUT NOTE (CoolProp-2uw.5): currently warning-only via
-# `continue-on-error: true` so we can observe what surfaces on real PRs
-# before flipping it to a gate. Once the noise level is validated, drop
-# the continue-on-error and the workflow will block PRs with violations
-# on touched lines (which is the eventual design intent).
+# Both the `continue-on-error` on the run step and `if: always()` on the
+# upload are load-bearing: they keep this workflow informational across
+# every code path.
 
 on:
   pull_request:
@@ -59,7 +61,7 @@ jobs:
           echo "Using: $path"
 
       - name: Run clang-tidy-diff on PR-touched lines
-        continue-on-error: true   # ROLLOUT: flip after validation
+        continue-on-error: true   # informational by design — see top-of-file
         shell: bash
         run: |
           BASE_SHA="${{ github.event.pull_request.base.sha }}"

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -107,6 +107,13 @@ they exist to surface signal, not to gate.
 - **cppcheck** (`.github/workflows/dev_cppcheck.yml`) — uploads a colorized
   cppcheck report. Run locally with `cppcheck --std=c++17 ./src` after
   `apt install cppcheck`.
+- **clang-tidy diff** (`.github/workflows/dev_clangtidy.yml`) — runs
+  `clang-tidy-diff.py` on PR-touched lines and uploads
+  `clang-tidy-diff.log`. Empirical noise survey on representative `src/`
+  files showed the strict `.clang-tidy` config produces a high cascade
+  of `misc-include-cleaner` / `misc-const-correctness` /
+  `readability-isolate-declaration` warnings before any meaningful
+  bug-finding signal — informational by design, no plans to gate.
 - **CodeQL** (`.github/workflows/dev_codeql.yml`) — runs the
   `security-and-quality` query suite on every PR. Findings appear in the
   repo's Security tab.
@@ -114,6 +121,8 @@ they exist to surface signal, not to gate.
   (twice weekly) due to free-tier quota. The workflow uploads
   `coverity-defects.json` (machine-readable) for AI-agent consumption;
   see also the Coverity Scan web UI for the curated view.
+- **IWYU** (`.github/workflows/dev_iwyu.yml`) — runs include-what-you-use
+  via the `COOLPROP_IWYU` CMake opt-in and uploads `iwyu.log`.
 - **AddressSanitizer** (`.github/workflows/dev_asan.yml`) — full Catch test
   suite under ASan on every PR. This one *does* fail builds, since memory
   bugs are real bugs.
@@ -123,6 +132,4 @@ they exist to surface signal, not to gate.
 These will land as the `CoolProp-2uw` epic progresses; cross-references
 will be added here as each lands:
 
-- clang-tidy diff-only PR check (Tier 2.1, `CoolProp-2uw.5`)
-- IWYU report artifact (Tier 3.4, `CoolProp-2uw.11`)
 - `.git-blame-ignore-revs` for the one-shot reformat (Tier 4.1, `CoolProp-2uw.12`)


### PR DESCRIPTION
## Summary
The clang-tidy-diff workflow shipped in #2798 with `continue-on-error: true` and a "ROLLOUT NOTE" implying we'd flip it to gating once noise was characterised.

Empirical survey (run inside Ubuntu 24.04 with apt clang-tidy-18 against the actual `compile_commands.json`, on `src/Solvers.cpp` / `CPstrings.cpp` / `HelmholtzEOSMixtureBackend.cpp`) showed that under the current `.clang-tidy` config + `WarningsAsErrors: '*'`:

- ~60% of warnings are style noise: `misc-include-cleaner` (every transitive include surfaces as an error), `misc-const-correctness` (locals that could be `const`), `readability-isolate-declaration` (`int a, b;` style)
- ~30% are useful modernization (deprecated-headers, modernize-*) — auto-fixable, ideal for the `2uw.13` cleanup pass
- ~10% are real-bug-adjacent (`cppcoreguidelines-init-variables`, narrowing-conversions)

Virtually every PR touching `src/` would fail diff-only gating because of `misc-include-cleaner` alone (e.g. any line that uses `std::abs`, `Eigen::VectorXd`, `_HUGE` flags as an error).

**Decision: keep clang-tidy-diff informational.** This commit makes that the documented design, not a transitional state.

## Changes
- `dev_clangtidy.yml`:
  - Rename `(diff-only)` → `(diff-only, informational)`
  - Rewrite the top-of-file rationale; drop the "flip after validation" TODO
  - Annotate the `continue-on-error: true` line as load-bearing
- `dev/ci/README.md`:
  - Move clang-tidy + IWYU into the "Other CI tooling (warning-only)" listing so they're discoverable next to cppcheck / CodeQL / Coverity
  - Drop the now-stale "Future tooling" entries for `2uw.5` and `2uw.11` (both shipped)

## Out of scope (could be follow-ups, only if you want)
- Tuning `.clang-tidy` to disable `misc-include-cleaner` / `misc-const-correctness` / `readability-isolate-declaration` — would make the artifact more useful by lowering noise. Skip if the current artifact is fine for AI-agent consumption.
- Tightening to `bugprone-*` + `cppcoreguidelines-*` only for an even cleaner signal.

## Test plan
- [ ] CI run on this PR passes (no functional change to the workflow other than comments)
- [ ] After merge, the doc accurately describes the eight CI workflows under `.github/workflows/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)