### PR TITLE
feat(python): expose AbstractState::Qmass on Python interface

### DIFF
--- a/src/pybind11_interface.cxx
+++ b/src/pybind11_interface.cxx
@@ -274,6 +274,7 @@ void init_CoolProp(py::module& m) {
       .def("rhomass", &AbstractState::rhomass)
       .def("p", &AbstractState::p)
       .def("Q", &AbstractState::Q)
+      .def("Qmass", &AbstractState::Qmass)
       .def("tau", &AbstractState::tau)
       .def("delta", &AbstractState::delta)
       .def("molar_mass", &AbstractState::molar_mass)

--- a/wrappers/Python/CoolProp/AbstractState.pxd
+++ b/wrappers/Python/CoolProp/AbstractState.pxd
@@ -105,6 +105,7 @@ cdef class AbstractState:
     cpdef double T(self) except *
     cpdef double p(self) except *
     cpdef double Q(self) except *
+    cpdef double Qmass(self) except *
     cpdef double compressibility_factor(self) except *
     cpdef double rhomolar(self) except *
     cpdef double hmolar(self) except *

--- a/wrappers/Python/CoolProp/AbstractState.pyx
+++ b/wrappers/Python/CoolProp/AbstractState.pyx
@@ -253,6 +253,9 @@ cdef class AbstractState:
     cpdef double Q(self) except *:
         """ Get the vapor quality in mol/mol - wrapper of c++ function :cpapi:`CoolProp::AbstractState::Q(void)` """
         return self.thisptr.Q()
+    cpdef double Qmass(self) except *:
+        """ Get the vapor quality on a mass basis in kg/kg - wrapper of c++ function :cpapi:`CoolProp::AbstractState::Qmass(void)` """
+        return self.thisptr.Qmass()
     cpdef double rhomolar(self) except *:
         """ Get the density in mol/m^3 - wrapper of c++ function :cpapi:`CoolProp::AbstractState::rhomolar(void)` """
         return self.thisptr.rhomolar()

--- a/wrappers/Python/CoolProp/cAbstractState.pxd
+++ b/wrappers/Python/CoolProp/cAbstractState.pxd
@@ -117,6 +117,7 @@ cdef extern from "AbstractState.h" namespace "CoolProp":
         double p() except +ValueError
         double compressibility_factor() except +ValueError
         double Q() except +ValueError
+        double Qmass() except +ValueError
         double hmolar() except +ValueError
         double hmass() except +ValueError
         double smolar() except +ValueError


### PR DESCRIPTION
## Summary

The C++ `AbstractState` gained a `Qmass()` accessor (mass-basis vapor quality, kg/kg) in #2840 but the Cython wrapper and the `pybind11` binding still only exposed the molar `Q()`. Python users had to round-trip through `PropsSI("Qmass", ...)` instead of being able to call `AS.Qmass()` directly.

This PR plumbs the binding through all four wrapper layers.

## Files

| File | Change |
|------|--------|
| `src/pybind11_interface.cxx` | `.def("Qmass", &AbstractState::Qmass)` |
| `wrappers/Python/CoolProp/cAbstractState.pxd` | C++ extern decl |
| `wrappers/Python/CoolProp/AbstractState.pxd` | `cpdef double Qmass(self) except *` |
| `wrappers/Python/CoolProp/AbstractState.pyx` | `cpdef` body returning `self.thisptr.Qmass()` |

## Usage

```python
import CoolProp.CoolProp as cp
AS = cp.AbstractState('HEOS', 'Water')
AS.update(cp.PQ_INPUTS, 101325, 0.5)
AS.Q()      # 0.5 (molar)
AS.Qmass()  # 0.5 (mass — identical for pure fluids; differs for mixtures)
```

Calling `Qmass()` outside the two-phase region throws the same `ValueError` the underlying C++ method already throws (the wrapper inherits the `except *`/`except +ValueError` propagation).

## Test plan

- [ ] CI builds the Python wheel
- [ ] `import CoolProp; AS = ...; AS.Qmass()` returns the mass quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)