### PR TITLE
ci: enable Dependabot version updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+
+# Closes #2815. Adds version-update monitoring for the GitHub Actions workflows
+# under .github/workflows/ — independent of the security-alert-driven npm/cargo
+# bumps Dependabot already opens against this repo.
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    # All third-party action references (uses: foo/bar@vX) get tracked here;
+    # actions/* and tauri-apps/* are the main consumers in our workflows.
+    groups:
+      actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci(deps)"
+      include: scope
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
Closes #2815.

## Summary

Adds `.github/dependabot.yml` with a single `github-actions` ecosystem entry that watches every `uses: foo/bar@vX` reference in `.github/workflows/`. Runs **weekly on Monday** and groups minor + patch bumps into one combined PR per cycle so workflow upgrades don't fan out into five separate PRs. Major bumps still come through individually (Dependabot's default outside the group), since those typically need behavioural review.

## Notes

- Security-alert-driven npm/cargo bumps continue via the repo's existing Dependabot security configuration — those don't require an explicit `dependabot.yml` entry.
- Easy to extend later: drop a new `- package-ecosystem: ...` block to also automate npm version updates under `wrappers/GUI/` or cargo updates under `wrappers/GUI/src-tauri/`.

## Test plan

- [ ] After merge, Dependabot's [insights tab](https://github.com/CoolProp/CoolProp/network/updates) should list a `github-actions / .github/workflows` entry.
- [ ] First PR cycle on the next Monday should open at most one grouped PR for any pending action updates (or zero if everything's current).