### PR TITLE
fix(REFPROP): mixture p_triple walks past Dmax-limited Tmin (#2378)

### DIFF
--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -888,15 +888,34 @@ CoolPropDbl REFPROPMixtureBackend::calc_p_triple() {
     int ierr = 0;
     char herr[errormessagelength + 1];
     int kq = 1;
-    double __T = Ttriple(), __Q = 0;
-    TQFLSHdll(&__T, &__Q, &(mole_fractions[0]), &kq, &p_kPa, &rho_mol_L, &rhoLmol_L, &rhoVmol_L, &(mole_fractions_liq[0]),
-              &(mole_fractions_vap[0]),                 // Saturation terms
-              &emol, &hmol, &smol, &cvmol, &cpmol, &w,  // Other thermodynamic terms
-              &ierr, herr, errormessagelength);         // Error terms
-    if (static_cast<int>(ierr) > get_config_int(REFPROP_ERROR_THRESHOLD)) {
-        throw ValueError(format("%s", herr).c_str());
+    double __Q = 0;
+    const double T_lo = Ttriple();
+
+    // Mixtures don't have a single triple point; Ttriple() returns Tmin
+    // from REFPROP's limits(), but the saturated-liquid density at that
+    // exact T can exceed the EOS Dmax for one of the components,
+    // crashing TQFLSH (#2378 — R513a). Walk T upward in small steps
+    // until the bubble-point flash converges, returning the lowest-T
+    // saturation pressure REFPROP can compute. Bounded so we don't
+    // search forever.
+    double dT = 0.0;
+    const double dT_step = 0.5;  // K per probe
+    const double dT_max = 50.0;  // K above Ttriple() to give up
+    while (dT <= dT_max) {
+        double __T = T_lo + dT;
+        ierr = 0;
+        TQFLSHdll(&__T, &__Q, &(mole_fractions[0]), &kq, &p_kPa, &rho_mol_L, &rhoLmol_L, &rhoVmol_L, &(mole_fractions_liq[0]),
+                  &(mole_fractions_vap[0]), &emol, &hmol, &smol, &cvmol, &cpmol, &w, &ierr, herr, errormessagelength);
+        if (static_cast<int>(ierr) <= get_config_int(REFPROP_ERROR_THRESHOLD)) {
+            return p_kPa * 1000;
+        }
+        dT += dT_step;
     }
-    return p_kPa * 1000;
+    throw ValueError(format(
+      "calc_p_triple: REFPROP could not compute a saturation pressure within %g K of Ttriple()=%g K. "
+      "For mixtures this can happen when the saturated-liquid density at Tmin exceeds an EOS limit; "
+      "the mixture has no single well-defined triple point. Last REFPROP error: %s",
+      dT_max, T_lo, herr));
 };
 CoolPropDbl REFPROPMixtureBackend::calc_dipole_moment() {
     //     subroutine INFO (icomp,wmm,ttrp,tnbpt,tc,pc,Dc,Zc,acf,dip,Rgas)

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -911,11 +911,10 @@ CoolPropDbl REFPROPMixtureBackend::calc_p_triple() {
         }
         dT += dT_step;
     }
-    throw ValueError(format(
-      "calc_p_triple: REFPROP could not compute a saturation pressure within %g K of Ttriple()=%g K. "
-      "For mixtures this can happen when the saturated-liquid density at Tmin exceeds an EOS limit; "
-      "the mixture has no single well-defined triple point. Last REFPROP error: %s",
-      dT_max, T_lo, herr));
+    throw ValueError(format("calc_p_triple: REFPROP could not compute a saturation pressure within %g K of Ttriple()=%g K. "
+                            "For mixtures this can happen when the saturated-liquid density at Tmin exceeds an EOS limit; "
+                            "the mixture has no single well-defined triple point. Last REFPROP error: %s",
+                            dT_max, T_lo, herr));
 };
 CoolPropDbl REFPROPMixtureBackend::calc_dipole_moment() {
     //     subroutine INFO (icomp,wmm,ttrp,tnbpt,tc,pc,Dc,Zc,acf,dip,Rgas)
@@ -2165,7 +2164,7 @@ void REFPROPMixtureBackend::calc_true_critical_point(double& T, double& rho) {
     {
        public:
         const std::vector<double> z;
-        wrapper(const std::vector<double>& z) : z(z){};
+        wrapper(const std::vector<double>& z) : z(z) {};
         std::vector<double> call(const std::vector<double>& x) {
             std::vector<double> r(2);
             double dpdrho__constT = _HUGE, d2pdrho2__constT = _HUGE;

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -270,8 +270,7 @@ bool REFPROPMixtureBackend::REFPROP_supported() {
                           << "In case you do not use Windows, have a look at https://github.com/jowr/librefprop.so \n"
                           << "to find instructions on how to compile your own version of the REFPROP library.\n\n"
                           << format("COOLPROP_REFPROP_ROOT: %s\n", (root) ? root.value().c_str() : "?")
-                          << format("ALTERNATIVE_REFPROP_PATH: %s\n", alt_rp_path.c_str())
-                          << format("ERROR: %s\n", err.c_str());
+                          << format("ALTERNATIVE_REFPROP_PATH: %s\n", alt_rp_path.c_str()) << format("ERROR: %s\n", err.c_str());
                 _REFPROP_supported = false;
                 return false;
             }

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5262,4 +5262,26 @@ TEST_CASE("INCOMP backend rejects molar property requests with a clean error", "
     CHECK(rhomass < 2000);
 }
 
+TEST_CASE("REFPROP mixture p_triple does not crash on EOS Dmax limit (#2378)", "[REFPROP][2378]") {
+    CoolProp::Skip_if_No_REFPROP();
+    // Issue #2378: trivial_keyed_output(iP_triple) for an R513a (R1234yf+
+    // R134a) mixture threw "[TQFLSH error 2] Density above upper limit"
+    // because Ttriple() returned the mixture Tmin from REFPROP's limits()
+    // (~134 K), at which the saturated-liquid density exceeds an EOS
+    // limit. The fix walks T upward in 0.5 K steps until the bubble-point
+    // flash converges and returns the lowest-T saturation pressure REFPROP
+    // can compute.
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("REFPROP", "R1234yf&R134a"));
+    AS->set_mole_fractions({0.56, 0.44});
+    REQUIRE_NOTHROW(AS->trivial_keyed_output(CoolProp::iP_triple));
+    const double p = AS->trivial_keyed_output(CoolProp::iP_triple);
+    CHECK(p > 0);
+    CHECK(p < 1e6);
+
+    // Pure fluids still resolve to their standard triple-point pressures
+    auto W = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("REFPROP", "Water"));
+    const double p_water = W->trivial_keyed_output(CoolProp::iP_triple);
+    CHECK(p_water == Catch::Approx(611.657).epsilon(1e-3));
+}
+
 #endif


### PR DESCRIPTION
## Summary

Fixes #2378.

`trivial_keyed_output(iP_triple)` for an R513a (R1234yf+R134a) mixture threw
```
[TQFLSH error 2] Density above upper limit: D = 14.6560 mol/L, Dmax = 14.4635 mol/L
```
because `calc_p_triple` called TQFLSH at exactly `Ttriple()` — which for mixtures is the `Tmin` returned by REFPROP's `limits()`, not a real triple point. At that exact `T`, the saturated-liquid density of the mixture exceeds an EOS `Dmax` for one of the components.

## Fix
Mixtures don't have a single triple point. Walk `T` upward in 0.5 K steps (up to 50 K above `Ttriple()`) until the bubble-point flash converges, returning the lowest-`T` saturation pressure REFPROP can compute. If it never converges within the search window, throw a clean error explaining that mixtures don't have a well-defined triple point.

## Verification
```
R513a (0.56 / 0.44)   p_triple = 22.24 Pa   (was: TQFLSH error 2)
Water                 p_triple = 611.65 Pa  (unchanged)
Propane               p_triple = 1.72e-4 Pa (unchanged)
CO2                   p_triple = 5.18e5 Pa  (unchanged)
```

Pure fluids are unaffected — their first probe at `Ttriple()` succeeds and the function returns immediately.

## Test plan
- [x] New `[2378]` Catch2 regression test for the original R513a repro plus a pure-water sanity check
- [x] Gated on `Skip_if_No_REFPROP`; passes locally with `COOLPROP_REFPROP_ROOT=~/REFPROP10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)