### PR TITLE
build(deps): bump Eigen 3.4.0 → 5.0.1

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -14,7 +14,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/CPM.cmake")
 CPMAddPackage(
   NAME Eigen
   GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
-  GIT_TAG        3.4.0
+  GIT_TAG        5.0.1
   DOWNLOAD_ONLY  YES   # header-only; skip Eigen's own CMake targets
 )
 


### PR DESCRIPTION
## Summary
- Bumps Eigen pin in `cmake/dependencies.cmake` from 3.4.0 (Aug 2021) to 5.0.1 (Nov 2025). One-line change.
- Driven by CoolProp-2uw code-quality program: Eigen 5.0 systematically renames reserved-identifier template params (`_Scalar`, `_Rows`, `_Cols`, `_Options`, …) — collapses the dominant clang-tidy noise source from third-party headers in our `bugprone-*` / `cert-*` checks.

## Eligibility
- C++17 satisfies Eigen 5.0's C++14 minimum.
- CoolProp uses **none** of the 5.0 breaking-change surfaces: no `Eigen::all`/`last`, no `JacobiSVD`/`BDCSVD`, no `EulerAngles`, no Eigen RNG, no internal `src/` header includes, no `aligned_allocator` inheritance assumptions.
- `unsupported/Eigen/Polynomials` still ships in 5.0 — `PolynomialSolver`, `poly_eval`, `roots_to_monicPolynomial` paths in `PolyMath`/`CPnumerics` keep working.

## Evaluation results

| Dimension | Master (Eigen 3.4.0) | Eigen 5.0.1 | Δ |
|---|---:|---:|---:|
| Catch2 cases | 135 / 125 passed / 10 skipped | identical | exact parity |
| Catch2 assertions | 57329 / 57329 passed | identical | exact parity |
| clang-tidy `bugprone-reserved-identifier` (PolyMath.cpp + CPnumerics.cpp) | 404 | 9 | **−97.8%** |
| co2n2 mixture density bench: convergence | 1845/1845 | 1845/1845 | parity |
| co2n2 `mean_solver_us` per-cell (rel) | — | — | mean **−22.4%** |
| co2n2 user-CPU time | 328s | 261s | **−20.4%** |
| co2n2 density numerical agreement | — | — | **bit-identical** (max abs rel diff = 0 across 3585 cells) |
| Binary size (`Main`) | 8.73 MB | 8.69 MB | flat |
| Catch2 wall time | 1:40 | 1:40 | flat |

The 9 residual reserved-identifier hits in 5.0.1 are Eigen-created `__bfloat16_raw`, `__half_raw`, `_EIGEN_MAYBE_CONSTEXPR`, and `JacobiSVD.h` `MatrixType__` / `Options__` patterns the rename pass missed. Upstream cleanup target, not blocking here.

The ~20% perf gain is most likely from Eigen 5.0's faster small fixed-size LU/inverse kernels, which `MixtureDerivatives` and bicubic interpolation paths exercise. CoolProp's hot paths use scalar `pow`/`log`/`exp` rather than Eigen array ops, which is why the marquee 5.0 vectorized-math overhaul doesn't show up as a bigger delta — and also why density results are bit-identical despite Eigen's elementwise math changes.

Tracking issue: CoolProp-idh.

## Test plan
- [x] Configure clean (Ninja, AppleClang, Release, `COOLPROP_CATCH_MODULE=ON`)
- [x] Catch2 suite: all 125 enabled test cases passing, 0 failures, parity with master
- [x] Smoke perf bench (co2n2): 1845/1845 convergence; bit-identical densities; ~20% user-CPU win
- [x] clang-tidy noise check: bugprone-reserved-identifier 404→9 on representative TUs
- [ ] CI green on this PR (Linux/Windows/macOS, all wrappers)
- [ ] Optional: extend bench to amarillo/ch4h2s/c10c1 systems before merge if reviewers want broader perf coverage