### PR TITLE
refactor(vararg): replace direct printf/fprintf with iostream + format (#2870)

### DIFF
--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -262,16 +262,16 @@ bool REFPROPMixtureBackend::REFPROP_supported() {
             if (loaded_REFPROP) {
                 return true;
             } else {
-                printf("Good news: It is possible to use REFPROP on your system! However, the library \n");
-                printf("could not be loaded. Please make sure that REFPROP is available on your system.\n\n");
-                printf("Neither found in current location nor found in system PATH.\n");
-                printf("If you already obtained a copy of REFPROP from http://www.nist.gov/srd/, \n");
-                printf("add location of REFPROP to the PATH environment variable or your library path.\n\n");
-                printf("In case you do not use Windows, have a look at https://github.com/jowr/librefprop.so \n");
-                printf("to find instructions on how to compile your own version of the REFPROP library.\n\n");
-                printf("COOLPROP_REFPROP_ROOT: %s\n", (root) ? root.value().c_str() : "?");
-                printf("ALTERNATIVE_REFPROP_PATH: %s\n", alt_rp_path.c_str());
-                printf("ERROR: %s\n", err.c_str());
+                std::cout << "Good news: It is possible to use REFPROP on your system! However, the library \n"
+                          << "could not be loaded. Please make sure that REFPROP is available on your system.\n\n"
+                          << "Neither found in current location nor found in system PATH.\n"
+                          << "If you already obtained a copy of REFPROP from http://www.nist.gov/srd/, \n"
+                          << "add location of REFPROP to the PATH environment variable or your library path.\n\n"
+                          << "In case you do not use Windows, have a look at https://github.com/jowr/librefprop.so \n"
+                          << "to find instructions on how to compile your own version of the REFPROP library.\n\n"
+                          << format("COOLPROP_REFPROP_ROOT: %s\n", (root) ? root.value().c_str() : "?")
+                          << format("ALTERNATIVE_REFPROP_PATH: %s\n", alt_rp_path.c_str())
+                          << format("ERROR: %s\n", err.c_str());
                 _REFPROP_supported = false;
                 return false;
             }

--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -364,21 +364,21 @@ void UseVirialCorrelations(int flag) {
     if (flag == 0 || flag == 1) {
         FlagUseVirialCorrelations = flag;
     } else {
-        printf("UseVirialCorrelations takes an integer, either 0 (no) or 1 (yes)\n");
+        std::cout << "UseVirialCorrelations takes an integer, either 0 (no) or 1 (yes)\n";
     }
 }
 void UseIsothermCompressCorrelation(int flag) {
     if (flag == 0 || flag == 1) {
         FlagUseIsothermCompressCorrelation = flag;
     } else {
-        printf("UseIsothermCompressCorrelation takes an integer, either 0 (no) or 1 (yes)\n");
+        std::cout << "UseIsothermCompressCorrelation takes an integer, either 0 (no) or 1 (yes)\n";
     }
 }
 void UseIdealGasEnthalpyCorrelations(int flag) {
     if (flag == 0 || flag == 1) {
         FlagUseIdealGasEnthalpyCorrelations = flag;
     } else {
-        printf("UseIdealGasEnthalpyCorrelations takes an integer, either 0 (no) or 1 (yes)\n");
+        std::cout << "UseIdealGasEnthalpyCorrelations takes an integer, either 0 (no) or 1 (yes)\n";
     }
 }
 static double Brent_HAProps_W(givens OutputKey, double p, givens In1Name, double Input1, double TargetVal, double W_min, double W_max) {
@@ -912,7 +912,7 @@ double f_factor(double T, double p) {
         return 1.0;
 }
 void HAHelp(void) {
-    printf("Sorry, Need to update!");
+    std::cout << "Sorry, Need to update!";
 }
 int returnHumAirCode(const char* Code) {
     if (!strcmp(Code, "GIVEN_TDP"))
@@ -926,7 +926,7 @@ int returnHumAirCode(const char* Code) {
     else if (!strcmp(Code, "GIVEN_ENTHALPY"))
         return GIVEN_ENTHALPY;
     else {
-        fprintf(stderr, "Code to returnHumAirCode in HumAir.c [%s] not understood", Code);
+        std::cerr << format("Code to returnHumAirCode in HumAir.c [%s] not understood", Code);
         return -1;
     }
 }
@@ -2271,7 +2271,7 @@ double HAProps_Aux(const char* Name, double T, double p, double W, char* units) 
             strcpy(units, "kg/m^3");
             return rho_Ice(T, p);
         } else {
-            printf("Sorry I didn't understand your input [%s] to HAProps_Aux\n", Name);
+            std::cout << format("Sorry I didn't understand your input [%s] to HAProps_Aux\n", Name);
             return -1;
         }
     } catch (...) {

--- a/src/Tests/Tests.cpp
+++ b/src/Tests/Tests.cpp
@@ -5,7 +5,8 @@ the build to avoid double declaration of the main function and
 Catch clashing
 */
 #include "Tests.h"
-#include "time.h"
+#include <ctime>
+#include <iostream>
 
 #if defined ENABLE_CATCH
 #    include <catch2/catch_all.hpp>
@@ -37,7 +38,7 @@ int run_not_slow_tests() {
     t1 = clock();
     session.run();
     t2 = clock();
-    printf("Elapsed time for not slow tests: %g s", (double)(t2 - t1) / CLOCKS_PER_SEC);
+    std::cout << "Elapsed time for not slow tests: " << ((double)(t2 - t1) / CLOCKS_PER_SEC) << " s";
 
     return 1;
 #else
@@ -58,7 +59,7 @@ int run_user_defined_tests(const std::vector<std::string>& tests_or_tags) {
     t1 = clock();
     session.run();
     t2 = clock();
-    printf("Elapsed time for user defined tests: %g s", (double)(t2 - t1) / CLOCKS_PER_SEC);
+    std::cout << "Elapsed time for user defined tests: " << ((double)(t2 - t1) / CLOCKS_PER_SEC) << " s";
 
     return 1;
 #else


### PR DESCRIPTION
## Summary

Closes #2870.

Replace direct C-stdio vararg calls (`printf`, `fprintf`) with `std::cout`/`std::cerr` writes, using CoolProp's existing `format()` helper for parameterised messages. The pattern already matches the majority of the codebase.

## Sites converted (17 total)

**`src/HumidAirProp.cpp`** (5): 3× `UseXxxCorrelations` invalid-flag warnings; `HAHelp()`; `fprintf(stderr, ...)` for unrecognised HumAirCode → `std::cerr << format(...)`; `HAProps_Aux` unrecognised input.

**`src/Backends/REFPROP/REFPROPMixtureBackend.cpp`** (10): combined the REFPROP-not-loaded help block into one multi-line `std::cout` stream; 3× `format()` for the parameterised path/error lines.

**`src/Tests/Tests.cpp`** (2): elapsed-time printfs for the not-slow and user-defined test runs (extension commit). Also refresh `time.h` → `<ctime>` per `modernize-deprecated-headers`.

## Out of scope
- `CPstrings.cpp` `vsnprintf` calls — those are inside the `format()` helper itself, intentional

## Test plan
- [x] Full Catch2 suite passes locally: 147/147 + 10 skipped, 57489 assertions
- [x] No behavioural change — same messages on the same streams

## Series
Part of the CoolProp-2uw modernization series (#2802, #2803, #2805, #2807, #2808). Companion: #2869, #2871, #2872, #2873, #2874.

🤖 Generated with [Claude Code](https://claude.com/claude-code)