### PR TITLE
fix(INCOMP): throw a clean error for molar properties (#1908)

### DIFF
--- a/src/Backends/Incompressible/IncompressibleBackend.h
+++ b/src/Backends/Incompressible/IncompressibleBackend.h
@@ -179,6 +179,41 @@ class IncompressibleBackend : public AbstractState
 
     // CoolPropDbl PUmass_flash(CoolPropDbl p, CoolPropDbl umass);  // not implemented
 
+    // Molar quantities are not meaningful for incompressible solutions,
+    // which are formulated entirely on a mass basis with no fixed
+    // composition / molecular weight (#1908). Throw a controlled
+    // exception with a helpful pointer at the mass-basis equivalents
+    // instead of silently returning the AbstractState default
+    // (-_HUGE) which surfaced as "PropsSI failed ungracefully".
+    CoolPropDbl calc_molar_mass(void) override {
+        throw NotImplementedError(
+          "Molar mass is not defined for the INCOMP (incompressible) backend; INCOMP fluids are mass-based.");
+    }
+    CoolPropDbl calc_rhomolar(void) override {
+        throw NotImplementedError(
+          "Dmolar / rhomolar is not defined for the INCOMP backend; use Dmass / rhomass instead.");
+    }
+    CoolPropDbl calc_hmolar(void) override {
+        throw NotImplementedError(
+          "Hmolar / hmolar is not defined for the INCOMP backend; use Hmass / hmass instead.");
+    }
+    CoolPropDbl calc_smolar(void) override {
+        throw NotImplementedError(
+          "Smolar / smolar is not defined for the INCOMP backend; use Smass / smass instead.");
+    }
+    CoolPropDbl calc_umolar(void) override {
+        throw NotImplementedError(
+          "Umolar / umolar is not defined for the INCOMP backend; use Umass / umass instead.");
+    }
+    CoolPropDbl calc_cpmolar(void) override {
+        throw NotImplementedError(
+          "Cpmolar / cpmolar is not defined for the INCOMP backend; use Cpmass / cpmass instead.");
+    }
+    CoolPropDbl calc_cvmolar(void) override {
+        throw NotImplementedError(
+          "Cvmolar / cvmolar is not defined for the INCOMP backend; use Cvmass / cvmass instead.");
+    }
+
     /// We start with the functions that do not need a reference state
     CoolPropDbl calc_rhomass(void) {
         return fluid->rho(_T, _p, _fractions[0]);

--- a/src/Backends/Incompressible/IncompressibleBackend.h
+++ b/src/Backends/Incompressible/IncompressibleBackend.h
@@ -186,32 +186,25 @@ class IncompressibleBackend : public AbstractState
     // instead of silently returning the AbstractState default
     // (-_HUGE) which surfaced as "PropsSI failed ungracefully".
     CoolPropDbl calc_molar_mass(void) override {
-        throw NotImplementedError(
-          "Molar mass is not defined for the INCOMP (incompressible) backend; INCOMP fluids are mass-based.");
+        throw NotImplementedError("Molar mass is not defined for the INCOMP (incompressible) backend; INCOMP fluids are mass-based.");
     }
     CoolPropDbl calc_rhomolar(void) override {
-        throw NotImplementedError(
-          "Dmolar / rhomolar is not defined for the INCOMP backend; use Dmass / rhomass instead.");
+        throw NotImplementedError("Dmolar / rhomolar is not defined for the INCOMP backend; use Dmass / rhomass instead.");
     }
     CoolPropDbl calc_hmolar(void) override {
-        throw NotImplementedError(
-          "Hmolar / hmolar is not defined for the INCOMP backend; use Hmass / hmass instead.");
+        throw NotImplementedError("Hmolar / hmolar is not defined for the INCOMP backend; use Hmass / hmass instead.");
     }
     CoolPropDbl calc_smolar(void) override {
-        throw NotImplementedError(
-          "Smolar / smolar is not defined for the INCOMP backend; use Smass / smass instead.");
+        throw NotImplementedError("Smolar / smolar is not defined for the INCOMP backend; use Smass / smass instead.");
     }
     CoolPropDbl calc_umolar(void) override {
-        throw NotImplementedError(
-          "Umolar / umolar is not defined for the INCOMP backend; use Umass / umass instead.");
+        throw NotImplementedError("Umolar / umolar is not defined for the INCOMP backend; use Umass / umass instead.");
     }
     CoolPropDbl calc_cpmolar(void) override {
-        throw NotImplementedError(
-          "Cpmolar / cpmolar is not defined for the INCOMP backend; use Cpmass / cpmass instead.");
+        throw NotImplementedError("Cpmolar / cpmolar is not defined for the INCOMP backend; use Cpmass / cpmass instead.");
     }
     CoolPropDbl calc_cvmolar(void) override {
-        throw NotImplementedError(
-          "Cvmolar / cvmolar is not defined for the INCOMP backend; use Cvmass / cvmass instead.");
+        throw NotImplementedError("Cvmolar / cvmolar is not defined for the INCOMP backend; use Cvmass / cvmass instead.");
     }
 
     /// We start with the functions that do not need a reference state

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5207,6 +5207,8 @@ TEST_CASE("DQ/HQ/QS flash benchmarks (#2773)", "[2773][bench][!benchmark]") {
     BENCHMARK("QS with guesses update_with_guesses(QSmolar,Q=0,s,T) [propane]") {
         return AS_prop->update_with_guesses(CoolProp::QSmolar_INPUTS, 0.0, s_QS, g_QS);
     };
+}
+
 TEST_CASE("INCOMP backend rejects molar property requests with a clean error", "[INCOMP][1908]") {
     // Issue #1908: PropsSI('Dmolar','T',298.15,'P',101325,'INCOMP::AEG[0.1]')
     // returned -infinity (the AbstractState default for _rhomolar) and the

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5207,6 +5207,22 @@ TEST_CASE("DQ/HQ/QS flash benchmarks (#2773)", "[2773][bench][!benchmark]") {
     BENCHMARK("QS with guesses update_with_guesses(QSmolar,Q=0,s,T) [propane]") {
         return AS_prop->update_with_guesses(CoolProp::QSmolar_INPUTS, 0.0, s_QS, g_QS);
     };
+TEST_CASE("INCOMP backend rejects molar property requests with a clean error", "[INCOMP][1908]") {
+    // Issue #1908: PropsSI('Dmolar','T',298.15,'P',101325,'INCOMP::AEG[0.1]')
+    // returned -infinity (the AbstractState default for _rhomolar) and the
+    // Python wrapper surfaced the unhelpful "PropsSI failed ungracefully"
+    // message because errstring was empty. The INCOMP backend now throws
+    // a NotImplementedError naming the mass-basis equivalent so PropsSI
+    // propagates a useful errstring.
+    double v = CoolProp::PropsSI("Dmolar", "T", 298.15, "P", 101325.0, "INCOMP::AEG[0.1]");
+    CHECK(!ValidNumber(v));
+    std::string err = CoolProp::get_global_param_string("errstring");
+    CAPTURE(err);
+    CHECK(err.find("INCOMP") != std::string::npos);
+    // Mass-basis output must still work for the same state
+    double rhomass = CoolProp::PropsSI("Dmass", "T", 298.15, "P", 101325.0, "INCOMP::AEG[0.1]");
+    CHECK(rhomass > 0);
+    CHECK(rhomass < 2000);
 }
 
 #endif

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4964,7 +4964,8 @@ TEST_CASE("Saturation branch flash: edge cases (#2773)", "[2773][edge_cases]") {
         // RAII guard ensures the global ref state is reset to DEF even if
         // an assertion below fails — otherwise downstream water tests would
         // operate under NBP and behave unpredictably.
-        struct WaterRefStateGuard {
+        struct WaterRefStateGuard
+        {
             ~WaterRefStateGuard() {
                 CoolProp::set_reference_stateS("Water", "DEF");
             }
@@ -5037,7 +5038,8 @@ TEST_CASE("Saturation branch flash: edge cases (#2773)", "[2773][edge_cases]") {
 TEST_CASE("Caloric superancillary is reference-state-agnostic (no thrashing)", "[2773][ref_state_shared]") {
     // RAII guard: ensure water is reset to DEF on exit, regardless of
     // assertion failures, so downstream tests aren't contaminated.
-    struct WaterRefStateGuard {
+    struct WaterRefStateGuard
+    {
         WaterRefStateGuard() {
             CoolProp::set_reference_stateS("Water", "DEF");
         }


### PR DESCRIPTION
## Summary

Fixes #1908.

The reproducer:

```python
CP.PropsSI('Dmolar', 'T', 298.15, 'P', 101325, 'INCOMP::AEG[0.1]')
# -> ValueError: PropsSI failed ungracefully :: inputs were ...
```

raised the unhelpful "ungracefully" message from the Python wrapper because the underlying `_PropsSI` call returned `-inf` cleanly and set no errstring.

### Root cause
`IncompressibleBackend` never overrode `calc_rhomolar` (or the other molar getters), so they fell through to `AbstractState`'s default that returns the cached `_rhomolar` member, which `clear()` initialises to `-_HUGE`. The call returned `-inf` cleanly and the "failed ungracefully" path was reached because no exception was thrown.

### Fix
Override the molar getters in `IncompressibleBackend` to throw `NotImplementedError` naming the mass-basis equivalent (`Dmass`, `Hmass`, etc.). `PropsSI` catches the exception and propagates a useful `errstring`.

```
Dmolar / rhomolar is not defined for the INCOMP backend; use Dmass / rhomass instead.
```

### Test plan
- [x] New `[1908]` Catch2 regression test: original repro now returns a non-finite value AND a non-empty errstring containing "INCOMP"; corresponding `Dmass` call still works
- [x] Test fails on master, passes with the fix
- [x] All existing `[PropsSI]` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
