### PR TITLE
fix(region,clenshaw): drop redundant >= 1 + break in unsigned loop (CodeQL #3512)

### DIFF
--- a/src/Region/PiecewiseChebyshevCurve.cpp
+++ b/src/Region/PiecewiseChebyshevCurve.cpp
@@ -54,13 +54,16 @@ double clenshaw_eval(const std::vector<double>& c, double s) noexcept {
     const std::size_t N = c.size() - 1;
     double b_kp1 = 0.0;
     double b_kp2 = 0.0;
-    for (std::size_t k = N; k >= 1; --k) {
+    // Iterate k = N, N-1, ..., 1 (inclusive).  Using `k > 0` instead of
+    // `k >= 1` for the condition is equivalent for unsigned k and lets
+    // CodeQL see that the loop terminates -- the previous form (which
+    // wrote `k >= 1` with an inner `break` for k == 1) tripped a "comparison
+    // always true" alert because std::size_t is non-negative by
+    // construction.
+    for (std::size_t k = N; k > 0; --k) {
         const double b_k = 2.0 * s * b_kp1 - b_kp2 + c[k];
         b_kp2 = b_kp1;
         b_kp1 = b_k;
-        if (k == 1) {
-            break;
-        }  // unsigned guard against k-- underflow
     }
     return s * b_kp1 - b_kp2 + c[0];
 }


### PR DESCRIPTION
## Summary

Follow-up to merged PR #2914 that addresses the one outstanding
review note (CodeQL alert [#3512](https://github.com/CoolProp/CoolProp/security/code-scanning/3512)):

```
src/Region/PiecewiseChebyshevCurve.cpp:57
Comparison result is always the same
Comparison is always true because k >= 1.
```

The Clenshaw recurrence iterates k = N down to 1 inclusive. The
original code used `for (std::size_t k = N; k >= 1; --k)` with an
inner `if (k == 1) break;` to dodge unsigned underflow. CodeQL
correctly noted that `k >= 1` is always true for unsigned k --
the break is the real loop exit, not the condition.

Canonical fix: `for (std::size_t k = N; k > 0; --k)`. Iterates k =
N, N-1, ..., 1, exits cleanly before k = 0 would happen. Same
semantics, same generated code, CodeQL happy.

All other actionable review items on #2914 were already addressed
in commits during that PR (the coderabbit review thread shows ✅
markers on 12 of 13 comments); this one slipped through because it
was a separate CodeQL alert, not a coderabbit suggestion.

## Test plan

- [x] `./build_catch/CatchTestRunner "[Region][boundary_curve_cheb]"` -- 404 assertions / 4 test cases pass
- [ ] CI green (CodeQL re-scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved loop condition logic in mathematical computation to enhance code clarity and maintainability while preserving existing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2921)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->