### PR TITLE
fix(plots): silence CodeQL uninitialized-locals in Plots/Common.py

### DIFF
--- a/wrappers/Python/CoolProp/Plots/Common.py
+++ b/wrappers/Python/CoolProp/Plots/Common.py
@@ -298,6 +298,7 @@ class PropertyDict(with_metaclass(ABCMeta), object):
 
 class SIunits(PropertyDict):
     def __init__(self):
+        super(SIunits, self).__init__()
         self._D = BaseDimension(add_SI=0.0, mul_SI=1.0, off_SI=0.0, label='Density', symbol=u'd', unit=u'kg/m3')
         self._H = BaseDimension(add_SI=0.0, mul_SI=1.0, off_SI=0.0, label='Specific Enthalpy', symbol=u'h', unit=u'J/kg')
         self._P = BaseDimension(add_SI=0.0, mul_SI=1.0, off_SI=0.0, label='Pressure', symbol=u'p', unit=u'Pa')
@@ -1083,8 +1084,14 @@ consider replacing it with \"_get_sat_bounds\".",
         """
         This will give the coordinates and rotation required to align a label with
         a line on a plot in SI units.
+
+        Exactly one of ``x`` or ``y`` must be supplied; the other is found by
+        interpolation along ``(xv, yv)``.
         """
-        if y is None and x is not None:
+        if (x is None) == (y is None):
+            raise ValueError("Provide exactly one of `x` or `y`; the other is interpolated.")
+
+        if y is None:
             trash = 0
             (xv, yv) = self._to_pixel_coords(xv, yv)
             # x is provided but y isn't
@@ -1094,7 +1101,7 @@ consider replacing it with \"_get_sat_bounds\".",
             x, y, dy_dx = BasePlot.get_x_y_dydx(xv, yv, x)
             rot = np.arctan(dy_dx) / np.pi * 180.
 
-        elif x is None and y is not None:
+        else:
             # y is provided, but x isn't
             _xv = xv[::-1]
             _yv = yv[::-1]


### PR DESCRIPTION
## Summary
Two real bugs in \`wrappers/Python/CoolProp/Plots/Common.py\` flagged by CodeQL.

### \`BasePlot._inline_label\` (alerts 2319–2322)
The two branches that compute \`rot\` are keyed on which of \`(x, y)\` is \`None\`. If **neither** branch fires — i.e. both are supplied, or both are \`None\` — control falls through to \`return (x, y, rot)\` with \`rot\` never assigned, raising \`UnboundLocalError\` at the return. That cascades to \`inline_label\` which then has \`x\`, \`y\`, \`rot\` undefined at the \`from_SI\` / \`return\` lines (CodeQL reports the same defect at lines 1111, 1125, 1126, 1127).

**Fix:** require exactly one of \`x\` or \`y\` with an explicit \`ValueError\`, then \`if/else\` on \`y is None\`. Semantics unchanged on valid input; clearer failure on invalid.

### \`SIunits.__init__\` (alert 2839, \`py/missing-call-to-init\`)
\`SIunits.__init__\` overrides \`PropertyDict.__init__\` without calling it. The base only sets the \`_D/_H/_P/_S/_T/_U/_Q\` attributes to \`None\` (which \`SIunits\` immediately overwrites), so behavior is unchanged today — but any future non-trivial addition to \`PropertyDict.__init__\` would silently break \`SIunits\`. Added \`super(SIunits, self).__init__()\`. \`KSIunits\` and \`EURunits\` already chain correctly through \`super()\`.

## Test plan
- [x] AST parse OK
- [ ] CI green
- [ ] Post-merge: 4 \`py/uninitialized-local-variable\` alerts (2319–2322) and 1 \`py/missing-call-to-init\` (2839) close on master scan