### PR TITLE
fix(thread-safety): make deriv_counter atomic (#2844 race 1)

### DIFF
--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -1983,7 +1983,7 @@ void HelmholtzEOSMixtureBackend::calc_ssat_max(void) {
     {
        public:
         HelmholtzEOSMixtureBackend* HEOS;
-        Residual(HelmholtzEOSMixtureBackend& HEOS) : HEOS(&HEOS){};
+        Residual(HelmholtzEOSMixtureBackend& HEOS) : HEOS(&HEOS) {};
         double call(double T) {
             HEOS->update(QT_INPUTS, 1, T);
             // dTdp_along_sat
@@ -2018,7 +2018,7 @@ void HelmholtzEOSMixtureBackend::calc_hsat_max(void) {
     {
        public:
         HelmholtzEOSMixtureBackend* HEOS;
-        Residualhmax(HelmholtzEOSMixtureBackend& HEOS) : HEOS(&HEOS){};
+        Residualhmax(HelmholtzEOSMixtureBackend& HEOS) : HEOS(&HEOS) {};
         double call(double T) {
             HEOS->update(QT_INPUTS, 1, T);
             // dTdp_along_sat
@@ -3857,7 +3857,7 @@ CoolProp::CriticalState HelmholtzEOSMixtureBackend::calc_critical_point(double r
         HelmholtzEOSMixtureBackend& HEOS;
         double L1, M1;
         Eigen::MatrixXd Lstar, Mstar;
-        Resid(HelmholtzEOSMixtureBackend& HEOS) : HEOS(HEOS), L1(_HUGE), M1(_HUGE){};
+        Resid(HelmholtzEOSMixtureBackend& HEOS) : HEOS(HEOS), L1(_HUGE), M1(_HUGE) {};
         std::vector<double> call(const std::vector<double>& tau_delta) {
             double rhomolar = tau_delta[1] * HEOS.rhomolar_reducing();
             double T = HEOS.T_reducing() / tau_delta[0];
@@ -3944,7 +3944,8 @@ class OneDimObjective : public FuncWrapper1DWithTwoDerivs
     CoolProp::HelmholtzEOSMixtureBackend& HEOS;
     const double delta;
     double _call, _deriv, _second_deriv;
-    OneDimObjective(HelmholtzEOSMixtureBackend& HEOS, double delta0) : HEOS(HEOS), delta(delta0), _call(_HUGE), _deriv(_HUGE), _second_deriv(_HUGE){};
+    OneDimObjective(HelmholtzEOSMixtureBackend& HEOS, double delta0)
+      : HEOS(HEOS), delta(delta0), _call(_HUGE), _deriv(_HUGE), _second_deriv(_HUGE) {};
     double call(double tau) {
         double rhomolar = HEOS.rhomolar_reducing() * delta, T = HEOS.T_reducing() / tau;
         HEOS.update_DmolarT_direct(rhomolar, T);

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -36,9 +36,12 @@
 #include "MixtureParameters.h"
 #include "IdealCurves.h"
 #include "MixtureParameters.h"
+#include <atomic>
 #include <cstdlib>
 
-static int deriv_counter = 0;
+// Instrumentation only: counts the number of EOS derivative-cache evaluations
+// across all HEOS instances. Atomic so concurrent calls do not race (#2844).
+static std::atomic<int> deriv_counter{0};
 
 namespace CoolProp {
 
@@ -3301,7 +3304,7 @@ void HelmholtzEOSMixtureBackend::calc_reducing_state(void) {
 }
 void HelmholtzEOSMixtureBackend::calc_all_alphar_deriv_cache(const std::vector<CoolPropDbl>& mole_fractions, const CoolPropDbl& tau,
                                                              const CoolPropDbl& delta) {
-    deriv_counter++;
+    deriv_counter.fetch_add(1, std::memory_order_relaxed);
     bool cache_values = true;
     HelmholtzDerivatives derivs = residual_helmholtz->all(*this, get_mole_fractions_ref(), tau, delta, cache_values);
     _alphar = derivs.alphar;


### PR DESCRIPTION
## Summary

Partially addresses #2844 — the file-scope \`static int deriv_counter\` in \`HelmholtzEOSMixtureBackend.cpp\` is incremented every time any thread evaluates an EOS derivative cache. ThreadSanitizer flagged this as a data race during the threading test added in #2835.

The counter is instrumentation only (nothing reads it for correctness), but a non-atomic increment from multiple threads is UB per the C++ standard and produces a TSan warning that drowns out real findings.

## Change
\`\`\`diff
-static int deriv_counter = 0;
+static std::atomic<int> deriv_counter{0};
...
-    deriv_counter++;
+    deriv_counter.fetch_add(1, std::memory_order_relaxed);
\`\`\`

Relaxed memory order: the value is purely diagnostic, so the increment does not need to participate in any happens-before ordering.

## Out of scope
Race 2 from #2844 — the \`IdealHelmholtzContainer\` cache TSan report — is a separate question of whether the per-instance \`components\` vector copies are truly shared between threads or whether TSan is reporting on aliased addresses. That investigation stays under #2844.

## Test plan
- [x] All \`[helmholtz]\` regression tests pass (415 assertions)
- [ ] TSan re-run after #2835 lands should no longer flag the counter (cannot verify in this PR since the threading test isn't on master yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)