### PR TITLE
fix(HEOS): mole_fractions_liquid/vapor reject single-phase states (#2308)

### DIFF
--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
@@ -332,9 +332,20 @@ class HelmholtzEOSMixtureBackend : public AbstractState
     };
 
     std::vector<CoolPropDbl> calc_mole_fractions_liquid(void) {
+        // SatL/SatV retain composition vectors from the most recent VLE flash
+        // (or phase-envelope build) — those are not meaningful when the
+        // current state is single-phase, and returning them silently surfaced
+        // as bug #2308. Require the current state to be two-phase before
+        // returning anything.
+        if (_phase != iphase_twophase) {
+            throw ValueError("mole_fractions_liquid is only defined in the two-phase region (current state is single-phase)");
+        }
         return SatL->get_mole_fractions();
     };
     std::vector<CoolPropDbl> calc_mole_fractions_vapor(void) {
+        if (_phase != iphase_twophase) {
+            throw ValueError("mole_fractions_vapor is only defined in the two-phase region (current state is single-phase)");
+        }
         return SatV->get_mole_fractions();
     };
 

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5508,6 +5508,41 @@ TEST_CASE("INCOMP backend rejects molar property requests with a clean error", "
     CHECK(rhomass < 2000);
 }
 
+TEST_CASE("mole_fractions_liquid/vapor reject single-phase states (#2308)", "[mole_fractions][2308]") {
+    // Issue #2308: SatL/SatV retain composition vectors from the most recent
+    // VLE flash (or phase-envelope build); calc_mole_fractions_liquid/vapor
+    // were returning those stale values when the current state was actually
+    // single-phase, which is misleading. Now they throw.
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(
+      CoolProp::AbstractState::factory("HEOS", "Nitrogen&Methane&Ethane&Propane"));
+    AS->set_mole_fractions({0.10, 0.34, 0.41, 0.15});
+
+    // Build the phase envelope so SatL/SatV pick up some non-trivial state
+    AS->build_phase_envelope("");
+
+    // Single-phase point: T well above the dew curve at 1.5 bar
+    AS->update(CoolProp::PT_INPUTS, 1.5e5, 298.15);
+    REQUIRE_FALSE(AS->phase() == CoolProp::iphase_twophase);
+    CHECK_THROWS_AS(AS->mole_fractions_liquid(), CoolProp::ValueError);
+    CHECK_THROWS_AS(AS->mole_fractions_vapor(), CoolProp::ValueError);
+
+    // Two-phase point: PQ flash, Q=0.5
+    AS->update(CoolProp::PQ_INPUTS, 1.5e5, 0.5);
+    REQUIRE(AS->phase() == CoolProp::iphase_twophase);
+    REQUIRE_NOTHROW(AS->mole_fractions_liquid());
+    REQUIRE_NOTHROW(AS->mole_fractions_vapor());
+    auto x = AS->mole_fractions_liquid();
+    auto y = AS->mole_fractions_vapor();
+    REQUIRE(x.size() == 4);
+    REQUIRE(y.size() == 4);
+    // Each composition must sum to ~1.0
+    double sx = 0.0, sy = 0.0;
+    for (auto v : x) sx += v;
+    for (auto v : y) sy += v;
+    CHECK(sx == Catch::Approx(1.0).epsilon(1e-9));
+    CHECK(sy == Catch::Approx(1.0).epsilon(1e-9));
+}
+
 TEST_CASE("REFPROP supports DmolarQ / DmassQ inputs (#1845)", "[REFPROP][1845]") {
     CoolProp::Skip_if_No_REFPROP();
     // Issue #1845: DmassQ_INPUTS / DmolarQ_INPUTS were missing from the


### PR DESCRIPTION
## Summary

Fixes #2308.

`calc_mole_fractions_liquid()` / `calc_mole_fractions_vapor()` in `HelmholtzEOSMixtureBackend` simply returned `SatL->get_mole_fractions()` / `SatV->get_mole_fractions()` — those companion backends keep their composition vectors populated from the most recent VLE flash (or phase-envelope build), so the accessors silently surfaced stale values when the current state was single-phase.

## Reproducer (from the original report)

```python
import CoolProp.CoolProp as CP
AS = CP.AbstractState('HEOS', 'Nitrogen&Methane&Ethane&Propane')
AS.set_mole_fractions([0.10, 0.34, 0.41, 0.15])
AS.build_phase_envelope("")
AS.update(CP.PT_INPUTS, 1.5e5, 254.0 + 273.15)  # well above dew curve
print(AS.Q())                          # -1.0 (single phase)
print(AS.mole_fractions_liquid())      # was: stale liquid composition (bug)
```

## Fix

Both accessors now check `_phase == iphase_twophase` and throw `ValueError` otherwise. Each error message names the specific accessor (`"mole_fractions_liquid is only defined in the two-phase region (current state is single-phase)"`) so callers can take action without guessing.

## Internal-caller compatibility

The two in-repo callers are already gated to only run in the two-phase interior:

- `AbstractState::calc_Qmass()` (`src/AbstractState.cpp:707`) checks `_Q < 0 || _Q > 1` and `_Q == 0 || _Q == 1` before going through `calc_phase_molar_masses()` — the only path that reaches `mole_fractions_liquid/vapor`.
- The test-only PTflash_twophase residual in `src/Backends/Helmholtz/VLERoutines.cpp:2104` runs immediately after a `PQ_INPUTS` dewpoint flash, so the state is two-phase by construction.

## Test

`src/Tests/CoolProp-Tests.cpp [mole_fractions][2308]` — verifies:
- single-phase point throws on both accessors
- two-phase point (PQ at Q=0.5) returns 4-element compositions summing to 1.0

## Test plan

- [ ] CI green on the new `[2308]` test
- [ ] No existing tests regress (the change is API-tightening only on the misleading paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)