### PR TITLE
fix(HEOS): validate Q before mutating state in update() (#2195)

### DIFF
--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -1470,34 +1470,39 @@ void HelmholtzEOSMixtureBackend::update(CoolProp::input_pairs input_pair, double
             _smolar = value2;
             FlashRoutines::HS_flash(*this);
             break;
+        // Validate quality BEFORE assigning to _Q so a thrown exception
+        // does not leave the cached state half-mutated. Without this, a
+        // subsequent hmass() / smass() / etc. would use the stale SatL/
+        // SatV pointers from a prior valid update plus the new bad _Q
+        // and return a meaningless extrapolated value (#2195).
         case QT_INPUTS:
+            if ((value1 < 0) || (value1 > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             _Q = value1;
             _T = value2;
-            if ((_Q < 0) || (_Q > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             FlashRoutines::QT_flash(*this);
             break;
         case PQ_INPUTS:
+            if ((value2 < 0) || (value2 > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             _p = value1;
             _Q = value2;
-            if ((_Q < 0) || (_Q > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             FlashRoutines::PQ_flash(*this);
             break;
         case QSmolar_INPUTS:
+            if ((value1 < 0) || (value1 > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             _Q = value1;
             _smolar = value2;
-            if ((_Q < 0) || (_Q > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             FlashRoutines::QS_flash(*this);
             break;
         case HmolarQ_INPUTS:
+            if ((value2 < 0) || (value2 > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             _hmolar = value1;
             _Q = value2;
-            if ((_Q < 0) || (_Q > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             FlashRoutines::HQ_flash(*this);
             break;
         case DmolarQ_INPUTS:
+            if ((value2 < 0) || (value2 > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             _rhomolar = value1;
             _Q = value2;
-            if ((_Q < 0) || (_Q > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             FlashRoutines::DQ_flash(*this);
             break;
         default:

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4811,6 +4811,7 @@ TEST_CASE("Water HS_INPUTS flash near H=3133800, S=6777 is smooth (no spike to 5
         CHECK(p < 1e8);
         CHECK(std::abs(p - 2.97e6) / 2.97e6 < 0.02);
     }
+}
 TEST_CASE("Out-of-range Q in update() does not corrupt cached state (#2195)", "[update][2195]") {
     // Issue #2195: PQ_INPUTS / QT_INPUTS / etc. assigned _Q = value
     // BEFORE validating the range, so a thrown OutOfRangeError left _Q at

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4811,6 +4811,31 @@ TEST_CASE("Water HS_INPUTS flash near H=3133800, S=6777 is smooth (no spike to 5
         CHECK(p < 1e8);
         CHECK(std::abs(p - 2.97e6) / 2.97e6 < 0.02);
     }
+TEST_CASE("Out-of-range Q in update() does not corrupt cached state (#2195)", "[update][2195]") {
+    // Issue #2195: PQ_INPUTS / QT_INPUTS / etc. assigned _Q = value
+    // BEFORE validating the range, so a thrown OutOfRangeError left _Q at
+    // the bad value (e.g. 1.1). A subsequent hmass() call then computed
+    //   _hmolar = _Q * SatV->hmolar() + (1 - _Q) * SatL->hmolar()
+    // with _Q = 1.1, returning a meaningless extrapolated number that
+    // looked plausible. The fix validates first; on throw the state is
+    // either left clean or surfaces NaN, never a misleading finite value.
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+    AS->update(CoolProp::PQ_INPUTS, 10e6, 0.5);
+    const double h_legal = AS->hmass();
+    CHECK(std::isfinite(h_legal));
+    CHECK(h_legal > 1e6);
+
+    CHECK_THROWS(AS->update(CoolProp::PQ_INPUTS, 10e6, 1.1));
+    // After the failed update, hmass must NOT silently return a finite
+    // value computed from the bad Q. NaN is acceptable (cleared cache);
+    // the legal cached value is also acceptable.
+    const double h_after = AS->hmass();
+    CAPTURE(h_after);
+    CHECK((!std::isfinite(h_after) || h_after == h_legal));
+
+    CHECK_THROWS(AS->update(CoolProp::PQ_INPUTS, 10e6, -0.1));
+    CHECK_THROWS(AS->update(CoolProp::QT_INPUTS, 1.5, 400.0));
+    CHECK_THROWS(AS->update(CoolProp::QT_INPUTS, -0.5, 400.0));
 }
 TEST_CASE("Water below 0 C at atmospheric pressure is not silently labelled liquid (#1098)", "[water_phase][1098]") {
     // Issue #1098 (2017): PhaseSI returned "liquid" for water at T=-5 C,


### PR DESCRIPTION
## Summary

Fixes #2195.

`PQ_INPUTS` / `QT_INPUTS` / `QSmolar_INPUTS` / `HmolarQ_INPUTS` / `DmolarQ_INPUTS` all assigned `_Q = value` BEFORE checking the `[0, 1]` range. When the range check threw, the cached state was left with the bad `_Q` and a subsequent `hmass()` / `smass()` / etc. silently returned a meaningless extrapolated value via

```cpp
_hmolar = _Q * SatV->hmolar() + (1 - _Q) * SatL->hmolar();
```

which (with `_Q = 1.1`) gave a finite, plausible-looking but wrong number.

Reproducer from the issue:
```python
AS = AbstractState("HEOS","Water")
AS.update(CoolProp.PQ_INPUTS, 10e6, 0.5)
AS.hmass()                                # 2.067e6 (correct)
try:
    AS.update(CoolProp.PQ_INPUTS, 10e6, 1.1)  # throws "Q must be between 0 and 1"
except: pass
AS.hmass()                                # was 2.857e6 (wrong); now NaN
```

## Fix
Move the range check ahead of the assignment in all five Q-input cases. After the throw, `hmass` returns NaN (cleared cache) instead of a misleading finite value.

## Test plan
- [x] New `[2195]` Catch2 regression test: legal PQ flash, illegal Q=1.1 throws, follow-up `hmass` is either NaN or the previous legal value (never a different finite number); also exercises Q<0 and the QT path
- [x] Test fails on master (h_after=2857235.30, neither NaN nor h_legal), passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
