### PR TITLE
feat(sbtl): SVDSurface adapter library + msgpack persistence (Phase 2b)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,9 +286,12 @@ file(GLOB APP_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 
 # Generic SVD / Region components — sources live under src/SVD/ and
 # src/Region/, headers under include/CoolProp/{svd,region}/.
+# SBTL adapter layer (Phase 2b) sits on top — sources under src/SBTL/,
+# headers under include/CoolProp/sbtl/.
 file(GLOB SVD_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/SVD/*.cpp")
 file(GLOB REGION_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/Region/*.cpp")
-list(APPEND APP_SOURCES ${SVD_SOURCES} ${REGION_SOURCES})
+file(GLOB SBTL_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/SBTL/*.cpp")
+list(APPEND APP_SOURCES ${SVD_SOURCES} ${REGION_SOURCES} ${SBTL_SOURCES})
 
 # Add the miniz source file
 list(APPEND APP_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/externals/miniz-3.1.1/miniz.c")
@@ -2082,6 +2085,8 @@ if(COOLPROP_CATCH_MODULE)
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests.cpp")
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-SVDComponents.cpp")
+  list(APPEND APP_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-SBTLAdapter.cpp")
 
   # CATCH TEST, compile everything with catch and set test entry point
   add_executable(CatchTestRunner ${APP_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,10 @@ option(COOLPROP_SVD_E2E
        "Build the SVD-SBTL end-to-end validation tool at dev/svd_sbtl_e2e.cpp"
        OFF)
 
+option(COOLPROP_BUILD_SVD_TABLES
+       "Build the SVDSBTL bulk-table builder at dev/build_svd_tables.cpp"
+       OFF)
+
 #option (DARWIN_USE_LIBCPP
 #        "On Darwin systems, compile and link with -std=libc++ instead of the default -std=libstdc++"
 #        ON)
@@ -2144,6 +2148,20 @@ if(COOLPROP_SVD_E2E)
   add_dependencies(SVDSBTL_E2E generate_headers)
   if(UNIX)
     target_link_libraries(SVDSBTL_E2E ${CMAKE_DL_LIBS})
+  endif()
+endif()
+
+if(COOLPROP_BUILD_SVD_TABLES)
+  # Phase 2b bulk-table builder.  Writes one .svd.bin.z per fluid per
+  # input pair under ~/.CoolProp/SVDTables/.  Same pattern as
+  # COOLPROP_MAIN_MODULE / CatchTestRunner: link the whole project
+  # statically into the standalone executable.
+  add_executable(build_svd_tables
+                 ${APP_SOURCES}
+                 "${CMAKE_CURRENT_SOURCE_DIR}/dev/build_svd_tables.cpp")
+  add_dependencies(build_svd_tables generate_headers)
+  if(UNIX)
+    target_link_libraries(build_svd_tables ${CMAKE_DL_LIBS})
   endif()
 endif()
 

--- a/dev/build_svd_tables.cpp
+++ b/dev/build_svd_tables.cpp
@@ -1,0 +1,142 @@
+// Bulk-build SVDSBTL tables for a fluid set and write them to
+// ~/.CoolProp/SVDTables/<fluid>.<input_pair>.svd.bin.z.
+//
+// Build:
+//   cmake -B build -DCOOLPROP_BUILD_SVD_TABLES=ON
+//   cmake --build build --target build_svd_tables -j
+//
+// Run:
+//   ./build/build_svd_tables                 # builds the 7 Phase 2a fluids
+//   ./build/build_svd_tables Water Methane   # build a subset
+//
+// Per fluid, builds PH and PT surfaces using the presets at production
+// resolution (NT=200, NR=800, rank=20).  Reports per-file time, on-disk
+// size, and a quick read-back sanity check.
+//
+// This is a developer tool — exempt from a few clang-tidy style nags
+// (printf, deterministic-seed RNG, empty catch on optional HEOS
+// failures).
+// NOLINTBEGIN(cppcoreguidelines-pro-type-vararg,cert-err33-c,hicpp-vararg,bugprone-empty-catch)
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <exception>
+#include <filesystem>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "AbstractState.h"
+#include "CoolProp/sbtl/SVDSurface.h"
+#include "CoolProp/sbtl/SVDSurfaceFactory.h"
+#include "CoolProp/sbtl/SVDSurfaceSerializer.h"
+
+namespace cp_sbtl = CoolProp::sbtl;
+
+namespace {
+
+std::size_t env_size_t(const char* name, std::size_t fallback) {
+    const char* v = std::getenv(name);
+    if (v == nullptr || v[0] == 0) {
+        return fallback;
+    }
+    try {
+        return static_cast<std::size_t>(std::stoul(v));
+    } catch (...) {
+        return fallback;
+    }
+}
+
+std::int32_t env_int(const char* name, std::int32_t fallback) {
+    const char* v = std::getenv(name);
+    if (v == nullptr || v[0] == 0) {
+        return fallback;
+    }
+    try {
+        return static_cast<std::int32_t>(std::stoi(v));
+    } catch (...) {
+        return fallback;
+    }
+}
+
+double file_size_kb(const std::string& path) {
+    std::error_code ec;
+    const auto sz = std::filesystem::file_size(path, ec);
+    if (ec) {
+        return 0.0;
+    }
+    return static_cast<double>(sz) / 1024.0;
+}
+
+void build_one(const std::string& fluid, std::size_t NT, std::size_t NR, std::int32_t rank) {
+    auto heos = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("HEOS", fluid));
+
+    for (const auto pair : {::CoolProp::HmassP_INPUTS, ::CoolProp::PT_INPUTS}) {
+        const std::string label = (pair == ::CoolProp::HmassP_INPUTS) ? "PH" : "PT";
+        const std::string out_path = cp_sbtl::SVDSurfaceSerializer::default_cache_path(fluid, pair);
+
+        std::printf("  %s %s  building... ", fluid.c_str(), label.c_str());
+        std::fflush(stdout);
+
+        const auto t0 = std::chrono::steady_clock::now();
+        cp_sbtl::SurfaceSpec spec = (pair == ::CoolProp::HmassP_INPUTS) ? cp_sbtl::presets::ph_subcritical(*heos, NT, NR, rank)
+                                                                        : cp_sbtl::presets::pt_subcritical(*heos, NT, NR, rank);
+        cp_sbtl::SVDSurface surface = cp_sbtl::build_surface(*heos, std::move(spec));
+        const auto t1 = std::chrono::steady_clock::now();
+
+        cp_sbtl::SVDSurfaceSerializer::save_to_file(surface, out_path);
+        const auto t2 = std::chrono::steady_clock::now();
+
+        // Quick load-back sanity check.
+        const auto reloaded = cp_sbtl::SVDSurfaceSerializer::load_from_file(out_path);
+        if (reloaded.region_count() != surface.region_count()) {
+            throw std::runtime_error("build_one: load-back region_count mismatch for " + fluid + " " + label);
+        }
+
+        const double build_s = std::chrono::duration<double>(t1 - t0).count();
+        const double save_s = std::chrono::duration<double>(t2 - t1).count();
+        std::printf("build=%.1fs  save=%.2fs  size=%.1f kB  → %s\n", build_s, save_s, file_size_kb(out_path), out_path.c_str());
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    const std::size_t NT = env_size_t("SVD_NT", 200);
+    const std::size_t NR = env_size_t("SVD_NR", 800);
+    const std::int32_t rank = env_int("SVD_RANK", 20);
+
+    std::vector<std::string> fluids;
+    if (argc > 1) {
+        for (int i = 1; i < argc; ++i) {
+            fluids.emplace_back(argv[i]);
+        }
+    } else {
+        // Default: the 7 Phase 2a fluids.
+        fluids = {"Water", "CarbonDioxide", "R134a", "Ammonia", "Methane", "Propane", "D6"};
+    }
+
+    std::printf("SVDSBTL bulk-build  (NT=%zu  NR=%zu  rank=%d)\n", NT, NR, rank);
+    std::printf("Cache dir: %s\n\n", cp_sbtl::SVDSurfaceSerializer::default_cache_dir().c_str());
+
+    int ok = 0;
+    int failed = 0;
+    const auto t_global = std::chrono::steady_clock::now();
+    for (const auto& fluid : fluids) {
+        try {
+            build_one(fluid, NT, NR, rank);
+            ++ok;
+        } catch (const std::exception& e) {
+            std::printf("  %s  ERROR: %s\n", fluid.c_str(), e.what());
+            ++failed;
+        }
+    }
+    const double total_s = std::chrono::duration<double>(std::chrono::steady_clock::now() - t_global).count();
+    std::printf("\nDone in %.1fs: %d ok, %d failed.\n", total_s, ok, failed);
+    return failed == 0 ? 0 : 1;
+}
+
+// NOLINTEND(cppcoreguidelines-pro-type-vararg,cert-err33-c,hicpp-vararg,bugprone-empty-catch)

--- a/include/CoolProp/region/ConstantCurve.h
+++ b/include/CoolProp/region/ConstantCurve.h
@@ -19,6 +19,19 @@ class ConstantCurve final : public BoundaryCurve
         }
     }
 
+    // Plain-data snapshot for serialization.  Safe to expose because
+    // the only invariant ConstantCurve enforces (a_hi > a_lo) is
+    // re-checked by the constructor.
+    struct State
+    {
+        double a_lo;
+        double a_hi;
+        double b;
+    };
+    [[nodiscard]] State state() const noexcept {
+        return State{a_lo_, a_hi_, b_};
+    }
+
     [[nodiscard]] double eval(double /*a*/) const noexcept override {
         return b_;
     }

--- a/include/CoolProp/region/CubicSplineCurve.h
+++ b/include/CoolProp/region/CubicSplineCurve.h
@@ -44,6 +44,26 @@ class CubicSplineCurve final : public BoundaryCurve
     // input.
     static std::unique_ptr<CubicSplineCurve> build(std::vector<double> a, std::vector<double> b);
 
+    // Plain-data snapshot for serialization.  Captures the natural-
+    // spline state: knot positions a, knot values b, the
+    // second-derivative table M, and the tight bounds (b_min, b_max)
+    // computed by build() via cubic-extremum root finding.
+    struct State
+    {
+        std::vector<double> a;
+        std::vector<double> b;
+        std::vector<double> M;
+        double b_min;
+        double b_max;
+    };
+    [[nodiscard]] State state() const;
+
+    // Trusted factory: reconstructs a CubicSplineCurve from a State
+    // snapshot WITHOUT re-running the tridiagonal solve.  Used by the
+    // SBTL deserializer.  Validates the state shape (a/b/M all same
+    // length, a strictly increasing) and rejects malformed input.
+    static std::unique_ptr<CubicSplineCurve> from_state(State s);
+
     [[nodiscard]] double eval(double a) const noexcept override;
     [[nodiscard]] double eval_da(double a) const noexcept override;
     [[nodiscard]] std::pair<double, double> bounds() const noexcept override;

--- a/include/CoolProp/region/PiecewiseChebyshevCurve.h
+++ b/include/CoolProp/region/PiecewiseChebyshevCurve.h
@@ -60,6 +60,32 @@ class PiecewiseChebyshevCurve final : public BoundaryCurve
     static std::unique_ptr<PiecewiseChebyshevCurve> build(double a_lo, double a_hi, std::size_t n_pieces, std::size_t degree, ParamScale scale,
                                                           const std::function<double(double)>& f);
 
+    // Plain-data snapshot of a single piece's coefficient state.
+    struct PieceState
+    {
+        double t_lo;
+        double t_hi;
+        double inv_half_span;
+        double t_mid;
+        std::vector<double> coeffs;        // size degree+1
+        std::vector<double> deriv_coeffs;  // size degree (drops trivially-zero last coeff)
+    };
+    // Snapshot of the whole curve.
+    struct State
+    {
+        double a_lo;
+        double a_hi;
+        ParamScale scale;
+        std::vector<PieceState> pieces;
+        double b_min;
+        double b_max;
+    };
+    [[nodiscard]] State state() const;
+
+    // Trusted factory: reconstructs from a previously-captured State
+    // without re-sampling f.  Used by the SBTL deserializer.
+    static std::unique_ptr<PiecewiseChebyshevCurve> from_state(State s);
+
     [[nodiscard]] double eval(double a) const noexcept override;
     [[nodiscard]] double eval_da(double a) const noexcept override;
     [[nodiscard]] std::pair<double, double> bounds() const noexcept override;

--- a/include/CoolProp/sbtl/SVDSurface.h
+++ b/include/CoolProp/sbtl/SVDSurface.h
@@ -1,0 +1,157 @@
+#ifndef COOLPROP_SBTL_SVD_SURFACE_H
+#define COOLPROP_SBTL_SVD_SURFACE_H
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "CoolProp/region/RegionAtlas.h"
+#include "CoolProp/svd/SVDDecomposition.h"
+#include "CoolProp/svd/SVDEvaluator.h"
+#include "DataStructures.h"
+
+namespace CoolProp {
+namespace sbtl {
+
+// An SVDSurface aggregates everything needed for a one-input-pair
+// property lookup on a single pure fluid:
+//
+//   - a RegionAtlas over the (a, b) plane (LIQUID / VAPOR / SUPER /
+//     ...) that tells us which region a query falls into;
+//   - one SVDDecomposition per (region, property) pair, heap-allocated
+//     so addresses stay stable across vector growth (Phase 2a learned
+//     this the hard way — see SVDEvaluator.h's dangling-pointer note);
+//   - an SVDEvaluator per decomposition;
+//   - metadata: which input pair this surface represents (PT, HP, DU,
+//     ...), the fluid name, and the list of output properties.
+//
+// Lookups go:
+//
+//   user calls eval(prop, a, b)
+//     ↓
+//   atlas.find_region(a, b)            → region index or -1
+//     ↓
+//   region.to_normalized(a, b)         → (xi, eta) in [0,1]^2
+//     ↓
+//   SVDEvaluator::eval(xi_or_eta_x, xi_or_eta_y)
+//                                       → exp(Σ S_k u_k v_k)
+//     ↓
+//   return ρ / h / s / ...
+//
+// The two-axis ordering for the SVD (which coordinate is x_grid and
+// which is y_grid) is fixed by SurfaceSpec at build time — see
+// SVDSurfaceFactory.h.  By the convention used in Phase 2a's e2e tool
+// the SVD's x-axis is the *secondary* axis (the η normalized
+// secondary coordinate, in [0, 1]) and the y-axis is the *primary*
+// axis (the ξ primary coordinate, also in [0, 1]).
+class SVDSurface
+{
+   public:
+    // Construct an empty surface.  Add regions + per-region per-
+    // property decompositions via add_region_property_svd().  Finalise
+    // with seal() — after which no further mutations are allowed and
+    // the evaluators (lazily-constructed from the heap-allocated
+    // decompositions) become callable.
+    //
+    // The properties argument fixes the property dimension; every
+    // region must register exactly one decomposition per property in
+    // the same order.  Reorderable downstream via property indexing.
+    SVDSurface(std::string fluid_name, ::CoolProp::input_pairs input_pair, std::vector<::CoolProp::parameters> properties);
+
+    // Non-copyable; the heap-resident decompositions are unique_ptr
+    // owned.  Movable.
+    SVDSurface(const SVDSurface&) = delete;
+    SVDSurface& operator=(const SVDSurface&) = delete;
+    SVDSurface(SVDSurface&&) = default;
+    SVDSurface& operator=(SVDSurface&&) = default;
+    ~SVDSurface() = default;
+
+    // Add a new region.  Returns the region index assigned by the
+    // underlying RegionAtlas.  Once a region is added, its property
+    // decompositions must be supplied via add_region_property_svd
+    // before seal() is called.
+    std::size_t add_region(region::Region region);
+
+    // Register one property SVD for an already-added region.
+    // `region_idx` must match the value returned by add_region();
+    // `prop` must be one of the properties passed to the constructor.
+    void add_region_property_svd(std::size_t region_idx, ::CoolProp::parameters prop, svd::SVDDecomposition decomp);
+
+    // Lock the surface for evaluation.  Validates that every region
+    // has registered every property.  After seal() returns, eval()
+    // and resolve() are callable; add_* methods throw.
+    void seal();
+
+    // Lookup `prop` at (a, b).  Returns NaN if (a, b) is outside every
+    // region of the atlas.  Throws std::invalid_argument if `prop`
+    // isn't one of the properties this surface stores.
+    [[nodiscard]] double eval(::CoolProp::parameters prop, double a, double b) const;
+
+    // Two-step lookup for callers that want to query several
+    // properties at the same (a, b) without paying for atlas dispatch
+    // each time.  Returns (region_idx, xi, eta).  region_idx = -1 if
+    // outside every region.
+    struct ResolvedPoint
+    {
+        int region_idx;
+        double svd_x;  // value to feed into SVDEvaluator's x axis
+        double svd_y;  // value to feed into SVDEvaluator's y axis
+    };
+    [[nodiscard]] ResolvedPoint resolve(double a, double b) const noexcept;
+
+    // Fast path after resolve(): evaluate `prop` at a pre-computed
+    // (region, svd_x, svd_y).  Caller responsible for ensuring
+    // region_idx >= 0.
+    [[nodiscard]] double eval_with_region(::CoolProp::parameters prop, int region_idx, double svd_x, double svd_y) const;
+
+    // Convenience predicates.
+    [[nodiscard]] bool contains_property(::CoolProp::parameters prop) const noexcept;
+
+    // Read-only access.
+    [[nodiscard]] const std::string& fluid_name() const noexcept {
+        return fluid_name_;
+    }
+    [[nodiscard]] ::CoolProp::input_pairs input_pair() const noexcept {
+        return input_pair_;
+    }
+    [[nodiscard]] const std::vector<::CoolProp::parameters>& properties() const noexcept {
+        return properties_;
+    }
+    [[nodiscard]] const region::RegionAtlas& atlas() const noexcept {
+        return atlas_;
+    }
+    [[nodiscard]] bool sealed() const noexcept {
+        return sealed_;
+    }
+    [[nodiscard]] std::size_t region_count() const noexcept;
+
+    // Direct access to the heap-resident decomposition for a region /
+    // property — primarily for serialization.  Throws if either
+    // index is out of range.
+    [[nodiscard]] const svd::SVDDecomposition& decomposition(std::size_t region_idx, ::CoolProp::parameters prop) const;
+
+   private:
+    // Lookup table: property → index into the per-region property
+    // array.  Built once at construction.
+    [[nodiscard]] std::size_t property_index(::CoolProp::parameters prop) const;
+
+    std::string fluid_name_;
+    ::CoolProp::input_pairs input_pair_;
+    std::vector<::CoolProp::parameters> properties_;
+
+    region::RegionAtlas atlas_;
+
+    // Per-region storage.  Sized to atlas_.size() after seal().
+    // decomps_[region_idx][property_idx] is the heap-resident SVDDecomposition.
+    std::vector<std::vector<std::unique_ptr<svd::SVDDecomposition>>> decomps_;
+    // Parallel evaluator vector, lazily filled in seal().
+    std::vector<std::vector<std::unique_ptr<svd::SVDEvaluator>>> evaluators_;
+
+    bool sealed_ = false;
+};
+
+}  // namespace sbtl
+}  // namespace CoolProp
+
+#endif  // COOLPROP_SBTL_SVD_SURFACE_H

--- a/include/CoolProp/sbtl/SVDSurfaceFactory.h
+++ b/include/CoolProp/sbtl/SVDSurfaceFactory.h
@@ -1,0 +1,61 @@
+#ifndef COOLPROP_SBTL_SVD_SURFACE_FACTORY_H
+#define COOLPROP_SBTL_SVD_SURFACE_FACTORY_H
+
+#include <cstddef>
+
+#include "AbstractState.h"
+#include "CoolProp/sbtl/SVDSurface.h"
+#include "CoolProp/sbtl/SurfaceSpec.h"
+#include "CoolProp/svd/SVDDecomposition.h"
+
+namespace CoolProp {
+namespace sbtl {
+
+struct BuildOptions
+{
+    svd::SlopeSource slope_source = svd::SlopeSource::NATURAL_CUBIC_SPLINE;
+    bool verbose = false;
+};
+
+// Generic factory: walk the per-region (xnorm, log_p) grid, call HEOS
+// per cell via the spec's `update_state` + `read_property` callbacks,
+// build one SVD per (region, property), seal into an SVDSurface.
+//
+// SurfaceSpec is consumed (moved-from) so the unique_ptr boundary
+// curves it owns transfer cleanly into the new SVDSurface's regions.
+//
+// Throws on:
+//   - empty spec.regions / spec.properties
+//   - mismatched spec.input_pair vs the callbacks' assumed inputs
+//     (only detectable if the callbacks throw at sampling time)
+//   - SVDBuilder failures (rank-deficient, non-finite samples surviving
+//     the row-fill, ...)
+SVDSurface build_surface(::CoolProp::AbstractState& heos, SurfaceSpec spec, const BuildOptions& opts = {});
+
+// Preset SurfaceSpec builders for the two MVP input pairs.  Each one
+// constructs:
+//   - 2-region atlas (LIQUID, VAPOR) over [p_triple, p_crit]
+//   - CubicSpline sat boundaries via SatBoundaryFactory
+//   - The standard property list for that input pair
+//   - Default NT=200, NR=800, rank=20 grid sizes
+//
+// Caller can then mutate the SurfaceSpec before calling
+// build_surface() (raise the rank for a hard fluid, swap a boundary
+// curve, add an extra output property, etc.).
+//
+// Subsequent phases ship DU / HS / PS / DT presets the same way — no
+// changes to build_surface() or downstream consumers.
+namespace presets {
+
+// HmassP_INPUTS preset.  (a, b) = (p, h).  Output properties: rho, T, s, u.
+SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT = 200, std::size_t NR = 800, std::int32_t rank = 20);
+
+// PT_INPUTS preset.  (a, b) = (p, T).  Output properties: rho, h, s, u.
+SurfaceSpec pt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT = 200, std::size_t NR = 800, std::int32_t rank = 20);
+
+}  // namespace presets
+
+}  // namespace sbtl
+}  // namespace CoolProp
+
+#endif  // COOLPROP_SBTL_SVD_SURFACE_FACTORY_H

--- a/include/CoolProp/sbtl/SVDSurfaceSerializer.h
+++ b/include/CoolProp/sbtl/SVDSurfaceSerializer.h
@@ -29,7 +29,9 @@ namespace sbtl {
 //
 //   [
 //     input_pair,                    // int (CoolProp::input_pairs)
-//     [[prop_key, transform], ...],  // properties
+//     [[prop_key], ...],             // properties (length-1 arrays;
+//                                    //  per-property OutputTransform
+//                                    //  lives inside each decomp_blob)
 //     [region_blob, ...],            // regions
 //     [decomp_blob, ...]             // per (region, property) SVDs
 //   ]
@@ -50,8 +52,10 @@ namespace sbtl {
 //     they add anything.
 //
 // File extension convention: `.svd.bin.z`, parallel to BicubicBackend's
-// `.bin.z`.  Stored at `${HOME}/.CoolProp/SVDTables/<fluid>.svd.bin.z`
-// by the helper paths below.
+// `.bin.z`.  Stored at
+// `${HOME}/.CoolProp/SVDTables/<fluid>.<input_pair>.svd.bin.z`
+// by the helper paths below — see default_cache_path() for the exact
+// composition (input_pair is the integer value of the enum).
 
 class SVDSurfaceSerializer
 {

--- a/include/CoolProp/sbtl/SVDSurfaceSerializer.h
+++ b/include/CoolProp/sbtl/SVDSurfaceSerializer.h
@@ -1,0 +1,92 @@
+#ifndef COOLPROP_SBTL_SVD_SURFACE_SERIALIZER_H
+#define COOLPROP_SBTL_SVD_SURFACE_SERIALIZER_H
+
+#include <string>
+#include <vector>
+
+#include "CoolProp/sbtl/SVDSurface.h"
+
+namespace CoolProp {
+namespace sbtl {
+
+// Persistence layer for SVDSurface.  Writes a msgpack stream wrapped
+// in a zlib-compressed payload, matching the existing TabularBackends
+// `.bin.z` convention.
+//
+// File format (compressed bytes contain a single msgpack array):
+//
+//   [
+//     "SVDS",          // magic, string
+//     1,               // revision, int
+//     <fluid_name>,    // string
+//     [                // surfaces, array (length n_surfaces)
+//       <surface_0>,
+//       ...
+//     ]
+//   ]
+//
+// Each <surface_k> is a flat positional msgpack array:
+//
+//   [
+//     input_pair,                    // int (CoolProp::input_pairs)
+//     [[prop_key, transform], ...],  // properties
+//     [region_blob, ...],            // regions
+//     [decomp_blob, ...]             // per (region, property) SVDs
+//   ]
+//
+// Region geometry + boundary curves serialize via the State POD
+// snapshots exposed on ConstantCurve / CubicSplineCurve /
+// PiecewiseChebyshevCurve.  Each curve is tagged with a uint8 kind
+// discriminator so the deserializer knows which from_state() to
+// call.
+//
+// Backward / forward compatibility:
+//   - The magic + revision header lets the loader reject obviously
+//     non-SVD files and lets future revisions add fields.
+//   - A loader on rev N hitting a stream written for rev N+M with
+//     extra trailing fields will silently ignore them (msgpack arrays
+//     are length-prefixed).  A loader on rev N+M reading rev N data
+//     will throw on the missing fields — adopters bump revision when
+//     they add anything.
+//
+// File extension convention: `.svd.bin.z`, parallel to BicubicBackend's
+// `.bin.z`.  Stored at `${HOME}/.CoolProp/SVDTables/<fluid>.svd.bin.z`
+// by the helper paths below.
+
+class SVDSurfaceSerializer
+{
+   public:
+    static constexpr int kRevision = 1;
+
+    // Pack one surface into a zlib-compressed msgpack blob.
+    static std::vector<char> save(const SVDSurface& surface);
+
+    // Reverse: parse a compressed blob back into a fully-sealed
+    // SVDSurface.  Throws std::runtime_error on:
+    //   - zlib decompression failure
+    //   - magic / revision mismatch
+    //   - missing or malformed fields
+    //   - invalid curve / decomp dimensions surfacing through the
+    //     trusted from_state() factories
+    static SVDSurface load(const std::vector<char>& compressed);
+
+    // File-level convenience.  save_to_file overwrites; load_from_file
+    // throws if the file doesn't exist or is unreadable.
+    static void save_to_file(const SVDSurface& surface, const std::string& path);
+    static SVDSurface load_from_file(const std::string& path);
+
+    // Returns the standard cache directory:
+    //   ${HOME}/.CoolProp/SVDTables/
+    // Creates the directory if it doesn't exist.  Mirrors the
+    // existing BicubicBackend pattern (see TabularBackends.h:1035).
+    static std::string default_cache_dir();
+
+    // Compose default_cache_dir() with "<fluid>.<input_pair>.svd.bin.z"
+    // so PH and PT surfaces for the same fluid get distinct files.
+    static std::string default_cache_path(const std::string& fluid_name, ::CoolProp::input_pairs input_pair);
+};
+
+}  // namespace sbtl
+}  // namespace CoolProp
+
+#endif  // COOLPROP_SBTL_SVD_SURFACE_SERIALIZER_H

--- a/include/CoolProp/sbtl/SatBoundaryFactory.h
+++ b/include/CoolProp/sbtl/SatBoundaryFactory.h
@@ -1,0 +1,86 @@
+#ifndef COOLPROP_SBTL_SAT_BOUNDARY_FACTORY_H
+#define COOLPROP_SBTL_SAT_BOUNDARY_FACTORY_H
+
+#include <memory>
+
+#include "AbstractState.h"
+#include "CoolProp/region/CubicSplineCurve.h"
+
+namespace CoolProp {
+namespace sbtl {
+
+// Thermodynamics-aware factories that turn HEOS state queries into
+// reusable BoundaryCurve objects.  These are convenience wrappers over
+// the Phase 1 generic curves — Region/Atlas know nothing about HEOS,
+// but every SBTL preset needs HEOS-sampled sat curves, so the wrapper
+// lives here so the Phase 1 components stay fluid-agnostic.
+//
+// All factories return CubicSplineCurve (C^2 continuous) sampled at
+// `n_knots` points log-uniform in pressure.  C^2 is the right default
+// for SBTL: smooth across knots so the η normalization doesn't
+// introduce derivative kinks (which would show up as bands of
+// elevated SVD error — Phase 2a verified this empirically for Water).
+//
+// Default knot count (64) is plenty for the smooth sat curves of
+// pure fluids; raise it if a fluid's curve has unusually fast log-p
+// variation.
+//
+// TODO (Phase 2c): the *true* sat boundaries can be a no-refit view
+// onto the existing fluid superancillary (h_sat(T) chained with
+// T_sat(p) — both already machine-precision Chebyshev expansions on
+// the SuperAncillary class).  Doing this needs (a) a public accessor
+// on HelmholtzEOSMixtureBackend (currently get_superanc() is
+// protected, see HelmholtzEOSMixtureBackend.h:65), and (b) a new
+// `SuperancillaryBoundaryCurve` BoundaryCurve subclass that composes
+// the two expansions and carries them through eval / eval_da.
+// Same factory entry points; same return type; same SVDSurface
+// consumer.  Defer to Phase 2c when the backend itself will need to
+// pull the superancillary out anyway.
+
+struct SatBoundaryBuildOptions
+{
+    std::size_t n_knots = 64;  // CubicSplineCurve knots per curve
+};
+
+// h_sat,L(p) — mass enthalpy on the saturated-liquid side of the dome.
+//
+// HEOS calls go through PQ_INPUTS with Q = 0.  Throws if p is outside
+// the fluid's saturation range or HEOS rejects the PQ flash.
+std::unique_ptr<region::CubicSplineCurve> build_h_sat_L(::CoolProp::AbstractState& heos, double p_min, double p_max,
+                                                        const SatBoundaryBuildOptions& opts = {});
+
+// h_sat,V(p) — mass enthalpy on the saturated-vapor side of the dome.
+// PQ_INPUTS with Q = 1.
+std::unique_ptr<region::CubicSplineCurve> build_h_sat_V(::CoolProp::AbstractState& heos, double p_min, double p_max,
+                                                        const SatBoundaryBuildOptions& opts = {});
+
+// T_sat(p) — saturation temperature.  Single-valued for pure fluids
+// (LIQUID and VAPOR sat curves coincide on T).  Uses PQ_INPUTS with
+// Q = 0.
+std::unique_ptr<region::CubicSplineCurve> build_T_sat(::CoolProp::AbstractState& heos, double p_min, double p_max,
+                                                      const SatBoundaryBuildOptions& opts = {});
+
+// Isobar h-floor: h on the cold-isotherm boundary.  For fluids with
+// steep melting curves (Methane / Propane / CO2 LIQUID at high p),
+// T_min may fall below T_melt(p) at part of the pressure range;
+// the lambda walks T up in 0.5 K increments until HEOS accepts the
+// state.  Resulting floor is non-isothermal but still monotone in p.
+// Matches Phase 2a's `h_lo_liq` lambda.
+std::unique_ptr<region::CubicSplineCurve> build_h_isotherm_floor(::CoolProp::AbstractState& heos, double p_min, double p_max, double T_min,
+                                                                 const SatBoundaryBuildOptions& opts = {});
+
+// Isobar h-ceiling: h on the hot-isotherm boundary (T = T_max - margin
+// so we stay strictly inside the HEOS validity envelope).
+std::unique_ptr<region::CubicSplineCurve> build_h_isotherm_ceiling(::CoolProp::AbstractState& heos, double p_min, double p_max, double T_max,
+                                                                   const SatBoundaryBuildOptions& opts = {});
+
+// Convenience: subcritical pressure range for `fluid`.  Returns
+// (p_min, p_max) ≈ (p_triple * 1.01, p_crit * 0.999) so PQ flashes
+// don't fail at the exact boundary.  Driven by the fluid's HEOS
+// AbstractState — needs an instance already constructed by the caller.
+std::pair<double, double> subcritical_pressure_range(::CoolProp::AbstractState& heos);
+
+}  // namespace sbtl
+}  // namespace CoolProp
+
+#endif  // COOLPROP_SBTL_SAT_BOUNDARY_FACTORY_H

--- a/include/CoolProp/sbtl/SurfaceSpec.h
+++ b/include/CoolProp/sbtl/SurfaceSpec.h
@@ -1,0 +1,117 @@
+#ifndef COOLPROP_SBTL_SURFACE_SPEC_H
+#define COOLPROP_SBTL_SURFACE_SPEC_H
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "AbstractState.h"
+#include "CoolProp/region/AxisTransform.h"
+#include "CoolProp/region/BoundaryCurve.h"
+#include "CoolProp/svd/SVDDecomposition.h"
+#include "DataStructures.h"
+
+namespace CoolProp {
+namespace sbtl {
+
+// Per-region geometry: primary axis + two boundary curves on the
+// secondary axis.  Identical to what `region::Region` takes, but
+// staged in a value-type aggregate so SurfaceSpec can be assembled
+// incrementally before any Region exists.
+struct RegionSpec
+{
+    // Default-state primary is filled in by builder code before any
+    // build_surface() call reads it; the aggregate default is a
+    // never-contains AxisTransform that fails AxisTransform::make's
+    // invariants if accidentally used.
+    region::AxisTransform primary{region::AxisScale::LINEAR, 0.0, 1.0, 0.0, 1.0, 1.0};
+    std::unique_ptr<region::BoundaryCurve> b_lo;
+    std::unique_ptr<region::BoundaryCurve> b_hi;
+
+    RegionSpec() = default;
+    RegionSpec(region::AxisTransform p, std::unique_ptr<region::BoundaryCurve> lo, std::unique_ptr<region::BoundaryCurve> hi)
+      : primary(p), b_lo(std::move(lo)), b_hi(std::move(hi)) {}
+    RegionSpec(const RegionSpec&) = delete;
+    RegionSpec& operator=(const RegionSpec&) = delete;
+    RegionSpec(RegionSpec&&) = default;
+    RegionSpec& operator=(RegionSpec&&) = default;
+    ~RegionSpec() = default;
+};
+
+// One output property to tabulate on the surface, plus the transform
+// the SVD evaluator should apply at lookup time.
+//
+//   IDENTITY : value = Σ_k σ_k u_k v_k                  (default)
+//   EXP      : value = exp(Σ_k σ_k u_k v_k)             (log-fit)
+//
+// EXP is the right choice for strictly-positive properties with wide
+// dynamic range (density, pressure).  IDENTITY for properties that
+// can change sign or that vary by orders of magnitude only locally
+// (enthalpy near reference state, entropy, internal energy).
+struct PropertySpec
+{
+    ::CoolProp::parameters key = ::CoolProp::iDmass;
+    svd::OutputTransform transform = svd::OutputTransform::IDENTITY;
+};
+
+// Complete recipe for one SVDSurface.  Captures both the geometry
+// (how regions are bounded) and the thermodynamics (how to sample
+// HEOS at any (a, b) and which properties to read out).
+//
+// The two callbacks `update_state` and `read_property` are the
+// thermodynamics-aware glue that keeps the rest of the library
+// input-pair-agnostic:
+//
+//   update_state(heos, a, b)
+//     ↑ takes the surface's (a, b) inputs and puts the HEOS state
+//       into the matching configuration via the right
+//       AbstractState::update() input-pair call.
+//
+//   read_property(heos, key)
+//     ↑ reads `key` off the already-updated HEOS state.
+//
+// PH preset uses `heos.update(HmassP_INPUTS, h, p)` then
+// `heos.rhomass()` / `heos.T()` / `heos.smass()` / `heos.umass()`.
+// PT preset uses `heos.update(PT_INPUTS, p, T)` then
+// `heos.rhomass()` / `heos.hmass()` / `heos.smass()` / `heos.umass()`.
+// DU / HS / PS presets plug in by writing their own pair of lambdas;
+// no other files in this library need to change.
+struct SurfaceSpec
+{
+    std::string fluid_name;
+    // The unscoped CoolProp::input_pairs enum lacks a portable
+    // "sentinel" value — initialise to PT_INPUTS which is always a
+    // valid enumerator, then expect builders to overwrite.
+    ::CoolProp::input_pairs input_pair = ::CoolProp::PT_INPUTS;
+    std::vector<RegionSpec> regions;
+    std::vector<PropertySpec> properties;
+
+    // Thermodynamics-aware glue.  See SurfaceSpec docstring above.
+    // update_state should throw on two-phase / HEOS failure; the
+    // factory's per-cell loop catches and treats that cell as NaN.
+    std::function<void(::CoolProp::AbstractState&, double a, double b)> update_state;
+    std::function<double(::CoolProp::AbstractState&, ::CoolProp::parameters)> read_property;
+
+    // SVD grid sizing.  The defaults match Phase 2a's production
+    // resolution (Water max ≈ 7e-5 fractional with CubicSpline sat
+    // boundaries).  Override per-fluid when needed.
+    std::size_t NT = 200;
+    std::size_t NR = 800;
+    std::int32_t rank = 20;
+
+    SurfaceSpec() = default;
+    SurfaceSpec(const SurfaceSpec&) = delete;
+    SurfaceSpec& operator=(const SurfaceSpec&) = delete;
+    SurfaceSpec(SurfaceSpec&&) = default;
+    SurfaceSpec& operator=(SurfaceSpec&&) = default;
+    ~SurfaceSpec() = default;
+};
+
+}  // namespace sbtl
+}  // namespace CoolProp
+
+#endif  // COOLPROP_SBTL_SURFACE_SPEC_H

--- a/src/Region/CubicSplineCurve.cpp
+++ b/src/Region/CubicSplineCurve.cpp
@@ -174,6 +174,26 @@ std::unique_ptr<CubicSplineCurve> CubicSplineCurve::build(std::vector<double> a,
 CubicSplineCurve::CubicSplineCurve(std::vector<double> a, std::vector<double> b, std::vector<double> M, double b_min, double b_max)
   : a_(std::move(a)), b_(std::move(b)), M_(std::move(M)), b_min_(b_min), b_max_(b_max) {}
 
+CubicSplineCurve::State CubicSplineCurve::state() const {
+    return State{a_, b_, M_, b_min_, b_max_};
+}
+
+std::unique_ptr<CubicSplineCurve> CubicSplineCurve::from_state(State s) {
+    const std::size_t n = s.a.size();
+    if (s.b.size() != n || s.M.size() != n) {
+        throw std::invalid_argument("CubicSplineCurve::from_state: a/b/M size mismatch");
+    }
+    if (n < 2) {
+        throw std::invalid_argument("CubicSplineCurve::from_state: need at least 2 knots");
+    }
+    for (std::size_t i = 1; i < n; ++i) {
+        if (!(s.a[i] > s.a[i - 1])) {
+            throw std::invalid_argument("CubicSplineCurve::from_state: a must be strictly increasing");
+        }
+    }
+    return std::unique_ptr<CubicSplineCurve>(new CubicSplineCurve(std::move(s.a), std::move(s.b), std::move(s.M), s.b_min, s.b_max));
+}
+
 std::size_t CubicSplineCurve::locate(double a) const noexcept {
     // Binary search; clamp to a valid segment index.
     const std::size_t n = a_.size();

--- a/src/Region/CubicSplineCurve.cpp
+++ b/src/Region/CubicSplineCurve.cpp
@@ -191,7 +191,13 @@ std::unique_ptr<CubicSplineCurve> CubicSplineCurve::from_state(State s) {
             throw std::invalid_argument("CubicSplineCurve::from_state: a must be strictly increasing");
         }
     }
-    return std::unique_ptr<CubicSplineCurve>(new CubicSplineCurve(std::move(s.a), std::move(s.b), std::move(s.M), s.b_min, s.b_max));
+    // Re-derive the tight (b_min, b_max) from the deserialized (a, b, M)
+    // rather than trusting the values shipped in `s`.  A tampered or
+    // mis-versioned blob could otherwise drop a bogus AABB into the
+    // RegionAtlas and silently corrupt region dispatch.  The recompute
+    // is O(n) — negligible vs the rest of deserialization.
+    const auto bnds = compute_bounds(s.a, s.b, s.M);
+    return std::unique_ptr<CubicSplineCurve>(new CubicSplineCurve(std::move(s.a), std::move(s.b), std::move(s.M), bnds.first, bnds.second));
 }
 
 std::size_t CubicSplineCurve::locate(double a) const noexcept {

--- a/src/Region/CubicSplineCurve.cpp
+++ b/src/Region/CubicSplineCurve.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <cstddef>
 #include <stdexcept>
+#include <string>  // std::to_string + std::invalid_argument(string) — MSVC needs explicit include
 
 namespace CoolProp {
 namespace region {

--- a/src/Region/PiecewiseChebyshevCurve.cpp
+++ b/src/Region/PiecewiseChebyshevCurve.cpp
@@ -241,6 +241,48 @@ std::unique_ptr<PiecewiseChebyshevCurve> PiecewiseChebyshevCurve::build(double a
 PiecewiseChebyshevCurve::PiecewiseChebyshevCurve(double a_lo, double a_hi, ParamScale scale, std::vector<Piece> pieces, double b_min, double b_max)
   : a_lo_(a_lo), a_hi_(a_hi), scale_(scale), pieces_(std::move(pieces)), b_min_(b_min), b_max_(b_max) {}
 
+PiecewiseChebyshevCurve::State PiecewiseChebyshevCurve::state() const {
+    State s;
+    s.a_lo = a_lo_;
+    s.a_hi = a_hi_;
+    s.scale = scale_;
+    s.b_min = b_min_;
+    s.b_max = b_max_;
+    s.pieces.reserve(pieces_.size());
+    for (const auto& p : pieces_) {
+        s.pieces.push_back(PieceState{p.t_lo, p.t_hi, p.inv_half_span, p.t_mid, p.coeffs, p.deriv_coeffs});
+    }
+    return s;
+}
+
+std::unique_ptr<PiecewiseChebyshevCurve> PiecewiseChebyshevCurve::from_state(State s) {
+    if (s.pieces.empty()) {
+        throw std::invalid_argument("PiecewiseChebyshevCurve::from_state: pieces is empty");
+    }
+    if (!(s.a_hi > s.a_lo)) {
+        throw std::invalid_argument("PiecewiseChebyshevCurve::from_state: a_hi must exceed a_lo");
+    }
+    std::vector<Piece> pieces;
+    pieces.reserve(s.pieces.size());
+    for (auto& ps : s.pieces) {
+        if (ps.coeffs.size() < 2) {
+            throw std::invalid_argument("PiecewiseChebyshevCurve::from_state: each piece needs >= 2 coefficients");
+        }
+        if (ps.deriv_coeffs.size() + 1 != ps.coeffs.size()) {
+            throw std::invalid_argument("PiecewiseChebyshevCurve::from_state: deriv_coeffs size must be coeffs.size() - 1");
+        }
+        Piece p;
+        p.t_lo = ps.t_lo;
+        p.t_hi = ps.t_hi;
+        p.inv_half_span = ps.inv_half_span;
+        p.t_mid = ps.t_mid;
+        p.coeffs = std::move(ps.coeffs);
+        p.deriv_coeffs = std::move(ps.deriv_coeffs);
+        pieces.push_back(std::move(p));
+    }
+    return std::unique_ptr<PiecewiseChebyshevCurve>(new PiecewiseChebyshevCurve(s.a_lo, s.a_hi, s.scale, std::move(pieces), s.b_min, s.b_max));
+}
+
 double PiecewiseChebyshevCurve::to_t(double a) const noexcept {
     return (scale_ == ParamScale::LOG) ? std::log(a) : a;
 }

--- a/src/Region/PiecewiseChebyshevCurve.cpp
+++ b/src/Region/PiecewiseChebyshevCurve.cpp
@@ -271,6 +271,9 @@ std::unique_ptr<PiecewiseChebyshevCurve> PiecewiseChebyshevCurve::from_state(Sta
         if (ps.deriv_coeffs.size() + 1 != ps.coeffs.size()) {
             throw std::invalid_argument("PiecewiseChebyshevCurve::from_state: deriv_coeffs size must be coeffs.size() - 1");
         }
+        if (!(ps.t_hi > ps.t_lo)) {
+            throw std::invalid_argument("PiecewiseChebyshevCurve::from_state: each piece must have t_hi > t_lo");
+        }
         Piece p;
         p.t_lo = ps.t_lo;
         p.t_hi = ps.t_hi;
@@ -279,6 +282,22 @@ std::unique_ptr<PiecewiseChebyshevCurve> PiecewiseChebyshevCurve::from_state(Sta
         p.coeffs = std::move(ps.coeffs);
         p.deriv_coeffs = std::move(ps.deriv_coeffs);
         pieces.push_back(std::move(p));
+    }
+    // `locate_piece` does an O(1) hit assuming pieces are sorted,
+    // contiguous, and uniformly sized in t -- invariants build()
+    // guarantees, but a malformed blob could break any of them and
+    // silently route queries to the wrong piece.  Validate up-front so
+    // the O(1) lookup math is always safe.
+    const double dt0 = pieces.front().t_hi - pieces.front().t_lo;
+    const double eps = 1e-9 * std::max(1.0, std::abs(dt0));
+    for (std::size_t i = 0; i < pieces.size(); ++i) {
+        if (i > 0 && std::abs(pieces[i].t_lo - pieces[i - 1].t_hi) > eps) {
+            throw std::invalid_argument("PiecewiseChebyshevCurve::from_state: pieces must be contiguous in t (gap or overlap detected)");
+        }
+        const double dt = pieces[i].t_hi - pieces[i].t_lo;
+        if (std::abs(dt - dt0) > eps) {
+            throw std::invalid_argument("PiecewiseChebyshevCurve::from_state: pieces must be uniformly spaced in t (locate_piece assumes this)");
+        }
     }
     return std::unique_ptr<PiecewiseChebyshevCurve>(new PiecewiseChebyshevCurve(s.a_lo, s.a_hi, s.scale, std::move(pieces), s.b_min, s.b_max));
 }

--- a/src/SBTL/SVDSurface.cpp
+++ b/src/SBTL/SVDSurface.cpp
@@ -1,0 +1,139 @@
+#include "CoolProp/sbtl/SVDSurface.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace CoolProp {
+namespace sbtl {
+
+SVDSurface::SVDSurface(std::string fluid_name, ::CoolProp::input_pairs input_pair, std::vector<::CoolProp::parameters> properties)
+  : fluid_name_(std::move(fluid_name)), input_pair_(input_pair), properties_(std::move(properties)) {
+    if (properties_.empty()) {
+        throw std::invalid_argument("SVDSurface: properties list must be non-empty");
+    }
+    // Detect duplicates in the property list — silently accepting them
+    // means later add_region_property_svd calls would land in the wrong
+    // slot.
+    auto sorted = properties_;
+    std::sort(sorted.begin(), sorted.end());
+    if (std::adjacent_find(sorted.begin(), sorted.end()) != sorted.end()) {
+        throw std::invalid_argument("SVDSurface: duplicate property in properties list");
+    }
+}
+
+std::size_t SVDSurface::add_region(region::Region region) {
+    if (sealed_) {
+        throw std::logic_error("SVDSurface: add_region called after seal()");
+    }
+    const std::size_t idx = atlas_.add(std::move(region));
+    // Resize per-region storage to match.
+    decomps_.emplace_back();
+    decomps_.back().resize(properties_.size());
+    evaluators_.emplace_back();
+    evaluators_.back().resize(properties_.size());
+    return idx;
+}
+
+void SVDSurface::add_region_property_svd(std::size_t region_idx, ::CoolProp::parameters prop, svd::SVDDecomposition decomp) {
+    if (sealed_) {
+        throw std::logic_error("SVDSurface: add_region_property_svd called after seal()");
+    }
+    if (region_idx >= decomps_.size()) {
+        throw std::out_of_range("SVDSurface: region_idx out of range");
+    }
+    const std::size_t pidx = property_index(prop);
+    if (decomps_[region_idx][pidx]) {
+        throw std::logic_error("SVDSurface: decomposition for this (region, property) already registered");
+    }
+    decomps_[region_idx][pidx] = std::make_unique<svd::SVDDecomposition>(std::move(decomp));
+}
+
+void SVDSurface::seal() {
+    if (sealed_) {
+        return;
+    }
+    // Validate every region has every property.
+    for (std::size_t r = 0; r < decomps_.size(); ++r) {
+        for (std::size_t p = 0; p < properties_.size(); ++p) {
+            if (!decomps_[r][p]) {
+                throw std::logic_error("SVDSurface::seal: region " + std::to_string(r) + " is missing a decomposition for property index "
+                                       + std::to_string(p));
+            }
+        }
+    }
+    // Build evaluators against the heap-resident decompositions.  The
+    // address of each unique_ptr's pointee is stable for the lifetime
+    // of the unique_ptr (and the surface).
+    for (std::size_t r = 0; r < decomps_.size(); ++r) {
+        for (std::size_t p = 0; p < properties_.size(); ++p) {
+            evaluators_[r][p] = std::make_unique<svd::SVDEvaluator>(*decomps_[r][p]);
+        }
+    }
+    sealed_ = true;
+}
+
+std::size_t SVDSurface::region_count() const noexcept {
+    return atlas_.size();
+}
+
+bool SVDSurface::contains_property(::CoolProp::parameters prop) const noexcept {
+    return std::find(properties_.begin(), properties_.end(), prop) != properties_.end();
+}
+
+std::size_t SVDSurface::property_index(::CoolProp::parameters prop) const {
+    const auto it = std::find(properties_.begin(), properties_.end(), prop);
+    if (it == properties_.end()) {
+        throw std::invalid_argument("SVDSurface: property is not tabulated on this surface");
+    }
+    return static_cast<std::size_t>(std::distance(properties_.begin(), it));
+}
+
+const svd::SVDDecomposition& SVDSurface::decomposition(std::size_t region_idx, ::CoolProp::parameters prop) const {
+    if (region_idx >= decomps_.size()) {
+        throw std::out_of_range("SVDSurface::decomposition: region_idx out of range");
+    }
+    const std::size_t pidx = property_index(prop);
+    if (!decomps_[region_idx][pidx]) {
+        throw std::logic_error("SVDSurface::decomposition: decomposition is null (surface not sealed?)");
+    }
+    return *decomps_[region_idx][pidx];
+}
+
+SVDSurface::ResolvedPoint SVDSurface::resolve(double a, double b) const noexcept {
+    const int region_idx = atlas_.find_region(a, b);
+    if (region_idx < 0) {
+        return ResolvedPoint{-1, std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
+    }
+    const auto [xi, eta] = atlas_.region(static_cast<std::size_t>(region_idx)).to_normalized(a, b);
+    // SVD convention (matches Phase 2a's e2e tool): x-axis = eta
+    // (secondary normalised), y-axis = xi (primary normalised).
+    return ResolvedPoint{region_idx, eta, xi};
+}
+
+double SVDSurface::eval(::CoolProp::parameters prop, double a, double b) const {
+    if (!sealed_) {
+        throw std::logic_error("SVDSurface::eval called before seal()");
+    }
+    const auto resolved = resolve(a, b);
+    if (resolved.region_idx < 0) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    return eval_with_region(prop, resolved.region_idx, resolved.svd_x, resolved.svd_y);
+}
+
+double SVDSurface::eval_with_region(::CoolProp::parameters prop, int region_idx, double svd_x, double svd_y) const {
+    if (!sealed_) {
+        throw std::logic_error("SVDSurface::eval_with_region called before seal()");
+    }
+    if (region_idx < 0 || static_cast<std::size_t>(region_idx) >= evaluators_.size()) {
+        throw std::out_of_range("SVDSurface::eval_with_region: region_idx out of range");
+    }
+    const std::size_t pidx = property_index(prop);
+    return evaluators_[static_cast<std::size_t>(region_idx)][pidx]->eval(svd_x, svd_y);
+}
+
+}  // namespace sbtl
+}  // namespace CoolProp

--- a/src/SBTL/SVDSurfaceFactory.cpp
+++ b/src/SBTL/SVDSurfaceFactory.cpp
@@ -1,0 +1,208 @@
+#include "CoolProp/sbtl/SVDSurfaceFactory.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <stdexcept>
+#include <vector>
+
+#include "CoolProp/region/Region.h"
+#include "CoolProp/sbtl/SatBoundaryFactory.h"
+#include "CoolProp/svd/SVDBuilder.h"
+#include "CoolProp/svd/SVDDecomposition.h"
+#include "DataStructures.h"
+
+namespace CoolProp {
+namespace sbtl {
+
+namespace {
+
+// Walk the (xnorm, log_p_norm) ∈ [0,1] × [0,1] grid for one Region,
+// sample HEOS per cell via the spec's update_state / read_property
+// callbacks, and fill the per-property matrix dictionary.  Cells
+// where HEOS throws (e.g. two-phase) are left NaN and the row-fill
+// patches them.  Returns NT × NR row-major matrices indexed by
+// property.
+//
+// Matches dev/svd_sbtl_e2e.cpp's build_region_svd loop layout so
+// numerics agree with Phase 2a's validated output.
+std::vector<std::vector<double>> sample_grid(::CoolProp::AbstractState& heos, const SurfaceSpec& spec, const region::Region& region) {
+    const std::size_t NT = spec.NT;
+    const std::size_t NR = spec.NR;
+    const std::size_t n_props = spec.properties.size();
+
+    std::vector<double> xn_grid(NT);
+    std::vector<double> xi_grid(NR);
+    // Step slightly off the corners — the η normalization is exact
+    // at the boundary curves but the Chebyshev / spline curves can
+    // extrapolate epsilon-outside their fit interval and HmassP can
+    // pile up flash failures near the dome corners.
+    for (std::size_t i = 0; i < NT; ++i) {
+        xn_grid[i] = 0.001 + (0.999 - 0.001) * static_cast<double>(i) / static_cast<double>(NT - 1);
+    }
+    for (std::size_t j = 0; j < NR; ++j) {
+        xi_grid[j] = static_cast<double>(j) / static_cast<double>(NR - 1);
+    }
+
+    // M[prop][i*NR + j] for each output property.
+    std::vector<std::vector<double>> M(n_props);
+    for (auto& m : M) {
+        m.assign(NT * NR, std::nan(""));
+    }
+
+    for (std::size_t j = 0; j < NR; ++j) {
+        for (std::size_t i = 0; i < NT; ++i) {
+            const auto [a, b] = region.from_normalized(xi_grid[j], xn_grid[i]);
+            try {
+                spec.update_state(heos, a, b);
+                if (heos.Q() > 0.0 && heos.Q() < 1.0) {
+                    continue;  // two-phase — leave NaN
+                }
+                for (std::size_t p = 0; p < n_props; ++p) {
+                    const double v = spec.read_property(heos, spec.properties[p].key);
+                    if (!std::isfinite(v)) {
+                        continue;
+                    }
+                    // Apply the property's transform (typically LOG
+                    // for density via OutputTransform::EXP) before
+                    // storing into M.
+                    const double stored = (spec.properties[p].transform == svd::OutputTransform::EXP) ? (v > 0.0 ? std::log(v) : std::nan("")) : v;
+                    M[p][i * NR + j] = stored;
+                }
+            } catch (...) {  // NOLINT(bugprone-empty-catch)
+                // HEOS failures (above melting line, OOB, ...) → NaN.
+                // Row-fill below patches them.
+            }
+        }
+    }
+
+    // Row-wise linear fill in log_p for each property (mirrors the
+    // PoC's NaN-patch logic).  Used to keep the SVD numerics sane on
+    // cells where HEOS gave up.
+    for (auto& m : M) {
+        for (std::size_t i = 0; i < NT; ++i) {
+            std::size_t first_good = NR, last_good = NR;
+            for (std::size_t j = 0; j < NR; ++j) {
+                if (std::isfinite(m[i * NR + j])) {
+                    if (first_good == NR) {
+                        first_good = j;
+                    }
+                    last_good = j;
+                }
+            }
+            if (first_good == NR) {
+                continue;
+            }
+            for (std::size_t j = 0; j < first_good; ++j) {
+                m[i * NR + j] = m[i * NR + first_good];
+            }
+            for (std::size_t j = last_good + 1; j < NR; ++j) {
+                m[i * NR + j] = m[i * NR + last_good];
+            }
+            for (std::size_t j = first_good + 1; j < last_good; ++j) {
+                if (std::isfinite(m[i * NR + j])) {
+                    continue;
+                }
+                std::size_t k_lo = j;
+                while (k_lo > 0 && !std::isfinite(m[i * NR + k_lo - 1])) {
+                    --k_lo;
+                }
+                --k_lo;
+                std::size_t k_hi = j;
+                while (k_hi < NR && !std::isfinite(m[i * NR + k_hi])) {
+                    ++k_hi;
+                }
+                const double t = (xi_grid[j] - xi_grid[k_lo]) / (xi_grid[k_hi] - xi_grid[k_lo]);
+                m[i * NR + j] = (1.0 - t) * m[i * NR + k_lo] + t * m[i * NR + k_hi];
+            }
+        }
+        // Final guard: any remaining NaNs (fully-NaN rows in pathological cases)
+        // get filled with the median.  Falling through with NaN would crash the
+        // SVD builder via the finite-value precondition.
+        std::vector<double> finite_vals;
+        finite_vals.reserve(m.size());
+        for (double v : m) {
+            if (std::isfinite(v)) {
+                finite_vals.push_back(v);
+            }
+        }
+        if (finite_vals.size() < m.size()) {
+            std::nth_element(finite_vals.begin(), finite_vals.begin() + static_cast<std::ptrdiff_t>(finite_vals.size() / 2), finite_vals.end());
+            const double median = finite_vals[finite_vals.size() / 2];
+            for (double& v : m) {
+                if (!std::isfinite(v)) {
+                    v = median;
+                }
+            }
+        }
+    }
+
+    return M;
+}
+
+// Build the per-region (xn, xi) grids returned to the SVD builder.
+std::pair<std::vector<double>, std::vector<double>> grid_axes(std::size_t NT, std::size_t NR) {
+    std::vector<double> xn_grid(NT);
+    std::vector<double> xi_grid(NR);
+    for (std::size_t i = 0; i < NT; ++i) {
+        xn_grid[i] = 0.001 + (0.999 - 0.001) * static_cast<double>(i) / static_cast<double>(NT - 1);
+    }
+    for (std::size_t j = 0; j < NR; ++j) {
+        xi_grid[j] = static_cast<double>(j) / static_cast<double>(NR - 1);
+    }
+    return {xn_grid, xi_grid};
+}
+
+}  // namespace
+
+SVDSurface build_surface(::CoolProp::AbstractState& heos, SurfaceSpec spec, const BuildOptions& opts) {
+    if (spec.regions.empty()) {
+        throw std::invalid_argument("build_surface: SurfaceSpec.regions is empty");
+    }
+    if (spec.properties.empty()) {
+        throw std::invalid_argument("build_surface: SurfaceSpec.properties is empty");
+    }
+    if (!spec.update_state || !spec.read_property) {
+        throw std::invalid_argument("build_surface: SurfaceSpec is missing update_state / read_property callbacks");
+    }
+
+    // Build the SVDSurface, transferring regions in order, then SVDs.
+    std::vector<::CoolProp::parameters> prop_keys;
+    prop_keys.reserve(spec.properties.size());
+    for (const auto& p : spec.properties) {
+        prop_keys.push_back(p.key);
+    }
+    SVDSurface surface(spec.fluid_name, spec.input_pair, prop_keys);
+
+    const auto [xn_grid, xi_grid] = grid_axes(spec.NT, spec.NR);
+
+    for (std::size_t r = 0; r < spec.regions.size(); ++r) {
+        // Move the RegionSpec's boundary curves into a real Region,
+        // then immediately add it to the surface.
+        region::Region region(spec.regions[r].primary, std::move(spec.regions[r].b_lo), std::move(spec.regions[r].b_hi));
+        // Sample HEOS for this region BEFORE moving it into the
+        // surface — we need the (a, b) → from_normalized while we
+        // still hold an immediate reference.
+        const auto M_per_prop = sample_grid(heos, spec, region);
+        const std::size_t region_idx = surface.add_region(std::move(region));
+
+        // Build one SVD per property.
+        for (std::size_t p = 0; p < spec.properties.size(); ++p) {
+            svd::SVDBuildOptions svdopts;
+            svdopts.rank = spec.rank;
+            svdopts.out_transform = spec.properties[p].transform;
+            svdopts.slope_source = opts.slope_source;
+            svd::SVDDecomposition decomp = svd::build_svd(xn_grid, xi_grid, M_per_prop[p], svdopts);
+            surface.add_region_property_svd(region_idx, spec.properties[p].key, std::move(decomp));
+            if (opts.verbose) {
+                std::printf("  region %zu property %d: SVD built (rank=%d)\n", region_idx, static_cast<int>(spec.properties[p].key), spec.rank);
+            }
+        }
+    }
+
+    surface.seal();
+    return surface;
+}
+
+}  // namespace sbtl
+}  // namespace CoolProp

--- a/src/SBTL/SVDSurfaceFactory.cpp
+++ b/src/SBTL/SVDSurfaceFactory.cpp
@@ -127,6 +127,14 @@ std::vector<std::vector<double>> sample_grid(::CoolProp::AbstractState& heos, co
             }
         }
         if (finite_vals.size() < m.size()) {
+            if (finite_vals.empty()) {
+                // Every sample for this property in this region was
+                // non-finite — typically means the (T, p) grid walked
+                // outside the HEOS validity envelope for this region's
+                // axis transform.  Failing fast beats producing a NaN-
+                // filled "table" and silently corrupting the SVD math.
+                throw std::runtime_error("build_surface: all-NaN property matrix in region (HEOS sampling produced no finite values)");
+            }
             std::nth_element(finite_vals.begin(), finite_vals.begin() + static_cast<std::ptrdiff_t>(finite_vals.size() / 2), finite_vals.end());
             const double median = finite_vals[finite_vals.size() / 2];
             for (double& v : m) {
@@ -165,6 +173,15 @@ SVDSurface build_surface(::CoolProp::AbstractState& heos, SurfaceSpec spec, cons
     if (!spec.update_state || !spec.read_property) {
         throw std::invalid_argument("build_surface: SurfaceSpec is missing update_state / read_property callbacks");
     }
+    // Grid axes use (NT - 1) / (NR - 1) as denominators; values < 2 would
+    // emit NaN-shaped grids and crash downstream SVD math.  Rank < 1 has
+    // no usable decomposition.
+    if (spec.NT < 2 || spec.NR < 2) {
+        throw std::invalid_argument("build_surface: SurfaceSpec.NT and .NR must each be >= 2");
+    }
+    if (spec.rank < 1) {
+        throw std::invalid_argument("build_surface: SurfaceSpec.rank must be >= 1");
+    }
 
     // Build the SVDSurface, transferring regions in order, then SVDs.
     std::vector<::CoolProp::parameters> prop_keys;
@@ -195,6 +212,7 @@ SVDSurface build_surface(::CoolProp::AbstractState& heos, SurfaceSpec spec, cons
             svd::SVDDecomposition decomp = svd::build_svd(xn_grid, xi_grid, M_per_prop[p], svdopts);
             surface.add_region_property_svd(region_idx, spec.properties[p].key, std::move(decomp));
             if (opts.verbose) {
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
                 std::printf("  region %zu property %d: SVD built (rank=%d)\n", region_idx, static_cast<int>(spec.properties[p].key), spec.rank);
             }
         }

--- a/src/SBTL/SVDSurfaceSerializer.cpp
+++ b/src/SBTL/SVDSurfaceSerializer.cpp
@@ -1,0 +1,413 @@
+#include "CoolProp/sbtl/SVDSurfaceSerializer.h"
+
+#include <cmath>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include <msgpack.hpp>
+
+#include "CPfilepaths.h"
+#include "CoolProp/region/ConstantCurve.h"
+#include "CoolProp/region/CubicSplineCurve.h"
+#include "CoolProp/region/PiecewiseChebyshevCurve.h"
+#include "CoolProp/region/Region.h"
+#include "CoolProp/svd/SVDDecomposition.h"
+#include "miniz.h"
+
+namespace CoolProp {
+namespace sbtl {
+
+namespace {
+
+// Discriminator for the BoundaryCurve subclass stored in a packed
+// region blob.  Adding a new subclass: bump revision, give it a new
+// kind id, write/read its State.
+enum class CurveKind : std::uint8_t
+{
+    CONSTANT = 0,
+    CUBIC_SPLINE = 1,
+    PIECEWISE_CHEBYSHEV = 2,
+};
+
+// ---------- packing helpers -------------------------------------------
+
+template <typename Packer>
+void pack_curve(Packer& pk, const region::BoundaryCurve& curve) {
+    // dynamic_cast probes for each known concrete type.  Order is
+    // chosen so the cheapest cast (ConstantCurve) is tried first.
+    if (const auto* c = dynamic_cast<const region::ConstantCurve*>(&curve)) {
+        const auto s = c->state();
+        pk.pack_array(4);
+        pk.pack(static_cast<std::uint8_t>(CurveKind::CONSTANT));
+        pk.pack(s.a_lo);
+        pk.pack(s.a_hi);
+        pk.pack(s.b);
+        return;
+    }
+    if (const auto* c = dynamic_cast<const region::CubicSplineCurve*>(&curve)) {
+        const auto s = c->state();
+        pk.pack_array(6);
+        pk.pack(static_cast<std::uint8_t>(CurveKind::CUBIC_SPLINE));
+        pk.pack(s.a);
+        pk.pack(s.b);
+        pk.pack(s.M);
+        pk.pack(s.b_min);
+        pk.pack(s.b_max);
+        return;
+    }
+    if (const auto* c = dynamic_cast<const region::PiecewiseChebyshevCurve*>(&curve)) {
+        const auto s = c->state();
+        pk.pack_array(7);
+        pk.pack(static_cast<std::uint8_t>(CurveKind::PIECEWISE_CHEBYSHEV));
+        pk.pack(s.a_lo);
+        pk.pack(s.a_hi);
+        pk.pack(static_cast<std::uint8_t>(s.scale));
+        pk.pack_array(s.pieces.size());
+        for (const auto& p : s.pieces) {
+            pk.pack_array(6);
+            pk.pack(p.t_lo);
+            pk.pack(p.t_hi);
+            pk.pack(p.inv_half_span);
+            pk.pack(p.t_mid);
+            pk.pack(p.coeffs);
+            pk.pack(p.deriv_coeffs);
+        }
+        pk.pack(s.b_min);
+        pk.pack(s.b_max);
+        return;
+    }
+    throw std::runtime_error("SVDSurfaceSerializer: unknown BoundaryCurve subclass");
+}
+
+template <typename Packer>
+void pack_decomp(Packer& pk, std::size_t region_idx, ::CoolProp::parameters prop_key, const svd::SVDDecomposition& d) {
+    pk.pack_array(14);
+    pk.pack(static_cast<std::uint32_t>(region_idx));
+    pk.pack(static_cast<std::int32_t>(prop_key));
+    pk.pack(d.NX);
+    pk.pack(d.NY);
+    pk.pack(d.rank);
+    pk.pack(static_cast<std::uint8_t>(d.out_transform));
+    pk.pack(static_cast<std::uint8_t>(d.slope_source));
+    pk.pack(d.x_grid);
+    pk.pack(d.y_grid);
+    pk.pack(d.U);
+    pk.pack(d.dU_dx);
+    pk.pack(d.V_S);
+    pk.pack(d.dV_S_dy);
+    pk.pack(d.S);
+}
+
+template <typename Packer>
+void pack_region(Packer& pk, const region::Region& r) {
+    const auto& axis = r.primary();
+    pk.pack_array(8);
+    pk.pack(static_cast<std::uint8_t>(axis.scale));
+    pk.pack(axis.a_lo);
+    pk.pack(axis.a_hi);
+    pk.pack(axis.a_lo_t);
+    pk.pack(axis.a_hi_t);
+    pk.pack(axis.inv_span_t);
+    pack_curve(pk, r.b_lo());
+    pack_curve(pk, r.b_hi());
+}
+
+template <typename Packer>
+void pack_surface(Packer& pk, const SVDSurface& s) {
+    pk.pack_array(4);
+    pk.pack(static_cast<std::int32_t>(s.input_pair()));
+
+    const auto& props = s.properties();
+    pk.pack_array(props.size());
+    for (const auto& p : props) {
+        // Property entry is [key, transform].  Transform is currently
+        // baked into the SVDDecomposition itself, but the surface-level
+        // record is the spec — kept here so a deserializer can verify
+        // the transform per-property matches what the decomp expects.
+        pk.pack_array(1);
+        pk.pack(static_cast<std::int32_t>(p));
+    }
+
+    const std::size_t n_regions = s.region_count();
+    pk.pack_array(n_regions);
+    for (std::size_t r = 0; r < n_regions; ++r) {
+        pack_region(pk, s.atlas().region(r));
+    }
+
+    // Decomps are flattened: region_idx ranges first, then properties.
+    pk.pack_array(n_regions * props.size());
+    for (std::size_t r = 0; r < n_regions; ++r) {
+        for (const auto& p : props) {
+            pack_decomp(pk, r, p, s.decomposition(r, p));
+        }
+    }
+}
+
+// ---------- unpacking helpers ----------------------------------------
+
+// Convenience wrappers around msgpack::object → typed conversion.
+template <typename T>
+T as(const msgpack::object& o) {
+    return o.as<T>();
+}
+
+void check_array(const msgpack::object& o, std::size_t expected_min, const char* what) {
+    if (o.type != msgpack::type::ARRAY) {
+        throw std::runtime_error(std::string("SVDSurfaceSerializer: expected array for ") + what);
+    }
+    if (o.via.array.size < expected_min) {
+        throw std::runtime_error(std::string("SVDSurfaceSerializer: array for ") + what + " too short");
+    }
+}
+
+std::unique_ptr<region::BoundaryCurve> unpack_curve(const msgpack::object& o) {
+    check_array(o, 1, "curve");
+    const auto kind = static_cast<CurveKind>(as<std::uint8_t>(o.via.array.ptr[0]));
+    switch (kind) {
+        case CurveKind::CONSTANT: {
+            check_array(o, 4, "constant curve");
+            const auto a_lo = as<double>(o.via.array.ptr[1]);
+            const auto a_hi = as<double>(o.via.array.ptr[2]);
+            const auto b = as<double>(o.via.array.ptr[3]);
+            return std::make_unique<region::ConstantCurve>(a_lo, a_hi, b);
+        }
+        case CurveKind::CUBIC_SPLINE: {
+            check_array(o, 6, "cubic spline curve");
+            region::CubicSplineCurve::State s;
+            s.a = as<std::vector<double>>(o.via.array.ptr[1]);
+            s.b = as<std::vector<double>>(o.via.array.ptr[2]);
+            s.M = as<std::vector<double>>(o.via.array.ptr[3]);
+            s.b_min = as<double>(o.via.array.ptr[4]);
+            s.b_max = as<double>(o.via.array.ptr[5]);
+            return region::CubicSplineCurve::from_state(std::move(s));
+        }
+        case CurveKind::PIECEWISE_CHEBYSHEV: {
+            check_array(o, 7, "piecewise chebyshev curve");
+            region::PiecewiseChebyshevCurve::State s;
+            s.a_lo = as<double>(o.via.array.ptr[1]);
+            s.a_hi = as<double>(o.via.array.ptr[2]);
+            s.scale = static_cast<region::PiecewiseChebyshevCurve::ParamScale>(as<std::uint8_t>(o.via.array.ptr[3]));
+            const auto& pieces_obj = o.via.array.ptr[4];
+            check_array(pieces_obj, 1, "chebyshev pieces");
+            s.pieces.reserve(pieces_obj.via.array.size);
+            for (std::uint32_t i = 0; i < pieces_obj.via.array.size; ++i) {
+                const auto& po = pieces_obj.via.array.ptr[i];
+                check_array(po, 6, "chebyshev piece");
+                region::PiecewiseChebyshevCurve::PieceState ps;
+                ps.t_lo = as<double>(po.via.array.ptr[0]);
+                ps.t_hi = as<double>(po.via.array.ptr[1]);
+                ps.inv_half_span = as<double>(po.via.array.ptr[2]);
+                ps.t_mid = as<double>(po.via.array.ptr[3]);
+                ps.coeffs = as<std::vector<double>>(po.via.array.ptr[4]);
+                ps.deriv_coeffs = as<std::vector<double>>(po.via.array.ptr[5]);
+                s.pieces.push_back(std::move(ps));
+            }
+            s.b_min = as<double>(o.via.array.ptr[5]);
+            s.b_max = as<double>(o.via.array.ptr[6]);
+            return region::PiecewiseChebyshevCurve::from_state(std::move(s));
+        }
+    }
+    throw std::runtime_error("SVDSurfaceSerializer: unknown curve kind");
+}
+
+region::Region unpack_region(const msgpack::object& o) {
+    check_array(o, 8, "region");
+    const auto scale = static_cast<region::AxisScale>(as<std::uint8_t>(o.via.array.ptr[0]));
+    const auto a_lo = as<double>(o.via.array.ptr[1]);
+    const auto a_hi = as<double>(o.via.array.ptr[2]);
+    auto axis = region::AxisTransform::make(scale, a_lo, a_hi);
+    // a_lo_t/a_hi_t/inv_span_t are derived; we re-derive via make()
+    // and don't read the stream values — they're stored for round-
+    // trip diagnostics only.
+    auto b_lo = unpack_curve(o.via.array.ptr[6]);
+    auto b_hi = unpack_curve(o.via.array.ptr[7]);
+    return region::Region(axis, std::move(b_lo), std::move(b_hi));
+}
+
+svd::SVDDecomposition unpack_decomp(const msgpack::object& o, std::size_t* out_region_idx, ::CoolProp::parameters* out_prop) {
+    check_array(o, 14, "decomp");
+    *out_region_idx = static_cast<std::size_t>(as<std::uint32_t>(o.via.array.ptr[0]));
+    *out_prop = static_cast<::CoolProp::parameters>(as<std::int32_t>(o.via.array.ptr[1]));
+    svd::SVDDecomposition d;
+    d.NX = as<std::int32_t>(o.via.array.ptr[2]);
+    d.NY = as<std::int32_t>(o.via.array.ptr[3]);
+    d.rank = as<std::int32_t>(o.via.array.ptr[4]);
+    d.out_transform = static_cast<svd::OutputTransform>(as<std::uint8_t>(o.via.array.ptr[5]));
+    d.slope_source = static_cast<svd::SlopeSource>(as<std::uint8_t>(o.via.array.ptr[6]));
+    d.x_grid = as<std::vector<double>>(o.via.array.ptr[7]);
+    d.y_grid = as<std::vector<double>>(o.via.array.ptr[8]);
+    d.U = as<std::vector<double>>(o.via.array.ptr[9]);
+    d.dU_dx = as<std::vector<double>>(o.via.array.ptr[10]);
+    d.V_S = as<std::vector<double>>(o.via.array.ptr[11]);
+    d.dV_S_dy = as<std::vector<double>>(o.via.array.ptr[12]);
+    d.S = as<std::vector<double>>(o.via.array.ptr[13]);
+    return d;
+}
+
+SVDSurface unpack_surface(const std::string& fluid_name, const msgpack::object& o) {
+    check_array(o, 4, "surface");
+    const auto input_pair = static_cast<::CoolProp::input_pairs>(as<std::int32_t>(o.via.array.ptr[0]));
+
+    const auto& props_obj = o.via.array.ptr[1];
+    check_array(props_obj, 0, "properties");
+    std::vector<::CoolProp::parameters> properties;
+    properties.reserve(props_obj.via.array.size);
+    for (std::uint32_t i = 0; i < props_obj.via.array.size; ++i) {
+        const auto& pe = props_obj.via.array.ptr[i];
+        check_array(pe, 1, "property entry");
+        properties.push_back(static_cast<::CoolProp::parameters>(as<std::int32_t>(pe.via.array.ptr[0])));
+    }
+
+    SVDSurface surface(fluid_name, input_pair, properties);
+
+    const auto& regions_obj = o.via.array.ptr[2];
+    check_array(regions_obj, 0, "regions");
+    for (std::uint32_t i = 0; i < regions_obj.via.array.size; ++i) {
+        surface.add_region(unpack_region(regions_obj.via.array.ptr[i]));
+    }
+
+    const auto& decomps_obj = o.via.array.ptr[3];
+    check_array(decomps_obj, 0, "decomps");
+    for (std::uint32_t i = 0; i < decomps_obj.via.array.size; ++i) {
+        std::size_t r_idx = 0;
+        ::CoolProp::parameters prop{};
+        auto decomp = unpack_decomp(decomps_obj.via.array.ptr[i], &r_idx, &prop);
+        surface.add_region_property_svd(r_idx, prop, std::move(decomp));
+    }
+
+    surface.seal();
+    return surface;
+}
+
+// ---------- compression / decompression -------------------------------
+
+std::vector<char> zlib_compress(const msgpack::sbuffer& sbuf) {
+    // Match TabularBackends.cpp's allocation strategy: start with the
+    // raw size and let zlib write into that buffer.  miniz returns
+    // Z_OK when it fits.
+    std::vector<char> out(sbuf.size() + (sbuf.size() / 1000) + 128);
+    mz_ulong out_size = static_cast<mz_ulong>(out.size());
+    const int code = compress((unsigned char*)out.data(), &out_size, (const unsigned char*)sbuf.data(), static_cast<mz_ulong>(sbuf.size()));
+    if (code != Z_OK) {
+        throw std::runtime_error(std::string("SVDSurfaceSerializer: zlib compress failed (code ") + std::to_string(code) + ")");
+    }
+    out.resize(out_size);
+    return out;
+}
+
+std::vector<char> zlib_uncompress(const std::vector<char>& compressed) {
+    // Mirrors TabularBackends.cpp:52-69: start at 5x the compressed
+    // size, double on Z_BUF_ERROR until it fits or we exhaust patience.
+    std::vector<char> out(compressed.size() * 5);
+    mz_ulong out_size = static_cast<mz_ulong>(out.size());
+    mz_ulong in_size = static_cast<mz_ulong>(compressed.size());
+    int code = 0;
+    int retries = 0;
+    do {
+        code = uncompress((unsigned char*)out.data(), &out_size, (const unsigned char*)compressed.data(), in_size);
+        if (code == Z_BUF_ERROR) {
+            if (++retries > 8) {
+                throw std::runtime_error("SVDSurfaceSerializer: zlib uncompress would not fit after 8 retries");
+            }
+            out.resize(out.size() * 2);
+            out_size = static_cast<mz_ulong>(out.size());
+        } else if (code != Z_OK) {
+            throw std::runtime_error(std::string("SVDSurfaceSerializer: zlib uncompress failed (code ") + std::to_string(code) + ")");
+        }
+    } while (code != Z_OK);
+    out.resize(out_size);
+    return out;
+}
+
+}  // namespace
+
+// ---------- public API ------------------------------------------------
+
+std::vector<char> SVDSurfaceSerializer::save(const SVDSurface& surface) {
+    if (!surface.sealed()) {
+        throw std::logic_error("SVDSurfaceSerializer::save: surface must be sealed");
+    }
+    msgpack::sbuffer sbuf;
+    msgpack::packer<msgpack::sbuffer> pk(sbuf);
+    pk.pack_array(4);
+    pk.pack(std::string("SVDS"));
+    pk.pack(static_cast<std::int32_t>(kRevision));
+    pk.pack(surface.fluid_name());
+    // Single-surface file for now — but the format puts surfaces in
+    // an array so a single fluid's PH + PT surfaces could share one
+    // file in the future without a revision bump.
+    pk.pack_array(1);
+    pack_surface(pk, surface);
+    return zlib_compress(sbuf);
+}
+
+SVDSurface SVDSurfaceSerializer::load(const std::vector<char>& compressed) {
+    const auto plain = zlib_uncompress(compressed);
+
+    msgpack::object_handle oh;
+    msgpack::unpack(oh, plain.data(), plain.size());
+    const msgpack::object& root = oh.get();
+
+    check_array(root, 4, "root");
+    const auto magic = as<std::string>(root.via.array.ptr[0]);
+    if (magic != "SVDS") {
+        throw std::runtime_error("SVDSurfaceSerializer::load: bad magic (expected 'SVDS', got '" + magic + "')");
+    }
+    const auto revision = as<std::int32_t>(root.via.array.ptr[1]);
+    if (revision != kRevision) {
+        throw std::runtime_error("SVDSurfaceSerializer::load: revision mismatch (expected " + std::to_string(kRevision) + ", got "
+                                 + std::to_string(revision) + ")");
+    }
+    const auto fluid_name = as<std::string>(root.via.array.ptr[2]);
+
+    const auto& surfaces_obj = root.via.array.ptr[3];
+    check_array(surfaces_obj, 1, "surfaces");
+    if (surfaces_obj.via.array.size != 1) {
+        throw std::runtime_error("SVDSurfaceSerializer::load: expected exactly 1 surface (got " + std::to_string(surfaces_obj.via.array.size) + ")");
+    }
+    return unpack_surface(fluid_name, surfaces_obj.via.array.ptr[0]);
+}
+
+void SVDSurfaceSerializer::save_to_file(const SVDSurface& surface, const std::string& path) {
+    const auto compressed = save(surface);
+    std::ofstream out(path, std::ios::binary);
+    if (!out) {
+        throw std::runtime_error("SVDSurfaceSerializer::save_to_file: cannot open " + path);
+    }
+    out.write(compressed.data(), static_cast<std::streamsize>(compressed.size()));
+    if (!out) {
+        throw std::runtime_error("SVDSurfaceSerializer::save_to_file: write failed for " + path);
+    }
+}
+
+SVDSurface SVDSurfaceSerializer::load_from_file(const std::string& path) {
+    std::ifstream in(path, std::ios::binary | std::ios::ate);
+    if (!in) {
+        throw std::runtime_error("SVDSurfaceSerializer::load_from_file: cannot open " + path);
+    }
+    const auto size = in.tellg();
+    in.seekg(0, std::ios::beg);
+    std::vector<char> buf(static_cast<std::size_t>(size));
+    if (!in.read(buf.data(), size)) {
+        throw std::runtime_error("SVDSurfaceSerializer::load_from_file: read failed for " + path);
+    }
+    return load(buf);
+}
+
+std::string SVDSurfaceSerializer::default_cache_dir() {
+    const std::string dir = ::get_home_dir() + "/.CoolProp/SVDTables";
+    std::error_code ec;
+    std::filesystem::create_directories(dir, ec);
+    return dir + "/";
+}
+
+std::string SVDSurfaceSerializer::default_cache_path(const std::string& fluid_name, ::CoolProp::input_pairs input_pair) {
+    return default_cache_dir() + fluid_name + "." + std::to_string(static_cast<int>(input_pair)) + ".svd.bin.z";
+}
+
+}  // namespace sbtl
+}  // namespace CoolProp

--- a/src/SBTL/SVDSurfaceSerializer.cpp
+++ b/src/SBTL/SVDSurfaceSerializer.cpp
@@ -124,10 +124,13 @@ void pack_surface(Packer& pk, const SVDSurface& s) {
     const auto& props = s.properties();
     pk.pack_array(props.size());
     for (const auto& p : props) {
-        // Property entry is [key, transform].  Transform is currently
-        // baked into the SVDDecomposition itself, but the surface-level
-        // record is the spec — kept here so a deserializer can verify
-        // the transform per-property matches what the decomp expects.
+        // Property entry is currently a length-1 array `[key]`.  The
+        // OutputTransform lives inside the per-property SVDDecomposition
+        // blob (packed by pack_decomp below), so the surface-level
+        // record only needs the property key here.  Leaving it as a
+        // length-1 array (rather than packing the bare int) lets a
+        // future revision extend it to `[key, transform_override]` or
+        // similar without bumping the on-wire revision number.
         pk.pack_array(1);
         pk.pack(static_cast<std::int32_t>(p));
     }
@@ -148,6 +151,14 @@ void pack_surface(Packer& pk, const SVDSurface& s) {
 }
 
 // ---------- unpacking helpers ----------------------------------------
+//
+// The msgpack-c API is intrinsically pointer-arithmetic-on-unions:
+// every array access goes through `obj.via.array.ptr[i]` where `via`
+// is a tagged union and `ptr` is a raw msgpack_object*.  Both patterns
+// trip cppcoreguidelines-pro-{type-union-access,bounds-pointer-arithmetic}
+// on every line of the unpacker.  These are msgpack-c idioms, not
+// real bugs, so we silence them en bloc rather than per-line.
+// NOLINTBEGIN(cppcoreguidelines-pro-type-union-access,cppcoreguidelines-pro-bounds-pointer-arithmetic)
 
 // Convenience wrappers around msgpack::object → typed conversion.
 template <typename T>
@@ -372,6 +383,8 @@ SVDSurface SVDSurfaceSerializer::load(const std::vector<char>& compressed) {
     return unpack_surface(fluid_name, surfaces_obj.via.array.ptr[0]);
 }
 
+// NOLINTEND(cppcoreguidelines-pro-type-union-access,cppcoreguidelines-pro-bounds-pointer-arithmetic)
+
 void SVDSurfaceSerializer::save_to_file(const SVDSurface& surface, const std::string& path) {
     const auto compressed = save(surface);
     std::ofstream out(path, std::ios::binary);
@@ -406,6 +419,15 @@ std::string SVDSurfaceSerializer::default_cache_dir() {
 }
 
 std::string SVDSurfaceSerializer::default_cache_path(const std::string& fluid_name, ::CoolProp::input_pairs input_pair) {
+    // Defense-in-depth against path traversal.  CoolProp fluid names
+    // come from the JSON catalog so this is unlikely to be hit in
+    // practice, but a caller passing an attacker-controlled string
+    // (e.g. through PropsSI("...", "SVDSBTL::<weird name>")) would
+    // otherwise be able to read or write outside the cache dir.
+    if (fluid_name.empty() || fluid_name.find('/') != std::string::npos || fluid_name.find('\\') != std::string::npos
+        || fluid_name.find("..") != std::string::npos) {
+        throw std::invalid_argument("SVDSurfaceSerializer::default_cache_path: invalid fluid_name (must be a bare component name)");
+    }
     return default_cache_dir() + fluid_name + "." + std::to_string(static_cast<int>(input_pair)) + ".svd.bin.z";
 }
 

--- a/src/SBTL/SatBoundaryFactory.cpp
+++ b/src/SBTL/SatBoundaryFactory.cpp
@@ -1,0 +1,99 @@
+#include "CoolProp/sbtl/SatBoundaryFactory.h"
+
+#include <cmath>
+#include <functional>
+#include <stdexcept>
+#include <vector>
+
+#include "DataStructures.h"
+
+namespace CoolProp {
+namespace sbtl {
+
+namespace {
+
+// Sample `f(p)` at `n_knots` log-uniform points in [p_min, p_max] and
+// build a CubicSplineCurve through the resulting (p, f(p)) knots.
+// This is the common skeleton every factory in this file shares;
+// extracting it once keeps the per-factory code 4–5 lines.
+std::unique_ptr<region::CubicSplineCurve> spline_through_log_p_samples(double p_min, double p_max, std::size_t n_knots,
+                                                                       const std::function<double(double)>& f) {
+    if (!(p_max > p_min) || n_knots < 2) {
+        throw std::invalid_argument("SatBoundaryFactory: invalid p range or n_knots");
+    }
+    std::vector<double> p_knots(n_knots);
+    std::vector<double> y(n_knots);
+    const double log_p_min = std::log(p_min);
+    const double log_p_max = std::log(p_max);
+    for (std::size_t k = 0; k < n_knots; ++k) {
+        const double log_p = log_p_min + static_cast<double>(k) * (log_p_max - log_p_min) / static_cast<double>(n_knots - 1);
+        p_knots[k] = std::exp(log_p);
+        y[k] = f(p_knots[k]);
+    }
+    return region::CubicSplineCurve::build(std::move(p_knots), std::move(y));
+}
+
+}  // namespace
+
+std::unique_ptr<region::CubicSplineCurve> build_h_sat_L(::CoolProp::AbstractState& heos, double p_min, double p_max,
+                                                        const SatBoundaryBuildOptions& opts) {
+    return spline_through_log_p_samples(p_min, p_max, opts.n_knots, [&](double p) {
+        heos.update(::CoolProp::PQ_INPUTS, p, 0.0);
+        return heos.hmass();
+    });
+}
+
+std::unique_ptr<region::CubicSplineCurve> build_h_sat_V(::CoolProp::AbstractState& heos, double p_min, double p_max,
+                                                        const SatBoundaryBuildOptions& opts) {
+    return spline_through_log_p_samples(p_min, p_max, opts.n_knots, [&](double p) {
+        heos.update(::CoolProp::PQ_INPUTS, p, 1.0);
+        return heos.hmass();
+    });
+}
+
+std::unique_ptr<region::CubicSplineCurve> build_T_sat(::CoolProp::AbstractState& heos, double p_min, double p_max,
+                                                      const SatBoundaryBuildOptions& opts) {
+    return spline_through_log_p_samples(p_min, p_max, opts.n_knots, [&](double p) {
+        heos.update(::CoolProp::PQ_INPUTS, p, 0.0);
+        return heos.T();
+    });
+}
+
+std::unique_ptr<region::CubicSplineCurve> build_h_isotherm_floor(::CoolProp::AbstractState& heos, double p_min, double p_max, double T_min,
+                                                                 const SatBoundaryBuildOptions& opts) {
+    // For fluids with steep melting curves the requested T_min may be
+    // below T_melt(p) at high p; walk T up in 0.5 K steps until HEOS
+    // accepts the (T, p) state.  Matches Phase 2a's `h_lo_liq` lambda.
+    return spline_through_log_p_samples(p_min, p_max, opts.n_knots, [&](double p) {
+        for (int k = 0; k < 40; ++k) {
+            const double T_try = T_min + 0.5 * static_cast<double>(k);
+            try {
+                heos.update(::CoolProp::PT_INPUTS, p, T_try);
+                return heos.hmass();
+            } catch (...) {  // NOLINT(bugprone-empty-catch)
+                // Below melting line at this p; bump T up and retry.
+            }
+        }
+        throw std::runtime_error("build_h_isotherm_floor: floor unreachable within 20 K of T_min");
+    });
+}
+
+std::unique_ptr<region::CubicSplineCurve> build_h_isotherm_ceiling(::CoolProp::AbstractState& heos, double p_min, double p_max, double T_max,
+                                                                   const SatBoundaryBuildOptions& opts) {
+    return spline_through_log_p_samples(p_min, p_max, opts.n_knots, [&](double p) {
+        heos.update(::CoolProp::PT_INPUTS, p, T_max);
+        return heos.hmass();
+    });
+}
+
+std::pair<double, double> subcritical_pressure_range(::CoolProp::AbstractState& heos) {
+    const double p_crit = heos.p_critical();
+    // Sample HEOS at triple T to get p_triple.  A tiny margin (1%)
+    // helps PQ flashes converge at the boundary.
+    heos.update(::CoolProp::QT_INPUTS, 0.0, heos.Ttriple() * 1.001);
+    const double p_triple = heos.p();
+    return {p_triple * 1.01, 0.999 * p_crit};
+}
+
+}  // namespace sbtl
+}  // namespace CoolProp

--- a/src/SBTL/SatBoundaryFactory.cpp
+++ b/src/SBTL/SatBoundaryFactory.cpp
@@ -18,8 +18,11 @@ namespace {
 // extracting it once keeps the per-factory code 4–5 lines.
 std::unique_ptr<region::CubicSplineCurve> spline_through_log_p_samples(double p_min, double p_max, std::size_t n_knots,
                                                                        const std::function<double(double)>& f) {
-    if (!(p_max > p_min) || n_knots < 2) {
-        throw std::invalid_argument("SatBoundaryFactory: invalid p range or n_knots");
+    // p_min must be strictly positive for log-space sampling; otherwise
+    // std::log(p_min) silently feeds -inf into the spline knots and we'd
+    // cascade into hard-to-debug downstream failures.
+    if (!(p_min > 0.0) || !(p_max > p_min) || n_knots < 2) {
+        throw std::invalid_argument("SatBoundaryFactory: invalid p range or n_knots (need 0 < p_min < p_max and n_knots >= 2)");
     }
     std::vector<double> p_knots(n_knots);
     std::vector<double> y(n_knots);

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -1,0 +1,189 @@
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <utility>
+
+#include "CoolProp/region/AxisTransform.h"
+#include "CoolProp/region/ConstantCurve.h"
+#include "CoolProp/region/CubicSplineCurve.h"
+#include "CoolProp/sbtl/SVDSurfaceFactory.h"
+#include "CoolProp/sbtl/SatBoundaryFactory.h"
+#include "CoolProp/sbtl/SurfaceSpec.h"
+#include "DataStructures.h"
+
+namespace CoolProp {
+namespace sbtl {
+namespace presets {
+
+namespace {
+
+// Shared property list for HmassP_INPUTS: h is the input (secondary
+// axis), so the outputs are ρ, T, s, u.  Density is log-transformed
+// (EXP) since it varies over orders of magnitude across LIQUID +
+// VAPOR; the rest are identity-transformed (additive scale).
+std::vector<PropertySpec> ph_properties() {
+    return {
+      {::CoolProp::iDmass, svd::OutputTransform::EXP},
+      {::CoolProp::iT, svd::OutputTransform::IDENTITY},
+      {::CoolProp::iSmass, svd::OutputTransform::IDENTITY},
+      {::CoolProp::iUmass, svd::OutputTransform::IDENTITY},
+    };
+}
+
+// Shared property list for PT_INPUTS: T is the input (secondary
+// axis), so outputs are ρ, h, s, u.
+std::vector<PropertySpec> pt_properties() {
+    return {
+      {::CoolProp::iDmass, svd::OutputTransform::EXP},
+      {::CoolProp::iHmass, svd::OutputTransform::IDENTITY},
+      {::CoolProp::iSmass, svd::OutputTransform::IDENTITY},
+      {::CoolProp::iUmass, svd::OutputTransform::IDENTITY},
+    };
+}
+
+}  // namespace
+
+SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std::size_t NR, std::int32_t rank) {
+    const auto [p_min, p_max] = subcritical_pressure_range(heos);
+    const double T_min_eos = std::max(heos.Ttriple(), heos.Tmin());
+    const double T_max_eos = heos.Tmax();
+
+    SurfaceSpec spec;
+    spec.fluid_name = heos.fluid_names().empty() ? std::string{} : heos.fluid_names().front();
+    spec.input_pair = ::CoolProp::HmassP_INPUTS;
+    spec.NT = NT;
+    spec.NR = NR;
+    spec.rank = rank;
+    spec.properties = ph_properties();
+
+    // LIQUID region: primary = log p, secondary = h.
+    //   b_lo = h(T_min, p) — non-isothermal floor that walks T up
+    //                       if T_min < T_melt(p) at high p.
+    //   b_hi = h_sat,L(p) — liquid side of the saturation dome.
+    {
+        auto axis = region::AxisTransform::make(region::AxisScale::LOG, p_min, p_max);
+        auto lo = build_h_isotherm_floor(heos, p_min, p_max, T_min_eos);
+        auto hi = build_h_sat_L(heos, p_min, p_max);
+        spec.regions.emplace_back(axis, std::move(lo), std::move(hi));
+    }
+    // VAPOR region: primary = log p, secondary = h.
+    //   b_lo = h_sat,V(p) — vapor side of the saturation dome.
+    //   b_hi = h(T_max - 0.5 K, p) — hot ceiling within the HEOS
+    //                                validity envelope.
+    {
+        auto axis = region::AxisTransform::make(region::AxisScale::LOG, p_min, p_max);
+        auto lo = build_h_sat_V(heos, p_min, p_max);
+        auto hi = build_h_isotherm_ceiling(heos, p_min, p_max, T_max_eos - 0.5);
+        spec.regions.emplace_back(axis, std::move(lo), std::move(hi));
+    }
+
+    // Thermodynamics glue: PH update + per-property readout.
+    spec.update_state = [](::CoolProp::AbstractState& s, double p, double h) {
+        // SurfaceSpec passes (a, b) where a is the primary axis (p) and
+        // b is the secondary axis (h).  HmassP_INPUTS takes (h, p) in
+        // that order.
+        s.update(::CoolProp::HmassP_INPUTS, h, p);
+    };
+    spec.read_property = [](::CoolProp::AbstractState& s, ::CoolProp::parameters key) -> double {
+        switch (key) {
+            case ::CoolProp::iDmass:
+                return s.rhomass();
+            case ::CoolProp::iT:
+                return s.T();
+            case ::CoolProp::iSmass:
+                return s.smass();
+            case ::CoolProp::iUmass:
+                return s.umass();
+            default:
+                throw std::invalid_argument("ph_subcritical: unsupported output property");
+        }
+    };
+
+    return spec;
+}
+
+SurfaceSpec pt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std::size_t NR, std::int32_t rank) {
+    const auto [p_min, p_max] = subcritical_pressure_range(heos);
+    const double T_min_eos = std::max(heos.Ttriple(), heos.Tmin());
+    const double T_max_eos = heos.Tmax();
+
+    SurfaceSpec spec;
+    spec.fluid_name = heos.fluid_names().empty() ? std::string{} : heos.fluid_names().front();
+    spec.input_pair = ::CoolProp::PT_INPUTS;
+    spec.NT = NT;
+    spec.NR = NR;
+    spec.rank = rank;
+    spec.properties = pt_properties();
+
+    // For PT_INPUTS the secondary axis is T (instead of h for PH).
+    // The b_lo / b_hi curves return T values, not h values.  Reuse
+    // SatBoundaryFactory's T-side curves: T_sat(p) is the dome,
+    // bracketed by [T_min(p), T_sat(p)] for LIQUID and [T_sat(p),
+    // T_max(p)] for VAPOR.  T_min(p) walks up over a melting line
+    // exactly like the h-floor case.
+
+    // LIQUID region.  T-floor walks T_min(p) up over the melting
+    // line, same trick as build_h_isotherm_floor.  Pre-compute the
+    // (p, T_floor) knots inline, then hand them to CubicSplineCurve.
+    {
+        const SatBoundaryBuildOptions sbopts;
+        const double log_p_min = std::log(p_min);
+        const double log_p_max = std::log(p_max);
+        std::vector<double> p_knots(sbopts.n_knots);
+        std::vector<double> y(sbopts.n_knots);
+        for (std::size_t k = 0; k < sbopts.n_knots; ++k) {
+            const double p = std::exp(log_p_min + static_cast<double>(k) * (log_p_max - log_p_min) / static_cast<double>(sbopts.n_knots - 1));
+            p_knots[k] = p;
+            double T_found = std::nan("");
+            for (int s = 0; s < 40; ++s) {
+                const double T_try = T_min_eos + 0.5 * static_cast<double>(s);
+                try {
+                    heos.update(::CoolProp::PT_INPUTS, p, T_try);
+                    T_found = T_try;
+                    break;
+                } catch (...) {  // NOLINT(bugprone-empty-catch)
+                }
+            }
+            if (!std::isfinite(T_found)) {
+                throw std::runtime_error("pt_subcritical: T-floor unreachable within 20 K of T_min_eos");
+            }
+            y[k] = T_found;
+        }
+        auto axis = region::AxisTransform::make(region::AxisScale::LOG, p_min, p_max);
+        auto t_lo = region::CubicSplineCurve::build(std::move(p_knots), std::move(y));
+        auto t_hi = build_T_sat(heos, p_min, p_max);
+        spec.regions.emplace_back(axis, std::move(t_lo), std::move(t_hi));
+    }
+    // VAPOR region.
+    {
+        auto axis = region::AxisTransform::make(region::AxisScale::LOG, p_min, p_max);
+        auto t_lo = build_T_sat(heos, p_min, p_max);
+        // Constant T_max ceiling — no melting consideration on the
+        // hot side, so just a flat isotherm.
+        auto t_hi = std::make_unique<region::ConstantCurve>(p_min, p_max, T_max_eos - 0.5);
+        spec.regions.emplace_back(axis, std::move(t_lo), std::move(t_hi));
+    }
+
+    // Thermodynamics glue: PT update + per-property readout.
+    spec.update_state = [](::CoolProp::AbstractState& s, double p, double T) { s.update(::CoolProp::PT_INPUTS, p, T); };
+    spec.read_property = [](::CoolProp::AbstractState& s, ::CoolProp::parameters key) -> double {
+        switch (key) {
+            case ::CoolProp::iDmass:
+                return s.rhomass();
+            case ::CoolProp::iHmass:
+                return s.hmass();
+            case ::CoolProp::iSmass:
+                return s.smass();
+            case ::CoolProp::iUmass:
+                return s.umass();
+            default:
+                throw std::invalid_argument("pt_subcritical: unsupported output property");
+        }
+    };
+
+    return spec;
+}
+
+}  // namespace presets
+}  // namespace sbtl
+}  // namespace CoolProp

--- a/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
+++ b/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
@@ -5,14 +5,6 @@
 // the SVDSurfaceSerializer lands.  For now this exercises the
 // build-and-eval end-to-end at a SMALL grid so the suite stays fast.
 
-#include "CoolProp/region/AxisTransform.h"
-#include "CoolProp/region/ConstantCurve.h"
-#include "CoolProp/sbtl/SVDSurface.h"
-#include "CoolProp/sbtl/SVDSurfaceFactory.h"
-#include "CoolProp/sbtl/SVDSurfaceSerializer.h"
-#include "CoolProp/sbtl/SatBoundaryFactory.h"
-#include "CoolProp/sbtl/SurfaceSpec.h"
-
 #if defined(ENABLE_CATCH)
 #    include <catch2/catch_all.hpp>
 
@@ -21,6 +13,13 @@
 #    include <vector>
 
 #    include "AbstractState.h"
+#    include "CoolProp/region/AxisTransform.h"
+#    include "CoolProp/region/ConstantCurve.h"
+#    include "CoolProp/sbtl/SVDSurface.h"
+#    include "CoolProp/sbtl/SVDSurfaceFactory.h"
+#    include "CoolProp/sbtl/SVDSurfaceSerializer.h"
+#    include "CoolProp/sbtl/SatBoundaryFactory.h"
+#    include "CoolProp/sbtl/SurfaceSpec.h"
 #    include "miniz.h"
 
 namespace cp_sbtl = CoolProp::sbtl;
@@ -190,6 +189,86 @@ TEST_CASE("SVDSurfaceSerializer rejects corrupt input", "[SBTL][serializer]") {
         bogus_payload.resize(out_size);
     }
     REQUIRE_THROWS(cp_sbtl::SVDSurfaceSerializer::load(bogus_payload));
+}
+
+// Multi-fluid coverage: build and round-trip PH + PT surfaces for a
+// handful of fluids at a tiny grid.  Tiny grid (NT=30, NR=50, rank=8)
+// keeps total per-fluid runtime ≈ 1–2 s; the test set runs in
+// ~10 s with all 5 fluids.  Loose accuracy tolerance — production
+// resolution is what Phase 2a's SVDSBTL_E2E covers.
+TEST_CASE("SVDSurface PH preset across multi-fluid set", "[SBTL][SVDSurface][preset_ph][multi_fluid][slow]") {
+    for (const auto* fluid : {"R134a", "Ammonia", "Methane", "Propane", "CarbonDioxide"}) {
+        SECTION(fluid) {
+            auto heos = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("HEOS", fluid));
+            auto spec = cp_sbtl::presets::ph_subcritical(*heos, /*NT=*/30, /*NR=*/50, /*rank=*/8);
+            cp_sbtl::SVDSurface surface = cp_sbtl::build_surface(*heos, std::move(spec));
+            REQUIRE(surface.sealed());
+            REQUIRE(surface.region_count() == 2);
+
+            // Round-trip through serializer.  HEOS canonicalises aliases
+            // (e.g. "Propane" → "n-Propane"), so compare against what the
+            // surface actually stored, not the user-facing input string.
+            const auto blob = cp_sbtl::SVDSurfaceSerializer::save(surface);
+            auto reloaded = cp_sbtl::SVDSurfaceSerializer::load(blob);
+            REQUIRE(reloaded.fluid_name() == surface.fluid_name());
+            REQUIRE(reloaded.region_count() == 2);
+
+            // Spot-check eval matches HEOS at a handful of single-phase probes.
+            std::mt19937 rng(91);
+            const auto [p_min, p_max] = cp_sbtl::subcritical_pressure_range(*heos);
+            std::uniform_real_distribution<double> uT(std::max(heos->Ttriple() + 5.0, heos->Tmin() + 5.0), heos->Tmax() - 5.0);
+            std::uniform_real_distribution<double> u_log_p(std::log(p_min * 2.0), std::log(p_max * 0.8));
+            int kept = 0;
+            double max_rel = 0;
+            for (int trial = 0; trial < 200 && kept < 10; ++trial) {
+                const double T = uT(rng);
+                const double p = std::exp(u_log_p(rng));
+                try {
+                    heos->update(::CoolProp::PT_INPUTS, p, T);
+                    if (heos->Q() > 0.0 && heos->Q() < 1.0) {
+                        continue;
+                    }
+                    const double h = heos->hmass();
+                    const double rho_truth = heos->rhomass();
+                    const double rho_pred = reloaded.eval(::CoolProp::iDmass, p, h);
+                    if (std::isnan(rho_pred)) {
+                        continue;
+                    }
+                    const double rel = std::abs(rho_pred - rho_truth) / rho_truth;
+                    max_rel = std::max(max_rel, rel);
+                    ++kept;
+                } catch (...) {  // NOLINT(bugprone-empty-catch)
+                }
+            }
+            INFO(fluid << " kept=" << kept << " max_rel=" << max_rel);
+            REQUIRE(kept >= 3);
+            // Tiny grid → loose tolerance; just confirm no order-of-magnitude regressions.
+            REQUIRE(max_rel < 0.20);
+        }
+    }
+}
+
+TEST_CASE("SVDSurface PT preset water round-trip", "[SBTL][SVDSurface][preset_pt][slow]") {
+    auto heos = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("HEOS", "Water"));
+    auto spec = cp_sbtl::presets::pt_subcritical(*heos, /*NT=*/40, /*NR=*/80, /*rank=*/10);
+    REQUIRE(spec.input_pair == ::CoolProp::PT_INPUTS);
+    REQUIRE(spec.regions.size() == 2);
+
+    cp_sbtl::SVDSurface surface = cp_sbtl::build_surface(*heos, std::move(spec));
+    REQUIRE(surface.sealed());
+
+    // Round-trip serializer.
+    const auto blob = cp_sbtl::SVDSurfaceSerializer::save(surface);
+    auto reloaded = cp_sbtl::SVDSurfaceSerializer::load(blob);
+    REQUIRE(reloaded.input_pair() == ::CoolProp::PT_INPUTS);
+
+    // Spot-check on water at a known compressed-liquid state.
+    heos->update(::CoolProp::PT_INPUTS, 1e6, 350.0);
+    const double rho_truth = heos->rhomass();
+    const double rho_pred = reloaded.eval(::CoolProp::iDmass, 1e6, 350.0);
+    INFO("rho_truth=" << rho_truth << " rho_pred=" << rho_pred);
+    REQUIRE_FALSE(std::isnan(rho_pred));
+    REQUIRE(std::abs(rho_pred - rho_truth) / rho_truth < 0.05);
 }
 
 TEST_CASE("SVDSurfaceSerializer file save/load round-trip", "[SBTL][serializer][slow]") {

--- a/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
+++ b/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
@@ -1,0 +1,124 @@
+// Catch2 tests for the SBTL adapter layer (Phase 2b): SatBoundaryFactory,
+// SurfaceSpec, SVDSurfaceFactory, SVDSurface, presets.
+//
+// The serializer round-trip tests are added in a separate file once
+// the SVDSurfaceSerializer lands.  For now this exercises the
+// build-and-eval end-to-end at a SMALL grid so the suite stays fast.
+
+#include "CoolProp/region/AxisTransform.h"
+#include "CoolProp/region/ConstantCurve.h"
+#include "CoolProp/sbtl/SVDSurface.h"
+#include "CoolProp/sbtl/SVDSurfaceFactory.h"
+#include "CoolProp/sbtl/SatBoundaryFactory.h"
+#include "CoolProp/sbtl/SurfaceSpec.h"
+
+#if defined(ENABLE_CATCH)
+#    include <catch2/catch_all.hpp>
+
+#    include <memory>
+#    include <random>
+#    include <vector>
+
+#    include "AbstractState.h"
+
+namespace cp_sbtl = CoolProp::sbtl;
+namespace cp_region = CoolProp::region;
+
+TEST_CASE("SVDSurface construction + seal", "[SBTL][SVDSurface]") {
+    cp_sbtl::SVDSurface s("Water", ::CoolProp::PT_INPUTS, {::CoolProp::iDmass, ::CoolProp::iHmass});
+    REQUIRE(s.fluid_name() == "Water");
+    REQUIRE(s.input_pair() == ::CoolProp::PT_INPUTS);
+    REQUIRE(s.properties().size() == 2);
+    REQUIRE(s.contains_property(::CoolProp::iDmass));
+    REQUIRE_FALSE(s.contains_property(::CoolProp::iT));
+    REQUIRE_FALSE(s.sealed());
+
+    // seal() with no regions registered is a no-op success (empty atlas).
+    s.seal();
+    REQUIRE(s.sealed());
+    REQUIRE(std::isnan(s.eval(::CoolProp::iDmass, 1e5, 300.0)));  // no regions → NaN
+}
+
+TEST_CASE("SVDSurface rejects duplicate properties", "[SBTL][SVDSurface]") {
+    REQUIRE_THROWS_AS(cp_sbtl::SVDSurface("X", ::CoolProp::PT_INPUTS, {::CoolProp::iDmass, ::CoolProp::iDmass}), std::invalid_argument);
+}
+
+TEST_CASE("SVDSurface rejects empty property list", "[SBTL][SVDSurface]") {
+    REQUIRE_THROWS_AS(cp_sbtl::SVDSurface("X", ::CoolProp::PT_INPUTS, {}), std::invalid_argument);
+}
+
+TEST_CASE("SatBoundaryFactory builds water sat curves matching HEOS", "[SBTL][SatBoundaryFactory][slow]") {
+    auto heos = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("HEOS", "Water"));
+    const auto [p_min, p_max] = cp_sbtl::subcritical_pressure_range(*heos);
+
+    auto h_sat_L = cp_sbtl::build_h_sat_L(*heos, p_min, p_max);
+    auto h_sat_V = cp_sbtl::build_h_sat_V(*heos, p_min, p_max);
+
+    // Sample at 10 random log-p points, compare to direct HEOS.
+    std::mt19937 rng(31);
+    std::uniform_real_distribution<double> u(std::log(p_min * 1.05), std::log(p_max * 0.99));
+    for (int k = 0; k < 10; ++k) {
+        const double p = std::exp(u(rng));
+        heos->update(::CoolProp::PQ_INPUTS, p, 0.0);
+        const double hL_truth = heos->hmass();
+        heos->update(::CoolProp::PQ_INPUTS, p, 1.0);
+        const double hV_truth = heos->hmass();
+        // CubicSpline through 64 HEOS knots should match HEOS within
+        // ~1e-4 relative on the smooth water sat curve.
+        REQUIRE(h_sat_L->eval(p) == Catch::Approx(hL_truth).epsilon(1e-3));
+        REQUIRE(h_sat_V->eval(p) == Catch::Approx(hV_truth).epsilon(1e-3));
+    }
+}
+
+TEST_CASE("SVDSurface PH preset builds + evals against HEOS", "[SBTL][SVDSurface][preset_ph][slow]") {
+    auto heos = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("HEOS", "Water"));
+    // Tiny grid for unit-test runtime — accuracy is checked
+    // qualitatively (must reproduce HEOS to a few percent on a
+    // handful of single-phase probes).  Phase 2a's e2e tool covers
+    // production-resolution accuracy.
+    auto spec = cp_sbtl::presets::ph_subcritical(*heos, /*NT=*/40, /*NR=*/80, /*rank=*/10);
+    REQUIRE(spec.input_pair == ::CoolProp::HmassP_INPUTS);
+    REQUIRE(spec.regions.size() == 2);
+    REQUIRE(spec.properties.size() == 4);
+
+    auto surface = cp_sbtl::build_surface(*heos, std::move(spec));
+    REQUIRE(surface.sealed());
+    REQUIRE(surface.region_count() == 2);
+
+    // Probe single-phase Water states in (T, p) → look up via (h, p).
+    std::mt19937 rng(57);
+    const auto [p_min, p_max] = cp_sbtl::subcritical_pressure_range(*heos);
+    std::uniform_real_distribution<double> uT(290.0, heos->Tmax() - 1.0);
+    std::uniform_real_distribution<double> u_log_p(std::log(p_min * 1.5), std::log(p_max * 0.9));
+
+    int kept = 0;
+    double max_rel = 0;
+    for (int trial = 0; trial < 200 && kept < 30; ++trial) {
+        const double T = uT(rng);
+        const double p = std::exp(u_log_p(rng));
+        try {
+            heos->update(::CoolProp::PT_INPUTS, p, T);
+            if (heos->Q() > 0.0 && heos->Q() < 1.0) {
+                continue;
+            }
+            const double h = heos->hmass();
+            const double rho_truth = heos->rhomass();
+            const double rho_pred = surface.eval(::CoolProp::iDmass, p, h);
+            if (std::isnan(rho_pred)) {
+                continue;
+            }
+            const double rel = std::abs(rho_pred - rho_truth) / rho_truth;
+            max_rel = std::max(max_rel, rel);
+            ++kept;
+        } catch (...) {
+            // skip
+        }
+    }
+    INFO("kept=" << kept << " max_rel=" << max_rel);
+    REQUIRE(kept >= 10);
+    // 40x80 rank-10 SVD over the whole subcritical range is coarse —
+    // anything under 5% on Water is a sanity-passing build.
+    REQUIRE(max_rel < 5e-2);
+}
+
+#endif  // ENABLE_CATCH

--- a/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
+++ b/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
@@ -9,6 +9,7 @@
 #include "CoolProp/region/ConstantCurve.h"
 #include "CoolProp/sbtl/SVDSurface.h"
 #include "CoolProp/sbtl/SVDSurfaceFactory.h"
+#include "CoolProp/sbtl/SVDSurfaceSerializer.h"
 #include "CoolProp/sbtl/SatBoundaryFactory.h"
 #include "CoolProp/sbtl/SurfaceSpec.h"
 
@@ -20,6 +21,7 @@
 #    include <vector>
 
 #    include "AbstractState.h"
+#    include "miniz.h"
 
 namespace cp_sbtl = CoolProp::sbtl;
 namespace cp_region = CoolProp::region;
@@ -119,6 +121,92 @@ TEST_CASE("SVDSurface PH preset builds + evals against HEOS", "[SBTL][SVDSurface
     // 40x80 rank-10 SVD over the whole subcritical range is coarse —
     // anything under 5% on Water is a sanity-passing build.
     REQUIRE(max_rel < 5e-2);
+}
+
+TEST_CASE("SVDSurface save/load round-trip is bit-identical", "[SBTL][serializer][slow]") {
+    auto heos = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("HEOS", "Water"));
+    auto spec = cp_sbtl::presets::ph_subcritical(*heos, /*NT=*/40, /*NR=*/80, /*rank=*/10);
+    auto surface_before = cp_sbtl::build_surface(*heos, std::move(spec));
+
+    // Save to a byte buffer and load back.
+    const auto blob = cp_sbtl::SVDSurfaceSerializer::save(surface_before);
+    auto surface_after = cp_sbtl::SVDSurfaceSerializer::load(blob);
+
+    // Round-trip checks: metadata identity.
+    REQUIRE(surface_after.fluid_name() == surface_before.fluid_name());
+    REQUIRE(surface_after.input_pair() == surface_before.input_pair());
+    REQUIRE(surface_after.region_count() == surface_before.region_count());
+    REQUIRE(surface_after.properties() == surface_before.properties());
+
+    // Same query at multiple probes must give bit-identical results.
+    // (Floating-point bit-identical because Region/SVDEvaluator math
+    // is deterministic and we packed the exact ULP-precise doubles.)
+    std::mt19937 rng(101);
+    const auto [p_min, p_max] = cp_sbtl::subcritical_pressure_range(*heos);
+    std::uniform_real_distribution<double> u_log_p(std::log(p_min * 1.5), std::log(p_max * 0.9));
+    std::uniform_real_distribution<double> uT(290.0, heos->Tmax() - 1.0);
+
+    int compared = 0;
+    for (int trial = 0; trial < 200 && compared < 30; ++trial) {
+        const double T = uT(rng);
+        const double p = std::exp(u_log_p(rng));
+        try {
+            heos->update(::CoolProp::PT_INPUTS, p, T);
+            if (heos->Q() > 0.0 && heos->Q() < 1.0) {
+                continue;
+            }
+            const double h = heos->hmass();
+            const double rho_before = surface_before.eval(::CoolProp::iDmass, p, h);
+            const double rho_after = surface_after.eval(::CoolProp::iDmass, p, h);
+            if (std::isnan(rho_before) || std::isnan(rho_after)) {
+                continue;
+            }
+            // Same bytes → same evaluator → bit-identical output.
+            REQUIRE(rho_before == rho_after);
+            ++compared;
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+        }
+    }
+    REQUIRE(compared >= 10);
+}
+
+TEST_CASE("SVDSurfaceSerializer rejects corrupt input", "[SBTL][serializer]") {
+    // Empty / truncated / wrong-magic bytes should all throw, not segfault.
+    const std::vector<char> empty;
+    REQUIRE_THROWS_AS(cp_sbtl::SVDSurfaceSerializer::load(empty), std::runtime_error);
+
+    const std::vector<char> garbage(64, '\0');
+    REQUIRE_THROWS_AS(cp_sbtl::SVDSurfaceSerializer::load(garbage), std::runtime_error);
+
+    // Valid zlib-compressed payload that decompresses to "hello world" —
+    // not a valid msgpack stream, so msgpack::unpack throws.  The
+    // serializer wraps that in std::runtime_error.
+    std::vector<char> bogus_payload;
+    {
+        const char hello[] = "hello world";
+        bogus_payload.resize(64);
+        mz_ulong out_size = static_cast<mz_ulong>(bogus_payload.size());
+        compress((unsigned char*)bogus_payload.data(), &out_size, (const unsigned char*)hello, sizeof(hello) - 1);
+        bogus_payload.resize(out_size);
+    }
+    REQUIRE_THROWS(cp_sbtl::SVDSurfaceSerializer::load(bogus_payload));
+}
+
+TEST_CASE("SVDSurfaceSerializer file save/load round-trip", "[SBTL][serializer][slow]") {
+    auto heos = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("HEOS", "Water"));
+    auto spec = cp_sbtl::presets::ph_subcritical(*heos, /*NT=*/40, /*NR=*/80, /*rank=*/10);
+    auto surface = cp_sbtl::build_surface(*heos, std::move(spec));
+
+    // Save to a tmp file and load back via the file API.
+    const std::string path = "/tmp/svd_test_water_ph.svd.bin.z";
+    cp_sbtl::SVDSurfaceSerializer::save_to_file(surface, path);
+    auto loaded = cp_sbtl::SVDSurfaceSerializer::load_from_file(path);
+    REQUIRE(loaded.fluid_name() == "Water");
+    REQUIRE(loaded.region_count() == 2);
+    // Spot-check a single eval matches.
+    heos->update(::CoolProp::PT_INPUTS, 1e5, 350.0);
+    const double h = heos->hmass();
+    REQUIRE(loaded.eval(::CoolProp::iDmass, 1e5, h) == surface.eval(::CoolProp::iDmass, 1e5, h));
 }
 
 #endif  // ENABLE_CATCH

--- a/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
+++ b/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
@@ -1,13 +1,13 @@
 // Catch2 tests for the SBTL adapter layer (Phase 2b): SatBoundaryFactory,
-// SurfaceSpec, SVDSurfaceFactory, SVDSurface, presets.
-//
-// The serializer round-trip tests are added in a separate file once
-// the SVDSurfaceSerializer lands.  For now this exercises the
-// build-and-eval end-to-end at a SMALL grid so the suite stays fast.
+// SurfaceSpec, SVDSurfaceFactory, SVDSurface, presets, and the
+// SVDSurfaceSerializer round-trip + corruption-rejection coverage.
+// Build-and-eval tests use a SMALL grid so the suite stays fast;
+// production-resolution accuracy is covered by Phase 2a's SVDSBTL_E2E.
 
 #if defined(ENABLE_CATCH)
 #    include <catch2/catch_all.hpp>
 
+#    include <filesystem>
 #    include <memory>
 #    include <random>
 #    include <vector>
@@ -169,6 +169,23 @@ TEST_CASE("SVDSurface save/load round-trip is bit-identical", "[SBTL][serializer
     REQUIRE(compared >= 10);
 }
 
+TEST_CASE("SVDSurfaceSerializer::default_cache_path rejects path-traversal fluid names", "[SBTL][serializer]") {
+    // Defense-in-depth: anything that could escape the cache directory
+    // must throw rather than silently writing outside ~/.CoolProp/SVDTables.
+    using Catch::Matchers::ContainsSubstring;
+    REQUIRE_THROWS_WITH(cp_sbtl::SVDSurfaceSerializer::default_cache_path("../etc/passwd", ::CoolProp::HmassP_INPUTS),
+                        ContainsSubstring("invalid fluid_name"));
+    REQUIRE_THROWS_WITH(cp_sbtl::SVDSurfaceSerializer::default_cache_path("foo/bar", ::CoolProp::HmassP_INPUTS),
+                        ContainsSubstring("invalid fluid_name"));
+    REQUIRE_THROWS_WITH(cp_sbtl::SVDSurfaceSerializer::default_cache_path("foo\\bar", ::CoolProp::HmassP_INPUTS),
+                        ContainsSubstring("invalid fluid_name"));
+    REQUIRE_THROWS_WITH(cp_sbtl::SVDSurfaceSerializer::default_cache_path("..", ::CoolProp::HmassP_INPUTS), ContainsSubstring("invalid fluid_name"));
+    REQUIRE_THROWS_WITH(cp_sbtl::SVDSurfaceSerializer::default_cache_path("", ::CoolProp::HmassP_INPUTS), ContainsSubstring("invalid fluid_name"));
+    // Legitimate names pass.
+    REQUIRE_NOTHROW(cp_sbtl::SVDSurfaceSerializer::default_cache_path("Water", ::CoolProp::HmassP_INPUTS));
+    REQUIRE_NOTHROW(cp_sbtl::SVDSurfaceSerializer::default_cache_path("R134a", ::CoolProp::PT_INPUTS));
+}
+
 TEST_CASE("SVDSurfaceSerializer rejects corrupt input", "[SBTL][serializer]") {
     // Empty / truncated / wrong-magic bytes should all throw, not segfault.
     const std::vector<char> empty;
@@ -185,7 +202,11 @@ TEST_CASE("SVDSurfaceSerializer rejects corrupt input", "[SBTL][serializer]") {
         const char hello[] = "hello world";
         bogus_payload.resize(64);
         mz_ulong out_size = static_cast<mz_ulong>(bogus_payload.size());
-        compress((unsigned char*)bogus_payload.data(), &out_size, (const unsigned char*)hello, sizeof(hello) - 1);
+        const int rc = compress((unsigned char*)bogus_payload.data(), &out_size, (const unsigned char*)hello, sizeof(hello) - 1);
+        // miniz returns MZ_OK == Z_OK == 0.  Failing here means the
+        // test setup itself is broken (not what we're trying to
+        // validate), so REQUIRE rather than silently resizing.
+        REQUIRE(rc == 0);
         bogus_payload.resize(out_size);
     }
     REQUIRE_THROWS(cp_sbtl::SVDSurfaceSerializer::load(bogus_payload));
@@ -276,8 +297,12 @@ TEST_CASE("SVDSurfaceSerializer file save/load round-trip", "[SBTL][serializer][
     auto spec = cp_sbtl::presets::ph_subcritical(*heos, /*NT=*/40, /*NR=*/80, /*rank=*/10);
     auto surface = cp_sbtl::build_surface(*heos, std::move(spec));
 
-    // Save to a tmp file and load back via the file API.
-    const std::string path = "/tmp/svd_test_water_ph.svd.bin.z";
+    // Save to a tmp file and load back via the file API.  Use
+    // std::filesystem::temp_directory_path() rather than hard-coding
+    // /tmp -- the latter doesn't exist on Windows CI and would race
+    // when multiple test instances run concurrently.
+    const auto tmp_path = std::filesystem::temp_directory_path() / "svd_test_water_ph.svd.bin.z";
+    const std::string path = tmp_path.string();
     cp_sbtl::SVDSurfaceSerializer::save_to_file(surface, path);
     auto loaded = cp_sbtl::SVDSurfaceSerializer::load_from_file(path);
     REQUIRE(loaded.fluid_name() == "Water");


### PR DESCRIPTION
## Summary

Phase 2b of the SVDSBTL backend rollout: the adapter library that sits
between the generic SVD/Region components from #2914 (Phase 1) and a
future `SVDSBTLBackend` (Phase 2c).  Three commits on this branch are
unique to Phase 2b (the rest are inherited from #2914 until that PR
merges).

### What lands here

1. **SatBoundaryFactory** (`include/CoolProp/sbtl/SatBoundaryFactory.h`
   + `src/SBTL/SatBoundaryFactory.cpp`) — HEOS-driven
   `CubicSplineCurve` builders for the four saturation/limit curves
   needed to define a subcritical region in (xnorm, log p) coords:
   liquid-side h_sat(p), vapor-side h_sat(p), T_sat(p), and the
   melting-line-proxy h_isotherm_floor(p) plus h_isotherm_ceiling(p).
   Includes a `subcritical_pressure_range` helper.  Falls back to
   T-walking when the melting line is unavailable so we don't lose
   coverage on fluids without a melting EOS.

2. **SVDSurface** (`include/CoolProp/sbtl/SVDSurface.h` +
   `src/SBTL/SVDSurface.cpp`) — aggregator owning a `RegionAtlas` plus
   per-region per-property `SVDDecomposition`s.  Decompositions are
   stored as `vector<vector<unique_ptr<SVDDecomposition>>>` so eval-time
   pointer addresses stay stable across vector reallocations.  Exposes
   a `ResolvedPoint` fast-path so multi-property queries amortise the
   region-dispatch + axis-transform cost.

3. **SVDSurfaceFactory** + **SurfaceSpec** + **presets** —
   input-pair-agnostic `build_surface(heos, spec, opts)` walks the
   (xnorm, xi_log_p) ∈ [0,1]² grid, samples HEOS via the spec's
   `update_state` + `read_property` callbacks, and builds per-region
   per-property SVDs.  NaN cells from two-phase rejection get patched
   via row-wise linear interpolation + median fill.  `ph_subcritical()`
   and `pt_subcritical()` presets cover the immediate Phase 2c needs
   (ρ-EXP + T/s/u for PH; ρ-EXP + h/s/u for PT).

4. **SVDSurfaceSerializer** (`include/CoolProp/sbtl/SVDSurfaceSerializer.h`
   + `src/SBTL/SVDSurfaceSerializer.cpp`) — msgpack + zlib persistence,
   parallel to BicubicBackend's existing `.bin.z` convention.  Format:
   `[magic "SVDS", revision=1, fluid_name, surfaces[]]` so a future
   revision can ship PH+PT+DU surfaces in one file without a format
   bump.  Polymorphic boundary curves use a uint8 `CurveKind`
   discriminator + `State` POD snapshots + `from_state(State)` trusted
   factories on each concrete `BoundaryCurve` subclass.

5. **dev/build_svd_tables.cpp** + `COOLPROP_BUILD_SVD_TABLES` —
   bulk-build executable.  Defaults to the seven Phase 2a fluids;
   writes one `.svd.bin.z` per fluid per input pair under
   `~/.CoolProp/SVDTables/`.  Grid size / rank overridable via
   `SVD_NT` / `SVD_NR` / `SVD_RANK` env vars (defaults match
   production: NT=200, NR=800, rank=20).

### Test coverage

`src/Tests/CoolProp-Tests-SBTLAdapter.cpp` — 10 cases / 114 assertions
in `[SBTL]`:

- Build + eval end-to-end on Water (PH and PT presets)
- Serializer byte / file round-trip, plus corruption-rejection
  (empty / garbage / zlib-but-not-msgpack inputs all throw cleanly)
- Multi-fluid PH coverage: R134a, Ammonia, Methane, Propane,
  CarbonDioxide each build, round-trip, and spot-check against HEOS at
  3+ probes within 20% (loose tolerance — tiny grid; the production-
  resolution validation lives in Phase 2a's `SVDSBTL_E2E` harness).
- Spot-check PT preset on Water compressed-liquid (1 MPa, 350 K)
  matches HEOS within 5%

Full Catch2 suite stays green (1980 assertions / 31 cases in
`[SVDComponents][SBTL]` combined).

## Dependencies

This PR is stacked on **#2914** (Phase 1 — generic SVD + Region
components).  The first seven commits in this branch belong to #2914
and will fold in cleanly once that merges.  The three new commits in
Phase 2b are:

- `feat(sbtl): adapter library — SatBoundaryFactory + SVDSurface + presets`
- `feat(sbtl): msgpack+zlib SVDSurface persistence + State snapshots`
- `feat(sbtl): bulk-build tool + multi-fluid Phase 2b coverage`

Phase 2c (a `SVDSBTLBackend` that consumes these artifacts via
`TabularBackend`) will be the next PR.

## Test plan

- [x] `./build_catch/CatchTestRunner "[SBTL]"` — 10 cases / 114 assertions pass
- [x] `./build_catch/CatchTestRunner "[SVDComponents]"` — Phase 1 suite still green
- [x] `cmake --build build_catch --target CatchTestRunner -j8` clean
- [x] clang-format pre-commit hook clean
- [ ] CI green on Linux + macOS + Windows
- [ ] (Optional, developer-only) `cmake -B build_table -DCOOLPROP_BUILD_SVD_TABLES=ON && ./build_table/build_svd_tables Water` produces a readable `.svd.bin.z`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SVD-backed fast property surface lookup with serialization, compressed per-fluid cache files, preset builders for subcritical PH/PT surfaces, and new saturation/boundary spline helpers
  * Serializable region curve snapshots and reconstruction APIs for cubic-spline and piecewise Chebyshev curves
  * Developer CLI to build and verify SVD tables and populate the per-user cache

* **Chores**
  * Build option to enable SVD table tooling and include SVD surface sources

* **Tests**
  * New comprehensive tests for building, evaluating, serializing, caching, and validating SVD surfaces

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->