### PR TITLE
fix(cmake): IWYU wiring fires for both Main creation paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2047,14 +2047,6 @@ if(COOLPROP_MAIN_MODULE)
                                           "${COMPILE_FLAGS} -DENABLE_CATCH")
   endif()
 
-  if(COOLPROP_IWYU)
-    find_program(iwyu_path NAMES include-what-you-use iwyu)
-    if(NOT iwyu_path)
-      message(FATAL_ERROR "Could not find the program include-what-you-use")
-    endif()
-    set_property(TARGET Main PROPERTY CXX_INCLUDE_WHAT_YOU_USE ${iwyu_path})
-  endif()
-
   if(UNIX)
     target_link_libraries(Main ${CMAKE_DL_LIBS})
   endif()
@@ -2088,15 +2080,6 @@ if(COOLPROP_CATCH_MODULE)
     catch_discover_tests(CatchTestRunner DISCOVERY_MODE PRE_TEST)
   endif()
 
-  if(COOLPROP_IWYU)
-    find_program(iwyu_path NAMES include-what-you-use iwyu)
-    if(NOT iwyu_path)
-      message(FATAL_ERROR "Could not find the program include-what-you-use")
-    endif()
-    set_property(TARGET CatchTestRunner PROPERTY CXX_INCLUDE_WHAT_YOU_USE
-                                                 ${iwyu_path})
-  endif()
-  
   if(COOLPROP_LAZY_LOAD_SUPERANCILLARIES)
     target_compile_definitions(CatchTestRunner PRIVATE LAZY_LOAD_SUPERANCILLARIES)
   else()
@@ -2223,6 +2206,25 @@ endif()
 #include_directories("${CMAKE_CURRENT_SOURCE_DIR}/CoolProp")
 #FILE(GLOB coolprop_files "${CMAKE_CURRENT_SOURCE_DIR}/CoolProp/*.cpp")
 #add_library(coolprop STATIC ${coolprop_files})
+
+# include-what-you-use wiring (CoolProp-2uw.11). Placed at the bottom so it
+# fires after every target-creation path: Main is created either inside
+# `if(COOLPROP_MY_MAIN)` (used by CodeQL/Coverity/IWYU CI) or inside
+# `if(COOLPROP_MAIN_MODULE)`; CatchTestRunner inside `if(COOLPROP_CATCH_MODULE)`.
+# An earlier version of this wiring lived inside one of those conditionals
+# and silently no-op'd for the IWYU CI path.
+if(COOLPROP_IWYU)
+  find_program(iwyu_path NAMES include-what-you-use iwyu)
+  if(NOT iwyu_path)
+    message(FATAL_ERROR "Could not find the program include-what-you-use")
+  endif()
+  foreach(_iwyu_target Main CatchTestRunner)
+    if(TARGET ${_iwyu_target})
+      set_property(TARGET ${_iwyu_target} PROPERTY CXX_INCLUDE_WHAT_YOU_USE
+                                                   ${iwyu_path})
+    endif()
+  endforeach()
+endif()
 
 # clang-format developer targets (CoolProp-2uw.2)
 # Whole-tree mode over src/ + include/, mirroring dev/ci/clang-format.sh's


### PR DESCRIPTION
## Summary
The IWYU artifact uploaded by `dev_iwyu.yml` (`CoolProp-2uw.11`, merged in #2797) is **empty of IWYU diagnostics**. The 70-line `iwyu.log` is just `[N/50] Building CXX object …` ninja progress — no `should add these lines:` / `should remove these lines:` / `(no_includes_to_add)` from IWYU.

## Root cause
The `if(COOLPROP_IWYU)` block that calls `set_property(TARGET Main PROPERTY CXX_INCLUDE_WHAT_YOU_USE …)` lived inside `if(COOLPROP_MAIN_MODULE)`. But the workflow uses `-DCOOLPROP_MY_MAIN=dev/ci/main.cpp` — a **different** conditional block (lines 2025-2033 of `CMakeLists.txt`) that creates the `Main` target *without ever entering* the `COOLPROP_MAIN_MODULE` branch.

Result: `COOLPROP_IWYU` was passed to CMake but never read. Visible in the run log as:

\`\`\`
CMake Warning:
  Manually-specified variables were not used by the project:
    COOLPROP_IWYU
\`\`\`

A duplicate `if(COOLPROP_IWYU)` block lived inside `if(COOLPROP_CATCH_MODULE)` with the same scoping bug.

## Fix
Extract the IWYU wiring into a single top-level block at the bottom of `CMakeLists.txt`. It runs after every target-creation path and applies `CXX_INCLUDE_WHAT_YOU_USE` to whichever of `Main` / `CatchTestRunner` exists:

\`\`\`cmake
if(COOLPROP_IWYU)
  find_program(iwyu_path NAMES include-what-you-use iwyu)
  if(NOT iwyu_path)
    message(FATAL_ERROR "Could not find the program include-what-you-use")
  endif()
  foreach(_iwyu_target Main CatchTestRunner)
    if(TARGET ${_iwyu_target})
      set_property(TARGET ${_iwyu_target} PROPERTY CXX_INCLUDE_WHAT_YOU_USE
                                                   ${iwyu_path})
    endif()
  endforeach()
endif()
\`\`\`

Removes the two old in-conditional blocks (net diff: +19 / −17 lines).

## Test plan
- [ ] CI's `Development include-what-you-use` workflow run on this PR produces an `iwyu.log` artifact containing actual IWYU diagnostics (lines like `xxx.cpp should add these lines:` / `xxx.cpp should remove these lines:` / `(no_includes_to_add)`)
- [ ] No more `Manually-specified variables were not used by the project: COOLPROP_IWYU` warning in the configure step
- [ ] Local `cmake -DCOOLPROP_IWYU=ON -DCOOLPROP_CATCH_MODULE=ON ...` also works (CatchTestRunner gets the property)

🤖 Generated with [Claude Code](https://claude.com/claude-code)