### PR TITLE
chore: blame-revs append + clang-tidy MathHeader (CoolProp-2uw.13b)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -68,3 +68,8 @@ CheckOptions:
     value:           'true'
   - key:             readability-implicit-bool-conversion.AllowPointerConditions
     value:           'true'
+  # Use <cmath> rather than <math.h> when init-variables --fix injects NAN.
+  # Without this option clang-tidy adds <math.h>, which then conflicts with
+  # the modernize-deprecated-headers cleanup already merged in PR #2805.
+  - key:             cppcoreguidelines-init-variables.MathHeader
+    value:           '<cmath>'

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -8,3 +8,7 @@
 
 # Whole-repo clang-format pass over src/ + include/ (CoolProp-2uw.12, PR #2803)
 6d2eb695ee8c15de5ef0daee58869db772e42fd7
+
+# Safe clang-tidy --fix passes: modernize-use-nullptr, modernize-use-emplace,
+# modernize-deprecated-headers (CoolProp-2uw.13 part 1, PR #2805)
+ee879788a10365c13f812993c4db6e69cb2d51a7


### PR DESCRIPTION
## Summary

Two small chores bundled in one PR after CoolProp-2uw.13 part 1 (#2805) merged.

- **`.git-blame-ignore-revs`**: append squash SHA `ee879788` of PR #2805 (safe `clang-tidy --fix` passes — `modernize-use-nullptr`, `modernize-use-emplace`, `modernize-deprecated-headers`) so `git blame` walks through that mechanical churn. GitHub blame honours this automatically; per-clone opt-in for local CLI is documented in the file header.
- **`.clang-tidy`**: add `cppcoreguidelines-init-variables.MathHeader = <cmath>` CheckOption so the upcoming part-2 NAN-init pass injects `<cmath>` rather than `<math.h>` — matches the `modernize-deprecated-headers` cleanup already in tree (otherwise the two checks would round-trip on the same file).

No source code changes; no behavior change.

Closes CoolProp-86n. Sets up CoolProp-2uw.13 part 2 (focused PR for `cppcoreguidelines-init-variables --fix`).

## Test plan

- [x] `.git-blame-ignore-revs` parses (only valid-format SHA lines plus comments)
- [x] `.clang-tidy` YAML still parses (verified via `clang-tidy --dump-config`-equivalent inspection)
- [ ] CI green