### PR TITLE
ci(devdocs): drop pull_request trigger so devdocs deploys only on master

### DIFF
--- a/.github/workflows/docs_devdocs-run.yml
+++ b/.github/workflows/docs_devdocs-run.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [ 'master', 'main']
     tags: [ 'v*' ]
-  pull_request:
-    branches: [ 'master', 'main']
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- `docs_devdocs-run.yml` listened on `pull_request: branches: [master, main]` in addition to push, so every PR targeting master fired a `repository_dispatch` to the `CoolProp/devdocs` repo and kicked off a devdocs deploy.
- Per #2913, devdocs should only deploy when changes land on master (or a tagged release), not on every PR.
- Removes the `pull_request` trigger; the `push` trigger on `master`/`main` + `v*` tags is retained.

Closes #2913

## Test plan

- [ ] Confirm this PR itself does **not** trigger the `Run devdocs deployment` workflow (only the push to master after merge should).
- [ ] After merge, confirm the workflow fires on the master push and dispatches `triggered-by-CoolProp-main` to `CoolProp/devdocs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated devdocs deployment workflow to trigger on push events to main/master branch and version tags, with pull request trigger removed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2918)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->