### PR TITLE
chore: blame-ignore #2808 init-variables fix pass (CoolProp-2uw.13c)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,7 @@
 # Safe clang-tidy --fix passes: modernize-use-nullptr, modernize-use-emplace,
 # modernize-deprecated-headers (CoolProp-2uw.13 part 1, PR #2805)
 ee879788a10365c13f812993c4db6e69cb2d51a7
+
+# clang-tidy --fix for cppcoreguidelines-init-variables across src/
+# (CoolProp-2uw.13 part 2, PR #2808)
+7adb0aa1a216a0495b075fb84ad402b331bf9655


### PR DESCRIPTION
## Summary

Trailing chore after PR #2808. Appends the squash SHA `7adb0aa1` of the `cppcoreguidelines-init-variables --fix` pass to `.git-blame-ignore-revs` so `git blame` walks through the mechanical churn (313/283 lines across 27 files).

Same pattern as #2804 → #2803 and #2807 → #2805.

Closes CoolProp-a01. Closes the CoolProp-2uw code-quality epic. 🎉

## Test plan

- [x] `.git-blame-ignore-revs` parses (only valid SHA + comment lines)
- [ ] CI green