### PR TITLE
fix(cmake): fetch Eigen via tarball to avoid Windows clone flakes

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -11,11 +11,16 @@ include("${CMAKE_CURRENT_LIST_DIR}/CPM.cmake")
 
 # ── Core header-only deps ──────────────────────────────────────────────────
 
+# Use tarball instead of git clone: gitlab.com cloning over CMake's
+# FetchContent custom-build step is flaky on Windows runners — when the
+# clone retries internally MSBuild still propagates the first failure
+# (see PR #2890/#2905 for similar wheel-build flake mitigations).
 CPMAddPackage(
   NAME Eigen
-  GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
-  GIT_TAG        5.0.1
-  DOWNLOAD_ONLY  YES   # header-only; skip Eigen's own CMake targets
+  VERSION 5.0.1
+  URL https://gitlab.com/libeigen/eigen/-/archive/5.0.1/eigen-5.0.1.tar.gz
+  URL_HASH SHA256=e9c326dc8c05cd1e044c71f30f1b2e34a6161a3b6ecf445d56b53ff1669e3dec
+  DOWNLOAD_ONLY YES   # header-only; skip Eigen's own CMake targets
 )
 
 CPMAddPackage(


### PR DESCRIPTION
## Summary

The Windows ARM64 `python_cibuildwheel` job has been flaking on the Eigen `git clone` from gitlab.com:

```
fetch-pack: unexpected disconnect while reading sideband packet
fatal: early EOF
fatal: fetch-pack: invalid index-pack output
```

CMake's `FetchContent` retries the clone internally and the second attempt succeeds (`Had to git clone more than once: 2 times. ... HEAD is now at bc3b39870`), but the MSBuild custom-build target has already recorded exit code -1 from the first attempt and reports `MSB8066`, failing the whole wheel build.

This switches `cmake/dependencies.cmake` to pull Eigen 5.0.1 as a tarball (with `URL_HASH` for integrity) instead of via git, avoiding the git protocol entirely.

- `${Eigen_SOURCE_DIR}` layout is unchanged (`Eigen/Core`, `Eigen/Dense` at the same depth) — drop-in for `CMakeLists.txt:302`.
- Same family of mitigations as #2890 (`PIP_RETRIES`/`PIP_TIMEOUT`) and #2905 (hashes.json swap retry).

## Test plan

- [x] `cmake -S . -B build -G Ninja` succeeds locally, Eigen extracted to `_deps/eigen-src/Eigen/` as before.
- [ ] CI: `python_cibuildwheel` (esp. windows-latest / 314 / ARM64) passes.
- [ ] CI: other wheel matrix entries still find Eigen.
- [ ] CI: `Testing Catch2`, `Development include-what-you-use`, `Library builds (shared)` still build (all consume Eigen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)