### PR TITLE
ci(clang-tidy): switch to high-signal whitelist (CoolProp-2uw)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,82 +1,70 @@
 ---
 
-# magic numbers are useful to layout stuff in Qt...
-#  -readability-magic-numbers and its alias cppcoreguidelines-avoid-magic-numbers
-
-# `protected`: followed by `protected slots:` would trigger it
-#  -readability-redundant-access-specifiers,
-
-# Problem with OS_ASSERT macro
-#  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
-
-# We use raw pointers for Qt, since usually the memory is then owned by the parent
-#  -cppcoreguidelines-owning-memory
-
-# Because of Google Tests
-#  -cppcoreguidelines-avoid-non-const-global-variables
-
-# I don't think this really helps clarify the intent
-#  -readability-else-after-return
-#  -modernize-concat-nested-namespaces
-
-# Aliases
-# - cppcoreguidelines-avoid-c-arrays => modernize-avoid-c-arrays
-# - cppcoreguidelines-non-private-member-variables-in-classes => misc-non-private-member-variables-in-classes
-# - cppcoreguidelines-explicit-virtual-functions, hicpp-use-override => modernize-use-override
-# - bugprone-narrowing-conversions => cppcoreguidelines-narrowing-conversions
-
-# Annoying: some config options exist only in later versions...
-# cppcoreguidelines-narrowing-conversions.WarnOnEquivalentBitWidth was added in clang-tidy 13, and that would allow avoiding uint->int narrowing conversions
-# Instead I have to disable the entire check...
+# Tuned for high signal-to-noise on a 937KLOC mature codebase (CoolProp-2uw).
+#
+# Whitelist mode: enable the bug-finding + modernization + perf categories
+# only, then preserve the project's accumulated suppress list within those.
+#
+# An empirical noise survey on representative src/ files (Solvers.cpp,
+# CPstrings.cpp, HelmholtzEOSMixtureBackend.cpp) showed the previous
+# "Checks: *, -<dropped>" pattern produced ~60% style/include-hygiene
+# noise (misc-include-cleaner, misc-const-correctness,
+# readability-isolate-declaration, etc.) before any bug-finding signal
+# could be acted on. Switched to a positive whitelist of high-signal
+# categories. The clang-tidy CI workflow (dev_clangtidy.yml) is
+# informational-only, so this config defines what gets surfaced as
+# "interesting" in the artifact.
+#
+# Per-category notes (from prior incarnation of this file):
+#   -cppcoreguidelines-pro-bounds-array-to-pointer-decay : breaks OS_ASSERT
+#   -cppcoreguidelines-owning-memory : we use raw pointers under Qt parent
+#   -cppcoreguidelines-avoid-non-const-global-variables : Google Tests
+#   -modernize-concat-nested-namespaces : doesn't clarify intent
+#   -modernize-use-override : project uses override+final via macros
+#   -cppcoreguidelines-narrowing-conversions / -bugprone-narrowing-conversions :
+#       WarnOnEquivalentBitWidth was added in clang-tidy 13; without it
+#       the check is too noisy on uint→int conversions, so disabled
+#   Aliases (one suppression covers both):
+#     cppcoreguidelines-avoid-c-arrays = modernize-avoid-c-arrays
+#     cppcoreguidelines-non-private-member-variables-in-classes
+#       = misc-non-private-member-variables-in-classes
+#     cppcoreguidelines-explicit-virtual-functions, hicpp-use-override
+#       = modernize-use-override
+#     bugprone-narrowing-conversions = cppcoreguidelines-narrowing-conversions
 
 Checks: |
-  *,
-  -fuchsia-*,
-  -google-*,
-  -zircon-*,
-  -abseil-*,
-  -llvm*,
-  -altera*,
-  -modernize-use-trailing-return-type,
-  -cppcoreguidelines-avoid-magic-numbers,
-  -readability-magic-numbers,
-  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
-  -cppcoreguidelines-owning-memory,
-  -cppcoreguidelines-pro-bounds-constant-array-index,
-  -readability-redundant-access-specifiers,
-  -cppcoreguidelines-explicit-virtual-functions,
-  -readability-else-after-return,
-  -modernize-concat-nested-namespaces,
-  -hicpp-*,
-  -hicpp-avoid-goto,
+  -*,
+  bugprone-*,
+  cert-*,
+  clang-analyzer-*,
+  cppcoreguidelines-*,
+  modernize-*,
+  performance-*,
+  readability-implicit-bool-conversion,
   hicpp-exception-baseclass,
   hicpp-multiway-paths-covered,
   hicpp-no-assembler,
   hicpp-signed-bitwise,
-  -cppcoreguidelines-avoid-c-arrays,
-  -cppcoreguidelines-non-private-member-variables-in-classes,
-  -bugprone-narrowing-conversions,
-  -cppcoreguidelines-narrowing-conversions,
-  -readability-function-cognitive-complexity,
-  -cppcoreguidelines-avoid-non-const-global-variables,
-  -modernize-use-override,
-  -readability-identifier-length,
   -bugprone-easily-swappable-parameters,
-  -readability-math-missing-parentheses,
+  -bugprone-narrowing-conversions,
+  -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-explicit-virtual-functions,
+  -cppcoreguidelines-narrowing-conversions,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -modernize-concat-nested-namespaces,
+  -modernize-use-override,
+  -modernize-use-trailing-return-type,
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: '*'
 FormatStyle:     file
 CheckOptions:
-  - key:             modernize-use-override.AllowOverrideAndFinal
-    value:           'true'
-  - key:             modernize-use-override.IgnoreDestructors
-    value:           'true'
   - key:             performance-for-range-copy.WarnOnAllAutoCopies
     value:           'true'
-  - key:             cppcoreguidelines-narrowing-conversions.WarnOnEquivalentBitWidth
-    value:           'false'
   - key:             readability-implicit-bool-conversion.AllowPointerConditions
-    value:           'true'
-  - key:             misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
     value:           'true'


### PR DESCRIPTION
## Summary
Tighten `.clang-tidy` from `Checks: '*, -<dropped>'` (everything-minus) to a positive whitelist of bug-finding + modernization + perf categories. The clang-tidy CI workflow is informational-only (per #2801), so this config defines what gets surfaced as "interesting" in the artifact — and previously most of it was style noise.

## Empirical before/after on representative src/ files

Same docker run as the survey for #2801, this time with the new config:

### `src/CPstrings.cpp`
| | Before | After |
|---|---|---|
| Warning count | 5+ | **1** |
| Categories | misc-include-cleaner, misc-use-internal-linkage, readability-isolate-declaration, readability-braces-around-statements, modernize-use-emplace | modernize-use-emplace (auto-fixable) |

### `src/Solvers.cpp`
| | Before | After |
|---|---|---|
| Warning count | 15+ (cascading) | **30** |
| Dominant category | misc-include-cleaner (Eigen::*, std::*, _HUGE, root_sum_square) | cppcoreguidelines-init-variables (×27) |
| Other | misc-const-correctness, readability-isolate-declaration | performance-avoid-endl (×2), modernize-deprecated-headers (×1) |

The 27× `cppcoreguidelines-init-variables` cluster is at solver entry points (lines 14, 109, 160, …) — uninitialized doubles in numerical code can cause non-deterministic results. **Real signal.**

## Whitelist categories
- `bugprone-*`, `cert-*`, `clang-analyzer-*`, `cppcoreguidelines-*`
- `modernize-*`, `performance-*`
- `readability-implicit-bool-conversion` (catches `if (n)` for integer `n`; pointer conditions already allowed via existing CheckOption)
- The project's `hicpp-*` survivors (exception-baseclass, multiway-paths-covered, no-assembler, signed-bitwise)

## Dropped categories (high noise on this codebase)
- `misc-*` — include-cleaner, const-correctness, use-internal-linkage
- `readability-*` (except implicit-bool-conversion) — isolate-declaration, braces-around-statements, use-concise-preprocessor-directives, etc.
- `portability-*`, `boost-*`, `fuchsia-*`, `google-*`, `zircon-*`, `abseil-*`, `llvm*`, `altera*` — irrelevant or noise

## Preserved
All existing per-check suppressions (narrowing-conversions noise, override macros, Qt raw pointers, Google Test global vars) are preserved verbatim within the whitelisted categories. Long-standing project knowledge stays intact.

## Cleaned up
Dropped dead `CheckOptions` for now-disabled checks: `modernize-use-override.*`, `cppcoreguidelines-narrowing-conversions.*`, `misc-non-private-member-variables-in-classes.*`.

## Test plan
- [ ] CI clang-tidy artifact for this PR contains far fewer entries than for prior PRs
- [ ] Categories are limited to bugprone-*, cppcoreguidelines-*, modernize-*, performance-*, hicpp-* survivors
- [ ] The 27 init-variables warnings on Solvers.cpp surface in the artifact (real signal we want)

## Related
- Sibling: #2801 documents informational-by-design rationale
- Open: #2799 (`2uw.6`, manual-stage clang-tidy pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)