### PR TITLE
fix(REFPROP): wire DmassQ / DmolarQ inputs through DQFL2 (#1845)

### DIFF
--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -2173,7 +2173,7 @@ void REFPROPMixtureBackend::calc_true_critical_point(double& T, double& rho) {
     {
        public:
         const std::vector<double> z;
-        wrapper(const std::vector<double>& z) : z(z){};
+        wrapper(const std::vector<double>& z) : z(z) {};
         std::vector<double> call(const std::vector<double>& x) {
             std::vector<double> r(2);
             double dpdrho__constT = _HUGE, d2pdrho2__constT = _HUGE;

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -1946,6 +1946,33 @@ void REFPROPMixtureBackend::update(CoolProp::input_pairs input_pair, double valu
             _rhoVmolar = rhoVmol_L * 1000;  // 1000 for conversion from mol/L to mol/m3
             break;
         }
+        case DmassQ_INPUTS: {
+            // Convert to molar and dispatch to DmolarQ_INPUTS
+            update(DmolarQ_INPUTS, value1 / static_cast<double>(_molar_mass), value2);
+            return;
+        }
+        case DmolarQ_INPUTS: {
+            // GitHub #1845: REFPROP supports D,Q via DQFL2 — wire it through.
+            // REFPROP's DQFL2(d,q,z,kq,t,p,Dl,Dv,xliq,xvap,ierr,herr) iterates
+            // for T given (rho, q) on the saturation envelope. Then THERMdll
+            // populates the remaining caloric and transport-prep outputs.
+            _rhomolar = value1;
+            _Q = value2;
+            rho_mol_L = 0.001 * value1;
+            q = value2;
+            int kq = 1;  // Q on a molar basis
+            DQFL2dll(&rho_mol_L, &q, &(mole_fractions[0]), &kq, &_T, &p_kPa, &rhoLmol_L, &rhoVmol_L, &(mole_fractions_liq[0]),
+                     &(mole_fractions_vap[0]), &ierr, herr, errormessagelength);
+            if (static_cast<int>(ierr) > get_config_int(REFPROP_ERROR_THRESHOLD)) {
+                throw ValueError(format("DmolarQ(%s): %s", LoadedREFPROPRef.c_str(), herr).c_str());
+            }
+            THERMdll(&_T, &rho_mol_L, &(mole_fractions[0]), &p_kPa, &emol, &hmol, &smol, &cvmol, &cpmol, &w, &hjt);
+
+            _p = p_kPa * 1000;
+            _rhoLmolar = rhoLmol_L * 1000;
+            _rhoVmolar = rhoVmol_L * 1000;
+            break;
+        }
         default: {
             throw ValueError(format("This pair of inputs [%s] is not yet supported", get_input_pair_short_desc(input_pair).c_str()));
         }

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5262,4 +5262,20 @@ TEST_CASE("INCOMP backend rejects molar property requests with a clean error", "
     CHECK(rhomass < 2000);
 }
 
+TEST_CASE("REFPROP supports DmolarQ / DmassQ inputs (#1845)", "[REFPROP][1845]") {
+    CoolProp::Skip_if_No_REFPROP();
+    // Issue #1845: DmassQ_INPUTS / DmolarQ_INPUTS were missing from the
+    // REFPROP backend dispatch. REFPROP itself supports them via DQFL2dll.
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("REFPROP", "CO2"));
+    REQUIRE_NOTHROW(AS->update(CoolProp::DmassQ_INPUTS, 15.0, 1.0));
+    const double T_refprop = AS->T();
+    CHECK(AS->rhomass() == Catch::Approx(15.0).epsilon(1e-9));
+    CHECK(T_refprop > 200.0);
+    CHECK(T_refprop < 250.0);
+    // Cross-check with HEOS
+    auto AS2 = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "CO2"));
+    AS2->update(CoolProp::DmassQ_INPUTS, 15.0, 1.0);
+    CHECK(AS->T() == Catch::Approx(AS2->T()).epsilon(1e-6));
+}
+
 #endif


### PR DESCRIPTION
## Summary

Fixes #1845.

`REFPROPMixtureBackend::update()` had no case for `DmolarQ_INPUTS` or `DmassQ_INPUTS`, so

```python
PropsSI("T","D",15,"Q",1,"REFPROP::CO2")
# This pair of inputs [DmassQ_INPUTS] is not yet supported
```

threw — even though REFPROP itself exposes `DQFL2dll` for the saturation D,Q flash.

## Fix
- `DmassQ_INPUTS` converts to molar and recurses into `DmolarQ_INPUTS`
- `DmolarQ_INPUTS` calls `DQFL2dll(d, q, z, kq=1, t, p, Dl, Dv, xliq, xvap, …)` then `THERMdll` for the remaining caloric outputs (mirrors the `DmolarT_INPUTS` pattern)

## Verification
```
REFPROP DmassQ(15, 1) -> T = 218.68933580059087 K
HEOS    DmassQ(15, 1) -> T = 218.68933580160922 K   (matches to 9 digits)
```

## Test plan
- [x] New `[1845]` Catch2 regression test for the original CO2 reproducer; cross-checks against HEOS to ~1e-6
- [x] Gated on `Skip_if_No_REFPROP`; passes locally with `COOLPROP_REFPROP_ROOT=~/REFPROP10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)