### PR TITLE
refactor: apply safe clang-tidy --fix passes (CoolProp-2uw.13, part 1)

### DIFF
--- a/include/rapidjson_include.h
+++ b/include/rapidjson_include.h
@@ -220,7 +220,7 @@ inline std::vector<std::string> get_string_array(const rapidjson::Value& v) {
         throw CoolProp::ValueError("input is not an array");
     }
     for (rapidjson::Value::ConstValueIterator itr = v.Begin(); itr != v.End(); ++itr) {
-        out.push_back(itr->GetString());
+        out.emplace_back(itr->GetString());
     }
     return out;
 };

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -78,7 +78,7 @@ void CoolProp::AbstractCubicBackend::set_alpha0_from_components() {
 
     for (std::size_t i = 0; i < N; ++i) {
         CoolPropFluid fld;
-        fld.EOSVector.push_back(EquationOfState());
+        fld.EOSVector.emplace_back();
         fld.EOS().alpha0 = components[i].alpha0;
         _components.push_back(fld);
     }

--- a/src/Backends/Cubics/CubicBackend.h
+++ b/src/Backends/Cubics/CubicBackend.h
@@ -360,7 +360,7 @@ class CubicResidualHelmholtz : public ResidualHelmholtz
 
    public:
     CubicResidualHelmholtz() {
-        ACB = NULL;
+        ACB = nullptr;
     };
     CubicResidualHelmholtz(AbstractCubicBackend* ACB) : ACB(ACB) {};
 

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.h
@@ -1244,8 +1244,8 @@ class JSONFluidLibrary
         } else {
             // Here we check for the use of a cubic Helmholtz energy transformation for a multi-fluid model
             std::vector<std::string> endings;
-            endings.push_back("-SRK");
-            endings.push_back("-PengRobinson");
+            endings.emplace_back("-SRK");
+            endings.emplace_back("-PengRobinson");
             for (std::vector<std::string>::const_iterator end = endings.begin(); end != endings.end(); ++end) {
                 if (endswith(key, *end)) {
                     std::string used_name = key.substr(0, key.size() - (*end).size());

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -35,7 +35,7 @@
 #include "MixtureParameters.h"
 #include "IdealCurves.h"
 #include "MixtureParameters.h"
-#include <stdlib.h>
+#include <cstdlib>
 
 static int deriv_counter = 0;
 

--- a/src/Backends/Helmholtz/MixtureParameters.cpp
+++ b/src/Backends/Helmholtz/MixtureParameters.cpp
@@ -765,10 +765,10 @@ void parse_HMX_BNC(const std::string& s, std::vector<REFPROP_binary_element>& BI
 
                 if (dep.Npower < 0) {  // Not extracted yet, let's do it now
                     // Extract the number of terms
-                    dep.Npower = static_cast<short>(strtol(bits[0].c_str(), NULL, 10));
-                    dep.Nterms_power = static_cast<short>(strtol(bits[1].c_str(), NULL, 10));
-                    dep.Nspecial = static_cast<short>(strtol(bits[3].c_str(), NULL, 10));
-                    dep.Nterms_special = static_cast<short>(strtol(bits[4].c_str(), NULL, 10));
+                    dep.Npower = static_cast<short>(strtol(bits[0].c_str(), nullptr, 10));
+                    dep.Nterms_power = static_cast<short>(strtol(bits[1].c_str(), nullptr, 10));
+                    dep.Nspecial = static_cast<short>(strtol(bits[3].c_str(), nullptr, 10));
+                    dep.Nterms_special = static_cast<short>(strtol(bits[4].c_str(), nullptr, 10));
                 } else {
                     dep.a.push_back(string2double(bits[0]));
                     dep.t.push_back(string2double(bits[1]));

--- a/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
+++ b/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
@@ -678,7 +678,7 @@ std::vector<std::pair<std::size_t, std::size_t>> PhaseEnvelopeRoutines::find_int
         }
 
         if (matched) {
-            intersections.push_back(std::pair<std::size_t, std::size_t>(i, i + 1));
+            intersections.emplace_back(i, i + 1);
         }
     }
     return intersections;

--- a/src/Backends/Helmholtz/VLERoutines.h
+++ b/src/Backends/Helmholtz/VLERoutines.h
@@ -366,7 +366,7 @@ class newton_raphson_twophase
     std::vector<SuccessiveSubstitutionStep> step_logger;
 
     newton_raphson_twophase()
-      : HEOS(NULL),
+      : HEOS(nullptr),
         imposed_variable(newton_raphson_twophase_options::NO_VARIABLE_IMPOSED),
         error_rms(_HUGE),
         rhomolar_liq(_HUGE),

--- a/src/Backends/Incompressible/IncompressibleFluid.cpp
+++ b/src/Backends/Incompressible/IncompressibleFluid.cpp
@@ -2,7 +2,7 @@
 #include "DataStructures.h"
 #include "IncompressibleFluid.h"
 #include "IncompressibleLibrary.h"
-#include "math.h"
+#include <cmath>
 #include "MatrixMath.h"
 #include "PolyMath.h"
 #include <Eigen/Core>

--- a/src/Backends/PCSAFT/PCSAFTBackend.cpp
+++ b/src/Backends/PCSAFT/PCSAFTBackend.cpp
@@ -1,9 +1,9 @@
 #include <vector>
 #include <string>
 #include <cmath>
-#include "math.h"
+#include <cmath>
 #include <Eigen/Dense>
-#include <stdlib.h>
+#include <cstdlib>
 
 #include "PCSAFTBackend.h"
 #include "Backends/Helmholtz/VLERoutines.h"

--- a/src/Backends/PCSAFT/PCSAFTFluid.cpp
+++ b/src/Backends/PCSAFT/PCSAFTFluid.cpp
@@ -1,7 +1,7 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <math.h>
+#include <cmath>
 
 #include "PCSAFTFluid.h"
 #include "rapidjson_include.h"

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -37,15 +37,15 @@ surface tension                 N/m
 #include "DataStructures.h"
 #include "AbstractState.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <optional>
 #include <string>
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <cassert>
 #include <memory>
 using std::shared_ptr;
-#include <stdlib.h>
+#include <cstdlib>
 
 #if defined(_MSC_VER)
 #    define _CRTDBG_MAP_ALLOC
@@ -226,7 +226,7 @@ bool REFPROPMixtureBackend::REFPROP_supported() {
      */
 
     // Abort check if Refprop has been loaded.
-    if (RefpropdllInstance != NULL) return true;
+    if (RefpropdllInstance != nullptr) return true;
 
     // Store result of previous check.
     if (_REFPROP_supported) {
@@ -1155,7 +1155,7 @@ void REFPROPMixtureBackend::calc_phase_envelope(const std::string& type) {
     */
     int N = 500;
     int isp = 0, iderv = -1;
-    if (SPLNVALdll == NULL) {
+    if (SPLNVALdll == nullptr) {
         std::string rpv = get_global_param_string("REFPROP_version");
         throw ValueError(
           format("Your version of REFFPROP(%s) does not have the SPLNVALdll function; cannot extract phase envelope values", rpv.c_str()));
@@ -2008,7 +2008,7 @@ void REFPROPMixtureBackend::update_with_guesses(CoolProp::input_pairs input_pair
 CoolPropDbl REFPROPMixtureBackend::call_phixdll(int itau, int idel) {
     this->check_loaded_fluid();
     double val = 0, tau = _tau, delta = _delta;
-    if (PHIXdll == NULL) {
+    if (PHIXdll == nullptr) {
         throw ValueError("PHIXdll function is not available in your version of REFPROP. Please upgrade");
     }
     PHIXdll(&itau, &idel, &tau, &delta, &(mole_fractions[0]), &val);
@@ -2017,7 +2017,7 @@ CoolPropDbl REFPROPMixtureBackend::call_phixdll(int itau, int idel) {
 CoolPropDbl REFPROPMixtureBackend::call_phi0dll(int itau, int idel) {
     this->check_loaded_fluid();
     double val = 0, tau = _tau, __T = T(), __rho = rhomolar() / 1000;
-    if (PHI0dll == NULL) {
+    if (PHI0dll == nullptr) {
         throw ValueError("PHI0dll function is not available in your version of REFPROP. Please upgrade");
     }
     PHI0dll(&itau, &idel, &__T, &__rho, &(mole_fractions[0]), &val);

--- a/src/Backends/Tabular/BicubicBackend.cpp
+++ b/src/Backends/Tabular/BicubicBackend.cpp
@@ -54,7 +54,7 @@ void CoolProp::BicubicBackend::find_nearest_neighbor(SinglePhaseGriddedTableData
 double CoolProp::BicubicBackend::evaluate_single_phase_transport(SinglePhaseGriddedTableData& table, parameters output, double x, double y,
                                                                  std::size_t i, std::size_t j) {
     // By definition i,i+1,j,j+1 are all in range and valid
-    std::vector<std::vector<double>>* f = NULL;
+    std::vector<std::vector<double>>* f = nullptr;
     switch (output) {
         case iconductivity:
             f = &table.cond;

--- a/src/Backends/Tabular/TabularBackends.cpp
+++ b/src/Backends/Tabular/TabularBackends.cpp
@@ -4,7 +4,7 @@
 #    include "TabularBackends.h"
 #    include "CoolProp.h"
 #    include <sstream>
-#    include "time.h"
+#    include <ctime>
 #    include "miniz.h"
 #    include <fstream>
 

--- a/src/CPfilepaths.cpp
+++ b/src/CPfilepaths.cpp
@@ -157,7 +157,7 @@ std::string get_separator(void) {
 std::string get_home_dir(void) {
 // See http://stackoverflow.com/questions/2552416/how-can-i-find-the-users-home-dir-in-a-cross-platform-manner-using-c
 #if defined(__ISLINUX__) || defined(__ISAPPLE__)
-    char* home = NULL;
+    char* home = nullptr;
     home = getenv("HOME");
 #    if defined(__ISAPPLE__)
     if (home == NULL) {
@@ -167,7 +167,7 @@ std::string get_home_dir(void) {
         }
     }
 #    endif
-    if (home == NULL) {
+    if (home == nullptr) {
         throw CoolProp::NotImplementedError("Could not detect home directory.");
     }
     return std::string(home);

--- a/src/CPstrings.cpp
+++ b/src/CPstrings.cpp
@@ -23,7 +23,7 @@ std::vector<std::string> strsplit(const std::string& s, char del) {
     std::string::const_iterator i1 = s.begin(), i2;
     while (true) {
         i2 = std::find(i1, s.end(), del);
-        v.push_back(std::string(i1, i2));
+        v.emplace_back(i1, i2);
         if (i2 == s.end()) break;
         i1 = i2 + 1;
     }

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -29,10 +29,10 @@
 #include <memory>
 
 #include <iostream>
-#include <stdlib.h>
+#include <cstdlib>
 #include <vector>
 #include <exception>
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 #include <locale>
 #include "CoolPropTools.h"

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -3,7 +3,7 @@
 #    define _CRT_SECURE_NO_WARNINGS
 #    include <crtdbg.h>
 #else
-#    include <fenv.h>
+#    include <cfenv>
 #endif
 
 #include "CoolPropLib.h"
@@ -11,7 +11,7 @@
 #include "HumidAirProp.h"
 #include "DataStructures.h"
 #include "Exceptions.h"
-#include "float.h"
+#include <cfloat>
 #include <memory>
 using std::shared_ptr;
 #include "AbstractState.h"
@@ -19,7 +19,7 @@ using std::shared_ptr;
 #include "Configuration.h"
 #include "Backends/Helmholtz/MixtureParameters.h"
 
-#include <string.h>
+#include <cstring>
 #include <mutex>
 
 void str2buf(const std::string& str, char* buf, int n) {

--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -18,11 +18,11 @@ using std::shared_ptr;
 #include "Configuration.h"
 
 #include <algorithm>  // std::next_permutation
-#include <stdlib.h>
-#include "math.h"
-#include "time.h"
-#include "stdio.h"
-#include <string.h>
+#include <cstdlib>
+#include <cmath>
+#include <ctime>
+#include <cstdio>
+#include <cstring>
 #include <iostream>
 #include <list>
 #include <IF97.h>

--- a/src/Ice.cpp
+++ b/src/Ice.cpp
@@ -1,6 +1,6 @@
 
 #ifndef __powerpc__
-#    include <math.h>
+#    include <cmath>
 #    include <complex>
 #    include <iostream>
 static std::complex<double> t1(0.368017112855051e-1, 0.510878114959572e-1);

--- a/src/MatrixMath.cpp
+++ b/src/MatrixMath.cpp
@@ -8,7 +8,7 @@
 #include <sstream>
 #include <vector>
 #include <numeric>
-#include <math.h>
+#include <cmath>
 
 namespace CoolProp {}; /* namespace CoolProp */
 

--- a/src/PolyMath.cpp
+++ b/src/PolyMath.cpp
@@ -8,7 +8,7 @@
 #include <string>
 //#include <sstream>
 //#include <numeric>
-#include <math.h>
+#include <cmath>
 #include <iostream>
 
 #include "Solvers.h"

--- a/src/Solvers.cpp
+++ b/src/Solvers.cpp
@@ -1,6 +1,6 @@
 #include <vector>
 #include "Solvers.h"
-#include "math.h"
+#include <cmath>
 #include "MatrixMath.h"
 #include <iostream>
 #include "CoolPropTools.h"

--- a/src/SpeedTest.cpp
+++ b/src/SpeedTest.cpp
@@ -4,7 +4,7 @@ using std::shared_ptr;
 #include "AbstractState.h"
 #include "DataStructures.h"
 
-#include <time.h>
+#include <ctime>
 
 // A hack to make powerpc happy since sysClkRateGet not found
 #if defined(__powerpc__)


### PR DESCRIPTION
## Summary
Tier 4.2 of the C++ code-quality epic (`CoolProp-2uw`), first installment. Mechanically applies the auto-fixable subset of three `modernize-*` checks via `run-clang-tidy --fix` in an Ubuntu 24.04 + clang-tidy-18 container.

## Checks applied
| Check | Raw diagnostics | What it does |
|---|---|---|
| `modernize-use-nullptr` | 21 | `NULL` / `0` → `nullptr` for pointer types |
| `modernize-use-emplace` | 53 | `push_back(T(args))` → `emplace_back(args)` |
| `modernize-deprecated-headers` | 24 | `<math.h>` → `<cmath>`, `<stdlib.h>` → `<cstdlib>`, `<stdio.h>` → `<cstdio>`, `<string.h>` → `<cstring>`, `<time.h>` → `<ctime>`, `<float.h>` → `<cfloat>`; quoted variants handled too |

> **Note**: the diagnostic counts are clang-tidy's raw output (some duplicated when a header is included from multiple TUs). The actual unique fixes are the **24-file +43/−43 diff** below.

Pure mechanical modernization. `cmake --build build --target format` ran after the tidy fixes; no formatting drift surfaced.

## What was deliberately skipped this round
**`cppcoreguidelines-init-variables`** (1058 raw diagnostics — would add `= NAN` to every uninitialized double). Two reasons:

1. **Header conflict**: the check's `MathHeader` option defaults to `<math.h>`, which `modernize-deprecated-headers` then immediately wants to remove. Running both together produced bogus diffs with `<math.h>` and `<cmath>` both included. Need to set `cppcoreguidelines-init-variables.MathHeader = <cmath>` in `.clang-tidy` first.
2. **Diff size + behavior change**: 1000+ NAN initializations is large enough to deserve its own focused review. NAN init is actually defensible (propagates as a tracer when reads happen before assignment) but worth reviewing per-call-site for solver paths.

Plan: small follow-up PR adds the `MathHeader = <cmath>` CheckOption, then a separate PR applies the init-variables fix cleanly.

## Verification
- All include changes are 1:1 swaps (43 insertions, 43 deletions; no orphaned includes)
- Format target run post-fix produced no additional drift
- ASan / build CI on this PR will validate compilation

## Follow-up
- Append the squash SHA of this PR to `.git-blame-ignore-revs` (separate small PR after merge)
- `cppcoreguidelines-init-variables.MathHeader = <cmath>` config tweak + the init-variables fix pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)