### PR TITLE
fix(cubic): add missing override on SRK/PR backend methods

### DIFF
--- a/src/Backends/Cubics/CubicBackend.h
+++ b/src/Backends/Cubics/CubicBackend.h
@@ -293,12 +293,12 @@ class SRKBackend : public AbstractCubicBackend
         cubic.reset(new SRK(Tc, pc, acentric, R_u));
         setup(generate_SatL_and_SatV);
     }
-    HelmholtzEOSMixtureBackend* get_copy(bool generate_SatL_and_SatV = true) {
+    HelmholtzEOSMixtureBackend* get_copy(bool generate_SatL_and_SatV = true) override {
         AbstractCubicBackend* ACB = new SRKBackend(cubic->get_Tc(), cubic->get_pc(), cubic->get_acentric(), cubic->get_R_u(), generate_SatL_and_SatV);
         ACB->copy_internals(*this);
         return static_cast<HelmholtzEOSMixtureBackend*>(ACB);
     }
-    std::string backend_name(void) {
+    std::string backend_name(void) override {
         return get_backend_string(SRK_BACKEND);
     }
     int get_superanc_eos_code() const override {
@@ -334,13 +334,13 @@ class PengRobinsonBackend : public AbstractCubicBackend
         cubic.reset(new PengRobinson(Tc, pc, acentric, R_u));
         setup(generate_SatL_and_SatV);
     };
-    HelmholtzEOSMixtureBackend* get_copy(bool generate_SatL_and_SatV = true) {
+    HelmholtzEOSMixtureBackend* get_copy(bool generate_SatL_and_SatV = true) override {
         AbstractCubicBackend* ACB =
           new PengRobinsonBackend(cubic->get_Tc(), cubic->get_pc(), cubic->get_acentric(), cubic->get_R_u(), generate_SatL_and_SatV);
         ACB->copy_internals(*this);
         return static_cast<HelmholtzEOSMixtureBackend*>(ACB);
     }
-    std::string backend_name(void) {
+    std::string backend_name(void) override {
         return get_backend_string(PR_BACKEND);
     }
     int get_superanc_eos_code() const override {


### PR DESCRIPTION
## Summary
- Adds `override` to `SRKBackend::get_copy`, `SRKBackend::backend_name`, `PengRobinsonBackend::get_copy`, and `PengRobinsonBackend::backend_name` in `src/Backends/Cubics/CubicBackend.h`.
- Silences clang's `-Winconsistent-missing-override` — these classes already mark `get_superanc_eos_code() const override`, so the unmarked overrides were the source of the warning.

## Test plan
- [x] Clean rebuild via `ninja -C build CoolProp`; `inconsistent-missing-override` count drops from many duplicates (per TU) to 0.
- [ ] CI green on Linux/macOS/Windows builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)