### PR TITLE
fix(INCOMP): psat throws below TminPsat instead of returning 0 silently (#2209)

### DIFF
--- a/src/Backends/Incompressible/IncompressibleFluid.cpp
+++ b/src/Backends/Incompressible/IncompressibleFluid.cpp
@@ -184,7 +184,15 @@ double IncompressibleFluid::cond(double T, double p, double x) {
 }
 /// Saturation pressure as a function of temperature and composition.
 double IncompressibleFluid::psat(double T, double x) {
-    if (T <= this->TminPsat) return 0.0;
+    // Below TminPsat the polynomial fit is not valid. Returning 0.0
+    // silently here surfaced as "Psat = 0 for the entire valid T range"
+    // for fluids whose TminPsat is at or above Tmax (e.g. MEG, where
+    // TminPsat = Tmax = 373.15 K leaves no valid range): #2209. Throw a
+    // controlled exception instead so callers see the limitation rather
+    // than a misleading zero.
+    if (T <= this->TminPsat) {
+        throw ValueError(format("Saturation pressure is not available below TminPsat=%g K (T=%g K)", this->TminPsat, T));
+    }
     switch (p_sat.type) {
         case IncompressibleData::INCOMPRESSIBLE_POLYNOMIAL:
             return poly.evaluate(p_sat.coeffs, T, x, 0, 0, Tbase, xbase);

--- a/src/Backends/Incompressible/IncompressibleFluid.cpp
+++ b/src/Backends/Incompressible/IncompressibleFluid.cpp
@@ -456,7 +456,20 @@ bool IncompressibleFluid::checkT(double T, double p, double x) {
  *  */
 bool IncompressibleFluid::checkP(double T, double p, double x) {
     double ps = 0.0;
-    if (p_sat.type != IncompressibleData::INCOMPRESSIBLE_NOT_SET) ps = psat(T, x);
+    if (p_sat.type != IncompressibleData::INCOMPRESSIBLE_NOT_SET) {
+        // psat() now throws below TminPsat (#2209). For this validation
+        // path, T below TminPsat means the saturation curve is not
+        // available — there is nothing to compare p against, so skip
+        // the p >= psat check rather than propagating the throw to
+        // callers that didn't ask for psat in the first place
+        // (e.g. PropsSI("D","P",101325,"T",300,"INCOMP::DowQ") where
+        // DowQ has TminPsat > 300 K).
+        try {
+            ps = psat(T, x);
+        } catch (const ValueError&) {
+            ps = 0.0;
+        }
+    }
     if (p < 0.0) throw ValueError(format("You cannot use negative pressures: %f < %f. ", p, 0.0));
     if (ps > 0.0 && p < ps) throw ValueError(format("Equations are valid for liquid phase only: %f < %f (psat). ", p, ps));
     return true;

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4811,6 +4811,7 @@ TEST_CASE("Water HS_INPUTS flash near H=3133800, S=6777 is smooth (no spike to 5
         CHECK(p < 1e8);
         CHECK(std::abs(p - 2.97e6) / 2.97e6 < 0.02);
     }
+}
 TEST_CASE("INCOMP psat throws below TminPsat instead of returning 0 silently (#2209)", "[INCOMP][2209]") {
     // Issue #2209: PropsSI('P','Q',0,'T',373,'INCOMP::MEG[0.1]') returned
     // 0.0 because MEG.json has TminPsat=373.15 (which equals Tmax for

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4811,6 +4811,22 @@ TEST_CASE("Water HS_INPUTS flash near H=3133800, S=6777 is smooth (no spike to 5
         CHECK(p < 1e8);
         CHECK(std::abs(p - 2.97e6) / 2.97e6 < 0.02);
     }
+TEST_CASE("INCOMP psat throws below TminPsat instead of returning 0 silently (#2209)", "[INCOMP][2209]") {
+    // Issue #2209: PropsSI('P','Q',0,'T',373,'INCOMP::MEG[0.1]') returned
+    // 0.0 because MEG.json has TminPsat=373.15 (which equals Tmax for
+    // this fluid, leaving no usable Psat range below the upper bound)
+    // and psat() silently returned 0.0 below TminPsat. Now throw a
+    // ValueError so PropsSI surfaces a non-finite return AND populates
+    // errstring rather than returning a misleading 0.
+    const double v = CoolProp::PropsSI("P", "Q", 0, "T", 373.0, "INCOMP::MEG[0.1]");
+    CHECK(!ValidNumber(v));
+    const std::string err = CoolProp::get_global_param_string("errstring");
+    CAPTURE(err);
+    CHECK(err.find("TminPsat") != std::string::npos);
+    // LiBr has TminPsat = 273.15 so T=373 is above it and still works
+    const double v2 = CoolProp::PropsSI("P", "Q", 0, "T", 373.0, "INCOMP::LiBr[0.1]");
+    CHECK(ValidNumber(v2));
+    CHECK(v2 > 0);
 }
 TEST_CASE("PropsSImulti with empty input vectors returns empty result instead of segfaulting", "[PropsSImulti][2417]") {
     // Issue #2417: PropsSI('T','P',[],'Q',[],'Ammonia') segfaulted because


### PR DESCRIPTION
## Summary

Fixes #2209.

`IncompressibleFluid::psat` returned `0.0` silently when `T <= TminPsat`. For fluids whose `TminPsat` equals their `Tmax` (e.g. MEG with `Tmin=173.15`, `Tmax=373.15`, `TminPsat=373.15`), this leaves the saturation pressure function returning `0.0` across the entire valid temperature range, indistinguishable from a real result of zero.

```python
PropsSI('P','Q',0,'T',373,'INCOMP::MEG[0.1]')   # was 0.0 (silently wrong)
PropsSI('P','Q',0,'T',373,'INCOMP::LiBr[0.1]')  # 97053.46 (correct)
```

## Fix

Two-part change in `src/Backends/Incompressible/IncompressibleFluid.cpp`:

1. **`psat(T, x)`** — throw a controlled `ValueError` naming `TminPsat` when `T <= TminPsat` (was: silent `return 0.0`). `PropsSI` catches the exception and surfaces an `errstring` + non-finite return so callers see the limitation rather than a misleading zero.

2. **`checkP(T, p, x)`** — wrap the internal `psat()` call in a `try/catch (ValueError)` and treat a thrown exception the same as `ps == 0.0` (skip the `p >= psat` check). This validation path is reached on **every** TP-input lookup (e.g. `PropsSI('D','P',101325,'T',300,'INCOMP::DowQ')` where DowQ has `TminPsat > 300 K`); it's not the user asking for `psat`, it's an internal sanity guard. Letting the throw propagate breaks normal property lookups for fluids with high `TminPsat`. Restoring the "skip" semantics inside `checkP` keeps those queries working while the user-facing `QT_INPUTS` dispatch in `IncompressibleBackend::update()` still propagates the throw — which is what #2209 wants.

## Test plan
- [x] New `[2209]` Catch2 regression test: MEG repro produces non-finite return AND `errstring` contains "TminPsat"; LiBr call still returns positive `Psat`
- [x] Test fails on master (val=0, errstring=""), passes with the fix
- [x] `PropsSI('D','P',101325,'T',300,'INCOMP::DowQ')` and `cp/d` checks at T=328.15 K continue to succeed (they hit `checkP`, not `psat` directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)