### PR TITLE
chore: add .git-blame-ignore-revs for the whole-repo reformat (CoolProp-2uw.12)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,10 @@
+# SHAs of pure-formatting / mechanical commits that `git blame` should
+# look through. Per-clone opt-in:
+#
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# GitHub's blame view honours this file automatically — no setup needed
+# in the web UI.
+
+# Whole-repo clang-format pass over src/ + include/ (CoolProp-2uw.12, PR #2803)
+6d2eb695ee8c15de5ef0daee58869db772e42fd7

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -139,6 +139,12 @@ cmake --build build --target format         # apply clang-format -i in place
 
 CI's `dev_clangformat.yml` workflow runs the same `clang-format` against PR-touched files and fails the build on any diff. Full contributor doc: [`dev/ci/README.md`](../dev/ci/README.md).
 
+The repo also ships a `.git-blame-ignore-revs` file listing SHAs of pure-formatting commits (the one-shot reformat). Opt in once per clone so `git blame` looks through them:
+
+```bash
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
 ### Git Commit Messages
 
 * Use the present tense ("Add feature" not "Added feature")

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -151,9 +151,16 @@ they exist to surface signal, not to gate.
   suite under ASan on every PR. This one *does* fail builds, since memory
   bugs are real bugs.
 
-## Future tooling
+## `git blame` and the one-shot reformat
 
-These will land as the `CoolProp-2uw` epic progresses; cross-references
-will be added here as each lands:
+The repo's `.git-blame-ignore-revs` lists SHAs of pure-formatting / mechanical
+commits (the whole-repo clang-format pass in PR #2803, plus future
+`clang-tidy --fix` passes). To make local `git blame` skip them, opt in
+once per clone:
 
-- `.git-blame-ignore-revs` for the one-shot reformat (Tier 4.1, `CoolProp-2uw.12`)
+```bash
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+GitHub's blame view honours this file automatically — no setup needed in the
+web UI.


### PR DESCRIPTION
## Summary
Small follow-up to #2803 (the whole-repo clang-format pass). Adds `.git-blame-ignore-revs` at the repo root listing the squash SHA of #2803:

\`\`\`
6d2eb695ee8c15de5ef0daee58869db772e42fd7
\`\`\`

So `git blame` can look through pure-formatting commits when contributors opt in once per clone:

\`\`\`bash
git config blame.ignoreRevsFile .git-blame-ignore-revs
\`\`\`

GitHub's blame view honours this file automatically — no setup needed in the web UI.

## Docs
- `dev/ci/README.md`: replaces the "Future tooling" stub for `2uw.12` with a "git blame and the one-shot reformat" section explaining the opt-in.
- `.github/CONTRIBUTING.md`: brief note appended to the C++ formatting Styleguides section.

## Future
`CoolProp-2uw.13` (Tier 4.2) `clang-tidy --fix` passes will append their own SHAs to this file as they land.

## Related
- Implements the second half of `CoolProp-2uw.12`
- Follows: #2803 (the reformat itself)
- Next: `CoolProp-2uw.13` (safe `clang-tidy --fix` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)