### PR TITLE
test(water): pin sub-zero water phase behaviour (#1098)

### DIFF
--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4811,6 +4811,7 @@ TEST_CASE("Water HS_INPUTS flash near H=3133800, S=6777 is smooth (no spike to 5
         CHECK(p < 1e8);
         CHECK(std::abs(p - 2.97e6) / 2.97e6 < 0.02);
     }
+}
 TEST_CASE("Water below 0 C at atmospheric pressure is not silently labelled liquid (#1098)", "[water_phase][1098]") {
     // Issue #1098 (2017): PhaseSI returned "liquid" for water at T=-5 C,
     // P=1 atm. The HEOS solid path is not implemented but the response

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4811,6 +4811,22 @@ TEST_CASE("Water HS_INPUTS flash near H=3133800, S=6777 is smooth (no spike to 5
         CHECK(p < 1e8);
         CHECK(std::abs(p - 2.97e6) / 2.97e6 < 0.02);
     }
+TEST_CASE("Water below 0 C at atmospheric pressure is not silently labelled liquid (#1098)", "[water_phase][1098]") {
+    // Issue #1098 (2017): PhaseSI returned "liquid" for water at T=-5 C,
+    // P=1 atm. The HEOS solid path is not implemented but the response
+    // should at least not be a misleading "liquid". On current master
+    // PhaseSI returns "unknown: ..." with a helpful "T below Tmelt(p)"
+    // message and PropsSI("Phase",...) throws. Pin both behaviours so
+    // the original silent-"liquid" failure mode cannot return.
+    const std::string phase = CoolProp::PhaseSI("T", 273.15 - 5, "P", 101325.0, "Water");
+    CAPTURE(phase);
+    CHECK(phase != "liquid");
+    CHECK(phase != "twophase");
+    CHECK(phase != "gas");
+    // PropsSI("Phase", ...) catches the underlying ValueError and surfaces
+    // it as a non-finite return + populated errstring (Cython then raises).
+    const double v = CoolProp::PropsSI("Phase", "T", 273.15 - 5, "P", 101325.0, "Water");
+    CHECK(!ValidNumber(v));
 }
 
 TEST_CASE("DmassSmass round-trip on the dew curve preserves enthalpy (#1907)", "[water_flash][1907]") {


### PR DESCRIPTION
## Summary

Closes #1098.

The 2017 report was that `PhaseSI('T', 273.15-5, 'P', 101325, 'Water')` returned the misleading string `"liquid"` for water at -5 °C / atm — the HEOS solid path is not implemented but the response should at least not pretend the state is fluid. On current master both the HEOS phase determination and the high-level wrappers handle this case correctly:

```
PhaseSI("T", 273.15-5, "P", 101325, "Water") -> "unknown: For now, we don't support T [268.15 K] below Tmelt(p) [273.153 K] : ..."
PropsSI("Phase", "T", 273.15-5, "P", 101325, "Water") -> ValueError (Python) / non-finite + errstring (C++)
```

This PR adds a Catch2 `[1098]` regression test pinning both behaviours so the original silent-`"liquid"` failure mode cannot return. The test fails loudly if `PhaseSI` ever resumes returning `"liquid"`/`"twophase"`/`"gas"` for sub-zero water at 1 atm, or if `PropsSI("Phase",...)` starts returning a finite value there.

## Test plan
- [x] `[1098]` test passes on master (4 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
