### PR TITLE
fix(docs): pin 3Dmol.js download to jsDelivr CDN

### DIFF
--- a/Web/conf.py
+++ b/Web/conf.py
@@ -306,11 +306,14 @@ assert(Path(html_logo).exists())
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-# 3Dmol.js — required for the interactive molecule viewers on fluid pages
-# Download locally to avoid CORS issues when docs are served from file:// or a local server
+# 3Dmol.js — required for the interactive molecule viewers on fluid pages.
+# Download locally to avoid CORS issues when docs are served from file:// or a local server.
+# Fetched from jsDelivr (CDN-backed npm mirror) with a pinned version, rather than the
+# single-host 3dmol.org/build/ path, which has intermittently timed out from CI runners.
+_3DMOL_VERSION = "2.5.4"
 _3dmol_js = Path(__file__).parent / '_static' / '3Dmol-min.js'
 if not _3dmol_js.exists():
-    _download('https://3dmol.org/build/3Dmol-min.js', _3dmol_js)
+    _download(f'https://cdn.jsdelivr.net/npm/3dmol@{_3DMOL_VERSION}/build/3Dmol-min.js', _3dmol_js)
 # Priority 450 ensures 3Dmol-min.js loads before require.js (added by sphinx.ext.mathjax
 # at priority 500). If 3Dmol loads after require.js, its AMD detection kicks in and
 # define([], factory) is called but never executed, silently preventing $3Dmol from being set.


### PR DESCRIPTION
## Summary

- **Root cause:** `Web/conf.py` fetches `3Dmol-min.js` at Sphinx config-load time. The previous URL — `https://3dmol.org/build/3Dmol-min.js` — is served by a single host that has intermittently timed out from GitHub-hosted runners. In [run 25767034101](https://github.com/CoolProp/CoolProp/actions/runs/25767034101/job/75681775813) the docs job aborted with exit 2 after a 60-s `ConnectTimeout` × 5 retries, after every other step (wheel, doxygen, etc.) had already succeeded.
- **Fix:** switch to a version-pinned [jsDelivr](https://www.jsdelivr.com/) URL — `https://cdn.jsdelivr.net/npm/3dmol@2.5.4/build/3Dmol-min.js` — which serves the same artifact from the npm registry via a real CDN. This mirrors how MathJax is already pulled from a version-pinned `github.com` URL elsewhere in the same `conf.py` (`Web/conf.py:140`), and avoids vendoring a 524 KB minified blob in the repo. The cache step in `docs_docker-run.yml` continues to amortise the download across builds.

## Why jsDelivr

- HTTP/2, full CORS, multi-region CDN — empirically far more reliable than `3dmol.org`.
- Serves directly from npm, where the upstream maintainers publish; `https://cdn.jsdelivr.net/npm/3dmol@2.5.4/` mirrors `package/build/3Dmol-min.js` from the tarball at `https://registry.npmjs.org/3dmol/-/3dmol-2.5.4.tgz`.
- Version is pinned (`@2.5.4`), so bumping it is an explicit edit, not a moving-target risk.
- Content verified to match upstream license header: `/*! For license information please see 3Dmol-min.js.LICENSE.txt */`.

## Test plan

- [ ] Docs job (`Documentation builds (HTML)`) succeeds on this PR
- [ ] Interactive molecule viewer on fluid pages renders correctly (manual spot-check after deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)