### PR TITLE
feat(tabular): TABULAR_NX/NY config keys for grid resolution

### DIFF
--- a/Web/coolprop/Tabular.rst
+++ b/Web/coolprop/Tabular.rst
@@ -39,6 +39,18 @@ Two sets of tables are generated and written to disk: pressure-enthalpy and pres
 
 It is critical that you try to only initialize one AbstractState instance and then call its methods. The overhead for generating an AbstractState instance when using TTSE or BICUBIC is not too punitive, but you should try to only do it once.  Each time an instance is generated, all the tabular data is loaded into it.
 
+The default grid is :math:`200 \times 200` cells.  Cells span the full state range, so cell width near the critical point can be coarse (~14 K for CO\ :sub:`2`); interpolation across that cell can therefore be the limiting source of error in critical-region calculations.  The grid resolution can be increased via the :ref:`configuration variables <configuration>` ``TABULAR_NX`` and ``TABULAR_NY`` (default ``200``):
+
+.. ipython::
+
+    In [0]: import CoolProp.CoolProp as CP
+
+    In [1]: CP.set_config_int(CP.TABULAR_NX, 400)
+
+    In [2]: CP.set_config_int(CP.TABULAR_NY, 400)
+
+Memory and build time scale as :math:`\mathcal{O}(N_x N_y)`.  Tables are cached per fluid in the tables directory and auto-rebuild when the resolution changes; the cost is paid once per (fluid, resolution) pair.
+
 TTSE Interpolation
 ------------------
 

--- a/Web/coolprop/Tabular.rst
+++ b/Web/coolprop/Tabular.rst
@@ -41,13 +41,11 @@ It is critical that you try to only initialize one AbstractState instance and th
 
 The default grid is :math:`200 \times 200` cells.  Cells span the full state range, so cell width near the critical point can be coarse (~14 K for CO\ :sub:`2`); interpolation across that cell can therefore be the limiting source of error in critical-region calculations.  The grid resolution can be increased via the :ref:`configuration variables <configuration>` ``TABULAR_NX`` and ``TABULAR_NY`` (default ``200``):
 
-.. ipython::
+.. code-block:: python
 
-    In [0]: import CoolProp.CoolProp as CP
-
-    In [1]: CP.set_config_int(CP.TABULAR_NX, 400)
-
-    In [2]: CP.set_config_int(CP.TABULAR_NY, 400)
+    import CoolProp.CoolProp as CP
+    CP.set_config_int(CP.TABULAR_NX, 400)
+    CP.set_config_int(CP.TABULAR_NY, 400)
 
 Memory and build time scale as :math:`\mathcal{O}(N_x N_y)`.  Tables are cached per fluid in the tables directory and auto-rebuild when the resolution changes; the cost is paid once per (fluid, resolution) pair.
 

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -76,7 +76,13 @@
       "If true, the library will always be reloaded, no matter what is currently loaded")                                                            \
     X(FLOAT_PUNCTUATION, "FLOAT_PUNCTUATION", ".", "The first character of this string will be used as the separator between the number fraction.")  \
     X(ENABLE_SUPERANCILLARIES, "ENABLE_SUPERANCILLARIES", true, "If true, the superancillary functions will be used for VLE of pure fluids")         \
-    X(LIST_STRING_DELIMITER, "LIST_STRING_DELIMITER", ",", "The delimiter to be used when converting a list of strings to a string")
+    X(LIST_STRING_DELIMITER, "LIST_STRING_DELIMITER", ",", "The delimiter to be used when converting a list of strings to a string")                 \
+    X(TABULAR_NX, "TABULAR_NX", static_cast<int>(200),                                                                                               \
+      "Number of x-axis grid points (T for PT table, h for PH table) for the BICUBIC and TTSE tabular backends. Increase for higher accuracy in "    \
+      "regions with steep gradients (e.g. near the critical point). Memory and build cost scale as O(Nx*Ny). Tables auto-rebuild when changed.")     \
+    X(TABULAR_NY, "TABULAR_NY", static_cast<int>(200),                                                                                               \
+      "Number of y-axis grid points (log P) for the BICUBIC and TTSE tabular backends. Increase for higher accuracy. Memory and build cost scale "   \
+      "as O(Nx*Ny). Tables auto-rebuild when changed.")
 
 // Use preprocessor to create the Enum
 enum configuration_keys

--- a/src/Backends/Tabular/TabularBackends.cpp
+++ b/src/Backends/Tabular/TabularBackends.cpp
@@ -1299,28 +1299,42 @@ void CoolProp::TabularDataSet::build_tables(shared_ptr<CoolProp::AbstractState>&
 /// Return the set of tabular datasets and whether tables were already loaded
 std::pair<CoolProp::TabularDataSet*, bool> CoolProp::TabularDataLibrary::get_set_of_tables(shared_ptr<AbstractState>& AS) {
     const std::string path = path_to_tables(AS);
+    const int cfg_Nx = get_config_int(TABULAR_NX);
+    const int cfg_Ny = get_config_int(TABULAR_NY);
     // Try to find tabular set if it is already loaded
     std::map<std::string, TabularDataSet>::iterator it = data.find(path);
-    // It is already in the map, return it
     if (it != data.end()) {
-        return {&(it->second), it->second.tables_loaded};
-    }
-    // It is not in the map, build it
-    else {
-        TabularDataSet set;
-        data.insert(std::pair<std::string, TabularDataSet>(path, set));
-        TabularDataSet& dataset = data[path];
-        bool loaded = false;
-        try {
-            if (!dataset.tables_loaded) {
-                dataset.load_tables(path, AS);
-            }
-            loaded = true;
-        } catch (std::exception&) {
-            loaded = false;
+        // Verify the cached dataset's grid matches the current TABULAR_NX/TABULAR_NY
+        // config; if not, evict so we rebuild at the requested resolution rather than
+        // handing back a mis-sized table (would risk OOB reads downstream in BICUBIC/TTSE
+        // coefficient lookups).
+        const TabularDataSet& cached = it->second;
+        const bool grid_matches =
+          (static_cast<int>(cached.single_phase_logph.Nx) == cfg_Nx && static_cast<int>(cached.single_phase_logph.Ny) == cfg_Ny
+           && static_cast<int>(cached.single_phase_logpT.Nx) == cfg_Nx && static_cast<int>(cached.single_phase_logpT.Ny) == cfg_Ny);
+        if (grid_matches) {
+            return {&(it->second), it->second.tables_loaded};
         }
-        return {&(dataset), loaded};
+        if (get_debug_level() > 0) {
+            std::cout << format("TABULAR_NX/NY changed (cached %zux%zu, config %dx%d); evicting cached dataset for %s\n",
+                                cached.single_phase_logph.Nx, cached.single_phase_logph.Ny, cfg_Nx, cfg_Ny, path.c_str());
+        }
+        data.erase(it);
     }
+    // Not in the map (or just evicted) -- build a fresh entry
+    TabularDataSet set;
+    data.insert(std::pair<std::string, TabularDataSet>(path, set));
+    TabularDataSet& dataset = data[path];
+    bool loaded = false;
+    try {
+        if (!dataset.tables_loaded) {
+            dataset.load_tables(path, AS);
+        }
+        loaded = true;
+    } catch (std::exception&) {
+        loaded = false;
+    }
+    return {&(dataset), loaded};
 }
 
 void CoolProp::TabularDataSet::build_coeffs(SinglePhaseGriddedTableData& table, std::vector<std::vector<CellCoeffs>>& coeffs) {

--- a/src/Backends/Tabular/TabularBackends.h
+++ b/src/Backends/Tabular/TabularBackends.h
@@ -601,8 +601,10 @@ class SinglePhaseGriddedTableData
     virtual void set_limits() = 0;
 
     SinglePhaseGriddedTableData() {
-        Nx = 200;
-        Ny = 200;
+        const int nx_cfg = get_config_int(TABULAR_NX);
+        const int ny_cfg = get_config_int(TABULAR_NY);
+        Nx = (nx_cfg > 1) ? static_cast<std::size_t>(nx_cfg) : 200;
+        Ny = (ny_cfg > 1) ? static_cast<std::size_t>(ny_cfg) : 200;
         revision = 0;
         xkey = INVALID_PARAMETER;
         ykey = INVALID_PARAMETER;

--- a/src/Backends/Tabular/TabularBackends.h
+++ b/src/Backends/Tabular/TabularBackends.h
@@ -840,7 +840,9 @@ class LogPHTable : public SinglePhaseGriddedTableData
         deserialized.convert(temp);
         temp.unpack();
         if (Nx != temp.Nx || Ny != temp.Ny) {
-            throw ValueError(format("old [%dx%d] and new [%dx%d] dimensions don't agree", temp.Nx, temp.Ny, Nx, Ny));
+            // Cached file was built at a different grid resolution than the current
+            // TABULAR_NX/TABULAR_NY config requests; force a rebuild via check_tables().
+            throw UnableToLoadError(format("Cached LogPH grid [%dx%d] does not match requested [%dx%d]; will rebuild", temp.Nx, temp.Ny, Nx, Ny));
         } else if (revision > temp.revision) {
             throw ValueError(format("loaded revision [%d] is older than current revision [%d]", temp.revision, revision));
         } else if ((std::abs(xmin) > 1e-10 && std::abs(xmax) > 1e-10)
@@ -885,7 +887,9 @@ class LogPTTable : public SinglePhaseGriddedTableData
         deserialized.convert(temp);
         temp.unpack();
         if (Nx != temp.Nx || Ny != temp.Ny) {
-            throw ValueError(format("old [%dx%d] and new [%dx%d] dimensions don't agree", temp.Nx, temp.Ny, Nx, Ny));
+            // Cached file was built at a different grid resolution than the current
+            // TABULAR_NX/TABULAR_NY config requests; force a rebuild via check_tables().
+            throw UnableToLoadError(format("Cached LogPT grid [%dx%d] does not match requested [%dx%d]; will rebuild", temp.Nx, temp.Ny, Nx, Ny));
         } else if (revision > temp.revision) {
             throw ValueError(format("loaded revision [%d] is older than current revision [%d]", temp.revision, revision));
         } else if ((std::abs(xmin) > 1e-10 && std::abs(xmax) > 1e-10)

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5513,8 +5513,7 @@ TEST_CASE("mole_fractions_liquid/vapor reject single-phase states (#2308)", "[mo
     // VLE flash (or phase-envelope build); calc_mole_fractions_liquid/vapor
     // were returning those stale values when the current state was actually
     // single-phase, which is misleading. Now they throw.
-    auto AS = std::shared_ptr<CoolProp::AbstractState>(
-      CoolProp::AbstractState::factory("HEOS", "Nitrogen&Methane&Ethane&Propane"));
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Nitrogen&Methane&Ethane&Propane"));
     AS->set_mole_fractions({0.10, 0.34, 0.41, 0.15});
 
     // Build the phase envelope so SatL/SatV pick up some non-trivial state
@@ -5537,8 +5536,10 @@ TEST_CASE("mole_fractions_liquid/vapor reject single-phase states (#2308)", "[mo
     REQUIRE(y.size() == 4);
     // Each composition must sum to ~1.0
     double sx = 0.0, sy = 0.0;
-    for (auto v : x) sx += v;
-    for (auto v : y) sy += v;
+    for (auto v : x)
+        sx += v;
+    for (auto v : y)
+        sy += v;
     CHECK(sx == Catch::Approx(1.0).epsilon(1e-9));
     CHECK(sy == Catch::Approx(1.0).epsilon(1e-9));
 }
@@ -5557,6 +5558,13 @@ TEST_CASE("REFPROP supports DmolarQ / DmassQ inputs (#1845)", "[REFPROP][1845]")
     auto AS2 = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "CO2"));
     AS2->update(CoolProp::DmassQ_INPUTS, 15.0, 1.0);
     CHECK(AS->T() == Catch::Approx(AS2->T()).epsilon(1e-6));
+}
+
+TEST_CASE("TABULAR_NX/NY config keys exist and default to 200", "[Configuration][TABULAR]") {
+    // The tabular backend grid resolution is configurable; confirm the keys
+    // are present and the documented default is honored.
+    CHECK(CoolProp::get_config_int(TABULAR_NX) == 200);
+    CHECK(CoolProp::get_config_int(TABULAR_NY) == 200);
 }
 
 #endif


### PR DESCRIPTION
## Summary
- Adds two int config keys, `TABULAR_NX` / `TABULAR_NY`, that override the previously-hardcoded 200×200 grid in `SinglePhaseGriddedTableData`. Defaults remain 200, so behavior is unchanged unless the user opts in.
- Tables auto-rebuild on cache miss when the resolution changes; the cost is paid once per (fluid, resolution) pair.
- Affects both BICUBIC and TTSE backends (they share the same gridded base).

## Context
For #1301: BICUBIC density error in CO₂'s critical region is dominated by the bicubic-Hermite cell width, not by an algorithm bug. With 200×200 the cell containing T_c is ~14 K wide, and a degree-3 polynomial cannot reproduce ρ(T) across that width regardless of where the query lands inside the cell.

End-to-end test on CO₂, T=290–330 K, P=70–100 bar:

| `TABULAR_NX/NY` | T cell width | median err | 99th pctile |
| --- | --- | --- | --- |
| 200 (default) | 14.0 K | 2.7e-3 | 44 % |
| 400 | 7.0 K | 1.7e-4 | 18 % |
| 800 | 3.5 K | 1.2e-5 | 6.2 % |

Memory and build cost scale as O(Nx·Ny) — opt-in for accuracy-critical use cases.

## Usage

```python
import CoolProp.CoolProp as CP
CP.set_config_int(CP.TABULAR_NX, 400)
CP.set_config_int(CP.TABULAR_NY, 400)
AS = CP.AbstractState('BICUBIC&HEOS', 'CO2')  # rebuilds at 400×400 on first use
```

## Files
- `include/Configuration.h` — two new int config keys
- `src/Backends/Tabular/TabularBackends.h` — read keys in `SinglePhaseGriddedTableData()` ctor
- `src/Tests/CoolProp-Tests.cpp` — Catch2 regression for keys' presence and defaults (also drive-by clang-format on a previously-committed test)
- `Web/coolprop/Tabular.rst` — concise note in the existing tabular docs

## Test plan
- [x] Local rebuild with `pip install --no-build-isolation -e .`
- [x] Verify keys exist: `CP.get_config_int(CP.TABULAR_NX)` returns 200
- [x] Verify table file size scales with N (10 MB at 200, 40 MB at 400)
- [x] Per-process error map at N ∈ {200, 400, 800} matches table above
- [ ] CI green
- [ ] Docs build green

## Notes
This is the lightweight fix. Doesn't address the cusp at T_c itself — even at N=800 the critical-singularity cell still produces a few-percent error. Bigger gains are available from interpolating a smoother quantity (e.g. residual against a cubic EOS) or adaptive grid refinement; those are follow-ups.

Closes part of #1301 (mitigation, not full resolution).