### PR TITLE
Expand Mathcad Wrapper Documentation [skip ci]

### DIFF
--- a/Web/coolprop/wrappers/MathCAD/MathcadPrime.rst
+++ b/Web/coolprop/wrappers/MathCAD/MathcadPrime.rst
@@ -12,13 +12,13 @@ Pre-compiled binaries
 
 Pre-compiled release binaries can be downloaded from :sfdownloads:`MathcadPrime`.  The latest development binaries coming from the nightly builds can be found at :sfnightly:`MathcadPrime`.
 
-To Use
-------
+Installation and Verification
+-----------------------------
 
-* Copy CoolPropMathcadWrapper.dll file to C:\\Program Files\\PTC\\Mathcad Prime x.0.0.0\\Custom Functions; where x.0.0.0 is the Mathcad Prime version being used (7 or later).
- 
-* Open the CoolPropFluidProperties.mcdx file in Mathcad Prime. Press `<Ctrl>-F5`` to force recalculation of the entire workbook. 
- 
+* Copy ``CoolPropMathcadWrapper.dll`` file to ``C:\Program Files\PTC\Mathcad Prime x.0.0.0\Custom Functions``; where x.0.0.0 is the Mathcad Prime version being used (*7 or later*).
+
+* Open the ``CoolPropFluidProperties.mcdx`` file in Mathcad Prime. Press ``<Ctrl>-F5`` to force recalculation of the entire workbook.  This file is in Mathcad Prime 7.0 format.
+
 * (Optional) Use the Custom Functions add-in at `CustFunc <https://github.com/henningjp/CustFunc>`_ to provide a Custom Function pop-up (by pressing `<F3>`) that gives descriptions of each available function and its inputs and allows easy insertion of the CoolProp functions into the worksheet.
 
 User-compiled binaries
@@ -49,29 +49,29 @@ To Build
 
 * Build the makefile using CMake (adjust root string for correct version of Prime)::
 
-    cmake .. -DCOOLPROP_PRIME_MODULE=ON  
-             -DCOOLPROP_PRIME_ROOT="C:/Program Files/PTC/Mathcad Prime 10.0.0.0"  
-             -G "Visual Studio 17 2022" -A x64  
-             -DCMAKE_VERBOSE_MAKEFILE=ON  
-  
-.. note::   
+    cmake .. -DCOOLPROP_PRIME_MODULE=ON
+             -DCOOLPROP_PRIME_ROOT="C:/Program Files/PTC/Mathcad Prime 10.0.0.0"
+             -G "Visual Studio 17 2022" -A x64
+             -DCMAKE_VERBOSE_MAKEFILE=ON
+
+.. note::
    Mathcad Version: Use your version of Mathcad Prime in place of **"10.0.0.0"** (with `7.0.0.0` or later)
 
 .. note::
-   Compiler Bitness: Mathcad Prime is 64-bit, so the `-A x64` option is necessary in the Visual Studio string for VS2017 or later.  
+   Compiler Bitness: Mathcad Prime is 64-bit, so the ``-A x64`` option is necessary in the Visual Studio string for VS2017 or later.
 
 .. note::
-   Older Compilers: Visual Studio versions earlier than 2017 will specify compiler bitness using the format **-G "Visual Studio 14 2015 Win64"** for the compiler string and will not use the `-A` option.
-             
+   Older Compilers: Visual Studio versions earlier than 2017 will specify compiler bitness using the format **-G "Visual Studio 14 2015 Win64"** for the compiler string and will not use the ``-A`` option.
+
 * Make the dynamic library (DLL)::
 
     cmake --build . --config Release
 
-To Use
-------
+To Install and Use
+------------------
 
-* Copy `CoolProp\\buildprime\\Release\\CoolPropMathcadWrapper.dll` file to `C:\\Program Files\\PTC\\Mathcad Prime 7.0.0.0\\Custom Functions` (or your current version) 
- 
-* Open the `CoolPropFluidProperties.mcdx` file in Mathcad Prime and Press `<Ctrl>-F5` to force recalculation of the entire workbook, all CoolProp functions should evaluate properly. 
- 
-* (Optional) Use the Custom Functions add-in at `CustFunc <https://github.com/henningjp/CustFunc>`_  to provide a Custom Function pop-up (by pressing `<F3>`) that gives descriptions of each available function and its inputs and allows easy insertion of the CoolProp functions into the worksheet.
+* Copy ``CoolProp\\buildprime\\Release\\CoolPropMathcadWrapper.dll`` file to ```C:\\Program Files\\PTC\\Mathcad Prime 10.0.0.0\\Custom Functions`` (or your current version)
+
+* Open the ``CoolPropFluidProperties.mcdx`` file in Mathcad Prime and Press **<Ctrl>-F5** to force recalculation of the entire workbook, all CoolProp functions should evaluate properly.
+
+* **(Optional)** Use the Custom Functions add-in at `CustFunc <https://github.com/henningjp/CustFunc>`_  to provide a Custom Function pop-up (by pressing **<F3>**) that gives descriptions of each available function and its inputs and allows easy insertion of the CoolProp functions into the worksheet.

--- a/Web/coolprop/wrappers/MathCAD/MathcadWrappers.rst
+++ b/Web/coolprop/wrappers/MathCAD/MathcadWrappers.rst
@@ -1,0 +1,367 @@
+.. _mathcadwrappers:
+
+*******************************************
+CoolProp Function Implementation in Mathcad
+*******************************************
+
+.. contents:: :depth: 3
+
+.. role::green
+   :class: green-text
+
+For the most part, the Mathcad wrappers follow the Python implementation and most of the examples on this site can be executed in Mathcad Prime with very little modification.  There are a few key difference:
+
+1. Mathcad Strings always use "double-quotes"
+2. Units (*see below*)
+3. Functions can be evaluated on their own, assigned to a variable, or both at the same time,
+    * PropsSI("D", "T", 295.15, "P", 101325.0, "Water") = 997.773
+
+    * ρ := PropsSI("D", "T", 295.15, "P", 101325.0, "Water")
+
+    * ρ := PropsSI("D", "T", 295.15, "P", 101325.0, "Water") = 997.773
+
+4. Mathcad *can* execute equations in random order as changes are made to the worksheet.  This can sometimes cause unexpected behavior if CoolProp settings are modified non-sequentially.  It is a good idea to press **<Ctrl>-<F9>** periodically to recalculate the entire worksheet from top to bottom.
+5. Unfortunately, there is no way to emulate the live Python examples found elsewhere on this web site with Mathcad Prime, so the Mathcad syntax and functionality will be emulated in the equations below.
+
+A majority of these functions and examples of their use are described in the Mathcad file ``CoolPropFluidProperties.mcdx``, found in the  :sfdownloads:`MathcadPrime` folder on SourceForge.
+
+High-Level Functions
+====================
+
+PropsSI - State Dependent Fluid Properties
+----------------------------------------------
+
+`PropsSI` is the basic, high-level function for returning the scalar value of a specified output property at a fixed state point.::
+
+    PropsSI("Output", "Input1", Val1, "Input2", Val2, "Fluid")
+
+Where,
+
+* "Output" = Requested output property string; see :ref:`Table of Valid Parameters <parameter_table>`.
+* "Input1" = First state-point property string.
+* Val1 = First state-point property value (scalar variable)
+* "Input2" = Second state-point property string.
+* Val2 = Second state-point property value (scalar variable)
+* "Fluid" = Fluid string (e.g, "Water", "Ammonia", "Air.mix", etc.).
+.. note::
+    The Fluid string can use a backend prefix (e.g., "HEOS::", "INCOMP::", "REFPROP::", etc.) to specify an alternative EOS; the default being the Helmholtz EOS ("HEOS::") if not provided.
+.. note::
+    In addition to pure and pseudo-pure fluid strings, the fluid string can be specified as a predefined mixture (e.g., "Air.mix") or an ad-hoc mixture, specifying each pure component and mole fraction (e.g., "O2[0.2096]&N2[0.7812]&AR[0.0092]") where the mole fractions are in square braces [ ] and the components are delimited with "&".
+**EXAMPLE:**
+    .. math::
+       h := PropsSI("H",\ "T",\ 300.0,\ "P",\ 500,\ "Helium") = 1562994.2
+|
+
+----
+
+
+PropsSImulti - Multiple State Dependent Fluid Properties
+------------------------------------------------------------
+
+`PropsSImulti` will return a vector/matrix of multiple fluid output properties spanning a range of state points. The return value is an (:math:`m x n`) matrix, where :math:`n` is the number of columns, one for each requested property, and :math:`m` is the number of rows for each state point. For the most part, the parameters of `PropsSImulti` are the same as `PropsSI` with the following exceptions.::
+
+    PropsSImulti("Outputs", "Input1", Vec1, "Input2", Vec2, "Fluid")
+
+Where,
+
+* "Outputs" = Requested output properties string containing a delimited list of one or more valid output property names from the :ref:`Table of Valid Parameters <parameter_table>`.  For this Mathcad wrapper, the delimiter can be any one of (*comma, <space>, colon, semi-colon, or ampersand*), but must be consistant.
+* Vec1, Vec2 = State point array pairs corresponding to "Input1" and "Input2".  These are single-column, :math:`m`-element vector arrays and must be the same length or an error will be thrown.
+|
+**EXAMPLE:**
+
+    Define a fluid:       :math:`fl` := "Water"
+
+    Triple Points:         :math:`T_t := 273.15`     &     :math:`P_t := 611.655`
+
+
+    Critical Points:       :math:`T_c := 273.15`     &     :math:`P_c := 2.206\cdot10^7`
+
+    Liquid points:       :math:`T_L := mean(T_t,T_c)`     &     :math:`P_L := mean(P_t,P_c)`
+.. math::
+   Tvec := \begin{bmatrix} T_t\\ T_L \\ T_L \end{bmatrix}       Pvec := \begin{bmatrix} P_L\\ P_L \\ P_c \end{bmatrix}
+.. math::
+   M := PropsSImulti("D\ H",\ "T",\ Tvec,\ "P",\ Pvec,\ fl) = \begin{bmatrix} 1005.334 & 1.115\cdot10^4\\ 886.137 & 7.987\cdot10^5 \\ 893.241 & 8.044\cdot10^5 \end{bmatrix}
+
+Extract individual variables from columns:         :math:`\rho = M^{<0>}`     &     :math:`h = M^{<1>}`
+
+|
+
+----
+
+Props1SI - State Independent Fluid Properties
+-------------------------------------------------
+
+`Props1SI` returns non-state-dependent properties of a fluid/mixture and does not require state point names or values.  This function only requires the output property and fluid name strings.::
+
+    Props1SI("Output", "Fluid")
+
+Where,
+
+* "Output" = One of the "*trivial*" output-only properties from the :ref:`Table of Valid Parameters <parameter_table>`.
+* "Fluid" = Fluid string, as defined above for `PropsSI`
+
+
+**EXAMPLE:**
+
+    Define a fluid:         :math:`fl` := "Water"
+
+    Triple Point Temperature:         :math:`T_t := Props1SI("Ttriple",\ fl) = 273.15`
+
+    Triple Point Pressure:               :math:`P_t := Props1SI("ptriple",\ fl) = 611.655`
+
+
+    Critical Temperature:                :math:`T_c := Props1SI("Tcrit",\ fl) = 647.096`
+
+    Critical Pressure:                       :math:`P_c := Props1SI("pcrit",\ fl) = 2.206\cdot10^7`
+
+|
+
+----
+
+PhaseSI - Phase Determination
+-----------------------------
+The function   is used to find the fluid phase at a specified state point.  The calling structure of the function is the same as `PropsSI` except that no "Output" properties are specified, given that the only output returned is a "string" representing the phase of the fluid.::
+
+    PhaseSI("Input1", Val1, "Input2", Val2, "Fluid")
+
+The input parameters are the same as for `PropsSI`.
+.. note::
+    The `PropsSI` function can be used with the output parameter "Phase", but this returns an enumerated integer value for the phase.  PhaseSI returns a string that represents the phase name for that enumerated value.
+
+|
+
+----
+
+HAPropsSI - Humid Air Fluid Properties
+----------------------------------------------
+
+`HA PropsSI`  is used to find fluid properties of humid air.  The physics behind the   function is based on the analysis in ASHRAE RP-1845, which is available online: https://www.tandfonline.com/doi/abs/10.1080/10789669.2009.10390874.  It employs real gas properties for both air and water, as well as the most accurate interaction parameters and enhancement factors.   RP-1845 is based largely on the IAPWS-95 formulation for the properties of water.  The calling structure of the function is as follows: ::
+
+    PropsSI("Output", "Input1", Val1, "Input2", Val2, "Input3", Val3)
+
+Where,
+
+* "Output" = Requested output property string; see :ref:`Table of Valid HA Parameters <HAparameter_table>`.
+* "Input1" = First state-point property string.
+* Val1 = First state-point property value (scalar variable)
+* "Input2" = Second state-point property string.
+* Val2 = Second state-point property value (scalar variable)
+* "Input3" = Third state-point property string.
+* Val2 = Third state-point property value (scalar variable)
+At least one of the inputs must be "T" (dry bulb temperature), "R" (Relative Humidity between 0.0 and 1.0), "W" (Humidity Ratio), or "Tdp" (dew point).
+
+**EXAMPLE:**
+
+    .. math::
+       h := PropsSI("H",\ "T",\ 298.15,\ "P",\ 101325,\ "R",\ 0.5) = 5.042\cdot10^4
+
+----
+
+Pseudo-Low-Level Functions
+==========================
+
+CoolProp's Low-level functions require the creation of an Abstract State object and then evaluation of properties using that object's member functions.  Mathcad does not have the ability to store objects as variables and so the Low-Level interface to CoolProp is not implemented.  However, there are some pseudo-Low-Level functions that to not require an abstract state object, or can at least create one temporarily for the purposes of extracting and setting CoolProp data and parameters.  These wrapper functions are listed here.
+
+get_global_param_string
+-----------------------
+
+This function retrieves global CoolProp parameters that are set and maintained by the CoolProp library.::
+
+    get_global_param_string("GlobalParameter")
+
+Where "GlobalParameter" can be one of the following:
+
+* "version"
+* "gitrevision"
+* "errstring"
+* "warnstring"
+* "FluidsList", "fluids_list", "fluidslist" ²
+* "incompressible_list_pure" ²
+* "incompressible_list_solution" ²
+* "mixture_binary_pairs_list" ²
+* "parameter_list" - Comma delimited list of valid fluid property strings used by ``PropsSI``
+* "predefined_mixtures" ²
+* "HOME" - User's $HOME or %HOME% directory
+* "REFPROP_version" (if installed)
+* "cubic_fluids_schema"
+* "cubic_fluids_list"
+* "pcsaft_fluids_schema"
+
+.. note::
+   The ``"errsting"`` option is *extremely* useful when using CoolProp functions in Mathcad.  While the wrapper functions attempt to trap common errors and display them as meaninful Mathcad error messages, highlighting the offending parameter(s), unknown errors will display as "CoolProp Issue: Use get_global_param_string("errstring") for more info". This is the only way to see the actaul CoolProp error message being thrown, even if the error is already trapped by the Mathcad wrapper.
+
+----
+
+get_fluid_param_string
+----------------------
+
+This function retrieves fluid property information for a specific fluid/mixture and its behavior and implementation depend on the backend being used.::
+
+    get_fluid_param_string("Fluid", "FluidParameter")
+
+Where,
+
+* "Fluid" is a fluid name string that follows the rules of of the fluid definition for ``PropsSI``, but is typically called for Pure Fluids.
+* "FluidParameter" for the HEOS (default) backend can be any of the following strings:
+    * "name" - Primary fluid name
+    * "aliases" - Fluid alias names that can be used to reference the fluid
+    * "CAS" - Unique, numerical identifier assigned by the Chemical Abstract Service
+    * "formula" - Chemical formula of the specified fluid
+    * "ASHRAE34" - ASHRAE classification of refrigerant toxicity and flammability
+    * "REFPROPname" - Equivalent fluid name in NIST REFPROP
+    * "BibTeX-<ref>" -
+    * "pure" - returns "true" for pure fluids, "false" for mixtures
+    * "INCHI" - International Chemical Identifier representation for chemical structures
+    * "INCHI_Key" - 27-character hashed string used for web searching
+    * "SMILES" - Simplified Molecular Input Line Entry System; compact, ASCII-based notation for representing 2D/3D chemical structures
+    * "CHEMSPIDER_ID" - unique ChemSpider database identifier
+    * "JSON" - Returns the full JSON definition of the fluid (*not very useful in Mathcad*)
+
+----
+
+set_reference_state
+-------------------
+
+Enthalpy and entropy are relative properties!  Always compare differences rather than absolute values of the enthalpy or entropy to other sources.  That said, if can be useful to set the reference state values for enthalpy and entropy to one of a few standard values. This is done by the use of the low-level ``set_reference_state`` function.::
+
+    set_reference_state("refState")
+
+A number of pre-defined reference states ("refSate") can be used:
+
+* IIR:              h = 200 kJ/kg, s = 1 kJ/kg/K at 0°C
+* ASHRAE:     h = 0, s = 0 @ -40°C saturated liquid
+* NBP:            h=0, s=0, for saturated liquid at 1 atmosphere
+* DEF:              Default reference state from the fluid file
+
+.. warning::
+   The changing of the reference state should only be done
+
+   1. at the very beginning of your worksheet, or
+   2. at the very beginning of a Mathcad program block, resetting it to "DEF" at the end of the program block
+
+   or unexpected results may occur. It is not recommended to change the reference state during the course of making calculations as done here for demonstration purposes only. Further more, because of Mathcad's top-down calculation order, switching back and forth between reference states can lead to very unexpected results (real or apparent) and is not recommended.
+
+----
+
+get_predefined_mixture_fluids
+-----------------------------
+
+This is not a wrapper of a CoolProp functions, but an additional helper function use to assist using predefined mixtures. This function  returns a semicolon delimited string of the predefined mixture component names.::
+
+    get_predefined_mixture_fluids("mixture")
+
+Where "mixture" is a predefined mixture name ending in .mix or .MIX. Mixture names are case sensitive, using the available predefined mixture names retrieved from ``get_global_parameter_string("predefined_mixtures")``.
+
+**EXAMPLES**
+
+    For air:        **get_predefined_mixture_fluis**("Air.mix") = "NITROGEN;ARGON;OXYGEN"
+
+    For R401A:  **get_predefined_mixture_fluis**("R401A.mix") = "R22;R152A;R124"
+
+.. note::
+   A few predefined mixtures are missing binary interaction parameters for at least one component pair.  These mixtures are defined, but cannot be used, for now, for property calculations.
+
+----
+
+get_predefined_mixture_fractions
+--------------------------------
+
+This is not a wrapper of a CoolProp functions, but an additional helper function use to assist using predefined mixtures. This function returns a Mathcad array (column vector) of the predefined mixture component *mole fractions*.::
+
+    get_predefined_mixture_fractions("mixture")
+
+Where "mixture" is a predefined mixture name ending in .mix or .MIX. Mixture names are case sensitive, using the available predefined mixture names retrieved from ``get_global_parameter_string("predefined_mixtures")``.
+
+**EXAMPLES**
+
+    For air:        :math:`mf_{Air}` :=**get_predefined_mixture_fraction**("Air.mix") = :math:`\begin{bmatrix} 0.7812\\ 0.0092 \\ 0.2096 \end{bmatrix}`
+
+    For R401A:  **get_predefined_mixture_fluis**("R401A.mix") = :math:`\begin{bmatrix} 0.578854\\ 0.0.185871 \\ 0.0.235274 \end{bmatrix}`
+
+.. note::
+   A few predefined mixtures are missing binary interaction parameters for at least one component pair.  These mixtures are defined, but cannot be used, for now, for property calculations.
+
+|
+
+----
+
+get_mixture_binary_pair_data
+----------------------------
+
+Get binary pair interaction parameters and other info for a pair of components::
+
+    get_mixture_binary_pair_data("CAS1", "CAS2", "mix_param")
+
+Where,
+* "CAS1", "CAS2" are the CAS identifiers for the two pure fluid components.  These must be CAS numbers of the format "7782-44-7" and cannot be the fluid name (in this case "Oxygen".
+* "mix_param" can be any of the following parameters:
+    * name1 - first component name (corresponding to CAS1)
+    * name2 - second component name (corresponding to CAS2)
+    * BibTeX - Reference for interaction parameters
+    * function - function for calculating parameters (if not constants)
+    * type - parameter model used
+    * F - :math:`F` parameter (if used)
+    * xi - :math:`\xi` parameter (if used)
+    * betaT, betaV - :math:`\beta_{T,ij}` and :math:`\beta_{v,ij}`
+    * gammaT, gammaV - :math:`\gamma_{T,ij}` and :math:`\gamma_{v,ij}`
+    * zeta - :math:`\zeta` parameter
+
+.. note::
+   Error message string from CoolProp may indicate that the input CAS numbers need to be reversed to retrieve values.
+
+|
+
+----
+
+apply_simple_mixing_rule
+------------------------
+
+The function ``apply_simpl_mixing_rule()`` will take either CAS strings or fluid alias strings as inputs and can be set to either "linear" or the "Lorentz-Berthelot" mixing rules.::
+
+    apply_simple_mixing_rule("Fluid1", "Fluid2", "rule")
+
+Use of this function follows the python example exactly on the Fluid Properties | Mixtures page and will not be repeated here.
+
+|
+
+----
+
+Set_mixture_binary_pair_data
+----------------------------
+
+Changes the default parameters with the following calls::
+
+    set_mixture_binary_pair_data("CAS1", "CAS2", "param", value)
+
+Where,
+
+* "param" is any of the mixing parameters as defined above under ``get_mixture_binary_pair_data``
+* `value` is the value of the parameter being set.
+
+Use of this function follows the python example exactly on the Fluid Properties | Mixtures page and will not be repeated here.
+
+----
+
+Applying Mathcad Units to CoolProp Functions
+============================================
+
+Mathcad has a built-in units system that allows variables and values to be defined with a specific set of units.  However, Custom Functions provided through DLL add-ins are C++ functions and cannot handle Mathcad's units on inputs or outputs to the functions.  If using values with units, the appropriate unitless values in SI can be provided to the CoolProp function calls and the appropriate units applied ot the results.
+
+.. note::
+    To strip units from a Mathcad variable, yet provide the numerical value scaled to a specific unit quantity, the a variable containing units can simply be divided by the desired units expression.  The value will become unitless, but will be scaled to the specified units expression.
+
+    Example:       :math:`P_{psi} / Pa\ =\ P`     (scaled to units of Pascals)
+
+    This is the technique used for plotting input ranges in a specific set of units using Mathcad's 2D Chart Component.
+
+A simple example of a call to ``PropsSI`` using variables with units is,
+
+    Define temperature (with units):       :math:`T\ :=\ 72\ °F`
+
+    Define pressure (with units):             :math:`P\ :=\ 1\ atm`
+
+    Evaluate:       :math:`h\ :=\ PropsSI("H",\ "T",\ \dfrac{T}{K},\ "P",\ \dfrac{P}{Pa},\ "Water")\cdot\dfrac{J}{kg}`
+
+    Show :math:`h` in English Engineering Units:       :math:`h\ =\ 40.133\ \dfrac{BTU}{lb}`
+.. note::
+    Technically, if input variables are not "stripped" of units, they will be passed as values in Mathcad's Base Units, which are SI.  This is compatible with CoolProp's base units of SI and will work.  However, units still have to be applied to the result and units should be stripped explicitely, as shown above as Mathcad allows the Base Units to be changed.  This will guarantee consistency of units between Mathcad and CoolProp.

--- a/Web/coolprop/wrappers/MathCAD/index.rst
+++ b/Web/coolprop/wrappers/MathCAD/index.rst
@@ -7,8 +7,10 @@ Mathcad Wrapper
 This wrapper is for PTC Mathcad Prime v7.0 and higher.  Files are maintained to be compatible with version 7.0, but are tested and supported on the latest available version of PTC Mathcad Prime.  Any pre-compiled binaries should run on versions 7.0 or higher.
 
 .. note::
-   Legacy Mathcad (up through Mathcad 15) and Mathcad Prime 1.0 through 6.0 have been discontinued by PTC and are no longer being distributed or licensed.  Some users may still have perpetual licenses of Legacy Mathcad and are free to attempt to compile their own add-in (there is no change in the C++ source code).   The only requirement is that Legacy Mathcad must still be installed on the machine on which the new binary is being built. 
-   
+   Legacy Mathcad (up through Mathcad 15) and Mathcad Prime 1.0 through 6.0 have been discontinued by PTC and are no longer being distributed or licensed.  Some users may still have perpetual licenses of Legacy Mathcad and are free to attempt to compile their own add-in (there is no change in the C++ source code).   The only requirement is that Legacy Mathcad must still be installed on the machine on which the new binary is being built.
+
+Wrapper Installation
+====================
 Please select your version from below:
 
 .. toctree::
@@ -16,3 +18,11 @@ Please select your version from below:
 
     MathcadPrime.rst
     LegacyMathcad.rst
+
+Mathcad Prime Function Implementation
+=====================================
+
+.. toctree::
+    :maxdepth: 1
+
+    MathcadWrappers.rst

--- a/Web/coolprop/wrappers/Mathematica/index.rst
+++ b/Web/coolprop/wrappers/Mathematica/index.rst
@@ -7,8 +7,9 @@ Mathematica Wrapper
 Pre-compiled Binaries
 =====================
 Pre-compiled binaries are no longer uploaded to the  :sfdownloads:`latest Release` on SourceForge or :sfnightly:`the nightly snapshots <Mathematica>`.  This is because:
+
 * Usage is one of the lowest of all the wrappers supported by CoolProp with few active developers
-* The wrapper should really be built by the user for their specific version of Wolfram Mathematica on their system.  Major and minor updates to Mathematica are just too frequent to keep up with. 
+* The wrapper should really be built by the user for their specific version of Wolfram Mathematica on their system.  Major and minor updates to Mathematica are just too frequent to keep up with.
 
 User-Compiled Binaries
 ======================
@@ -53,17 +54,17 @@ You need to just slightly modify the building procedure
 
         # Build the makefile using CMake
         cmake .. -DCOOLPROP_MATHEMATICA_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -G "Visual Studio 17 2022" -A x64"
-        
-.. note::   
+
+.. note::
     If you have a different version of Visual Studio installed, replace the generator name in the ``-G`` argument.  Note that the DLL must be 64-bit by using the ``-A x64`` option at the end.  Prior to VS 2017, this "bitness" was embedded in the ``-G`` argument using the format **-G "Visual Studio 14 2015 Win64"** and will not use the ``-A`` option.
-        
+
     B: Building using MinGW::
 
         # Build the makefile using CMake
         cmake .. -DCOOLPROP_MATHEMATICA_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -G "MinGW Makefiles"
-    
+
 3. Actually do the build::
-    
+
     # Make the shared library
     cmake --build . --config Release
 

--- a/Web/fluid_properties/HumidAir.rst
+++ b/Web/fluid_properties/HumidAir.rst
@@ -7,9 +7,9 @@ Humid Air Properties
 
 If you are feeling impatient, jump to :ref:`HAProps_Sample`, or to go to the code documentation :mod:`CoolProp.HumidAirProp`, otherwise, hang in there.
 
-The equations implemented in CoolProp are based on a publication by Hermann et al. :cite:`Herrmann2009`, which describes the outcome of the ASHRAE research project ASHREA-RP1485. 
-The same source has been used in the ASHRAE Handbook 2009 to generate reference saturation property tables. The code implemented here passes all tests and reproduces the original 
-data with a very high accuracy. It is applicable for pressure from 0.01 kPa up to 10 MPa, in a temperature range from -143.15 °C up to 350 °C with a humidity ratio from 0 kg of water 
+The equations implemented in CoolProp are based on a publication by Hermann et al. :cite:`Herrmann2009`, which describes the outcome of the ASHRAE research project ASHREA-RP1485.
+The same source has been used in the ASHRAE Handbook 2009 to generate reference saturation property tables. The code implemented here passes all tests and reproduces the original
+data with a very high accuracy. It is applicable for pressure from 0.01 kPa up to 10 MPa, in a temperature range from -143.15 °C up to 350 °C with a humidity ratio from 0 kg of water
 up to 10 kg of water per kg of dry air.
 
 Humid air can be modeled as a mixture of air and water vapor.  In the simplest analysis, water and air are treated as ideal gases but in principle there is interaction between the air and water molecules that must be included through the use of interaction parameters.
@@ -27,7 +27,7 @@ The humidity ratio :math:`W` is the ratio of the mass of water vapor to the mass
 .. math::
 
     \psi_w=\frac{n_w}{n}=\frac{n_w}{n_a+n_w}=\frac{m_w/M_w}{m_a/M_a+m_w/M_w}=\frac{m_w}{(M_w/M_a)m_a+m_w}=\frac{1}{(M_w/M_a)/W+1}=\frac{W}{(M_w/M_a)+W}
-    
+
 or
 
 .. math::
@@ -46,18 +46,18 @@ Mathematically, the result is
 
     \varphi=\frac{\psi_w}{\psi_{w,s}}
 
-where 
+where
 
 .. math::
 
     \psi_{w,s}=\frac{fp_{w,s}}{p}
-    
+
 The product :math:`p_s` is defined by :math:`p_s=fp_{w,s}`, and :math:`p_{w,s}` is the saturation pressure of pure water (or ice) at temperature :math:`T`. This yields the result for :math:`\psi_w` of
 
 .. math::
 
     \varphi=\frac{\psi_w}{p_s/p}
-    
+
 .. math::
 
     \psi_w=\frac{\varphi p_s}{p}
@@ -75,28 +75,28 @@ and the mole fraction of water vapor is obtained from
 .. math::
 
     \psi_w=\frac{p_w}{p}
-    
+
 Once the state has been fixed by a set of :math:`T,p,\psi_w`, any parameter of interest can be calculated
 
 Molar Volume
 ------------
 .. math::
     :label: eq1
-    
+
     p=\frac{\bar R T}{\bar v}\left( 1+\frac{B_m}{\bar v}+\frac{C_m}{\bar v^2}\right)
-    
+
 The bracketed term on the right hand side is the compressibility Z factor, equal to 1 for ideal gas, and is a measure of non-ideality of the air.  The virial terms are given by
-    
+
 .. math::
-    
+
     B_m=(1-\psi_w)^2B_{aa}+2(1-\psi_w)\psi_wB_{aw}+\psi_w^2B_{ww}
-    
+
     C_m=(1-\psi_w)^3C_{aaa}+3(1-\psi_w)^2\psi_wC_{aaw}+3(1-\psi_w)\psi_w^2C_{aww}+\psi_w^3C_{www}
-    
-where the virial coefficients are described in ASRAE RP-1485 and their values are provided in :ref:`HA-Validation`.  All virial terms are functions only of temperature.
+
+where the virial coefficients are described in ASHRAE RP-1485 and their values are provided in :ref:`HA-Validation`.  All virial terms are functions only of temperature.
 
 Usually the temperature is known, the water mole fraction is calculated, and :math:`\bar v` is found using iterative methods, in HAProps, using a secant solver and the first guess that the compressibility factor is 1.0.
-    
+
 Molar Enthalpy
 --------------
 
@@ -115,11 +115,11 @@ with :math:`\bar h` in kJ/kmol.  For both air and water, the full EOS is used to
 which is in kJ/kmol, using the mixture :math:`\bar v` to define the parameter :math:`\delta=1/(\bar v \bar \rho_c)` for each fluid, and using the critical molar density for the fluid obtained from :math:`\bar \rho_c=1000\rho_c/M` to give units of mol/m\ :sup:`3`\ .  The offset enthalpies for air and water are given by
 
 .. math::
-    
+
     \bar h_{0,a}=-7,914.149298\mbox{ kJ/kmol}
-    
+
     \bar h_{0,w}=-0.01102303806\mbox{ kJ/kmol}
-    
+
 respectively.  The enthalpy per kg of dry air is given by
 
 .. math::
@@ -131,7 +131,7 @@ Enhancement factor
 
 The enhancement factor is a parameter that includes the impact of the air on the saturation pressure of water vapor.  It is only a function of temperature and pressure, but it must be iteratively obtained due to the nature of the expression for the enhancement factor.
 
-:math:`\psi_{w,s}` is given by :math:`\psi_{w,s}=fp_{w,s}/p`, where :math:`f` can be obtained from 
+:math:`\psi_{w,s}` is given by :math:`\psi_{w,s}=fp_{w,s}/p`, where :math:`f` can be obtained from
 
 .. math::
 
@@ -154,13 +154,13 @@ For water, the isothermal compressibility [in 1/Pa] is evaluated from
 .. math::
 
     k_T=\frac{1}{\rho\frac{\partial p}{\partial \rho}}\frac{1\mbox{ kPa}}{1000\mbox{ Pa}}
-    
+
 with
 
 .. math::
 
     \frac{\partial p}{\partial \rho}=RT\left[1+2\delta\left(\frac{\partial \alpha^r}{\partial \delta}\right)_{\tau}+\delta^2\left(\frac{\partial^2 \alpha^r}{\partial \delta^2}\right)_{\tau}\right]
-    
+
 in kPa/(kg/m\ :sup:`3`\ ). And for ice,
 
 .. math::
@@ -175,19 +175,21 @@ To use the HAPropsSI function, import it and do some calls, do something like th
 
 .. ipython::
 
-    #import the things you need 
+    #import the things you need
     In [1]: from CoolProp.HumidAirProp import HAPropsSI
-    
-    #Enthalpy (J per kg dry air) as a function of temperature, pressure, 
-    #    and relative humidity at dry bulb temperature T of 25C, pressure 
+
+    #Enthalpy (J per kg dry air) as a function of temperature, pressure,
+    #    and relative humidity at dry bulb temperature T of 25C, pressure
     #    P of one atmosphere, relative humidity R of 50%
     In [2]: h = HAPropsSI('H','T',298.15,'P',101325,'R',0.5); print(h)
-    
+
     #Temperature of saturated air at the previous enthalpy
     In [2]: T = HAPropsSI('T','P',101325,'H',h,'R',1.0); print(T)
-    
+
     #Temperature of saturated air - order of inputs doesn't matter
     In [2]: T = HAPropsSI('T','H',h,'R',1.0,'P',101325); print(T)
+
+.. _HAparameter_table:
 
 Table of Inputs/Outputs to HAPropsSI
 ------------------------------------
@@ -196,7 +198,7 @@ Table of Inputs/Outputs to HAPropsSI
     :header: "Parameter"; "Units"; "Input/Output"; "Description"
     :widths: 25, 25, 25, 25
     :delim: ;
-   
+
     ``B``, ``Twb``, ``T_wb``, ``WetBulb``; K; Input/Output; Wet-Bulb Temperature
     ``C``, ``cp``; J/kg dry air/K; Output; Mixture specific heat per unit dry air
     ``Cha``, ``cp_ha``; J/kg humid air/K; Output; Mixture specific heat per unit humid air
@@ -204,7 +206,7 @@ Table of Inputs/Outputs to HAPropsSI
     ``CVha``, ``cv_ha``; J/kg humid air/K; Output; Mixture specific heat at constant volume per unit humid air
     ``D``, ``Tdp``, ``DewPoint``, ``T_dp``; K; Input/Output;	Dew-Point Temperature
     ``H``, ``Hda``, ``Enthalpy``;	J/kg dry air; Input/Output; Mixture enthalpy per dry air
-    ``Hha``; J/kg humid air; Input/Output; Mixture enthalpy per humid air 
+    ``Hha``; J/kg humid air; Input/Output; Mixture enthalpy per humid air
     ``K``, ``k``, ``Conductivity``; W/m/K; Output; Mixture thermal conductivity
     ``M``, ``Visc``, ``mu``;Pa-s;Output;Mixture viscosity
     ``psi_w``, ``Y``; mol water/mol humid air; Input/Output; Water mole fraction
@@ -212,13 +214,13 @@ Table of Inputs/Outputs to HAPropsSI
     ``P_w``;Pa;Input;Partial pressure of water vapor
     ``R``, ``RH``, ``RelHum``; ; Input/Output; Relative humidity in [0, 1]
     ``S``, ``Sda``, ``Entropy``; J/kg dry air/K; Input/Output; Mixture entropy per unit dry air
-    ``Sha``; J/kg humid air/K; Input/Output; Mixture entropy per unit humid air 
+    ``Sha``; J/kg humid air/K; Input/Output; Mixture entropy per unit humid air
     ``T``, ``Tdb``, ``T_db``; K; Input/Output; Dry-Bulb Temperature
     ``V``, ``Vda``; m :math:`^3` /kg dry air; Input/Output;  Mixture volume per unit dry air
     ``Vha``; m :math:`^3` /kg humid air; Input/Output;  Mixture volume per unit humid air
     ``W``, ``Omega``, ``HumRat``; kg water/kg dry air; Input/Output; Humidity Ratio
     ``Z``; ; Output; Compressibility factor (:math:`Z = pv/(RT)`)
-    
+
 Psychrometric Chart
 -------------------
 
@@ -268,11 +270,11 @@ Psychrometric Chart
 Humid Air Validation
 --------------------
 Values here are obtained at documentation build-time using the Humid Air Properties module
- 
+
 .. ipython::
 
     In [1]: %run 'fluid_properties/Validation/HAValidation.py'
-    
+
 
 Verification Script
 -------------------
@@ -340,7 +342,7 @@ This script, written in Python, should yield no failures::
             errors = pool.map(calculate, input_values)
             for err in itertools.chain.from_iterable(errors):
                 print(err)
-    
+
 ..  Appendices
 
 


### PR DESCRIPTION
### Description of the Change

Provides users with an expanded documentation page of the Mathcad wrapper functions that are implemented and in some cases an equation emulation of how to use them in Mathcad Prime.  I've been wanting to implement this for a while, but only recently found a workable editor with ReST preview (PyCharm with Restructured Text Pro extension) to facilitate such a large page build using LaTeX math equations.

Additionally:
- Updated references and toctree in existing Mathcad wrapper docs
- Updated typos in the Mathematica wrapper doc
- Added a referenceable tag above the Humid Air parameter table of `HumidAir.rst`

### Benefits

Provides an up-to-date reference of implemented wrapper functions without having to update the binary Mathcad example sheet.

### Possible Drawbacks

Some equation formatting might be slightly off when processed by the nightly docs build, but this can be adjusted after seeing it.

### Verification Process

No code changes or dynamic code examples in the Mathcad wrapper documentation.  Spell checking on and doc reviewed thoroughly.

### Applicable Issues

None.
