### PR TITLE
ci(clang-format): pin CI version via uvx to match pre-commit hook

### DIFF
--- a/.github/workflows/dev_clangformat.yml
+++ b/.github/workflows/dev_clangformat.yml
@@ -15,11 +15,18 @@ jobs:
       with:
         fetch-depth: 0   # Fetch all history (especially branches)
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
     - name: Run clang-format against C++ files touched by the PR
       shell: bash
       run: |
           echo "GITHUB_REF=$GITHUB_REF GITHUB_BASE_REF=$GITHUB_BASE_REF GITHUB_HEAD_REF=$GITHUB_HEAD_REF"
-          clang-format --version
+          # Pin clang-format to the version declared in .pre-commit-config.yaml
+          # so CI and the local pre-commit hook always run the same binary.
+          VER=$(awk '/mirrors-clang-format/{f=1} f && /^[[:space:]]*rev:/{print $2; exit}' .pre-commit-config.yaml | tr -d 'v"')
+          export CLANG_FORMAT="uvx clang-format@$VER"
+          $CLANG_FORMAT --version
           # Use SHAs directly so this works for both fork PRs and local-branch PRs.
           # remotes/origin/<branch> is unreliable for fork PRs because the fork's
           # branch is not fetched into origin.

--- a/dev/ci/clang-format.sh
+++ b/dev/ci/clang-format.sh
@@ -40,7 +40,11 @@ then
   exit 0
 fi
 
-git diff $TARGET_BRANCH_NAME $PR_BRANCH_NAME --name-only | grep '.*\.\(cpp\|c\|hpp\|h\)$' | xargs clang-format -style=file -i -fallback-style=none
+# CLANG_FORMAT lets callers pin a specific version (e.g. "uvx clang-format@18.1.8")
+# so CI and local runs use the same binary. Defaults to whatever `clang-format` is on PATH.
+: "${CLANG_FORMAT:=clang-format}"
+
+git diff $TARGET_BRANCH_NAME $PR_BRANCH_NAME --name-only | grep '.*\.\(cpp\|c\|hpp\|h\)$' | xargs $CLANG_FORMAT -style=file -i -fallback-style=none
 
 # clang-format will auto correct files so prepare the diff and use this as artifact
 git diff > clang_format.patch


### PR DESCRIPTION
## Summary

- The `Development Clang Format` workflow was running `ubuntu-latest`'s system `clang-format` (currently 18.1.3), while `.pre-commit-config.yaml` pins `v18.1.8` for local pre-commit runs. Contributors who don't run pre-commit drift from CI, and the runner image version can change without notice — both produced spurious red CI on otherwise-clean PRs (e.g. #2835, #2836, #2840 all hit this in the last 24h).
- Install `uv` in the workflow, parse the pin out of `.pre-commit-config.yaml`, and invoke `uvx clang-format@<VER>` so CI and pre-commit always execute the **same** binary. The pin lives in one place and is read by both consumers.
- `dev/ci/clang-format.sh` now honors a `CLANG_FORMAT` env var, so locals can opt into the same pinned binary without needing the pre-commit framework:

  ```
  CLANG_FORMAT="uvx clang-format@18.1.8" ./dev/ci/clang-format.sh HEAD origin/master
  ```

  Default behavior (`clang-format` on `PATH`) is unchanged when `CLANG_FORMAT` is unset.

## Test plan

- [ ] `Development Clang Format` job goes green on this PR (no C++ changes — should hit the "no files changed" early exit).
- [ ] Verify `$CLANG_FORMAT --version` line in the CI log prints `clang-format version 18.1.8`.
- [ ] On a separate test PR with intentional formatting violations, confirm CI flags only those files and the patch artifact is attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)