### PR TITLE
fix(ancillaries): return NaN above the reducing T instead of UB / SIGFPE (#1611)

### DIFF
--- a/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
+++ b/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
@@ -1,6 +1,7 @@
 #include "Ancillaries.h"
 
 #include <cmath>
+#include <limits>
 #include "DataStructures.h"
 #include "AbstractState.h"
 #include "Configuration.h"
@@ -55,12 +56,17 @@ double SaturationAncillaryFunction::evaluate(double T) {
     } else {
         double THETA = 1 - T / T_r;
         // Saturation ancillaries are only defined at or below the reducing
-        // temperature. A negative THETA combined with a non-integer exponent
-        // gives pow(negative, fractional) -> NaN and (depending on FE flags)
-        // an FPE that escapes C++ try/catch (#1611). Throw a controlled
-        // exception so callers like the Brent inversion can react cleanly.
+        // temperature. For T > T_r, pow(THETA, t) with non-integer t was
+        // pow(negative, fractional), producing NaN and (depending on FP
+        // trap settings) sometimes a SIGFPE that escaped C++ try/catch
+        // (#1611). Many internal callers (mixture critical-point search,
+        // VLE initialisers, etc.) legitimately probe ancillaries at T
+        // ranges where the pure component is supercritical and rely on
+        // the result being well-behaved-but-invalid (NaN) rather than an
+        // exception. Return NaN explicitly so the caller's existing
+        // sanity check / fallback runs without a SIGFPE.
         if (THETA < 0) {
-            throw ValueError(format("Temperature %g K exceeds the saturation-ancillary reducing temperature %g K", T, T_r));
+            return std::numeric_limits<double>::quiet_NaN();
         }
 
         for (std::size_t i = 0; i < N; ++i) {

--- a/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
+++ b/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
@@ -54,6 +54,15 @@ double SaturationAncillaryFunction::evaluate(double T) {
         return poly.evaluate(num_coeffs, T) / poly.evaluate(den_coeffs, T);
     } else {
         double THETA = 1 - T / T_r;
+        // Saturation ancillaries are only defined at or below the reducing
+        // temperature. A negative THETA combined with a non-integer exponent
+        // gives pow(negative, fractional) -> NaN and (depending on FE flags)
+        // an FPE that escapes C++ try/catch (#1611). Throw a controlled
+        // exception so callers like the Brent inversion can react cleanly.
+        if (THETA < 0) {
+            throw ValueError(format(
+              "Temperature %g K exceeds the saturation-ancillary reducing temperature %g K", T, T_r));
+        }
 
         for (std::size_t i = 0; i < N; ++i) {
             s[i] = n[i] * pow(THETA, t[i]);

--- a/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
+++ b/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
@@ -60,8 +60,7 @@ double SaturationAncillaryFunction::evaluate(double T) {
         // an FPE that escapes C++ try/catch (#1611). Throw a controlled
         // exception so callers like the Brent inversion can react cleanly.
         if (THETA < 0) {
-            throw ValueError(format(
-              "Temperature %g K exceeds the saturation-ancillary reducing temperature %g K", T, T_r));
+            throw ValueError(format("Temperature %g K exceeds the saturation-ancillary reducing temperature %g K", T, T_r));
         }
 
         for (std::size_t i = 0; i < N; ++i) {
@@ -217,7 +216,7 @@ CoolPropDbl MeltingLineVariables::evaluate(int OF, int GIVEN, CoolPropDbl value)
                public:
                 MeltingLinePiecewisePolynomialInTrSegment* part;
                 CoolPropDbl given_p;
-                solver_resid(MeltingLinePiecewisePolynomialInTrSegment* part, CoolPropDbl p) : part(part), given_p(p){};
+                solver_resid(MeltingLinePiecewisePolynomialInTrSegment* part, CoolPropDbl p) : part(part), given_p(p) {};
                 double call(double T) {
 
                     CoolPropDbl calc_p = part->evaluate(T);
@@ -245,7 +244,7 @@ CoolPropDbl MeltingLineVariables::evaluate(int OF, int GIVEN, CoolPropDbl value)
                public:
                 MeltingLinePiecewisePolynomialInThetaSegment* part;
                 CoolPropDbl given_p;
-                solver_resid(MeltingLinePiecewisePolynomialInThetaSegment* part, CoolPropDbl p) : part(part), given_p(p){};
+                solver_resid(MeltingLinePiecewisePolynomialInThetaSegment* part, CoolPropDbl p) : part(part), given_p(p) {};
                 double call(double T) {
 
                     CoolPropDbl calc_p = part->evaluate(T);

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4815,21 +4815,28 @@ TEST_CASE("Saturation ancillary throws cleanly above T_r instead of returning Na
     // Issue #1611: pow(THETA, t) with THETA = 1 - T/T_r < 0 produced
     // NaN (and sometimes a SIGFPE that escaped the C++ try/catch chain).
     // The defensive guard now throws a CoolProp ValueError when T > T_r.
+TEST_CASE("Saturation ancillary returns NaN above T_r instead of UB / SIGFPE (#1611)", "[ancillary][1611]") {
+    // Issue #1611: pow(THETA, t) with THETA = 1 - T/T_r < 0 was
+    // pow(negative, fractional) which produced NaN and (depending on
+    // FP trap settings) sometimes a SIGFPE that escaped C++ try/catch.
+    // Internal callers (mixture critical-point search, VLE init) probe
+    // ancillaries above the pure-component T_r and rely on getting a
+    // well-behaved value back, so the guard returns NaN explicitly
+    // (no UB, no SIGFPE) instead of throwing.
     auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "R134a"));
     auto& heos = *dynamic_cast<CoolProp::HelmholtzEOSMixtureBackend*>(AS.get());
     auto& fluid = heos.get_components()[0];
     double Tcrit = AS->T_critical();
 
-    // Direct ancillary evaluation a few K above the reducing T must
-    // throw (was: returned NaN), and must not return NaN. Use Tcrit + 5 K
-    // since the ancillary's T_r may be slightly below the EOS Tcrit.
-    CHECK_THROWS(fluid.ancillaries.pL.evaluate(Tcrit + 5.0));
-    CHECK_THROWS(fluid.ancillaries.pV.evaluate(Tcrit + 5.0));
-    CHECK_THROWS(fluid.ancillaries.rhoL.evaluate(Tcrit + 5.0));
-    CHECK_THROWS(fluid.ancillaries.rhoV.evaluate(Tcrit + 5.0));
-    // Comfortably below T_r still works
-    CHECK_NOTHROW(fluid.ancillaries.pL.evaluate(0.95 * Tcrit));
-    CHECK_NOTHROW(fluid.ancillaries.pL.evaluate(0.5 * Tcrit));
+    // Direct ancillary evaluation a few K above the reducing T returns
+    // NaN cleanly (no SIGFPE, no UB).
+    CHECK(std::isnan(fluid.ancillaries.pL.evaluate(Tcrit + 5.0)));
+    CHECK(std::isnan(fluid.ancillaries.pV.evaluate(Tcrit + 5.0)));
+    CHECK(std::isnan(fluid.ancillaries.rhoL.evaluate(Tcrit + 5.0)));
+    CHECK(std::isnan(fluid.ancillaries.rhoV.evaluate(Tcrit + 5.0)));
+    // Comfortably below T_r still produces finite values
+    CHECK(std::isfinite(fluid.ancillaries.pL.evaluate(0.95 * Tcrit)));
+    CHECK(std::isfinite(fluid.ancillaries.pL.evaluate(0.5 * Tcrit)));
 
     // The original user-facing reproducer no longer crashes
     // (PropsSI returns NaN with errstring set rather than SIGFPE).

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4811,10 +4811,8 @@ TEST_CASE("Water HS_INPUTS flash near H=3133800, S=6777 is smooth (no spike to 5
         CHECK(p < 1e8);
         CHECK(std::abs(p - 2.97e6) / 2.97e6 < 0.02);
     }
-TEST_CASE("Saturation ancillary throws cleanly above T_r instead of returning NaN", "[ancillary][1611]") {
-    // Issue #1611: pow(THETA, t) with THETA = 1 - T/T_r < 0 produced
-    // NaN (and sometimes a SIGFPE that escaped the C++ try/catch chain).
-    // The defensive guard now throws a CoolProp ValueError when T > T_r.
+}
+
 TEST_CASE("Saturation ancillary returns NaN above T_r instead of UB / SIGFPE (#1611)", "[ancillary][1611]") {
     // Issue #1611: pow(THETA, t) with THETA = 1 - T/T_r < 0 was
     // pow(negative, fractional) which produced NaN and (depending on
@@ -4843,6 +4841,7 @@ TEST_CASE("Saturation ancillary returns NaN above T_r instead of UB / SIGFPE (#1
     CHECK_NOTHROW(CoolProp::PropsSI("T", "P", 4863285.0, "Q", 0.0, "HEOS::R407C"));
     CHECK_NOTHROW(CoolProp::PropsSI("T", "P", 1.0e6, "Q", 0.0, "HEOS::R407C"));
 }
+
 TEST_CASE("INCOMP psat throws below TminPsat instead of returning 0 silently (#2209)", "[INCOMP][2209]") {
     // Issue #2209: PropsSI('P','Q',0,'T',373,'INCOMP::MEG[0.1]') returned
     // 0.0 because MEG.json has TminPsat=373.15 (which equals Tmax for

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4811,6 +4811,30 @@ TEST_CASE("Water HS_INPUTS flash near H=3133800, S=6777 is smooth (no spike to 5
         CHECK(p < 1e8);
         CHECK(std::abs(p - 2.97e6) / 2.97e6 < 0.02);
     }
+TEST_CASE("Saturation ancillary throws cleanly above T_r instead of returning NaN", "[ancillary][1611]") {
+    // Issue #1611: pow(THETA, t) with THETA = 1 - T/T_r < 0 produced
+    // NaN (and sometimes a SIGFPE that escaped the C++ try/catch chain).
+    // The defensive guard now throws a CoolProp ValueError when T > T_r.
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "R134a"));
+    auto& heos = *dynamic_cast<CoolProp::HelmholtzEOSMixtureBackend*>(AS.get());
+    auto& fluid = heos.get_components()[0];
+    double Tcrit = AS->T_critical();
+
+    // Direct ancillary evaluation a few K above the reducing T must
+    // throw (was: returned NaN), and must not return NaN. Use Tcrit + 5 K
+    // since the ancillary's T_r may be slightly below the EOS Tcrit.
+    CHECK_THROWS(fluid.ancillaries.pL.evaluate(Tcrit + 5.0));
+    CHECK_THROWS(fluid.ancillaries.pV.evaluate(Tcrit + 5.0));
+    CHECK_THROWS(fluid.ancillaries.rhoL.evaluate(Tcrit + 5.0));
+    CHECK_THROWS(fluid.ancillaries.rhoV.evaluate(Tcrit + 5.0));
+    // Comfortably below T_r still works
+    CHECK_NOTHROW(fluid.ancillaries.pL.evaluate(0.95 * Tcrit));
+    CHECK_NOTHROW(fluid.ancillaries.pL.evaluate(0.5 * Tcrit));
+
+    // The original user-facing reproducer no longer crashes
+    // (PropsSI returns NaN with errstring set rather than SIGFPE).
+    CHECK_NOTHROW(CoolProp::PropsSI("T", "P", 4863285.0, "Q", 0.0, "HEOS::R407C"));
+    CHECK_NOTHROW(CoolProp::PropsSI("T", "P", 1.0e6, "Q", 0.0, "HEOS::R407C"));
 }
 TEST_CASE("INCOMP psat throws below TminPsat instead of returning 0 silently (#2209)", "[INCOMP][2209]") {
     // Issue #2209: PropsSI('P','Q',0,'T',373,'INCOMP::MEG[0.1]') returned


### PR DESCRIPTION
## Summary

Fixes #1611.

`SaturationAncillaryFunction::evaluate(T)` computed `THETA = 1 - T/T_r` and then `pow(THETA, t[i])` with non-integer `t[i]`. For `T > T_r` this is `pow(negative, fractional)`, which is undefined in standard C++ — the C library typically returns NaN, but with FP traps enabled this path can raise a `SIGFPE` that escapes C++ try/catch (exactly the symptom in the original 2018 report).

The user-facing Python reproducer in the issue stopped reaching this code path after PR #2173 in 2022 (which added an `ExtrapolatingSecant` fallback in `invert`), but `evaluate(T)` itself remained latently undefined for any direct caller passing `T > T_r`.

```python
# Latent crash potential before this fix:
PropsSI('T','P',4863285,'Q',0,'HEOS::R407C')
```

## Why NaN instead of throw

Many internal callers — mixture critical-point search, VLE initialisers, ancillary-driven pseudo-pure construction — legitimately *probe* ancillaries at temperatures above the pure-component `T_r` and rely on getting a well-behaved-but-invalid value back so their existing sanity check or fallback can run. Throwing here would surface as new exceptions in callers that already handle the "no usable ancillary value" case correctly, breaking working flows in service of a defensive change.

So the guard returns `std::numeric_limits<double>::quiet_NaN()` explicitly: no UB, no SIGFPE, and existing `if (!ValidNumber(...))` patterns at call sites continue to work unchanged.

## Changes

- `src/Backends/Helmholtz/Fluids/Ancillaries.cpp` — early-return `quiet_NaN` from `evaluate(T)` when `THETA < 0`. (Also adds the `<limits>` include.)
- `src/Tests/CoolProp-Tests.cpp` — new `[ancillary][1611]` regression test.

## Test plan

- [x] Direct `evaluate(Tcrit + 5)` on R134a's `pL`/`pV`/`rhoL`/`rhoV` returns `std::isnan` cleanly (no SIGFPE, no UB)
- [x] Below `T_r` evaluation still produces finite values (`0.95 * Tcrit`, `0.5 * Tcrit`)
- [x] Original user-facing R407C reproducer (`PropsSI('T','P',4863285,'Q',0,'HEOS::R407C')`) doesn't throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)