### PR TITLE
refactor(cert-err58-cpp): NOLINT static-init that may throw (#2874)

### DIFF
--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -75,7 +75,14 @@ class IF97BackendGenerator : public AbstractStateGenerator
         };
     };
 };
-// This static initialization will cause the generator to register
+// This static initialization will cause the generator to register.
+// GeneratorInitializer's constructor only inserts a single entry into a
+// std::map keyed by backend_family; in practice this cannot throw under
+// normal startup, and if std::bad_alloc fires here the process is
+// unrecoverable anyway. NOLINT rather than convert to call_once + lazy
+// registration (option 1 from #2874) which would be the cleaner refactor
+// but is out of this PR's scope.
+// NOLINTNEXTLINE(cert-err58-cpp)
 static GeneratorInitializer<IF97BackendGenerator> if97_gen(IF97_BACKEND_FAMILY);
 class SRKGenerator : public AbstractStateGenerator
 {
@@ -84,6 +91,7 @@ class SRKGenerator : public AbstractStateGenerator
         return new SRKBackend(fluid_names, get_config_double(R_U_CODATA));
     };
 };
+// NOLINTNEXTLINE(cert-err58-cpp)
 static GeneratorInitializer<SRKGenerator> srk_gen(CoolProp::SRK_BACKEND_FAMILY);
 class PRGenerator : public AbstractStateGenerator
 {
@@ -92,6 +100,7 @@ class PRGenerator : public AbstractStateGenerator
         return new PengRobinsonBackend(fluid_names, get_config_double(R_U_CODATA));
     };
 };
+// NOLINTNEXTLINE(cert-err58-cpp)
 static GeneratorInitializer<PRGenerator> pr_gen(CoolProp::PR_BACKEND_FAMILY);
 class IncompressibleBackendGenerator : public AbstractStateGenerator
 {
@@ -104,6 +113,7 @@ class IncompressibleBackendGenerator : public AbstractStateGenerator
     };
 };
 // This static initialization will cause the generator to register
+// NOLINTNEXTLINE(cert-err58-cpp)
 static GeneratorInitializer<IncompressibleBackendGenerator> incomp_gen(INCOMP_BACKEND_FAMILY);
 class VTPRGenerator : public CoolProp::AbstractStateGenerator
 {
@@ -113,6 +123,7 @@ class VTPRGenerator : public CoolProp::AbstractStateGenerator
     };
 };
 // This static initialization will cause the generator to register
+// NOLINTNEXTLINE(cert-err58-cpp)
 static CoolProp::GeneratorInitializer<VTPRGenerator> vtpr_gen(CoolProp::VTPR_BACKEND_FAMILY);
 
 class PCSAFTGenerator : public CoolProp::AbstractStateGenerator
@@ -123,6 +134,7 @@ class PCSAFTGenerator : public CoolProp::AbstractStateGenerator
     };
 };
 // This static initialization will cause the generator to register
+// NOLINTNEXTLINE(cert-err58-cpp)
 static CoolProp::GeneratorInitializer<PCSAFTGenerator> pcsaft_gen(CoolProp::PCSAFT_BACKEND_FAMILY);
 
 AbstractState* AbstractState::factory(const std::string& backend, const std::vector<std::string>& fluid_names) {
@@ -798,11 +810,9 @@ void AbstractState::update_Qmass_pair(CoolProp::input_pairs pair, double v1, dou
     const double fa = residual(a);
     const double fb = residual(b);
     if (fa * fb > 0) {
-        throw SolutionError(
-          format("update_Qmass_pair: cannot bracket Qmolar for Qmass=%g (fa=%g, fb=%g)", Qmass_target, fa, fb));
+        throw SolutionError(format("update_Qmass_pair: cannot bracket Qmolar for Qmass=%g (fa=%g, fb=%g)", Qmass_target, fa, fb));
     }
-    const auto [lo, hi] =
-      boost::math::tools::toms748_solve(residual, a, b, fa, fb, boost::math::tools::eps_tolerance<double>(bits), max_iter);
+    const auto [lo, hi] = boost::math::tools::toms748_solve(residual, a, b, fa, fb, boost::math::tools::eps_tolerance<double>(bits), max_iter);
     const double Qmolar_solution = 0.5 * (lo + hi);
     if (!ValidNumber(Qmolar_solution)) {
         throw SolutionError(format("update_Qmass_pair: did not converge for Qmass=%g", Qmass_target));

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -56,7 +56,11 @@ class HEOSGenerator : public AbstractStateGenerator
         }
     };
 };
-// This static initialization will cause the generator to register
+// This static initialization will cause the generator to register.
+// See REFPROPMixtureBackend.cpp for the cert-err58-cpp rationale — the
+// constructor inserts a single entry into a std::map at program start;
+// if allocation fails here the process is unrecoverable anyway.
+// NOLINTNEXTLINE(cert-err58-cpp)
 static CoolProp::GeneratorInitializer<HEOSGenerator> heos_gen(CoolProp::HEOS_BACKEND_FAMILY);
 
 HelmholtzEOSMixtureBackend::HelmholtzEOSMixtureBackend() {

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -61,10 +61,12 @@ using std::shared_ptr;
 #    include <sys/stat.h>
 #endif
 
+// NOLINTNEXTLINE(cert-err58-cpp): default-constructed std::string is noexcept since C++11
 std::string LoadedREFPROPRef;
 
 static bool dbg_refprop = false;
 static const unsigned int number_of_endings = 5;
+// NOLINTNEXTLINE(cert-err58-cpp): five short string literals — constructors won't throw on this input
 std::string endings[number_of_endings] = {"", ".FLD", ".fld", ".PPF", ".ppf"};
 
 static char default_reference_state[] = "DEF";
@@ -185,7 +187,15 @@ class REFPROPGenerator : public AbstractStateGenerator
         }
     };
 };
-// This static initialization will cause the generator to register
+// This static initialization will cause the generator to register.
+// GeneratorInitializer's constructor only inserts into a std::map keyed by
+// backend_family — std::map::operator[] / insert can technically throw
+// std::bad_alloc on allocation failure, but in practice this is a single
+// small entry inserted at program start; if allocation fails here the
+// process is unrecoverable anyway. Mark NOLINT rather than wrap in
+// call_once + lazy registration (option 1 from #2874) which would be the
+// cleaner refactor but is out of this PR's scope.
+// NOLINTNEXTLINE(cert-err58-cpp)
 static GeneratorInitializer<REFPROPGenerator> refprop_gen(REFPROP_BACKEND_FAMILY);
 
 void REFPROPMixtureBackend::construct(const std::vector<std::string>& fluid_names) {


### PR DESCRIPTION
## Summary

Closes #2874.

Apply targeted `NOLINTNEXTLINE(cert-err58-cpp)` to all static-storage initialisations that clang-tidy flags as "may throw an exception that cannot be caught." Eight `GeneratorInitializer<T>` backend-registration sites plus two file-scope `std::string` objects in REFPROPMixtureBackend.cpp.

## Approach

Per the issue, two options were on the table:
1. Replace static-init with an explicit `register_backends()` guarded by `std::call_once` on first `AbstractState` construction.
2. NOLINT each site with a comment explaining the assertion.

This PR takes **option 2** — one line per site, no behavioural change. Option 1 is a worthwhile follow-up (cleaner; lazy registration; testable) but requires restructuring all eight backend generators in lockstep, so it's a separate refactor.

## Sites covered

| File | Sites | Pattern |
|------|-------|---------|
| `src/AbstractState.cpp` | 6 | `GeneratorInitializer<{IF97,SRK,PR,INCOMP,VTPR,PCSAFT}Generator>` |
| `src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp` | 1 | `GeneratorInitializer<HEOSGenerator>` |
| `src/Backends/REFPROP/REFPROPMixtureBackend.cpp` | 1 | `GeneratorInitializer<REFPROPGenerator>` |
| `src/Backends/REFPROP/REFPROPMixtureBackend.cpp` | 1 | `std::string LoadedREFPROPRef;` (default-constructed, noexcept since C++11) |
| `src/Backends/REFPROP/REFPROPMixtureBackend.cpp` | 1 | `std::string endings[5] = {"", ".FLD", ...}` (short string literals) |

## Justification per site

`GeneratorInitializer<T>::GeneratorInitializer(family)` is a constructor that does one thing: insert a single small entry into a `std::map<backend_families, ...>`. The only way it can throw is `std::bad_alloc` on allocation failure. An allocation failure at static-init time is unrecoverable anyway — the process can't even reach `main`.

The REFPROP file-scope strings are default-constructed (noexcept since C++11) or initialised from short string literals where the `std::string(const char*)` constructor cannot throw on the small input.

## Test plan

- [ ] CI green (no behavioural change)
- [ ] `clang-tidy --checks='cert-err58-cpp'` should report 0 violations on the modified files

## Related

- Series: #2802, #2803, #2805, #2807, #2808
- Closes part of (now stale) #2104

🤖 Generated with [Claude Code](https://claude.com/claude-code)