### PR TITLE
fix(REFPROP): DmolarSmolar honours imposed phase via DSFL1 (#2042)

### DIFF
--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -1499,14 +1499,26 @@ void REFPROPMixtureBackend::update(CoolProp::input_pairs input_pair, double valu
             rho_mol_L = 0.001 * value1;
             smol = value2;  // Want rho in [mol/L] in REFPROP
 
-            // Use flash routine to find properties
-            // from REFPROP: subroutine DSFLSH (D,s,z,t,p,Dl,Dv,x,y,q,e,h,cv,cp,w,ierr,herr)
-            DSFLSHdll(&rho_mol_L, &smol, &(mole_fractions[0]), &_T, &p_kPa, &rhoLmol_L, &rhoVmol_L, &(mole_fractions_liq[0]),
-                      &(mole_fractions_vap[0]),  // Saturation terms
-                      &q, &emol, &hmol, &cvmol, &cpmol, &w, &ierr, herr, errormessagelength);
-            if (static_cast<int>(ierr) > get_config_int(REFPROP_ERROR_THRESHOLD)) {
-                throw ValueError(format("DmolarSmolar: %s", herr).c_str());
-            }  // TODO: else if (ierr < 0) {set_warning(format("%s",herr).c_str());}
+            if (imposed_phase_index == iphase_not_imposed || imposed_phase_index == iphase_twophase) {
+                // Use the full 2-phase flash routine
+                // from REFPROP: subroutine DSFLSH (D,s,z,t,p,Dl,Dv,x,y,q,e,h,cv,cp,w,ierr,herr)
+                DSFLSHdll(&rho_mol_L, &smol, &(mole_fractions[0]), &_T, &p_kPa, &rhoLmol_L, &rhoVmol_L, &(mole_fractions_liq[0]),
+                          &(mole_fractions_vap[0]),  // Saturation terms
+                          &q, &emol, &hmol, &cvmol, &cpmol, &w, &ierr, herr, errormessagelength);
+                if (static_cast<int>(ierr) > get_config_int(REFPROP_ERROR_THRESHOLD)) {
+                    throw ValueError(format("DmolarSmolar: %s", herr).c_str());
+                }  // TODO: else if (ierr < 0) {set_warning(format("%s",herr).c_str());}
+            } else {
+                // Phase is imposed -> use the single-phase D,S iterator (DSFL1)
+                // followed by THERMdll for the remaining properties. Avoids the
+                // 2-phase iteration that DSFL2 reaches inside DSFLSH and
+                // sometimes fails to converge for mixtures (#2042).
+                DSFL1dll(&rho_mol_L, &smol, &(mole_fractions[0]), &_T, &ierr, herr, errormessagelength);
+                if (static_cast<int>(ierr) > get_config_int(REFPROP_ERROR_THRESHOLD)) {
+                    throw ValueError(format("DmolarSmolar (imposed phase): %s", herr).c_str());
+                }
+                THERMdll(&_T, &rho_mol_L, &(mole_fractions[0]), &p_kPa, &emol, &hmol, &smol, &cvmol, &cpmol, &w, &hjt);
+            }
 
             // Set all cache values that can be set with unit conversion to SI
             _p = p_kPa * 1000;

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -270,8 +270,7 @@ bool REFPROPMixtureBackend::REFPROP_supported() {
                           << "In case you do not use Windows, have a look at https://github.com/jowr/librefprop.so \n"
                           << "to find instructions on how to compile your own version of the REFPROP library.\n\n"
                           << format("COOLPROP_REFPROP_ROOT: %s\n", (root) ? root.value().c_str() : "?")
-                          << format("ALTERNATIVE_REFPROP_PATH: %s\n", alt_rp_path.c_str())
-                          << format("ERROR: %s\n", err.c_str());
+                          << format("ALTERNATIVE_REFPROP_PATH: %s\n", alt_rp_path.c_str()) << format("ERROR: %s\n", err.c_str());
                 _REFPROP_supported = false;
                 return false;
             }

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4811,6 +4811,7 @@ TEST_CASE("Water HS_INPUTS flash near H=3133800, S=6777 is smooth (no spike to 5
         CHECK(p < 1e8);
         CHECK(std::abs(p - 2.97e6) / 2.97e6 < 0.02);
     }
+}
 TEST_CASE("REFPROP DmolarSmolar honours imposed phase (#2042)", "[REFPROP][2042]") {
     CoolProp::Skip_if_No_REFPROP();
     // Issue #2042: a multi-component natural-gas mixture with phase

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4811,6 +4811,23 @@ TEST_CASE("Water HS_INPUTS flash near H=3133800, S=6777 is smooth (no spike to 5
         CHECK(p < 1e8);
         CHECK(std::abs(p - 2.97e6) / 2.97e6 < 0.02);
     }
+TEST_CASE("REFPROP DmolarSmolar honours imposed phase (#2042)", "[REFPROP][2042]") {
+    CoolProp::Skip_if_No_REFPROP();
+    // Issue #2042: a multi-component natural-gas mixture with phase
+    // imposed to gas via specify_phase still routed through DSFLSH ->
+    // DSFL2, which threw "2-phase iteration did not converge". Imposed
+    // single-phase now uses DSFL1 + THERMdll directly.
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(
+      CoolProp::AbstractState::factory("REFPROP", "METHANE&ETHANE&PROPANE&BUTANE&ISOBUTAN&PENTANE&IPENTANE&HEXANE&NITROGEN&H2S&CO2"));
+    AS->set_mole_fractions({0.30241, 0.03639, 0.02119, 0.007, 0.0031, 0.0039, 0.0015, 0.0008, 0.0025, 0.0002, 0.62101});
+    AS->update(CoolProp::PT_INPUTS, 14500000.0, 315.35);
+    const double rho_in = 405.4197781472575;
+    const double s_in = 2004.9031527899563;
+    AS->specify_phase(CoolProp::iphase_gas);
+    REQUIRE_NOTHROW(AS->update(CoolProp::DmassSmass_INPUTS, rho_in, s_in));
+    CHECK(std::abs(AS->rhomass() - rho_in) / rho_in < 1e-6);
+    CHECK(AS->T() > 0);
+    CHECK(AS->p() > 0);
 }
 TEST_CASE("change_EOS rejects unknown EOS name", "[change_EOS][1703]") {
     // Issue #1703: change_EOS used to silently no-op for unrecognized


### PR DESCRIPTION
## Summary

Fixes #2042.

The `DmolarSmolar` / `DmassSmass` dispatch in `REFPROPMixtureBackend` always called `DSFLSHdll`, which internally runs `DSFL2` (the 2-phase flash). For the 11-component natural-gas mixture in the issue with phase forced to gas via `specify_phase`, this still attempted the 2-phase iteration and failed with `"DSFL2 error 226: 2-phase iteration did not converge"` — even though a single-phase REFPROP routine was available.

```python
s.update(CP.PT_INPUTS, 14500000, 315.35)        # OK
s.specify_phase(CP.iphase_gas)
s.update(CP.DmassSmass_INPUTS, 405.42, 2004.9)  # was: DSFL2 error 226
                                                # now: T=328.84 K, p=18.7 MPa, rho=405.42
```

## Fix
When `imposed_phase_index` is a single-phase value, dispatch to `DSFL1dll` (REFPROP's single-phase D,S iterator) followed by `THERMdll` for the remaining properties. Mirrors the pattern already used for `DmolarT_INPUTS` (which switches to `THERMdll` directly when phase is imposed).

## Test plan
- [x] New `[2042]` regression test using the original 11-component gas mixture from the issue
- [x] Gated on `Skip_if_No_REFPROP`; passes locally with `COOLPROP_REFPROP_ROOT=~/REFPROP10`
- [x] Test fails on master with "DSFL2 error 226", passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
