### PR TITLE
fix(pcsaft): widen num_sites multiply to size_t (CodeQL int-overflow)

### DIFF
--- a/src/Backends/PCSAFT/PCSAFTBackend.cpp
+++ b/src/Backends/PCSAFT/PCSAFTBackend.cpp
@@ -437,7 +437,7 @@ CoolPropDbl PCSAFTBackend::calc_alphar(void) {
 
         // these indices are necessary because we are only using 1D vectors
         vector<double> XA(num_sites, 0);
-        vector<double> delta_ij(num_sites * num_sites, 0);
+        vector<double> delta_ij(static_cast<std::size_t>(num_sites) * num_sites, 0);
         auto idxa = 0ULL;
         auto idxi = 0ULL;  // index for the ii-th compound
         auto idxj = 0ULL;  // index for the jj-th compound
@@ -754,8 +754,8 @@ CoolPropDbl PCSAFTBackend::calc_dadt(void) {
 
         // these indices are necessary because we are only using 1D vectors
         vector<double> XA(num_sites, 0);
-        vector<double> delta_ij(num_sites * num_sites, 0);
-        vector<double> ddelta_dt(num_sites * num_sites, 0);
+        vector<double> delta_ij(static_cast<std::size_t>(num_sites) * num_sites, 0);
+        vector<double> ddelta_dt(static_cast<std::size_t>(num_sites) * num_sites, 0);
         std::size_t idxa = 0UL;
         std::size_t idxi = 0UL;  // index for the ii-th compound
         std::size_t idxj = 0UL;  // index for the jj-th compound
@@ -1221,7 +1221,7 @@ vector<CoolPropDbl> PCSAFTBackend::calc_fugacity_coefficients(void) {
 
         // these indices are necessary because we are only using 1D vectors
         vector<double> XA(num_sites, 0);
-        vector<double> delta_ij(num_sites * num_sites, 0);
+        vector<double> delta_ij(static_cast<std::size_t>(num_sites) * num_sites, 0);
         std::size_t idxa = 0UL;
         std::size_t idxi = 0UL;  // index for the ii-th compound
         std::size_t idxj = 0UL;  // index for the jj-th compound
@@ -1243,7 +1243,7 @@ vector<CoolPropDbl> PCSAFTBackend::calc_fugacity_coefficients(void) {
             }
         }
 
-        vector<double> ddelta_dx(num_sites * num_sites * ncomp, 0);
+        vector<double> ddelta_dx(static_cast<std::size_t>(num_sites) * num_sites * ncomp, 0);
         int idx_ddelta = 0;
         for (size_t k = 0; k < ncomp; k++) {
             std::size_t idxi = 0UL;  // index for the ii-th compound
@@ -1581,7 +1581,7 @@ CoolPropDbl PCSAFTBackend::calc_compressibility_factor(void) {
 
         // these indices are necessary because we are only using 1D vectors
         vector<double> XA(num_sites, 0);
-        vector<double> delta_ij(num_sites * num_sites, 0);
+        vector<double> delta_ij(static_cast<std::size_t>(num_sites) * num_sites, 0);
         std::size_t idxa = 0UL;
         std::size_t idxi = 0UL;  // index for the ii-th compound
         std::size_t idxj = 0UL;  // index for the jj-th compound
@@ -1603,7 +1603,7 @@ CoolPropDbl PCSAFTBackend::calc_compressibility_factor(void) {
             }
         }
 
-        vector<double> ddelta_dx(num_sites * num_sites * ncomp, 0);
+        vector<double> ddelta_dx(static_cast<std::size_t>(num_sites) * num_sites * ncomp, 0);
         int idx_ddelta = 0;
         for (size_t k = 0; k < ncomp; k++) {
             std::size_t idxi = 0UL;  // index for the ii-th compound


### PR DESCRIPTION
## Summary
- Fixes 7 high-severity [\`cpp/integer-multiplication-cast-to-long\`](https://github.com/CoolProp/CoolProp/security/code-scanning?query=is%3Aopen+rule%3Acpp%2Finteger-multiplication-cast-to-long) alerts in \`PCSAFTBackend.cpp\`.
- Each \`vector<double>(num_sites * num_sites, 0)\` (and the triple product with \`ncomp\` in two sites) does an \`int*int\` multiply before promotion to \`vector::size_type\`. Cast one operand to \`std::size_t\` so the whole expression is computed in \`size_t\`.

## Sites
| Function | Lines |
| --- | --- |
| \`calc_alphar\` | 440 |
| \`calc_dadt\` | 757, 758 |
| \`calc_fugacity_coefficients\` | 1224, 1246 |
| \`calc_compressibility_factor\` | 1584, 1606 |

## Notes
- The remaining \`num_sites * num_sites\` at line 2917 is in \`dXAdx_find\` where \`auto num_sites = XA.size()\` is already \`std::size_t\` — no overflow risk and CodeQL did not flag it.
- Closes [bd CoolProp-wp4](#); related to the CodeQL triage in #2845.

## Test plan
- [x] Local build (\`cmake --build . --target CoolProp\`) clean
- [ ] CI green
- [ ] Post-merge: 7 PCSAFT alerts close on master scan