### PR TITLE
ci(codeql): exclude vendored sources via paths-ignore config

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,17 @@
+name: "CoolProp CodeQL config"
+
+# Keep the default security-and-quality query suite (added by the workflow
+# via `queries: +security-and-quality`).
+
+# Exclude vendored / fetched third-party sources we cannot patch.
+# - build/_deps/**     : CPM/FetchContent downloads (Eigen, fmt, msgpack, …)
+# - externals/miniz-*  : vendored miniz copy
+# - externals/fmt*     : any in-tree fmt copy (defensive; fetched copy lives under build/_deps)
+# - .claude/worktrees  : local Claude Code worktrees, never analysed
+paths-ignore:
+  - build/**
+  - build_*/**
+  - "**/_deps/**"
+  - externals/miniz-*/**
+  - externals/fmt*/**
+  - .claude/**

--- a/.github/workflows/dev_codeql.yml
+++ b/.github/workflows/dev_codeql.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild Python
         if: ${{ matrix.language == 'python' }}


### PR DESCRIPTION
## Summary
- Adds `.github/codeql/codeql-config.yml` and wires it through the init action in `dev_codeql.yml`.
- Excludes `build/_deps/**` (CPM/FetchContent: Eigen, fmt, msgpack, …), `externals/miniz-*`, `externals/fmt*`, `build_*/**`, and `.claude/**` (local worktrees).

## Why
On the [master CodeQL view](https://github.com/CoolProp/CoolProp/security/code-scanning?query=is%3Aopen+branch%3Amaster+severity%3Acritical%2Chigh) we currently have 16 high/critical alerts plus a tail of error-severity alerts in vendored deps that we cannot patch:
- ~20 `cpp/duplicate-include-guard` errors from the Eigen 5.0.1 bump (#2827)
- 3 miniz alerts: `cpp/potentially-dangerous-function` (localtime, **critical**), `cpp/world-writable-file-creation`, `cpp/toctou-race-condition`
- 1 fmt `cpp/incorrect-not-operator-usage` at `format-inl.h:1330` — verified the same pattern still exists on fmt master at line 1341 (intentional micro-opt in their Dragon/Grisu number-formatting code; bumping fmt does not fix it)

After this lands, the high/critical count on master should drop from 16 → ~11 (all in our code), making the remaining queue tractable. Follow-ups already filed in beads (CoolProp-wp4 PCSAFT casts, CoolProp-eye Plots/Common.py uninit, CoolProp-8bt cppcheck real bugs, CoolProp-lws jinja2, CoolProp-ewe path-injection).

No code change.

## Test plan
- [ ] CodeQL CI passes on this PR
- [ ] After merge, confirm vendored-path alerts disappear from the master scan