### PR TITLE
refactor(modernize-redundant-void-arg): drop (void) parameter lists (#2871)

### DIFF
--- a/include/AbstractState.h
+++ b/include/AbstractState.h
@@ -82,15 +82,15 @@ class AbstractState
     phases _phase;               ///< The key for the phase from CoolProp::phases enum
     phases imposed_phase_index;  ///< If the phase is imposed, the imposed phase index
 
-    bool isSupercriticalPhase(void) {
+    bool isSupercriticalPhase() {
         return (this->_phase == iphase_supercritical || this->_phase == iphase_supercritical_liquid || this->_phase == iphase_supercritical_gas);
     }
 
-    bool isHomogeneousPhase(void) {
+    bool isHomogeneousPhase() {
         return (this->_phase == iphase_liquid || this->_phase == iphase_gas || isSupercriticalPhase() || this->_phase == iphase_critical_point);
     }
 
-    bool isTwoPhase(void) {
+    bool isTwoPhase() {
         return (this->_phase == iphase_twophase);
     }
 
@@ -154,95 +154,95 @@ class AbstractState
     // for properties that are not always calculated
     // ----------------------------------------
     /// Using this backend, calculate the molar enthalpy in J/mol
-    virtual CoolPropDbl calc_hmolar(void) {
+    virtual CoolPropDbl calc_hmolar() {
         throw NotImplementedError("calc_hmolar is not implemented for this backend");
     };
     /// Using this backend, calculate the residual molar enthalpy in J/mol
-    virtual CoolPropDbl calc_hmolar_residual(void) {
+    virtual CoolPropDbl calc_hmolar_residual() {
         throw NotImplementedError("calc_hmolar_residual is not implemented for this backend");
     };
     /// Using this backend, calculate the molar entropy in J/mol/K
-    virtual CoolPropDbl calc_smolar(void) {
+    virtual CoolPropDbl calc_smolar() {
         throw NotImplementedError("calc_smolar is not implemented for this backend");
     };
     /// Using this backend, calculate the residual molar entropy in J/mol/K
-    virtual CoolPropDbl calc_smolar_residual(void) {
+    virtual CoolPropDbl calc_smolar_residual() {
         throw NotImplementedError("calc_smolar_residual is not implemented for this backend");
     };
     /// Using this backend, calculate effective hardness of interaction
-    virtual CoolPropDbl calc_neff(void) {
+    virtual CoolPropDbl calc_neff() {
         throw NotImplementedError("calc_neff is not implemented for this backend");
     };
     /// Using this backend, calculate the molar internal energy in J/mol
-    virtual CoolPropDbl calc_umolar(void) {
+    virtual CoolPropDbl calc_umolar() {
         throw NotImplementedError("calc_umolar is not implemented for this backend");
     };
     /// Using this backend, calculate the molar constant-pressure specific heat in J/mol/K
-    virtual CoolPropDbl calc_cpmolar(void) {
+    virtual CoolPropDbl calc_cpmolar() {
         throw NotImplementedError("calc_cpmolar is not implemented for this backend");
     };
     /// Using this backend, calculate the ideal gas molar constant-pressure specific heat in J/mol/K
-    virtual CoolPropDbl calc_cpmolar_idealgas(void) {
+    virtual CoolPropDbl calc_cpmolar_idealgas() {
         throw NotImplementedError("calc_cpmolar_idealgas is not implemented for this backend");
     };
     /// Using this backend, calculate the molar constant-volume specific heat in J/mol/K
-    virtual CoolPropDbl calc_cvmolar(void) {
+    virtual CoolPropDbl calc_cvmolar() {
         throw NotImplementedError("calc_cvmolar is not implemented for this backend");
     };
     /// Using this backend, calculate the molar Gibbs function in J/mol
-    virtual CoolPropDbl calc_gibbsmolar(void) {
+    virtual CoolPropDbl calc_gibbsmolar() {
         throw NotImplementedError("calc_gibbsmolar is not implemented for this backend");
     };
     /// Using this backend, calculate the residual molar Gibbs function in J/mol
-    virtual CoolPropDbl calc_gibbsmolar_residual(void) {
+    virtual CoolPropDbl calc_gibbsmolar_residual() {
         throw NotImplementedError("calc_gibbsmolar_residual is not implemented for this backend");
     };
     /// Using this backend, calculate the molar Helmholtz energy in J/mol
-    virtual CoolPropDbl calc_helmholtzmolar(void) {
+    virtual CoolPropDbl calc_helmholtzmolar() {
         throw NotImplementedError("calc_helmholtzmolar is not implemented for this backend");
     };
     /// Using this backend, calculate the speed of sound in m/s
-    virtual CoolPropDbl calc_speed_sound(void) {
+    virtual CoolPropDbl calc_speed_sound() {
         throw NotImplementedError("calc_speed_sound is not implemented for this backend");
     };
     /// Using this backend, calculate the isothermal compressibility \f$ \kappa = -\frac{1}{v}\left.\frac{\partial v}{\partial p}\right|_T=\frac{1}{\rho}\left.\frac{\partial \rho}{\partial p}\right|_T\f$  in 1/Pa
-    virtual CoolPropDbl calc_isothermal_compressibility(void) {
+    virtual CoolPropDbl calc_isothermal_compressibility() {
         throw NotImplementedError("calc_isothermal_compressibility is not implemented for this backend");
     };
     /// Using this backend, calculate the isobaric expansion coefficient \f$ \beta = \frac{1}{v}\left.\frac{\partial v}{\partial T}\right|_p = -\frac{1}{\rho}\left.\frac{\partial \rho}{\partial T}\right|_p\f$  in 1/K
-    virtual CoolPropDbl calc_isobaric_expansion_coefficient(void) {
+    virtual CoolPropDbl calc_isobaric_expansion_coefficient() {
         throw NotImplementedError("calc_isobaric_expansion_coefficient is not implemented for this backend");
     };
     /// Using this backend, calculate the isentropic expansion coefficient \f$ \kappa_s = -\frac{c_p}{c_v}\frac{v}{p}\left.\frac{\partial p}{\partial v}\right|_T = \frac{\rho}{p}\left.\frac{\partial p}{\partial \rho}\right|_s\f$
-    virtual CoolPropDbl calc_isentropic_expansion_coefficient(void) {
+    virtual CoolPropDbl calc_isentropic_expansion_coefficient() {
         throw NotImplementedError("calc_isentropic_expansion_coefficient is not implemented for this backend");
     };
     /// Using this backend, calculate the viscosity in Pa-s
-    virtual CoolPropDbl calc_viscosity(void) {
+    virtual CoolPropDbl calc_viscosity() {
         throw NotImplementedError("calc_viscosity is not implemented for this backend");
     };
     /// Using this backend, calculate the thermal conductivity in W/m/K
-    virtual CoolPropDbl calc_conductivity(void) {
+    virtual CoolPropDbl calc_conductivity() {
         throw NotImplementedError("calc_conductivity is not implemented for this backend");
     };
     /// Using this backend, calculate the surface tension in N/m
-    virtual CoolPropDbl calc_surface_tension(void) {
+    virtual CoolPropDbl calc_surface_tension() {
         throw NotImplementedError("calc_surface_tension is not implemented for this backend");
     };
     /// Using this backend, calculate the molar mass in kg/mol
-    virtual CoolPropDbl calc_molar_mass(void) {
+    virtual CoolPropDbl calc_molar_mass() {
         throw NotImplementedError("calc_molar_mass is not implemented for this backend");
     };
     /// Using this backend, calculate the acentric factor
-    virtual CoolPropDbl calc_acentric_factor(void) {
+    virtual CoolPropDbl calc_acentric_factor() {
         throw NotImplementedError("calc_acentric_factor is not implemented for this backend");
     };
     /// Using this backend, calculate the pressure in Pa
-    virtual CoolPropDbl calc_pressure(void) {
+    virtual CoolPropDbl calc_pressure() {
         throw NotImplementedError("calc_pressure is not implemented for this backend");
     };
     /// Using this backend, calculate the universal gas constant \f$R_u\f$ in J/mol/K
-    virtual CoolPropDbl calc_gas_constant(void) {
+    virtual CoolPropDbl calc_gas_constant() {
         throw NotImplementedError("calc_gas_constant is not implemented for this backend");
     };
     /// Using this backend, calculate the fugacity coefficient (dimensionless)
@@ -262,13 +262,13 @@ class AbstractState
         throw NotImplementedError("calc_chemical_potential is not implemented for this backend");
     };
     /// Using this backend, calculate the phase identification parameter (PIP)
-    virtual CoolPropDbl calc_PIP(void) {
+    virtual CoolPropDbl calc_PIP() {
         throw NotImplementedError("calc_PIP is not implemented for this backend");
     };
 
     /// Mass-basis vapor quality. Default implementation uses _Q (molar) and
     /// calc_phase_molar_masses(); override only if a backend has a faster route.
-    virtual CoolPropDbl calc_Qmass(void);
+    virtual CoolPropDbl calc_Qmass();
 
     /// Phase molar masses (kg/mol) at the current saturated state.
     struct PhaseMolarMasses
@@ -288,162 +288,162 @@ class AbstractState
 
     // Excess properties
     /// Using this backend, calculate and cache the excess properties
-    virtual void calc_excess_properties(void) {
+    virtual void calc_excess_properties() {
         throw NotImplementedError("calc_excess_properties is not implemented for this backend");
     };
 
     // Derivatives of residual helmholtz energy
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r\f$ (dimensionless)
-    virtual CoolPropDbl calc_alphar(void) {
+    virtual CoolPropDbl calc_alphar() {
         throw NotImplementedError("calc_alphar is not implemented for this backend");
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta}\f$ (dimensionless)
-    virtual CoolPropDbl calc_dalphar_dDelta(void) {
+    virtual CoolPropDbl calc_dalphar_dDelta() {
         throw NotImplementedError("calc_dalphar_dDelta is not implemented for this backend");
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau}\f$ (dimensionless)
-    virtual CoolPropDbl calc_dalphar_dTau(void) {
+    virtual CoolPropDbl calc_dalphar_dTau() {
         throw NotImplementedError("calc_dalphar_dTau is not implemented for this backend");
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d2alphar_dDelta2(void) {
+    virtual CoolPropDbl calc_d2alphar_dDelta2() {
         throw NotImplementedError("calc_d2alphar_dDelta2 is not implemented for this backend");
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d2alphar_dDelta_dTau(void) {
+    virtual CoolPropDbl calc_d2alphar_dDelta_dTau() {
         throw NotImplementedError("calc_d2alphar_dDelta_dTau is not implemented for this backend");
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d2alphar_dTau2(void) {
+    virtual CoolPropDbl calc_d2alphar_dTau2() {
         throw NotImplementedError("calc_d2alphar_dTau2 is not implemented for this backend");
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\delta}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d3alphar_dDelta3(void) {
+    virtual CoolPropDbl calc_d3alphar_dDelta3() {
         throw NotImplementedError("calc_d3alphar_dDelta3 is not implemented for this backend");
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\tau}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d3alphar_dDelta2_dTau(void) {
+    virtual CoolPropDbl calc_d3alphar_dDelta2_dTau() {
         throw NotImplementedError("calc_d3alphar_dDelta2_dTau is not implemented for this backend");
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau\tau}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d3alphar_dDelta_dTau2(void) {
+    virtual CoolPropDbl calc_d3alphar_dDelta_dTau2() {
         throw NotImplementedError("calc_d3alphar_dDelta_dTau2 is not implemented for this backend");
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau\tau}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d3alphar_dTau3(void) {
+    virtual CoolPropDbl calc_d3alphar_dTau3() {
         throw NotImplementedError("calc_d3alphar_dTau3 is not implemented for this backend");
     };
 
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\delta\delta}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d4alphar_dDelta4(void) {
+    virtual CoolPropDbl calc_d4alphar_dDelta4() {
         throw NotImplementedError("calc_d4alphar_dDelta4 is not implemented for this backend");
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\delta\tau}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d4alphar_dDelta3_dTau(void) {
+    virtual CoolPropDbl calc_d4alphar_dDelta3_dTau() {
         throw NotImplementedError("calc_d4alphar_dDelta3_dTau is not implemented for this backend");
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\tau\tau}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d4alphar_dDelta2_dTau2(void) {
+    virtual CoolPropDbl calc_d4alphar_dDelta2_dTau2() {
         throw NotImplementedError("calc_d4alphar_dDelta2_dTau2 is not implemented for this backend");
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau\tau\tau}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d4alphar_dDelta_dTau3(void) {
+    virtual CoolPropDbl calc_d4alphar_dDelta_dTau3() {
         throw NotImplementedError("calc_d4alphar_dDelta_dTau3 is not implemented for this backend");
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau\tau\tau}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d4alphar_dTau4(void) {
+    virtual CoolPropDbl calc_d4alphar_dTau4() {
         throw NotImplementedError("calc_d4alphar_dTau4 is not implemented for this backend");
     };
 
     // Derivatives of ideal-gas helmholtz energy
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0\f$ (dimensionless)
-    virtual CoolPropDbl calc_alpha0(void) {
+    virtual CoolPropDbl calc_alpha0() {
         throw NotImplementedError("calc_alpha0 is not implemented for this backend");
     };
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\delta}\f$ (dimensionless)
-    virtual CoolPropDbl calc_dalpha0_dDelta(void) {
+    virtual CoolPropDbl calc_dalpha0_dDelta() {
         throw NotImplementedError("calc_dalpha0_dDelta is not implemented for this backend");
     };
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\tau}\f$ (dimensionless)
-    virtual CoolPropDbl calc_dalpha0_dTau(void) {
+    virtual CoolPropDbl calc_dalpha0_dTau() {
         throw NotImplementedError("calc_dalpha0_dTau is not implemented for this backend");
     };
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\delta\delta}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d2alpha0_dDelta_dTau(void) {
+    virtual CoolPropDbl calc_d2alpha0_dDelta_dTau() {
         throw NotImplementedError("calc_d2alpha0_dDelta_dTau is not implemented for this backend");
     };
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\delta\tau}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d2alpha0_dDelta2(void) {
+    virtual CoolPropDbl calc_d2alpha0_dDelta2() {
         throw NotImplementedError("calc_d2alpha0_dDelta2 is not implemented for this backend");
     };
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\tau\tau}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d2alpha0_dTau2(void) {
+    virtual CoolPropDbl calc_d2alpha0_dTau2() {
         throw NotImplementedError("calc_d2alpha0_dTau2 is not implemented for this backend");
     };
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\delta\delta\delta}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d3alpha0_dDelta3(void) {
+    virtual CoolPropDbl calc_d3alpha0_dDelta3() {
         throw NotImplementedError("calc_d3alpha0_dDelta3 is not implemented for this backend");
     };
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\delta\delta\tau}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d3alpha0_dDelta2_dTau(void) {
+    virtual CoolPropDbl calc_d3alpha0_dDelta2_dTau() {
         throw NotImplementedError("calc_d3alpha0_dDelta2_dTau is not implemented for this backend");
     };
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\delta\tau\tau}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d3alpha0_dDelta_dTau2(void) {
+    virtual CoolPropDbl calc_d3alpha0_dDelta_dTau2() {
         throw NotImplementedError("calc_d3alpha0_dDelta_dTau2 is not implemented for this backend");
     };
     /// Using this backend, calculate the ideal-gas Helmholtz energy term \f$\alpha^0_{\tau\tau\tau}\f$ (dimensionless)
-    virtual CoolPropDbl calc_d3alpha0_dTau3(void) {
+    virtual CoolPropDbl calc_d3alpha0_dTau3() {
         throw NotImplementedError("calc_d3alpha0_dTau3 is not implemented for this backend");
     };
 
-    virtual void calc_reducing_state(void) {
+    virtual void calc_reducing_state() {
         throw NotImplementedError("calc_reducing_state is not implemented for this backend");
     };
 
     /// Using this backend, calculate the maximum temperature in K
-    virtual CoolPropDbl calc_Tmax(void) {
+    virtual CoolPropDbl calc_Tmax() {
         throw NotImplementedError("calc_Tmax is not implemented for this backend");
     };
     /// Using this backend, calculate the minimum temperature in K
-    virtual CoolPropDbl calc_Tmin(void) {
+    virtual CoolPropDbl calc_Tmin() {
         throw NotImplementedError("calc_Tmin is not implemented for this backend");
     };
     /// Using this backend, calculate the maximum pressure in Pa
-    virtual CoolPropDbl calc_pmax(void) {
+    virtual CoolPropDbl calc_pmax() {
         throw NotImplementedError("calc_pmax is not implemented for this backend");
     };
 
     /// Using this backend, calculate the 20-year global warming potential (GWP)
-    virtual CoolPropDbl calc_GWP20(void) {
+    virtual CoolPropDbl calc_GWP20() {
         throw NotImplementedError("calc_GWP20 is not implemented for this backend");
     };
     /// Using this backend, calculate the 100-year global warming potential (GWP)
-    virtual CoolPropDbl calc_GWP100(void) {
+    virtual CoolPropDbl calc_GWP100() {
         throw NotImplementedError("calc_GWP100 is not implemented for this backend");
     };
     /// Using this backend, calculate the 500-year global warming potential (GWP)
-    virtual CoolPropDbl calc_GWP500(void) {
+    virtual CoolPropDbl calc_GWP500() {
         throw NotImplementedError("calc_GWP500 is not implemented for this backend");
     };
     /// Using this backend, calculate the ozone depletion potential (ODP)
-    virtual CoolPropDbl calc_ODP(void) {
+    virtual CoolPropDbl calc_ODP() {
         throw NotImplementedError("calc_ODP is not implemented for this backend");
     };
     /// Using this backend, calculate the flame hazard
-    virtual CoolPropDbl calc_flame_hazard(void) {
+    virtual CoolPropDbl calc_flame_hazard() {
         throw NotImplementedError("calc_flame_hazard is not implemented for this backend");
     };
     /// Using this backend, calculate the health hazard
-    virtual CoolPropDbl calc_health_hazard(void) {
+    virtual CoolPropDbl calc_health_hazard() {
         throw NotImplementedError("calc_health_hazard is not implemented for this backend");
     };
     /// Using this backend, calculate the physical hazard
-    virtual CoolPropDbl calc_physical_hazard(void) {
+    virtual CoolPropDbl calc_physical_hazard() {
         throw NotImplementedError("calc_physical_hazard is not implemented for this backend");
     };
     /// Using this backend, calculate the dipole moment in C-m (1 D = 3.33564e-30 C-m)
-    virtual CoolPropDbl calc_dipole_moment(void) {
+    virtual CoolPropDbl calc_dipole_moment() {
         throw NotImplementedError("calc_dipole_moment is not implemented for this backend");
     };
 
@@ -453,79 +453,79 @@ class AbstractState
     virtual CoolPropDbl calc_second_partial_deriv(parameters Of1, parameters Wrt1, parameters Constant1, parameters Wrt2, parameters Constant2);
 
     /// Using this backend, calculate the reduced density (rho/rhoc)
-    virtual CoolPropDbl calc_reduced_density(void) {
+    virtual CoolPropDbl calc_reduced_density() {
         throw NotImplementedError("calc_reduced_density is not implemented for this backend");
     };
     /// Using this backend, calculate the reciprocal reduced temperature (Tc/T)
-    virtual CoolPropDbl calc_reciprocal_reduced_temperature(void) {
+    virtual CoolPropDbl calc_reciprocal_reduced_temperature() {
         throw NotImplementedError("calc_reciprocal_reduced_temperature is not implemented for this backend");
     };
 
     /// Using this backend, calculate the second virial coefficient
-    virtual CoolPropDbl calc_Bvirial(void) {
+    virtual CoolPropDbl calc_Bvirial() {
         throw NotImplementedError("calc_Bvirial is not implemented for this backend");
     };
     /// Using this backend, calculate the third virial coefficient
-    virtual CoolPropDbl calc_Cvirial(void) {
+    virtual CoolPropDbl calc_Cvirial() {
         throw NotImplementedError("calc_Cvirial is not implemented for this backend");
     };
     /// Using this backend, calculate the derivative dB/dT
-    virtual CoolPropDbl calc_dBvirial_dT(void) {
+    virtual CoolPropDbl calc_dBvirial_dT() {
         throw NotImplementedError("calc_dBvirial_dT is not implemented for this backend");
     };
     /// Using this backend, calculate the derivative dC/dT
-    virtual CoolPropDbl calc_dCvirial_dT(void) {
+    virtual CoolPropDbl calc_dCvirial_dT() {
         throw NotImplementedError("calc_dCvirial_dT is not implemented for this backend");
     };
     /// Using this backend, calculate the compressibility factor Z \f$ Z = p/(\rho R T) \f$
-    virtual CoolPropDbl calc_compressibility_factor(void) {
+    virtual CoolPropDbl calc_compressibility_factor() {
         throw NotImplementedError("calc_compressibility_factor is not implemented for this backend");
     };
 
     /// Using this backend, get the name of the fluid
-    virtual std::string calc_name(void) {
+    virtual std::string calc_name() {
         throw NotImplementedError("calc_name is not implemented for this backend");
     };
     /// Using this backend, get the description of the fluid
-    virtual std::string calc_description(void) {
+    virtual std::string calc_description() {
         throw NotImplementedError("calc_description is not implemented for this backend");
     };
 
     /// Using this backend, get the triple point temperature in K
-    virtual CoolPropDbl calc_Ttriple(void) {
+    virtual CoolPropDbl calc_Ttriple() {
         throw NotImplementedError("calc_Ttriple is not implemented for this backend");
     };
     /// Using this backend, get the triple point pressure in Pa
-    virtual CoolPropDbl calc_p_triple(void) {
+    virtual CoolPropDbl calc_p_triple() {
         throw NotImplementedError("calc_p_triple is not implemented for this backend");
     };
 
     /// Using this backend, get the critical point temperature in K
-    virtual CoolPropDbl calc_T_critical(void) {
+    virtual CoolPropDbl calc_T_critical() {
         throw NotImplementedError("calc_T_critical is not implemented for this backend");
     };
     /// Using this backend, get the reducing point temperature in K
-    virtual CoolPropDbl calc_T_reducing(void) {
+    virtual CoolPropDbl calc_T_reducing() {
         throw NotImplementedError("calc_T_reducing is not implemented for this backend");
     };
     /// Using this backend, get the critical point pressure in Pa
-    virtual CoolPropDbl calc_p_critical(void) {
+    virtual CoolPropDbl calc_p_critical() {
         throw NotImplementedError("calc_p_critical is not implemented for this backend");
     };
     /// Using this backend, get the reducing point pressure in Pa
-    virtual CoolPropDbl calc_p_reducing(void) {
+    virtual CoolPropDbl calc_p_reducing() {
         throw NotImplementedError("calc_p_reducing is not implemented for this backend");
     };
     /// Using this backend, get the critical point molar density in mol/m^3
-    virtual CoolPropDbl calc_rhomolar_critical(void) {
+    virtual CoolPropDbl calc_rhomolar_critical() {
         throw NotImplementedError("calc_rhomolar_critical is not implemented for this backend");
     };
     /// Using this backend, get the critical point mass density in kg/m^3 - Added for IF97Backend which is mass based
-    virtual CoolPropDbl calc_rhomass_critical(void) {
+    virtual CoolPropDbl calc_rhomass_critical() {
         throw NotImplementedError("calc_rhomass_critical is not implemented for this backend");
     };
     /// Using this backend, get the reducing point molar density in mol/m^3
-    virtual CoolPropDbl calc_rhomolar_reducing(void) {
+    virtual CoolPropDbl calc_rhomolar_reducing() {
         throw NotImplementedError("calc_rhomolar_reducing is not implemented for this backend");
     };
     /// Using this backend, construct the phase envelope, the variable type describes the type of phase envelope to be built.
@@ -533,54 +533,54 @@ class AbstractState
         throw NotImplementedError("calc_phase_envelope is not implemented for this backend");
     };
     ///
-    virtual CoolPropDbl calc_rhomass(void) {
+    virtual CoolPropDbl calc_rhomass() {
         return rhomolar() * molar_mass();
     }
-    virtual CoolPropDbl calc_hmass(void) {
+    virtual CoolPropDbl calc_hmass() {
         return hmolar() / molar_mass();
     }
-    virtual CoolPropDbl calc_hmass_excess(void) {
+    virtual CoolPropDbl calc_hmass_excess() {
         return hmolar_excess() / molar_mass();
     }
-    virtual CoolPropDbl calc_smass(void) {
+    virtual CoolPropDbl calc_smass() {
         return smolar() / molar_mass();
     }
-    virtual CoolPropDbl calc_smass_excess(void) {
+    virtual CoolPropDbl calc_smass_excess() {
         return smolar_excess() / molar_mass();
     }
-    virtual CoolPropDbl calc_cpmass(void) {
+    virtual CoolPropDbl calc_cpmass() {
         return cpmolar() / molar_mass();
     }
-    virtual CoolPropDbl calc_cp0mass(void) {
+    virtual CoolPropDbl calc_cp0mass() {
         return cp0molar() / molar_mass();
     }
-    virtual CoolPropDbl calc_cvmass(void) {
+    virtual CoolPropDbl calc_cvmass() {
         return cvmolar() / molar_mass();
     }
-    virtual CoolPropDbl calc_umass(void) {
+    virtual CoolPropDbl calc_umass() {
         return umolar() / molar_mass();
     }
-    virtual CoolPropDbl calc_umass_excess(void) {
+    virtual CoolPropDbl calc_umass_excess() {
         return umolar_excess() / molar_mass();
     }
-    virtual CoolPropDbl calc_gibbsmass(void) {
+    virtual CoolPropDbl calc_gibbsmass() {
         return gibbsmolar() / molar_mass();
     }
-    virtual CoolPropDbl calc_gibbsmass_excess(void) {
+    virtual CoolPropDbl calc_gibbsmass_excess() {
         return gibbsmolar_excess() / molar_mass();
     }
-    virtual CoolPropDbl calc_helmholtzmass(void) {
+    virtual CoolPropDbl calc_helmholtzmass() {
         return helmholtzmolar() / molar_mass();
     }
-    virtual CoolPropDbl calc_helmholtzmass_excess(void) {
+    virtual CoolPropDbl calc_helmholtzmass_excess() {
         return helmholtzmolar_excess() / molar_mass();
     }
-    virtual CoolPropDbl calc_volumemass_excess(void) {
+    virtual CoolPropDbl calc_volumemass_excess() {
         return volumemolar_excess() / molar_mass();
     }
 
     /// Update the states after having changed the reference state for enthalpy and entropy
-    virtual void update_states(void) {
+    virtual void update_states() {
         throw NotImplementedError("This backend does not implement update_states function");
     };
 
@@ -597,7 +597,7 @@ class AbstractState
     };
 
     /// Using this backend, calculate the phase
-    virtual phases calc_phase(void) {
+    virtual phases calc_phase() {
         throw NotImplementedError("This backend does not implement calc_phase function");
     };
     /// Using this backend, specify the phase to be used for all further calculations
@@ -605,11 +605,11 @@ class AbstractState
         throw NotImplementedError("This backend does not implement calc_specify_phase function");
     };
     /// Using this backend, unspecify the phase
-    virtual void calc_unspecify_phase(void) {
+    virtual void calc_unspecify_phase() {
         throw NotImplementedError("This backend does not implement calc_unspecify_phase function");
     };
     /// Using this backend, get a vector of fluid names
-    virtual std::vector<std::string> calc_fluid_names(void) {
+    virtual std::vector<std::string> calc_fluid_names() {
         throw NotImplementedError("This backend does not implement calc_fluid_names function");
     };
     /// Using this backend, calculate a phase given by the state string
@@ -618,29 +618,29 @@ class AbstractState
         throw NotImplementedError("calc_state is not implemented for this backend");
     };
 
-    virtual const CoolProp::PhaseEnvelopeData& calc_phase_envelope_data(void) {
+    virtual const CoolProp::PhaseEnvelopeData& calc_phase_envelope_data() {
         throw NotImplementedError("calc_phase_envelope_data is not implemented for this backend");
     };
 
-    virtual std::vector<CoolPropDbl> calc_mole_fractions_liquid(void) {
+    virtual std::vector<CoolPropDbl> calc_mole_fractions_liquid() {
         throw NotImplementedError("calc_mole_fractions_liquid is not implemented for this backend");
     };
-    virtual std::vector<CoolPropDbl> calc_mole_fractions_vapor(void) {
+    virtual std::vector<CoolPropDbl> calc_mole_fractions_vapor() {
         throw NotImplementedError("calc_mole_fractions_vapor is not implemented for this backend");
     };
-    virtual const std::vector<CoolPropDbl> calc_mass_fractions(void) {
+    virtual const std::vector<CoolPropDbl> calc_mass_fractions() {
         throw NotImplementedError("calc_mass_fractions is not implemented for this backend");
     };
 
     /// Get the minimum fraction (mole, mass, volume) for incompressible fluid
-    virtual CoolPropDbl calc_fraction_min(void) {
+    virtual CoolPropDbl calc_fraction_min() {
         throw NotImplementedError("calc_fraction_min is not implemented for this backend");
     };
     /// Get the maximum fraction (mole, mass, volume) for incompressible fluid
-    virtual CoolPropDbl calc_fraction_max(void) {
+    virtual CoolPropDbl calc_fraction_max() {
         throw NotImplementedError("calc_fraction_max is not implemented for this backend");
     };
-    virtual CoolPropDbl calc_T_freeze(void) {
+    virtual CoolPropDbl calc_T_freeze() {
         throw NotImplementedError("calc_T_freeze is not implemented for this backend");
     };
 
@@ -671,11 +671,11 @@ class AbstractState
     };
 
     /// Using this backend, get the temperature
-    virtual CoolPropDbl calc_T(void) {
+    virtual CoolPropDbl calc_T() {
         return _T;
     }
     /// Using this backend, get the molar density in mol/m^3
-    virtual CoolPropDbl calc_rhomolar(void) {
+    virtual CoolPropDbl calc_rhomolar() {
         return _rhomolar;
     }
 
@@ -699,7 +699,7 @@ class AbstractState
     virtual void calc_conductivity_contributions(CoolPropDbl& dilute, CoolPropDbl& initial_density, CoolPropDbl& residual, CoolPropDbl& critical) {
         throw NotImplementedError("calc_conductivity_contributions is not implemented for this backend");
     };
-    virtual std::vector<CriticalState> calc_all_critical_points(void) {
+    virtual std::vector<CriticalState> calc_all_critical_points() {
         throw NotImplementedError("calc_all_critical_points is not implemented for this backend");
     };
     virtual void calc_build_spinodal() {
@@ -724,7 +724,7 @@ class AbstractState
     AbstractState() : _fluid_type(FLUID_TYPE_UNDEFINED), _phase(iphase_unknown) {
         clear();
     }
-    virtual ~AbstractState(){};
+    virtual ~AbstractState() {};
 
     /// A factory function to return a pointer to a new-allocated instance of one of the backends.
     /**
@@ -771,12 +771,12 @@ class AbstractState
     /// for the core mixture model in CoolProp
     ///
     /// Must be overloaded by the backend to provide the backend's name
-    virtual std::string backend_name(void) = 0;
+    virtual std::string backend_name() = 0;
 
     // The derived classes must implement this function to define whether they use mole fractions (true) or mass fractions (false)
-    virtual bool using_mole_fractions(void) = 0;
-    virtual bool using_mass_fractions(void) = 0;
-    virtual bool using_volu_fractions(void) = 0;
+    virtual bool using_mole_fractions() = 0;
+    virtual bool using_mass_fractions() = 0;
+    virtual bool using_volu_fractions() = 0;
 
     virtual void set_mole_fractions(const std::vector<CoolPropDbl>& mole_fractions) = 0;
     virtual void set_mass_fractions(const std::vector<CoolPropDbl>& mass_fractions) = 0;
@@ -837,29 +837,29 @@ class AbstractState
 #endif
 
     /// Get the mole fractions of the equilibrium liquid phase
-    std::vector<CoolPropDbl> mole_fractions_liquid(void) {
+    std::vector<CoolPropDbl> mole_fractions_liquid() {
         return calc_mole_fractions_liquid();
     };
     /// Get the mole fractions of the equilibrium liquid phase (but as a double for use in SWIG wrapper)
-    std::vector<double> mole_fractions_liquid_double(void) {
+    std::vector<double> mole_fractions_liquid_double() {
         std::vector<CoolPropDbl> x = calc_mole_fractions_liquid();
         return std::vector<double>(x.begin(), x.end());
     };
 
     /// Get the mole fractions of the equilibrium vapor phase
-    std::vector<CoolPropDbl> mole_fractions_vapor(void) {
+    std::vector<CoolPropDbl> mole_fractions_vapor() {
         return calc_mole_fractions_vapor();
     };
     /// Get the mole fractions of the equilibrium vapor phase (but as a double for use in SWIG wrapper)
-    std::vector<double> mole_fractions_vapor_double(void) {
+    std::vector<double> mole_fractions_vapor_double() {
         std::vector<CoolPropDbl> y = calc_mole_fractions_vapor();
         return std::vector<double>(y.begin(), y.end());
     };
 
     /// Get the mole fractions of the fluid
-    virtual const std::vector<CoolPropDbl>& get_mole_fractions(void) = 0;
+    virtual const std::vector<CoolPropDbl>& get_mole_fractions() = 0;
     /// Get the mass fractions of the fluid
-    virtual const std::vector<CoolPropDbl> get_mass_fractions(void) {
+    virtual const std::vector<CoolPropDbl> get_mass_fractions() {
         return this->calc_mass_fractions();
     };
 
@@ -880,7 +880,7 @@ class AbstractState
     /// A function that says whether the backend instance can be instantiated in the high-level interface
     /// In general this should be true, except for some other backends (especially the tabular backends)
     /// To disable use in high-level interface, implement this function and return false
-    virtual bool available_in_high_level(void) {
+    virtual bool available_in_high_level() {
         return true;
     }
 
@@ -890,7 +890,7 @@ class AbstractState
     }
 
     /// Return a vector of strings of the fluid names that are in use
-    std::vector<std::string> fluid_names(void);
+    std::vector<std::string> fluid_names();
 
     /** Get a constant for one of the fluids forming this mixture
      *  @param i Index (0-based) of the fluid
@@ -964,16 +964,16 @@ class AbstractState
     };
 
     /// Get the minimum temperature in K
-    double Tmin(void);
+    double Tmin();
     /// Get the maximum temperature in K
-    double Tmax(void);
+    double Tmax();
     /// Get the maximum pressure in Pa
-    double pmax(void);
+    double pmax();
     /// Get the triple point temperature in K
-    double Ttriple(void);
+    double Ttriple();
 
     /// Get the phase of the state
-    phases phase(void) {
+    phases phase() {
         return calc_phase();
     };
     /// Specify the phase for all further calculations with this state class
@@ -981,21 +981,21 @@ class AbstractState
         calc_specify_phase(phase);
     };
     /// Unspecify the phase and go back to calculating it based on the inputs
-    void unspecify_phase(void) {
+    void unspecify_phase() {
         calc_unspecify_phase();
     };
 
     /// Return the critical temperature in K
-    double T_critical(void);
+    double T_critical();
     /// Return the critical pressure in Pa
-    double p_critical(void);
+    double p_critical();
     /// Return the critical molar density in mol/m^3
-    double rhomolar_critical(void);
+    double rhomolar_critical();
     /// Return the critical mass density in kg/m^3
-    double rhomass_critical(void);
+    double rhomass_critical();
 
     /// Return the vector of critical points, including points that are unstable or correspond to negative pressure
-    std::vector<CriticalState> all_critical_points(void) {
+    std::vector<CriticalState> all_critical_points() {
         return calc_all_critical_points();
     };
 
@@ -1042,14 +1042,14 @@ class AbstractState
     };
 
     /// Return the reducing point temperature in K
-    double T_reducing(void);
+    double T_reducing();
     /// Return the molar density at the reducing point in mol/m^3
-    double rhomolar_reducing(void);
+    double rhomolar_reducing();
     /// Return the mass density at the reducing point in kg/m^3
-    double rhomass_reducing(void);
+    double rhomass_reducing();
 
     /// Return the triple point pressure in Pa
-    double p_triple(void);
+    double p_triple();
 
     /// Return the name - backend dependent
     std::string name() {
@@ -1083,159 +1083,159 @@ class AbstractState
     };
 
     /// Return the temperature in K
-    double T(void) {
+    double T() {
         return calc_T();
     };
     /// Return the molar density in mol/m^3
-    double rhomolar(void) {
+    double rhomolar() {
         return calc_rhomolar();
     };
     /// Return the mass density in kg/m^3
-    double rhomass(void) {
+    double rhomass() {
         return calc_rhomass();
     };
     /// Return the pressure in Pa
-    double p(void) {
+    double p() {
         return _p;
     };
     /// Return the vapor quality (mol/mol); Q = 0 for saturated liquid
-    double Q(void) {
+    double Q() {
         return _Q;
     };
     /// Mass-basis vapor quality (kg vapor / kg total). Throws if not two-phase.
-    double Qmass(void);
+    double Qmass();
     /// Return the reciprocal of the reduced temperature (\f$\tau = T_c/T\f$)
-    double tau(void);
+    double tau();
     /// Return the reduced density (\f$\delta = \rho/\rho_c\f$)
-    double delta(void);
+    double delta();
     /// Return the molar mass in kg/mol
-    double molar_mass(void);
+    double molar_mass();
     /// Return the acentric factor
-    double acentric_factor(void);
+    double acentric_factor();
     /// Return the mole-fraction weighted gas constant in J/mol/K
-    double gas_constant(void);
+    double gas_constant();
     /// Return the B virial coefficient
-    double Bvirial(void);
+    double Bvirial();
     /// Return the derivative of the B virial coefficient with respect to temperature
-    double dBvirial_dT(void);
+    double dBvirial_dT();
     /// Return the C virial coefficient
-    double Cvirial(void);
+    double Cvirial();
     /// Return the derivative of the C virial coefficient with respect to temperature
-    double dCvirial_dT(void);
+    double dCvirial_dT();
     /// Return the compressibility factor \f$ Z = p/(rho R T) \f$
-    double compressibility_factor(void);
+    double compressibility_factor();
     /// Return the molar enthalpy in J/mol
-    double hmolar(void);
+    double hmolar();
     /// Return the residual molar enthalpy in J/mol
-    double hmolar_residual(void);
+    double hmolar_residual();
     /// Return the ideal gas molar enthalpy in J/mol
-    double hmolar_idealgas(void);
+    double hmolar_idealgas();
     /// Return the ideal gas specific enthalpy in J/kg
-    double hmass_idealgas(void);
+    double hmass_idealgas();
     /// Return the mass enthalpy in J/kg
-    double hmass(void) {
+    double hmass() {
         return calc_hmass();
     };
     /// Return the excess molar enthalpy in J/mol
-    double hmolar_excess(void);
+    double hmolar_excess();
     /// Return the excess mass enthalpy in J/kg
-    double hmass_excess(void) {
+    double hmass_excess() {
         return calc_hmass_excess();
     };
     /// Return the molar entropy in J/mol/K
-    double smolar(void);
+    double smolar();
     /// Return the residual molar entropy (as a function of temperature and density) in J/mol/K
-    double smolar_residual(void);
+    double smolar_residual();
     /// Return the ideal gas molar entropy in J/mol/K
-    double smolar_idealgas(void);
+    double smolar_idealgas();
     /// Return the ideal gas specific entropy in J/kg/K
-    double smass_idealgas(void);
+    double smass_idealgas();
     /// Return the effective hardness of interaction
-    double neff(void);
+    double neff();
     /// Return the molar entropy in J/kg/K
-    double smass(void) {
+    double smass() {
         return calc_smass();
     };
     /// Return the molar entropy in J/mol/K
-    double smolar_excess(void);
+    double smolar_excess();
     /// Return the molar entropy in J/kg/K
-    double smass_excess(void) {
+    double smass_excess() {
         return calc_smass_excess();
     };
     /// Return the molar internal energy in J/mol
-    double umolar(void);
+    double umolar();
     /// Return the mass internal energy in J/kg
-    double umass(void) {
+    double umass() {
         return calc_umass();
     };
     /// Return the excess internal energy in J/mol
-    double umolar_excess(void);
+    double umolar_excess();
     /// Return the excess internal energy in J/kg
-    double umass_excess(void) {
+    double umass_excess() {
         return calc_umass_excess();
     };
     /// Return the ideal gas molar internal energy in J/mol
-    double umolar_idealgas(void);
+    double umolar_idealgas();
     /// Return the ideal gas specific internal energy in J/kg
-    double umass_idealgas(void);
+    double umass_idealgas();
     /// Return the molar constant pressure specific heat in J/mol/K
-    double cpmolar(void);
+    double cpmolar();
     /// Return the mass constant pressure specific heat in J/kg/K
-    double cpmass(void) {
+    double cpmass() {
         return calc_cpmass();
     };
     /// Return the molar constant pressure specific heat for ideal gas part only in J/mol/K
-    double cp0molar(void);
+    double cp0molar();
     /// Return the mass constant pressure specific heat for ideal gas part only in J/kg/K
-    double cp0mass(void) {
+    double cp0mass() {
         return calc_cp0mass();
     };
     /// Return the molar constant volume specific heat in J/mol/K
-    double cvmolar(void);
+    double cvmolar();
     /// Return the mass constant volume specific heat in J/kg/K
-    double cvmass(void) {
+    double cvmass() {
         return calc_cvmass();
     };
     /// Return the Gibbs energy in J/mol
-    double gibbsmolar(void);
+    double gibbsmolar();
     /// Return the residual Gibbs energy in J/mol
-    double gibbsmolar_residual(void);
+    double gibbsmolar_residual();
     /// Return the Gibbs energy in J/kg
-    double gibbsmass(void) {
+    double gibbsmass() {
         return calc_gibbsmass();
     };
     /// Return the excess Gibbs energy in J/mol
-    double gibbsmolar_excess(void);
+    double gibbsmolar_excess();
     /// Return the excess Gibbs energy in J/kg
-    double gibbsmass_excess(void) {
+    double gibbsmass_excess() {
         return calc_gibbsmass_excess();
     };
     /// Return the Helmholtz energy in J/mol
-    double helmholtzmolar(void);
+    double helmholtzmolar();
     /// Return the Helmholtz energy in J/kg
-    double helmholtzmass(void) {
+    double helmholtzmass() {
         return calc_helmholtzmass();
     };
     /// Return the excess Helmholtz energy in J/mol
-    double helmholtzmolar_excess(void);
+    double helmholtzmolar_excess();
     /// Return the excess Helmholtz energy in J/kg
-    double helmholtzmass_excess(void) {
+    double helmholtzmass_excess() {
         return calc_helmholtzmass_excess();
     };
     /// Return the excess volume in m^3/mol
-    double volumemolar_excess(void);
+    double volumemolar_excess();
     /// Return the excess volume in m^3/kg
-    double volumemass_excess(void) {
+    double volumemass_excess() {
         return calc_volumemass_excess();
     };
     /// Return the speed of sound in m/s
-    double speed_sound(void);
+    double speed_sound();
     /// Return the isothermal compressibility \f$ \kappa = -\frac{1}{v}\left.\frac{\partial v}{\partial p}\right|_T=\frac{1}{\rho}\left.\frac{\partial \rho}{\partial p}\right|_T\f$  in 1/Pa
-    double isothermal_compressibility(void);
+    double isothermal_compressibility();
     /// Return the isobaric expansion coefficient \f$ \beta = \frac{1}{v}\left.\frac{\partial v}{\partial T}\right|_p = -\frac{1}{\rho}\left.\frac{\partial \rho}{\partial T}\right|_p\f$  in 1/K
-    double isobaric_expansion_coefficient(void);
+    double isobaric_expansion_coefficient();
     /// Return the isentropic expansion coefficient \f$ \kappa_s = -\frac{c_p}{c_v}\frac{v}{p}\left.\frac{\partial p}{\partial v}\right|_T = \frac{\rho}{p}\left.\frac{\partial p}{\partial \rho}\right|_s\f$
-    double isentropic_expansion_coefficient(void);
+    double isentropic_expansion_coefficient();
     /// Return the fugacity coefficient of the i-th component of the mixture
     double fugacity_coefficient(std::size_t i);
     /// Return a vector of the fugacity coefficients for all components in the mixture
@@ -1252,7 +1252,7 @@ class AbstractState
      *
      * Note: densities are mass-based densities, not mole-based densities
      */
-    double fundamental_derivative_of_gas_dynamics(void);
+    double fundamental_derivative_of_gas_dynamics();
     /// Return the phase identification parameter (PIP) of G. Venkatarathnam and L.R. Oellrich, "Identification of the phase of a fluid using partial derivatives of pressure, volume, and temperature without reference to saturation properties: Applications in phase equilibria calculations"
     double PIP() {
         return calc_PIP();
@@ -1448,7 +1448,7 @@ class AbstractState
     // ----------------------------------------
 
     /// Return true if the fluid has a melting line - default is false, but can be re-implemented by derived class
-    virtual bool has_melting_line(void) {
+    virtual bool has_melting_line() {
         return false;
     };
     /// Return a value from the melting line
@@ -1467,21 +1467,21 @@ class AbstractState
     // Transport properties
     // ----------------------------------------
     /// Return the viscosity in Pa-s
-    double viscosity(void);
+    double viscosity();
     /// Return the viscosity contributions, each in Pa-s
     void viscosity_contributions(CoolPropDbl& dilute, CoolPropDbl& initial_density, CoolPropDbl& residual, CoolPropDbl& critical) {
         calc_viscosity_contributions(dilute, initial_density, residual, critical);
     };
     /// Return the thermal conductivity in W/m/K
-    double conductivity(void);
+    double conductivity();
     /// Return the thermal conductivity contributions, each in W/m/K
     void conductivity_contributions(CoolPropDbl& dilute, CoolPropDbl& initial_density, CoolPropDbl& residual, CoolPropDbl& critical) {
         calc_conductivity_contributions(dilute, initial_density, residual, critical);
     };
     /// Return the surface tension in N/m
-    double surface_tension(void);
+    double surface_tension();
     /// Return the Prandtl number (dimensionless)
-    double Prandtl(void) {
+    double Prandtl() {
         return cpmass() * viscosity() / conductivity();
     };
     /**
@@ -1506,128 +1506,128 @@ class AbstractState
     // Helmholtz energy and derivatives
     // ----------------------------------------
     /// Return the term \f$ \alpha^0 \f$
-    CoolPropDbl alpha0(void) {
+    CoolPropDbl alpha0() {
         if (!_alpha0) _alpha0 = calc_alpha0();
         return _alpha0;
     };
     /// Return the term \f$ \alpha^0_{\delta} \f$
-    CoolPropDbl dalpha0_dDelta(void) {
+    CoolPropDbl dalpha0_dDelta() {
         if (!_dalpha0_dDelta) _dalpha0_dDelta = calc_dalpha0_dDelta();
         return _dalpha0_dDelta;
     };
     /// Return the term \f$ \alpha^0_{\tau} \f$
-    CoolPropDbl dalpha0_dTau(void) {
+    CoolPropDbl dalpha0_dTau() {
         if (!_dalpha0_dTau) _dalpha0_dTau = calc_dalpha0_dTau();
         return _dalpha0_dTau;
     };
     /// Return the term \f$ \alpha^0_{\delta\delta} \f$
-    CoolPropDbl d2alpha0_dDelta2(void) {
+    CoolPropDbl d2alpha0_dDelta2() {
         if (!_d2alpha0_dDelta2) _d2alpha0_dDelta2 = calc_d2alpha0_dDelta2();
         return _d2alpha0_dDelta2;
     };
     /// Return the term \f$ \alpha^0_{\delta\tau} \f$
-    CoolPropDbl d2alpha0_dDelta_dTau(void) {
+    CoolPropDbl d2alpha0_dDelta_dTau() {
         if (!_d2alpha0_dDelta_dTau) _d2alpha0_dDelta_dTau = calc_d2alpha0_dDelta_dTau();
         return _d2alpha0_dDelta_dTau;
     };
     /// Return the term \f$ \alpha^0_{\tau\tau} \f$
-    CoolPropDbl d2alpha0_dTau2(void) {
+    CoolPropDbl d2alpha0_dTau2() {
         if (!_d2alpha0_dTau2) _d2alpha0_dTau2 = calc_d2alpha0_dTau2();
         return _d2alpha0_dTau2;
     };
     /// Return the term \f$ \alpha^0_{\tau\tau\tau} \f$
-    CoolPropDbl d3alpha0_dTau3(void) {
+    CoolPropDbl d3alpha0_dTau3() {
         if (!_d3alpha0_dTau3) _d3alpha0_dTau3 = calc_d3alpha0_dTau3();
         return _d3alpha0_dTau3;
     };
     /// Return the term \f$ \alpha^0_{\delta\tau\tau} \f$
-    CoolPropDbl d3alpha0_dDelta_dTau2(void) {
+    CoolPropDbl d3alpha0_dDelta_dTau2() {
         if (!_d3alpha0_dDelta_dTau2) _d3alpha0_dDelta_dTau2 = calc_d3alpha0_dDelta_dTau2();
         return _d3alpha0_dDelta_dTau2;
     };
     /// Return the term \f$ \alpha^0_{\delta\delta\tau} \f$
-    CoolPropDbl d3alpha0_dDelta2_dTau(void) {
+    CoolPropDbl d3alpha0_dDelta2_dTau() {
         if (!_d3alpha0_dDelta2_dTau) _d3alpha0_dDelta2_dTau = calc_d3alpha0_dDelta2_dTau();
         return _d3alpha0_dDelta2_dTau;
     };
     /// Return the term \f$ \alpha^0_{\delta\delta\delta} \f$
-    CoolPropDbl d3alpha0_dDelta3(void) {
+    CoolPropDbl d3alpha0_dDelta3() {
         if (!_d3alpha0_dDelta3) _d3alpha0_dDelta3 = calc_d3alpha0_dDelta3();
         return _d3alpha0_dDelta3;
     };
 
     /// Return the term \f$ \alpha^r \f$
-    CoolPropDbl alphar(void) {
+    CoolPropDbl alphar() {
         if (!_alphar) _alphar = calc_alphar();
         return _alphar;
     };
     /// Return the term \f$ \alpha^r_{\delta} \f$
-    CoolPropDbl dalphar_dDelta(void) {
+    CoolPropDbl dalphar_dDelta() {
         if (!_dalphar_dDelta) _dalphar_dDelta = calc_dalphar_dDelta();
         return _dalphar_dDelta;
     };
     /// Return the term \f$ \alpha^r_{\tau} \f$
-    CoolPropDbl dalphar_dTau(void) {
+    CoolPropDbl dalphar_dTau() {
         if (!_dalphar_dTau) _dalphar_dTau = calc_dalphar_dTau();
         return _dalphar_dTau;
     };
     /// Return the term \f$ \alpha^r_{\delta\delta} \f$
-    CoolPropDbl d2alphar_dDelta2(void) {
+    CoolPropDbl d2alphar_dDelta2() {
         if (!_d2alphar_dDelta2) _d2alphar_dDelta2 = calc_d2alphar_dDelta2();
         return _d2alphar_dDelta2;
     };
     /// Return the term \f$ \alpha^r_{\delta\tau} \f$
-    CoolPropDbl d2alphar_dDelta_dTau(void) {
+    CoolPropDbl d2alphar_dDelta_dTau() {
         if (!_d2alphar_dDelta_dTau) _d2alphar_dDelta_dTau = calc_d2alphar_dDelta_dTau();
         return _d2alphar_dDelta_dTau;
     };
     /// Return the term \f$ \alpha^r_{\tau\tau} \f$
-    CoolPropDbl d2alphar_dTau2(void) {
+    CoolPropDbl d2alphar_dTau2() {
         if (!_d2alphar_dTau2) _d2alphar_dTau2 = calc_d2alphar_dTau2();
         return _d2alphar_dTau2;
     };
     /// Return the term \f$ \alpha^r_{\delta\delta\delta} \f$
-    CoolPropDbl d3alphar_dDelta3(void) {
+    CoolPropDbl d3alphar_dDelta3() {
         if (!_d3alphar_dDelta3) _d3alphar_dDelta3 = calc_d3alphar_dDelta3();
         return _d3alphar_dDelta3;
     };
     /// Return the term \f$ \alpha^r_{\delta\delta\tau} \f$
-    CoolPropDbl d3alphar_dDelta2_dTau(void) {
+    CoolPropDbl d3alphar_dDelta2_dTau() {
         if (!_d3alphar_dDelta2_dTau) _d3alphar_dDelta2_dTau = calc_d3alphar_dDelta2_dTau();
         return _d3alphar_dDelta2_dTau;
     };
     /// Return the term \f$ \alpha^r_{\delta\tau\tau} \f$
-    CoolPropDbl d3alphar_dDelta_dTau2(void) {
+    CoolPropDbl d3alphar_dDelta_dTau2() {
         if (!_d3alphar_dDelta_dTau2) _d3alphar_dDelta_dTau2 = calc_d3alphar_dDelta_dTau2();
         return _d3alphar_dDelta_dTau2;
     };
     /// Return the term \f$ \alpha^r_{\tau\tau\tau} \f$
-    CoolPropDbl d3alphar_dTau3(void) {
+    CoolPropDbl d3alphar_dTau3() {
         if (!_d3alphar_dTau3) _d3alphar_dTau3 = calc_d3alphar_dTau3();
         return _d3alphar_dTau3;
     };
     /// Return the term \f$ \alpha^r_{\delta\delta\delta\delta} \f$
-    CoolPropDbl d4alphar_dDelta4(void) {
+    CoolPropDbl d4alphar_dDelta4() {
         if (!_d4alphar_dDelta4) _d4alphar_dDelta4 = calc_d4alphar_dDelta4();
         return _d4alphar_dDelta4;
     };
     /// Return the term \f$ \alpha^r_{\delta\delta\delta\tau} \f$
-    CoolPropDbl d4alphar_dDelta3_dTau(void) {
+    CoolPropDbl d4alphar_dDelta3_dTau() {
         if (!_d4alphar_dDelta3_dTau) _d4alphar_dDelta3_dTau = calc_d4alphar_dDelta3_dTau();
         return _d4alphar_dDelta3_dTau;
     };
     /// Return the term \f$ \alpha^r_{\delta\delta\tau\tau} \f$
-    CoolPropDbl d4alphar_dDelta2_dTau2(void) {
+    CoolPropDbl d4alphar_dDelta2_dTau2() {
         if (!_d4alphar_dDelta2_dTau2) _d4alphar_dDelta2_dTau2 = calc_d4alphar_dDelta2_dTau2();
         return _d4alphar_dDelta2_dTau2;
     };
     /// Return the term \f$ \alpha^r_{\delta\tau\tau\tau} \f$
-    CoolPropDbl d4alphar_dDelta_dTau3(void) {
+    CoolPropDbl d4alphar_dDelta_dTau3() {
         if (!_d4alphar_dDelta_dTau3) _d4alphar_dDelta_dTau3 = calc_d4alphar_dDelta_dTau3();
         return _d4alphar_dDelta_dTau3;
     };
     /// Return the term \f$ \alpha^r_{\tau\tau\tau\tau} \f$
-    CoolPropDbl d4alphar_dTau4(void) {
+    CoolPropDbl d4alphar_dTau4() {
         if (!_d4alphar_dTau4) _d4alphar_dTau4 = calc_d4alphar_dTau4();
         return _d4alphar_dTau4;
     };
@@ -1644,7 +1644,7 @@ class AbstractStateGenerator
 {
    public:
     virtual AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) = 0;
-    virtual ~AbstractStateGenerator(){};
+    virtual ~AbstractStateGenerator() {};
 };
 
 /** Register a backend in the backend library (statically defined in AbstractState.cpp and not

--- a/include/Ancillaries.h
+++ b/include/Ancillaries.h
@@ -117,7 +117,7 @@ class SaturationAncillaryFunction
     SaturationAncillaryFunction(rapidjson::Value& json_code);
 
     /// Return true if the ancillary is enabled (type is not TYPE_NOT_SET)
-    bool enabled(void) {
+    bool enabled() {
         return type != TYPE_NOT_SET;
     }
 
@@ -140,12 +140,12 @@ class SaturationAncillaryFunction
     double invert(double value, double min_bound = -1, double max_bound = -1);
 
     /// Get the minimum temperature in K
-    double get_Tmin(void) {
+    double get_Tmin() {
         return Tmin;
     };
 
     /// Get the maximum temperature in K
-    double get_Tmax(void) {
+    double get_Tmax() {
         return Tmax;
     };
 };

--- a/include/CPfilepaths.h
+++ b/include/CPfilepaths.h
@@ -5,10 +5,10 @@
 #include <vector>
 
 /// Get directory separator
-std::string get_separator(void);
+std::string get_separator();
 
 /// Get the user's home directory;  It is believed that is is always a place that files can be written
-std::string get_home_dir(void);
+std::string get_home_dir();
 
 /// Return true if path exists
 bool path_exists(const std::string& path);

--- a/include/CPnumerics.h
+++ b/include/CPnumerics.h
@@ -452,7 +452,7 @@ class SplineClass
    public:
     double a, b, c, d;
     SplineClass() : Nconstraints(0), A(4, std::vector<double>(4, 0)), B(4, 0), a(_HUGE), b(_HUGE), c(_HUGE), d(_HUGE) {}
-    bool build(void);
+    bool build();
     bool add_value_constraint(double x, double y);
     void add_4value_constraints(double x1, double x2, double x3, double x4, double y1, double y2, double y3, double y4);
     bool add_derivative_constraint(double x, double dydx);

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -187,7 +187,7 @@ class ConfigurationItem
         v_string = val;
     }
 
-    configuration_keys get_key(void) const {
+    configuration_keys get_key() const {
         return this->key;
     }
 #if !defined(SWIG)
@@ -285,7 +285,7 @@ class Configuration
     Configuration() {
         set_defaults();
     };
-    ~Configuration(){};
+    ~Configuration() {};
 
     /// Get an item from the configuration
     ConfigurationItem& get_item(configuration_keys key) {
@@ -306,7 +306,7 @@ class Configuration
     };
 
     /// Return a reference to all of the items
-    std::unordered_map<configuration_keys, ConfigurationItem>& get_items(void) {
+    std::unordered_map<configuration_keys, ConfigurationItem>& get_items() {
         return items;
     };
 
@@ -382,7 +382,7 @@ class Configuration
     }
 
     /// Set the default values in the configuration
-    void set_defaults(void) {
+    void set_defaults() {
 /* ***MAGIC WARNING**!!
              * See http://stackoverflow.com/a/148610
              * See http://stackoverflow.com/questions/147267/easy-way-to-use-variables-of-enum-types-as-string-in-c#202511

--- a/include/CoolPropTools.h
+++ b/include/CoolPropTools.h
@@ -65,7 +65,7 @@ class Dictionary
 
    public:
     Dictionary() {};
-    bool is_empty(void) const {
+    bool is_empty() const {
         return numbers.empty() && strings.empty() && double_vectors.empty() && string_vectors.empty();
     }
     void add_string(const std::string& s1, const std::string& s2) {

--- a/include/HumidAirProp.h
+++ b/include/HumidAirProp.h
@@ -35,7 +35,7 @@ void UseIdealGasEnthalpyCorrelations(int flag);
 // --------------
 // Help functions
 // --------------
-void HAHelp(void);
+void HAHelp();
 int returnHumAirCode(const char* Code);
 
 // ----------------------

--- a/include/IdealCurves.h
+++ b/include/IdealCurves.h
@@ -28,7 +28,7 @@ class CurveTracer : public FuncWrapper1D
         this->T.push_back(Secant(this, T0, 0.001 * T0, 1e-10, 100));
     }
 
-    virtual double objective(void) = 0;
+    virtual double objective() = 0;
 
     virtual double starting_direction() {
         return M_PI / 2.0;
@@ -90,7 +90,7 @@ class IdealCurveTracer : public CurveTracer
         init();
     };
     /// Z = 1
-    double objective(void) {
+    double objective() {
         return this->AS->keyed_output(iZ) - 1;
     };
 };
@@ -102,7 +102,7 @@ class BoyleCurveTracer : public CurveTracer
         init();
     };
     /// dZ/dv|T = 0
-    double objective(void) {
+    double objective() {
         double r =
           (this->AS->p() - this->AS->rhomolar() * this->AS->first_partial_deriv(iP, iDmolar, iT)) / (this->AS->gas_constant() * this->AS->T());
         return r;
@@ -115,7 +115,7 @@ class JouleInversionCurveTracer : public CurveTracer
         init();
     };
     /// dZ/dT|v = 0
-    double objective(void) {
+    double objective() {
         double r = (this->AS->gas_constant() * this->AS->T() * 1 / this->AS->rhomolar() * this->AS->first_partial_deriv(iP, iT, iDmolar)
                     - this->AS->p() * this->AS->gas_constant() / this->AS->rhomolar())
                    / POW2(this->AS->gas_constant() * this->AS->T());
@@ -129,7 +129,7 @@ class JouleThomsonCurveTracer : public CurveTracer
         init();
     };
     /// dZ/dT|p = 0
-    double objective(void) {
+    double objective() {
         double dvdT__constp = -this->AS->first_partial_deriv(iDmolar, iT, iP) / POW2(this->AS->rhomolar());
         double r = this->AS->p() / (this->AS->gas_constant() * POW2(this->AS->T())) * (this->AS->T() * dvdT__constp - 1 / this->AS->rhomolar());
         return r;

--- a/include/PolyMath.h
+++ b/include/PolyMath.h
@@ -165,7 +165,7 @@ class Polynomial2D
     [[deprecated("Deprecated since move to Eigen framework; use Eigen-based routines instead")]] double
       baseHorner(const std::vector<std::vector<double>>& coefficients, double x, double y);
 
-    bool do_debug(void) {
+    bool do_debug() {
         return get_debug_level() >= 500;
     }
 };

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -712,11 +712,11 @@ double AbstractState::molar_mass() {
     if (!_molar_mass) _molar_mass = calc_molar_mass();
     return _molar_mass;
 }
-double AbstractState::Qmass(void) {
+double AbstractState::Qmass() {
     if (!_Qmass) _Qmass = calc_Qmass();
     return _Qmass;
 }
-CoolPropDbl AbstractState::calc_Qmass(void) {
+CoolPropDbl AbstractState::calc_Qmass() {
     if (!ValidNumber(_Q) || _Q < 0 || _Q > 1) {
         throw ValueError("Qmass requires a two-phase state (0 <= Q <= 1)");
     }

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -126,7 +126,7 @@ std::string CoolProp::AbstractCubicBackend::fluid_param_string(const std::string
     }
 }
 
-std::vector<std::string> CoolProp::AbstractCubicBackend::calc_fluid_names(void) {
+std::vector<std::string> CoolProp::AbstractCubicBackend::calc_fluid_names() {
     std::vector<std::string> out;
     for (std::size_t i = 0; i < components.size(); ++i) {
         out.push_back(components[i].name);
@@ -587,7 +587,7 @@ CoolPropDbl CoolProp::AbstractCubicBackend::solver_rho_Tp(CoolPropDbl T, CoolPro
     return rho;
 }
 
-CoolPropDbl CoolProp::AbstractCubicBackend::calc_molar_mass(void) {
+CoolPropDbl CoolProp::AbstractCubicBackend::calc_molar_mass() {
     double summer = 0;
     for (unsigned int i = 0; i < N; ++i) {
         summer += mole_fractions[i] * components[i].molemass;

--- a/src/Backends/Cubics/CubicBackend.h
+++ b/src/Backends/Cubics/CubicBackend.h
@@ -50,15 +50,15 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
         return cubic;
     };
 
-    std::vector<std::string> calc_fluid_names(void);
+    std::vector<std::string> calc_fluid_names();
 
-    bool using_mole_fractions(void) {
+    bool using_mole_fractions() {
         return true;
     };
-    bool using_mass_fractions(void) {
+    bool using_mass_fractions() {
         return false;
     };
-    bool using_volu_fractions(void) {
+    bool using_volu_fractions() {
         return false;
     };
 
@@ -68,7 +68,7 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
     void set_volu_fractions(const std::vector<CoolPropDbl>& volu_fractions) {
         throw NotImplementedError("Volume composition has not been implemented.");
     };
-    const std::vector<CoolPropDbl>& get_mole_fractions(void) {
+    const std::vector<CoolPropDbl>& get_mole_fractions() {
         return this->mole_fractions;
     };
 
@@ -100,7 +100,7 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
     /// Return a string from the backend for the mixture/fluid
     std::string fluid_param_string(const std::string&);
     /// Calculate the gas constant in J/mol/K
-    CoolPropDbl calc_gas_constant(void) {
+    CoolPropDbl calc_gas_constant() {
         return cubic->get_R_u();
     };
     /// Get the reducing state to be used
@@ -110,36 +110,36 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
         reducing.rhomolar = cubic->get_rhor();
         return reducing;
     };
-    CoolPropDbl calc_reduced_density(void) {
+    CoolPropDbl calc_reduced_density() {
         return _rhomolar / get_cubic()->get_rhor();
     };
-    CoolPropDbl calc_reciprocal_reduced_temperature(void) {
+    CoolPropDbl calc_reciprocal_reduced_temperature() {
         return get_cubic()->get_Tr() / _T;
     };
     std::vector<double> spinodal_densities();
 
-    CoolPropDbl calc_T_critical(void) {
+    CoolPropDbl calc_T_critical() {
         if (is_pure_or_pseudopure) {
             return cubic->get_Tc()[0];
         } else {
             return HelmholtzEOSMixtureBackend::calc_T_critical();
         }
     };
-    CoolPropDbl calc_p_critical(void) {
+    CoolPropDbl calc_p_critical() {
         if (is_pure_or_pseudopure) {
             return cubic->get_pc()[0];
         } else {
             return HelmholtzEOSMixtureBackend::calc_p_critical();
         }
     };
-    CoolPropDbl calc_acentric_factor(void) {
+    CoolPropDbl calc_acentric_factor() {
         if (is_pure_or_pseudopure) {
             return cubic->get_acentric()[0];
         } else {
             throw ValueError("acentric factor cannot be calculated for mixtures");
         }
     }
-    CoolPropDbl calc_rhomolar_critical(void) {
+    CoolPropDbl calc_rhomolar_critical() {
         if (is_pure_or_pseudopure) {
             // Curve fit from all the pure fluids in CoolProp (thanks to recommendation of A. Kazakov)
             double v_c_Lmol = 2.14107171795 * (cubic->get_Tc()[0] / cubic->get_pc()[0] * 1000) + 0.00773144012514;  // [L/mol]
@@ -218,7 +218,7 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
     /// Cubic backend flashes for PQ, and QT
     void saturation(CoolProp::input_pairs inputs);
 
-    CoolPropDbl calc_molar_mass(void);
+    CoolPropDbl calc_molar_mass();
 
     void set_binary_interaction_double(const std::size_t i1, const std::size_t i2, const std::string& parameter, const double value);
     double get_binary_interaction_double(const std::size_t i1, const std::size_t i2, const std::string& parameter);
@@ -298,7 +298,7 @@ class SRKBackend : public AbstractCubicBackend
         ACB->copy_internals(*this);
         return static_cast<HelmholtzEOSMixtureBackend*>(ACB);
     }
-    std::string backend_name(void) override {
+    std::string backend_name() override {
         return get_backend_string(SRK_BACKEND);
     }
     int get_superanc_eos_code() const override {
@@ -340,7 +340,7 @@ class PengRobinsonBackend : public AbstractCubicBackend
         ACB->copy_internals(*this);
         return static_cast<HelmholtzEOSMixtureBackend*>(ACB);
     }
-    std::string backend_name(void) override {
+    std::string backend_name() override {
         return get_backend_string(PR_BACKEND);
     }
     int get_superanc_eos_code() const override {

--- a/src/Backends/Cubics/VTPRBackend.cpp
+++ b/src/Backends/Cubics/VTPRBackend.cpp
@@ -90,7 +90,7 @@ void CoolProp::VTPRBackend::set_alpha_from_components() {
     }
 }
 
-CoolPropDbl CoolProp::VTPRBackend::calc_molar_mass(void) {
+CoolPropDbl CoolProp::VTPRBackend::calc_molar_mass() {
     double summer = 0;
     for (unsigned int i = 0; i < N; ++i) {
         summer += mole_fractions[i] * molemass[i];

--- a/src/Backends/Cubics/VTPRBackend.h
+++ b/src/Backends/Cubics/VTPRBackend.h
@@ -57,7 +57,7 @@ class VTPRBackend : public PengRobinsonBackend
         setup(fluid_identifiers, generate_SatL_and_SatV);
     };
 
-    std::string backend_name(void) {
+    std::string backend_name() {
         return get_backend_string(VTPR_BACKEND);
     }
 
@@ -72,7 +72,7 @@ class VTPRBackend : public PengRobinsonBackend
     void set_alpha_from_components();
 
     /// Return the fluid names
-    std::vector<std::string> calc_fluid_names(void) {
+    std::vector<std::string> calc_fluid_names() {
         return m_fluid_names;
     }
 
@@ -89,7 +89,7 @@ class VTPRBackend : public PengRobinsonBackend
     };
 
     /// Calculate the molar mass
-    CoolPropDbl calc_molar_mass(void);
+    CoolPropDbl calc_molar_mass();
 
     /// Allows to modify the interactions parameters aij, bij and cij
     void set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter, const double value);

--- a/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
+++ b/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
@@ -120,7 +120,7 @@ double SaturationAncillaryFunction::invert(double value, double min_bound, doubl
     }
 }
 
-void MeltingLineVariables::set_limits(void) {
+void MeltingLineVariables::set_limits() {
     if (type == MELTING_LINE_SIMON_TYPE) {
 
         // Fill in the min and max pressures for each part

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
@@ -380,7 +380,7 @@ void JSONFluidLibrary::add_one(rapidjson::Value& fluid_json) {
     }
 };
 
-JSONFluidLibrary& get_library(void) {
+JSONFluidLibrary& get_library() {
     ensure_library_loaded();
     return library;
 }
@@ -395,7 +395,7 @@ std::string get_fluid_as_JSONstring(const std::string& identifier) {
     return library.get_JSONstring(identifier);
 }
 
-std::string get_fluid_list(void) {
+std::string get_fluid_list() {
     ensure_library_loaded();
     return library.get_fluid_list();
 };

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.h
@@ -1197,7 +1197,7 @@ class JSONFluidLibrary
     JSONFluidLibrary() {
         _is_empty = true;
     };
-    bool is_empty(void) {
+    bool is_empty() {
         return _is_empty;
     };
 
@@ -1341,16 +1341,16 @@ class JSONFluidLibrary
     };
     void set_fluid_enthalpy_entropy_offset(const std::string& fluid, double delta_a1, double delta_a2, const std::string& ref);
     /// Return a comma-separated list of fluid names
-    std::string get_fluid_list(void) {
+    std::string get_fluid_list() {
         return strjoin(name_vector, get_config_string(LIST_STRING_DELIMITER));
     };
 };
 
 /// Get a reference to the library instance
-JSONFluidLibrary& get_library(void);
+JSONFluidLibrary& get_library();
 
 /// Get a comma-separated-list of fluids that are included
-std::string get_fluid_list(void);
+std::string get_fluid_list();
 
 /// Get the fluid structure
 CoolPropFluid get_fluid(const std::string& fluid_string);

--- a/src/Backends/Helmholtz/HelmholtzEOSBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSBackend.h
@@ -62,7 +62,7 @@ class HelmholtzEOSBackend : public HelmholtzEOSMixtureBackend
         }
     };
     virtual ~HelmholtzEOSBackend() {};
-    std::string backend_name(void) {
+    std::string backend_name() {
         return get_backend_string(HEOS_BACKEND_PURE);
     }
 };

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -501,7 +501,7 @@ void HelmholtzEOSMixtureBackend::set_mixture_parameters() {
     // Build the matrix of binary-pair reducing functions
     MixtureParameters::set_mixture_parameters(*this);
 }
-void HelmholtzEOSMixtureBackend::update_states(void) {
+void HelmholtzEOSMixtureBackend::update_states() {
     CoolPropFluid& component = components[0];
     EquationOfState& EOS = component.EOSVector[0];
 
@@ -548,14 +548,14 @@ const CoolProp::SimpleState& HelmholtzEOSMixtureBackend::calc_state(const std::s
         }
     }
 };
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_acentric_factor(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_acentric_factor() {
     if (is_pure_or_pseudopure) {
         return components[0].EOS().acentric;
     } else {
         throw ValueError("acentric factor cannot be calculated for mixtures");
     }
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_gas_constant(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_gas_constant() {
     if (is_pure_or_pseudopure) {
         return components[0].gas_constant();
     } else {
@@ -571,7 +571,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_gas_constant(void) {
         }
     }
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_molar_mass(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_molar_mass() {
     double summer = 0;
     for (unsigned int i = 0; i < components.size(); ++i) {
         summer += mole_fractions[i] * components[i].molar_mass();
@@ -651,7 +651,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_melting_line(int param, int given, 
         throw NotImplementedError(format("calc_melting_line not implemented for mixtures"));
     }
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_surface_tension(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_surface_tension() {
     if (is_pure_or_pseudopure) {
         if ((_phase == iphase_twophase) || (_phase == iphase_critical_point)) {  // if within the two phase region or at critical point
             return components[0].ancillaries.surface_tension.evaluate(T());      //    calculate surface tension and return
@@ -662,7 +662,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_surface_tension(void) {
         throw NotImplementedError(format("surface tension not implemented for mixtures"));
     }
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity_dilute(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity_dilute() {
     if (is_pure_or_pseudopure) {
         CoolPropDbl eta_dilute = NAN;
         switch (components[0].transport.viscosity_dilute.type) {
@@ -758,7 +758,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity_background(CoolPropDbl et
     return initial_density + residual;
 }
 
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity() {
     if (is_pure_or_pseudopure) {
         CoolPropDbl dilute = 0, initial_density = 0, residual = 0, critical = 0;
         calc_viscosity_contributions(dilute, initial_density, residual, critical);
@@ -978,7 +978,7 @@ void HelmholtzEOSMixtureBackend::calc_conductivity_contributions(CoolPropDbl& di
     }
 };
 
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_conductivity_background(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_conductivity_background() {
     // Residual part
     CoolPropDbl lambda_residual = _HUGE;
     switch (components[0].transport.conductivity_residual.type) {
@@ -994,7 +994,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_conductivity_background(void) {
     }
     return lambda_residual;
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_conductivity(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_conductivity() {
     if (is_pure_or_pseudopure) {
         CoolPropDbl dilute = 0, initial_density = 0, residual = 0, critical = 0;
         calc_conductivity_contributions(dilute, initial_density, residual, critical);
@@ -1035,21 +1035,21 @@ void HelmholtzEOSMixtureBackend::calc_conformal_state(const std::string& referen
 
     TransportRoutines::conformal_state_solver(*this, *REF, T, rhomolar);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_Ttriple(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_Ttriple() {
     double summer = 0;
     for (unsigned int i = 0; i < components.size(); ++i) {
         summer += mole_fractions[i] * components[i].EOS().Ttriple;
     }
     return summer;
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_p_triple(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_p_triple() {
     double summer = 0;
     for (unsigned int i = 0; i < components.size(); ++i) {
         summer += mole_fractions[i] * components[i].EOS().ptriple;
     }
     return summer;
 }
-std::string HelmholtzEOSMixtureBackend::calc_name(void) {
+std::string HelmholtzEOSMixtureBackend::calc_name() {
     if (components.size() != 1) {
         throw ValueError(format("calc_name is only valid for pure and pseudo-pure fluids, %d components", components.size()));
     } else {
@@ -1085,14 +1085,14 @@ void HelmholtzEOSMixtureBackend::calc_ideal_curve(const std::string& type, std::
         throw ValueError(format("Invalid ideal curve type: %s", type.c_str()));
     }
 };
-std::vector<std::string> HelmholtzEOSMixtureBackend::calc_fluid_names(void) {
+std::vector<std::string> HelmholtzEOSMixtureBackend::calc_fluid_names() {
     std::vector<std::string> out;
     for (std::size_t i = 0; i < components.size(); ++i) {
         out.push_back(components[i].name);
     }
     return out;
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_ODP(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_ODP() {
     if (components.size() != 1) {
         throw ValueError(format("For now, calc_ODP is only valid for pure and pseudo-pure fluids, %d components", components.size()));
     } else {
@@ -1103,7 +1103,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_ODP(void) {
         return v;
     }
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_GWP20(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_GWP20() {
     if (components.size() != 1) {
         throw ValueError(format("For now, calc_GWP20 is only valid for pure and pseudo-pure fluids, %d components", components.size()));
     } else {
@@ -1114,7 +1114,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_GWP20(void) {
         return v;
     }
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_GWP100(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_GWP100() {
     if (components.size() != 1) {
         throw ValueError(format("For now, calc_GWP100 is only valid for pure and pseudo-pure fluids, %d components", components.size()));
     } else {
@@ -1125,7 +1125,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_GWP100(void) {
         return v;
     }
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_GWP500(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_GWP500() {
     if (components.size() != 1) {
         throw ValueError(format("For now, calc_GWP500 is only valid for pure and pseudo-pure fluids, %d components", components.size()));
     } else {
@@ -1136,7 +1136,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_GWP500(void) {
         return v;
     }
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_T_critical(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_T_critical() {
     if (components.size() != 1) {
         std::vector<CriticalState> critpts = calc_all_critical_points();
         if (critpts.size() == 1) {
@@ -1155,7 +1155,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_T_critical(void) {
         return components[0].crit.T;
     }
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_p_critical(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_p_critical() {
     if (components.size() != 1) {
         std::vector<CriticalState> critpts = calc_all_critical_points();
         if (critpts.size() == 1) {
@@ -1174,7 +1174,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_p_critical(void) {
         return components[0].crit.p;
     }
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_rhomolar_critical(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_rhomolar_critical() {
     if (components.size() != 1) {
         std::vector<CriticalState> critpts = calc_all_critical_points();
         if (critpts.size() == 1) {
@@ -1193,7 +1193,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_rhomolar_critical(void) {
         return components[0].crit.rhomolar;
     }
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_pmax_sat(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_pmax_sat() {
     if (is_pure_or_pseudopure) {
         if (components[0].EOS().pseudo_pure) {
             return components[0].EOS().max_sat_p.p;
@@ -1204,7 +1204,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_pmax_sat(void) {
         throw ValueError("calc_pmax_sat not yet defined for mixtures");
     }
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_Tmax_sat(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_Tmax_sat() {
     if (is_pure_or_pseudopure) {
         if (components[0].EOS().pseudo_pure) {
             double Tmax_sat = components[0].EOS().max_sat_T.T;
@@ -1244,21 +1244,21 @@ void HelmholtzEOSMixtureBackend::calc_pmin_sat(CoolPropDbl& pmin_satL, CoolPropD
 // Minimum allowed saturation temperature the maximum of the saturation temperatures of liquid and vapor
 // For pure fluids, both values are the same, for pseudo-pure they are probably the same, for mixtures they are definitely not the same
 
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_Tmax(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_Tmax() {
     double summer = 0;
     for (unsigned int i = 0; i < components.size(); ++i) {
         summer += mole_fractions[i] * components[i].EOS().limits.Tmax;
     }
     return summer;
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_Tmin(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_Tmin() {
     double summer = 0;
     for (unsigned int i = 0; i < components.size(); ++i) {
         summer += mole_fractions[i] * components[i].EOS().limits.Tmin;
     }
     return summer;
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_pmax(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_pmax() {
     double summer = 0;
     for (unsigned int i = 0; i < components.size(); ++i) {
         summer += mole_fractions[i] * components[i].EOS().limits.pmax;
@@ -2043,7 +2043,7 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
         throw ValueError(format("The pressure [%g Pa] cannot be used in p_phase_determination", _p));
     }
 }
-void HelmholtzEOSMixtureBackend::calc_ssat_max(void) {
+void HelmholtzEOSMixtureBackend::calc_ssat_max() {
     class Residual : public FuncWrapper1D
     {
        public:
@@ -2078,7 +2078,7 @@ void HelmholtzEOSMixtureBackend::calc_ssat_max(void) {
         }
     }
 }
-void HelmholtzEOSMixtureBackend::calc_hsat_max(void) {
+void HelmholtzEOSMixtureBackend::calc_hsat_max() {
     class Residualhmax : public FuncWrapper1D
     {
        public:
@@ -3006,7 +3006,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::solver_rho_Tp_SRK(CoolPropDbl T, CoolPro
     return rhomolar;
 }
 
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_pressure(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_pressure() {
     // Calculate the reducing parameters
     _delta = _rhomolar / _reducing.rhomolar;
     _tau = _reducing.T / _T;
@@ -3040,7 +3040,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_hmolar_nocache(CoolPropDbl T, CoolP
     // Get molar enthalpy
     return R_u * T * (1 + tau * (da0_dTau + dar_dTau) + delta * dar_dDelta);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_hmolar(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_hmolar() {
     if (get_debug_level() >= 50)
         std::cout << format("HelmholtzEOSMixtureBackend::calc_hmolar: 2phase: %d T: %g rhomomolar: %g", isTwoPhase(), _T, _rhomolar) << std::endl;
     if (isTwoPhase()) {
@@ -3088,7 +3088,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_smolar_nocache(CoolPropDbl T, CoolP
     // Get molar entropy
     return R_u * (tau * (da0_dTau + dar_dTau) - a0 - ar);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_smolar(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_smolar() {
     if (isTwoPhase()) {
         if (!this->SatL || !this->SatV) throw ValueError(format("The saturation properties are needed for the two-phase properties"));
         if (std::abs(_Q) < DBL_EPSILON) {
@@ -3135,7 +3135,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_umolar_nocache(CoolPropDbl T, CoolP
     // Get molar internal energy
     return R_u * T * tau * (da0_dTau + dar_dTau);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_umolar(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_umolar() {
     if (isTwoPhase()) {
         if (!this->SatL || !this->SatV) throw ValueError(format("The saturation properties are needed for the two-phase properties"));
         if (std::abs(_Q) < DBL_EPSILON) {
@@ -3164,7 +3164,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_umolar(void) {
         throw ValueError(format("phase is invalid in calc_umolar"));
     }
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_cvmolar(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_cvmolar() {
     // Calculate the reducing parameters
     _delta = _rhomolar / _reducing.rhomolar;
     _tau = _reducing.T / _T;
@@ -3179,7 +3179,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_cvmolar(void) {
 
     return static_cast<double>(_cvmolar);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_cpmolar(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_cpmolar() {
     // Calculate the reducing parameters
     _delta = _rhomolar / _reducing.rhomolar;
     _tau = _reducing.T / _T;
@@ -3200,7 +3200,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_cpmolar(void) {
 
     return static_cast<double>(_cpmolar);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_cpmolar_idealgas(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_cpmolar_idealgas() {
     // Calculate the reducing parameters
     _delta = _rhomolar / _reducing.rhomolar;
     _tau = _reducing.T / _T;
@@ -3212,7 +3212,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_cpmolar_idealgas(void) {
     // Get cp of the ideal gas
     return R_u * (1 + (-pow(_tau.pt(), 2)) * d2a0_dTau2);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_speed_sound(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_speed_sound() {
     if (isTwoPhase()) {
         if (std::abs(_Q) < DBL_EPSILON) {
             return SatL->speed_sound();
@@ -3260,7 +3260,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_gibbsmolar_nocache(CoolPropDbl T, C
     // Get molar gibbs function
     return gas_constant() * T * (1 + a0 + ar + delta * dar_dDelta);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_gibbsmolar(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_gibbsmolar() {
     if (isTwoPhase()) {
         if (!this->SatL || !this->SatV) throw ValueError(format("The saturation properties are needed for the two-phase properties"));
         _gibbsmolar = _Q * SatV->gibbsmolar() + (1 - _Q) * SatL->gibbsmolar();
@@ -3284,7 +3284,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_gibbsmolar(void) {
         throw ValueError(format("phase is invalid in calc_gibbsmolar"));
     }
 }
-void HelmholtzEOSMixtureBackend::calc_excess_properties(void) {
+void HelmholtzEOSMixtureBackend::calc_excess_properties() {
     _gibbsmolar_excess = this->gibbsmolar(), _smolar_excess = this->smolar(), _hmolar_excess = this->hmolar();
     _umolar_excess = this->umolar();
     _volumemolar_excess = 1 / this->rhomolar();
@@ -3302,7 +3302,7 @@ void HelmholtzEOSMixtureBackend::calc_excess_properties(void) {
     _helmholtzmolar_excess = static_cast<double>(_umolar_excess) - _T * static_cast<double>(_smolar_excess);
 }
 
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_helmholtzmolar(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_helmholtzmolar() {
     if (isTwoPhase()) {
         if (!this->SatL || !this->SatV) throw ValueError(format("The saturation properties are needed for the two-phase properties"));
         _helmholtzmolar = _Q * SatV->helmholtzmolar() + (1 - _Q) * SatL->helmholtzmolar();
@@ -3342,7 +3342,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_chemical_potential(std::size_t i) {
       components[i].EOS().alpha0.base(tau() * (Tci / T_reducing()), delta() / (rhoci / rhomolar_reducing())) + 1 + log(mole_fractions[i]);
     return gas_constant() * T() * (dna0_dni__const_T_V_nj + dnar_dni__const_T_V_nj);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_phase_identification_parameter(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_phase_identification_parameter() {
     return 2
            - rhomolar()
                * (second_partial_deriv(iP, iDmolar, iT, iT, iDmolar) / first_partial_deriv(iP, iT, iDmolar)
@@ -3359,7 +3359,7 @@ SimpleState HelmholtzEOSMixtureBackend::calc_reducing_state_nocache(const std::v
     }
     return reducing;
 }
-void HelmholtzEOSMixtureBackend::calc_reducing_state(void) {
+void HelmholtzEOSMixtureBackend::calc_reducing_state() {
     if (get_mole_fractions_ref().empty()) {
         throw ValueError("Mole fractions must be set before calling calc_reducing_state");
     }
@@ -3545,105 +3545,105 @@ HelmholtzDerivatives HelmholtzEOSMixtureBackend::calc_all_alpha0_derivs_nocache(
     }
 }
 
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_alphar(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_alphar() {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
     return static_cast<CoolPropDbl>(_alphar);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_dalphar_dDelta(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_dalphar_dDelta() {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
     return static_cast<CoolPropDbl>(_dalphar_dDelta);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_dalphar_dTau(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_dalphar_dTau() {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
     return static_cast<CoolPropDbl>(_dalphar_dTau);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alphar_dTau2(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alphar_dTau2() {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
     return static_cast<CoolPropDbl>(_d2alphar_dTau2);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alphar_dDelta_dTau(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alphar_dDelta_dTau() {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
     return static_cast<CoolPropDbl>(_d2alphar_dDelta_dTau);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alphar_dDelta2(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alphar_dDelta2() {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
     return static_cast<CoolPropDbl>(_d2alphar_dDelta2);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alphar_dDelta3(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alphar_dDelta3() {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
     return static_cast<CoolPropDbl>(_d3alphar_dDelta3);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alphar_dDelta2_dTau(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alphar_dDelta2_dTau() {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
     return static_cast<CoolPropDbl>(_d3alphar_dDelta2_dTau);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alphar_dDelta_dTau2(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alphar_dDelta_dTau2() {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
     return static_cast<CoolPropDbl>(_d3alphar_dDelta_dTau2);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alphar_dTau3(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alphar_dTau3() {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
     return static_cast<CoolPropDbl>(_d3alphar_dTau3);
 }
 
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d4alphar_dDelta4(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d4alphar_dDelta4() {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
     return static_cast<CoolPropDbl>(_d4alphar_dDelta4);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d4alphar_dDelta3_dTau(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d4alphar_dDelta3_dTau() {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
     return static_cast<CoolPropDbl>(_d4alphar_dDelta3_dTau);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d4alphar_dDelta2_dTau2(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d4alphar_dDelta2_dTau2() {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
     return static_cast<CoolPropDbl>(_d4alphar_dDelta2_dTau2);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d4alphar_dDelta_dTau3(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d4alphar_dDelta_dTau3() {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
     return static_cast<CoolPropDbl>(_d4alphar_dDelta_dTau3);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d4alphar_dTau4(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d4alphar_dTau4() {
     calc_all_alphar_deriv_cache(mole_fractions, _tau, _delta);
     return static_cast<CoolPropDbl>(_d4alphar_dTau4);
 }
 
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_alpha0(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_alpha0() {
     const int nTau = 0, nDelta = 0;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_dalpha0_dDelta(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_dalpha0_dDelta() {
     const int nTau = 0, nDelta = 1;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_dalpha0_dTau(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_dalpha0_dTau() {
     const int nTau = 1, nDelta = 0;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alpha0_dDelta2(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alpha0_dDelta2() {
     const int nTau = 0, nDelta = 2;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alpha0_dDelta_dTau(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alpha0_dDelta_dTau() {
     const int nTau = 1, nDelta = 1;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alpha0_dTau2(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d2alpha0_dTau2() {
     const int nTau = 2, nDelta = 0;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alpha0_dDelta3(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alpha0_dDelta3() {
     const int nTau = 0, nDelta = 3;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alpha0_dDelta2_dTau(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alpha0_dDelta2_dTau() {
     const int nTau = 1, nDelta = 2;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alpha0_dDelta_dTau2(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alpha0_dDelta_dTau2() {
     const int nTau = 2, nDelta = 1;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }
-CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alpha0_dTau3(void) {
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_d3alpha0_dTau3() {
     const int nTau = 3, nDelta = 0;
     return calc_alpha0_deriv_nocache(nTau, nDelta, mole_fractions, _tau, _delta, _reducing.T, _reducing.rhomolar);
 }

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
@@ -130,8 +130,8 @@ class HelmholtzEOSMixtureBackend : public AbstractState
     // Copy over the reducing and departure terms to all linked states (recursively)
     void sync_linked_states(const HelmholtzEOSMixtureBackend* const);
 
-    virtual ~HelmholtzEOSMixtureBackend(){};
-    std::string backend_name(void) {
+    virtual ~HelmholtzEOSMixtureBackend() {};
+    std::string backend_name() {
         return get_backend_string(HEOS_BACKEND_MIX);
     }
     shared_ptr<ReducingFunction> Reducing;
@@ -212,7 +212,7 @@ class HelmholtzEOSMixtureBackend : public AbstractState
     };
     virtual double get_fluid_parameter_double(const size_t i, const std::string& parameter);
 
-    phases calc_phase(void) {
+    phases calc_phase() {
         return _phase;
     };
 
@@ -230,8 +230,8 @@ class HelmholtzEOSMixtureBackend : public AbstractState
         imposed_phase_index = iphase_not_imposed;
     }
     CoolPropDbl calc_saturation_ancillary(parameters param, int Q, parameters given, double value);
-    void calc_ssat_max(void);
-    void calc_hsat_max(void);
+    void calc_ssat_max();
+    void calc_hsat_max();
     CoolPropDbl calc_GWP20();
     CoolPropDbl calc_GWP500();
     CoolPropDbl calc_GWP100();
@@ -331,7 +331,7 @@ class HelmholtzEOSMixtureBackend : public AbstractState
         return *SatV;
     };
 
-    std::vector<CoolPropDbl> calc_mole_fractions_liquid(void) {
+    std::vector<CoolPropDbl> calc_mole_fractions_liquid() {
         // SatL/SatV retain composition vectors from the most recent VLE flash
         // (or phase-envelope build) — those are not meaningful when the
         // current state is single-phase, and returning them silently surfaced
@@ -342,14 +342,14 @@ class HelmholtzEOSMixtureBackend : public AbstractState
         }
         return SatL->get_mole_fractions();
     };
-    std::vector<CoolPropDbl> calc_mole_fractions_vapor(void) {
+    std::vector<CoolPropDbl> calc_mole_fractions_vapor() {
         if (_phase != iphase_twophase) {
             throw ValueError("mole_fractions_vapor is only defined in the two-phase region (current state is single-phase)");
         }
         return SatV->get_mole_fractions();
     };
 
-    const std::vector<CoolPropDbl> calc_mass_fractions(void);
+    const std::vector<CoolPropDbl> calc_mass_fractions();
 
     const CoolProp::PhaseEnvelopeData& calc_phase_envelope_data() {
         return PhaseEnvelope;
@@ -411,7 +411,7 @@ class HelmholtzEOSMixtureBackend : public AbstractState
     std::vector<CoolPropDbl>& get_mole_fractions_ref() {
         return mole_fractions;
     };
-    std::vector<double>& get_mole_fractions_doubleref(void) {
+    std::vector<double>& get_mole_fractions_doubleref() {
         return mole_fractions;
     }
 
@@ -423,43 +423,43 @@ class HelmholtzEOSMixtureBackend : public AbstractState
 
     void calc_ideal_curve(const std::string& type, std::vector<double>& T, std::vector<double>& p);
 
-    CoolPropDbl calc_molar_mass(void);
+    CoolPropDbl calc_molar_mass();
     PhaseMolarMasses calc_phase_molar_masses() override;
-    CoolPropDbl calc_gas_constant(void);
-    CoolPropDbl calc_acentric_factor(void);
+    CoolPropDbl calc_gas_constant();
+    CoolPropDbl calc_acentric_factor();
 
-    CoolPropDbl calc_Bvirial(void);
-    CoolPropDbl calc_Cvirial(void);
-    CoolPropDbl calc_dBvirial_dT(void);
-    CoolPropDbl calc_dCvirial_dT(void);
+    CoolPropDbl calc_Bvirial();
+    CoolPropDbl calc_Cvirial();
+    CoolPropDbl calc_dBvirial_dT();
+    CoolPropDbl calc_dCvirial_dT();
 
-    CoolPropDbl calc_pressure(void);
-    CoolPropDbl calc_cvmolar(void);
-    CoolPropDbl calc_cpmolar(void);
-    CoolPropDbl calc_gibbsmolar(void);
-    CoolPropDbl calc_gibbsmolar_residual(void) {
+    CoolPropDbl calc_pressure();
+    CoolPropDbl calc_cvmolar();
+    CoolPropDbl calc_cpmolar();
+    CoolPropDbl calc_gibbsmolar();
+    CoolPropDbl calc_gibbsmolar_residual() {
         return gas_constant() * _T * (alphar() + delta() * dalphar_dDelta());
     }
     CoolPropDbl calc_gibbsmolar_nocache(CoolPropDbl T, CoolPropDbl rhomolar);
 
-    CoolPropDbl calc_helmholtzmolar(void);
-    CoolPropDbl calc_cpmolar_idealgas(void);
+    CoolPropDbl calc_helmholtzmolar();
+    CoolPropDbl calc_cpmolar_idealgas();
     CoolPropDbl calc_pressure_nocache(CoolPropDbl T, CoolPropDbl rhomolar);
-    CoolPropDbl calc_smolar(void);
-    CoolPropDbl calc_smolar_residual(void) {
+    CoolPropDbl calc_smolar();
+    CoolPropDbl calc_smolar_residual() {
         return gas_constant() * (tau() * dalphar_dTau() - alphar());
     }
     CoolPropDbl calc_smolar_nocache(CoolPropDbl T, CoolPropDbl rhomolar);
 
-    CoolPropDbl calc_hmolar(void);
-    CoolPropDbl calc_hmolar_residual(void) {
+    CoolPropDbl calc_hmolar();
+    CoolPropDbl calc_hmolar_residual() {
         return gas_constant() * _T * (tau() * dalphar_dTau() + delta() * dalphar_dDelta());
     }
     CoolPropDbl calc_hmolar_nocache(CoolPropDbl T, CoolPropDbl rhomolar);
 
     CoolPropDbl calc_umolar_nocache(CoolPropDbl T, CoolPropDbl rhomolar);
-    CoolPropDbl calc_umolar(void);
-    CoolPropDbl calc_speed_sound(void);
+    CoolPropDbl calc_umolar();
+    CoolPropDbl calc_speed_sound();
 
     void calc_excess_properties();
 
@@ -468,73 +468,73 @@ class HelmholtzEOSMixtureBackend : public AbstractState
      *
      */
 
-    CoolPropDbl calc_phase_identification_parameter(void);
+    CoolPropDbl calc_phase_identification_parameter();
     CoolPropDbl calc_fugacity(std::size_t i);
     virtual CoolPropDbl calc_fugacity_coefficient(std::size_t i);
     CoolPropDbl calc_chemical_potential(std::size_t i);
 
     /// Using this backend, calculate the flame hazard
-    CoolPropDbl calc_flame_hazard(void) {
+    CoolPropDbl calc_flame_hazard() {
         return components[0].environment.FH;
     };
     /// Using this backend, calculate the health hazard
-    CoolPropDbl calc_health_hazard(void) {
+    CoolPropDbl calc_health_hazard() {
         return components[0].environment.HH;
     };
     /// Using this backend, calculate the physical hazard
-    CoolPropDbl calc_physical_hazard(void) {
+    CoolPropDbl calc_physical_hazard() {
         return components[0].environment.PH;
     };
 
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r\f$ (dimensionless)
-    CoolPropDbl calc_alphar(void);
+    CoolPropDbl calc_alphar();
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta}\f$ (dimensionless)
-    CoolPropDbl calc_dalphar_dDelta(void);
+    CoolPropDbl calc_dalphar_dDelta();
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau}\f$ (dimensionless)
-    CoolPropDbl calc_dalphar_dTau(void);
+    CoolPropDbl calc_dalphar_dTau();
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta}\f$ (dimensionless)
-    CoolPropDbl calc_d2alphar_dDelta2(void);
+    CoolPropDbl calc_d2alphar_dDelta2();
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d2alphar_dDelta_dTau(void);
+    CoolPropDbl calc_d2alphar_dDelta_dTau();
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d2alphar_dTau2(void);
+    CoolPropDbl calc_d2alphar_dTau2();
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\delta}\f$ (dimensionless)
-    CoolPropDbl calc_d3alphar_dDelta3(void);
+    CoolPropDbl calc_d3alphar_dDelta3();
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d3alphar_dDelta2_dTau(void);
+    CoolPropDbl calc_d3alphar_dDelta2_dTau();
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d3alphar_dDelta_dTau2(void);
+    CoolPropDbl calc_d3alphar_dDelta_dTau2();
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d3alphar_dTau3(void);
+    CoolPropDbl calc_d3alphar_dTau3();
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\delta\delta}\f$ (dimensionless)
-    CoolPropDbl calc_d4alphar_dDelta4(void);
+    CoolPropDbl calc_d4alphar_dDelta4();
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\delta\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d4alphar_dDelta3_dTau(void);
+    CoolPropDbl calc_d4alphar_dDelta3_dTau();
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d4alphar_dDelta2_dTau2(void);
+    CoolPropDbl calc_d4alphar_dDelta2_dTau2();
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d4alphar_dDelta_dTau3(void);
+    CoolPropDbl calc_d4alphar_dDelta_dTau3();
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d4alphar_dTau4(void);
+    CoolPropDbl calc_d4alphar_dTau4();
 
-    CoolPropDbl calc_alpha0(void);
-    CoolPropDbl calc_dalpha0_dDelta(void);
-    CoolPropDbl calc_dalpha0_dTau(void);
-    CoolPropDbl calc_d2alpha0_dDelta2(void);
-    CoolPropDbl calc_d2alpha0_dDelta_dTau(void);
-    CoolPropDbl calc_d2alpha0_dTau2(void);
-    CoolPropDbl calc_d3alpha0_dDelta3(void);
-    CoolPropDbl calc_d3alpha0_dDelta2_dTau(void);
-    CoolPropDbl calc_d3alpha0_dDelta_dTau2(void);
-    CoolPropDbl calc_d3alpha0_dTau3(void);
+    CoolPropDbl calc_alpha0();
+    CoolPropDbl calc_dalpha0_dDelta();
+    CoolPropDbl calc_dalpha0_dTau();
+    CoolPropDbl calc_d2alpha0_dDelta2();
+    CoolPropDbl calc_d2alpha0_dDelta_dTau();
+    CoolPropDbl calc_d2alpha0_dTau2();
+    CoolPropDbl calc_d3alpha0_dDelta3();
+    CoolPropDbl calc_d3alpha0_dDelta2_dTau();
+    CoolPropDbl calc_d3alpha0_dDelta_dTau2();
+    CoolPropDbl calc_d3alpha0_dTau3();
 
-    CoolPropDbl calc_surface_tension(void);
-    CoolPropDbl calc_viscosity(void);
-    CoolPropDbl calc_viscosity_dilute(void);
-    CoolPropDbl calc_viscosity_background(void);
+    CoolPropDbl calc_surface_tension();
+    CoolPropDbl calc_viscosity();
+    CoolPropDbl calc_viscosity_dilute();
+    CoolPropDbl calc_viscosity_background();
     CoolPropDbl calc_viscosity_background(CoolPropDbl eta_dilute, CoolPropDbl& initial_density, CoolPropDbl& residual);
-    CoolPropDbl calc_conductivity(void);
-    CoolPropDbl calc_conductivity_background(void);
+    CoolPropDbl calc_conductivity();
+    CoolPropDbl calc_conductivity_background();
 
     /**
      * \brief Calculate each of the contributions to the viscosity
@@ -552,40 +552,40 @@ class HelmholtzEOSMixtureBackend : public AbstractState
     CoolPropDbl calc_saturated_liquid_keyed_output(parameters key);
     CoolPropDbl calc_saturated_vapor_keyed_output(parameters key);
 
-    CoolPropDbl calc_Tmin(void);
-    CoolPropDbl calc_Tmax(void);
-    CoolPropDbl calc_pmax(void);
-    CoolPropDbl calc_Ttriple(void);
-    CoolPropDbl calc_p_triple(void);
-    CoolPropDbl calc_pmax_sat(void);
-    CoolPropDbl calc_Tmax_sat(void);
+    CoolPropDbl calc_Tmin();
+    CoolPropDbl calc_Tmax();
+    CoolPropDbl calc_pmax();
+    CoolPropDbl calc_Ttriple();
+    CoolPropDbl calc_p_triple();
+    CoolPropDbl calc_pmax_sat();
+    CoolPropDbl calc_Tmax_sat();
     void calc_Tmin_sat(CoolPropDbl& Tmin_satL, CoolPropDbl& Tmin_satV);
     void calc_pmin_sat(CoolPropDbl& pmin_satL, CoolPropDbl& pmin_satV);
 
-    virtual CoolPropDbl calc_T_critical(void);
-    virtual CoolPropDbl calc_p_critical(void);
-    virtual CoolPropDbl calc_rhomolar_critical(void);
+    virtual CoolPropDbl calc_T_critical();
+    virtual CoolPropDbl calc_p_critical();
+    virtual CoolPropDbl calc_rhomolar_critical();
 
-    CoolPropDbl calc_T_reducing(void) {
+    CoolPropDbl calc_T_reducing() {
         return get_reducing_state().T;
     };
-    CoolPropDbl calc_rhomolar_reducing(void) {
+    CoolPropDbl calc_rhomolar_reducing() {
         return get_reducing_state().rhomolar;
     };
-    CoolPropDbl calc_p_reducing(void) {
+    CoolPropDbl calc_p_reducing() {
         return get_reducing_state().p;
     };
 
     // Calculate the phase identification parameter of Venkatarathnam et al, Fluid Phase Equilibria
-    CoolPropDbl calc_PIP(void) {
+    CoolPropDbl calc_PIP() {
         return 2
                - rhomolar()
                    * (second_partial_deriv(iP, iDmolar, iT, iT, iDmolar) / first_partial_deriv(iP, iT, iDmolar)
                       - second_partial_deriv(iP, iDmolar, iT, iDmolar, iT) / first_partial_deriv(iP, iDmolar, iT));
     };
 
-    std::string calc_name(void);
-    std::vector<std::string> calc_fluid_names(void);
+    std::string calc_name();
+    std::vector<std::string> calc_fluid_names();
 
     void calc_all_alphar_deriv_cache(const std::vector<CoolPropDbl>& mole_fractions, const CoolPropDbl& tau, const CoolPropDbl& delta);
     virtual CoolPropDbl calc_alphar_deriv_nocache(const int nTau, const int nDelta, const std::vector<CoolPropDbl>& mole_fractions,
@@ -621,7 +621,7 @@ class HelmholtzEOSMixtureBackend : public AbstractState
     HelmholtzDerivatives calc_all_alpha0_derivs_nocache(const std::vector<CoolPropDbl>& mole_fractions, const CoolPropDbl& tau,
                                                         const CoolPropDbl& delta, const CoolPropDbl& Tr, const CoolPropDbl& rhor);
 
-    virtual void calc_reducing_state(void);
+    virtual void calc_reducing_state();
     virtual SimpleState calc_reducing_state_nocache(const std::vector<CoolPropDbl>& mole_fractions);
 
     const CoolProp::SimpleState& get_reducing_state() {
@@ -631,7 +631,7 @@ class HelmholtzEOSMixtureBackend : public AbstractState
 
     void update_states();
 
-    CoolPropDbl calc_compressibility_factor(void) {
+    CoolPropDbl calc_compressibility_factor() {
         return 1 + delta() * dalphar_dDelta();
     };
 
@@ -828,8 +828,8 @@ class ResidualHelmholtz
     ExcessTerm Excess;
     CorrespondingStatesTerm CS;
 
-    ResidualHelmholtz(){};
-    ResidualHelmholtz(const ExcessTerm& E, const CorrespondingStatesTerm& C) : Excess(E), CS(C){};
+    ResidualHelmholtz() {};
+    ResidualHelmholtz(const ExcessTerm& E, const CorrespondingStatesTerm& C) : Excess(E), CS(C) {};
     virtual ~ResidualHelmholtz() = default;
 
     ResidualHelmholtz copy() {

--- a/src/Backends/IF97/IF97Backend.h
+++ b/src/Backends/IF97/IF97Backend.h
@@ -22,18 +22,18 @@ class IF97Backend : public AbstractState
 
    public:
     /// The name of the backend being used
-    std::string backend_name(void) {
+    std::string backend_name() {
         return get_backend_string(IF97_BACKEND);
     }
 
     // REQUIRED BUT NOT USED IN IF97 FUNCTIONS
-    bool using_mole_fractions(void) {
+    bool using_mole_fractions() {
         return false;
     };
-    bool using_mass_fractions(void) {
+    bool using_mass_fractions() {
         return true;
     };  // But actually it doesn't matter since it is only a pure fluid
-    bool using_volu_fractions(void) {
+    bool using_volu_fractions() {
         return false;
     };
     void set_mole_fractions(const std::vector<CoolPropDbl>& mole_fractions) {
@@ -43,7 +43,7 @@ class IF97Backend : public AbstractState
     void set_volu_fractions(const std::vector<CoolPropDbl>& volu_fractions) {
         throw NotImplementedError("Volume composition has not been implemented.");
     };
-    const std::vector<CoolPropDbl>& get_mole_fractions(void) {
+    const std::vector<CoolPropDbl>& get_mole_fractions() {
         throw NotImplementedError("get_mole_fractions composition has not been implemented.");
     };
 
@@ -415,111 +415,111 @@ class IF97Backend : public AbstractState
         }
     }
     /// Return the mass density in kg/m³
-    double rhomass(void) {
+    double rhomass() {
         return calc_rhomass();
     };
-    double calc_rhomass(void) {
+    double calc_rhomass() {
         return calc_Flash(iDmass);
     };
     /// Return the molar density in mol/m³
-    double rhomolar(void) {
+    double rhomolar() {
         return calc_rhomolar();
     };
-    double calc_rhomolar(void) {
+    double calc_rhomolar() {
         return rhomass() / molar_mass();
     };  /// kg/m³ * mol/kg = mol/m³
 
     /// Return the mass enthalpy in J/kg
-    double hmass(void) {
+    double hmass() {
         return calc_hmass();
     };
-    double calc_hmass(void) {
+    double calc_hmass() {
         if (_reverse && _smass)
             return IF97::hmass_psmass(_p, _smass);  // Special IF97 function for handling reverse h(p,s) evaluation
         else
             return calc_Flash(iHmass);
     };
     /// Return the molar enthalpy in J/mol
-    double hmolar(void) {
+    double hmolar() {
         return calc_hmolar();
     };
-    double calc_hmolar(void) {
+    double calc_hmolar() {
         return hmass() * molar_mass();
     };  /// J/kg * kg/mol = J/mol
 
     /// Return the mass entropy in J/kg/K
-    double smass(void) {
+    double smass() {
         return calc_smass();
     };
-    double calc_smass(void) {
+    double calc_smass() {
         if (_reverse && _hmass)
             return IF97::smass_phmass(_p, _hmass);  // Special IF97 function for handling reverse s(p,h) evaluation
         else
             return calc_Flash(iSmass);
     };
     /// Return the molar entropy in J/mol/K
-    double smolar(void) {
+    double smolar() {
         return calc_smolar();
     };
-    double calc_smolar(void) {
+    double calc_smolar() {
         return smass() * molar_mass();
     };  /// J/kg-K * kg/mol = J/mol-K
 
     /// Return the mass internal energy in J/kg
-    double umass(void) {
+    double umass() {
         return calc_umass();
     };
-    double calc_umass(void) {
+    double calc_umass() {
         return calc_Flash(iUmass);
     };
     /// Return the molar internal energy in J/mol
-    double umolar(void) {
+    double umolar() {
         return calc_umolar();
     };
-    double calc_umolar(void) {
+    double calc_umolar() {
         return umass() * molar_mass();
     };  /// J/kg * kg/mol = J/mol
 
     /// Return the mass-based constant pressure specific heat in J/kg/K
-    double cpmass(void) {
+    double cpmass() {
         return calc_cpmass();
     };
-    double calc_cpmass(void) {
+    double calc_cpmass() {
         return calc_Flash(iCpmass);
     };
     /// Return the molar-based constant pressure specific heat in J/mol/K
-    double cpmolar(void) {
+    double cpmolar() {
         return calc_cpmolar();
     };
-    double calc_cpmolar(void) {
+    double calc_cpmolar() {
         return cpmass() * molar_mass();
     };  /// J/kg-K * kg/mol = J/mol-K
 
     /// Return the mass-based constant volume specific heat in J/kg/K
-    double cvmass(void) {
+    double cvmass() {
         return calc_cvmass();
     };
-    double calc_cvmass(void) {
+    double calc_cvmass() {
         return calc_Flash(iCvmass);
     };
     /// Return the molar-based constant volume specific heat in J/mol/K
-    double cvmolar(void) {
+    double cvmolar() {
         return calc_cvmolar();
     };
-    double calc_cvmolar(void) {
+    double calc_cvmolar() {
         return cvmass() * molar_mass();
     };  /// J/kg-K * kg/mol = J/mol-K
 
     /// Return the speed of sound in m/s
-    double speed_sound(void) {
+    double speed_sound() {
         return calc_speed_sound();
     };
-    double calc_speed_sound(void) {
+    double calc_speed_sound() {
         return calc_Flash(ispeed_sound);
     };
 
     // Return the phase
-    phases calc_phase(void) {
+    phases calc_phase() {
         return _phase;
     };
 
@@ -529,62 +529,62 @@ class IF97Backend : public AbstractState
     // ************************************************************************* //
     //
     /// Using this backend, get the triple point temperature in K
-    double calc_Ttriple(void) {
+    double calc_Ttriple() {
         return IF97::get_Ttrip();
     };
     /// Using this backend, get the triple point pressure in Pa
-    double calc_p_triple(void) {
+    double calc_p_triple() {
         return IF97::get_ptrip();
     };
     /// Using this backend, get the critical point temperature in K
-    double calc_T_critical(void) {
+    double calc_T_critical() {
         return IF97::get_Tcrit();
     };
     /// Using this backend, get the critical point pressure in Pa
-    double calc_p_critical(void) {
+    double calc_p_critical() {
         return IF97::get_pcrit();
     };
     /// Using this backend, get the ideal gas constant in J/mol*K
     /// ==> multiplies IF97 Rgas by molar_mass() to put on molar basis per CoolProp convention
-    double calc_gas_constant(void) {
+    double calc_gas_constant() {
         return IF97::get_Rgas() * molar_mass();
     };
     /// Using this backend, get the molar mass in kg/mol
-    double calc_molar_mass(void) {
+    double calc_molar_mass() {
         return IF97::get_MW();
     };
     /// Using this backend, get the acentric factor (unitless)
-    double calc_acentric_factor(void) {
+    double calc_acentric_factor() {
         return IF97::get_Acentric();
     };
     /// Using this backend, get the high pressure limit in Pa
     // TODO: May want to adjust this based on _T, since Region 5
     //       is limited to 50 MPa, instead of 100 MPa elsewhere.
-    double calc_pmax(void) {
+    double calc_pmax() {
         return IF97::get_Pmax();
     };
     /// Note: Pmin not implemented in Abstract State or CoolProp
     /// Using this backend, get the high temperature limit in K
-    double calc_Tmax(void) {
+    double calc_Tmax() {
         return IF97::get_Tmax();
     };
     /// Using this backend, get the high pressure limit in K
-    double calc_Tmin(void) {
+    double calc_Tmin() {
         return IF97::get_Tmin();
     };
     /// Using this backend, get the critical point density in kg/m³
     /// Replace molar-based AbstractState functions since IF97 is mass based only
-    double rhomolar_critical(void) {
+    double rhomolar_critical() {
         return calc_rhomass_critical() / molar_mass();
     }
-    double rhomass_critical(void) {
+    double rhomass_critical() {
         return calc_rhomass_critical();
     }
     // Overwrite the virtual calc_ functions for density
-    double calc_rhomolar_critical(void) {
+    double calc_rhomolar_critical() {
         return rhomass_critical() / molar_mass();
     };
-    double calc_rhomass_critical(void) {
+    double calc_rhomass_critical() {
         return IF97::get_rhocrit();
     };
     //
@@ -592,7 +592,7 @@ class IF97Backend : public AbstractState
     //                      Saturation Functions                                 //
     // ************************************************************************* //
     //
-    double calc_pressure(void) {
+    double calc_pressure() {
         return _p;
     };
     //
@@ -601,28 +601,28 @@ class IF97Backend : public AbstractState
     // ************************************************************************* //
     //
     // Return viscosity in [Pa-s]
-    double viscosity(void) {
+    double viscosity() {
         return calc_viscosity();
     };
-    double calc_viscosity(void) {
+    double calc_viscosity() {
         return calc_Flash(iviscosity);
     };
     // Return thermal conductivity in [W/m-K]
-    double conductivity(void) {
+    double conductivity() {
         return calc_conductivity();
     };
-    double calc_conductivity(void) {
+    double calc_conductivity() {
         return calc_Flash(iconductivity);
     };
     // Return surface tension in [N/m]
-    double surface_tension(void) {
+    double surface_tension() {
         return calc_surface_tension();
     };
-    double calc_surface_tension(void) {
+    double calc_surface_tension() {
         return calc_Flash(isurface_tension);
     };
     // Return Prandtl number (mu*Cp/k) [dimensionless]
-    double Prandtl(void) {
+    double Prandtl() {
         return calc_Flash(iPrandtl);
     };
 };

--- a/src/Backends/Incompressible/IncompressibleBackend.cpp
+++ b/src/Backends/Incompressible/IncompressibleBackend.cpp
@@ -295,93 +295,93 @@ void IncompressibleBackend::check_status() {
  *  We also have a few new chaced variables that we need.
  */
 /// Return the mass density in kg/m^3
-double IncompressibleBackend::rhomass(void) {
+double IncompressibleBackend::rhomass() {
     if (!_rhomass) _rhomass = calc_rhomass();
     return _rhomass;
 }
 /// Return the mass enthalpy in J/kg
-double IncompressibleBackend::hmass(void) {
+double IncompressibleBackend::hmass() {
     if (!_hmass) _hmass = calc_hmass();
     return _hmass;
 }
 /// Return the molar entropy in J/mol/K
-double IncompressibleBackend::smass(void) {
+double IncompressibleBackend::smass() {
     if (!_smass) _smass = calc_smass();
     return _smass;
 }
 /// Return the molar internal energy in J/mol
-double IncompressibleBackend::umass(void) {
+double IncompressibleBackend::umass() {
     if (!_umass) _umass = calc_umass();
     return _umass;
 }
 /// Return the mass constant pressure specific heat in J/kg/K
-double IncompressibleBackend::cmass(void) {
+double IncompressibleBackend::cmass() {
     if (!_cmass) _cmass = calc_cmass();
     return _cmass;
 }
 
-double IncompressibleBackend::drhodTatPx(void) {
+double IncompressibleBackend::drhodTatPx() {
     if (!_drhodTatPx) _drhodTatPx = calc_drhodTatPx(_T, _p, _fractions[0]);
     return _drhodTatPx;
 }
-double IncompressibleBackend::dsdTatPx(void) {
+double IncompressibleBackend::dsdTatPx() {
     if (!_dsdTatPx) _dsdTatPx = calc_dsdTatPx(_T, _p, _fractions[0]);
     return _dsdTatPx;
 }
-double IncompressibleBackend::dhdTatPx(void) {
+double IncompressibleBackend::dhdTatPx() {
     if (!_dhdTatPx) _dhdTatPx = calc_dhdTatPx(_T, _p, _fractions[0]);
     return _dhdTatPx;
 }
-double IncompressibleBackend::dsdTatPxdT(void) {
+double IncompressibleBackend::dsdTatPxdT() {
     if (!_dsdTatPxdT) _dsdTatPxdT = calc_dsdTatPxdT(_T, _p, _fractions[0]);
     return _dsdTatPxdT;
 }
-double IncompressibleBackend::dhdTatPxdT(void) {
+double IncompressibleBackend::dhdTatPxdT() {
     if (!_dhdTatPxdT) _dhdTatPxdT = calc_dhdTatPxdT(_T, _p, _fractions[0]);
     return _dhdTatPxdT;
 }
-double IncompressibleBackend::dsdpatTx(void) {
+double IncompressibleBackend::dsdpatTx() {
     if (!_dsdpatTx) _dsdpatTx = calc_dsdpatTx(rhomass(), drhodTatPx());
     return _dsdpatTx;
 }
-double IncompressibleBackend::dhdpatTx(void) {
+double IncompressibleBackend::dhdpatTx() {
     if (!_dhdpatTx) _dhdpatTx = calc_dhdpatTx(_T, rhomass(), drhodTatPx());
     return _dhdpatTx;
 }
 
 /// Return the temperature in K
-double IncompressibleBackend::T_ref(void) {
+double IncompressibleBackend::T_ref() {
     if (!_T_ref) throw ValueError("Reference temperature is not set");
     return _T_ref;
 }
 /// Return the pressure in Pa
-double IncompressibleBackend::p_ref(void) {
+double IncompressibleBackend::p_ref() {
     if (!_p_ref) throw ValueError("Reference pressure is not set");
     return _p_ref;
 }
 /// Return the composition
-double IncompressibleBackend::x_ref(void) {
+double IncompressibleBackend::x_ref() {
     if (!_x_ref) throw ValueError("Reference composition is not set");
     return _x_ref;
 }
 /// Return the mass enthalpy in J/kg
-double IncompressibleBackend::h_ref(void) {
+double IncompressibleBackend::h_ref() {
     if (!_h_ref) throw ValueError("Reference enthalpy is not set");
     return _h_ref;
 }
 /// Return the molar entropy in J/mol/K
-double IncompressibleBackend::s_ref(void) {
+double IncompressibleBackend::s_ref() {
     if (!_s_ref) throw ValueError("Reference entropy is not set");
     return _s_ref;
 }
 
 /// Return the mass enthalpy in J/kg
-double IncompressibleBackend::hmass_ref(void) {
+double IncompressibleBackend::hmass_ref() {
     if (!_hmass_ref) _hmass_ref = raw_calc_hmass(T_ref(), p_ref(), x_ref());
     return _hmass_ref;
 }
 /// Return the molar entropy in J/mol/K
-double IncompressibleBackend::smass_ref(void) {
+double IncompressibleBackend::smass_ref() {
     if (!_smass_ref) _smass_ref = raw_calc_smass(T_ref(), p_ref(), x_ref());
     return _smass_ref;
 }
@@ -499,15 +499,15 @@ CoolPropDbl IncompressibleBackend::calc_melting_line(int param, int given, CoolP
         throw ValueError("For incompressibles, the only valid inputs to calc_melting_line are T(p)");
     }
 };
-CoolPropDbl IncompressibleBackend::calc_umass(void) {
+CoolPropDbl IncompressibleBackend::calc_umass() {
     return hmass() - _p / rhomass();
 };
 
 /// ... and continue with the ones that depend on reference conditions.
-CoolPropDbl IncompressibleBackend::calc_hmass(void) {
+CoolPropDbl IncompressibleBackend::calc_hmass() {
     return h_ref() + raw_calc_hmass(_T, _p, _fractions[0]) - hmass_ref();
 };
-CoolPropDbl IncompressibleBackend::calc_smass(void) {
+CoolPropDbl IncompressibleBackend::calc_smass() {
     return s_ref() + raw_calc_smass(_T, _p, _fractions[0]) - smass_ref();
 };
 

--- a/src/Backends/Incompressible/IncompressibleBackend.h
+++ b/src/Backends/Incompressible/IncompressibleBackend.h
@@ -38,7 +38,7 @@ class IncompressibleBackend : public AbstractState
    public:
     IncompressibleBackend();
     virtual ~IncompressibleBackend() {};
-    std::string backend_name(void) {
+    std::string backend_name() {
         return get_backend_string(INCOMP_BACKEND);
     }
 
@@ -53,13 +53,13 @@ class IncompressibleBackend : public AbstractState
     IncompressibleBackend(const std::vector<std::string>& component_names);
 
     // Incompressible backend uses different compositions
-    bool using_mole_fractions(void) {
+    bool using_mole_fractions() {
         return this->fluid->getxid() == IFRAC_MOLE;
     };
-    bool using_mass_fractions(void) {
+    bool using_mass_fractions() {
         return (this->fluid->getxid() == IFRAC_MASS || this->fluid->getxid() == IFRAC_PURE);
     };
-    bool using_volu_fractions(void) {
+    bool using_volu_fractions() {
         return this->fluid->getxid() == IFRAC_VOLUME;
     };
 
@@ -93,7 +93,7 @@ class IncompressibleBackend : public AbstractState
     @param mole_fractions The vector of mole fractions of the components
     */
     void set_mole_fractions(const std::vector<CoolPropDbl>& mole_fractions);
-    const std::vector<CoolPropDbl>& get_mole_fractions(void) {
+    const std::vector<CoolPropDbl>& get_mole_fractions() {
         throw NotImplementedError("get_mole_fractions not implemented for this backend");
     };
 
@@ -118,39 +118,39 @@ class IncompressibleBackend : public AbstractState
 	 *  We also have a few new chaced variables that we need.
 	 */
     /// Return the mass density in kg/m^3
-    double rhomass(void);
+    double rhomass();
     /// Return the mass enthalpy in J/kg
-    double hmass(void);
+    double hmass();
     /// Return the molar entropy in J/mol/K
-    double smass(void);
+    double smass();
     /// Return the molar internal energy in J/mol
-    double umass(void);
+    double umass();
     /// Return the mass constant pressure specific heat in J/kg/K
-    double cmass(void);
+    double cmass();
 
-    double drhodTatPx(void);
-    double dsdTatPx(void);
-    double dhdTatPx(void);
-    double dsdTatPxdT(void);
-    double dhdTatPxdT(void);
-    double dsdpatTx(void);
-    double dhdpatTx(void);
+    double drhodTatPx();
+    double dsdTatPx();
+    double dhdTatPx();
+    double dsdTatPxdT();
+    double dhdTatPxdT();
+    double dsdpatTx();
+    double dhdpatTx();
 
     /// Return the temperature in K
-    double T_ref(void);
+    double T_ref();
     /// Return the pressure in Pa
-    double p_ref(void);
+    double p_ref();
     /// Return the composition
-    double x_ref(void);
+    double x_ref();
     /// Return the mass enthalpy in J/kg
-    double h_ref(void);
+    double h_ref();
     /// Return the molar entropy in J/mol/K
-    double s_ref(void);
+    double s_ref();
 
     /// Return the mass enthalpy in J/kg
-    double hmass_ref(void);
+    double hmass_ref();
     /// Return the molar entropy in J/mol/K
-    double smass_ref(void);
+    double smass_ref();
 
     /** These functions should be protected, but that requires new tests.
      *  I'll leave that as a TODO item for now.
@@ -185,58 +185,58 @@ class IncompressibleBackend : public AbstractState
     // exception with a helpful pointer at the mass-basis equivalents
     // instead of silently returning the AbstractState default
     // (-_HUGE) which surfaced as "PropsSI failed ungracefully".
-    CoolPropDbl calc_molar_mass(void) override {
+    CoolPropDbl calc_molar_mass() override {
         throw NotImplementedError("Molar mass is not defined for the INCOMP (incompressible) backend; INCOMP fluids are mass-based.");
     }
-    CoolPropDbl calc_rhomolar(void) override {
+    CoolPropDbl calc_rhomolar() override {
         throw NotImplementedError("Dmolar / rhomolar is not defined for the INCOMP backend; use Dmass / rhomass instead.");
     }
-    CoolPropDbl calc_hmolar(void) override {
+    CoolPropDbl calc_hmolar() override {
         throw NotImplementedError("Hmolar / hmolar is not defined for the INCOMP backend; use Hmass / hmass instead.");
     }
-    CoolPropDbl calc_smolar(void) override {
+    CoolPropDbl calc_smolar() override {
         throw NotImplementedError("Smolar / smolar is not defined for the INCOMP backend; use Smass / smass instead.");
     }
-    CoolPropDbl calc_umolar(void) override {
+    CoolPropDbl calc_umolar() override {
         throw NotImplementedError("Umolar / umolar is not defined for the INCOMP backend; use Umass / umass instead.");
     }
-    CoolPropDbl calc_cpmolar(void) override {
+    CoolPropDbl calc_cpmolar() override {
         throw NotImplementedError("Cpmolar / cpmolar is not defined for the INCOMP backend; use Cpmass / cpmass instead.");
     }
-    CoolPropDbl calc_cvmolar(void) override {
+    CoolPropDbl calc_cvmolar() override {
         throw NotImplementedError("Cvmolar / cvmolar is not defined for the INCOMP backend; use Cvmass / cvmass instead.");
     }
 
     /// We start with the functions that do not need a reference state
-    CoolPropDbl calc_rhomass(void) {
+    CoolPropDbl calc_rhomass() {
         return fluid->rho(_T, _p, _fractions[0]);
     };
-    CoolPropDbl calc_cmass(void) {
+    CoolPropDbl calc_cmass() {
         return fluid->c(_T, _p, _fractions[0]);
     };
-    CoolPropDbl calc_cpmass(void) {
+    CoolPropDbl calc_cpmass() {
         return cmass();
     };
-    CoolPropDbl calc_cvmass(void) {
+    CoolPropDbl calc_cvmass() {
         return cmass();
     };
-    CoolPropDbl calc_viscosity(void) {
+    CoolPropDbl calc_viscosity() {
         return fluid->visc(_T, _p, _fractions[0]);
     };
-    CoolPropDbl calc_conductivity(void) {
+    CoolPropDbl calc_conductivity() {
         return fluid->cond(_T, _p, _fractions[0]);
     };
-    CoolPropDbl calc_T_freeze(void) {
+    CoolPropDbl calc_T_freeze() {
         // No update is called - T_freeze is a trivial output
         fluid->checkX(_fractions[0]);
         return fluid->Tfreeze(_p, _fractions[0]);
     };
     CoolPropDbl calc_melting_line(int param, int given, CoolPropDbl value);
-    CoolPropDbl calc_umass(void);
+    CoolPropDbl calc_umass();
 
     /// ... and continue with the ones that depend on reference conditions.
-    CoolPropDbl calc_hmass(void);
-    CoolPropDbl calc_smass(void);
+    CoolPropDbl calc_hmass();
+    CoolPropDbl calc_smass();
 
    public:
     /// Functions that can be used with the solver, they miss the reference values!
@@ -287,22 +287,22 @@ class IncompressibleBackend : public AbstractState
 
    public:
     /// Constants from the fluid object
-    CoolPropDbl calc_Tmax(void) {
+    CoolPropDbl calc_Tmax() {
         return fluid->getTmax();
     };
-    CoolPropDbl calc_Tmin(void) {
+    CoolPropDbl calc_Tmin() {
         return fluid->getTmin();
     };
-    CoolPropDbl calc_fraction_min(void) {
+    CoolPropDbl calc_fraction_min() {
         return fluid->getxmin();
     };
-    CoolPropDbl calc_fraction_max(void) {
+    CoolPropDbl calc_fraction_max() {
         return fluid->getxmax();
     };
-    std::string calc_name(void) {
+    std::string calc_name() {
         return fluid->getName();
     };
-    std::string calc_description(void) {
+    std::string calc_description() {
         return fluid->getDescription();
     };
 };

--- a/src/Backends/Incompressible/IncompressibleLibrary.cpp
+++ b/src/Backends/Incompressible/IncompressibleLibrary.cpp
@@ -568,7 +568,7 @@ void load_incompressible_library() {
     //library.add_obj(LiBrSolution());
 }
 
-JSONIncompressibleLibrary& get_incompressible_library(void) {
+JSONIncompressibleLibrary& get_incompressible_library() {
     ensure_library_loaded();
     return library;
 }
@@ -578,11 +578,11 @@ IncompressibleFluid& get_incompressible_fluid(const std::string& fluid_string) {
     return library.get(fluid_string);
 }
 
-std::string get_incompressible_list_pure(void) {
+std::string get_incompressible_list_pure() {
     ensure_library_loaded();
     return library.get_incompressible_list_pure();
 };
-std::string get_incompressible_list_solution(void) {
+std::string get_incompressible_list_solution() {
     ensure_library_loaded();
     return library.get_incompressible_list_solution();
 };

--- a/src/Backends/Incompressible/IncompressibleLibrary.h
+++ b/src/Backends/Incompressible/IncompressibleLibrary.h
@@ -157,7 +157,7 @@ class JSONIncompressibleLibrary
     JSONIncompressibleLibrary();
     ~JSONIncompressibleLibrary();
 
-    bool is_empty(void) {
+    bool is_empty() {
         return _is_empty;
     };
 
@@ -179,23 +179,23 @@ class JSONIncompressibleLibrary
     IncompressibleFluid& get(std::size_t key);
 
     /// Return a comma-separated list of incompressible pure fluid names
-    std::string get_incompressible_list_pure(void) {
+    std::string get_incompressible_list_pure() {
         return strjoin(name_vector_pure, ",");
     };
     /// Return a comma-separated list of solution names
-    std::string get_incompressible_list_solution(void) {
+    std::string get_incompressible_list_solution() {
         return strjoin(name_vector_solution, ",");
     };
 };
 
 /// Get a reference to the library instance
-JSONIncompressibleLibrary& get_incompressible_library(void);
+JSONIncompressibleLibrary& get_incompressible_library();
 
 /// Return a comma-separated list of incompressible pure fluid names
-std::string get_incompressible_list_pure(void);
+std::string get_incompressible_list_pure();
 
 /// Return a comma-separated list of solution names
-std::string get_incompressible_list_solution(void);
+std::string get_incompressible_list_solution();
 
 /// Get the fluid structure returned as a reference
 IncompressibleFluid& get_incompressible_fluid(const std::string& fluid_string);

--- a/src/Backends/PCSAFT/PCSAFTBackend.cpp
+++ b/src/Backends/PCSAFT/PCSAFTBackend.cpp
@@ -234,7 +234,7 @@ CoolPropDbl PCSAFTBackend::update_DmolarT(CoolPropDbl rho) {
     return this->calc_pressure();
 }
 
-CoolPropDbl PCSAFTBackend::calc_pressure(void) {
+CoolPropDbl PCSAFTBackend::calc_pressure() {
     double den = _rhomolar * N_AV / 1.0e30;
 
     CoolPropDbl Z = this->calc_compressibility_factor();
@@ -242,7 +242,7 @@ CoolPropDbl PCSAFTBackend::calc_pressure(void) {
     return P;
 }
 
-CoolPropDbl PCSAFTBackend::calc_alphar(void) {
+CoolPropDbl PCSAFTBackend::calc_alphar() {
     auto ncomp = N;  // number of components
     vector<double> d(ncomp);
     for (auto i = 0U; i < ncomp; i++) {
@@ -512,7 +512,7 @@ CoolPropDbl PCSAFTBackend::calc_alphar(void) {
     return ares;
 }
 
-CoolPropDbl PCSAFTBackend::calc_dadt(void) {
+CoolPropDbl PCSAFTBackend::calc_dadt() {
     auto ncomp = N;  // number of components
     vector<double> d(ncomp), dd_dt(ncomp);
     for (auto i = 0U; i < ncomp; i++) {
@@ -842,7 +842,7 @@ CoolPropDbl PCSAFTBackend::calc_dadt(void) {
     return dadt;
 }
 
-CoolPropDbl PCSAFTBackend::calc_hmolar_residual(void) {
+CoolPropDbl PCSAFTBackend::calc_hmolar_residual() {
     CoolPropDbl Z = calc_compressibility_factor();
     CoolPropDbl dares_dt = calc_dadt();
 
@@ -850,7 +850,7 @@ CoolPropDbl PCSAFTBackend::calc_hmolar_residual(void) {
     return hres;
 }
 
-CoolPropDbl PCSAFTBackend::calc_smolar_residual(void) {
+CoolPropDbl PCSAFTBackend::calc_smolar_residual() {
     CoolPropDbl dares_dt = calc_dadt();
     CoolPropDbl ares = calc_alphar();
 
@@ -858,7 +858,7 @@ CoolPropDbl PCSAFTBackend::calc_smolar_residual(void) {
     return sres;
 }
 
-vector<CoolPropDbl> PCSAFTBackend::calc_fugacity_coefficients(void) {
+vector<CoolPropDbl> PCSAFTBackend::calc_fugacity_coefficients() {
     auto ncomp = N;  // number of components
     vector<double> d(ncomp);
     for (auto i = 0U; i < ncomp; i++) {
@@ -1348,7 +1348,7 @@ vector<CoolPropDbl> PCSAFTBackend::calc_fugacity_coefficients(void) {
     return fugcoef;
 }
 
-CoolPropDbl PCSAFTBackend::calc_gibbsmolar_residual(void) {
+CoolPropDbl PCSAFTBackend::calc_gibbsmolar_residual() {
     CoolPropDbl ares = calc_alphar();
     CoolPropDbl Z = calc_compressibility_factor();
 
@@ -1362,7 +1362,7 @@ CoolPropDbl PCSAFTBackend::calc_gibbsmolar_residual(void) {
     return gres;
 }
 
-CoolPropDbl PCSAFTBackend::calc_compressibility_factor(void) {
+CoolPropDbl PCSAFTBackend::calc_compressibility_factor() {
     auto ncomp = N;  // number of components
     vector<double> d(ncomp);
     for (auto i = 0UL; i < ncomp; i++) {
@@ -2866,7 +2866,7 @@ CoolPropDbl PCSAFTBackend::reduced_to_molar(CoolPropDbl nu, CoolPropDbl T) {
     return 6 / PI * nu / summ * 1.0e30 / N_AV;
 }
 
-CoolPropDbl PCSAFTBackend::calc_molar_mass(void) {
+CoolPropDbl PCSAFTBackend::calc_molar_mass() {
     double summer = 0;
     for (unsigned int i = 0; i < N; ++i) {
         summer += mole_fractions[i] * components[i].molar_mass();

--- a/src/Backends/PCSAFT/PCSAFTBackend.h
+++ b/src/Backends/PCSAFT/PCSAFTBackend.h
@@ -71,17 +71,17 @@ class PCSAFTBackend : public AbstractState
     virtual PCSAFTBackend* get_copy(bool generate_SatL_and_SatV = true);
 
     /// The name of the backend being used
-    std::string backend_name(void) {
+    std::string backend_name() {
         return get_backend_string(PCSAFT_BACKEND);
     }
 
-    bool using_mole_fractions(void) {
+    bool using_mole_fractions() {
         return true;
     };
-    bool using_mass_fractions(void) {
+    bool using_mass_fractions() {
         return false;
     };
-    bool using_volu_fractions(void) {
+    bool using_volu_fractions() {
         return false;
     };
 
@@ -90,7 +90,7 @@ class PCSAFTBackend : public AbstractState
         throw NotImplementedError("Volume composition has not been implemented.");
     };
     void set_mole_fractions(const std::vector<CoolPropDbl>& mole_fractions);
-    const std::vector<CoolPropDbl>& get_mole_fractions(void) {
+    const std::vector<CoolPropDbl>& get_mole_fractions() {
         return this->mole_fractions;
     };
 
@@ -121,26 +121,26 @@ class PCSAFTBackend : public AbstractState
     // ************************************************************************* //
     //
     /// Calculate the pressure
-    CoolPropDbl calc_pressure(void);
+    CoolPropDbl calc_pressure();
 
     /// Update the state for DT inputs if phase is imposed. Otherwise delegate to base class
     CoolPropDbl update_DmolarT(CoolPropDbl rho);
 
-    // CoolPropDbl calc_alpha0(void); // ideal gas helmholtz energy term
-    CoolPropDbl calc_alphar(void);  // residual helmholtz energy
-    CoolPropDbl calc_dadt(void);    // derivative of the residual helmholtz energy with respect to temperature
-    CoolPropDbl calc_hmolar_residual(void);
-    CoolPropDbl calc_smolar_residual(void);
-    vector<CoolPropDbl> calc_fugacity_coefficients(void);
-    CoolPropDbl calc_gibbsmolar_residual(void);
-    // CoolPropDbl calc_cpmolar(void); // TODO implement these heat capacity functions
-    // CoolPropDbl calc_cp0molar(void);
-    CoolPropDbl calc_compressibility_factor(void);
+    // CoolPropDbl calc_alpha0(); // ideal gas helmholtz energy term
+    CoolPropDbl calc_alphar();  // residual helmholtz energy
+    CoolPropDbl calc_dadt();    // derivative of the residual helmholtz energy with respect to temperature
+    CoolPropDbl calc_hmolar_residual();
+    CoolPropDbl calc_smolar_residual();
+    vector<CoolPropDbl> calc_fugacity_coefficients();
+    CoolPropDbl calc_gibbsmolar_residual();
+    // CoolPropDbl calc_cpmolar(); // TODO implement these heat capacity functions
+    // CoolPropDbl calc_cp0molar();
+    CoolPropDbl calc_compressibility_factor();
 
     void flash_QT(PCSAFTBackend& PCSAFT);
     void flash_PQ(PCSAFTBackend& PCSAFT);
 
-    phases calc_phase(void) {
+    phases calc_phase() {
         return _phase;
     };
     /** \brief Specify the phase - this phase will always be used in calculations
@@ -161,7 +161,7 @@ class PCSAFTBackend : public AbstractState
     //                         Trivial Functions                                 //
     // ************************************************************************* //
     //
-    double calc_molar_mass(void);
+    double calc_molar_mass();
     PhaseMolarMasses calc_phase_molar_masses() override;
     //
 };

--- a/src/Backends/PCSAFT/PCSAFTLibrary.cpp
+++ b/src/Backends/PCSAFT/PCSAFTLibrary.cpp
@@ -50,7 +50,7 @@ void add_fluids_from_JSON_string(PCSAFTLibraryClass& dest, const std::string_vie
 }
 }  // anonymous namespace
 
-PCSAFTLibraryClass& get_library(void) {
+PCSAFTLibraryClass& get_library() {
     // Function-local static (Meyers singleton): C++11 guarantees the
     // constructor runs exactly once even under concurrent first calls. The
     // previous namespace-scope `static PCSAFTLibraryClass library;` relied on

--- a/src/Backends/PCSAFT/PCSAFTLibrary.h
+++ b/src/Backends/PCSAFT/PCSAFTLibrary.h
@@ -56,7 +56,7 @@ void add_fluids_as_JSON(const std::string_view& JSON);
 /// Get the schema used to validate the PC-SAFT fluids
 std::string_view get_pcsaft_fluids_schema();
 
-PCSAFTLibraryClass& get_library(void);
+PCSAFTLibraryClass& get_library();
 }  // namespace PCSAFTLibrary
 } /* namespace CoolProp */
 

--- a/src/Backends/REFPROP/REFPROPBackend.h
+++ b/src/Backends/REFPROP/REFPROPBackend.h
@@ -23,7 +23,7 @@ class REFPROPBackend : public REFPROPMixtureBackend
    public:
     REFPROPBackend();
     REFPROPBackend(const std::string& fluid_name);
-    std::string backend_name(void) {
+    std::string backend_name() {
         return get_backend_string(REFPROP_BACKEND_PURE);
     }
 

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -769,7 +769,7 @@ void REFPROPMixtureBackend::set_mass_fractions(const std::vector<CoolPropDbl>& m
     }
     this->set_mole_fractions(moles);
 };
-void REFPROPMixtureBackend::check_status(void) {
+void REFPROPMixtureBackend::check_status() {
     if (!_mole_fractions_set) {
         throw ValueError("Mole fractions not yet set");
     }
@@ -806,17 +806,17 @@ void REFPROPMixtureBackend::limits(double& Tmin, double& Tmax, double& rhomolarm
     pmax = pmax_kPa * 1000;
     rhomolarmax = Dmax_mol_L * 1000;
 }
-CoolPropDbl REFPROPMixtureBackend::calc_pmax(void) {
+CoolPropDbl REFPROPMixtureBackend::calc_pmax() {
     double Tmin = NAN, Tmax = NAN, rhomolarmax = NAN, pmax = NAN;
     limits(Tmin, Tmax, rhomolarmax, pmax);
     return static_cast<CoolPropDbl>(pmax);
 };
-CoolPropDbl REFPROPMixtureBackend::calc_Tmax(void) {
+CoolPropDbl REFPROPMixtureBackend::calc_Tmax() {
     double Tmin = NAN, Tmax = NAN, rhomolarmax = NAN, pmax = NAN;
     limits(Tmin, Tmax, rhomolarmax, pmax);
     return static_cast<CoolPropDbl>(Tmax);
 };
-CoolPropDbl REFPROPMixtureBackend::calc_Tmin(void) {
+CoolPropDbl REFPROPMixtureBackend::calc_Tmin() {
     double Tmin = NAN, Tmax = NAN, rhomolarmax = NAN, pmax = NAN;
     limits(Tmin, Tmax, rhomolarmax, pmax);
     return static_cast<CoolPropDbl>(Tmin);
@@ -971,7 +971,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_gas_constant() {
     RMIX2dll(&(mole_fractions[0]), &Rmix);
     return static_cast<CoolPropDbl>(Rmix);
 };
-CoolPropDbl REFPROPMixtureBackend::calc_molar_mass(void) {
+CoolPropDbl REFPROPMixtureBackend::calc_molar_mass() {
     this->check_loaded_fluid();
     double wmm_kg_kmol = NAN;
     WMOLdll(&(mole_fractions[0]), &wmm_kg_kmol);  // returns mole mass in kg/kmol
@@ -1045,17 +1045,17 @@ void REFPROPMixtureBackend::update_Qmass_pair(CoolProp::input_pairs pair, double
     AbstractState::update_Qmass_pair(pair, v1, v2);
 }
 
-CoolPropDbl REFPROPMixtureBackend::calc_Bvirial(void) {
+CoolPropDbl REFPROPMixtureBackend::calc_Bvirial() {
     double b = NAN;
     VIRBdll(&_T, &(mole_fractions[0]), &b);
     return b * 0.001;  // 0.001 to convert from l/mol to m^3/mol
 }
-CoolPropDbl REFPROPMixtureBackend::calc_dBvirial_dT(void) {
+CoolPropDbl REFPROPMixtureBackend::calc_dBvirial_dT() {
     double b = NAN;
     DBDTdll(&_T, &(mole_fractions[0]), &b);
     return b * 0.001;  // 0.001 to convert from l/mol to m^3/mol
 }
-CoolPropDbl REFPROPMixtureBackend::calc_Cvirial(void) {
+CoolPropDbl REFPROPMixtureBackend::calc_Cvirial() {
     double c = NAN;
     VIRCdll(&_T, &(mole_fractions[0]), &c);
     return c * 1e-6;  // 1e-6 to convert from (l/mol)^2 to (m^3/mol)^2
@@ -1128,7 +1128,7 @@ const std::vector<CoolPropDbl> REFPROPMixtureBackend::calc_mass_fractions() {
     return mass_fractions;
 }
 
-CoolPropDbl REFPROPMixtureBackend::calc_PIP(void) {
+CoolPropDbl REFPROPMixtureBackend::calc_PIP() {
     // Calculate the PIP factor of Venkatharathnam and Oellrich, "Identification of the phase of a fluid using
     // partial derivatives of pressure, volume,and temperature without reference to saturation properties:
     // Applications in phase equilibria calculations"
@@ -1143,7 +1143,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_PIP(void) {
     return 2 - rho * (d2PdTD / dPT - d2PdD2 / dPdrho);
 };
 
-CoolPropDbl REFPROPMixtureBackend::calc_viscosity(void) {
+CoolPropDbl REFPROPMixtureBackend::calc_viscosity() {
     this->check_loaded_fluid();
     double eta = NAN, tcx = NAN, rhomol_L = 0.001 * _rhomolar;
     int ierr = 0;
@@ -1159,12 +1159,12 @@ CoolPropDbl REFPROPMixtureBackend::calc_viscosity(void) {
     _conductivity = tcx;
     return static_cast<double>(_viscosity);
 }
-CoolPropDbl REFPROPMixtureBackend::calc_conductivity(void) {
+CoolPropDbl REFPROPMixtureBackend::calc_conductivity() {
     // Calling viscosity also caches conductivity, use that to save calls
     calc_viscosity();
     return static_cast<double>(_conductivity);
 }
-CoolPropDbl REFPROPMixtureBackend::calc_surface_tension(void) {
+CoolPropDbl REFPROPMixtureBackend::calc_surface_tension() {
     this->check_loaded_fluid();
     double sigma = NAN, rho_mol_L = 0.001 * _rhomolar;
     int ierr = 0;
@@ -1320,7 +1320,7 @@ void REFPROPMixtureBackend::calc_phase_envelope(const std::string& type) {
         PhaseEnvelope.conductivity_vap.push_back(tcx);
     }
 }
-CoolPropDbl REFPROPMixtureBackend::calc_cpmolar_idealgas(void) {
+CoolPropDbl REFPROPMixtureBackend::calc_cpmolar_idealgas() {
     this->check_loaded_fluid();
     double rho_mol_L = 0.001 * _rhomolar;
     double p0 = NAN, e0 = NAN, h0 = NAN, s0 = NAN, cv0 = NAN, cp0 = NAN, w0 = NAN, A0 = NAN, G0 = NAN;

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.h
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.h
@@ -63,7 +63,7 @@ class REFPROPMixtureBackend : public AbstractState
     /// A function to actually do the initialization to allow it to be called in derived classes
     void construct(const std::vector<std::string>& fluid_names);
 
-    std::string backend_name(void) {
+    std::string backend_name() {
         return get_backend_string(REFPROP_BACKEND_MIX);
     }
     virtual ~REFPROPMixtureBackend();
@@ -110,7 +110,7 @@ class REFPROPMixtureBackend : public AbstractState
     }
 
     // Get _phase for pure fluids only
-    phases calc_phase(void) {
+    phases calc_phase() {
         if (this->Ncomp > 1) {
             throw NotImplementedError("The REFPROP backend does not implement calc_phase function for mixtures.");
         } else {
@@ -155,22 +155,22 @@ class REFPROPMixtureBackend : public AbstractState
      */
     void update_with_guesses(CoolProp::input_pairs, double value1, double value2, const GuessesStructure& guesses);
 
-    CoolPropDbl calc_molar_mass(void);
+    CoolPropDbl calc_molar_mass();
 
     PhaseMolarMasses calc_phase_molar_masses() override;
 
-    void check_loaded_fluid(void);
+    void check_loaded_fluid();
 
     void calc_excess_properties();
 
     /// Returns true if REFPROP is supported on this platform
-    static bool REFPROP_supported(void);
+    static bool REFPROP_supported();
 
     std::string fluid_param_string(const std::string& ParamName);
 
-    CoolPropDbl calc_PIP(void);
+    CoolPropDbl calc_PIP();
 
-    CoolPropDbl calc_cpmolar_idealgas(void);
+    CoolPropDbl calc_cpmolar_idealgas();
 
     /// Set the fluids in REFPROP DLL by calling the SETUPdll function
     /**
@@ -198,7 +198,7 @@ class REFPROPMixtureBackend : public AbstractState
 
     void calc_phase_envelope(const std::string& type);
 
-    CoolPropDbl calc_compressibility_factor(void) {
+    CoolPropDbl calc_compressibility_factor() {
         return _p / (_rhomolar * gas_constant() * _T);
     };
 
@@ -206,10 +206,10 @@ class REFPROPMixtureBackend : public AbstractState
         return PhaseEnvelope;
     };
 
-    std::vector<CoolPropDbl> calc_mole_fractions_liquid(void) {
+    std::vector<CoolPropDbl> calc_mole_fractions_liquid() {
         return std::vector<CoolPropDbl>(mole_fractions_liq.begin(), mole_fractions_liq.begin() + this->Ncomp);
     }
-    std::vector<CoolPropDbl> calc_mole_fractions_vapor(void) {
+    std::vector<CoolPropDbl> calc_mole_fractions_vapor() {
         return std::vector<CoolPropDbl>(mole_fractions_vap.begin(), mole_fractions_vap.begin() + this->Ncomp);
     }
 
@@ -217,17 +217,17 @@ class REFPROPMixtureBackend : public AbstractState
     void check_status();
 
     /// Get the viscosity [Pa-s] (based on the temperature and density in the state class)
-    CoolPropDbl calc_viscosity(void);
+    CoolPropDbl calc_viscosity();
     /// Get the thermal conductivity [W/m/K] (based on the temperature and density in the state class)
-    CoolPropDbl calc_conductivity(void);
+    CoolPropDbl calc_conductivity();
     /// Get the surface tension [N/m] (based on the temperature in the state class).  Invalid for temperatures above critical point or below triple point temperature
-    CoolPropDbl calc_surface_tension(void);
+    CoolPropDbl calc_surface_tension();
     /// Calc the B virial coefficient
-    CoolPropDbl calc_Bvirial(void);
+    CoolPropDbl calc_Bvirial();
     /// Calc the temperature derivative of the second virial coefficient
-    CoolPropDbl calc_dBvirial_dT(void);
+    CoolPropDbl calc_dBvirial_dT();
     /// Calc the C virial coefficient
-    CoolPropDbl calc_Cvirial(void);
+    CoolPropDbl calc_Cvirial();
 
     CoolPropDbl calc_fugacity_coefficient(std::size_t i);
     CoolPropDbl calc_fugacity(std::size_t i);
@@ -235,20 +235,20 @@ class REFPROPMixtureBackend : public AbstractState
     CoolPropDbl calc_melting_line(int param, int given, CoolPropDbl value);
     bool has_melting_line();
     double calc_melt_Tmax();
-    CoolPropDbl calc_T_critical(void);
-    CoolPropDbl calc_T_reducing(void);
-    void calc_reducing_state(void);
-    CoolPropDbl calc_p_critical(void);
-    CoolPropDbl calc_p_triple(void);
-    CoolPropDbl calc_p_min(void) {
+    CoolPropDbl calc_T_critical();
+    CoolPropDbl calc_T_reducing();
+    void calc_reducing_state();
+    CoolPropDbl calc_p_critical();
+    CoolPropDbl calc_p_triple();
+    CoolPropDbl calc_p_min() {
         return calc_p_triple();
     };
-    CoolPropDbl calc_rhomolar_critical(void);
-    CoolPropDbl calc_rhomolar_reducing(void);
-    CoolPropDbl calc_Ttriple(void);
-    CoolPropDbl calc_acentric_factor(void);
-    CoolPropDbl calc_gas_constant(void);
-    CoolPropDbl calc_dipole_moment(void);
+    CoolPropDbl calc_rhomolar_critical();
+    CoolPropDbl calc_rhomolar_reducing();
+    CoolPropDbl calc_Ttriple();
+    CoolPropDbl calc_acentric_factor();
+    CoolPropDbl calc_gas_constant();
+    CoolPropDbl calc_dipole_moment();
 
     /// Calculate the "true" critical point where dp/drho|T and d2p/drho2|T are zero
     void calc_true_critical_point(double& T, double& rho);
@@ -263,89 +263,89 @@ class REFPROPMixtureBackend : public AbstractState
     /// A wrapper function to calculate the limits for the EOS
     void limits(double& Tmin, double& Tmax, double& rhomolarmax, double& pmax);
     /// Calculate the maximum pressure
-    CoolPropDbl calc_pmax(void);
+    CoolPropDbl calc_pmax();
     /// Calculate the maximum temperature
-    CoolPropDbl calc_Tmax(void);
+    CoolPropDbl calc_Tmax();
     /// Calculate the minimum temperature
-    CoolPropDbl calc_Tmin(void);
+    CoolPropDbl calc_Tmin();
 
     /// Call into the THERM0dll method and return outputs as a struct. REFPROP must already be setup
     THERM0dllOutputs call_THERM0dll(double T, double rho_mol_dm3, const std::vector<double>& mole_fractions);
 
     /// Calculate the residual entropy in J/mol/K (should be a uniquely negative quantity)
-    CoolPropDbl calc_smolar_residual(void) {
+    CoolPropDbl calc_smolar_residual() {
         return (tau() * calc_dalphar_dTau() - calc_alphar()) * gas_constant();
     }
 
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r\f$ (dimensionless)
-    CoolPropDbl calc_alphar(void) {
+    CoolPropDbl calc_alphar() {
         return call_phixdll(0, 0);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta}\f$ (dimensionless)
-    CoolPropDbl calc_dalphar_dDelta(void) {
+    CoolPropDbl calc_dalphar_dDelta() {
         return call_phixdll(0, 1);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau}\f$ (dimensionless)
-    CoolPropDbl calc_dalphar_dTau(void) {
+    CoolPropDbl calc_dalphar_dTau() {
         return call_phixdll(1, 0);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta}\f$ (dimensionless)
-    CoolPropDbl calc_d2alphar_dDelta2(void) {
+    CoolPropDbl calc_d2alphar_dDelta2() {
         return call_phixdll(0, 2);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d2alphar_dDelta_dTau(void) {
+    CoolPropDbl calc_d2alphar_dDelta_dTau() {
         return call_phixdll(1, 1);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d2alphar_dTau2(void) {
+    CoolPropDbl calc_d2alphar_dTau2() {
         return call_phixdll(2, 0);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\delta}\f$ (dimensionless)
-    CoolPropDbl calc_d3alphar_dDelta3(void) {
+    CoolPropDbl calc_d3alphar_dDelta3() {
         return call_phixdll(0, 3);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d3alphar_dDelta2_dTau(void) {
+    CoolPropDbl calc_d3alphar_dDelta2_dTau() {
         return call_phixdll(1, 2);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d3alphar_dDelta_dTau2(void) {
+    CoolPropDbl calc_d3alphar_dDelta_dTau2() {
         return call_phixdll(2, 1);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d3alphar_dTau3(void) {
+    CoolPropDbl calc_d3alphar_dTau3() {
         return call_phixdll(3, 0);
     };
 
-    CoolPropDbl calc_alpha0(void) {
+    CoolPropDbl calc_alpha0() {
         return call_phi0dll(0, 0);
     };
-    CoolPropDbl calc_dalpha0_dDelta(void) {
+    CoolPropDbl calc_dalpha0_dDelta() {
         return call_phi0dll(0, 1);
     };
-    CoolPropDbl calc_dalpha0_dTau(void) {
+    CoolPropDbl calc_dalpha0_dTau() {
         return call_phi0dll(1, 0);
     };
-    CoolPropDbl calc_d2alpha0_dDelta2(void) {
+    CoolPropDbl calc_d2alpha0_dDelta2() {
         return call_phi0dll(0, 2);
     };
-    CoolPropDbl calc_d2alpha0_dDelta_dTau(void) {
+    CoolPropDbl calc_d2alpha0_dDelta_dTau() {
         return call_phi0dll(1, 1);
     };
-    CoolPropDbl calc_d2alpha0_dTau2(void) {
+    CoolPropDbl calc_d2alpha0_dTau2() {
         return call_phi0dll(2, 0);
     };
-    CoolPropDbl calc_d3alpha0_dDelta3(void) {
+    CoolPropDbl calc_d3alpha0_dDelta3() {
         return call_phi0dll(0, 3);
     };
-    CoolPropDbl calc_d3alpha0_dDelta2_dTau(void) {
+    CoolPropDbl calc_d3alpha0_dDelta2_dTau() {
         return call_phi0dll(1, 2);
     };
-    CoolPropDbl calc_d3alpha0_dDelta_dTau2(void) {
+    CoolPropDbl calc_d3alpha0_dDelta_dTau2() {
         return call_phi0dll(2, 1);
     };
-    CoolPropDbl calc_d3alpha0_dTau3(void) {
+    CoolPropDbl calc_d3alpha0_dTau3() {
         return call_phi0dll(3, 0);
     };
 };

--- a/src/Backends/Tabular/BicubicBackend.h
+++ b/src/Backends/Tabular/BicubicBackend.h
@@ -86,7 +86,7 @@ class BicubicBackend : public TabularBackend
         dataset->build_coeffs(single_phase_logph, dataset->coeffs_ph);
         dataset->build_coeffs(single_phase_logpT, dataset->coeffs_pT);
     };
-    std::string backend_name(void) {
+    std::string backend_name() {
         return get_backend_string(BICUBIC_BACKEND);
     }
 

--- a/src/Backends/Tabular/TTSEBackend.h
+++ b/src/Backends/Tabular/TTSEBackend.h
@@ -9,7 +9,7 @@ namespace CoolProp {
 class TTSEBackend : public TabularBackend
 {
    public:
-    std::string backend_name(void) {
+    std::string backend_name() {
         return get_backend_string(TTSE_BACKEND);
     }
     /// Instantiator; base class loads or makes tables

--- a/src/Backends/Tabular/TabularBackends.cpp
+++ b/src/Backends/Tabular/TabularBackends.cpp
@@ -349,7 +349,7 @@ void CoolProp::SinglePhaseGriddedTableData::build(shared_ptr<CoolProp::AbstractS
         }
     }
 }
-std::string CoolProp::TabularBackend::path_to_tables(void) {
+std::string CoolProp::TabularBackend::path_to_tables() {
     std::vector<std::string> fluids = AS->fluid_names();
     std::vector<CoolPropDbl> fractions = AS->get_mole_fractions();
     std::vector<std::string> components;
@@ -411,7 +411,7 @@ CoolPropDbl CoolProp::TabularBackend::calc_saturated_liquid_keyed_output(paramet
     }
 };
 
-CoolPropDbl CoolProp::TabularBackend::calc_p(void) {
+CoolPropDbl CoolProp::TabularBackend::calc_p() {
     PhaseEnvelopeData& phase_envelope = dataset->phase_envelope;
     if (using_single_phase_table) {
         return _p;
@@ -423,7 +423,7 @@ CoolPropDbl CoolProp::TabularBackend::calc_p(void) {
         }
     }
 }
-CoolPropDbl CoolProp::TabularBackend::calc_T(void) {
+CoolPropDbl CoolProp::TabularBackend::calc_T() {
     PhaseEnvelopeData& phase_envelope = dataset->phase_envelope;
     PureFluidSaturationTableData& pure_saturation = dataset->pure_saturation;
     if (using_single_phase_table) {
@@ -448,7 +448,7 @@ CoolPropDbl CoolProp::TabularBackend::calc_T(void) {
         }
     }
 }
-CoolPropDbl CoolProp::TabularBackend::calc_rhomolar(void) {
+CoolPropDbl CoolProp::TabularBackend::calc_rhomolar() {
     PhaseEnvelopeData& phase_envelope = dataset->phase_envelope;
     PureFluidSaturationTableData& pure_saturation = dataset->pure_saturation;
     if (using_single_phase_table) {
@@ -469,7 +469,7 @@ CoolPropDbl CoolProp::TabularBackend::calc_rhomolar(void) {
         }
     }
 }
-CoolPropDbl CoolProp::TabularBackend::calc_hmolar(void) {
+CoolPropDbl CoolProp::TabularBackend::calc_hmolar() {
     PhaseEnvelopeData& phase_envelope = dataset->phase_envelope;
     PureFluidSaturationTableData& pure_saturation = dataset->pure_saturation;
     if (using_single_phase_table) {
@@ -490,7 +490,7 @@ CoolPropDbl CoolProp::TabularBackend::calc_hmolar(void) {
         }
     }
 }
-CoolPropDbl CoolProp::TabularBackend::calc_smolar(void) {
+CoolPropDbl CoolProp::TabularBackend::calc_smolar() {
     PhaseEnvelopeData& phase_envelope = dataset->phase_envelope;
     PureFluidSaturationTableData& pure_saturation = dataset->pure_saturation;
     if (using_single_phase_table) {
@@ -511,7 +511,7 @@ CoolPropDbl CoolProp::TabularBackend::calc_smolar(void) {
         }
     }
 }
-CoolPropDbl CoolProp::TabularBackend::calc_umolar(void) {
+CoolPropDbl CoolProp::TabularBackend::calc_umolar() {
     PhaseEnvelopeData& phase_envelope = dataset->phase_envelope;
     PureFluidSaturationTableData& pure_saturation = dataset->pure_saturation;
     if (using_single_phase_table) {
@@ -535,7 +535,7 @@ CoolPropDbl CoolProp::TabularBackend::calc_umolar(void) {
         }
     }
 }
-CoolPropDbl CoolProp::TabularBackend::calc_cpmolar(void) {
+CoolPropDbl CoolProp::TabularBackend::calc_cpmolar() {
     PhaseEnvelopeData& phase_envelope = dataset->phase_envelope;
     PureFluidSaturationTableData& pure_saturation = dataset->pure_saturation;
     if (using_single_phase_table) {
@@ -548,7 +548,7 @@ CoolPropDbl CoolProp::TabularBackend::calc_cpmolar(void) {
         }
     }
 }
-CoolPropDbl CoolProp::TabularBackend::calc_cvmolar(void) {
+CoolPropDbl CoolProp::TabularBackend::calc_cvmolar() {
     PhaseEnvelopeData& phase_envelope = dataset->phase_envelope;
     PureFluidSaturationTableData& pure_saturation = dataset->pure_saturation;
     if (using_single_phase_table) {
@@ -562,7 +562,7 @@ CoolPropDbl CoolProp::TabularBackend::calc_cvmolar(void) {
     }
 }
 
-CoolPropDbl CoolProp::TabularBackend::calc_viscosity(void) {
+CoolPropDbl CoolProp::TabularBackend::calc_viscosity() {
     PhaseEnvelopeData& phase_envelope = dataset->phase_envelope;
     PureFluidSaturationTableData& pure_saturation = dataset->pure_saturation;
     if (using_single_phase_table) {
@@ -583,7 +583,7 @@ CoolPropDbl CoolProp::TabularBackend::calc_viscosity(void) {
         }
     }
 }
-CoolPropDbl CoolProp::TabularBackend::calc_conductivity(void) {
+CoolPropDbl CoolProp::TabularBackend::calc_conductivity() {
     PhaseEnvelopeData& phase_envelope = dataset->phase_envelope;
     PureFluidSaturationTableData& pure_saturation = dataset->pure_saturation;
     if (using_single_phase_table) {
@@ -604,7 +604,7 @@ CoolPropDbl CoolProp::TabularBackend::calc_conductivity(void) {
         }
     }
 }
-CoolPropDbl CoolProp::TabularBackend::calc_speed_sound(void) {
+CoolPropDbl CoolProp::TabularBackend::calc_speed_sound() {
     PhaseEnvelopeData& phase_envelope = dataset->phase_envelope;
     PureFluidSaturationTableData& pure_saturation = dataset->pure_saturation;
     if (using_single_phase_table) {

--- a/src/Backends/Tabular/TabularBackends.h
+++ b/src/Backends/Tabular/TabularBackends.h
@@ -633,7 +633,7 @@ class SinglePhaseGriddedTableData
         make_axis_vectors();
     };
     /// Make vectors for the x-axis values and the y-axis values
-    void make_axis_vectors(void) {
+    void make_axis_vectors() {
         if (logx) {
             xvec = logspace(xmin, xmax, Nx);
         } else {
@@ -646,7 +646,7 @@ class SinglePhaseGriddedTableData
         }
     };
     /// Make matrices of good neighbors if the current value for i,j corresponds to a bad node
-    void make_good_neighbors(void) {
+    void make_good_neighbors() {
         nearest_neighbor_i.resize(Nx, std::vector<std::size_t>(Ny, std::numeric_limits<std::size_t>::max()));
         nearest_neighbor_j.resize(Nx, std::vector<std::size_t>(Ny, std::numeric_limits<std::size_t>::max()));
         for (std::size_t i = 0; i < xvec.size(); ++i) {
@@ -1085,14 +1085,14 @@ class TabularBackend : public AbstractState
     };
 
     // None of the tabular methods are available from the high-level interface
-    bool available_in_high_level(void) {
+    bool available_in_high_level() {
         return false;
     }
 
-    std::string calc_name(void) {
+    std::string calc_name() {
         return AS->name();
     }
-    std::vector<std::string> calc_fluid_names(void) {
+    std::vector<std::string> calc_fluid_names() {
         return AS->fluid_names();
     }
 
@@ -1206,40 +1206,40 @@ class TabularBackend : public AbstractState
     virtual void invert_single_phase_y(const SinglePhaseGriddedTableData& table, const std::vector<std::vector<CellCoeffs>>& coeffs,
                                        parameters output, double x, double y, std::size_t i, std::size_t j) = 0;
 
-    phases calc_phase(void) {
+    phases calc_phase() {
         return _phase;
     }
-    CoolPropDbl calc_T_critical(void) {
+    CoolPropDbl calc_T_critical() {
         return this->AS->T_critical();
     };
-    CoolPropDbl calc_Ttriple(void) {
+    CoolPropDbl calc_Ttriple() {
         return this->AS->Ttriple();
     };
-    CoolPropDbl calc_p_triple(void) {
+    CoolPropDbl calc_p_triple() {
         return this->AS->p_triple();
     };
-    CoolPropDbl calc_pmax(void) {
+    CoolPropDbl calc_pmax() {
         return this->AS->pmax();
     };
-    CoolPropDbl calc_Tmax(void) {
+    CoolPropDbl calc_Tmax() {
         return this->AS->Tmax();
     };
-    CoolPropDbl calc_Tmin(void) {
+    CoolPropDbl calc_Tmin() {
         return this->AS->Tmin();
     };
-    CoolPropDbl calc_p_critical(void) {
+    CoolPropDbl calc_p_critical() {
         return this->AS->p_critical();
     }
-    CoolPropDbl calc_rhomolar_critical(void) {
+    CoolPropDbl calc_rhomolar_critical() {
         return this->AS->rhomolar_critical();
     }
-    bool using_mole_fractions(void) {
+    bool using_mole_fractions() {
         return true;
     }
-    bool using_mass_fractions(void) {
+    bool using_mass_fractions() {
         return false;
     }
-    bool using_volu_fractions(void) {
+    bool using_volu_fractions() {
         return false;
     }
     void update(CoolProp::input_pairs input_pair, double Value1, double Value2);
@@ -1252,11 +1252,11 @@ class TabularBackend : public AbstractState
     const std::vector<CoolPropDbl>& get_mole_fractions() {
         return AS->get_mole_fractions();
     };
-    const std::vector<CoolPropDbl> calc_mass_fractions(void) {
+    const std::vector<CoolPropDbl> calc_mass_fractions() {
         return AS->get_mass_fractions();
     };
 
-    CoolPropDbl calc_molar_mass(void) {
+    CoolPropDbl calc_molar_mass() {
         return AS->molar_mass();
     };
 
@@ -1264,7 +1264,7 @@ class TabularBackend : public AbstractState
     [[nodiscard]] CoolPropDbl calc_saturated_vapor_keyed_output(parameters key);
 
     /// Returns the path to the tables that shall be written
-    std::string path_to_tables(void);
+    std::string path_to_tables();
     /// Load the tables from file; throws UnableToLoadException if there is a problem
     void load_tables();
     void pack_matrices() {
@@ -1286,28 +1286,28 @@ class TabularBackend : public AbstractState
         CoolPropDbl yV = PhaseEnvelopeRoutines::evaluate(phase_envelope, output, iInput1, value1, cached_saturation_iV);
         return _Q * yV + (1 - _Q) * yL;
     }
-    CoolPropDbl calc_cpmolar_idealgas(void) {
+    CoolPropDbl calc_cpmolar_idealgas() {
         this->AS->set_T(_T);
         return this->AS->cp0molar();
     }
     /// Calculate the surface tension using the wrapped class (fast enough)
-    CoolPropDbl calc_surface_tension(void) {
+    CoolPropDbl calc_surface_tension() {
         this->AS->set_T(_T);
         return this->AS->surface_tension();
         this->AS->set_T(_HUGE);
     }
-    CoolPropDbl calc_p(void);
-    CoolPropDbl calc_T(void);
-    CoolPropDbl calc_rhomolar(void);
-    CoolPropDbl calc_hmolar(void);
-    CoolPropDbl calc_smolar(void);
-    CoolPropDbl calc_umolar(void);
-    CoolPropDbl calc_cpmolar(void);
-    CoolPropDbl calc_cvmolar(void);
-    CoolPropDbl calc_viscosity(void);
-    CoolPropDbl calc_conductivity(void);
+    CoolPropDbl calc_p();
+    CoolPropDbl calc_T();
+    CoolPropDbl calc_rhomolar();
+    CoolPropDbl calc_hmolar();
+    CoolPropDbl calc_smolar();
+    CoolPropDbl calc_umolar();
+    CoolPropDbl calc_cpmolar();
+    CoolPropDbl calc_cvmolar();
+    CoolPropDbl calc_viscosity();
+    CoolPropDbl calc_conductivity();
     /// Calculate the speed of sound using a tabular backend [m/s]
-    CoolPropDbl calc_speed_sound(void);
+    CoolPropDbl calc_speed_sound();
     CoolPropDbl calc_first_partial_deriv(parameters Of, parameters Wrt, parameters Constant);
     /** /brief calculate the derivative along the saturation curve, but only if quality is 0 or 1
         */

--- a/src/CPfilepaths.cpp
+++ b/src/CPfilepaths.cpp
@@ -134,13 +134,13 @@ void make_dirs(std::string file_path) {
 
 // ---- get_separator ----------------------------------------------------------
 
-std::string get_separator(void) {
+std::string get_separator() {
     return std::string(1, fs::path::preferred_separator);
 }
 
 // Legacy implementation kept for reference (powerpc / pre-NDK-r23 Android):
 //
-// std::string get_separator(void) {
+// std::string get_separator() {
 // #if defined(__ISLINUX__)
 //     return std::string("/");
 // #elif defined(__ISAPPLE__)
@@ -154,7 +154,7 @@ std::string get_separator(void) {
 
 // ---- get_home_dir -----------------------------------------------------------
 
-std::string get_home_dir(void) {
+std::string get_home_dir() {
 // See http://stackoverflow.com/questions/2552416/how-can-i-find-the-users-home-dir-in-a-cross-platform-manner-using-c
 #if defined(__ISLINUX__) || defined(__ISAPPLE__)
     char* home = nullptr;

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -63,7 +63,7 @@ static std::string warning_string;
 void set_debug_level(int level) {
     debug_level = level;
 }
-int get_debug_level(void) {
+int get_debug_level() {
     return debug_level;
 }
 

--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -157,11 +157,11 @@ static inline bool check_bounds(const givens prop, const double& value, double& 
 }
 
 // A couple of convenience functions that are needed quite a lot
-static double MM_Air(void) {
+static double MM_Air() {
     check_fluid_instantiation();
     return Air->keyed_output(CoolProp::imolar_mass);
 }
-static double MM_Water(void) {
+static double MM_Water() {
     check_fluid_instantiation();
     return Water->keyed_output(CoolProp::imolar_mass);
 }
@@ -911,7 +911,7 @@ double f_factor(double T, double p) {
     else
         return 1.0;
 }
-void HAHelp(void) {
+void HAHelp() {
     std::cout << "Sorry, Need to update!";
 }
 int returnHumAirCode(const char* Code) {


### PR DESCRIPTION
## Summary

Closes #2871.

Replace `(void)` parameter lists with `()` across `src/` and `include/`. Cosmetic but consistent with modern C++ — the `(void)` form is a C holdover that's redundant since C++98.

## Approach

Mechanical pass with BSD-compatible sed, then `uvx clang-format@18.1.8` to normalise:

```sed
s/([a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*)\(void\)/\1()/g
```

The regex requires an identifier immediately before the parenthesis, so `(void)expr` casts are left alone. Manually verified the two cast sites in the codebase (`src/Tests/CoolProp-Tests.cpp:922,930` — `(void)Z_T2;` / `(void)H_T2;`) are unchanged. Vendored externals (`include/miniz.h`, `externals/`) skipped.

## Stats

- 39 files modified
- 716 insertions, 718 deletions (essentially per-line replacements)
- ~700 occurrences

## Test plan

- [ ] CI green on full matrix (this is a no-op semantic change, so any failure = unrelated flake or pre-existing)
- [ ] Add this commit's SHA to `.git-blame-ignore-revs`

## Related

- Series: #2802, #2803, #2805, #2807, #2808
- Closes part of (now stale) #2104

🤖 Generated with [Claude Code](https://claude.com/claude-code)