### PR TITLE
fix(ci): use pull_request.head.sha for clang-format diff

### DIFF
--- a/.github/workflows/dev_clangformat.yml
+++ b/.github/workflows/dev_clangformat.yml
@@ -30,8 +30,14 @@ jobs:
           # Use SHAs directly so this works for both fork PRs and local-branch PRs.
           # remotes/origin/<branch> is unreliable for fork PRs because the fork's
           # branch is not fetched into origin.
+          #
+          # HEAD must be pull_request.head.sha (the actual PR tip), NOT github.sha
+          # (the synthetic refs/pull/N/merge commit). Using the merge SHA causes
+          # `git diff base..merge` to include every change master made after the
+          # PR was opened — so any file master modified gets flagged on every
+          # downstream PR even when the PR did not touch it.
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          HEAD_SHA="${{ github.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
           echo "Comparing HEAD $HEAD_SHA against base $BASE_SHA"
           ./dev/ci/clang-format.sh "$HEAD_SHA" "$BASE_SHA"
 


### PR DESCRIPTION
## Summary

CI's clang-format check has been reporting violations on `src/Backends/REFPROP/REFPROPMixtureBackend.cpp` across many open PRs even when the PR doesn't touch that file. Root cause: the workflow used `github.sha` (the synthetic `refs/pull/N/merge` commit) as the HEAD side of the diff, then compared against `pull_request.base.sha`. The merge commit incorporates every change master made since the PR was opened, so `git diff base..merge --name-only` returned files master had modified — leaking master drift into every downstream PR's clang-format check.

After #2876 (printf → `<< format()` vararg rewrite) landed in master, the rewritten REFPROPMixtureBackend.cpp showed up in the diff for every older-base PR.

Fix: use `pull_request.head.sha` (the actual PR tip) as HEAD. That SHA contains only the PR's own commits, so the diff against `base.sha` is the PR's true change set and master drift can no longer leak in.

## Test plan

- [ ] CI's clang-format job on this PR itself should pass (the only file in the diff is the workflow YAML — not C++)
- [ ] After merge, recheck downstream PRs (#2877, #2875, #2867, #2865, #2862, #2861, #2860, #2859, #2853, #2852, #2851, #2850, #2868, #2866) — they should turn green without needing rebases

🤖 Generated with [Claude Code](https://claude.com/claude-code)