### PR TITLE
feat(AbstractState): cache-bypassing batch fast_evaluate (Tabular + IF97)

### DIFF
--- a/include/AbstractState.h
+++ b/include/AbstractState.h
@@ -877,6 +877,40 @@ class AbstractState
         throw NotImplementedError("update_with_guesses is not implemented for this backend");
     };
 
+    /**
+     * @brief Vectorized direct evaluation that bypasses the AbstractState cache.
+     *
+     * Evaluate one or more outputs at one or more input points, writing into
+     * caller-supplied buffers. Performs no heap allocations and does not touch
+     * any cached state on the AbstractState instance — fast batch fluid-property
+     * evaluation without the per-call overhead of update()/keyed_output().
+     *
+     * Backends opt in; the default impl here throws NotImplementedError.
+     * Currently overridden by: TabularBackend (Bicubic, TTSE) and IF97Backend.
+     *
+     * Output layout: out_buffer[k * N_outputs + o] is output index o at point k.
+     *
+     * @param input_pair        Which input pair (e.g. HmolarP_INPUTS, PT_INPUTS).
+     * @param val1              First-input array, length N_inputs.
+     * @param val2              Second-input array, length N_inputs.
+     * @param N_inputs          Number of input points.
+     * @param outputs           Output parameter keys, length N_outputs.
+     * @param N_outputs         Number of outputs requested per input point.
+     * @param out_buffer        Row-major output, length >= N_inputs * N_outputs.
+     * @param out_buffer_size   Capacity of out_buffer (validated against N_inputs*N_outputs).
+     * @param status_flags      Per-point status, length >= N_inputs. 0 = ok.
+     * @param status_flags_size Capacity of status_flags (validated against N_inputs).
+     * @param imposed_phase     Optional phase hint; iphase_not_imposed = detect.
+     *
+     * On a per-point failure the corresponding output-buffer slice is filled
+     * with NaN and status_flags[k] is set to a nonzero fast_evaluate_status.
+     */
+    virtual void fast_evaluate(CoolProp::input_pairs input_pair, const double* val1, const double* val2, std::size_t N_inputs,
+                               const CoolProp::parameters* outputs, std::size_t N_outputs, double* out_buffer, std::size_t out_buffer_size,
+                               int* status_flags, std::size_t status_flags_size, CoolProp::phases imposed_phase = CoolProp::iphase_not_imposed) {
+        throw NotImplementedError("fast_evaluate is not implemented for this backend");
+    };
+
     /// A function that says whether the backend instance can be instantiated in the high-level interface
     /// In general this should be true, except for some other backends (especially the tabular backends)
     /// To disable use in high-level interface, implement this function and return false

--- a/include/AbstractState.h
+++ b/include/AbstractState.h
@@ -902,8 +902,11 @@ class AbstractState
      * @param status_flags_size Capacity of status_flags (validated against N_inputs).
      * @param imposed_phase     Optional phase hint; iphase_not_imposed = detect.
      *
-     * On a per-point failure the corresponding output-buffer slice is filled
-     * with NaN and status_flags[k] is set to a nonzero fast_evaluate_status.
+     * On a per-point failure all N_outputs entries for that point —
+     * `out_buffer[k * N_outputs + 0 .. k * N_outputs + (N_outputs - 1)]` —
+     * are filled with NaN, and `status_flags[k]` is set to a nonzero
+     * fast_evaluate_status.  Callers may rely on a single `status_flags[k]`
+     * check rather than scanning the row.
      */
     virtual void fast_evaluate(CoolProp::input_pairs input_pair, const double* val1, const double* val2, std::size_t N_inputs,
                                const CoolProp::parameters* outputs, std::size_t N_outputs, double* out_buffer, std::size_t out_buffer_size,

--- a/include/DataStructures.h
+++ b/include/DataStructures.h
@@ -193,6 +193,17 @@ enum phases : int
     iphase_not_imposed
 };  ///< Phase is not imposed
 
+/// Per-point status codes for AbstractState::fast_evaluate. Zero means success.
+enum fast_evaluate_status : int
+{
+    fast_evaluate_ok = 0,
+    fast_evaluate_out_of_range = 1,
+    fast_evaluate_two_phase_disallowed = 2,
+    fast_evaluate_unsupported_input = 3,
+    fast_evaluate_unsupported_output = 4,
+    fast_evaluate_internal_error = 5
+};
+
 /// Constants for the different PC-SAFT association schemes (see Huang and Radosz 1990)
 enum schemes
 {

--- a/src/Backends/IF97/IF97Backend.h
+++ b/src/Backends/IF97/IF97Backend.h
@@ -625,6 +625,207 @@ class IF97Backend : public AbstractState
     double Prandtl() {
         return calc_Flash(iPrandtl);
     };
+
+    /// Vectorized direct evaluation. See AbstractState::fast_evaluate for contract.
+    /// IF97 is stateless under the hood; this entry point just dispatches each
+    /// (T,p) or (h,p) point straight to the IF97 namespace evaluators with no
+    /// allocations and no writes to the AbstractState cache.
+    void fast_evaluate(CoolProp::input_pairs input_pair, const double* val1, const double* val2, std::size_t N_inputs,
+                       const CoolProp::parameters* outputs, std::size_t N_outputs, double* out_buffer, std::size_t out_buffer_size, int* status_flags,
+                       std::size_t status_flags_size, CoolProp::phases imposed_phase = CoolProp::iphase_not_imposed) override {
+        if (out_buffer_size < N_inputs * N_outputs) {
+            throw ValueError(
+              format("fast_evaluate: out_buffer_size=%zu < required %zu (N_inputs * N_outputs)", out_buffer_size, N_inputs * N_outputs));
+        }
+        if (status_flags_size < N_inputs) {
+            throw ValueError(format("fast_evaluate: status_flags_size=%zu < required %zu (N_inputs)", status_flags_size, N_inputs));
+        }
+        if (N_inputs == 0) return;
+        if (N_outputs == 0) {
+            for (std::size_t k = 0; k < N_inputs; ++k)
+                status_flags[k] = CoolProp::fast_evaluate_ok;
+            return;
+        }
+        if (val1 == nullptr || val2 == nullptr || outputs == nullptr || out_buffer == nullptr || status_flags == nullptr) {
+            throw ValueError("fast_evaluate: null pointer argument");
+        }
+
+        const bool is_PT = (input_pair == PT_INPUTS);
+        const bool is_HmassP = (input_pair == HmassP_INPUTS);
+        const bool is_HmolarP = (input_pair == HmolarP_INPUTS);
+        if (!is_PT && !is_HmassP && !is_HmolarP) {
+            throw ValueError(format("fast_evaluate (IF97): input_pair %s not supported (use PT_INPUTS, HmassP_INPUTS, HmolarP_INPUTS)",
+                                    get_input_pair_short_desc(input_pair).c_str()));
+        }
+
+        // Validate output keys up-front. IF97 covers everything its calc_Flash supports.
+        constexpr std::size_t MAX_FE_OUTPUTS = 64;
+        if (N_outputs > MAX_FE_OUTPUTS) {
+            throw ValueError(format("fast_evaluate: N_outputs=%zu exceeds compile-time limit %zu", N_outputs, MAX_FE_OUTPUTS));
+        }
+        for (std::size_t o = 0; o < N_outputs; ++o) {
+            switch (outputs[o]) {
+                case iT:
+                case iP:
+                case iDmass:
+                case iDmolar:
+                case iHmass:
+                case iHmolar:
+                case iSmass:
+                case iSmolar:
+                case iUmass:
+                case iUmolar:
+                case iCpmass:
+                case iCpmolar:
+                case iCvmass:
+                case iCvmolar:
+                case ispeed_sound:
+                case iviscosity:
+                case iconductivity:
+                case iPrandtl:
+                    break;
+                default:
+                    throw ValueError(
+                      format("fast_evaluate (IF97): output[%zu]=%s not supported", o, get_parameter_information(outputs[o], "short").c_str()));
+            }
+        }
+
+        const double M = calc_molar_mass();  // kg/mol, constant for water
+        const double NaN = std::numeric_limits<double>::quiet_NaN();
+
+        // imposed_phase: IF97 derives phase from (T,p) — we honour the hint by
+        // skipping the two-phase check when caller asserts single-phase.
+        const bool skip_twophase_check = (imposed_phase != iphase_not_imposed && imposed_phase != iphase_twophase && imposed_phase != iphase_unknown);
+
+        auto fill_nan_row = [&](std::size_t k) {
+            for (std::size_t o = 0; o < N_outputs; ++o) {
+                out_buffer[k * N_outputs + o] = NaN;
+            }
+        };
+
+        for (std::size_t k = 0; k < N_inputs; ++k) {
+            const double v1 = val1[k];
+            const double v2 = val2[k];
+
+            double T_k, p_k;
+            if (is_PT) {
+                p_k = v1;
+                T_k = v2;
+            } else {
+                // (h, p) input — convert h to mass basis and use IF97's
+                // backward T_phmass to recover T. Both branches must produce
+                // a clean (T, p) for the forward evaluators below.
+                p_k = v2;
+                double hmass_k = is_HmolarP ? (v1 / M) : v1;
+                try {
+                    T_k = IF97::T_phmass(p_k, hmass_k);
+                } catch (const std::exception&) {
+                    status_flags[k] = CoolProp::fast_evaluate_out_of_range;
+                    fill_nan_row(k);
+                    continue;
+                }
+            }
+
+            // Range check before evaluation. IF97 has explicit T/p limits; we
+            // reject points outside and let in-range points go to the kernel,
+            // which itself will throw on Region-5 etc. (caught below).
+            if (!(p_k > 0 && T_k > 0 && p_k <= IF97::get_Pmax() && T_k >= IF97::get_Tmin() && T_k <= IF97::get_Tmax())) {
+                status_flags[k] = CoolProp::fast_evaluate_out_of_range;
+                fill_nan_row(k);
+                continue;
+            }
+
+            // Two-phase rejection: PT_INPUTS landing exactly on the saturation
+            // curve is ambiguous; caller can use imposed_phase or QT/PQ inputs
+            // (which we don't support here yet). For (h,p) inputs the backward
+            // solver places us in a specific region so this is less common.
+            if (!skip_twophase_check && is_PT && T_k <= IF97::Tcrit) {
+                const double psat = IF97::psat97(T_k);
+                const double eps = 3.3e-5;
+                if (std::abs(p_k - psat) <= psat * eps) {
+                    status_flags[k] = CoolProp::fast_evaluate_two_phase_disallowed;
+                    fill_nan_row(k);
+                    continue;
+                }
+            }
+
+            bool eval_failed = false;
+            for (std::size_t o = 0; o < N_outputs; ++o) {
+                const parameters out_key = outputs[o];
+                try {
+                    double val;
+                    switch (out_key) {
+                        case iT:
+                            val = T_k;
+                            break;
+                        case iP:
+                            val = p_k;
+                            break;
+                        case iDmass:
+                            val = IF97::rhomass_Tp(T_k, p_k);
+                            break;
+                        case iDmolar:
+                            val = IF97::rhomass_Tp(T_k, p_k) / M;
+                            break;
+                        case iHmass:
+                            val = IF97::hmass_Tp(T_k, p_k);
+                            break;
+                        case iHmolar:
+                            val = IF97::hmass_Tp(T_k, p_k) * M;
+                            break;
+                        case iSmass:
+                            val = IF97::smass_Tp(T_k, p_k);
+                            break;
+                        case iSmolar:
+                            val = IF97::smass_Tp(T_k, p_k) * M;
+                            break;
+                        case iUmass:
+                            val = IF97::umass_Tp(T_k, p_k);
+                            break;
+                        case iUmolar:
+                            val = IF97::umass_Tp(T_k, p_k) * M;
+                            break;
+                        case iCpmass:
+                            val = IF97::cpmass_Tp(T_k, p_k);
+                            break;
+                        case iCpmolar:
+                            val = IF97::cpmass_Tp(T_k, p_k) * M;
+                            break;
+                        case iCvmass:
+                            val = IF97::cvmass_Tp(T_k, p_k);
+                            break;
+                        case iCvmolar:
+                            val = IF97::cvmass_Tp(T_k, p_k) * M;
+                            break;
+                        case ispeed_sound:
+                            val = IF97::speed_sound_Tp(T_k, p_k);
+                            break;
+                        case iviscosity:
+                            val = IF97::visc_Tp(T_k, p_k);
+                            break;
+                        case iconductivity:
+                            val = IF97::tcond_Tp(T_k, p_k);
+                            break;
+                        case iPrandtl:
+                            val = IF97::prandtl_Tp(T_k, p_k);
+                            break;
+                        default:
+                            val = NaN;
+                            eval_failed = true;
+                            break;
+                    }
+                    out_buffer[k * N_outputs + o] = val;
+                } catch (const std::exception&) {
+                    eval_failed = true;
+                    out_buffer[k * N_outputs + o] = NaN;
+                }
+            }
+            status_flags[k] = eval_failed ? CoolProp::fast_evaluate_internal_error : CoolProp::fast_evaluate_ok;
+        }
+        // IF97 is stateless externally; clear() resets internal cached values to
+        // be consistent with the TabularBackend contract (state untouched).
+        clear();
+    };
 };
 
 } /* namespace CoolProp */

--- a/src/Backends/IF97/IF97Backend.h
+++ b/src/Backends/IF97/IF97Backend.h
@@ -633,21 +633,26 @@ class IF97Backend : public AbstractState
     void fast_evaluate(CoolProp::input_pairs input_pair, const double* val1, const double* val2, std::size_t N_inputs,
                        const CoolProp::parameters* outputs, std::size_t N_outputs, double* out_buffer, std::size_t out_buffer_size, int* status_flags,
                        std::size_t status_flags_size, CoolProp::phases imposed_phase = CoolProp::iphase_not_imposed) override {
-        if (out_buffer_size < N_inputs * N_outputs) {
-            throw ValueError(
-              format("fast_evaluate: out_buffer_size=%zu < required %zu (N_inputs * N_outputs)", out_buffer_size, N_inputs * N_outputs));
+        if (N_outputs != 0 && N_inputs > std::numeric_limits<std::size_t>::max() / N_outputs) {
+            throw ValueError(format("fast_evaluate: N_inputs * N_outputs would overflow size_t (N_inputs=%zu, N_outputs=%zu)", N_inputs, N_outputs));
+        }
+        const std::size_t required_out = N_inputs * N_outputs;
+        if (out_buffer_size < required_out) {
+            throw ValueError(format("fast_evaluate: out_buffer_size=%zu < required %zu (N_inputs * N_outputs)", out_buffer_size, required_out));
         }
         if (status_flags_size < N_inputs) {
             throw ValueError(format("fast_evaluate: status_flags_size=%zu < required %zu (N_inputs)", status_flags_size, N_inputs));
         }
         if (N_inputs == 0) return;
+        // Null-pointer check BEFORE the N_outputs==0 early-write path: that path
+        // dereferences status_flags, so the check has to dominate it.
+        if (val1 == nullptr || val2 == nullptr || outputs == nullptr || out_buffer == nullptr || status_flags == nullptr) {
+            throw ValueError("fast_evaluate: null pointer argument");
+        }
         if (N_outputs == 0) {
             for (std::size_t k = 0; k < N_inputs; ++k)
                 status_flags[k] = CoolProp::fast_evaluate_ok;
             return;
-        }
-        if (val1 == nullptr || val2 == nullptr || outputs == nullptr || out_buffer == nullptr || status_flags == nullptr) {
-            throw ValueError("fast_evaluate: null pointer argument");
         }
 
         const bool is_PT = (input_pair == PT_INPUTS);
@@ -820,7 +825,15 @@ class IF97Backend : public AbstractState
                     out_buffer[k * N_outputs + o] = NaN;
                 }
             }
-            status_flags[k] = eval_failed ? CoolProp::fast_evaluate_internal_error : CoolProp::fast_evaluate_ok;
+            // API contract: when status_flags[k] is non-zero, the entire row is
+            // NaN. The per-output catch above only NaNs the specific failing
+            // output; finish the job here so callers don't see partial rows.
+            if (eval_failed) {
+                fill_nan_row(k);
+                status_flags[k] = CoolProp::fast_evaluate_internal_error;
+            } else {
+                status_flags[k] = CoolProp::fast_evaluate_ok;
+            }
         }
         // IF97 is stateless externally; clear() resets internal cached values to
         // be consistent with the TabularBackend contract (state untouched).

--- a/src/Backends/Tabular/TabularBackends.cpp
+++ b/src/Backends/Tabular/TabularBackends.cpp
@@ -868,20 +868,26 @@ void CoolProp::TabularBackend::fast_evaluate(CoolProp::input_pairs input_pair, c
                                              CoolProp::phases imposed_phase) {
     // Pre-loop validation. These conditions are programmer errors (mismatched
     // buffers, unsupported keys), not data errors — throw so misuse fails loud.
-    if (out_buffer_size < N_inputs * N_outputs) {
-        throw ValueError(format("fast_evaluate: out_buffer_size=%zu < required %zu (N_inputs * N_outputs)", out_buffer_size, N_inputs * N_outputs));
+    if (N_outputs != 0 && N_inputs > std::numeric_limits<std::size_t>::max() / N_outputs) {
+        throw ValueError(format("fast_evaluate: N_inputs * N_outputs would overflow size_t (N_inputs=%zu, N_outputs=%zu)", N_inputs, N_outputs));
+    }
+    const std::size_t required_out = N_inputs * N_outputs;
+    if (out_buffer_size < required_out) {
+        throw ValueError(format("fast_evaluate: out_buffer_size=%zu < required %zu (N_inputs * N_outputs)", out_buffer_size, required_out));
     }
     if (status_flags_size < N_inputs) {
         throw ValueError(format("fast_evaluate: status_flags_size=%zu < required %zu (N_inputs)", status_flags_size, N_inputs));
     }
     if (N_inputs == 0) return;
+    // Null-pointer check BEFORE the N_outputs==0 early-write path: that path
+    // dereferences status_flags, so the check has to dominate it.
+    if (val1 == nullptr || val2 == nullptr || outputs == nullptr || out_buffer == nullptr || status_flags == nullptr) {
+        throw ValueError("fast_evaluate: null pointer argument");
+    }
     if (N_outputs == 0) {
         for (std::size_t k = 0; k < N_inputs; ++k)
             status_flags[k] = CoolProp::fast_evaluate_ok;
         return;
-    }
-    if (val1 == nullptr || val2 == nullptr || outputs == nullptr || out_buffer == nullptr || status_flags == nullptr) {
-        throw ValueError("fast_evaluate: null pointer argument");
     }
 
     const bool is_ph = (input_pair == HmolarP_INPUTS);
@@ -998,7 +1004,15 @@ void CoolProp::TabularBackend::fast_evaluate(CoolProp::input_pairs input_pair, c
                 out_buffer[k * N_outputs + o] = NaN;
             }
         }
-        status_flags[k] = eval_failed ? fast_evaluate_internal_error : fast_evaluate_ok;
+        // API contract: when status_flags[k] is non-zero, the entire row is NaN.
+        // The per-output catch above only NaNs the specific failing output;
+        // finish the job here so callers don't see partial rows.
+        if (eval_failed) {
+            fill_nan_row(k);
+            status_flags[k] = fast_evaluate_internal_error;
+        } else {
+            status_flags[k] = fast_evaluate_ok;
+        }
     }
 
     // Restore phase override and clear the AS cache so no per-point residue

--- a/src/Backends/Tabular/TabularBackends.cpp
+++ b/src/Backends/Tabular/TabularBackends.cpp
@@ -833,6 +833,180 @@ CoolPropDbl CoolProp::TabularBackend::calc_first_two_phase_deriv_splined(paramet
     return _HUGE;
 }
 
+namespace {
+/// Categorize an output key for routing to the appropriate eval kernel inside
+/// TabularBackend::fast_evaluate. Values >0 mean the output is supported.
+enum FastEvalOutputKind : unsigned char
+{
+    fe_unsupported = 0,
+    fe_single_phase = 1,  // iT, iP, iDmolar, iHmolar, iSmolar, iUmolar
+    fe_transport = 2,     // iviscosity, iconductivity
+};
+
+FastEvalOutputKind classify_fast_eval_output(CoolProp::parameters key) {
+    using namespace CoolProp;
+    switch (key) {
+        case iT:
+        case iP:
+        case iDmolar:
+        case iHmolar:
+        case iSmolar:
+        case iUmolar:
+            return fe_single_phase;
+        case iviscosity:
+        case iconductivity:
+            return fe_transport;
+        default:
+            return fe_unsupported;
+    }
+}
+}  // namespace
+
+void CoolProp::TabularBackend::fast_evaluate(CoolProp::input_pairs input_pair, const double* val1, const double* val2, std::size_t N_inputs,
+                                             const CoolProp::parameters* outputs, std::size_t N_outputs, double* out_buffer,
+                                             std::size_t out_buffer_size, int* status_flags, std::size_t status_flags_size,
+                                             CoolProp::phases imposed_phase) {
+    // Pre-loop validation. These conditions are programmer errors (mismatched
+    // buffers, unsupported keys), not data errors — throw so misuse fails loud.
+    if (out_buffer_size < N_inputs * N_outputs) {
+        throw ValueError(format("fast_evaluate: out_buffer_size=%zu < required %zu (N_inputs * N_outputs)", out_buffer_size, N_inputs * N_outputs));
+    }
+    if (status_flags_size < N_inputs) {
+        throw ValueError(format("fast_evaluate: status_flags_size=%zu < required %zu (N_inputs)", status_flags_size, N_inputs));
+    }
+    if (N_inputs == 0) return;
+    if (N_outputs == 0) {
+        for (std::size_t k = 0; k < N_inputs; ++k)
+            status_flags[k] = CoolProp::fast_evaluate_ok;
+        return;
+    }
+    if (val1 == nullptr || val2 == nullptr || outputs == nullptr || out_buffer == nullptr || status_flags == nullptr) {
+        throw ValueError("fast_evaluate: null pointer argument");
+    }
+
+    const bool is_ph = (input_pair == HmolarP_INPUTS);
+    const bool is_pT = (input_pair == PT_INPUTS);
+    if (!is_ph && !is_pT) {
+        throw ValueError(
+          format("fast_evaluate: input_pair %s not supported (use HmolarP_INPUTS or PT_INPUTS)", get_input_pair_short_desc(input_pair).c_str()));
+    }
+
+    // Validate output keys up-front (caller passes typically a few; fits on stack)
+    constexpr std::size_t MAX_FE_OUTPUTS = 64;
+    if (N_outputs > MAX_FE_OUTPUTS) {
+        throw ValueError(format("fast_evaluate: N_outputs=%zu exceeds compile-time limit %zu", N_outputs, MAX_FE_OUTPUTS));
+    }
+    FastEvalOutputKind output_kinds[MAX_FE_OUTPUTS];
+    for (std::size_t o = 0; o < N_outputs; ++o) {
+        output_kinds[o] = classify_fast_eval_output(outputs[o]);
+        if (output_kinds[o] == fe_unsupported) {
+            throw ValueError(format("fast_evaluate: output[%zu]=%s not supported", o, get_parameter_information(outputs[o], "short").c_str()));
+        }
+    }
+
+    // Build tables if not already built; this is the only "lazy alloc" we tolerate
+    // here, and it happens at most once per AS lifetime — outside the hot loop.
+    check_tables();
+
+    // The two tables are concrete derived types of SinglePhaseGriddedTableData;
+    // bind through a pointer to the common base for the conditional.
+    SinglePhaseGriddedTableData* table_ptr = is_ph ? static_cast<SinglePhaseGriddedTableData*>(&dataset->single_phase_logph)
+                                                   : static_cast<SinglePhaseGriddedTableData*>(&dataset->single_phase_logpT);
+    SinglePhaseGriddedTableData& table = *table_ptr;
+    const std::vector<std::vector<CellCoeffs>>& coeffs = is_ph ? dataset->coeffs_ph : dataset->coeffs_pT;
+
+    // Apply imposed phase for the duration of the call; restore at end. (The
+    // existing per-output kernels do not consult imposed_phase_index — they
+    // operate on the (i,j) we already located — but downstream callers and
+    // diagnostic paths do, so keeping it in sync avoids surprises.)
+    const phases saved_imposed_phase = imposed_phase_index;
+    if (imposed_phase != iphase_not_imposed) {
+        imposed_phase_index = imposed_phase;
+    }
+
+    const double NaN = std::numeric_limits<double>::quiet_NaN();
+
+    auto fill_nan_row = [&](std::size_t k) {
+        for (std::size_t o = 0; o < N_outputs; ++o) {
+            out_buffer[k * N_outputs + o] = NaN;
+        }
+    };
+
+    for (std::size_t k = 0; k < N_inputs; ++k) {
+        // x is the table's primary axis (logh for ph table, logT-equivalent for pT)
+        // and y is the secondary (logp). The table internally translates from
+        // (h,p) or (T,p) → (x,y); we just pass the raw inputs.
+        const double v1 = val1[k];
+        const double v2 = val2[k];
+        const double x = is_ph ? v1 : v2;  // logph: x=h ; logpT: x=T
+        const double y = is_ph ? v2 : v1;  // y is always p
+
+        if (!table.native_inputs_are_in_range(x, y)) {
+            status_flags[k] = fast_evaluate_out_of_range;
+            fill_nan_row(k);
+            continue;
+        }
+
+        std::size_t i = 0, j = 0;
+        try {
+            find_native_nearest_good_indices(table, coeffs, x, y, i, j);
+        } catch (const std::exception&) {
+            // Cell exists but has no valid neighbour (e.g., deep inside the table's
+            // two-phase notch with no alternate). Report and skip.
+            status_flags[k] = fast_evaluate_out_of_range;
+            fill_nan_row(k);
+            continue;
+        }
+
+        // The per-output kernels in BicubicBackend / TTSEBackend read from
+        // _hmolar/_p (ph) or _T/_p (pT) to recompute the normalised cell coords.
+        // We must set those before each call; we restore at the end of the
+        // function so the AS's cached state is not silently polluted.
+        if (is_ph) {
+            _hmolar = v1;
+            _p = v2;
+        } else {
+            _T = v2;
+            _p = v1;
+        }
+
+        bool eval_failed = false;
+        for (std::size_t o = 0; o < N_outputs; ++o) {
+            const parameters out_key = outputs[o];
+            const FastEvalOutputKind kind = output_kinds[o];
+            try {
+                double val;
+                if (kind == fe_transport) {
+                    val = is_ph ? evaluate_single_phase_phmolar_transport(out_key, i, j) : evaluate_single_phase_pT_transport(out_key, i, j);
+                } else {
+                    // For the (h,p) table requesting iHmolar, or (T,p) table requesting
+                    // iT/iP, the answer is just the input — short-circuit to skip
+                    // pointless polynomial evaluation. iP is always one of the inputs.
+                    if (out_key == iP) {
+                        val = is_ph ? v2 : v1;
+                    } else if (is_ph && out_key == iHmolar) {
+                        val = v1;
+                    } else if (is_pT && out_key == iT) {
+                        val = v2;
+                    } else {
+                        val = is_ph ? evaluate_single_phase_phmolar(out_key, i, j) : evaluate_single_phase_pT(out_key, i, j);
+                    }
+                }
+                out_buffer[k * N_outputs + o] = val;
+            } catch (const std::exception&) {
+                eval_failed = true;
+                out_buffer[k * N_outputs + o] = NaN;
+            }
+        }
+        status_flags[k] = eval_failed ? fast_evaluate_internal_error : fast_evaluate_ok;
+    }
+
+    // Restore phase override and clear the AS cache so no per-point residue
+    // leaks into subsequent keyed_output() / T() / p() calls on this instance.
+    imposed_phase_index = saved_imposed_phase;
+    clear();
+}
+
 void CoolProp::TabularBackend::update(CoolProp::input_pairs input_pair, double val1, double val2) {
 
     if (get_debug_level() > 0) {
@@ -1729,6 +1903,120 @@ TEST_CASE_METHOD(TabularFixture, "Tests for tabular backends with water", "[Tabu
         CHECK(std::abs((expected - actual_TTSE) / expected) < 1e-3);
         CHECK(std::abs((expected - actual_BICUBIC) / expected) < 1e-3);
     }
+
+    SECTION("fast_evaluate single point matches keyed_output (PT, BICUBIC)") {
+        setup();
+        const double T = 400, p = 1e6;
+        // Reference via the standard path
+        ASHEOS->update(CoolProp::PT_INPUTS, p, T);
+        const double ref_D = ASHEOS->rhomolar();
+        const double ref_H = ASHEOS->hmolar();
+        const double ref_S = ASHEOS->smolar();
+
+        const double val1[1] = {p};
+        const double val2[1] = {T};
+        const CoolProp::parameters outs[3] = {CoolProp::iDmolar, CoolProp::iHmolar, CoolProp::iSmolar};
+        double buf[3] = {0, 0, 0};
+        int status[1] = {-1};
+        ASBICUBIC->fast_evaluate(CoolProp::PT_INPUTS, val1, val2, 1, outs, 3, buf, 3, status, 1);
+        CAPTURE(status[0]);
+        CHECK(status[0] == CoolProp::fast_evaluate_ok);
+        CHECK(std::abs((ref_D - buf[0]) / ref_D) < 1e-3);
+        CHECK(std::abs((ref_H - buf[1]) / ref_H) < 1e-3);
+        CHECK(std::abs((ref_S - buf[2]) / ref_S) < 1e-3);
+    }
+
+    SECTION("fast_evaluate batch — Hmolar/p inputs over a range (BICUBIC)") {
+        setup();
+        constexpr std::size_t N = 32;
+        const double p = 5e5;
+        std::vector<double> hs(N), ps(N, p);
+        // Pick a band of single-phase enthalpies above saturation at 500 kPa.
+        ASHEOS->update(CoolProp::PQ_INPUTS, p, 1.0);
+        const double h_satV = ASHEOS->hmolar();
+        for (std::size_t k = 0; k < N; ++k) {
+            hs[k] = h_satV + 100.0 + k * 50.0;  // walk above saturation
+        }
+        const CoolProp::parameters outs[2] = {CoolProp::iT, CoolProp::iDmolar};
+        std::vector<double> buf(2 * N, 0);
+        std::vector<int> status(N, -1);
+        ASBICUBIC->fast_evaluate(CoolProp::HmolarP_INPUTS, hs.data(), ps.data(), N, outs, 2, buf.data(), buf.size(), status.data(), status.size());
+        for (std::size_t k = 0; k < N; ++k) {
+            CAPTURE(k);
+            CAPTURE(status[k]);
+            CHECK(status[k] == CoolProp::fast_evaluate_ok);
+            // Compare against the cached path
+            ASBICUBIC->update(CoolProp::HmolarP_INPUTS, hs[k], p);
+            CHECK(std::abs((ASBICUBIC->T() - buf[2 * k + 0]) / ASBICUBIC->T()) < 1e-9);
+            CHECK(std::abs((ASBICUBIC->rhomolar() - buf[2 * k + 1]) / ASBICUBIC->rhomolar()) < 1e-9);
+        }
+    }
+
+    SECTION("fast_evaluate validates buffer sizes") {
+        setup();
+        const double v1[1] = {1e6};
+        const double v2[1] = {400};
+        const CoolProp::parameters outs[2] = {CoolProp::iDmolar, CoolProp::iHmolar};
+        double buf[2] = {0, 0};
+        int status[1] = {0};
+        // out_buffer too small (1 instead of N*M=2)
+        CHECK_THROWS(ASBICUBIC->fast_evaluate(CoolProp::PT_INPUTS, v1, v2, 1, outs, 2, buf, 1, status, 1));
+        // status_flags too small (0 instead of N=1)
+        CHECK_THROWS(ASBICUBIC->fast_evaluate(CoolProp::PT_INPUTS, v1, v2, 1, outs, 2, buf, 2, status, 0));
+        // Unsupported input pair
+        CHECK_THROWS(ASBICUBIC->fast_evaluate(CoolProp::QT_INPUTS, v1, v2, 1, outs, 2, buf, 2, status, 1));
+    }
+
+    SECTION("fast_evaluate out-of-range point reports NaN + flag, others ok") {
+        setup();
+        const double v1[2] = {1e6, 1e20};  // p: 1 MPa (ok), 1e20 Pa (out of range)
+        const double v2[2] = {400, 400};
+        const CoolProp::parameters outs[1] = {CoolProp::iDmolar};
+        double buf[2] = {-1, -1};
+        int status[2] = {-1, -1};
+        ASBICUBIC->fast_evaluate(CoolProp::PT_INPUTS, v1, v2, 2, outs, 1, buf, 2, status, 2);
+        CHECK(status[0] == CoolProp::fast_evaluate_ok);
+        CHECK(status[1] == CoolProp::fast_evaluate_out_of_range);
+        CHECK(std::isnan(buf[1]));
+        CHECK(buf[0] > 0);  // a sensible density value
+    }
+}
+
+TEST_CASE("fast_evaluate works with IF97 backend", "[fast_evaluate][IF97]") {
+    using namespace CoolProp;
+    std::shared_ptr<AbstractState> AS(AbstractState::factory("IF97", "Water"));
+
+    SECTION("PT batch matches the cached path") {
+        constexpr std::size_t N = 16;
+        std::vector<double> ps(N), Ts(N);
+        for (std::size_t k = 0; k < N; ++k) {
+            ps[k] = 1e5 + k * 1e4;
+            Ts[k] = 500 + k * 5.0;  // superheated vapor / supercritical band
+        }
+        const parameters outs[3] = {iDmass, iHmass, iSmass};
+        std::vector<double> buf(3 * N, 0);
+        std::vector<int> status(N, -1);
+        AS->fast_evaluate(PT_INPUTS, ps.data(), Ts.data(), N, outs, 3, buf.data(), buf.size(), status.data(), status.size());
+        for (std::size_t k = 0; k < N; ++k) {
+            CAPTURE(k);
+            CHECK(status[k] == fast_evaluate_ok);
+            AS->update(PT_INPUTS, ps[k], Ts[k]);
+            CHECK(std::abs((AS->rhomass() - buf[3 * k + 0]) / AS->rhomass()) < 1e-12);
+            CHECK(std::abs((AS->hmass() - buf[3 * k + 1]) / AS->hmass()) < 1e-12);
+            CHECK(std::abs((AS->smass() - buf[3 * k + 2]) / AS->smass()) < 1e-12);
+        }
+    }
+}
+
+TEST_CASE("fast_evaluate is not implemented for HEOS backend", "[fast_evaluate][HEOS]") {
+    using namespace CoolProp;
+    std::shared_ptr<AbstractState> AS(AbstractState::factory("HEOS", "Water"));
+    const double v1[1] = {1e6};
+    const double v2[1] = {400};
+    const parameters outs[1] = {iDmolar};
+    double buf[1] = {0};
+    int status[1] = {0};
+    CHECK_THROWS(AS->fast_evaluate(PT_INPUTS, v1, v2, 1, outs, 1, buf, 1, status, 1));
 }
 #    endif  // ENABLE_CATCH
 

--- a/src/Backends/Tabular/TabularBackends.h
+++ b/src/Backends/Tabular/TabularBackends.h
@@ -1195,6 +1195,12 @@ class TabularBackend : public AbstractState
     virtual double evaluate_single_phase_pT(parameters output, std::size_t i, std::size_t j) = 0;
     virtual double evaluate_single_phase_phmolar_transport(parameters output, std::size_t i, std::size_t j) = 0;
     virtual double evaluate_single_phase_pT_transport(parameters output, std::size_t i, std::size_t j) = 0;
+
+    /// Vectorized direct evaluation; see AbstractState::fast_evaluate for contract.
+    virtual void fast_evaluate(CoolProp::input_pairs input_pair, const double* val1, const double* val2, std::size_t N_inputs,
+                               const CoolProp::parameters* outputs, std::size_t N_outputs, double* out_buffer, std::size_t out_buffer_size,
+                               int* status_flags, std::size_t status_flags_size,
+                               CoolProp::phases imposed_phase = CoolProp::iphase_not_imposed) override;
     virtual double evaluate_single_phase_phmolar_derivative(parameters output, std::size_t i, std::size_t j, std::size_t Nx, std::size_t Ny) = 0;
     virtual double evaluate_single_phase_pT_derivative(parameters output, std::size_t i, std::size_t j, std::size_t Nx, std::size_t Ny) = 0;
 

--- a/src/CoolProp.i
+++ b/src/CoolProp.i
@@ -13,6 +13,13 @@
 %ignore CoolProp::set_config_json(rapidjson::Document &);
 %ignore CoolProp::get_config_as_json(rapidjson::Document &);
 
+// fast_evaluate is a C++-only raw-pointer batch API; SWIG's default
+// typemaps for `const double*` / `int*` produce wrappers that don't
+// compile on at least the R binding (int -> SEXP).  Scripted-language
+// callers should keep using update()/keyed_output() or the Cython
+// AbstractState.fast_evaluate wrapper in the Python binding.
+%ignore CoolProp::AbstractState::fast_evaluate;
+
 %include "std_string.i" // This %include allows the use of std::string natively
 %include "std_vector.i" // This allows for the use of STL vectors natively(ish)
 %include "exception.i" //

--- a/wrappers/Python/CoolProp/AbstractState.pyx
+++ b/wrappers/Python/CoolProp/AbstractState.pyx
@@ -121,6 +121,73 @@ cdef class AbstractState:
         _guesses.y = guesses.y
         self.thisptr.update_with_guesses(ipair, Value1, Value2, _guesses)
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    def fast_evaluate(self,
+                      constants_header.input_pairs input_pair,
+                      double[::1] val1 not None,
+                      double[::1] val2 not None,
+                      int[::1] outputs not None,
+                      double[:, ::1] out not None,
+                      int[::1] status not None,
+                      constants_header.phases imposed_phase=constants_header.iphase_not_imposed):
+        """
+        Vectorized cache-bypassing batch evaluation - wrapper of c++ function
+        :cpapi:`CoolProp::AbstractState::fast_evaluate`.
+
+        This is a zero-allocation fast path supported on tabular backends
+        (BICUBIC, TTSE) and the IF97 backend. All buffers are caller-allocated
+        and validated for shape before the call:
+
+        :param input_pair: One of ``HmolarP_INPUTS``, ``PT_INPUTS`` (tabular)
+            or ``PT_INPUTS``/``HmolarP_INPUTS``/``HmassP_INPUTS`` (IF97).
+        :param val1: 1D contiguous array of first inputs, length ``N_inputs``.
+        :param val2: 1D contiguous array of second inputs, length ``N_inputs``.
+        :param outputs: 1D int32 array of CoolProp output keys (e.g.
+            ``[iDmolar, iHmolar]``), length ``N_outputs``.
+        :param out: 2D contiguous (C-order) output array, shape
+            ``(N_inputs, N_outputs)``. Populated in place.
+        :param status: 1D int32 status array, length ``N_inputs``. ``0`` on
+            success, nonzero ``fast_evaluate_status`` on per-point failure.
+        :param imposed_phase: Optional phase hint (default: detect).
+
+        .. note::
+            Unlike :meth:`update`, this fast path does not perform saturation-
+            curve cell bumping for tabular backends. PT_INPUTS points that
+            land near the saturation curve may evaluate using a cell that
+            straddles the two-phase notch, giving values that diverge from
+            the cached path. To get strict single-phase results near
+            saturation, either:
+
+            * use ``HmolarP_INPUTS`` (which natively distinguishes liquid
+              vs vapor by enthalpy), or
+            * pass ``imposed_phase=iphase_liquid`` / ``iphase_gas``.
+        """
+        cdef Py_ssize_t N = val1.shape[0]
+        cdef Py_ssize_t M = outputs.shape[0]
+        cdef Py_ssize_t k
+        if val2.shape[0] != N:
+            raise ValueError("val1 and val2 must have the same length, got {0} and {1}".format(N, val2.shape[0]))
+        if out.shape[0] != N or out.shape[1] != M:
+            raise ValueError("out must have shape (N_inputs, N_outputs) = ({0}, {1}), got ({2}, {3})".format(N, M, out.shape[0], out.shape[1]))
+        if status.shape[0] != N:
+            raise ValueError("status must have length N_inputs = {0}, got {1}".format(N, status.shape[0]))
+        if N == 0:
+            return
+        if M == 0:
+            # Nothing to compute per point. C++ contract: status=ok, no output writes.
+            for k in range(N):
+                status[k] = 0
+            return
+        self.thisptr.fast_evaluate(
+            <constants_header.input_pairs>input_pair,
+            &val1[0], &val2[0], <size_t>N,
+            <constants_header.parameters*>&outputs[0], <size_t>M,
+            &out[0, 0], <size_t>(N * M),
+            &status[0], <size_t>N,
+            <constants_header.phases>imposed_phase,
+        )
+
     cpdef set_mole_fractions(self, vector[double] z):
         """ Set the mole fractions - wrapper of c++ function :cpapi:`CoolProp::AbstractState::set_mole_fractions` """
         self.thisptr.set_mole_fractions(z)

--- a/wrappers/Python/CoolProp/cAbstractState.pxd
+++ b/wrappers/Python/CoolProp/cAbstractState.pxd
@@ -108,6 +108,14 @@ cdef extern from "AbstractState.h" namespace "CoolProp":
         ## Uses the indices in CoolProp for the input parameters
         void update_with_guesses(constants_header.input_pairs iInput1, double Value1, double Value2, GuessesStructure) except +ValueError
 
+        ## Vectorized, cache-bypassing direct evaluation (Tabular/IF97 only)
+        void fast_evaluate(constants_header.input_pairs input_pair,
+                           const double* val1, const double* val2, size_t N_inputs,
+                           const constants_header.parameters* outputs, size_t N_outputs,
+                           double* out_buffer, size_t out_buffer_size,
+                           int* status_flags, size_t status_flags_size,
+                           constants_header.phases imposed_phase) except +ValueError
+
         ## Bulk properties accessors - temperature, pressure and density are directly calculated every time
         ## All other parameters are calculated on an as-needed basis
         ## If single-phase, just plug into the EOS, otherwise need to do two-phase analysis

--- a/wrappers/Python/generate_constants_module.py
+++ b/wrappers/Python/generate_constants_module.py
@@ -105,7 +105,7 @@ def generate_cython(data, config_data):
 
 
 def generate():
-    data = [(enum, params_constants(enum)) for enum in ['parameters', 'input_pairs', 'fluid_types', 'phases']]
+    data = [(enum, params_constants(enum)) for enum in ['parameters', 'input_pairs', 'fluid_types', 'phases', 'fast_evaluate_status']]
     generate_cython(data, config_constants())
 
 


### PR DESCRIPTION
## Summary

Resolves the speed gap surfaced in #2897. Adds a new virtual method
`AbstractState::fast_evaluate(...)` that performs vectorized, allocation-free,
cache-bypassing direct evaluation on backends where the per-call
`update()` / `keyed_output()` machinery dominates the math cost
(tabular Bicubic/TTSE, IF97).

* Takes 1D arrays of input points + a list of output keys.
* Writes into a caller-allocated row-major buffer; **no internal allocations**.
* Reports per-point failure via a caller-allocated `int` status array
  (`fast_evaluate_status` enum, NaN-filled output slice on failure).
* Validates buffer sizes against `N_inputs * N_outputs`.
* Optional `imposed_phase` hint to skip phase detection.
* Cython binding (`AbstractState.pyx`) takes `double[::1]` / `int[::1]` /
  `double[:, ::1]` memoryviews — no copies. Numpy shape validation at the
  Python boundary is the authoritative size check (raw `double*` C++ args
  cannot physically verify the allocation; this is called out in the docstring).
* Default base impl throws `NotImplementedError`; HEOS and others inherit it.

### Backends supported in this PR

| Backend | Input pairs |
|---|---|
| BICUBIC, TTSE (via `TabularBackend`) | `HmolarP_INPUTS`, `PT_INPUTS` |
| IF97 | `PT_INPUTS`, `HmolarP_INPUTS`, `HmassP_INPUTS` |

### Benchmark

Water on `BICUBIC&HEOS`, N=50000, 4 outputs:

| | time | per-point |
|---|---|---|
| `fast_evaluate` | 2.5 ms | 0.05 µs |
| baseline loop (`update` + 4× property accessors) | 36 ms | 0.72 µs |
| | | **~14.5× speedup** |

IF97 is roughly at parity per-point — the FFI savings are offset by the
per-output try/catch needed to map IF97 exceptions to per-point status
codes. Even at parity, batching N points into a single Python call
materialises results directly into a numpy array, which has its own
ergonomic and downstream-perf benefits.

### Known limitation

`PT_INPUTS` near the saturation curve may diverge from `update()` because
this fast path skips the cell-bump heuristic in `TabularBackend::update`.
Documented in the Python docstring; callers can use `HmolarP_INPUTS` or
pass `imposed_phase=iphase_liquid`/`iphase_gas` to disambiguate.

## Test plan

- [x] C++ Catch2 tests: single-point parity with the cached path,
      buffer-size validation, out-of-range NaN behaviour, IF97 PT batch
      agreement (1e-12), HEOS `NotImplementedError`. **All 57803 existing
      test assertions still pass.**
- [x] Python smoke tests: shape validation, out-of-range flag/NaN,
      IF97 PT batch parity (1e-12), HEOS throws.
- [x] Bench harness compares against the per-point loop.
- [ ] (Optional follow-up) richer Python test suite under
      `wrappers/Python/CoolProp/tests/`.
- [ ] (Optional follow-up) saturation-curve cell bumping for the fast
      path on PT_INPUTS, or a richer two-phase signal in `status_flags`.

Closes #2897.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a batch/vectorized evaluation API for computing properties over many input points with per-point status codes and NaN-on-failure behavior
  * IF97 and Tabular backends implement the batch API and honor optional phase hints
  * Python wrapper exposes array-based batch evaluation

* **Tests**
  * New tests cover batch correctness, buffer validation, and out-of-range/failure handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2920?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->