### PR TITLE
fix(PropsSI): handle length-0 and length-1 array inputs (#2417)

### DIFF
--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -320,6 +320,15 @@ void _PropsSI_outputs(shared_ptr<AbstractState>& State, const std::vector<output
     if (in1.size() != in2.size()) {
         throw ValueError(format("lengths of in1 [%d] and in2 [%d] are not the same", in1.size(), in2.size()));
     }
+    // If the input pair is valid (state inputs are required) but the
+    // input vectors are empty, return an empty IO. Without this guard
+    // the N1 = std::max(1, in1.size()) hack below sized IO to one row
+    // and the i==0 iteration dereferenced in1[0] / in2[0] on empty
+    // vectors -> segfault (#2417).
+    if (input_pair != INPUT_PAIR_INVALID && in1.empty()) {
+        IO.clear();
+        return;
+    }
     const bool one_input_one_output = (in1.size() == 1 && in2.size() == 1 && output_parameters.size() == 1);
     // If all trivial outputs, never do a state update
     bool all_trivial_outputs = true;

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -118,7 +118,7 @@ bool has_solution_concentration(const std::string& fluid_string) {
 struct delim : std::numpunct<char>
 {
     char m_c;
-    delim(char c) : m_c(c){};
+    delim(char c) : m_c(c) {};
     char do_decimal_point() const {
         return m_c;
     }

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4811,6 +4811,7 @@ TEST_CASE("Water HS_INPUTS flash near H=3133800, S=6777 is smooth (no spike to 5
         CHECK(p < 1e8);
         CHECK(std::abs(p - 2.97e6) / 2.97e6 < 0.02);
     }
+}
 TEST_CASE("PropsSImulti with empty input vectors returns empty result instead of segfaulting", "[PropsSImulti][2417]") {
     // Issue #2417: PropsSI('T','P',[],'Q',[],'Ammonia') segfaulted because
     // _PropsSI_outputs forced N1 = max(1, in1.size()) and then dereferenced

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4811,6 +4811,24 @@ TEST_CASE("Water HS_INPUTS flash near H=3133800, S=6777 is smooth (no spike to 5
         CHECK(p < 1e8);
         CHECK(std::abs(p - 2.97e6) / 2.97e6 < 0.02);
     }
+TEST_CASE("PropsSImulti with empty input vectors returns empty result instead of segfaulting", "[PropsSImulti][2417]") {
+    // Issue #2417: PropsSI('T','P',[],'Q',[],'Ammonia') segfaulted because
+    // _PropsSI_outputs forced N1 = max(1, in1.size()) and then dereferenced
+    // in1[0] / in2[0]. Empty inputs must now return an empty IO matrix.
+    std::vector<std::string> outputs{"T"};
+    std::vector<std::string> fluids{"Ammonia"};
+    std::vector<double> fractions{1.0};
+    std::vector<double> p_empty;
+    std::vector<double> q_empty;
+    auto IO = CoolProp::PropsSImulti(outputs, "P", p_empty, "Q", q_empty, "HEOS", fluids, fractions);
+    CHECK(IO.empty());
+    // And the non-empty path still works
+    std::vector<double> p_one{101325.0};
+    std::vector<double> q_one{0.0};
+    auto IO2 = CoolProp::PropsSImulti(outputs, "P", p_one, "Q", q_one, "HEOS", fluids, fractions);
+    REQUIRE(IO2.size() == 1);
+    REQUIRE(IO2[0].size() == 1);
+    CHECK(IO2[0][0] > 0);
 }
 TEST_CASE("first_saturation_deriv mixture: dT/dP via Gernert vs finite-difference along bubble curve", "[first_saturation_deriv][2091]") {
     // Issue #2091: the mixture path used the pure-fluid Clapeyron

--- a/wrappers/Python/CoolProp/CoolProp.pyx
+++ b/wrappers/Python/CoolProp/CoolProp.pyx
@@ -217,7 +217,14 @@ cdef bint iterable(object a):
 
 cdef ndarray_or_iterable(object input):
     if _numpy_supported:
-        return np.squeeze(np.array(input))
+        result = np.squeeze(np.array(input))
+        # np.squeeze of a (1,1) input collapses to a 0-d array, which
+        # has no len() and confuses callers (#2417). Restore at least
+        # one dimension so list-shaped inputs always yield array-shaped
+        # outputs.
+        if result.ndim == 0:
+            result = result.reshape(-1)
+        return result
     else:
         return input
 
@@ -517,6 +524,16 @@ cpdef PropsSI(in1, in2, in3 = None, in4 = None, in5 = None, in6 = None, in7 = No
             raise ValueError("Input 5 is not one-dimensional")
 
         if is_iterable1 or is_iterable3 or is_iterable5:
+            # Empty state inputs -> empty result (no work to do).
+            # Without this short-circuit, _PropsSImulti returns an empty
+            # IO vector, which the post-call check below would raise on
+            # as if it were an error (#2417).
+            if (is_iterable3 and len(in3) == 0) or (is_iterable5 and len(in5) == 0):
+                if _numpy_supported:
+                    return np.array([])
+                else:
+                    return []
+
             # Prepare the output datatype
             if not is_iterable1:
                 vin1.push_back(in1)


### PR DESCRIPTION
## Summary

Fixes #2417.

Two related bugs in the same reproducer:

```python
CP.PropsSI('T', 'P', [101325], 'Q', [0], 'Ammonia')   # returned a 0-d array (no len())
CP.PropsSI('T', 'P', [],       'Q', [],  'Ammonia')   # segfaulted the kernel
```

### C++ (segfault on empty inputs)
`_PropsSI_outputs` forced `N1 = std::max(1, in1.size())` when the input pair was valid but the input vectors were empty, then dereferenced `in1[0] / in2[0]` -> SIGSEGV. Added an early return that clears IO and returns when `input_pair` is valid and `in1` is empty.

### Python (length-1 collapsed to 0-d)
- `ndarray_or_iterable` was `np.squeeze(np.array(input))` which turns a (1,1) result into a 0-d scalar array (no `len()`). It now reshapes a 0-d result back to 1-d so list-shaped inputs always yield array-shaped outputs.
- `PropsSI` short-circuits when any iterable state input has length zero, returning an empty `np.array` instead of calling `_PropsSImulti` and tripping the post-call "no result" `ValueError`.

## Test plan
- [x] New `[2417]` Catch2 regression test: `PropsSImulti` with empty `Prop1/Prop2` returns empty IO instead of segfaulting; non-empty path unchanged
- [x] All four cases verified at the Python level against the freshly built local `.so`:
  - length-1 list/ndarray -> 1-D array of length 1, `len() == 1`
  - length-0 list -> empty 1-D array, `len() == 0`
  - length-2 list -> 1-D array of length 2 (regression check)
  - scalar input -> scalar output (regression check)
  - single iterable input + multiple outputs -> existing 1-D shape preserved
- [x] All existing `[PropsSI]` and `[PropsSImulti]` Catch2 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
