### PR TITLE
fix(HumidAir): T_db from (T_wb, RelHum, P) at low RH (#2690 modes B+C)

### DIFF
--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -797,10 +797,24 @@ double isothermal_compressibility(double T, double p) {
             k_T = 1.6261876614E-22 * pow(T, 6) - 3.3016385196E-19 * pow(T, 5) + 2.7978984577E-16 * pow(T, 4) - 1.2672392901E-13 * pow(T, 3)
                   + 3.2382864853E-11 * pow(T, 2) - 4.4318979503E-09 * T + 2.5455947289E-07;
         } else {
-            // Use IF97 to do the P,T call
-            WaterIF97->update(CoolProp::PT_INPUTS, p, T);
-            Water->update(CoolProp::DmassT_INPUTS, WaterIF97->rhomass(), T);
-            k_T = Water->keyed_output(CoolProp::iisothermal_compressibility);
+            // IF97Backend::set_phase rejects PT_INPUTS whenever |p - psat(T)|
+            // is within IF97's 3.3e-5 RMS saturation-line tolerance — the
+            // pure-water phase is ambiguous there. Pre-check that same
+            // condition and route the near-saturation case through the
+            // polynomial correlation instead; for f_factor purposes the
+            // precise k_T at saturation does not matter much, and a
+            // single-valued surrogate keeps the outer (T_wb,RelHum) solver
+            // from blowing up when its T_db iterate brushes Tsat(p). (#2690)
+            constexpr double if97_sat_tol = 3.3e-5;
+            const double p_ws_T = IF97::psat97(T);
+            if (std::abs(p - p_ws_T) <= p_ws_T * if97_sat_tol) {
+                k_T = 1.6261876614E-22 * pow(T, 6) - 3.3016385196E-19 * pow(T, 5) + 2.7978984577E-16 * pow(T, 4) - 1.2672392901E-13 * pow(T, 3)
+                      + 3.2382864853E-11 * pow(T, 2) - 4.4318979503E-09 * T + 2.5455947289E-07;
+            } else {
+                WaterIF97->update(CoolProp::PT_INPUTS, p, T);
+                Water->update(CoolProp::DmassT_INPUTS, WaterIF97->rhomass(), T);
+                k_T = Water->keyed_output(CoolProp::iisothermal_compressibility);
+            }
         }
     } else {
         k_T = IsothermCompress_Ice(T, p);  //[1/Pa]
@@ -1392,12 +1406,20 @@ double WetbulbTemperature(double T, double p, double psi_w) {
     // Instantiate the solver container class
     WetBulbSolver WBS(T, p, psi_w);
 
-    // Upper bracket for Brent. Historically this was Tmax + 1, which when
-    // T >= Tsat lands ABOVE Tsat where W_s_wb in the residual goes
-    // negative (p_ws_wb > p) and the function becomes meaningless.
-    // Brent then converges to a spurious "root" near Tsat (#2255).
-    // Clamp the upper bracket to stay strictly below Tsat in that case.
-    double Tupper = (T >= Tsat) ? (Tsat - 1e-3) : (Tmax + 1);
+    // Upper bracket for Brent. Historically this was Tmax + 1, which can
+    // straddle Tsat from either side: above (T >= Tsat) makes W_s_wb in
+    // the residual go negative since p_ws_wb > p (#2255), and from below
+    // (Tsat - 1 < T < Tsat) gives Tupper = T + 1 > Tsat so internal
+    // Brent steps still land on the singular point (#2690 isolated
+    // outliers like T_wb=28, RH=1e-4, P=87550). Clamp Tupper strictly
+    // below Tsat with a margin large enough to clear IF97's saturation-
+    // tolerance band — WaterIF97->update(PT_INPUTS, p, T) throws when
+    // |psat(T) - p|/p falls below ~3e-3 %, i.e. roughly 1 mK below Tsat
+    // for atmospheric P. Use 0.1 K to give that check several orders of
+    // headroom while preserving plenty of bracket for the true Twb,
+    // which is typically tens of K below Tsat for the wet-bulb cases
+    // we care about.
+    double Tupper = std::min(Tmax + 1.0, Tsat - 0.1);
 
     double return_val = NAN;
     try {
@@ -1409,8 +1431,11 @@ double WetbulbTemperature(double T, double p, double psi_w) {
         }
         // Reject solutions that are essentially the upper bracket — that
         // is Brent giving up rather than finding a true root in the
-        // physical region (#2255).
-        if (T >= Tsat && return_val > Tsat - 1e-2) {
+        // physical region (#2255). The threshold tracks the Tupper
+        // margin above (0.1 K below Tsat); allow a small additional
+        // tolerance to distinguish "found the bracket" from "found
+        // close to the bracket".
+        if (T >= Tsat && return_val > Tsat - 0.11) {
             throw CoolProp::ValueError();
         }
     } catch (...) {
@@ -1832,6 +1857,32 @@ void _HAPropsSI_inputs(double p, const std::vector<givens>& input_keys, const st
                 }
             } else {
                 T_max = CoolProp::PropsSI("T", "P", p, "Q", 0, "Water") - 1;
+                // For (RelHum, T_wb) at very low RH the wet-bulb energy balance
+                // implies a T_db that can exceed Tsat(p): for moderate T_wb the
+                // overshoot is small (Mode A/B), for high T_wb it diverges
+                // (Mode C). Estimate T_db from the energy balance and either
+                // (a) widen T_max so Brent brackets the root directly — avoiding
+                // Secant overextrapolation into psi_w > 1 territory — or
+                // (b) reject upfront when T_db_est is beyond model validity. (#2690)
+                if (SecondaryInputKey == GIVEN_TWB && MainInputValue < 1e-3) {
+                    double T_wb_K = SecondaryInputValue;
+                    double psat_Twb = (T_wb_K > 273.16) ? IF97::psat97(T_wb_K) : psub_Ice(T_wb_K);
+                    if (psat_Twb < p) {
+                        const double eps_W = 0.621945;
+                        double W_sat_wb = eps_W * psat_Twb / (p - psat_Twb);
+                        double hfg = 2.501e6 - 2400.0 * (T_wb_K - 273.15);
+                        double cp_a = 1006.0;
+                        double T_db_est = T_wb_K + W_sat_wb * hfg / cp_a;
+                        if (T_db_est > 500.0) {
+                            throw CoolProp::ValueError(format("HAPropsSI(T_wb=%g K, RelHum=%g, P=%g Pa): the wet-bulb energy "
+                                                              "balance implies T_db ~ %g K, beyond the validity range (~500 K) "
+                                                              "of the humid-air mixture model for very dry conditions.",
+                                                              T_wb_K, MainInputValue, p, T_db_est)
+                                                         .c_str());
+                        }
+                        T_max = std::max(T_max, T_db_est + 20.0);
+                    }
+                }
             }
         }
         // Minimum drybulb temperature is the drybulb temperature corresponding to saturated air for the humidity ratio

--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -1431,11 +1431,10 @@ double WetbulbTemperature(double T, double p, double psi_w) {
         }
         // Reject solutions that are essentially the upper bracket — that
         // is Brent giving up rather than finding a true root in the
-        // physical region (#2255). The threshold tracks the Tupper
-        // margin above (0.1 K below Tsat); allow a small additional
-        // tolerance to distinguish "found the bracket" from "found
-        // close to the bracket".
-        if (T >= Tsat && return_val > Tsat - 0.11) {
+        // physical region (#2255). Derive the threshold from Tupper so
+        // it tracks the margin chosen above; the extra 10 mK distinguishes
+        // "found the bracket" from "found close to the bracket".
+        if (T >= Tsat && return_val > Tupper - 1e-2) {
             throw CoolProp::ValueError();
         }
     } catch (...) {

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4945,6 +4945,125 @@ TEST_CASE("HAPropsSI Twb at high T (T > Tsat) returns the physical root (#2255)"
         prev = Twb;
     }
 }
+TEST_CASE("HAPropsSI T_db from (T_wb, RelHum, P) — issue #2690 surviving failure modes", "[HAPropsSI][humid_air][2690]") {
+    // Issue #2690: HAPropsSI('T_db','T_wb',T_wb,'RelHum',RH,'P',P) returned
+    // "Temperature value (inf)" for narrow pressure bands at very low RH.
+    // A reporter sweep (td.xlsx, May 2026) decomposes the failures into
+    // distinct modes. The b3360b8c6 fix for #2255 (Twb solver bracket
+    // handling) already addressed the bulk of the originally-reported
+    // bands. This test pins the two surviving modes addressed in this PR.
+
+    SECTION("Mode B — Tsat(p) crossing isolated outliers") {
+        // The inner WetbulbTemperature historically used Tupper = Tmax + 1.
+        // For T just below Tsat(p), this Tupper crosses Tsat and Brent steps
+        // hit the W_s_wb singularity (p_ws_wb -> p, denominator -> 0).
+        // The fix tightens Tupper to std::min(Tmax + 1, Tsat - 1e-3).
+        const double T_db_a = HumidAir::HAPropsSI("T_db", "T_wb", 30 + 273.15, "RelHum", 1e-5, "P", 97950.0);
+        CAPTURE(T_db_a);
+        CHECK(std::isfinite(T_db_a));
+        CHECK(T_db_a > 30 + 273.15);   // T_db must exceed T_wb
+        CHECK(T_db_a < 200 + 273.15);  // and stay within HVAC range
+
+        const double T_db_b = HumidAir::HAPropsSI("T_db", "T_wb", 28 + 273.15, "RelHum", 1e-4, "P", 87550.0);
+        CAPTURE(T_db_b);
+        CHECK(std::isfinite(T_db_b));
+        CHECK(T_db_b > 28 + 273.15);
+    }
+
+    SECTION("Mode A — pressure-band cases incidentally fixed by b3360b8c6 stay green") {
+        // Sample points from the reporter's failing band on CoolProp 7.2.0.
+        // These passed once b3360b8c6 landed; pin them so the new Tupper
+        // clamp (Mode B fix) doesn't accidentally regress them.
+        for (double P : {90200.0, 90550.0, 90700.0, 91000.0, 91100.0, 91024.0}) {
+            const double T_db = HumidAir::HAPropsSI("T_db", "T_wb", 30 + 273.15, "RelHum", 1e-5, "P", P);
+            CAPTURE(P);
+            CAPTURE(T_db);
+            CHECK(std::isfinite(T_db));
+            CHECK(T_db > 30 + 273.15);
+            CHECK(T_db < 200 + 273.15);
+        }
+    }
+
+    SECTION("Mode C — physically infeasible inputs surface a clear error, not 'inf'") {
+        // At T_wb >= ~55 C with RH <= 1e-4 the wet-bulb energy balance
+        // implies T_db > 500 K, beyond the validity of the humid-air
+        // mixture model. The previous behavior was an opaque
+        // "Temperature value (inf)" from check_bounds at the bounds-check
+        // boundary. The fix detects infeasibility upfront and throws a
+        // CoolProp::ValueError whose message names T_wb / RelHum / P /
+        // T_db_estimate. HAPropsSI catches all exceptions and returns _HUGE,
+        // so we verify (a) the result is not a valid number and (b) the
+        // diagnostic error string contains the new message — not the old
+        // misleading "outside the range of validity" wording.
+        const double r1 = HumidAir::HAPropsSI("T_db", "T_wb", 60 + 273.15, "RelHum", 1e-5, "P", 90000.0);
+        CHECK_FALSE(ValidNumber(r1));
+        const std::string err1 = CoolProp::get_global_param_string("errstring");
+        CAPTURE(err1);
+        CHECK(err1.find("beyond the validity range") != std::string::npos);
+
+        const double r2 = HumidAir::HAPropsSI("T_db", "T_wb", 65 + 273.15, "RelHum", 1e-4, "P", 95000.0);
+        CHECK_FALSE(ValidNumber(r2));
+        const std::string err2 = CoolProp::get_global_param_string("errstring");
+        CAPTURE(err2);
+        CHECK(err2.find("beyond the validity range") != std::string::npos);
+    }
+
+    SECTION("Reporter sweep (td.xlsx) — Modes B+C clean, Mode D out of scope") {
+        // Abbreviated replay of the reporter's sweep over (RH, T_wb, P).
+        // After this PR, for T_wb >= 5 °C every point should either
+        // (a) return a finite T_db, or (b) surface the explicit
+        // "beyond the validity range" Mode C infeasibility error —
+        // never the misleading "Temperature value (inf)" of the prior
+        // code path. Mode D (sub-freezing T_wb=0 °C) is a separate
+        // failure mechanism and is explicitly excluded from this PR.
+        int unexpected_failures_above_freezing = 0;
+        int mode_c_above_freezing = 0;
+        int fail_at_freezing = 0;
+        const double T_wbs[] = {0, 5, 10, 15, 20, 25, 28, 29, 30, 31, 32, 35, 40, 45, 50, 55, 60, 65};
+        const double RHs[] = {0.01, 1e-3, 1e-4, 1e-5};
+        for (double RH : RHs) {
+            for (double T_wb_C : T_wbs) {
+                for (int P = 87000; P < 99000; P += 250) {  // step 250 keeps test ~< 1s
+                    const double v = HumidAir::HAPropsSI("T_db", "T_wb", T_wb_C + 273.15, "RelHum", RH, "P", (double)P);
+                    if (!ValidNumber(v)) {
+                        if (T_wb_C == 0) {
+                            ++fail_at_freezing;
+                        } else {
+                            const std::string err = CoolProp::get_global_param_string("errstring");
+                            if (err.find("beyond the validity range") != std::string::npos) {
+                                ++mode_c_above_freezing;
+                            } else {
+                                ++unexpected_failures_above_freezing;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        CAPTURE(unexpected_failures_above_freezing);
+        CAPTURE(mode_c_above_freezing);
+        CAPTURE(fail_at_freezing);
+        // Modes A+B: zero unexpected failures above freezing.
+        CHECK(unexpected_failures_above_freezing == 0);
+        // Mode C: the infeasibility detector should fire for at least the
+        // T_wb >= 60 °C low-RH points; confirms the throw path is wired up.
+        CHECK(mode_c_above_freezing > 0);
+        // Mode D: sub-freezing failures still exist (out of scope here).
+        CHECK(fail_at_freezing > 0);
+    }
+
+    SECTION("Regression guard — #2697 high-pressure Twb cases must still work") {
+        // PR #2697 was reverted because raising T_max unconditionally to 640 K
+        // broke ASHRAE A.8/A.9-style high-pressure wet-bulb computations.
+        // Re-pin a representative high-P Twb case to catch a repeat over-correction.
+        const double Twb = HumidAir::HAPropsSI("Twb", "T", 200 + 273.15, "W", 0.05, "P", 5.0e6);
+        CAPTURE(Twb);
+        CHECK(std::isfinite(Twb));
+        CHECK(Twb > 100 + 273.15);
+        CHECK(Twb < 250 + 273.15);
+    }
+}
+
 TEST_CASE("Out-of-range Q in update() does not corrupt cached state (#2195)", "[update][2195]") {
     // Issue #2195: PQ_INPUTS / QT_INPUTS / etc. assigned _Q = value
     // BEFORE validating the range, so a thrown OutOfRangeError left _Q at


### PR DESCRIPTION
## Summary

Closes Modes B and C of the residual failure surface in #2690 (after b3360b8c6's #2255 fix incidentally cleared Mode A). Sub-freezing Mode D split out to #2906.

- **Mode B** (Tsat(p)-crossing isolated outliers, e.g. `T_wb=28, RH=1e-4, P=87550`): tighten `WetbulbTemperature`'s inner Brent `Tupper` to `std::min(Tmax+1, Tsat-0.1)` (one expression now covers both #2255's `T >= Tsat` regime and #2690's `T just below Tsat` regime), and pre-check IF97's saturation tolerance in `isothermal_compressibility` so `f_factor` doesn't trip `WaterIF97->update(PT_INPUTS, …)` when the outer `Brent_HAProps_T` iterate brushes Tsat.
- **Mode C** (high `T_wb` + low RH where the wet-bulb energy balance implies `T_db > 500 K`): in `_HAPropsSI_inputs`'s `(RelHum, T_wb)` branch, estimate `T_db` from the energy balance and either (a) widen `T_max` to `T_db_est + 20 K` so Brent brackets directly, or (b) throw a clear `ValueError` naming `T_wb / RelHum / P / T_db_estimate` instead of letting the iterative solver emit `inf`. Gated on `(RelHum, T_wb)` + `RH < 1e-3` to stay clear of the high-pressure regression that got #2697 reverted in #2704.

The `catch (...)` I prototyped in `isothermal_compressibility` was replaced with an explicit pre-check (`|p - psat(T)| <= psat * 3.3e-5`) — same condition `IF97Backend::set_phase` uses, no exception-based control flow.

## Test plan

- [x] New tests under `[humid_air][2690]`:
    - Mode B isolated points (`T=30/RH=1e-5/P=97950`, `T=28/RH=1e-4/P=87550`)
    - Mode A pressure-band cases (`P ∈ {90200, 90550, 90700, 91000, 91100, 91024}`) — pin against b3360b8c6 + the new Tupper clamp
    - Mode C infeasibility error-string check (must contain "beyond the validity range")
    - ASHRAE-style high-P Twb regression guard against repeating the #2697 over-correction
    - Abbreviated replay of the reporter's `td.xlsx` sweep asserting `unexpected_failures_above_freezing == 0`
- [x] `./CatchTestRunner "[humid_air],[HAPropsSI],[2255],[2690],[2670],[2195],[water_flash],[virial_cache],[alpha0_cache]"` → 200 / 200 assertions in 12 cases
- [ ] CI: full Catch suite + clang-format pre-commit

## Out of scope

Sub-freezing `T_wb=0 °C` scatter (Mode D, ~124 points across all RH) is a separate `WetBulbSolver` discontinuity at the 273.16 K boundary between the IF97 and ice EOS branches — tracked in #2906.

🤖 Generated with [Claude Code](https://claude.com/claude-code)