### PR TITLE
fix(HEOS): RAII clear of imposed iphase_gas in HSU_D_flash::solver_resid

### DIFF
--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -1405,6 +1405,15 @@ void FlashRoutines::HSU_D_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
             /// Something homogeneous to avoid flash calls
             HEOS->specify_phase(iphase_gas);
         };
+        // RAII: ensure the imposed gas phase is cleared on every exit
+        // path, including exceptions thrown from Halley/Brent.  Without
+        // this, the imposed phase leaks into subsequent state queries,
+        // which take fast paths that assume gas-phase ideal-gas
+        // guesses and converge to metastable roots in the compressed-
+        // liquid region (e.g. CO2 LIQUID).  See solver_rho_Tp; #2738.
+        ~solver_resid() {
+            HEOS->unspecify_phase();
+        }
         double call(double T) {
             HEOS->update_DmolarT_direct(rhomolar, T);
             double eos = HEOS->keyed_output(other);


### PR DESCRIPTION
## Summary

Tiny independent bugfix hoisted from the `ihb/SBTL` branch (where it landed as part of the SBTL backend squash and was flagged in PR #2678's review).

`HSU_D_flash` calls `HEOS->specify_phase(iphase_gas)` inside its `solver_resid` constructor so the 1D root-finder skips flash recursion while driving the residual to zero. On the success path the imposition is cleared by an explicit `HEOS.unspecify_phase()` call after the solve.

**The clean-up is bypassed when both Halley AND Brent throw** — the exception unwinds past the explicit `unspecify_phase()` and the gas phase stays imposed on the HEOS state. Subsequent queries (notably `solver_rho_Tp` for `PT_INPUTS`) then take gas-biased fast paths and converge to **metastable gas roots in the compressed-liquid region**, with the worst exposure on CO₂ LIQUID.

## The fix

One-line RAII destructor on `solver_resid` that calls `HEOS->unspecify_phase()`. The destructor runs on every exit path (normal return AND exception unwind), so the imposition is now exception-safe.

```diff
 solver_resid(...)
   : HEOS(HEOS), rhomolar(rhomolar), value(value), other(other), Tmin(Tmin), Tmax(Tmax) {
     /// Something homogeneous to avoid flash calls
     HEOS->specify_phase(iphase_gas);
 };
+~solver_resid() {
+    HEOS->unspecify_phase();
+}
 double call(double T) {
```

The existing explicit `unspecify_phase()` calls at the success paths become redundant but remain idempotent — kept verbatim for minimal diff.

## Test plan

- [x] `DmassSmass round-trip on the dew curve (#1907)` regression still passes (32 assertions / 1 test case).
- [x] Full Catch2 suite still passes locally.
- [ ] CI green on Linux + macOS + Windows.

## Why no new regression test

The leak only manifests when both Halley AND Brent throw inside `HSU_D_flash`. I tried to construct deterministic inputs that force both to fail — the candidate states either succeeded with one solver or were rejected by HEOS guards before reaching the solver. The fix itself is provably correct (RAII unspecify on every exit path is strictly an extension of the existing explicit unspecify), so I'm shipping the fix without a new regression. PR #2678's review surfaced the bug; its reviewers can speak to the original repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception handling robustness in flash calculations to ensure proper cleanup of internal state during error conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2916)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->