### PR TITLE
fix(tabular): validate cell after sat-curve bump (BICUBIC PT segfault, #1950)

### DIFF
--- a/src/Backends/Tabular/BicubicBackend.cpp
+++ b/src/Backends/Tabular/BicubicBackend.cpp
@@ -92,6 +92,16 @@ double CoolProp::BicubicBackend::evaluate_single_phase(const SinglePhaseGriddedT
     // Get the cell
     const CellCoeffs& cell = coeffs[i][j];
 
+    // Defense-in-depth: cells in the table's two-phase notch carry no bicubic
+    // coefficients. Caller should have routed through find_native_nearest_good_indices
+    // (or the saturation-curve cell-bump logic in TabularBackend::update) which
+    // already resolve to a good neighbour. This guard catches the residual case
+    // (e.g. #1950: PT_INPUTS at sub-saturation) so an invalid cell raises a
+    // ValueError instead of dereferencing an empty alpha[] vector and segfaulting.
+    if (!cell.valid()) {
+        throw ValueError(format("evaluate_single_phase called on cell (%zu, %zu) with no bicubic coefficients (x=%g, y=%g)", i, j, x, y));
+    }
+
     // Get the alpha coefficients
     const std::vector<double>& alpha = cell.get(output);
 

--- a/src/Backends/Tabular/TabularBackends.cpp
+++ b/src/Backends/Tabular/TabularBackends.cpp
@@ -964,10 +964,10 @@ void CoolProp::TabularBackend::update(CoolProp::input_pairs input_pair, double v
                                     cached_single_phase_i = ai;
                                     cached_single_phase_j = aj;
                                 } else {
-                                    throw ValueError(format(
-                                      "Imposed phase %s: bumped cell (%zu, %zu) has no bicubic coefficients and no good neighbour "
-                                      "(p=%g Pa, T=%g K)",
-                                      context, cached_single_phase_i, cached_single_phase_j, _p, static_cast<double>(_T)));
+                                    throw ValueError(
+                                      format("Imposed phase %s: bumped cell (%zu, %zu) has no bicubic coefficients and no good neighbour "
+                                             "(p=%g Pa, T=%g K)",
+                                             context, cached_single_phase_i, cached_single_phase_j, _p, static_cast<double>(_T)));
                                 }
                             }
                         };
@@ -1044,10 +1044,10 @@ void CoolProp::TabularBackend::update(CoolProp::input_pairs input_pair, double v
                                         cached_single_phase_i = ai;
                                         cached_single_phase_j = aj;
                                     } else {
-                                        throw ValueError(format(
-                                          "P,T near saturation: bumped cell (%zu, %zu) has no bicubic coefficients and no good neighbour "
-                                          "(p=%g Pa, T=%g K, Tsat=%g K)",
-                                          cached_single_phase_i, cached_single_phase_j, _p, static_cast<double>(_T), Ts));
+                                        throw ValueError(
+                                          format("P,T near saturation: bumped cell (%zu, %zu) has no bicubic coefficients and no good neighbour "
+                                                 "(p=%g Pa, T=%g K, Tsat=%g K)",
+                                                 cached_single_phase_i, cached_single_phase_j, _p, static_cast<double>(_T), Ts));
                                     }
                                 }
                             }

--- a/src/Backends/Tabular/TabularBackends.cpp
+++ b/src/Backends/Tabular/TabularBackends.cpp
@@ -951,6 +951,26 @@ void CoolProp::TabularBackend::update(CoolProp::input_pairs input_pair, double v
 
                     if (imposed_phase_index != iphase_not_imposed) {
                         double rhoc = rhomolar_critical();
+                        // Lambda: validate the bumped cell. If the imposed-phase walk lands on a
+                        // table cell with no bicubic coefficients (i.e., inside the two-phase
+                        // notch of the table), evaluate_single_phase_pT will dereference an
+                        // empty alpha[] vector and segfault. Resolve to a good neighbour or
+                        // throw cleanly. Same fix idiom as the non-imposed branch below.
+                        auto ensure_bumped_cell_valid = [&](const char* context) {
+                            const auto& cell = dataset->coeffs_pT[cached_single_phase_i][cached_single_phase_j];
+                            if (!cell.valid()) {
+                                if (auto alt = cell.get_alternate()) {
+                                    auto [ai, aj] = *alt;
+                                    cached_single_phase_i = ai;
+                                    cached_single_phase_j = aj;
+                                } else {
+                                    throw ValueError(format(
+                                      "Imposed phase %s: bumped cell (%zu, %zu) has no bicubic coefficients and no good neighbour "
+                                      "(p=%g Pa, T=%g K)",
+                                      context, cached_single_phase_i, cached_single_phase_j, _p, static_cast<double>(_T)));
+                                }
+                            }
+                        };
                         if (imposed_phase_index == iphase_liquid && cached_single_phase_i > 0) {
                             // We want a liquid solution, but we got a vapor solution
                             if (_p < this->AS->p_critical()) {
@@ -959,6 +979,7 @@ void CoolProp::TabularBackend::update(CoolProp::input_pairs input_pair, double v
                                     // Bump to lower temperature
                                     cached_single_phase_i--;
                                 }
+                                ensure_bumped_cell_valid("liquid");
                                 double rho = evaluate_single_phase_pT(iDmolar, cached_single_phase_i, cached_single_phase_j);
                                 if (rho < rhoc) {
                                     // Didn't work
@@ -977,6 +998,7 @@ void CoolProp::TabularBackend::update(CoolProp::input_pairs input_pair, double v
                                     // Bump to lower temperature
                                     cached_single_phase_i++;
                                 }
+                                ensure_bumped_cell_valid("gas");
                                 double rho = evaluate_single_phase_pT(iDmolar, cached_single_phase_i, cached_single_phase_j);
                                 if (rho > rhoc) {
                                     // Didn't work
@@ -1008,6 +1030,25 @@ void CoolProp::TabularBackend::update(CoolProp::input_pairs input_pair, double v
                                     }
                                     // It's vapor, move to the right
                                     cached_single_phase_i++;
+                                }
+                                // The bumped cell may land in the table's two-phase region where
+                                // CellCoeffs has no bicubic alpha[] populated. Subsequent
+                                // evaluate_single_phase dereferences alpha[] without checking
+                                // validity → segfault (#1950: N2 BICUBIC at PT=2e5,78 K).
+                                // Resolve the same way find_native_nearest_good_indices does:
+                                // try the cell's alternate; otherwise throw cleanly.
+                                const auto& bumped_cell = dataset->coeffs_pT[cached_single_phase_i][cached_single_phase_j];
+                                if (!bumped_cell.valid()) {
+                                    if (auto alt = bumped_cell.get_alternate()) {
+                                        auto [ai, aj] = *alt;
+                                        cached_single_phase_i = ai;
+                                        cached_single_phase_j = aj;
+                                    } else {
+                                        throw ValueError(format(
+                                          "P,T near saturation: bumped cell (%zu, %zu) has no bicubic coefficients and no good neighbour "
+                                          "(p=%g Pa, T=%g K, Tsat=%g K)",
+                                          cached_single_phase_i, cached_single_phase_j, _p, static_cast<double>(_T), Ts));
+                                    }
                                 }
                             }
                         }

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5567,4 +5567,30 @@ TEST_CASE("TABULAR_NX/NY config keys exist and default to 200", "[Configuration]
     CHECK(CoolProp::get_config_int(TABULAR_NY) == 200);
 }
 
+TEST_CASE("BICUBIC PT below saturation no longer segfaults (#1950)", "[BICUBIC][1950]") {
+    // Issue #1950: BICUBIC&HEOS update(PT_INPUTS, p, T) where T is just below
+    // Tsat(p) and the saturation curve sits inside the table cell:
+    //   - find_native_nearest_good_indices returns a valid cell on the vapor side
+    //   - saturation-curve check bumps `cached_single_phase_i--` to land in the
+    //     table's two-phase notch, where CellCoeffs has no alpha[] populated
+    //   - evaluate_single_phase dereferences alpha[12] → segfault
+    //
+    // After the fix, the bumped cell is checked for validity; if the alternate
+    // neighbour is set, we use it; otherwise we throw a clean ValueError.
+    auto BICU = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("BICUBIC&HEOS", "Nitrogen"));
+    // P=2 bar, T=78 K is sub-saturation for N2 (Tsat(2 bar) ~ 83.6 K) — was the
+    // original repro from the issue that crashed.
+    REQUIRE_NOTHROW(BICU->update(CoolProp::PT_INPUTS, 2.0e5, 78.0));
+    // BICU should land on a valid liquid cell and produce a sensible density.
+    const double rho = BICU->rhomass();
+    CHECK(std::isfinite(rho));
+    CHECK(rho > 700.0);  // liquid N2 ~803 kg/m^3 at this state
+    CHECK(rho < 900.0);
+
+    // Cross-check vs HEOS — the magnitudes should agree to within bicubic noise.
+    auto HEOS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Nitrogen"));
+    HEOS->update(CoolProp::PT_INPUTS, 2.0e5, 78.0);
+    CHECK(rho == Catch::Approx(HEOS->rhomass()).epsilon(1e-2));  // 1% bicubic tolerance
+}
+
 #endif


### PR DESCRIPTION
## Summary

Fixes #1950 — `BICUBIC&HEOS::Nitrogen.update(PT_INPUTS, 2e5, 78)` segfaults the interpreter (T=78 K is below Tsat(2 bar)≈83.6 K, so sub-cooled liquid).

## Trace

`TabularBackend::update` for `PT_INPUTS`:

1. `find_native_nearest_good_indices` lands on a valid cell on the vapor side (T>Tsat).
2. The "near saturation curve" check at `p<pcrit` decrements `cached_single_phase_i` to walk one cell to the left.
3. The bumped cell falls inside the table's two-phase notch — its `CellCoeffs` has no `alpha[]` populated.
4. `evaluate_single_phase` reads `alpha[12]` on an empty `std::vector<double>` → SIGSEGV.

## Fix

- **`TabularBackends.cpp`** — after the cell bump in `PT_INPUTS` dispatch, check `cell.valid()`. If invalid, route through `CellCoeffs::get_alternate()` (same idiom `find_native_nearest_good_indices` uses); else throw `ValueError` naming the state. Applied to the imposed-phase walk (lines ~960/978) and the no-imposed-phase branch (~1004/1010).
- **`BicubicBackend.cpp`** — defense-in-depth: `evaluate_single_phase` checks `cell.valid()` before reading `alpha[]`.

## Scope

This fixes the **segfault** class only — when cell selection lands on a cell with no bicubic coefficients. It does **not** fix the *wrong-cell-on-the-other-side-of-saturation* class (e.g. #2247, #1301), where the chosen cell is valid but on the wrong phase side and the bicubic returns the wrong number silently. That requires making `find_native_nearest_good_indices` saturation-aware, which is queued separately as the deeper root-cause-A work.

## Test

`src/Tests/CoolProp-Tests.cpp [BICUBIC][1950]` — `BICU.update(PT_INPUTS, 2e5, 78)` for Nitrogen returns ~803 kg/m³ (matches HEOS to 1 %). Segfaults on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)