### PR TITLE
fix(cppcheck): four real bugs / suppressions across src/

### DIFF
--- a/src/Backends/Cubics/UNIFAC.cpp
+++ b/src/Backends/Cubics/UNIFAC.cpp
@@ -163,6 +163,10 @@ void UNIFAC::UNIFACMixture::set_temperature(const double T) {
                 int sgim = c.groups[m].group.sgi;
                 sum1 += theta_pure(i, sgim) * Psi_.find(std::pair<std::size_t, std::size_t>(sgim, sgik))->second;
             }
+            // sum1 > 0: c.groups is the set of groups present in component i, theta_pure
+            // returns the (positive) surface-area fraction of each, and Psi = exp(-a/T) > 0.
+            // cppcheck cannot prove this symbolically.
+            // cppcheck-suppress invalidFunctionArg
             double s = 1 - log(sum1);
             for (std::size_t m = 0; m < c.groups.size(); ++m) {
                 int sgim = c.groups[m].group.sgi;

--- a/src/Backends/Helmholtz/ExcessHEFunction.h
+++ b/src/Backends/Helmholtz/ExcessHEFunction.h
@@ -204,17 +204,11 @@ class ExcessTerm
 
     ExcessTerm() : N(0) {};
 
-    // copy assignment
-    ExcessTerm& operator=(ExcessTerm& other) {
-        for (std::size_t i = 0; i < N; ++i) {
-            for (std::size_t j = 0; j < N; ++j) {
-                if (i != j) {
-                    *(other.DepartureFunctionMatrix[i][j].get()) = *(other.DepartureFunctionMatrix[i][j].get());
-                }
-            }
-        }
-        return *this;
-    }
+    // operator= and copy-ctor: rely on the compiler-generated defaults, which
+    // shallow-copy N, F, and DepartureFunctionMatrix (vector of shared_ptr).
+    // The hand-written operator= that lived here did not actually copy any
+    // member of *this and self-assigned other's matrix — see ::copy() below
+    // for an explicit deep-copy variant.
 
     ExcessTerm copy() {
         ExcessTerm _term;

--- a/src/Backends/Helmholtz/MixtureParameters.h
+++ b/src/Backends/Helmholtz/MixtureParameters.h
@@ -74,7 +74,7 @@ struct REFPROP_binary_element
 /// A data structure for holding departure functions coming from REFPROP
 struct REFPROP_departure_function
 {
-    short Npower, Nspecial, Nterms_power, Nterms_special;
+    short Npower = 0, Nspecial = 0, Nterms_power = 0, Nterms_special = 0;
     std::string model;
     std::vector<double> a, t, d, e, eta, epsilon, beta, gamma;
     std::vector<std::string> comments;

--- a/src/ODEIntegrators.cpp
+++ b/src/ODEIntegrators.cpp
@@ -59,7 +59,8 @@ bool ODEIntegrators::AdaptiveRK54(AbstractODEIntegrator& ode, double tmin, doubl
             ode.pre_step_callback();
 
             // We check stepAccepted again because if the derived class
-            // sets the variable stepAccepted, we should not actually do the evaluation
+            // sets the variable stepAccepted, we should not actually do the evaluation.
+            // cppcheck-suppress identicalInnerCondition
             if (!stepAccepted) {
 
                 Eigen::Map<Eigen::VectorXd> xold_w(&(xold[0]), N);


### PR DESCRIPTION
## Summary
Four cppcheck-flagged issues from the dev_cppcheck artifact. Net: one real fix, one default-init hardening, and two cppcheck-suppress pragmas with rationale where the warning is symbolically unprovable but locally correct.

## Changes

### 1. \`MixtureParameters.h\` — \`REFPROP_departure_function\` default-init (real bug)
\`short Npower, Nspecial, Nterms_power, Nterms_special\` had no default initializers. \`parse_HMX_BNC\` sets \`dep.Npower = -1\` explicitly, but if a \`#MXM\` block contains zero parsable data lines (only comments / \`!\` markers), the \`dep\` gets \`push_back\`'d with the other three shorts uninitialized (\`uninitvar\` at \`MixtureParameters.cpp:796\`). Default them to 0.

### 2. \`ExcessHEFunction.h\` — drop broken \`ExcessTerm::operator=\` (real bug, dead code)
The hand-written operator= took a non-const reference, never assigned \`N\` or \`F\`, and its loop body was \`*(other.M[i][j]) = *(other.M[i][j])\` — self-assigning **other's** matrix elements, copying nothing into \`*this\`. cppcheck flagged \`operatorEqVarError\` on all three members.

\`grep -rn ExcessTerm src/\` confirms there is no call site that uses operator= — \`ExcessTerm\` is only copy-constructed in \`ResidualHelmholtz(const ExcessTerm& E, …) : Excess(E), …\`. Removing the broken function lets the compiler-generated default \`operator=\` take over (correct shallow copy: \`std::size_t\`, \`STLMatrix\`, and a vector of \`shared_ptr<DepartureFunction>\` all copy correctly). The explicit deep-copy variant is still available via \`::copy()\` directly below.

### 3. \`UNIFAC.cpp:166\` — \`invalidFunctionArg\` \`log(sum1)\` suppression
\`sum1\` sums \`theta_pure(i, sgim) * Psi(sgim, sgik)\` over groups \`m\` in component \`i\`'s group list. \`theta_pure\` returns the (positive) surface-area fraction of a group present in \`i\`, and \`Psi = exp(-a/T) > 0\`. So \`sum1 > 0\` always — cppcheck cannot prove it symbolically. Added inline-suppr with a one-line explanation.

### 4. \`ODEIntegrators.cpp:63\` — \`identicalInnerCondition\` suppression
The inner \`if (!stepAccepted)\` matches the outer \`while (!stepAccepted)\`. cppcheck calls this redundant, but the intervening \`ode.pre_step_callback()\` can flip \`stepAccepted\` from a derived class — exactly what the existing comment already explains. Added inline-suppr.

## Test plan
- [x] Local build (\`cmake --build … --target CoolProp\`) clean
- [ ] CI green (catch2, cppcheck artifact)
- [ ] Manually compare cppcheck artifact before/after — confirm the 4 sites no longer flagged