### PR TITLE
ci(python): add PIP_RETRIES/PIP_TIMEOUT for cibw pip-install flakes

### DIFF
--- a/.github/workflows/python_cibuildwheel.yml
+++ b/.github/workflows/python_cibuildwheel.yml
@@ -68,12 +68,19 @@ jobs:
     - name: Build and test wheels
       uses: pypa/cibuildwheel@v3.4.1
       env:
+        # Make pip tolerant of transient DNS / connection failures on the
+        # post-build wheel test (most often hits macOS runners pulling
+        # numpy from files.pythonhosted.org). Default pip retries=5 with a
+        # short timeout is too aggressive about giving up.
+        PIP_RETRIES: 10
+        PIP_TIMEOUT: 60
+        PIP_DEFAULT_TIMEOUT: 60
         MACOSX_DEPLOYMENT_TARGET: 11.0
-        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=11.0 SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk CPM_SOURCE_CACHE=$HOME/.cache/CPM
+        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=11.0 SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk CPM_SOURCE_CACHE=$HOME/.cache/CPM PIP_RETRIES=10 PIP_TIMEOUT=60 PIP_DEFAULT_TIMEOUT=60
         CIBW_BEFORE_BUILD_LINUX: >
           pip install ninja &&
           git config --global --add safe.directory "*"
-        CIBW_ENVIRONMENT_LINUX: COOLPROP_CMAKE=default,NATIVE CPM_SOURCE_CACHE=/root/.cache/CPM
+        CIBW_ENVIRONMENT_LINUX: COOLPROP_CMAKE=default,NATIVE CPM_SOURCE_CACHE=/root/.cache/CPM PIP_RETRIES=10 PIP_TIMEOUT=60 PIP_DEFAULT_TIMEOUT=60
         CIBW_BUILD: cp${{ inputs.python-version }}-*
         CIBW_ARCHS_MACOS: ${{ inputs.arch }} # x86_64 arm64 # universal2 is redundant
         CIBW_ARCHS_WINDOWS: ${{ inputs.arch }} # AMD64 x86 # ARM64 creates problems with msgpack-c


### PR DESCRIPTION
## Summary

Recurring overnight CI failure: `pypa/cibuildwheel` runs a `pip install <wheel>` post-build to verify the wheel imports. That triggers pip to resolve and download runtime deps (numpy, etc.) from `files.pythonhosted.org`. macOS runners intermittently hit DNS failures, e.g.

```
WARNING: Retrying ... [Errno 8] nodename nor servname provided, or not known
ERROR: Could not install packages due to an OSError: HTTPSConnectionPool(
  host='files.pythonhosted.org', port=443): Max retries exceeded ...
##[error]cibuildwheel: Command [...] failed with code 1.
```

pip defaults to `retries=5` with a short timeout — too aggressive about giving up on transient DNS failures. This PR sets `PIP_RETRIES=10` and `PIP_TIMEOUT=60` so each transient failure gets ~10× the chance to recover.

## Where the env var is set

Three places to cover all three runner kinds:

| Scope | Covers |
|-------|--------|
| Step `env:` block | Windows + macOS runners (cibw runs on the runner directly) |
| `CIBW_ENVIRONMENT_MACOS` | the macOS subprocesses cibw spawns for build/test |
| `CIBW_ENVIRONMENT_LINUX` | the manylinux container builds (where step-level env doesn't cross the container boundary) |

## Doesn't help

Two other recurring flakes are uses-action steps without easy retry:

- `actions/upload-artifact` — wheel built fine, upload itself fails. No native retry input.
- `tauri-apps/tauri-action` macOS `bundle_dmg.sh` — would need replacing with a shell call wrapped in `nick-fields/retry`.

Both stay known-rerun-only for now. If the upload-artifact flake recurs more, we can switch to `Wandalen/wretry.action` or split the Tauri step into a shell call + retry wrapper.

## Test plan

- [ ] CI runs over the matrix at least once without spurious DNS-driven `pip install` failures
- [ ] No regression on builds that previously passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)