### PR TITLE
fix(PCSAFT): align gibbsmolar_residual with g_res = h_res - T*s_res (#1943)

### DIFF
--- a/src/Backends/PCSAFT/PCSAFTBackend.cpp
+++ b/src/Backends/PCSAFT/PCSAFTBackend.cpp
@@ -1352,7 +1352,13 @@ CoolPropDbl PCSAFTBackend::calc_gibbsmolar_residual(void) {
     CoolPropDbl ares = calc_alphar();
     CoolPropDbl Z = calc_compressibility_factor();
 
-    CoolPropDbl gres = (ares + (Z - 1) - log(Z)) * kb * N_AV * _T;  // Equation A.50 from Gross and Sadowski 2001
+    // Residual Gibbs energy on the (T, V) basis CoolProp uses everywhere
+    // else (matches HEOS::calc_gibbsmolar_residual = R*T*(alphar + delta*
+    // dalphar_ddelta) and satisfies g_res = h_res - T*s_res). Gross &
+    // Sadowski's A.50 includes an additional -ln(Z)*RT term that converts
+    // to (T, P) basis (the residual chemical potential at fixed P);
+    // dropping it removes the inconsistency reported in #1943.
+    CoolPropDbl gres = (ares + (Z - 1)) * kb * N_AV * _T;
     return gres;
 }
 
@@ -2818,7 +2824,14 @@ CoolPropDbl PCSAFTBackend::solver_rho_Tp(CoolPropDbl T, CoolPropDbl p, phases ph
             double rho_i = Brent(resid, x_lo_molar, x_hi_molar, DBL_EPSILON, 1e-8, 200);
             double rho_original = this->_rhomolar;
             this->_rhomolar = rho_i;
-            double g_i = calc_gibbsmolar_residual();
+            // Phase selection between roots at the SAME (T, P) requires the
+            // residual Gibbs energy on the (T, P) basis — i.e. with the
+            // -ln(Z)*RT correction. calc_gibbsmolar_residual itself is on
+            // the (T, ρ) basis to match HEOS / satisfy g_res = h_res - T*s_res
+            // (#1943); add the conversion term locally so phase selection
+            // still picks the correct (lowest-g(T, P)) root.
+            double Z_i = calc_compressibility_factor();
+            double g_i = calc_gibbsmolar_residual() - log(Z_i) * kb * N_AV * _T;
             this->_rhomolar = rho_original;
             if (g_i < g_min) {
                 g_min = g_i;

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -2873,29 +2873,52 @@ TEST_CASE("Check the PC-SAFT residual entropy function", "[pcsaft_entropy]") {
 }
 
 TEST_CASE("Check the PC-SAFT residual gibbs energy function", "[pcsaft_gibbs]") {
-    double g = -5489.471870270737;
+    // Expected values were updated in #1943 — the previous formula was
+    // (alphar + Z - 1 - ln Z) * RT (g_res on (T,P) basis), which did not
+    // satisfy the CoolProp-wide convention g_res = h_res - T*s_res.
+    // The new values come from g_res = h_res - T*s_res on (T,ρ) basis,
+    // matching HEOS::calc_gibbsmolar_residual.
+    double g = -20294.461258;
     double g_calc = CoolProp::PropsSI("Gmolar_residual", "T|liquid", 325., "Dmolar", 8983.377872003264, "PCSAFT::TOLUENE");
     CHECK(abs((g_calc / g) - 1) < 1e-5);
 
-    g = -130.63592030187894;
+    g = -267.470804;
     g_calc = CoolProp::PropsSI("Gmolar_residual", "T|gas", 325., "Dmolar", 39.44491269148218, "PCSAFT::TOLUENE");
     CHECK(abs((g_calc / g) - 1) < 1e-5);
 
-    g = -7038.128334100866;
+    g = -23511.405979;
     g_calc = CoolProp::PropsSI("Gmolar_residual", "T|liquid", 325., "Dmolar", 16655.853314424, "PCSAFT::ACETIC ACID");
     CHECK(abs((g_calc / g) - 1) < 1e-5);
 
-    g = -2109.4916554917604;
+    g = -4343.156768;
     g_calc = CoolProp::PropsSI("Gmolar_residual", "T|gas", 325., "Dmolar", 85.70199446609787, "PCSAFT::ACETIC ACID");
     CHECK(abs((g_calc / g) - 1) < 1e-5);
 
-    g = 6178.973332408309;
+    g = -9653.922736;
     g_calc = CoolProp::PropsSI("Gmolar_residual", "T|liquid", 325., "Dmolar", 13141.47619110254, "PCSAFT::DIMETHYL ETHER");
     CHECK(abs((g_calc / g) - 1) < 1e-5);
 
-    g = -33.038791982589615;
+    g = -66.429712;
     g_calc = CoolProp::PropsSI("Gmolar_residual", "T|gas", 325., "Dmolar", 37.96344503293008, "PCSAFT::DIMETHYL ETHER");
     CHECK(abs((g_calc / g) - 1) < 1e-5);
+}
+
+TEST_CASE("PC-SAFT gibbsmolar_residual satisfies g_res = h_res - T*s_res (#1943)", "[pcsaft_gibbs][1943]") {
+    // Issue #1943: PCSAFT's calc_gibbsmolar_residual used Gross & Sadowski
+    // A.50 [(alphar + Z - 1 - ln Z) * RT, on (T,P) basis] which does not
+    // equal h_res - T*s_res. CoolProp's HEOS uses (T,ρ) basis throughout,
+    // so the two backends gave inconsistent answers. The fix drops the
+    // -ln(Z)*RT term so all backends satisfy g_res = h_res - T*s_res.
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("PCSAFT", "METHANE"));
+    const double T = 100.0;
+    AS->update(CoolProp::QT_INPUTS, 0.0, T);
+    const double g = AS->gibbsmolar_residual();
+    const double h = AS->hmolar_residual();
+    const double s = AS->smolar_residual();
+    CAPTURE(g);
+    CAPTURE(h);
+    CAPTURE(s);
+    CHECK(std::abs(g - (h - T * s)) < 1e-6);
 }
 
 TEST_CASE("Check vapor pressures calculated using PC-SAFT", "[pcsaft_vapor_pressure]") {


### PR DESCRIPTION
## Summary

Fixes #1943.

\`PCSAFT::calc_gibbsmolar_residual\` used Gross & Sadowski 2001 eq. A.50:

\`\`\`
g_res = (alphar + Z - 1 - ln Z) * R * T
\`\`\`

which is the residual chemical potential on the **(T, P) basis**. The rest of CoolProp — \`HEOS::calc_gibbsmolar_residual = R*T*(alphar + delta*dalphar_ddelta)\` and the user-visible \`h_res / s_res\` getters — is on the **(T, ρ) basis**. As a result the two backends gave inconsistent answers and PCSAFT did not satisfy \`g_res = h_res - T*s_res\`:

| backend | \`g_res\` | \`h_res - T*s_res\` |
|---------|---------|---------------------|
| HEOS    | -5413.81 | -5413.81 ✅ |
| PCSAFT  | -12.35   | -5407.84 ❌ |

(methane, T=100 K, Q=0)

## Fix
Drop the \`-ln(Z)*RT\` term from \`calc_gibbsmolar_residual\` so the (T, ρ) identity \`g_res = h_res - T*s_res\` holds for both backends.

## Internal usage
The phase-selection at \`PCSAFTBackend.cpp:2827\` still needs the (T, P)-basis residual Gibbs energy — it picks the lowest-Gibbs density root at fixed T, P, where the densities (and so ln Z) differ across roots. The \`-ln(Z)*RT\` shift is added back locally there so phase selection still picks the correct root.

## Test plan
- [x] Update existing \`[pcsaft_gibbs]\` expected values to the new (T, ρ)-basis numbers (computed via \`h_res - T*s_res\`)
- [x] New \`[1943]\` regression test asserts \`abs(g - (h - T*s)) < 1e-6\` for methane saturated liquid
- [x] All \`[pcsaft_pressure]\` / \`[pcsaft_density]\` / \`[pcsaft_enthalpy]\` / \`[pcsaft_entropy]\` / \`[pcsaft_gibbs]\` tests pass (44 assertions)
- [x] \`[pcsaft_vapor_pressure]\` test still passes — confirms internal phase-selection still works after restoring the -ln(Z) shift locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)