### PR TITLE
refactor: cppcoreguidelines-init-variables --fix pass (CoolProp-2uw.13 part 2)

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -285,7 +285,7 @@ class Configuration
     Configuration() {
         set_defaults();
     };
-    ~Configuration() {};
+    ~Configuration(){};
 
     /// Get an item from the configuration
     ConfigurationItem& get_item(configuration_keys key) {
@@ -329,7 +329,7 @@ class Configuration
                     items.erase(key);
                     items.emplace(key, ConfigurationItem(key, std::string(envval)));
                     break;
-                case ConfigurationDataTypes::CONFIGURATION_INTEGER_TYPE:
+                case ConfigurationDataTypes::CONFIGURATION_INTEGER_TYPE: {
                     int i;
                     try {
                         i = std::stoi(envval);
@@ -342,7 +342,8 @@ class Configuration
                     items.erase(key);
                     items.emplace(key, ConfigurationItem(key, i));
                     break;
-                case ConfigurationDataTypes::CONFIGURATION_DOUBLE_TYPE:
+                }
+                case ConfigurationDataTypes::CONFIGURATION_DOUBLE_TYPE: {
                     double d;
                     try {
                         d = std::stod(envval);
@@ -355,7 +356,8 @@ class Configuration
                     items.erase(key);
                     items.emplace(key, ConfigurationItem(key, d));
                     break;
-                case ConfigurationDataTypes::CONFIGURATION_BOOL_TYPE:
+                }
+                case ConfigurationDataTypes::CONFIGURATION_BOOL_TYPE: {
                     bool b;
                     try {
                         b = tobool(envval);
@@ -368,9 +370,11 @@ class Configuration
                     items.erase(key);
                     items.emplace(key, ConfigurationItem(key, b));
                     break;
-                default:
+                }
+                default: {
                     auto skey = config_key_to_string(key);
                     throw ValueError("This key [" + skey + "] has the wrong type; value was " + std::string(envval) + " ");
+                }
             }
             return true;
         }

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -9,8 +9,8 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#include <cstdlib>
 #include <cmath>
+#include <cstdlib>
 #include "AbstractState.h"
 #include "DataStructures.h"
 #include "Backends/IF97/IF97Backend.h"
@@ -965,7 +965,7 @@ void get_dT_drho_second_derivatives(AbstractState& AS, int index, CoolPropDbl& d
     }
 }
 CoolPropDbl AbstractState::calc_first_partial_deriv(parameters Of, parameters Wrt, parameters Constant) {
-    CoolPropDbl dOf_dT, dOf_drho, dWrt_dT, dWrt_drho, dConstant_dT, dConstant_drho;
+    CoolPropDbl dOf_dT = NAN, dOf_drho = NAN, dWrt_dT = NAN, dWrt_drho = NAN, dConstant_dT = NAN, dConstant_drho = NAN;
 
     get_dT_drho(*this, Of, dOf_dT, dOf_drho);
     get_dT_drho(*this, Wrt, dWrt_dT, dWrt_drho);
@@ -974,9 +974,11 @@ CoolPropDbl AbstractState::calc_first_partial_deriv(parameters Of, parameters Wr
     return (dOf_dT * dConstant_drho - dOf_drho * dConstant_dT) / (dWrt_dT * dConstant_drho - dWrt_drho * dConstant_dT);
 }
 CoolPropDbl AbstractState::calc_second_partial_deriv(parameters Of1, parameters Wrt1, parameters Constant1, parameters Wrt2, parameters Constant2) {
-    CoolPropDbl dOf1_dT, dOf1_drho, dWrt1_dT, dWrt1_drho, dConstant1_dT, dConstant1_drho, d2Of1_dT2, d2Of1_drhodT, d2Of1_drho2, d2Wrt1_dT2,
-      d2Wrt1_drhodT, d2Wrt1_drho2, d2Constant1_dT2, d2Constant1_drhodT, d2Constant1_drho2, dWrt2_dT, dWrt2_drho, dConstant2_dT, dConstant2_drho, N, D,
-      dNdrho__T, dDdrho__T, dNdT__rho, dDdT__rho, dderiv1_drho, dderiv1_dT, second;
+    CoolPropDbl dOf1_dT = NAN, dOf1_drho = NAN, dWrt1_dT = NAN, dWrt1_drho = NAN, dConstant1_dT = NAN, dConstant1_drho = NAN, d2Of1_dT2 = NAN,
+                d2Of1_drhodT = NAN, d2Of1_drho2 = NAN, d2Wrt1_dT2 = NAN, d2Wrt1_drhodT = NAN, d2Wrt1_drho2 = NAN, d2Constant1_dT2 = NAN,
+                d2Constant1_drhodT = NAN, d2Constant1_drho2 = NAN, dWrt2_dT = NAN, dWrt2_drho = NAN, dConstant2_dT = NAN, dConstant2_drho = NAN,
+                N = NAN, D = NAN, dNdrho__T = NAN, dDdrho__T = NAN, dNdT__rho = NAN, dDdT__rho = NAN, dderiv1_drho = NAN, dderiv1_dT = NAN,
+                second = NAN;
 
     // First and second partials needed for terms involved in first derivative
     get_dT_drho(*this, Of1, dOf1_dT, dOf1_drho);

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -1,4 +1,6 @@
 #include "CubicBackend.h"
+
+#include <cmath>
 #include "Solvers.h"
 #include "Configuration.h"
 #include "Backends/Helmholtz/VLERoutines.h"
@@ -152,7 +154,7 @@ void CoolProp::AbstractCubicBackend::get_critical_point_search_radii(double& R_d
     CoolProp::HelmholtzEOSMixtureBackend::get_critical_point_search_radii(R_delta, R_tau);
 
     // Now we scale them to get the appropriate search radii
-    double Tr_GERGlike, rhor_GERGlike;
+    double Tr_GERGlike = NAN, rhor_GERGlike = NAN;
     get_linear_reducing_parameters(rhor_GERGlike, Tr_GERGlike);
     R_delta *= rhor_GERGlike / rhomolar_reducing() * 5;
     R_tau *= T_reducing() / Tr_GERGlike * 5;
@@ -184,7 +186,7 @@ void CoolProp::AbstractCubicBackend::get_critical_point_starting_values(double& 
     // delta0 = rho/rhor_GERG*(rhor_GERGlike/rhor_cubic)
     // tau0 = Tr_GERG/T*(Tr_cubic/Tr_GERGlike)
     //
-    double Tr_GERGlike, rhor_GERGlike;
+    double Tr_GERGlike = NAN, rhor_GERGlike = NAN;
     get_linear_reducing_parameters(rhor_GERGlike, Tr_GERGlike);
     delta0 *= rhor_GERGlike / rhomolar_reducing();
     tau0 *= T_reducing() / Tr_GERGlike;
@@ -366,13 +368,13 @@ class SaturationResidual : public CoolProp::FuncWrapper1D
     double imposed_variable;
     double deltaL, deltaV;
 
-    SaturationResidual() {};
+    SaturationResidual(){};
     SaturationResidual(CoolProp::AbstractCubicBackend* ACB, CoolProp::input_pairs inputs, double imposed_variable)
-      : ACB(ACB), inputs(inputs), imposed_variable(imposed_variable) {};
+      : ACB(ACB), inputs(inputs), imposed_variable(imposed_variable){};
 
     double call(double value) {
         int Nsolns = 0;
-        double rho0 = -1, rho1 = -1, rho2 = -1, T, p;
+        double rho0 = -1, rho1 = -1, rho2 = -1, T = NAN, p = NAN;
 
         if (inputs == CoolProp::PQ_INPUTS) {
             T = value;
@@ -425,8 +427,8 @@ std::vector<double> CoolProp::AbstractCubicBackend::spinodal_densities() {
     double crho2 = ((-Delta_1 * Delta_1 - Delta_2 * Delta_2 - 4 * Delta_1 * Delta_2) * R * _T * powInt(b, 2) + a * b * (Delta_1 + Delta_2 - 4));
     double crho1 = -2 * (Delta_1 + Delta_2) * R * _T * b + 2 * a;
     double crho0 = -R * _T;
-    double rho0, rho1, rho2, rho3;
-    int Nsoln;
+    double rho0 = NAN, rho1 = NAN, rho2 = NAN, rho3 = NAN;
+    int Nsoln = 0;
     solve_quartic(crho4, crho3, crho2, crho1, crho0, Nsoln, rho0, rho1, rho2, rho3);
     std::vector<double> roots;
     if (rho0 > 0 && 1 / rho0 > b) {
@@ -477,7 +479,7 @@ void CoolProp::AbstractCubicBackend::saturation(CoolProp::input_pairs inputs) {
             double neg_log10_pr = (acentric + 1) / (1 / 0.7 - 1) * (Tc / _T - 1);
             double ps_est = pc * pow(10.0, -neg_log10_pr);
 
-            double ps;
+            double ps = NAN;
             if (roots.size() == 2) {
                 double p0 = calc_pressure_nocache(_T, roots[0]);
                 double p1 = calc_pressure_nocache(_T, roots[1]);

--- a/src/Backends/Cubics/GeneralizedCubic.cpp
+++ b/src/Backends/Cubics/GeneralizedCubic.cpp
@@ -91,7 +91,7 @@ double TwuAlphaFunction::term(double tau, std::size_t itau) {
                  : -N / powInt(tau, 4)
                      * (L * powInt(M, 4) * powInt(N, 3) * A + 6 * L * M * M * M * N * N * A + 11 * L * M * M * N * A + 6 * L * M * A - 6 * M + 6);
 
-    double dam_dtau, d2am_dtau2, d3am_dtau3, d4am_dtau4;
+    double dam_dtau = NAN, d2am_dtau2 = NAN, d3am_dtau3 = NAN, d4am_dtau4 = NAN;
     double am = a0 * pow(Tr_over_Tci / tau, N * (M - 1)) * exp(L * (1 - A));
 
     if (itau == 0) {

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -1,5 +1,7 @@
 #include "VLERoutines.h"
 #include "FlashRoutines.h"
+
+#include <cmath>
 #include "HelmholtzEOSMixtureBackend.h"
 #include "HelmholtzEOSBackend.h"
 #include "PhaseEnvelopeRoutines.h"
@@ -19,7 +21,7 @@ void FlashRoutines::PT_flash_mixtures(HelmholtzEOSMixtureBackend& HEOS) {
         // Use the phase envelope if already constructed to determine phase boundary
         // Determine whether you are inside (two-phase) or outside (single-phase)
         SimpleState closest_state;
-        std::size_t i;
+        std::size_t i = 0;
         bool twophase = PhaseEnvelopeRoutines::is_inside(HEOS.PhaseEnvelope, iP, HEOS._p, iT, HEOS._T, i, closest_state);
         if (!twophase && HEOS._T > closest_state.T) {
             // Gas solution - bounded between phase envelope temperature and very high temperature
@@ -175,7 +177,7 @@ p = \frac{{R{T_r}{T_c}}}{{v - b}} - \frac{{a\left( {1 + 2\kappa  + {\kappa ^2}} 
 \f]
  */
 double FlashRoutines::T_DP_PengRobinson(HelmholtzEOSMixtureBackend& HEOS, double rhomolar, double p) {
-    double omega, R, kappa, a, b, A, B, C, Tc, pc, V = 1 / rhomolar;
+    double omega = NAN, R = NAN, kappa = NAN, a = NAN, b = NAN, A = NAN, B = NAN, C = NAN, Tc = NAN, pc = NAN, V = 1 / rhomolar;
     omega = HEOS.acentric_factor();
     Tc = HEOS.T_critical();
     pc = HEOS.p_critical();
@@ -210,7 +212,7 @@ void FlashRoutines::DP_flash(HelmholtzEOSMixtureBackend& HEOS) {
         HEOS.p_phase_determination_pure_or_pseudopure(iDmolar, HEOS._rhomolar, saturation_called);
 
         if (HEOS.isHomogeneousPhase()) {
-            CoolPropDbl T0;
+            CoolPropDbl T0 = NAN;
             if (HEOS._phase == iphase_liquid) {
                 // If it is a liquid, start off at the ancillary value
                 if (saturation_called) {
@@ -256,7 +258,7 @@ class DQ_flash_residual : public FuncWrapper1DWithTwoDerivs
    public:
     HelmholtzEOSMixtureBackend& HEOS;
     double rhomolar, Q_target;
-    DQ_flash_residual(HelmholtzEOSMixtureBackend& HEOS, double rhomolar, double Q_target) : HEOS(HEOS), rhomolar(rhomolar), Q_target(Q_target) {};
+    DQ_flash_residual(HelmholtzEOSMixtureBackend& HEOS, double rhomolar, double Q_target) : HEOS(HEOS), rhomolar(rhomolar), Q_target(Q_target){};
     double call(double T) {
         HEOS.update(QT_INPUTS, 0, T);  // Doesn't matter whether liquid or vapor, we are just doing a full VLE call for given T
         double rhoL = HEOS.saturated_liquid_keyed_output(iDmolar);
@@ -394,7 +396,7 @@ void FlashRoutines::QT_flash(HelmholtzEOSMixtureBackend& HEOS) {
         CoolPropDbl Tmax_sat = HEOS.calc_Tmax_sat() + 1e-13;
 
         // Check what the minimum limits for the equation of state are
-        CoolPropDbl Tmin_satL, Tmin_satV, Tmin_sat;
+        CoolPropDbl Tmin_satL = NAN, Tmin_satV = NAN, Tmin_sat = NAN;
         HEOS.calc_Tmin_sat(Tmin_satL, Tmin_satV);
         Tmin_sat = std::max(Tmin_satL, Tmin_satV) - 1e-13;
 
@@ -660,7 +662,7 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend& HEOS) {
             CoolPropDbl pmax_sat = HEOS.calc_pmax_sat();
 
             // Check what the minimum limits for the equation of state are
-            CoolPropDbl pmin_satL, pmin_satV, pmin_sat;
+            CoolPropDbl pmin_satL = NAN, pmin_satV = NAN, pmin_sat = NAN;
             HEOS.calc_pmin_sat(pmin_satL, pmin_satV);
             pmin_sat = std::max(pmin_satL, pmin_satV);
 
@@ -750,7 +752,7 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend& HEOS) {
                         iWater = i;
                         continue;
                     } else {
-                        double A, B, C, Tmin, Tmax;
+                        double A = NAN, B = NAN, C = NAN, Tmin = NAN, Tmax = NAN;
                         get_Henrys_coeffs_FP(components[i].CAS, A, B, C, Tmin, Tmax);
                         double T_R = Tguess / 647.096, tau = 1 - T_R;
                         double k_H = p1star * exp(A / T_R + B * pow(tau, 0.355) / T_R + C * pow(T_R, -0.41) * exp(tau));
@@ -1019,8 +1021,8 @@ void FlashRoutines::PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend& HEOS, parame
         SaturationSolvers::newton_raphson_twophase_options IO;
         IO.beta = HEOS._Q;
 
-        CoolPropDbl rhomolar_vap_sat_vap, T_sat_vap, rhomolar_liq_sat_vap, rhomolar_liq_sat_liq, T_sat_liq, rhomolar_vap_sat_liq, p_sat_liq,
-          p_sat_vap;
+        CoolPropDbl rhomolar_vap_sat_vap = NAN, T_sat_vap = NAN, rhomolar_liq_sat_vap = NAN, rhomolar_liq_sat_liq = NAN, T_sat_liq = NAN,
+                    rhomolar_vap_sat_liq = NAN, p_sat_liq = NAN, p_sat_vap = NAN;
 
         if (other == iP) {
             IO.p = HEOS._p;
@@ -1112,7 +1114,7 @@ void FlashRoutines::HSU_D_flash_twophase(HelmholtzEOSMixtureBackend& HEOS, CoolP
     CoolPropDbl Tmax_sat = HEOS.calc_Tmax_sat() - 1e-13;
 
     // Check what the minimum limits for the equation of state are
-    CoolPropDbl Tmin_satL, Tmin_satV, Tmin_sat;
+    CoolPropDbl Tmin_satL = NAN, Tmin_satV = NAN, Tmin_sat = NAN;
     HEOS.calc_Tmin_sat(Tmin_satL, Tmin_satV);
     Tmin_sat = std::max(Tmin_satL, Tmin_satV) - 1e-13;
 
@@ -1172,7 +1174,7 @@ void FlashRoutines::HSU_D_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
         CoolPropDbl rhoVtriple = component.triple_vapor.rhomolar;
         // Check if in the "normal" region
         if (HEOS._rhomolar >= rhoVtriple && HEOS._rhomolar <= rhoLtriple) {
-            CoolPropDbl yL, yV, value, y_solid;
+            CoolPropDbl yL = NAN, yV = NAN, value = NAN, y_solid = NAN;
             CoolPropDbl TLtriple = component.triple_liquid.T;  ///TODO: separate TL and TV for ppure
             CoolPropDbl TVtriple = component.triple_vapor.T;
 
@@ -1277,7 +1279,7 @@ void FlashRoutines::HSU_D_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
         }
         // Check if vapor/solid region below triple point vapor density
         else if (HEOS._rhomolar < component.triple_vapor.rhomolar) {
-            CoolPropDbl y, value;
+            CoolPropDbl y = NAN, value = NAN;
             CoolPropDbl TVtriple = component.triple_vapor.T;  //TODO: separate TL and TV for ppure
 
             // If value is above the value calculated from X(Ttriple, _rhomolar), it is vapor
@@ -1318,7 +1320,7 @@ void FlashRoutines::HSU_D_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
         }
         // Check in the liquid/solid region above the triple point density
         else {
-            CoolPropDbl y, value;
+            CoolPropDbl y = NAN, value = NAN;
             CoolPropDbl TLtriple = component.EOS().Ttriple;
 
             // If value is above the value calculated from X(Ttriple, _rhomolar), it is vapor
@@ -1387,7 +1389,7 @@ void FlashRoutines::HSU_P_flash_singlephase_Newton(HelmholtzEOSMixtureBackend& H
     CoolPropDbl worst_error = 999;
     int iter = 0;
     bool failed = false;
-    CoolPropDbl omega = 1.0, f2, df2_dtau, df2_ddelta;
+    CoolPropDbl omega = 1.0, f2 = NAN, df2_dtau = NAN, df2_ddelta = NAN;
     CoolPropDbl tau = _HEOS.tau(), delta = _HEOS.delta();
     while (worst_error > 1e-6 && failed == false) {
 
@@ -1492,8 +1494,7 @@ void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend& HE
                     HEOS->specify_phase(phase);
                 default:
                     // Otherwise don't do anything (this is to make compiler happy)
-                    {
-                    }
+                    {}
             }
         }
         double call(double T) {
@@ -1671,7 +1672,7 @@ void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend& HE
 // P given and one of H, S, or U
 void FlashRoutines::HSU_P_flash(HelmholtzEOSMixtureBackend& HEOS, parameters other) {
     bool saturation_called = false;
-    CoolPropDbl value;
+    CoolPropDbl value = NAN;
 
     // Find the phase, while updating all internal variables possible
     switch (other) {
@@ -1695,7 +1696,7 @@ void FlashRoutines::HSU_P_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
         if (HEOS.isHomogeneousPhase()) {
             // Now we use the single-phase solver to find T,rho given P,Y using a
             // bounded 1D solver by adjusting T and using given value of p
-            CoolPropDbl Tmin, Tmax;
+            CoolPropDbl Tmin = NAN, Tmax = NAN;
             switch (HEOS._phase) {
                 case iphase_gas: {
                     Tmax = 1.5 * HEOS.Tmax();
@@ -1785,7 +1786,7 @@ void FlashRoutines::HSU_P_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
         if (HEOS.PhaseEnvelope.built) {
             // Determine whether you are inside or outside
             SimpleState closest_state;
-            std::size_t iclosest;
+            std::size_t iclosest = 0;
             bool twophase = PhaseEnvelopeRoutines::is_inside(HEOS.PhaseEnvelope, iP, HEOS._p, other, value, iclosest, closest_state);
 
             if (!twophase) {
@@ -1831,7 +1832,7 @@ void FlashRoutines::solver_for_rho_given_T_oneof_HSU(HelmholtzEOSMixtureBackend&
 
     // Supercritical temperature
     if (HEOS._T > T_critical_) {
-        CoolPropDbl yc, ymin, y;
+        CoolPropDbl yc = NAN, ymin = NAN, y = NAN;
         CoolPropDbl rhoc = (HEOS.is_pure_or_pseudopure) ? HEOS.rhomolar_critical() : HEOS._crit.rhomolar;
         CoolPropDbl rhomin = 1e-10;
 
@@ -1896,7 +1897,7 @@ void FlashRoutines::solver_for_rho_given_T_oneof_HSU(HelmholtzEOSMixtureBackend&
     }
     // Subcritical temperature liquid
     else if ((HEOS._phase == iphase_liquid) || (HEOS._phase == iphase_supercritical_liquid)) {
-        CoolPropDbl ymelt, yL, y;
+        CoolPropDbl ymelt = NAN, yL = NAN, y = NAN;
         CoolPropDbl rhomelt = HEOS.components[0].triple_liquid.rhomolar;
         CoolPropDbl rhoL = static_cast<double>(HEOS._rhoLanc);
 
@@ -1983,7 +1984,7 @@ void FlashRoutines::DHSU_T_flash(HelmholtzEOSMixtureBackend& HEOS, parameters ot
                     HEOS._rhoVmolar = HEOS.SatV->rhomolar();
                 }
 
-                CoolPropDbl Q;
+                CoolPropDbl Q = NAN;
 
                 switch (other) {
                     case iDmolar:
@@ -2079,7 +2080,7 @@ void FlashRoutines::HS_flash_twophase(HelmholtzEOSMixtureBackend& HEOS, CoolProp
         HelmholtzEOSMixtureBackend& HEOS;
         CoolPropDbl hmolar, smolar, Qs;
         Residual(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl hmolar_spec, CoolPropDbl smolar_spec)
-          : HEOS(HEOS), hmolar(hmolar_spec), smolar(smolar_spec), Qs(_HUGE) {};
+          : HEOS(HEOS), hmolar(hmolar_spec), smolar(smolar_spec), Qs(_HUGE){};
         double call(double T) {
             HEOS.update(QT_INPUTS, 0, T);
             HelmholtzEOSMixtureBackend &SatL = HEOS.get_SatL(), &SatV = HEOS.get_SatV();
@@ -2096,7 +2097,7 @@ void FlashRoutines::HS_flash_twophase(HelmholtzEOSMixtureBackend& HEOS, CoolProp
     CoolPropDbl Tmax_sat = HEOS.calc_Tmax_sat() - 1e-13;
 
     // Check what the minimum limits for the equation of state are
-    CoolPropDbl Tmin_satL, Tmin_satV, Tmin_sat;
+    CoolPropDbl Tmin_satL = NAN, Tmin_satV = NAN, Tmin_sat = NAN;
     HEOS.calc_Tmin_sat(Tmin_satL, Tmin_satV);
     Tmin_sat = std::max(Tmin_satL, Tmin_satV) - 1e-13;
 
@@ -2170,7 +2171,7 @@ void FlashRoutines::HS_flash(HelmholtzEOSMixtureBackend& HEOS) {
         HelmholtzEOSMixtureBackend& HEOS;
         CoolPropDbl hmolar, smolar;
         Residual(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl hmolar_spec, CoolPropDbl smolar_spec)
-          : HEOS(HEOS), hmolar(hmolar_spec), smolar(smolar_spec) {};
+          : HEOS(HEOS), hmolar(hmolar_spec), smolar(smolar_spec){};
         double call(double T) {
             HEOS.update(SmolarT_INPUTS, smolar, T);
             double r = HEOS.hmolar() - hmolar;
@@ -2181,7 +2182,7 @@ void FlashRoutines::HS_flash(HelmholtzEOSMixtureBackend& HEOS) {
     // Find minimum temperature
     bool good_Tmin = false;
     double Tmin = HEOS.Ttriple();
-    double rmin;
+    double rmin = NAN;
     do {
         try {
             rmin = resid.call(Tmin);
@@ -2197,7 +2198,7 @@ void FlashRoutines::HS_flash(HelmholtzEOSMixtureBackend& HEOS) {
     // Find maximum temperature
     bool good_Tmax = false;
     double Tmax = HEOS.Tmax() * 1.01;  // Just a little above, so if we use Tmax as input, it should still work
-    double rmax;
+    double rmax = NAN;
     do {
         try {
             rmax = resid.call(Tmax);

--- a/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
+++ b/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
@@ -1,4 +1,6 @@
 #include "Ancillaries.h"
+
+#include <cmath>
 #include "DataStructures.h"
 #include "AbstractState.h"
 #include "Configuration.h"
@@ -61,7 +63,7 @@ double SaturationAncillaryFunction::evaluate(double T) {
         if (type == TYPE_NOT_EXPONENTIAL) {
             return reducing_value * (1 + summer);
         } else {
-            double tau_r_value;
+            double tau_r_value = NAN;
             if (using_tau_r)
                 tau_r_value = T_r / T;
             else
@@ -206,7 +208,7 @@ CoolPropDbl MeltingLineVariables::evaluate(int OF, int GIVEN, CoolPropDbl value)
                public:
                 MeltingLinePiecewisePolynomialInTrSegment* part;
                 CoolPropDbl given_p;
-                solver_resid(MeltingLinePiecewisePolynomialInTrSegment* part, CoolPropDbl p) : part(part), given_p(p) {};
+                solver_resid(MeltingLinePiecewisePolynomialInTrSegment* part, CoolPropDbl p) : part(part), given_p(p){};
                 double call(double T) {
 
                     CoolPropDbl calc_p = part->evaluate(T);
@@ -234,7 +236,7 @@ CoolPropDbl MeltingLineVariables::evaluate(int OF, int GIVEN, CoolPropDbl value)
                public:
                 MeltingLinePiecewisePolynomialInThetaSegment* part;
                 CoolPropDbl given_p;
-                solver_resid(MeltingLinePiecewisePolynomialInThetaSegment* part, CoolPropDbl p) : part(part), given_p(p) {};
+                solver_resid(MeltingLinePiecewisePolynomialInThetaSegment* part, CoolPropDbl p) : part(part), given_p(p){};
                 double call(double T) {
 
                     CoolPropDbl calc_p = part->evaluate(T);

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -5,6 +5,7 @@
  *      Author: jowr
  */
 
+#include <cmath>
 #include <memory>
 
 #if defined(_MSC_VER)
@@ -602,7 +603,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_surface_tension(void) {
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity_dilute(void) {
     if (is_pure_or_pseudopure) {
-        CoolPropDbl eta_dilute;
+        CoolPropDbl eta_dilute = NAN;
         switch (components[0].transport.viscosity_dilute.type) {
             case ViscosityDiluteVariables::VISCOSITY_DILUTE_KINETIC_THEORY:
                 eta_dilute = TransportRoutines::viscosity_dilute_kinetic_theory(*this);
@@ -1654,7 +1655,7 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
                 }
                 SatL->update_TDmolarP_unchecked(Tsat, rhoL, psat);
                 SatV->update_TDmolarP_unchecked(Tsat, rhoV, psat);
-                double Q;
+                double Q = NAN;
                 switch (other) {
                     case iDmolar:
                         Q = (1 / value - 1 / SatL->rhomolar()) / (1 / SatV->rhomolar() - 1 / SatL->rhomolar());
@@ -1870,7 +1871,7 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
             // the other solvers
             saturation_called = true;
 
-            CoolPropDbl Q;
+            CoolPropDbl Q = NAN;
 
             if (other == iT) {
                 if (value < HEOS.SatL->T() - 100 * DBL_EPSILON) {
@@ -1952,7 +1953,7 @@ void HelmholtzEOSMixtureBackend::calc_ssat_max(void) {
     {
        public:
         HelmholtzEOSMixtureBackend* HEOS;
-        Residual(HelmholtzEOSMixtureBackend& HEOS) : HEOS(&HEOS) {};
+        Residual(HelmholtzEOSMixtureBackend& HEOS) : HEOS(&HEOS){};
         double call(double T) {
             HEOS->update(QT_INPUTS, 1, T);
             // dTdp_along_sat
@@ -1987,7 +1988,7 @@ void HelmholtzEOSMixtureBackend::calc_hsat_max(void) {
     {
        public:
         HelmholtzEOSMixtureBackend* HEOS;
-        Residualhmax(HelmholtzEOSMixtureBackend& HEOS) : HEOS(&HEOS) {};
+        Residualhmax(HelmholtzEOSMixtureBackend& HEOS) : HEOS(&HEOS){};
         double call(double T) {
             HEOS->update(QT_INPUTS, 1, T);
             // dTdp_along_sat
@@ -2281,7 +2282,7 @@ void HelmholtzEOSMixtureBackend::T_phase_determination_pure_or_pseudopure(int ot
         SaturationSolvers::saturation_T_pure_options options;
         SaturationSolvers::saturation_T_pure(HEOS, _T, options);
 
-        CoolPropDbl Q;
+        CoolPropDbl Q = NAN;
 
         if (other == iP) {
             if (value > HEOS.SatL->p() * (1e-6 + 1)) {
@@ -2750,7 +2751,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::solver_rho_Tp(CoolPropDbl T, CoolPropDbl
                 rhomolar_guess = p / (gas_constant() * T);
             }
         } else if (phase == iphase_liquid) {
-            double rhomolar;
+            double rhomolar = NAN;
             if (is_pure_or_pseudopure) {
                 // It's liquid at subcritical pressure, we can use ancillaries as guess value
                 CoolPropDbl _rhoLancval = static_cast<CoolPropDbl>(components[0].ancillaries.rhoL.evaluate(T));
@@ -2838,7 +2839,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::solver_rho_Tp(CoolPropDbl T, CoolPropDbl
     }
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::solver_rho_Tp_SRK(CoolPropDbl T, CoolPropDbl p, phases phase) {
-    CoolPropDbl rhomolar, R_u = gas_constant(), a = 0, b = 0, k_ij = 0;
+    CoolPropDbl rhomolar = NAN, R_u = gas_constant(), a = 0, b = 0, k_ij = 0;
 
     for (std::size_t i = 0; i < components.size(); ++i) {
         CoolPropDbl Tci = components[i].EOS().reduce.T, pci = components[i].EOS().reduce.p, acentric_i = components[i].EOS().acentric;
@@ -2870,8 +2871,8 @@ CoolPropDbl HelmholtzEOSMixtureBackend::solver_rho_Tp_SRK(CoolPropDbl T, CoolPro
     CoolPropDbl B = b * p / (R_u * T);
 
     //Solve the cubic for solutions for Z = p/(rho*R*T)
-    double Z0, Z1, Z2;
-    int Nsolns;
+    double Z0 = NAN, Z1 = NAN, Z2 = NAN;
+    int Nsolns = 0;
     solve_cubic(1, -1, A - B - B * B, -A * B, Nsolns, Z0, Z1, Z2);
 
     // Determine the guess value
@@ -3302,7 +3303,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_alphar_deriv_nocache(const int nTau
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_alpha0_deriv_nocache(const int nTau, const int nDelta, const std::vector<CoolPropDbl>& mole_fractions,
                                                                   const CoolPropDbl& tau, const CoolPropDbl& delta, const CoolPropDbl& Tr,
                                                                   const CoolPropDbl& rhor) {
-    CoolPropDbl val;
+    CoolPropDbl val = NAN;
     if (components.size() == 0) {
         throw ValueError("No alpha0 derivatives are available");
     }
@@ -3352,7 +3353,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_alpha0_deriv_nocache(const int nTau
         // See Table B5, GERG 2008 from Kunz Wagner, JCED, 2012
         std::size_t N = mole_fractions.size();
         CoolPropDbl summer = 0;
-        CoolPropDbl tau_i, delta_i, rho_ci, T_ci;
+        CoolPropDbl tau_i = NAN, delta_i = NAN, rho_ci = NAN, T_ci = NAN;
         CoolPropDbl Rmix = gas_constant();
         for (unsigned int i = 0; i < N; ++i) {
 
@@ -3410,7 +3411,7 @@ HelmholtzDerivatives HelmholtzEOSMixtureBackend::calc_all_alpha0_derivs_nocache(
         // See Table B5, GERG 2008 from Kunz Wagner, JCED, 2012
         std::size_t N = mole_fractions.size();
         CoolPropDbl summer_00 = 0, summer_01 = 0, summer_10 = 0, summer_02 = 0, summer_11 = 0, summer_20 = 0;
-        CoolPropDbl tau_i, delta_i, rho_ci, T_ci;
+        CoolPropDbl tau_i = NAN, delta_i = NAN, rho_ci = NAN, T_ci = NAN;
         CoolPropDbl Rmix = gas_constant();
         for (unsigned int i = 0; i < N; ++i) {
 
@@ -3826,7 +3827,7 @@ CoolProp::CriticalState HelmholtzEOSMixtureBackend::calc_critical_point(double r
         HelmholtzEOSMixtureBackend& HEOS;
         double L1, M1;
         Eigen::MatrixXd Lstar, Mstar;
-        Resid(HelmholtzEOSMixtureBackend& HEOS) : HEOS(HEOS), L1(_HUGE), M1(_HUGE) {};
+        Resid(HelmholtzEOSMixtureBackend& HEOS) : HEOS(HEOS), L1(_HUGE), M1(_HUGE){};
         std::vector<double> call(const std::vector<double>& tau_delta) {
             double rhomolar = tau_delta[1] * HEOS.rhomolar_reducing();
             double T = HEOS.T_reducing() / tau_delta[0];
@@ -3913,8 +3914,7 @@ class OneDimObjective : public FuncWrapper1DWithTwoDerivs
     CoolProp::HelmholtzEOSMixtureBackend& HEOS;
     const double delta;
     double _call, _deriv, _second_deriv;
-    OneDimObjective(HelmholtzEOSMixtureBackend& HEOS, double delta0)
-      : HEOS(HEOS), delta(delta0), _call(_HUGE), _deriv(_HUGE), _second_deriv(_HUGE) {};
+    OneDimObjective(HelmholtzEOSMixtureBackend& HEOS, double delta0) : HEOS(HEOS), delta(delta0), _call(_HUGE), _deriv(_HUGE), _second_deriv(_HUGE){};
     double call(double tau) {
         double rhomolar = HEOS.rhomolar_reducing() * delta, T = HEOS.T_reducing() / tau;
         HEOS.update_DmolarT_direct(rhomolar, T);
@@ -3980,7 +3980,7 @@ class L0CurveTracer : public FuncWrapper1DWithDeriv
      @param theta The angle
      */
     double call(double theta) {
-        double tau_new, delta_new;
+        double tau_new = NAN, delta_new = NAN;
         this->get_tau_delta(theta, tau, delta, tau_new, delta_new);
         double rhomolar = HEOS.rhomolar_reducing() * delta_new, T = HEOS.T_reducing() / tau_new;
         HEOS.update_DmolarT_direct(rhomolar, T);
@@ -4002,7 +4002,7 @@ class L0CurveTracer : public FuncWrapper1DWithDeriv
 
     void trace() {
         bool debug = (get_debug_level() > 0) | false;
-        double theta;
+        double theta = NAN;
         for (int i = 0; i < 300; ++i) {
             if (i == 0) {
                 // In the first iteration, search all angles in the positive delta direction using a
@@ -4048,7 +4048,7 @@ class L0CurveTracer : public FuncWrapper1DWithDeriv
             double p_MPa = HEOS.p() / 1e6;
 
             // Calculate the new tau and delta at the new point
-            double tau_new, delta_new;
+            double tau_new = NAN, delta_new = NAN;
             this->get_tau_delta(theta, tau, delta, tau_new, delta_new);
 
             // Stop if bounds are exceeded

--- a/src/Backends/Helmholtz/MixtureParameters.cpp
+++ b/src/Backends/Helmholtz/MixtureParameters.cpp
@@ -732,7 +732,7 @@ void parse_HMX_BNC(const std::string& s, std::vector<REFPROP_binary_element>& BI
     //      Parse the departure functions
     // ****************************************
     for (std::size_t i = i_ended + 1; i < lines.size(); ++i) {
-        std::size_t j_end;
+        std::size_t j_end = 0;
         // Find the end of this block
         for (j_end = i + 1; j_end < lines.size(); ++j_end) {
             if (strstrip(lines[j_end]).empty()) {

--- a/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
+++ b/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
@@ -430,7 +430,7 @@ void PhaseEnvelopeRoutines::refine(HelmholtzEOSMixtureBackend& HEOS, const std::
 }
 double PhaseEnvelopeRoutines::evaluate(const PhaseEnvelopeData& env, parameters output, parameters iInput1, double value1, std::size_t& i) {
     int _i = static_cast<int>(i);
-    std::vector<double> const *x, *y;
+    std::vector<double> const *x = nullptr, *y = nullptr;
 
     switch (output) {
         case iT:
@@ -513,7 +513,7 @@ void PhaseEnvelopeRoutines::finalize(HelmholtzEOSMixtureBackend& HEOS) {
         PMAX_SAT = 0,
         TMAX_SAT = 1
     };
-    std::size_t imax;  // Index of the maximal temperature or pressure
+    std::size_t imax = 0;  // Index of the maximal temperature or pressure
 
     PhaseEnvelopeData& env = HEOS.PhaseEnvelope;
 
@@ -718,7 +718,7 @@ bool PhaseEnvelopeRoutines::is_inside(const PhaseEnvelopeData& env, parameters i
             throw ValueError("for now only even value accepted is 2");
         }
         std::vector<std::size_t> other_indices(4, 0);
-        std::vector<double> const* y;
+        std::vector<double> const* y = nullptr;
         std::vector<double> other_values(4, 0);
         other_indices[0] = intersections[0].first;
         other_indices[1] = intersections[0].second;

--- a/src/Backends/Helmholtz/TransportRoutines.cpp
+++ b/src/Backends/Helmholtz/TransportRoutines.cpp
@@ -1,5 +1,7 @@
 
 #include "TransportRoutines.h"
+
+#include <cmath>
 #include "CoolPropFluid.h"
 
 namespace CoolProp {
@@ -30,7 +32,7 @@ CoolPropDbl TransportRoutines::viscosity_dilute_collision_integral(HelmholtzEOSM
         const std::vector<CoolPropDbl>&a = data.a, &t = data.t;
         const CoolPropDbl C = data.C, molar_mass = data.molar_mass;
 
-        CoolPropDbl S;
+        CoolPropDbl S = NAN;
         // Unit conversions and variable definitions
         const CoolPropDbl Tstar = HEOS.T() / HEOS.components[0].transport.epsilon_over_k;
         const CoolPropDbl sigma_nm = HEOS.components[0].transport.sigma_eta * 1e9;  // 1e9 to convert from m to nm
@@ -141,7 +143,7 @@ CoolPropDbl TransportRoutines::viscosity_initial_density_dependence_Rainwater_Fr
         CoolProp::ViscosityRainWaterFriendData& data = HEOS.components[0].transport.viscosity_initial.rainwater_friend;
         const std::vector<CoolPropDbl>&b = data.b, &t = data.t;
 
-        CoolPropDbl B_eta, B_eta_star;
+        CoolPropDbl B_eta = NAN, B_eta_star = NAN;
         CoolPropDbl Tstar = HEOS.T() / HEOS.components[0].transport.epsilon_over_k;  // [no units]
         CoolPropDbl sigma = HEOS.components[0].transport.sigma_eta;                  // [m]
 
@@ -179,8 +181,8 @@ CoolPropDbl TransportRoutines::viscosity_initial_density_dependence_empirical(He
 
 static void visc_Helper(double Tbar, double rhobar, double* mubar_0, double* mubar_1) {
     std::vector<std::vector<CoolPropDbl>> H(6, std::vector<CoolPropDbl>(7, 0));
-    double sum;
-    int i, j;
+    double sum = NAN;
+    int i = 0, j = 0;
 
     // Dilute-gas component
     *mubar_0 = 100.0 * sqrt(Tbar) / (1.67752 + 2.20462 / Tbar + 0.6366564 / powInt(Tbar, 2) - 0.241605 / powInt(Tbar, 3));
@@ -248,9 +250,11 @@ CoolPropDbl TransportRoutines::viscosity_heavywater_hardcoded(HelmholtzEOSMixtur
     return 55.2651e-6 * mubar;
 }
 CoolPropDbl TransportRoutines::viscosity_water_hardcoded(HelmholtzEOSMixtureBackend& HEOS) {
-    double x_mu = 0.068, qc = 1 / 1.9, qd = 1 / 1.1, nu = 0.630, gamma = 1.239, zeta_0 = 0.13, LAMBDA_0 = 0.06, Tbar_R = 1.5, pstar, Tstar, rhostar;
-    double delta, tau, mubar_0, mubar_1, mubar_2, drhodp, drhodp_R, DeltaChibar, zeta, w, L, Y, psi_D, Tbar, rhobar;
-    double drhobar_dpbar, drhobar_dpbar_R, R_Water;
+    double x_mu = 0.068, qc = 1 / 1.9, qd = 1 / 1.1, nu = 0.630, gamma = 1.239, zeta_0 = 0.13, LAMBDA_0 = 0.06, Tbar_R = 1.5, pstar = NAN,
+           Tstar = NAN, rhostar = NAN;
+    double delta = NAN, tau = NAN, mubar_0 = NAN, mubar_1 = NAN, mubar_2 = NAN, drhodp = NAN, drhodp_R = NAN, DeltaChibar = NAN, zeta = NAN, w = NAN,
+           L = NAN, Y = NAN, psi_D = NAN, Tbar = NAN, rhobar = NAN;
+    double drhobar_dpbar = NAN, drhobar_dpbar_R = NAN, R_Water = NAN;
 
     pstar = 22.064e6;  // [Pa]
     Tstar = 647.096;   // [K]
@@ -355,7 +359,7 @@ CoolPropDbl TransportRoutines::viscosity_higher_order_friction_theory(HelmholtzE
     if (HEOS.is_pure_or_pseudopure) {
         CoolProp::ViscosityFrictionTheoryData& F = HEOS.components[0].transport.viscosity_higher_order.friction_theory;
 
-        CoolPropDbl tau = F.T_reduce / HEOS.T(), kii = 0, krrr = 0, kaaa = 0, krr, kdrdr;
+        CoolPropDbl tau = F.T_reduce / HEOS.T(), kii = 0, krrr = 0, kaaa = 0, krr = NAN, kdrdr = NAN;
 
         double psi1 = exp(tau) - F.c1;
         double psi2 = exp(pow(tau, 2)) - F.c2;
@@ -397,7 +401,7 @@ CoolPropDbl TransportRoutines::viscosity_higher_order_friction_theory(HelmholtzE
 }
 
 CoolPropDbl TransportRoutines::viscosity_helium_hardcoded(HelmholtzEOSMixtureBackend& HEOS) {
-    double eta_0, eta_0_slash, eta_E_slash, B, C, D, ln_eta, x;
+    double eta_0 = NAN, eta_0_slash = NAN, eta_E_slash = NAN, B = NAN, C = NAN, D = NAN, ln_eta = NAN, x = NAN;
     //
     // Arp, V.D., McCarty, R.D., and Friend, D.G.,
     // "Thermophysical Properties of Helium-4 from 0.8 to 1500 K with Pressures to 2000 MPa",
@@ -434,14 +438,14 @@ CoolPropDbl TransportRoutines::viscosity_helium_hardcoded(HelmholtzEOSMixtureBac
 }
 
 CoolPropDbl TransportRoutines::viscosity_methanol_hardcoded(HelmholtzEOSMixtureBackend& HEOS) {
-    CoolPropDbl B_eta, C_eta, epsilon_over_k = 577.87, /* [K]*/
-      sigma0 = 0.3408e-9,                              /* [m] */
-      delta = 0.4575,                                  /* NOT the reduced density, that is rhor here*/
-      N_A = 6.02214129e23, M = 32.04216,               /* kg/kmol */
+    CoolPropDbl B_eta = NAN, C_eta = NAN, epsilon_over_k = 577.87, /* [K]*/
+      sigma0 = 0.3408e-9,                                          /* [m] */
+      delta = 0.4575,                                              /* NOT the reduced density, that is rhor here*/
+      N_A = 6.02214129e23, M = 32.04216,                           /* kg/kmol */
       T = HEOS.T();
     CoolPropDbl rhomolar = HEOS.rhomolar();
 
-    CoolPropDbl B_eta_star, C_eta_star;
+    CoolPropDbl B_eta_star = NAN, C_eta_star = NAN;
     CoolPropDbl Tstar = T / epsilon_over_k;  // [no units]
     CoolPropDbl rhor = HEOS.rhomass() / 273;
     CoolPropDbl Tr = T / 512.6;
@@ -577,7 +581,7 @@ CoolPropDbl TransportRoutines::viscosity_p_xylene_hardcoded(HelmholtzEOSMixtureB
 CoolPropDbl TransportRoutines::viscosity_dilute_ethane(HelmholtzEOSMixtureBackend& HEOS) {
     double C[] = {
       0, -3.0328138281, 16.918880086, -37.189364917, 41.288861858, -24.615921140, 8.9488430959, -1.8739245042, 0.20966101390, -9.6570437074e-3};
-    double OMEGA_2_2 = 0, e_k = 245, Tstar;
+    double OMEGA_2_2 = 0, e_k = 245, Tstar = NAN;
 
     Tstar = HEOS.T() / e_k;
     for (int i = 1; i <= 9; i++) {
@@ -595,7 +599,7 @@ CoolPropDbl TransportRoutines::viscosity_dilute_cyclohexane(HelmholtzEOSMixtureB
 
 CoolPropDbl TransportRoutines::viscosity_dilute_CO2_LaeseckeJPCRD2017(HelmholtzEOSMixtureBackend& HEOS) {
     // From Laesecke, JPRCD, 2016
-    double eta0, den;
+    double eta0 = NAN, den = NAN;
     double T = HEOS.T();
 
     double a[] = {1749.354893188350, -369.069300007128, 5423856.34887691, -2.21283852168356, -269503.247933569, 73145.021531826, 5.34368649509278};
@@ -731,8 +735,8 @@ CoolPropDbl TransportRoutines::conductivity_critical_simplified_Olchowy_Sengers(
                Tc = HEOS.get_reducing_state().T,      // [K]
           rhoc = HEOS.get_reducing_state().rhomolar,  // [mol/m^3]
           Pcrit = HEOS.get_reducing_state().p,        // [Pa]
-          Tref,                                       // [K]
-          cp, cv, delta, num, zeta, mu, pi = M_PI, OMEGA_tilde, OMEGA_tilde0;
+          Tref = NAN,                                 // [K]
+          cp = NAN, cv = NAN, delta = NAN, num = NAN, zeta = NAN, mu = NAN, pi = M_PI, OMEGA_tilde = NAN, OMEGA_tilde0 = NAN;
 
         if (ValidNumber(data.T_ref))
             Tref = data.T_ref;
@@ -778,7 +782,7 @@ CoolPropDbl TransportRoutines::conductivity_critical_hardcoded_R123(HelmholtzEOS
 };
 
 CoolPropDbl TransportRoutines::conductivity_critical_hardcoded_CO2_ScalabrinJPCRD2006(HelmholtzEOSMixtureBackend& HEOS) {
-    CoolPropDbl nc = 0.775547504e-3 * 4.81384, Tr = HEOS.T() / 304.1282, alpha, rhor = HEOS.keyed_output(iDmass) / 467.6;
+    CoolPropDbl nc = 0.775547504e-3 * 4.81384, Tr = HEOS.T() / 304.1282, alpha = NAN, rhor = HEOS.keyed_output(iDmass) / 467.6;
     static CoolPropDbl a[] = {0.0, 3.0, 6.70697, 0.94604, 0.30, 0.30, 0.39751, 0.33791, 0.77963, 0.79857, 0.90, 0.02, 0.20};
 
     // Equation 6 from Scalabrin
@@ -793,7 +797,7 @@ CoolPropDbl TransportRoutines::conductivity_critical_hardcoded_CO2_ScalabrinJPCR
 
 CoolPropDbl TransportRoutines::conductivity_dilute_hardcoded_CO2(HelmholtzEOSMixtureBackend& HEOS) {
 
-    double e_k = 251.196, Tstar;
+    double e_k = 251.196, Tstar = NAN;
     double b[] = {0.4226159, 0.6280115, -0.5387661, 0.6735941, 0, 0, -0.4362677, 0.2255388};
     double c[] = {0, 2.387869e-2, 4.350794, -10.33404, 7.981590, -1.940558};
 
@@ -883,10 +887,10 @@ CoolPropDbl TransportRoutines::conductivity_hardcoded_water(HelmholtzEOSMixtureB
                       {-1.21051378, 1.60812989, -0.621178141, 0.0716373224, 0, 0},
                       {-2.7203370, 4.57586331, -3.18369245, 1.1168348, -0.19268305, 0.012913842}};
 
-    double lambdabar_0, lambdabar_1, lambdabar_2, rhobar, Tbar, sum;
+    double lambdabar_0 = NAN, lambdabar_1 = NAN, lambdabar_2 = NAN, rhobar = NAN, Tbar = NAN, sum = NAN;
     double Tstar = 647.096, rhostar = 322, pstar = 22064000, lambdastar = 1e-3, mustar = 1e-6;
-    double xi;
-    int i, j;
+    double xi = NAN;
+    int i = 0, j = 0;
     double R = 461.51805;  //[J/kg/K]
 
     Tbar = HEOS.T() / Tstar;
@@ -926,7 +930,7 @@ CoolPropDbl TransportRoutines::conductivity_hardcoded_water(HelmholtzEOSMixtureB
         xi = xi_0 * pow(DELTAchibar_T / Lambda_0, nu / gamma);
     double y = qd_bar * xi;
 
-    double Z;
+    double Z = NAN;
     double kappa = cp / cv;
     if (y < 1.2e-7)
         Z = 0;
@@ -974,9 +978,10 @@ CoolPropDbl TransportRoutines::conductivity_critical_hardcoded_ammonia(Helmholtz
     Bereicht der Bunsengesellschaft Phys. Chem. 88 (1984) 422-427
     */
 
-    double T = HEOS.T(), Tc = 405.4, rhoc = 235, rho;
-    double LAMBDA = 1.2, nu = 0.63, gamma = 1.24, DELTA = 0.50, t, zeta_0_plus = 1.34e-10, a_zeta = 1, GAMMA_0_plus = 0.423e-8;
-    double pi = 3.141592654, a_chi, k_B = 1.3806504e-23, X_T, DELTA_lambda, dPdT, eta_B, DELTA_lambda_id, DELTA_lambda_i;
+    double T = HEOS.T(), Tc = 405.4, rhoc = 235, rho = NAN;
+    double LAMBDA = 1.2, nu = 0.63, gamma = 1.24, DELTA = 0.50, t = NAN, zeta_0_plus = 1.34e-10, a_zeta = 1, GAMMA_0_plus = 0.423e-8;
+    double pi = 3.141592654, a_chi = NAN, k_B = 1.3806504e-23, X_T = NAN, DELTA_lambda = NAN, dPdT = NAN, eta_B = NAN, DELTA_lambda_id = NAN,
+           DELTA_lambda_i = NAN;
 
     rho = HEOS.keyed_output(CoolProp::iDmass);
     t = std::abs((T - Tc) / Tc);
@@ -1001,7 +1006,7 @@ CoolPropDbl TransportRoutines::conductivity_hardcoded_helium(HelmholtzEOSMixture
     /*
     What an incredibly annoying formulation!  Implied coefficients?? Not cool.
     */
-    double rhoc = 68.0, lambda_e, lambda_c, T = HEOS.T(), rho = HEOS.rhomass();
+    double rhoc = 68.0, lambda_e = NAN, lambda_c = NAN, T = HEOS.T(), rho = HEOS.rhomass();
     double summer = 3.739232544 / T - 2.620316969e1 / T / T + 5.982252246e1 / T / T / T - 4.926397634e1 / T / T / T / T;
     double lambda_0 = 2.7870034e-3 * pow(T, 7.034007057e-1) * exp(summer);
     double c[] = {1.862970530e-4,  -7.275964435e-7, -1.427549651e-4, 3.290833592e-5, -5.213335363e-8, 4.492659933e-8,
@@ -1019,7 +1024,7 @@ CoolPropDbl TransportRoutines::conductivity_hardcoded_helium(HelmholtzEOSMixture
 
         double DeltaT = std::abs(1 - T / Tc), DeltaRho = std::abs(1 - rho / rhoc_crit);
         double eta = HEOS.viscosity();  // [Pa-s]
-        double K_T = HEOS.isothermal_compressibility(), K_Tprime, K_Tbar;
+        double K_T = HEOS.isothermal_compressibility(), K_Tprime = NAN, K_Tbar = NAN;
         double dpdT = HEOS.first_partial_deriv(CoolProp::iP, CoolProp::iT, CoolProp::iDmolar);
 
         double W = pow(DeltaT / 0.2, 2) + pow(DeltaRho / 0.25, 2);
@@ -1058,7 +1063,7 @@ CoolPropDbl TransportRoutines::conductivity_hardcoded_helium(HelmholtzEOSMixture
 CoolPropDbl TransportRoutines::conductivity_hardcoded_methane(HelmholtzEOSMixtureBackend& HEOS) {
 
     double delta = HEOS.rhomolar() / 10139.0, tau = 190.55 / HEOS.T();
-    double lambda_dilute, lambda_residual, lambda_critical;
+    double lambda_dilute = NAN, lambda_residual = NAN, lambda_critical = NAN;
 
     // Viscosity formulation from Friend, JPCRD, 1989
     // Dilute
@@ -1105,7 +1110,7 @@ CoolPropDbl TransportRoutines::conductivity_hardcoded_methane(HelmholtzEOSMixtur
     double rhostar = 1 - delta;
     double F_T = 2.646, F_rho = 2.678, F_A = -0.637;
     double F = exp(-F_T * sqrt(std::abs(Tstar)) - F_rho * POW2(rhostar) - F_A * rhostar);
-    double CHI_T_star;
+    double CHI_T_star = NAN;
     if (std::abs(Tstar) < 0.03) {
         if (std::abs(rhostar) < 1e-16) {
             // Equation 26

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -1,6 +1,8 @@
 
 #include "HelmholtzEOSMixtureBackend.h"
 #include "VLERoutines.h"
+
+#include <cmath>
 #include "MatrixMath.h"
 #include "MixtureDerivatives.h"
 #include "Configuration.h"
@@ -16,7 +18,7 @@ void SaturationSolvers::saturation_critical(HelmholtzEOSMixtureBackend& HEOS, pa
         HelmholtzEOSMixtureBackend* HEOS;
         CoolPropDbl T, desired_p;
 
-        inner_resid(HelmholtzEOSMixtureBackend* HEOS, CoolPropDbl T, CoolPropDbl desired_p) : HEOS(HEOS), T(T), desired_p(desired_p) {};
+        inner_resid(HelmholtzEOSMixtureBackend* HEOS, CoolPropDbl T, CoolPropDbl desired_p) : HEOS(HEOS), T(T), desired_p(desired_p){};
         double call(double rhomolar_liq) {
             HEOS->SatL->update(DmolarT_INPUTS, rhomolar_liq, T);
             CoolPropDbl calc_p = HEOS->SatL->p();
@@ -36,10 +38,10 @@ void SaturationSolvers::saturation_critical(HelmholtzEOSMixtureBackend& HEOS, pa
         CoolPropDbl rhomolar_crit;
 
         outer_resid(HelmholtzEOSMixtureBackend& HEOS, CoolProp::parameters ykey, CoolPropDbl y)
-          : HEOS(&HEOS), ykey(ykey), y(y), rhomolar_crit(HEOS.rhomolar_critical()) {};
+          : HEOS(&HEOS), ykey(ykey), y(y), rhomolar_crit(HEOS.rhomolar_critical()){};
         double call(double rhomolar_vap) {
             // Calculate the other variable (T->p or p->T) for given vapor density
-            CoolPropDbl T, p, rhomolar_liq;
+            CoolPropDbl T = NAN, p = NAN, rhomolar_liq = NAN;
             switch (ykey) {
                 case iT: {
                     T = y;
@@ -83,7 +85,7 @@ void SaturationSolvers::saturation_T_pure_1D_P(HelmholtzEOSMixtureBackend& HEOS,
         CoolPropDbl T, rhomolar_liq, rhomolar_vap;
 
         solver_resid(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl T, CoolPropDbl rhomolar_liq_guess, CoolPropDbl rhomolar_vap_guess)
-          : HEOS(&HEOS), T(T), rhomolar_liq(rhomolar_liq_guess), rhomolar_vap(rhomolar_vap_guess) {};
+          : HEOS(&HEOS), T(T), rhomolar_liq(rhomolar_liq_guess), rhomolar_vap(rhomolar_vap_guess){};
         double call(double p) {
             // Recalculate the densities using the current guess values
             HEOS->SatL->update_TP_guessrho(T, p, rhomolar_liq);
@@ -128,7 +130,7 @@ void SaturationSolvers::saturation_P_pure_1D_T(HelmholtzEOSMixtureBackend& HEOS,
         CoolPropDbl p, rhomolar_liq, rhomolar_vap;
 
         solver_resid(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl p, CoolPropDbl rhomolar_liq_guess, CoolPropDbl rhomolar_vap_guess)
-          : HEOS(&HEOS), p(p), rhomolar_liq(rhomolar_liq_guess), rhomolar_vap(rhomolar_vap_guess) {};
+          : HEOS(&HEOS), p(p), rhomolar_liq(rhomolar_liq_guess), rhomolar_vap(rhomolar_vap_guess){};
         double call(double T) {
             // Recalculate the densities using the current guess values
             HEOS->SatL->update_TP_guessrho(T, p, rhomolar_liq);
@@ -177,9 +179,9 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend& HEOS, C
     CoolProp::SimpleState crit = HEOS.get_state("reducing");
     shared_ptr<HelmholtzEOSMixtureBackend> SatL = HEOS.SatL, SatV = HEOS.SatV;
 
-    CoolPropDbl T, rhoL, rhoV, pL, pV, hL, sL, hV, sV;
-    CoolPropDbl deltaL = 0, deltaV = 0, tau = 0, error;
-    int iter = 0, specified_parameter;
+    CoolPropDbl T = NAN, rhoL = NAN, rhoV = NAN, pL = NAN, pV = NAN, hL = NAN, sL = NAN, hV = NAN, sV = NAN;
+    CoolPropDbl deltaL = 0, deltaV = 0, tau = 0, error = NAN;
+    int iter = 0, specified_parameter = 0;
 
     // Use the density ancillary function as the starting point for the solver
     try {
@@ -218,7 +220,7 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend& HEOS, C
             Residual resid(HEOS.get_components()[0], HEOS.hmolar());
 
             // Ancillary is deltah = h - hs_anchor.h
-            CoolPropDbl Tmin_satL, Tmin_satV;
+            CoolPropDbl Tmin_satL = NAN, Tmin_satV = NAN;
             HEOS.calc_Tmin_sat(Tmin_satL, Tmin_satV);
             double Tmin = Tmin_satL;
             double Tmax = HEOS.calc_Tmax_sat();
@@ -240,7 +242,7 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend& HEOS, C
             if (std::abs(HEOS.smolar() - crit.smolar) < std::abs(component.ancillaries.sL.get_max_abs_error())) {
                 T = std::max(0.99 * crit.T, crit.T - 0.1);
             } else {
-                CoolPropDbl Tmin, Tmax, Tmin_satV;
+                CoolPropDbl Tmin = NAN, Tmax = NAN, Tmin_satV = NAN;
                 HEOS.calc_Tmin_sat(Tmin, Tmin_satV);
                 Tmax = HEOS.calc_Tmax_sat();
                 // Ancillary is deltas = s - hs_anchor.s
@@ -284,7 +286,7 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend& HEOS, C
             Residual resid(component, HEOS.smolar());
 
             // Ancillary is deltas = s - hs_anchor.s
-            CoolPropDbl Tmin_satL, Tmin_satV;
+            CoolPropDbl Tmin_satL = NAN, Tmin_satV = NAN;
             HEOS.calc_Tmin_sat(Tmin_satL, Tmin_satV);
             double Tmin = Tmin_satL;
             double Tmax = HEOS.calc_Tmax_sat();
@@ -618,8 +620,8 @@ void SaturationSolvers::saturation_D_pure(HelmholtzEOSMixtureBackend& HEOS, Cool
     const SimpleState& reduce = HEOS.get_reducing_state();
     shared_ptr<HelmholtzEOSMixtureBackend> SatL = HEOS.SatL, SatV = HEOS.SatV;
 
-    CoolPropDbl T, rhoL, rhoV;
-    CoolPropDbl deltaL = 0, deltaV = 0, tau = 0, error, p_error;
+    CoolPropDbl T = NAN, rhoL = NAN, rhoV = NAN;
+    CoolPropDbl deltaL = 0, deltaV = 0, tau = 0, error = NAN, p_error = NAN;
     int iter = 0;
 
     // Use the density ancillary function as the starting point for the solver
@@ -794,8 +796,8 @@ void SaturationSolvers::saturation_T_pure_Akasaka(HelmholtzEOSMixtureBackend& HE
     CoolPropDbl R_u = HEOS.gas_constant();
     shared_ptr<HelmholtzEOSMixtureBackend> SatL = HEOS.SatL, SatV = HEOS.SatV;
 
-    CoolPropDbl rhoL = _HUGE, rhoV = _HUGE, JL, JV, KL, KV, dJL, dJV, dKL, dKV;
-    CoolPropDbl DELTA, deltaL = 0, deltaV = 0, error, PL, PV, stepL, stepV;
+    CoolPropDbl rhoL = _HUGE, rhoV = _HUGE, JL = NAN, JV = NAN, KL = NAN, KV = NAN, dJL = NAN, dJV = NAN, dKL = NAN, dKV = NAN;
+    CoolPropDbl DELTA = NAN, deltaL = 0, deltaV = 0, error = NAN, PL = NAN, PV = NAN, stepL = NAN, stepV = NAN;
     int iter = 0;
 
     try {
@@ -935,7 +937,7 @@ void SaturationSolvers::saturation_T_pure_Maxwell(HelmholtzEOSMixtureBackend& HE
     HEOS.calc_reducing_state();
     shared_ptr<HelmholtzEOSMixtureBackend> SatL = HEOS.SatL, SatV = HEOS.SatV;
     CoolProp::SimpleState& crit = HEOS.get_components()[0].crit;
-    CoolPropDbl rhoL = _HUGE, rhoV = _HUGE, error = 999, DeltavL, DeltavV, pL, pV, p, last_error;
+    CoolPropDbl rhoL = _HUGE, rhoV = _HUGE, error = 999, DeltavL = NAN, DeltavV = NAN, pL = NAN, pV = NAN, p = NAN, last_error = NAN;
     int iter = 0, small_step_count = 0,
         backwards_step_count = 0;  // Counter for the number of times you have taken a step that increases error
 
@@ -1129,7 +1131,7 @@ void SaturationSolvers::x_and_y_from_K(CoolPropDbl beta, const std::vector<CoolP
 void SaturationSolvers::successive_substitution(HelmholtzEOSMixtureBackend& HEOS, const CoolPropDbl beta, CoolPropDbl T, CoolPropDbl p,
                                                 const std::vector<CoolPropDbl>& z, std::vector<CoolPropDbl>& K, mixture_VLE_IO& options) {
     int iter = 1;
-    CoolPropDbl change, f, df, deriv_liq, deriv_vap;
+    CoolPropDbl change = NAN, f = NAN, df = NAN, deriv_liq = NAN, deriv_vap = NAN;
     std::size_t N = z.size();
     std::vector<CoolPropDbl> ln_phi_liq, ln_phi_vap;
     ln_phi_liq.resize(N);
@@ -1728,7 +1730,7 @@ class RachfordRiceResidual : public FuncWrapper1DWithDeriv
     const std::vector<double>&z, &lnK;
 
    public:
-    RachfordRiceResidual(const std::vector<double>& z, const std::vector<double>& lnK) : z(z), lnK(lnK) {};
+    RachfordRiceResidual(const std::vector<double>& z, const std::vector<double>& lnK) : z(z), lnK(lnK){};
     double call(double beta) {
         return FlashRoutines::g_RachfordRice(z, lnK, beta);
     }
@@ -2016,7 +2018,7 @@ void StabilityRoutines::StabilityEvaluationClass::rho_TP_SRK_translated() {
 void SaturationSolvers::PTflash_twophase::solve() {
     const std::size_t N = IO.x.size();
     int iter = 0;
-    double min_rel_change;
+    double min_rel_change = NAN;
     do {
         // Build the Jacobian and residual vectors
         build_arrays();

--- a/src/Backends/PCSAFT/PCSAFTBackend.cpp
+++ b/src/Backends/PCSAFT/PCSAFTBackend.cpp
@@ -1,7 +1,6 @@
+#include <cmath>
 #include <vector>
 #include <string>
-#include <cmath>
-#include <cmath>
 #include <Eigen/Dense>
 #include <cstdlib>
 
@@ -261,7 +260,7 @@ CoolPropDbl PCSAFTBackend::calc_alphar(void) {
     double den = _rhomolar * N_AV / 1.0e30;
 
     vector<double> zeta(4, 0);
-    double summ;
+    double summ = NAN;
     for (int i = 0; i < 4; i++) {
         summ = 0;
         for (size_t j = 0; j < ncomp; j++) {
@@ -373,9 +372,9 @@ CoolPropDbl PCSAFTBackend::calc_alphar(void) {
         vector<double> adip(5, 0);
         vector<double> bdip(5, 0);
         vector<double> cdip(5, 0);
-        double J2, J3;
-        double m_ij;
-        double m_ijk;
+        double J2 = NAN, J3 = NAN;
+        double m_ij = NAN;
+        double m_ijk = NAN;
         for (size_t i = 0; i < ncomp; i++) {
             for (size_t j = 0; j < ncomp; j++) {
                 m_ij = sqrt(components[i].getM() * components[j].getM());
@@ -533,7 +532,7 @@ CoolPropDbl PCSAFTBackend::calc_dadt(void) {
     double den = _rhomolar * N_AV / 1.0e30;
 
     vector<double> zeta(4, 0);
-    double summ;
+    double summ = NAN;
     for (int i = 0; i < 4; i++) {
         summ = 0;
         for (size_t j = 0; j < ncomp; j++) {
@@ -563,7 +562,7 @@ CoolPropDbl PCSAFTBackend::calc_dadt(void) {
     vector<double> s_ij(ncomp * ncomp, 0);
     double m2es3 = 0.;
     double m2e2s3 = 0.;
-    double ddij_dt;
+    double ddij_dt = NAN;
     int idx = -1;
     for (size_t i = 0; i < ncomp; i++) {
         for (size_t j = 0; j < ncomp; j++) {
@@ -675,9 +674,9 @@ CoolPropDbl PCSAFTBackend::calc_dadt(void) {
         vector<double> adip(5, 0);
         vector<double> bdip(5, 0);
         vector<double> cdip(5, 0);
-        double J2, J3, dJ2_dt, dJ3_dt;
-        double m_ij;
-        double m_ijk;
+        double J2 = NAN, J3 = NAN, dJ2_dt = NAN, dJ3_dt = NAN;
+        double m_ij = NAN;
+        double m_ijk = NAN;
         for (size_t i = 0; i < ncomp; i++) {
             for (size_t j = 0; j < ncomp; j++) {
                 m_ij = sqrt(components[i].getM() * components[j].getM());
@@ -819,7 +818,7 @@ CoolPropDbl PCSAFTBackend::calc_dadt(void) {
         double kappa =
           sqrt(den * E_CHRG * E_CHRG / kb / _T / (dielc * perm_vac) * summ);  // the inverse Debye screening length. Equation 4 in Held et al. 2008.
 
-        double dkappa_dt;
+        double dkappa_dt = NAN;
         if (kappa != 0) {
             vector<double> chi(ncomp);
             vector<double> dchikap_dk(ncomp);
@@ -877,7 +876,7 @@ vector<CoolPropDbl> PCSAFTBackend::calc_fugacity_coefficients(void) {
     double den = _rhomolar * N_AV / 1.0e30;
 
     vector<double> zeta(4, 0);
-    double summ;
+    double summ = NAN;
     for (int i = 0; i < 4; i++) {
         summ = 0;
         for (size_t j = 0; j < ncomp; j++) {
@@ -1016,7 +1015,7 @@ vector<CoolPropDbl> PCSAFTBackend::calc_fugacity_coefficients(void) {
 
     vector<double> dadisp_dx(ncomp, 0);
     vector<double> dahc_dx(ncomp, 0);
-    double dzeta3_dx, daa_dx, db_dx, dI1_dx, dI2_dx, dm2es3_dx, dm2e2s3_dx, dC1_dx;
+    double dzeta3_dx = NAN, daa_dx = NAN, db_dx = NAN, dI1_dx = NAN, dI2_dx = NAN, dm2es3_dx = NAN, dm2e2s3_dx = NAN, dC1_dx = NAN;
     for (size_t i = 0; i < ncomp; i++) {
         dzeta3_dx = PI / 6. * den * components[i].getM() * pow(d[i], 3);
         dI1_dx = 0.0;
@@ -1088,9 +1087,9 @@ vector<CoolPropDbl> PCSAFTBackend::calc_fugacity_coefficients(void) {
         vector<double> adip(5, 0);
         vector<double> bdip(5, 0);
         vector<double> cdip(5, 0);
-        double J2, dJ2_det, detJ2_det, J3, dJ3_det, detJ3_det;
-        double m_ij;
-        double m_ijk;
+        double J2 = NAN, dJ2_det = NAN, detJ2_det = NAN, J3 = NAN, dJ3_det = NAN, detJ3_det = NAN;
+        double m_ij = NAN;
+        double m_ijk = NAN;
         for (size_t i = 0; i < ncomp; i++) {
             for (size_t j = 0; j < ncomp; j++) {
                 m_ij = sqrt(components[i].getM() * components[j].getM());
@@ -1375,7 +1374,7 @@ CoolPropDbl PCSAFTBackend::calc_compressibility_factor(void) {
     double den = _rhomolar * N_AV / 1.0e30;
 
     vector<double> zeta(4, 0);
-    double summ;
+    double summ = NAN;
     for (int i = 0; i < 4; i++) {
         summ = 0;
         for (size_t j = 0; j < ncomp; j++) {
@@ -1483,7 +1482,7 @@ CoolPropDbl PCSAFTBackend::calc_compressibility_factor(void) {
         vector<double> bdip(5, 0);
         vector<double> cdip(5, 0);
         vector<double> dipmSQ(ncomp, 0);
-        double J2, detJ2_det, J3, detJ3_det;
+        double J2 = NAN, detJ2_det = NAN, J3 = NAN, detJ3_det = NAN;
 
         static double a0dip[5] = {0.3043504, -0.1358588, 1.4493329, 0.3556977, -2.0653308};
         static double a1dip[5] = {0.9534641, -1.8396383, 2.0131180, -7.3724958, 8.2374135};
@@ -1501,7 +1500,7 @@ CoolPropDbl PCSAFTBackend::calc_compressibility_factor(void) {
             dipmSQ[i] = pow(components[i].getDipm(), 2.) / (components[i].getM() * components[i].getU() * pow(components[i].getSigma(), 3.)) * conv;
         }
 
-        double m_ij;
+        double m_ij = NAN;
         for (size_t i = 0; i < ncomp; i++) {
             for (size_t j = 0; j < ncomp; j++) {
                 m_ij = sqrt(components[i].getM() * components[j].getM());
@@ -1526,7 +1525,7 @@ CoolPropDbl PCSAFTBackend::calc_compressibility_factor(void) {
             }
         }
 
-        double m_ijk;
+        double m_ijk = NAN;
         for (size_t i = 0; i < ncomp; i++) {
             for (size_t j = 0; j < ncomp; j++) {
                 for (size_t k = 0; k < ncomp; k++) {
@@ -1680,7 +1679,7 @@ CoolPropDbl PCSAFTBackend::calc_compressibility_factor(void) {
           sqrt(den * E_CHRG * E_CHRG / kb / _T / (dielc * perm_vac) * summ);  // the inverse Debye screening length. Equation 4 in Held et al. 2008.
 
         if (kappa != 0) {
-            double chi, sigma_k;
+            double chi = NAN, sigma_k = NAN;
             summ = 0.;
             for (size_t i = 0; i < ncomp; i++) {
                 chi = 3 / pow(kappa * d[i], 3) * (1.5 + log(1 + kappa * d[i]) - 2 * (1 + kappa * d[i]) + 0.5 * pow(1 + kappa * d[i], 2));
@@ -1871,8 +1870,8 @@ void PCSAFTBackend::update(CoolProp::input_pairs input_pair, double value1, doub
 phases PCSAFTBackend::calc_phase_internal(CoolProp::input_pairs input_pair) {
     phases phase = iphase_unknown;
 
-    double p_input, rho_input;
-    double p_bub, p_dew, p_equil;
+    double p_input = NAN, rho_input = NAN;
+    double p_bub = NAN, p_dew = NAN, p_equil = NAN;
     switch (input_pair) {
         case PT_INPUTS:
             p_input = _p;
@@ -1926,8 +1925,8 @@ phases PCSAFTBackend::calc_phase_internal(CoolProp::input_pairs input_pair) {
                 }
             }
             break;
-        case DmolarT_INPUTS:
-            double rho_bub, rho_dew;
+        case DmolarT_INPUTS: {
+            double rho_bub = NAN, rho_dew = NAN;
             p_input = _p;
             rho_input = _rhomolar;
 
@@ -1969,6 +1968,7 @@ phases PCSAFTBackend::calc_phase_internal(CoolProp::input_pairs input_pair) {
                 }
             }
             break;
+        }
         default:
             throw ValueError(
               format("Phase determination for this pair of inputs [%s] is not yet supported", get_input_pair_short_desc(input_pair).c_str()));
@@ -2820,7 +2820,7 @@ CoolPropDbl PCSAFTBackend::solver_rho_Tp(CoolPropDbl T, CoolPropDbl p, phases ph
     } else {
         int num_pts = 25;
         double err_min = 1e40;
-        double rho_min;
+        double rho_min = NAN;
         for (int i = 0; i < num_pts; i++) {
             double rho_guess = (0.7405 - 1e-8) / (double)num_pts * i + 1e-8;
             double err = (update_DmolarT(reduced_to_molar(rho_guess, T)) - p) / p;
@@ -2877,7 +2877,7 @@ vector<double> PCSAFTBackend::dXAdt_find(vector<double> delta_ij, double den, ve
     Eigen::MatrixXd B = Eigen::MatrixXd::Zero(num_sites, 1);
     Eigen::MatrixXd A = Eigen::MatrixXd::Zero(num_sites, num_sites);
 
-    double summ;
+    double summ = NAN;
     int ij = 0;
     for (auto i = 0U; i < num_sites; i++) {
         summ = 0;
@@ -2907,7 +2907,7 @@ vector<double> PCSAFTBackend::dXAdx_find(vector<int> assoc_num, vector<double> d
     Eigen::MatrixXd B(num_sites * ncomp, 1);
     Eigen::MatrixXd A = Eigen::MatrixXd::Zero(num_sites * ncomp, num_sites * ncomp);
 
-    double sum1, sum2;
+    double sum1 = NAN, sum2 = NAN;
     int idx1 = 0;
     int ij = 0;
     for (auto i = 0U; i < ncomp; i++) {
@@ -3034,7 +3034,7 @@ double PCSAFTBackend::dielc_water(double t) {
     Limiting Law Slopes,” J. Phys. Chem. Ref. Data, vol. 19, no. 2, pp. 371–411,
     Mar. 1990.
     */
-    double dielc;
+    double dielc = NAN;
     if (t < 263.15) {
         throw ValueError("The current function for the dielectric constant for water is only valid for temperatures above 263.15 K.");
     } else if (t <= 368.15) {

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -37,6 +37,7 @@ surface tension                 N/m
 #include "DataStructures.h"
 #include "AbstractState.h"
 
+#include <cmath>
 #include <cstdlib>
 #include <optional>
 #include <string>
@@ -553,7 +554,7 @@ double REFPROPMixtureBackend::get_binary_interaction_double(const std::string& C
 /// Get binary mixture string value
 std::string REFPROPMixtureBackend::get_binary_interaction_string(const std::string& CAS1, const std::string& CAS2, const std::string& parameter) {
 
-    int icomp, jcomp;
+    int icomp = 0, jcomp = 0;
     char hmodij[3], hfmix[255], hbinp[255], hfij[255], hmxrul[255];
     double fij[6];
 
@@ -680,7 +681,7 @@ double REFPROPMixtureBackend::get_binary_interaction_double(const std::size_t i,
     std::string shmodij(hmodij);
     //if (shmodij.find("KW") == 0 || shmodij.find("GE") == 0)  // Starts with KW or GE
     //{
-    double val;
+    double val = NAN;
     if (parameter == "betaT") {
         val = fij[0];
     } else if (parameter == "gammaT") {
@@ -721,7 +722,7 @@ void REFPROPMixtureBackend::set_mass_fractions(const std::vector<CoolPropDbl>& m
     }
     std::vector<double> moles(this->Ncomp);
     double sum_moles = 0.0;
-    double wmm, ttrp, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
+    double wmm = NAN, ttrp = NAN, tnbpt = NAN, tc = NAN, pc = NAN, Dc = NAN, Zc = NAN, acf = NAN, dip = NAN, Rgas = NAN;
     for (int i = 1L; i <= static_cast<int>(this->Ncomp); ++i) {
         INFOdll(&i, &wmm, &ttrp, &tnbpt, &tc, &pc, &Dc, &Zc, &acf, &dip, &Rgas);
         moles[i - 1] = static_cast<double>(mass_fractions[i - 1]) / (wmm / 1000.0);
@@ -763,24 +764,24 @@ void REFPROPMixtureBackend::limits(double& Tmin, double& Tmax, double& rhomolarm
      *
      */
     this->check_loaded_fluid();
-    double Dmax_mol_L, pmax_kPa;
+    double Dmax_mol_L = NAN, pmax_kPa = NAN;
     char htyp[] = "EOS";
     LIMITSdll(htyp, &(mole_fractions[0]), &Tmin, &Tmax, &Dmax_mol_L, &pmax_kPa, 3);
     pmax = pmax_kPa * 1000;
     rhomolarmax = Dmax_mol_L * 1000;
 }
 CoolPropDbl REFPROPMixtureBackend::calc_pmax(void) {
-    double Tmin, Tmax, rhomolarmax, pmax;
+    double Tmin = NAN, Tmax = NAN, rhomolarmax = NAN, pmax = NAN;
     limits(Tmin, Tmax, rhomolarmax, pmax);
     return static_cast<CoolPropDbl>(pmax);
 };
 CoolPropDbl REFPROPMixtureBackend::calc_Tmax(void) {
-    double Tmin, Tmax, rhomolarmax, pmax;
+    double Tmin = NAN, Tmax = NAN, rhomolarmax = NAN, pmax = NAN;
     limits(Tmin, Tmax, rhomolarmax, pmax);
     return static_cast<CoolPropDbl>(Tmax);
 };
 CoolPropDbl REFPROPMixtureBackend::calc_Tmin(void) {
-    double Tmin, Tmax, rhomolarmax, pmax;
+    double Tmin = NAN, Tmax = NAN, rhomolarmax = NAN, pmax = NAN;
     limits(Tmin, Tmax, rhomolarmax, pmax);
     return static_cast<CoolPropDbl>(Tmin);
 };
@@ -788,7 +789,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_T_critical() {
     this->check_loaded_fluid();
     int ierr = 0;
     char herr[255];
-    double Tcrit, pcrit_kPa, dcrit_mol_L;
+    double Tcrit = NAN, pcrit_kPa = NAN, dcrit_mol_L = NAN;
     CRITPdll(&(mole_fractions[0]), &Tcrit, &pcrit_kPa, &dcrit_mol_L, &ierr, herr, 255);
     if (static_cast<int>(ierr) > get_config_int(REFPROP_ERROR_THRESHOLD)) {
         throw ValueError(format("%s", herr).c_str());
@@ -799,7 +800,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_p_critical() {
     this->check_loaded_fluid();
     int ierr = 0;
     char herr[255];
-    double Tcrit, pcrit_kPa, dcrit_mol_L;
+    double Tcrit = NAN, pcrit_kPa = NAN, dcrit_mol_L = NAN;
     CRITPdll(&(mole_fractions[0]), &Tcrit, &pcrit_kPa, &dcrit_mol_L, &ierr, herr, 255);
     if (static_cast<int>(ierr) > get_config_int(REFPROP_ERROR_THRESHOLD)) {
         throw ValueError(format("%s", herr).c_str());
@@ -809,7 +810,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_p_critical() {
 CoolPropDbl REFPROPMixtureBackend::calc_rhomolar_critical() {
     int ierr = 0;
     char herr[255];
-    double Tcrit, pcrit_kPa, dcrit_mol_L;
+    double Tcrit = NAN, pcrit_kPa = NAN, dcrit_mol_L = NAN;
     CRITPdll(&(mole_fractions[0]), &Tcrit, &pcrit_kPa, &dcrit_mol_L, &ierr, herr, 255);
     if (static_cast<int>(ierr) > get_config_int(REFPROP_ERROR_THRESHOLD)) {
         throw ValueError(format("%s", herr).c_str());
@@ -838,7 +839,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_rhomolar_reducing() {
 CoolPropDbl REFPROPMixtureBackend::calc_acentric_factor() {
     //     subroutine INFO (icomp,wmm,ttrp,tnbpt,tc,pc,Dc,Zc,acf,dip,Rgas) (see calc_Ttriple())
     this->check_loaded_fluid();
-    double wmm, ttrp, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
+    double wmm = NAN, ttrp = NAN, tnbpt = NAN, tc = NAN, pc = NAN, Dc = NAN, Zc = NAN, acf = NAN, dip = NAN, Rgas = NAN;
     int icomp = 1L;
     // Check if more than one
     if (Ncomp == 1) {
@@ -868,7 +869,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_Ttriple() {
     //     c      dip--dipole moment [debye]
     //     c     Rgas--gas constant [J/mol-K]
     this->check_loaded_fluid();
-    double wmm, ttrp, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
+    double wmm = NAN, ttrp = NAN, tnbpt = NAN, tc = NAN, pc = NAN, Dc = NAN, Zc = NAN, acf = NAN, dip = NAN, Rgas = NAN;
     int icomp = 1L;
     // Check if more than one
     if (Ncomp == 1) {
@@ -876,7 +877,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_Ttriple() {
         INFOdll(&icomp, &wmm, &ttrp, &tnbpt, &tc, &pc, &Dc, &Zc, &acf, &dip, &Rgas);
         return static_cast<CoolPropDbl>(ttrp);
     } else {
-        double Tmin, Tmax, rhomolarmax, pmax;
+        double Tmin = NAN, Tmax = NAN, rhomolarmax = NAN, pmax = NAN;
         limits(Tmin, Tmax, rhomolarmax, pmax);
         return static_cast<CoolPropDbl>(Tmin);
     }
@@ -917,7 +918,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_dipole_moment() {
     //     c      dip--dipole moment [debye]
     //     c     Rgas--gas constant [J/mol-K]
     this->check_loaded_fluid();
-    double wmm, ttrp, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
+    double wmm = NAN, ttrp = NAN, tnbpt = NAN, tc = NAN, pc = NAN, Dc = NAN, Zc = NAN, acf = NAN, dip = NAN, Rgas = NAN;
     int icomp = 1L;
     // Check if more than one
     if (Ncomp == 1) {
@@ -936,23 +937,23 @@ CoolPropDbl REFPROPMixtureBackend::calc_gas_constant() {
 };
 CoolPropDbl REFPROPMixtureBackend::calc_molar_mass(void) {
     this->check_loaded_fluid();
-    double wmm_kg_kmol;
+    double wmm_kg_kmol = NAN;
     WMOLdll(&(mole_fractions[0]), &wmm_kg_kmol);  // returns mole mass in kg/kmol
     _molar_mass = wmm_kg_kmol / 1000;             // kg/mol
     return static_cast<CoolPropDbl>(_molar_mass.pt());
 };
 CoolPropDbl REFPROPMixtureBackend::calc_Bvirial(void) {
-    double b;
+    double b = NAN;
     VIRBdll(&_T, &(mole_fractions[0]), &b);
     return b * 0.001;  // 0.001 to convert from l/mol to m^3/mol
 }
 CoolPropDbl REFPROPMixtureBackend::calc_dBvirial_dT(void) {
-    double b;
+    double b = NAN;
     DBDTdll(&_T, &(mole_fractions[0]), &b);
     return b * 0.001;  // 0.001 to convert from l/mol to m^3/mol
 }
 CoolPropDbl REFPROPMixtureBackend::calc_Cvirial(void) {
-    double c;
+    double c = NAN;
     VIRCdll(&_T, &(mole_fractions[0]), &c);
     return c * 1e-6;  // 1e-6 to convert from (l/mol)^2 to (m^3/mol)^2
 }
@@ -960,7 +961,7 @@ double REFPROPMixtureBackend::calc_melt_Tmax() {
     this->check_loaded_fluid();
     int ierr = 0;
     char herr[255];
-    double tmin, tmax, Dmax_mol_L, pmax_kPa, Tmax_melt;
+    double tmin = NAN, tmax = NAN, Dmax_mol_L = NAN, pmax_kPa = NAN, Tmax_melt = NAN;
     char htyp[] = "EOS";
     LIMITSdll(htyp, &(mole_fractions[0]), &tmin, &tmax, &Dmax_mol_L, &pmax_kPa, 3);
     // Get the maximum temperature for the melting curve by using the maximum pressure
@@ -977,14 +978,14 @@ CoolPropDbl REFPROPMixtureBackend::calc_melting_line(int param, int given, CoolP
     char herr[255];
 
     if (param == iP && given == iT) {
-        double _T = static_cast<double>(value), p_kPa;
+        double _T = static_cast<double>(value), p_kPa = NAN;
         MELTTdll(&_T, &(mole_fractions[0]), &p_kPa, &ierr, herr, errormessagelength);  // Error message
         if (static_cast<int>(ierr) > get_config_int(REFPROP_ERROR_THRESHOLD)) {
             throw ValueError(format("%s", herr).c_str());
         }  //else if (ierr < 0) {set_warning(format("%s",herr).c_str());}
         return p_kPa * 1000;
     } else if (param == iT && given == iP) {
-        double p_kPa = static_cast<double>(value) / 1000.0, _T;
+        double p_kPa = static_cast<double>(value) / 1000.0, _T = NAN;
         MELTPdll(&p_kPa, &(mole_fractions[0]), &_T, &ierr, herr, errormessagelength);  // Error message
         if (static_cast<int>(ierr) > get_config_int(REFPROP_ERROR_THRESHOLD)) {
             throw ValueError(format("%s", herr).c_str());
@@ -1000,7 +1001,7 @@ bool REFPROPMixtureBackend::has_melting_line() {
 
     int ierr = 0;
     char herr[255];
-    double _T = 300, p_kPa;
+    double _T = 300, p_kPa = NAN;
     MELTTdll(&_T, &(mole_fractions[0]), &p_kPa, &ierr, herr, errormessagelength);  // Error message
     if (static_cast<int>(ierr) == 1) {
         return false;
@@ -1014,7 +1015,7 @@ const std::vector<CoolPropDbl> REFPROPMixtureBackend::calc_mass_fractions() {
     // REFPROP yields mm in kg/kmol, CP uses base SI units of kg/mol;
     CoolPropDbl mm = molar_mass();
     std::vector<CoolPropDbl> mass_fractions(mole_fractions_long_double.size());
-    double wmm, ttrp, tnbpt, tc, pc, Dc, Zc, acf, dip, Rgas;
+    double wmm = NAN, ttrp = NAN, tnbpt = NAN, tc = NAN, pc = NAN, Dc = NAN, Zc = NAN, acf = NAN, dip = NAN, Rgas = NAN;
     // FORTRAN is 1-based indexing!
     for (int i = 1L; i <= static_cast<int>(mole_fractions_long_double.size()); ++i) {
         // Get value for first component
@@ -1041,7 +1042,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_PIP(void) {
 
 CoolPropDbl REFPROPMixtureBackend::calc_viscosity(void) {
     this->check_loaded_fluid();
-    double eta, tcx, rhomol_L = 0.001 * _rhomolar;
+    double eta = NAN, tcx = NAN, rhomol_L = 0.001 * _rhomolar;
     int ierr = 0;
     char herr[255];
     TRNPRPdll(&_T, &rhomol_L, &(mole_fractions[0]),  // Inputs
@@ -1062,7 +1063,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_conductivity(void) {
 }
 CoolPropDbl REFPROPMixtureBackend::calc_surface_tension(void) {
     this->check_loaded_fluid();
-    double sigma, rho_mol_L = 0.001 * _rhomolar;
+    double sigma = NAN, rho_mol_L = 0.001 * _rhomolar;
     int ierr = 0;
     char herr[255];
     SURFTdll(&_T, &rho_mol_L, &(mole_fractions[0]),  // Inputs
@@ -1124,7 +1125,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_chemical_potential(std::size_t i) {
 
 void REFPROPMixtureBackend::calc_phase_envelope(const std::string& type) {
     this->check_loaded_fluid();
-    double rhoymin, rhoymax, c = 0;
+    double rhoymin = NAN, rhoymax = NAN, c = 0;
     int ierr = 0;
     char herr[255];
     SATSPLNdll(&(mole_fractions[0]),              // Inputs
@@ -1166,7 +1167,7 @@ void REFPROPMixtureBackend::calc_phase_envelope(const std::string& type) {
     int nc = static_cast<int>(this->Ncomp);
     double ratio = pow(rhoymax / rhoymin, 1 / double(N));
     for (double rho_molL = rhoymin; rho_molL < rhoymax; rho_molL *= ratio) {
-        double y;
+        double y = NAN;
         iderv = 0;
 
         PhaseEnvelope.x.resize(nc);
@@ -1203,7 +1204,7 @@ void REFPROPMixtureBackend::calc_phase_envelope(const std::string& type) {
         // Other outputs that could be useful
         int ierr = 0;
         char herr[255];
-        double p_kPa, emol, hmol, smol, cvmol, cpmol, w, hjt, eta, tcx;
+        double p_kPa = NAN, emol = NAN, hmol = NAN, smol = NAN, cvmol = NAN, cpmol = NAN, w = NAN, hjt = NAN, eta = NAN, tcx = NAN;
         // "Vapor"
         THERMdll(&T, &rho_molL, &(mole_fractions[0]), &p_kPa, &emol, &hmol, &smol, &cvmol, &cpmol, &w, &hjt);
         PhaseEnvelope.cpmolar_vap.push_back(cpmol);
@@ -1219,7 +1220,7 @@ void REFPROPMixtureBackend::calc_phase_envelope(const std::string& type) {
 CoolPropDbl REFPROPMixtureBackend::calc_cpmolar_idealgas(void) {
     this->check_loaded_fluid();
     double rho_mol_L = 0.001 * _rhomolar;
-    double p0, e0, h0, s0, cv0, cp0, w0, A0, G0;
+    double p0 = NAN, e0 = NAN, h0 = NAN, s0 = NAN, cv0 = NAN, cp0 = NAN, w0 = NAN, A0 = NAN, G0 = NAN;
     THERM0dll(&_T, &rho_mol_L, &(mole_fractions[0]), &p0, &e0, &h0, &s0, &cv0, &cp0, &w0, &A0, &G0);
     return static_cast<CoolPropDbl>(cp0);
 }
@@ -2072,7 +2073,7 @@ void REFPROPMixtureBackend::calc_true_critical_point(double& T, double& rho) {
     {
        public:
         const std::vector<double> z;
-        wrapper(const std::vector<double>& z) : z(z) {};
+        wrapper(const std::vector<double>& z) : z(z){};
         std::vector<double> call(const std::vector<double>& x) {
             std::vector<double> r(2);
             double dpdrho__constT = _HUGE, d2pdrho2__constT = _HUGE;

--- a/src/Backends/Tabular/BicubicBackend.cpp
+++ b/src/Backends/Tabular/BicubicBackend.cpp
@@ -1,6 +1,8 @@
 #if !defined(NO_TABULAR_BACKENDS)
 
 #    include "BicubicBackend.h"
+
+#    include <cmath>
 #    include "MatrixMath.h"
 #    include "DataStructures.h"
 #    include "Backends/Helmholtz/PhaseEnvelopeRoutines.h"
@@ -202,7 +204,7 @@ void CoolProp::BicubicBackend::invert_single_phase_x(const SinglePhaseGriddedTab
     double c = alpha[1 + 0 * 4] * y_0 + alpha[1 + 1 * 4] * y_1 + alpha[1 + 2 * 4] * y_2 + alpha[1 + 3 * 4] * y_3;          // factors of xhat
     double d = alpha[0 + 0 * 4] * y_0 + alpha[0 + 1 * 4] * y_1 + alpha[0 + 2 * 4] * y_2 + alpha[0 + 3 * 4] * y_3 - other;  // constant factors
     int N = 0;
-    double xhat0, xhat1, xhat2, val, xhat = _HUGE;
+    double xhat0 = NAN, xhat1 = NAN, xhat2 = NAN, val = NAN, xhat = _HUGE;
     solve_cubic(a, b, c, d, N, xhat0, xhat1, xhat2);
     if (N == 1) {
         xhat = xhat0;
@@ -258,7 +260,7 @@ void CoolProp::BicubicBackend::invert_single_phase_y(const SinglePhaseGriddedTab
     double c = alpha[0 + 1 * 4] * x_0 + alpha[1 + 1 * 4] * x_1 + alpha[2 + 1 * 4] * x_2 + alpha[3 + 1 * 4] * x_3;          // factors of yhat
     double d = alpha[0 + 0 * 4] * x_0 + alpha[1 + 0 * 4] * x_1 + alpha[2 + 0 * 4] * x_2 + alpha[3 + 0 * 4] * x_3 - other;  // constant factors
     int N = 0;
-    double yhat0, yhat1, yhat2, val, yhat = _HUGE;
+    double yhat0 = NAN, yhat1 = NAN, yhat2 = NAN, val = NAN, yhat = _HUGE;
     solve_cubic(a, b, c, d, N, yhat0, yhat1, yhat2);
     if (N == 1) {
         yhat = yhat0;

--- a/src/Backends/Tabular/TTSEBackend.cpp
+++ b/src/Backends/Tabular/TTSEBackend.cpp
@@ -1,6 +1,8 @@
 #if !defined(NO_TABULAR_BACKENDS)
 
 #    include "TTSEBackend.h"
+
+#    include <cmath>
 #    include "CoolProp.h"
 
 /** Use the single_phase table to evaluate an output for a transport property
@@ -58,7 +60,7 @@ void CoolProp::TTSEBackend::invert_single_phase_x(const SinglePhaseGriddedTableD
     double deltax2 = (-b - sqrt(b * b - 4 * a * c)) / (2 * a);
 
     // If only one is less than a multiple of x spacing, that's your solution
-    double xspacing, xratio, val;
+    double xspacing = NAN, xratio = NAN, val = NAN;
     if (!table.logx) {
         xspacing = table.xvec[1] - table.xvec[0];
         if (std::abs(deltax1) < xspacing && !(std::abs(deltax2) < xspacing)) {
@@ -116,7 +118,7 @@ void CoolProp::TTSEBackend::invert_single_phase_y(const SinglePhaseGriddedTableD
     double deltay2 = (-b - sqrt(b * b - 4 * a * c)) / (2 * a);
 
     // If only one is less than a multiple of x spacing, that's your solution
-    double yspacing, yratio, val;
+    double yspacing = NAN, yratio = NAN, val = NAN;
     if (!table.logy) {
         yspacing = table.yvec[1] - table.yvec[0];
         if (std::abs(deltay1) < yspacing && !(std::abs(deltay2) < yspacing)) {
@@ -221,7 +223,7 @@ double CoolProp::TTSEBackend::evaluate_single_phase_derivative(SinglePhaseGridde
     // Distances from the node
     double deltax = x - table.xvec[i];
     double deltay = y - table.yvec[j];
-    double val;
+    double val = NAN;
     // Calculate the output value desired
     if (Nx == 1 && Ny == 0) {
         if (output == table.xkey) {

--- a/src/Backends/Tabular/TabularBackends.cpp
+++ b/src/Backends/Tabular/TabularBackends.cpp
@@ -3,6 +3,7 @@
 
 #    include "TabularBackends.h"
 #    include "CoolProp.h"
+#    include <cmath>
 #    include <sstream>
 #    include <ctime>
 #    include "miniz.h"
@@ -51,7 +52,7 @@ void load_table(T& table, const std::string& path_to_tables, const std::string& 
     std::vector<unsigned char> newBuffer(raw.size() * 5);
     uLong newBufferSize = static_cast<uLong>(newBuffer.size());
     mz_ulong rawBufferSize = static_cast<mz_ulong>(raw.size());
-    int code;
+    int code = 0;
     do {
         code = uncompress((unsigned char*)(&(newBuffer[0])), &newBufferSize, (unsigned char*)(&(raw[0])), rawBufferSize);
         if (code == Z_BUF_ERROR) {
@@ -122,7 +123,7 @@ void CoolProp::PureFluidSaturationTableData::build(shared_ptr<CoolProp::Abstract
     CoolPropDbl Tmin = std::max(AS->Ttriple(), AS->Tmin());
     AS->update(QT_INPUTS, 0, Tmin);
     CoolPropDbl p_triple = AS->p();
-    CoolPropDbl p, pmin = p_triple, pmax = 0.9999 * AS->p_critical();
+    CoolPropDbl p = NAN, pmin = p_triple, pmax = 0.9999 * AS->p_critical();
     for (std::size_t i = 0; i < N - 1; ++i) {
         if (i == 0) {
             CoolProp::set_config_bool(DONT_CHECK_PROPERTY_LIMITS, true);
@@ -222,7 +223,7 @@ void CoolProp::PureFluidSaturationTableData::build(shared_ptr<CoolProp::Abstract
 }
 
 void CoolProp::SinglePhaseGriddedTableData::build(shared_ptr<CoolProp::AbstractState>& AS) {
-    CoolPropDbl x, y;
+    CoolPropDbl x = NAN, y = NAN;
     const bool debug = get_debug_level() > 5 || false;
 
     resize(Nx, Ny);
@@ -261,7 +262,7 @@ void CoolProp::SinglePhaseGriddedTableData::build(shared_ptr<CoolProp::AbstractS
             }
 
             // Generate the input pair
-            CoolPropDbl v1, v2;
+            CoolPropDbl v1 = NAN, v2 = NAN;
             input_pairs input_pair = generate_update_pair(xkey, x, ykey, y, v1, v2);
 
             // --------------------
@@ -618,7 +619,7 @@ CoolPropDbl CoolProp::TabularBackend::calc_speed_sound(void) {
 }
 CoolPropDbl CoolProp::TabularBackend::calc_first_partial_deriv(parameters Of, parameters Wrt, parameters Constant) {
     if (using_single_phase_table) {
-        CoolPropDbl dOf_dx, dOf_dy, dWrt_dx, dWrt_dy, dConstant_dx, dConstant_dy;
+        CoolPropDbl dOf_dx = NAN, dOf_dy = NAN, dWrt_dx = NAN, dWrt_dy = NAN, dConstant_dx = NAN, dConstant_dy = NAN;
 
         // If a mass-based parameter is provided, get a conversion factor and change the key to the molar-based key
         double Of_conversion_factor = 1.0, Wrt_conversion_factor = 1.0, Constant_conversion_factor = 1.0, MM = AS->molar_mass();
@@ -1020,7 +1021,7 @@ void CoolProp::TabularBackend::update(CoolProp::input_pairs input_pair, double v
         case PUmolar_INPUTS:
         case PSmolar_INPUTS:
         case DmolarP_INPUTS: {
-            CoolPropDbl otherval;
+            CoolPropDbl otherval = NAN;
             parameters otherkey;
             switch (input_pair) {
                 case PUmolar_INPUTS:
@@ -1103,7 +1104,7 @@ void CoolProp::TabularBackend::update(CoolProp::input_pairs input_pair, double v
         }
         case SmolarT_INPUTS:
         case DmolarT_INPUTS: {
-            CoolPropDbl otherval;
+            CoolPropDbl otherval = NAN;
             parameters otherkey;
             switch (input_pair) {
                 case SmolarT_INPUTS:

--- a/src/CPnumerics.cpp
+++ b/src/CPnumerics.cpp
@@ -1,5 +1,6 @@
 #include "CPnumerics.h"
 #include "MatrixMath.h"
+#include <cmath>
 #include <unsupported/Eigen/Polynomials>
 
 double root_sum_square(const std::vector<double>& x) {
@@ -10,7 +11,7 @@ double root_sum_square(const std::vector<double>& x) {
     return sqrt(sum);
 }
 double interp1d(const std::vector<double>* x, const std::vector<double>* y, double x0) {
-    std::size_t i, L, R, M;
+    std::size_t i = 0, L = 0, R = 0, M = 0;
     L = 0;
     R = (*x).size() - 1;
     M = (L + R) / 2;
@@ -39,10 +40,10 @@ double interp1d(const std::vector<double>* x, const std::vector<double>* y, doub
 double powInt(double x, int y) {
     // Raise a double to an integer power
     // Overload not provided in math.h
-    int i;
+    int i = 0;
     double product = 1.0;
-    double x_in;
-    int y_in;
+    double x_in = NAN;
+    int y_in = 0;
 
     if (y == 0) {
         return 1.0;
@@ -68,7 +69,7 @@ double powInt(double x, int y) {
 }
 
 void MatInv_2(double A[2][2], double B[2][2]) {
-    double Det;
+    double Det = NAN;
     //Using Cramer's Rule to solve
 
     Det = A[0][0] * A[1][1] - A[1][0] * A[0][1];
@@ -107,7 +108,7 @@ void solve_cubic(double a, double b, double c, double d, int& N, double& x0, dou
 
     if (DELTA < 0) {
         // One real root
-        double t0;
+        double t0 = NAN;
         if (4 * p * p * p + 27 * q * q > 0 && p < 0) {
             t0 = -2.0 * std::abs(q) / q * sqrt(-p / 3.0) * cosh(1.0 / 3.0 * acosh(-3.0 * std::abs(q) / (2.0 * p) * sqrt(-3.0 / p)));
         } else {

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -26,6 +26,7 @@
 #    endif
 #endif
 
+#include <cmath>
 #include <memory>
 
 #include <iostream>
@@ -83,7 +84,7 @@ bool has_backend_in_string(const std::string& fluid_string, std::size_t& i) {
 }
 
 void extract_backend(std::string fluid_string, std::string& backend, std::string& fluid) {
-    std::size_t i;
+    std::size_t i = 0;
     // For backwards compatibility reasons, if "REFPROP-" or "REFPROP-MIX:" start
     // the fluid_string, replace them with "REFPROP::"
     if (fluid_string.find("REFPROP-MIX:") == 0) {
@@ -117,7 +118,7 @@ bool has_solution_concentration(const std::string& fluid_string) {
 struct delim : std::numpunct<char>
 {
     char m_c;
-    delim(char c) : m_c(c) {};
+    delim(char c) : m_c(c){};
     char do_decimal_point() const {
         return m_c;
     }
@@ -155,7 +156,7 @@ std::string extract_fractions(const std::string& fluid_string, std::vector<doubl
             std::stringstream ssfraction(fraction);
             const char c = get_config_string(FLOAT_PUNCTUATION)[0];
             ssfraction.imbue(std::locale(ssfraction.getloc(), new delim(c)));
-            double f;
+            double f = NAN;
             ssfraction >> f;
             if (ssfraction.rdbuf()->in_avail() != 0) {
                 throw ValueError(format("fraction [%s] was not converted fully", fraction.c_str()));
@@ -183,7 +184,7 @@ std::string extract_fractions(const std::string& fluid_string, std::vector<doubl
         return strjoin(names, "&");
     } else if (has_solution_concentration(fluid_string)) {
         fractions.clear();
-        double x;
+        double x = NAN;
 
         std::vector<std::string> fluid_parts = strsplit(fluid_string, '-');
         // Check it worked
@@ -193,7 +194,7 @@ std::string extract_fractions(const std::string& fluid_string, std::vector<doubl
         }
 
         // Convert the concentration into a string
-        char* pEnd;
+        char* pEnd = nullptr;
         x = strtod(fluid_parts[1].c_str(), &pEnd);
 
         // Check if per cent or fraction syntax is used

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -1,6 +1,7 @@
 #include "CoolPropPlot.h"
 #include "CoolProp.h"
 #include "CPnumerics.h"
+#include <cmath>
 #include <map>
 
 namespace CoolProp {
@@ -151,7 +152,7 @@ Range Isoline::get_sat_bounds(CoolProp::parameters key) const {
     double p_small = critical_state_->keyed_output(CoolProp::iP) * s;
 
     double t_triple = state_->trivial_keyed_output(CoolProp::iT_triple);
-    double t_min;
+    double t_min = NAN;
     try {
         t_min = state_->trivial_keyed_output(CoolProp::iT_min);
     } catch (...) {
@@ -200,7 +201,7 @@ void Isoline::calc_sat_range(int count) {
 
 void Isoline::update_pair(int& ipos, int& xpos, int& ypos, int& pair) {
     Detail::IsolineSupported should_switch = Detail::xy_switch.at(key_).at(ykey_ * 10 + xkey_);
-    double out1, out2;
+    double out1 = NAN, out2 = NAN;
     if (should_switch == Detail::IsolineSupported::No)
         throw CoolProp::ValueError("This isoline cannot be calculated!");
     else if (should_switch == Detail::IsolineSupported::Yes)
@@ -235,7 +236,7 @@ void Isoline::calc_range(std::vector<double>& xvals, std::vector<double>& yvals)
     if (key_ == CoolProp::iQ) {
         calc_sat_range(static_cast<int>(xvals.size()));
     } else {
-        int ipos, xpos, ypos, pair;
+        int ipos = 0, xpos = 0, ypos = 0, pair = 0;
         update_pair(ipos, xpos, ypos, pair);
 
         std::vector<double> ivals(xvals.size(), value);
@@ -276,7 +277,7 @@ PropertyPlot::PropertyPlot(const std::string& fluid_name, CoolProp::parameters y
     // We are just assuming that all inputs and outputs are in SI units. We
     // take care of any conversions before calling the library and after
     // getting the results.
-    int out1, out2;
+    int out1 = 0, out2 = 0;
     axis_pair_ = CoolProp::generate_update_pair(xkey, 0, ykey, 1, out1, out2);
     swap_axis_inputs_for_update_ = (out1 == 1);
 
@@ -370,7 +371,7 @@ Range PropertyPlot::get_sat_bounds(CoolProp::parameters key) const {
     double p_small = critical_state_->keyed_output(CoolProp::iP) * s;
 
     double t_triple = state_->trivial_keyed_output(CoolProp::iT_triple);
-    double t_min;
+    double t_min = NAN;
     try {
         t_min = state_->trivial_keyed_output(CoolProp::iT_min);
     } catch (...) {

--- a/src/DataStructures.cpp
+++ b/src/DataStructures.cpp
@@ -177,7 +177,7 @@ bool is_trivial_parameter(int key) {
 }
 
 std::string get_parameter_information(int key, std::string_view info) {
-    const std::map<int, std::string>* M;
+    const std::map<int, std::string>* M = nullptr;
     auto& parameter_information = get_parameter_information();
     // Hook up the right map (since they are all of the same type)
     if (info == "IO") {

--- a/src/Helmholtz.cpp
+++ b/src/Helmholtz.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <numeric>
 #include "Helmholtz.h"
 
@@ -11,7 +12,7 @@
 namespace CoolProp {
 
 CoolPropDbl kahanSum(const std::vector<CoolPropDbl>& x) {
-    CoolPropDbl sum = x[0], y, t;
+    CoolPropDbl sum = x[0], y = NAN, t = NAN;
     CoolPropDbl c = 0.0;  //A running compensation for lost low-order bits.
     for (std::size_t i = 1; i < x.size(); ++i) {
         y = x[i] - c;       //So far, so good: c is zero.
@@ -135,7 +136,7 @@ void ResidualHelmholtzGeneralizedExponential::allEigen(const CoolPropDbl &tau, c
 };
 */
 void ResidualHelmholtzGeneralizedExponential::all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) {
-    CoolPropDbl log_tau = log(tau), log_delta = log(delta), ndteu, one_over_delta = 1 / delta,
+    CoolPropDbl log_tau = log(tau), log_delta = log(delta), ndteu = NAN, one_over_delta = 1 / delta,
                 one_over_tau = 1 / tau;  // division is much slower than multiplication, so do one division here
 
     // Maybe split the construction of u and other parts into two separate loops?

--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -4,6 +4,7 @@
 #    endif
 #endif
 
+#include <cmath>
 #include <memory>
 #include <mutex>
 using std::shared_ptr;
@@ -19,7 +20,6 @@ using std::shared_ptr;
 
 #include <algorithm>  // std::next_permutation
 #include <cstdlib>
-#include <cmath>
 #include <ctime>
 #include <cstdio>
 #include <cstring>
@@ -367,7 +367,7 @@ void UseIdealGasEnthalpyCorrelations(int flag) {
 }
 static double Brent_HAProps_W(givens OutputKey, double p, givens In1Name, double Input1, double TargetVal, double W_min, double W_max) {
     // Iterating for W,
-    double W;
+    double W = NAN;
     class BrentSolverResids : public CoolProp::FuncWrapper1D
     {
        private:
@@ -437,7 +437,7 @@ static double Brent_HAProps_W(givens OutputKey, double p, givens In1Name, double
     return W;
 }
 static double Brent_HAProps_T(givens OutputKey, double p, givens In1Name, double Input1, double TargetVal, double T_min, double T_max) {
-    double T;
+    double T = NAN;
     class BrentSolverResids : public CoolProp::FuncWrapper1D
     {
        private:
@@ -459,7 +459,7 @@ static double Brent_HAProps_T(givens OutputKey, double p, givens In1Name, double
         };
 
         double call(double T_drybulb) {
-            double psi_w;
+            double psi_w = NAN;
             psi_w = MoleFractionWater(T_drybulb, p, input_keys[0], input_vals[0]);
             double val = _HAPropsSI_outputs(OutputKey, p, T_drybulb, psi_w);
             return val - TargetVal;
@@ -505,7 +505,7 @@ static double Brent_HAProps_T(givens OutputKey, double p, givens In1Name, double
     return T;
 }
 static double Secant_Tdb_at_saturated_W(double psi_w, double p, double T_guess) {
-    double T;
+    double T = NAN;
     class BrentSolverResids : public CoolProp::FuncWrapper1D
     {
        private:
@@ -515,10 +515,10 @@ static double Secant_Tdb_at_saturated_W(double psi_w, double p, double T_guess) 
         BrentSolverResids(double psi_w, double p) : psi_w(psi_w), p(p) {
             pp_water = psi_w * p;
         };
-        ~BrentSolverResids() {};
+        ~BrentSolverResids(){};
 
         double call(double T) {
-            double p_ws;
+            double p_ws = NAN;
             if (T >= 273.16) {
                 // Saturation pressure [Pa] using IF97 formulation
                 p_ws = IF97::psat97(T);
@@ -637,7 +637,7 @@ static double _C_aaw(double T) {
     // Function return has units of m^6/mol^2
     double c[] = {0, 0.482737e3, 0.105678e6, -0.656394e8, 0.294442e11, -0.319317e13};
     double rhobarstar = 1000, Tstar = 1, summer = 0;
-    int i;
+    int i = 0;
     for (i = 1; i <= 5; i++) {
         summer += c[i] * pow(T / Tstar, 1 - i);
     }
@@ -649,7 +649,7 @@ static double _dC_aaw_dT(double T) {
     // Function return in units of m^6/mol^2/K
     double c[] = {0, 0.482737e3, 0.105678e6, -0.656394e8, 0.294442e11, -0.319317e13};
     double rhobarstar = 1000, Tstar = 1, summer = 0;
-    int i;
+    int i = 0;
     for (i = 2; i <= 5; i++) {
         summer += c[i] * (1 - i) * pow(T / Tstar, -i);
     }
@@ -661,7 +661,7 @@ static double _C_aww(double T) {
     // Function return has units of m^6/mol^2
     double d[] = {0, -0.1072887e2, 0.347804e4, -0.383383e6, 0.334060e8};
     double rhobarstar = 1, Tstar = 1, summer = 0;
-    int i;
+    int i = 0;
     for (i = 1; i <= 4; i++) {
         summer += d[i] * pow(T / Tstar, 1 - i);
     }
@@ -673,7 +673,7 @@ static double _dC_aww_dT(double T) {
     // Function return in units of m^6/mol^2/K
     double d[] = {0, -0.1072887e2, 0.347804e4, -0.383383e6, 0.334060e8};
     double rhobarstar = 1, Tstar = 1, summer1 = 0, summer2 = 0;
-    int i;
+    int i = 0;
     for (i = 1; i <= 4; i++) {
         summer1 += d[i] * pow(T / Tstar, 1 - i);
     }
@@ -686,7 +686,7 @@ static double _dC_aww_dT(double T) {
 
 static double B_m(double T, double psi_w) {
     // Bm has units of m^3/mol
-    double B_aa, B_ww, B_aw;
+    double B_aa = NAN, B_ww = NAN, B_aw = NAN;
     if (FlagUseVirialCorrelations == 1) {
         B_aa = -0.000721183853646 + 1.142682674467e-05 * T - 8.838228412173e-08 * pow(T, 2) + 4.104150642775e-10 * pow(T, 3)
                - 1.192780880645e-12 * pow(T, 4) + 2.134201312070e-15 * pow(T, 5) - 2.157430412913e-18 * pow(T, 6) + 9.453830907795e-22 * pow(T, 7);
@@ -703,7 +703,7 @@ static double B_m(double T, double psi_w) {
 
 static double dB_m_dT(double T, double psi_w) {
     //dBm_dT has units of m^3/mol/K
-    double dB_dT_aa, dB_dT_ww, dB_dT_aw;
+    double dB_dT_aa = NAN, dB_dT_ww = NAN, dB_dT_aw = NAN;
     if (FlagUseVirialCorrelations) {
         dB_dT_aa = 1.65159324353e-05 - 3.026130954749e-07 * T + 2.558323847166e-09 * pow(T, 2) - 1.250695660784e-11 * pow(T, 3)
                    + 3.759401946106e-14 * pow(T, 4) - 6.889086380822e-17 * pow(T, 5) + 7.089457032972e-20 * pow(T, 6)
@@ -721,7 +721,7 @@ static double dB_m_dT(double T, double psi_w) {
 
 static double C_m(double T, double psi_w) {
     // Cm has units of m^6/mol^2
-    double C_aaa, C_www, C_aww, C_aaw;
+    double C_aaa = NAN, C_www = NAN, C_aww = NAN, C_aaw = NAN;
     if (FlagUseVirialCorrelations) {
         C_aaa = 1.29192158975e-08 - 1.776054020409e-10 * T + 1.359641176409e-12 * pow(T, 2) - 6.234878717893e-15 * pow(T, 3)
                 + 1.791668730770e-17 * pow(T, 4) - 3.175283581294e-20 * pow(T, 5) + 3.184306136120e-23 * pow(T, 6) - 1.386043640106e-26 * pow(T, 7);
@@ -739,7 +739,7 @@ static double C_m(double T, double psi_w) {
 static double dC_m_dT(double T, double psi_w) {
     // dCm_dT has units of m^6/mol^2/K
 
-    double dC_dT_aaa, dC_dT_www, dC_dT_aww, dC_dT_aaw;
+    double dC_dT_aaa = NAN, dC_dT_www = NAN, dC_dT_aww = NAN, dC_dT_aaw = NAN;
     // NDG for fluid EOS for virial terms
     if (FlagUseVirialCorrelations) {
         dC_dT_aaa = -2.46582342273e-10 + 4.425401935447e-12 * T - 3.669987371644e-14 * pow(T, 2) + 1.765891183964e-16 * pow(T, 3)
@@ -763,7 +763,7 @@ double HumidityRatio(double psi_w) {
 
 static double HenryConstant(double T) {
     // Result has units of 1/Pa
-    double p_ws, beta_N2, beta_O2, beta_Ar, beta_a, tau, Tr, Tc = 647.096;
+    double p_ws = NAN, beta_N2 = NAN, beta_O2 = NAN, beta_Ar = NAN, beta_a = NAN, tau = NAN, Tr = NAN, Tc = 647.096;
     Tr = T / Tc;
     tau = 1 - Tr;
     p_ws = IF97::psat97(T);  //[Pa]
@@ -774,7 +774,7 @@ static double HenryConstant(double T) {
     return 1 / (1.01325 * beta_a);
 }
 double isothermal_compressibility(double T, double p) {
-    double k_T;
+    double k_T = NAN;
 
     if (T > 273.16) {
         if (FlagUseIsothermCompressCorrelation) {
@@ -793,10 +793,11 @@ double isothermal_compressibility(double T, double p) {
 }
 double f_factor(double T, double p) {
     double f = 0, Rbar = 8.314371, eps = 1e-8;
-    double x1 = 0, x2 = 0, x3, y1 = 0, y2, change = _HUGE;
+    double x1 = 0, x2 = 0, x3 = NAN, y1 = 0, y2 = NAN, change = _HUGE;
     int iter = 1;
-    double p_ws, B_aa, B_aw, B_ww, C_aaa, C_aaw, C_aww, C_www, line1, line2, line3, line4, line5, line6, line7, line8, k_T, beta_H, LHS, RHS, psi_ws,
-      vbar_ws;
+    double p_ws = NAN, B_aa = NAN, B_aw = NAN, B_ww = NAN, C_aaa = NAN, C_aaw = NAN, C_aww = NAN, C_www = NAN, line1 = NAN, line2 = NAN, line3 = NAN,
+           line4 = NAN, line5 = NAN, line6 = NAN, line7 = NAN, line8 = NAN, k_T = NAN, beta_H = NAN, LHS = NAN, RHS = NAN, psi_ws = NAN,
+           vbar_ws = NAN;
 
     // Saturation pressure [Pa]
     if (T > 273.16) {
@@ -921,7 +922,7 @@ double Viscosity(double T, double p, double psi_w) {
 
     but using the detailed measurements for pure fluid from IAPWS formulations
     */
-    double mu_a, mu_w, Phi_av, Phi_va, Ma, Mw;
+    double mu_a = NAN, mu_w = NAN, Phi_av = NAN, Phi_va = NAN, Ma = NAN, Mw = NAN;
     Mw = MM_Water();
     Ma = MM_Air();
     // Viscosity of dry air at dry-bulb temp and total pressure
@@ -942,7 +943,7 @@ double Conductivity(double T, double p, double psi_w) {
 
     but using the detailed measurements for pure fluid from IAPWS formulations
     */
-    double mu_a, mu_w, k_a, k_w, Phi_av, Phi_va, Ma, Mw;
+    double mu_a = NAN, mu_w = NAN, k_a = NAN, k_w = NAN, Phi_av = NAN, Phi_va = NAN, Ma = NAN, Mw = NAN;
     Mw = MM_Water();
     Ma = MM_Air();
 
@@ -966,8 +967,8 @@ double Conductivity(double T, double p, double psi_w) {
  */
 double MolarVolume(double T, double p, double psi_w) {
     // Output in m^3/mol_ha
-    int iter;
-    double v_bar0, v_bar = 0, R_bar = 8.314472, x1 = 0, x2 = 0, x3, y1 = 0, y2, resid, eps, Bm, Cm;
+    int iter = 0;
+    double v_bar0 = NAN, v_bar = 0, R_bar = 8.314472, x1 = 0, x2 = 0, x3 = NAN, y1 = 0, y2 = NAN, resid = NAN, eps = NAN, Bm = NAN, Cm = NAN;
 
     // -----------------------------
     // Iteratively find molar volume
@@ -1068,7 +1069,7 @@ double MolarEnthalpy(double T, double p, double psi_w, double vmolar) {
 
     // vbar (molar volume) in m^3/kg
 
-    double hbar_0, hbar_a, hbar_w, hbar, R_bar = 8.314472;
+    double hbar_0 = NAN, hbar_a = NAN, hbar_w = NAN, hbar = NAN, R_bar = 8.314472;
     // ----------------------------------------
     //      Enthalpy
     // ----------------------------------------
@@ -1134,8 +1135,8 @@ double MolarEntropy(double T, double p, double psi_w, double v_bar) {
     // vbar (molar volume) in m^3/mol
     double x1 = 0, x2 = 0, x3 = 0, y1 = 0, y2 = 0, eps = 1e-8, f = 999, R_bar_Lem = 8.314510;
     int iter = 1;
-    double sbar_0, sbar_a = 0, sbar_w = 0, sbar, R_bar = 8.314472, vbar_a_guess, Baa, Caaa, vbar_a = 0;
-    double B, dBdT, C, dCdT;
+    double sbar_0 = NAN, sbar_a = 0, sbar_w = 0, sbar = NAN, R_bar = 8.314472, vbar_a_guess = NAN, Baa = NAN, Caaa = NAN, vbar_a = 0;
+    double B = NAN, dBdT = NAN, C = NAN, dCdT = NAN;
     // Constant for entropy
     sbar_0 = 0.02366427495;  //[J/mol/K]
 
@@ -1206,9 +1207,9 @@ double MassEntropy_per_kgda(double T, double p, double psi_w) {
 }
 
 double DewpointTemperature(double T, double p, double psi_w) {
-    int iter;
-    double p_w, eps, resid, Tdp = 0, x1 = 0, x2 = 0, x3, y1 = 0, y2, T0;
-    double p_ws_dp, f_dp;
+    int iter = 0;
+    double p_w = NAN, eps = NAN, resid = NAN, Tdp = 0, x1 = 0, x2 = 0, x3 = NAN, y1 = 0, y2 = NAN, T0 = NAN;
+    double p_ws_dp = NAN, f_dp = NAN;
 
     // Make sure it isn't dry air, return an impossible temperature otherwise
     if ((1 - psi_w) < 1e-16) {
@@ -1288,7 +1289,7 @@ class WetBulbSolver : public CoolProp::FuncWrapper1D
     }
     double call(double Twb) {
         double epsilon = 0.621945;
-        double f_wb, p_ws_wb, p_s_wb, W_s_wb, h_w, M_ha_wb, psi_wb, v_bar_wb;
+        double f_wb = NAN, p_ws_wb = NAN, p_s_wb = NAN, W_s_wb = NAN, h_w = NAN, M_ha_wb = NAN, psi_wb = NAN, v_bar_wb = NAN;
 
         // Enhancement Factor at wetbulb temperature [-]
         f_wb = f_factor(Twb, _p);
@@ -1336,7 +1337,7 @@ class WetBulbTminSolver : public CoolProp::FuncWrapper1D
     double call(double Ts) {
         //double RHS = HAPropsSI("H","T",Ts,"P",p,"R",1);
 
-        double psi_w, T = Ts;
+        double psi_w = NAN, T = Ts;
         //std::vector<givens> inp = { HumidAir::GIVEN_T, HumidAir::GIVEN_RH }; // C++11
         std::vector<givens> inp(2);
         inp[0] = HumidAir::GIVEN_T;
@@ -1375,7 +1376,7 @@ double WetbulbTemperature(double T, double p, double psi_w) {
     // Instantiate the solver container class
     WetBulbSolver WBS(T, p, psi_w);
 
-    double return_val;
+    double return_val = NAN;
     try {
         return_val = Brent(WBS, Tmax + 1, 100, DBL_EPSILON, 1e-12, 50);
 
@@ -1466,7 +1467,7 @@ int TypeMatch(int TypeCode, const std::string& Input1Name, const std::string& In
         return -1;
 }
 double MoleFractionWater(double T, double p, int HumInput, double InVal) {
-    double p_ws, f, W, epsilon = 0.621945, Tdp, p_ws_dp, f_dp, p_w_dp, p_s, RH;
+    double p_ws = NAN, f = NAN, W = NAN, epsilon = 0.621945, Tdp = NAN, p_ws_dp = NAN, f_dp = NAN, p_w_dp = NAN, p_s = NAN, RH = NAN;
 
     if (HumInput == GIVEN_HUMRAT)  //(2)
     {
@@ -1511,7 +1512,7 @@ double MoleFractionWater(double T, double p, int HumInput, double InVal) {
 }
 
 double RelativeHumidity(double T, double p, double psi_w) {
-    double p_ws, f, p_s;
+    double p_ws = NAN, f = NAN, p_s = NAN;
     if (T >= 273.16) {
         // Saturation pressure [Pa]
         p_ws = IF97::psat97(T);
@@ -1926,7 +1927,7 @@ double _HAPropsSI_outputs(givens OutputType, double p, double T, double psi_w) {
             return _HAPropsSI_outputs(GIVEN_CPHA, p, T, psi_w) * (1 + HumidityRatio(psi_w));
         }
         case GIVEN_CPHA: {
-            double v_bar1, v_bar2, h_bar1, h_bar2, cp_ha, dT = 1e-3;
+            double v_bar1 = NAN, v_bar2 = NAN, h_bar1 = NAN, h_bar2 = NAN, cp_ha = NAN, dT = 1e-3;
             v_bar1 = MolarVolume(T - dT, p, psi_w);            //[m^3/mol_ha]
             h_bar1 = MolarEnthalpy(T - dT, p, psi_w, v_bar1);  //[J/mol_ha]
             v_bar2 = MolarVolume(T + dT, p, psi_w);            //[m^3/mol_ha]
@@ -1939,7 +1940,7 @@ double _HAPropsSI_outputs(givens OutputType, double p, double T, double psi_w) {
             return _HAPropsSI_outputs(GIVEN_CVHA, p, T, psi_w) * (1 + HumidityRatio(psi_w));
         }
         case GIVEN_CVHA: {
-            double v_bar, p_1, p_2, u_bar1, u_bar2, cv_bar, dT = 1e-3;
+            double v_bar = NAN, p_1 = NAN, p_2 = NAN, u_bar1 = NAN, u_bar2 = NAN, cv_bar = NAN, dT = 1e-3;
             v_bar = MolarVolume(T, p, psi_w);  //[m^3/mol_ha]
             p_1 = Pressure(T - dT, v_bar, psi_w);
             u_bar1 = MolarInternalEnergy(T - dT, p_1, psi_w, v_bar);  //[J/mol_ha]
@@ -1949,7 +1950,7 @@ double _HAPropsSI_outputs(givens OutputType, double p, double T, double psi_w) {
             return cv_bar / M_ha;                                     //[J/kg_ha/K]
         }
         case GIVEN_ISENTROPIC_EXPONENT: {
-            CoolPropDbl v_bar, dv = 1e-8, p_1, p_2;
+            CoolPropDbl v_bar = NAN, dv = 1e-8, p_1 = NAN, p_2 = NAN;
             CoolPropDbl cp = _HAPropsSI_outputs(GIVEN_CPHA, p, T, psi_w);  //[J/kg_da/K]
             CoolPropDbl cv = _HAPropsSI_outputs(GIVEN_CVHA, p, T, psi_w);  //[J/kg_da/K]
             v_bar = MolarVolume(T, p, psi_w);                              //[m^3/mol_ha]
@@ -1959,7 +1960,7 @@ double _HAPropsSI_outputs(givens OutputType, double p, double T, double psi_w) {
             return -cp / cv * dpdv__constT * v_bar / p;
         }
         case GIVEN_SPEED_OF_SOUND: {
-            CoolPropDbl v_bar, dv = 1e-8, p_1, p_2;
+            CoolPropDbl v_bar = NAN, dv = 1e-8, p_1 = NAN, p_2 = NAN;
             CoolPropDbl cp = _HAPropsSI_outputs(GIVEN_CPHA, p, T, psi_w);  //[J/kg_da/K]
             CoolPropDbl cv = _HAPropsSI_outputs(GIVEN_CVHA, p, T, psi_w);  //[J/kg_da/K]
             v_bar = MolarVolume(T, p, psi_w);                              //[m^3/mol_ha]
@@ -1995,7 +1996,7 @@ double HAPropsSI(const std::string& OutputName, const std::string& Input1Name, d
         std::vector<double> input_vals(2);
 
         givens In1Type, In2Type, In3Type, OutputType;
-        double p, T = _HUGE, psi_w = _HUGE;
+        double p = NAN, T = _HUGE, psi_w = _HUGE;
 
         // First figure out what kind of inputs you have, convert names to enum values
         In1Type = Name2Type(Input1Name.c_str());
@@ -2120,7 +2121,7 @@ double HAProps_Aux(const char* Name, double T, double p, double W, char* units) 
     // Requires W since it is nice and fast and always defined.  Put a dummy value if you want something that doesn't use humidity
 
     // Takes temperature, pressure, and humidity ratio W as inputs;
-    double psi_w, B_aa, C_aaa, B_ww, C_www, B_aw, C_aaw, C_aww, v_bar;
+    double psi_w = NAN, B_aa = NAN, C_aaa = NAN, B_ww = NAN, C_www = NAN, B_aw = NAN, C_aaw = NAN, C_aww = NAN, v_bar = NAN;
 
     try {
         if (!strcmp(Name, "Baa")) {

--- a/src/Ice.cpp
+++ b/src/Ice.cpp
@@ -37,7 +37,7 @@ double psub_Ice(double T) {
 #ifndef __powerpc__
     double a[] = {0, -0.212144006e2, 0.273203819e2, -0.610598130e1};
     double b[] = {0, 0.333333333e-2, 0.120666667e1, 0.170333333e1};
-    double summer = 0, theta;
+    double summer = 0, theta = NAN;
     theta = T / T_t;
     for (int i = 1; i <= 3; i++) {
         summer += a[i] * pow(theta, b[i]);
@@ -51,7 +51,7 @@ double psub_Ice(double T) {
 double g_Ice(double T, double p) {
 #ifndef __powerpc__
     std::complex<double> r2, term1, term2;
-    double g0, theta, pi, pi_0;
+    double g0 = NAN, theta = NAN, pi = NAN, pi_0 = NAN;
     theta = T / T_t;
     pi = p / p_t;
     pi_0 = p_0 / p_t;
@@ -69,7 +69,7 @@ double g_Ice(double T, double p) {
 double dg_dp_Ice(double T, double p) {
 #ifndef __powerpc__
     std::complex<double> r2_p;
-    double g0_p, theta, pi, pi_0;
+    double g0_p = NAN, theta = NAN, pi = NAN, pi_0 = NAN;
     theta = T / T_t;
     pi = p / p_t;
     pi_0 = p_0 / p_t;
@@ -85,7 +85,7 @@ double dg_dp_Ice(double T, double p) {
 double dg2_dp2_Ice(double T, double p) {
 #ifndef __powerpc__
     std::complex<double> r2_pp;
-    double g0_pp, theta, pi, pi_0;
+    double g0_pp = NAN, theta = NAN, pi = NAN, pi_0 = NAN;
     theta = T / T_t;
     pi = p / p_t;
     pi_0 = p_0 / p_t;
@@ -101,7 +101,7 @@ double dg2_dp2_Ice(double T, double p) {
 double dg_dT_Ice(double T, double p) {
 #ifndef __powerpc__
     std::complex<double> r2, term1, term2;
-    double theta, pi, pi_0;
+    double theta = NAN, pi = NAN, pi_0 = NAN;
     theta = T / T_t;
     pi = p / p_t;
     pi_0 = p_0 / p_t;

--- a/src/ODEIntegrators.cpp
+++ b/src/ODEIntegrators.cpp
@@ -4,6 +4,7 @@
 #include "CPstrings.h"
 #include "Exceptions.h"
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 
 bool ODEIntegrators::AdaptiveRK54(AbstractODEIntegrator& ode, double tmin, double tmax, double hmin, double hmax, double eps_allowed,
@@ -24,7 +25,7 @@ bool ODEIntegrators::AdaptiveRK54(AbstractODEIntegrator& ode, double tmin, doubl
         h *= -1;
     }
 
-    double max_error;
+    double max_error = NAN;
 
     std::vector<double> xnew1(N), xnew2(N), xnew3(N), xnew4(N), xnew5(N), f1(N), f2(N), f3(N), f4(N), f5(N), f6(N), error(N), xnew(N);
 

--- a/src/PolyMath.cpp
+++ b/src/PolyMath.cpp
@@ -4,11 +4,11 @@
 #include "Exceptions.h"
 #include "MatrixMath.h"
 
+#include <cmath>
 #include <vector>
 #include <string>
 //#include <sstream>
 //#include <numeric>
-#include <cmath>
 #include <iostream>
 
 #include "Solvers.h"
@@ -69,7 +69,7 @@ Eigen::MatrixXd Polynomial2D::integrateCoeffs(const Eigen::MatrixXd& coefficient
             break;
     }
 
-    std::size_t r, c;
+    std::size_t r = 0, c = 0;
     for (int k = 0; k < times; k++) {
         oldCoefficients = Eigen::MatrixXd(newCoefficients);
         r = oldCoefficients.rows(), c = oldCoefficients.cols();
@@ -123,7 +123,7 @@ Eigen::MatrixXd Polynomial2D::deriveCoeffs(const Eigen::MatrixXd& coefficients, 
             break;
     }
 
-    std::size_t r, c, i, j;
+    std::size_t r = 0, c = 0, i = 0, j = 0;
     for (int k = 0; k < times; k++) {
         r = newCoefficients.rows(), c = newCoefficients.cols();
         for (i = 1; i < r; ++i) {
@@ -384,7 +384,7 @@ Eigen::MatrixXd Polynomial2DFrac::deriveCoeffs(const Eigen::MatrixXd& coefficien
     }
 
     std::size_t r = newCoefficients.rows(), c = newCoefficients.cols();
-    std::size_t i, j;
+    std::size_t i = 0, j = 0;
     for (int k = 0; k < times; k++) {
         for (i = 0; i < r; ++i) {
             for (j = 0; j < c; ++j) {
@@ -489,7 +489,7 @@ double Polynomial2DFrac::evaluate(const Eigen::MatrixXd& coefficients, const dou
 
     Eigen::MatrixXd tmpCoeffs(coefficients);
     Eigen::MatrixXd newCoeffs;
-    size_t r;
+    size_t r = 0;
     size_t c = tmpCoeffs.cols();
     double negExp = 0;  // First we treat the negative exponents
     double posExp = 0;  // then the positive exponents
@@ -528,9 +528,9 @@ double Polynomial2DFrac::evaluate(const Eigen::MatrixXd& coefficients, const dou
 double Polynomial2DFrac::derivative(const Eigen::MatrixXd& coefficients, const double& x_in, const double& y_in, const int& axis, const int& x_exp,
                                     const int& y_exp, const double& x_base, const double& y_base) {
     Eigen::MatrixXd newCoefficients;
-    int der_exp, other_exp;
-    double der_val, other_val;
-    double int_base, other_base;
+    int der_exp = 0, other_exp = 0;
+    double der_val = NAN, other_val = NAN;
+    double int_base = NAN, other_base = NAN;
 
     switch (axis) {
         case 0:
@@ -568,9 +568,9 @@ double Polynomial2DFrac::integral(const Eigen::MatrixXd& coefficients, const dou
                                   const int& y_exp, const double& x_base, const double& y_base, const double& ax_val) {
 
     Eigen::MatrixXd newCoefficients;
-    int int_exp, other_exp;
-    double int_val, other_val;
-    double int_base, other_base;
+    int int_exp = 0, other_exp = 0;
+    double int_val = NAN, other_val = NAN;
+    double int_base = NAN, other_base = NAN;
 
     switch (axis) {
         case 0:
@@ -642,8 +642,8 @@ Eigen::VectorXd Polynomial2DFrac::solve(const Eigen::MatrixXd& coefficients, con
 
     Eigen::MatrixXd newCoefficients;
     Eigen::VectorXd tmpCoefficients;
-    int solve_exp, other_exp;
-    double input;
+    int solve_exp = 0, other_exp = 0;
+    double input = NAN;
 
     switch (axis) {
         case 0:
@@ -759,7 +759,7 @@ Eigen::MatrixXd Polynomial2DFrac::fracIntCentralDvector(const int& m, const doub
     if (m < 1) throw ValueError(format("%s (%d): You have to provide coefficients, a vector length of %d is not a valid. ", __FILE__, __LINE__, m));
 
     Eigen::MatrixXd D = Eigen::MatrixXd::Zero(1, m);
-    double tmp;
+    double tmp = NAN;
     // TODO: This can be optimized using the Horner scheme!
     for (int j = 0; j < m; j++) {  // loop through row
         tmp = pow(-1.0, j) * log(x_in) * pow(x_base, j);

--- a/src/Solvers.cpp
+++ b/src/Solvers.cpp
@@ -1,6 +1,6 @@
+#include <cmath>
 #include <vector>
 #include "Solvers.h"
-#include <cmath>
 #include "MatrixMath.h"
 #include <iostream>
 #include "CoolPropTools.h"
@@ -11,7 +11,7 @@ namespace CoolProp {
 /** \brief Calculate the Jacobian using numerical differentiation by column
  */
 std::vector<std::vector<double>> FuncWrapperND::Jacobian(const std::vector<double>& x) {
-    double epsilon;
+    double epsilon = NAN;
     std::size_t N = x.size();
     std::vector<double> r, xp;
     std::vector<std::vector<double>> J(N, std::vector<double>(N, 0));
@@ -106,7 +106,7 @@ In the newton function, a 1-D Newton-Raphson solver is implemented using exact s
 @returns If no errors are found, the solution, otherwise the value _HUGE, the value for infinity
 */
 double Newton(FuncWrapper1DWithDeriv* f, double x0, double ftol, int maxiter) {
-    double x, dx, dfdx, fval = 999;
+    double x = NAN, dx = NAN, dfdx = NAN, fval = 999;
 
     // Initialize
     f->iter = 0;
@@ -157,7 +157,7 @@ http://en.wikipedia.org/wiki/Halley%27s_method
 @returns If no errors are found, the solution, otherwise the value _HUGE, the value for infinity
 */
 double Halley(FuncWrapper1DWithTwoDerivs* f, double x0, double ftol, int maxiter, double xtol_rel) {
-    double x, dx, fval = 999, dfdx, d2fdx2;
+    double x = NAN, dx = NAN, fval = 999, dfdx = NAN, d2fdx2 = NAN;
 
     // Initialize
     f->iter = 0;
@@ -225,7 +225,7 @@ http://numbers.computation.free.fr/Constants/Algorithms/newton.ps
  @returns If no errors are found, the solution, otherwise the value _HUGE, the value for infinity
  */
 double Householder4(FuncWrapper1DWithThreeDerivs* f, double x0, double ftol, int maxiter, double xtol_rel) {
-    double x, dx, fval = 999, dfdx, d2fdx2, d3fdx3;
+    double x = NAN, dx = NAN, fval = 999, dfdx = NAN, d2fdx2 = NAN, d3fdx3 = NAN;
 
     // Initialization
     f->iter = 1;
@@ -371,7 +371,7 @@ In the secant function, a 1-D Newton-Raphson solver is implemented.  An initial 
 @returns If no errors are found, the solution, otherwise the value _HUGE, the value for infinity
 */
 double BoundedSecant(FuncWrapper1D* f, double x0, double xmin, double xmax, double dx, double tol, int maxiter) {
-    double x1 = 0, x2 = 0, x3 = 0, y1 = 0, y2 = 0, x, fval = 999;
+    double x1 = 0, x2 = 0, x3 = 0, y1 = 0, y2 = 0, x = NAN, fval = 999;
     int iter = 1;
     f->errstring.clear();
     if (std::abs(dx) == 0) {
@@ -520,9 +520,9 @@ at least one solution in the interval [a,b].
 @param maxiter Maximum number of steps allowed.  Will throw a SolutionError if the solution cannot be found
 */
 double Brent(FuncWrapper1D* f, double a, double b, double macheps, double t, int maxiter) {
-    int iter;
+    int iter = 0;
     f->errstring.clear();
-    double fa, fb, c, fc, m, tol, d, e, p, q, s, r;
+    double fa = NAN, fb = NAN, c = NAN, fc = NAN, m = NAN, tol = NAN, d = NAN, e = NAN, p = NAN, q = NAN, s = NAN, r = NAN;
     fa = f->call(a);
     fb = f->call(b);
 

--- a/src/SpeedTest.cpp
+++ b/src/SpeedTest.cpp
@@ -15,7 +15,7 @@ namespace CoolProp {
 
 void compare_REFPROP_and_CoolProp(const std::string& fluid, CoolProp::input_pairs inputs, double val1, double val2, std::size_t N, double d1,
                                   double d2) {
-    time_t t1, t2;
+    time_t t1 = 0, t2 = 0;
 
     shared_ptr<AbstractState> State(AbstractState::factory("HEOS", fluid));
     t1 = clock();


### PR DESCRIPTION
## Summary

Final task in the CoolProp-2uw code-quality epic. Apply `clang-tidy --fix` for the `cppcoreguidelines-init-variables` check across `src/` translation units.

- **444 init-variables warnings resolved**, 27 files modified
- Each fix adds a default initializer (`= NAN`, `= 0`, `= false`, `= nullptr`) at declaration to eliminate read-before-write UB on stack locals
- `<cmath>` is added where `NAN` initializers are introduced into files that didn't already include it (uses the `.clang-tidy` `MathHeader=<cmath>` option landed in #2807)
- `--header-filter` scoped to project headers (excludes `_deps/`, `externals/`, generated `_JSON*.h`/`miniz.h`/`gitrevision.h`); run with `-j1` to avoid a parallel-fix race observed during testing

### Hand prep before the fix run

Two switch statements were pre-emptively wrapped in case-body braces to make scoped initializers legal under C++ scope rules (clang-tidy's fix would otherwise produce `error: jump to case label crosses initialization`):

- `include/Configuration.h::set_config_*_envvar` switch on type tag
- `src/Backends/PCSAFT/PCSAFTBackend.cpp::calc_phase_internal` `DmolarT_INPUTS` case

### Behavior note

Previously-UB-but-by-luck-zero code paths will now propagate `NaN` if any read-before-write exists. That is the *point* — it surfaces real bugs — and was the motivation for choosing `NAN` (not `0`) as the float default. Verified locally:

- ✅ `Main` target builds in Docker (Ubuntu 24.04, GCC 13, `clang-tidy-18`)
- ✅ Full Catch test suite passes: **125 cases / 57329 assertions**, all green (10 REFPROP-only cases skipped — librefprop.so absent)

### Follow-up

After merge, append the squash SHA of this PR to `.git-blame-ignore-revs` in a small follow-up so `git blame` walks through the mechanical churn. (Same pattern as #2804 for #2803, and #2807 for #2805.)

Closes CoolProp-acn. Closes the CoolProp-2uw code-quality epic.

## Test plan

- [x] Builds locally under GCC 13 in Docker
- [x] Catch test suite passes locally (excluding REFPROP-gated)
- [ ] CI green (clang-format, ASan, CodeQL, cppcheck artifact, IWYU artifact, clang-tidy diff)