### PR TITLE
fix(build): retry hashes.json swap on Windows PermissionError (#2903)

### DIFF
--- a/dev/generate_headers.py
+++ b/dev/generate_headers.py
@@ -8,6 +8,7 @@ from datetime import datetime
 import subprocess
 import os
 import sys
+import time
 import json
 import hashlib
 import struct
@@ -439,14 +440,26 @@ def generate():
     # (32-bit cdecl/stdcall, 64-bit, arm64) that all share this same
     # dev/hashes.json; a plain open(..., 'w') would let a shorter write only
     # partially overwrite a longer one and leave stale tail bytes that break
-    # the next JSON parse.
+    # the next JSON parse. On Windows the swap step itself races against
+    # peer processes that may briefly hold the destination open, so retry
+    # os.replace with exponential backoff before giving up (issue #2903).
     if hashes:
         dirname = os.path.dirname(hashes_fname) or '.'
         fd, tmp_fname = tempfile.mkstemp(prefix='hashes.', suffix='.json.tmp', dir=dirname)
         try:
             with os.fdopen(fd, 'w') as fp:
                 fp.write(json.dumps(hashes))
-            os.replace(tmp_fname, hashes_fname)
+            attempts = 8
+            delay = 0.05
+            for i in range(attempts):
+                try:
+                    os.replace(tmp_fname, hashes_fname)
+                    break
+                except PermissionError:
+                    if i == attempts - 1:
+                        raise
+                    time.sleep(delay)
+                    delay *= 2
         except BaseException:
             if os.path.exists(tmp_fname):
                 try:


### PR DESCRIPTION
Closes #2903.

## Summary
- The Windows installer build runs `generate_headers.py` concurrently from several sub-CMake configurations (32-bit cdecl/stdcall, 64-bit, arm64) — they all target the same `dev/hashes.json`.
- The previous atomic-swap fix kept JSON valid, but the `os.replace` step itself races against peer processes that briefly hold the destination open, surfacing as `WinError 5: Access is denied` and failing the installer job.
- Wrapped `os.replace` in an 8-attempt exponential backoff (0.05s base → ~6.4s worst case) so transient sharing-violation windows are ridden out instead of aborting the build.

## Notes
- Non-Windows platforms never hit `PermissionError` on `os.replace`, so the retry path is effectively a no-op there.
- If all 8 attempts fail, the original `PermissionError` is re-raised — behavior matches today's failure mode, just much less likely.

## Test plan
- [ ] Windows installer workflow (the one that originally failed in #2903) completes through `generate_headers.py` on a re-run
- [ ] Linux / macOS CI still pass — single-process `os.replace` continues to succeed on the first attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)