### PR TITLE
fix(build): atomic dev/hashes.json write — fixes Windows installer race (#2828)

### DIFF
--- a/dev/generate_headers.py
+++ b/dev/generate_headers.py
@@ -13,7 +13,8 @@ import hashlib
 import struct
 import glob
 from pathlib import Path
-import pickle 
+import pickle
+import tempfile
 import zlib
 
 json_options = {'indent': 2, 'sort_keys': True}
@@ -433,11 +434,26 @@ def generate():
 
     TO_CPP(root_dir=repo_root_path, hashes=hashes)
 
-    # Write the hashes to a hashes JSON file
+    # Write the hashes JSON file atomically. The Windows installer build runs
+    # generate_headers.py concurrently from several sub-CMake configurations
+    # (32-bit cdecl/stdcall, 64-bit, arm64) that all share this same
+    # dev/hashes.json; a plain open(..., 'w') would let a shorter write only
+    # partially overwrite a longer one and leave stale tail bytes that break
+    # the next JSON parse.
     if hashes:
-        fp = open(hashes_fname, 'w')
-        fp.write(json.dumps(hashes))
-        fp.close()
+        dirname = os.path.dirname(hashes_fname) or '.'
+        fd, tmp_fname = tempfile.mkstemp(prefix='hashes.', suffix='.json.tmp', dir=dirname)
+        try:
+            with os.fdopen(fd, 'w') as fp:
+                fp.write(json.dumps(hashes))
+            os.replace(tmp_fname, hashes_fname)
+        except BaseException:
+            if os.path.exists(tmp_fname):
+                try:
+                    os.remove(tmp_fname)
+                except OSError:
+                    pass
+            raise
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Fixes #2828 — the Windows Installer workflow has been failing on most recent PRs with a `CUSTOMBUILD : decoding error : Extra data: line 1 column 1010 (char 1009)` error coming out of `generate_headers.vcxproj`.

Root cause: the workflow drives several parallel sub-CMake configurations (32-bit cdecl, 32-bit stdcall, 64-bit, arm64) that each invoke `dev/generate_headers.py`, and they all share the same `<repo>/dev/hashes.json` (the path is derived from `__file__`, not from the build dir). The script wrote the file with a plain `open(..., 'w')` + `write()`, so a shorter concurrent write could only partially overwrite a longer one and leave stale tail bytes:

```
{"version": "...", ..., "mixture_binary_pairs_pcsaft_JSON": "..."}re_binary_pairs_pcsaft_JSON": "..."}
```

The script itself catches `JSONDecodeError` and recovers with an empty dict, but the `decoding error :` line it prints to stdout matches MSBuild's CUSTOMBUILD error pattern and fails the job.

Fix: use the standard write-to-tempfile-then-`os.replace()` pattern. Each process gets a unique tmp file via `tempfile.mkstemp()` in the same directory, and `os.replace()` is atomic on both POSIX and Windows — so the file is always either old-complete or new-complete, never spliced. Failed writes clean up the orphan tmp.

Per-arch paths (the other option in the issue) would need plumbing the build dir into the script via CMake; this is the smaller, lower-risk change that fully addresses the corruption.

## Test plan

- [x] Single-process run: `python3 dev/generate_headers.py` → produces a valid `dev/hashes.json`
- [x] 64-process stress test of the same atomic-write pattern, repeated 5×: every run produced a clean parseable JSON with zero leftover `.tmp` files
- [ ] Windows Installer workflow on the PR run (the only environment where the original race actually fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)