### PR TITLE
fix(HEOS): change_EOS throws on unknown EOS name (#1703)

### DIFF
--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -475,6 +475,8 @@ void HelmholtzEOSMixtureBackend::calc_change_EOS(const std::size_t i, const std:
             EOS.alphar.empty_the_EOS();
             // Set the Xiang & Deiters contribution
             EOS.alphar.XiangDeiters = ResidualHelmholtzXiangDeiters(Tc, pc, rhomolarc, acentric, R);
+        } else {
+            throw ValueError(format("EOS name [%s] is invalid; valid options are SRK, Peng-Robinson, XiangDeiters", EOS_name.c_str()));
         }
     } else {
         throw ValueError(format("Index [%d] is invalid", i));

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4811,6 +4811,7 @@ TEST_CASE("Water HS_INPUTS flash near H=3133800, S=6777 is smooth (no spike to 5
         CHECK(p < 1e8);
         CHECK(std::abs(p - 2.97e6) / 2.97e6 < 0.02);
     }
+}
 TEST_CASE("change_EOS rejects unknown EOS name", "[change_EOS][1703]") {
     // Issue #1703: change_EOS used to silently no-op for unrecognized
     // EOS names; it now throws. Valid names (SRK, Peng-Robinson,

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4811,6 +4811,17 @@ TEST_CASE("Water HS_INPUTS flash near H=3133800, S=6777 is smooth (no spike to 5
         CHECK(p < 1e8);
         CHECK(std::abs(p - 2.97e6) / 2.97e6 < 0.02);
     }
+TEST_CASE("change_EOS rejects unknown EOS name", "[change_EOS][1703]") {
+    // Issue #1703: change_EOS used to silently no-op for unrecognized
+    // EOS names; it now throws. Valid names (SRK, Peng-Robinson,
+    // XiangDeiters) must still work; an out-of-range index must still throw.
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "CO2"));
+    CHECK_THROWS(AS->change_EOS(0, "kdsfakhds"));
+    CHECK_THROWS(AS->change_EOS(0, ""));
+    CHECK_THROWS(AS->change_EOS(99, "SRK"));
+    CHECK_NOTHROW(AS->change_EOS(0, "SRK"));
+    CHECK_NOTHROW(AS->change_EOS(0, "Peng-Robinson"));
+    CHECK_NOTHROW(AS->change_EOS(0, "XiangDeiters"));
 }
 TEST_CASE("Ammonia d(U)/d(P)|sigma at P=60110.77... is finite (#2244)", "[ammonia][2244]") {
     // Issue #2244: PropsSI('d(U)/d(P)|sigma','P',60110.7723310773,'Q',0,


### PR DESCRIPTION
## Summary

Fixes #1703.

`HelmholtzEOSMixtureBackend::calc_change_EOS` had an `if/else if` chain matching `SRK`, `Peng-Robinson`, and `XiangDeiters` with no fallback, so any other (mis-typed) EOS name silently no-op'd while the call returned cleanly. The reproducer from the issue:

```python
fluid = CP.AbstractState("HEOS","CO2")
fluid.change_EOS(0, "kdsfakhds")  # silently did nothing
```

now raises `ValueError` listing the offending name and the valid options.

## Changes
- `src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp`: add explicit `else { throw ValueError(...) }` after the EOS-name dispatch
- `src/Tests/CoolProp-Tests.cpp`: add `[1703]` Catch2 case asserting unknown names throw, valid names still succeed, and out-of-range index still throws

## Test plan
- [x] New `[1703]` test case fails on master, passes with the fix
- [x] All `[1703]`-tagged tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)