### PR TITLE
feat(svdsbtl): require explicit source-of-truth backend (HEOS/REFPROP/IF97)

### DIFF
--- a/dev/bench_svdsbtl_ph.cpp
+++ b/dev/bench_svdsbtl_ph.cpp
@@ -249,7 +249,7 @@ double time_phflsh_direct(PHFLSHdll_t phflsh, double p_kPa, double h_mol, double
 }
 
 void bench_one(const std::string& fluid, std::size_t NT, std::size_t NP, std::size_t repeats, const std::string& refprop_path) {
-    auto svd = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("SVDSBTL", fluid));
+    auto svd = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("SVDSBTL&HEOS", fluid));
     auto heos = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("HEOS", fluid));
 
     // IF97 only applies to water; lazily allocate so other fluids skip it.

--- a/dev/build_svd_tables.cpp
+++ b/dev/build_svd_tables.cpp
@@ -142,7 +142,8 @@ int main(int argc, char** argv) {
     std::printf("SVDSBTL bulk-build  (NT=%zu  NR=%zu  rank=%d)\n", NT, NR, rank);
     std::printf("Cache dir: %s\n", cp_sbtl::SVDSurfaceSerializer::default_cache_dir().c_str());
     std::printf("Sources:   ");
-    for (std::size_t i = 0; i < sources.size(); ++i) std::printf("%s%s", i > 0 ? "," : "", sources[i].c_str());
+    for (std::size_t i = 0; i < sources.size(); ++i)
+        std::printf("%s%s", i > 0 ? "," : "", sources[i].c_str());
     std::printf("\n\n");
 
     int ok = 0;

--- a/dev/build_svd_tables.cpp
+++ b/dev/build_svd_tables.cpp
@@ -71,20 +71,20 @@ double file_size_kb(const std::string& path) {
     return static_cast<double>(sz) / 1024.0;
 }
 
-void build_one(const std::string& fluid, std::size_t NT, std::size_t NR, std::int32_t rank) {
-    auto heos = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("HEOS", fluid));
+void build_one(const std::string& fluid, const std::string& source_backend, std::size_t NT, std::size_t NR, std::int32_t rank) {
+    auto source = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory(source_backend, fluid));
 
     for (const auto pair : {::CoolProp::HmassP_INPUTS, ::CoolProp::PT_INPUTS}) {
         const std::string label = (pair == ::CoolProp::HmassP_INPUTS) ? "PH" : "PT";
-        const std::string out_path = cp_sbtl::SVDSurfaceSerializer::default_cache_path(fluid, pair);
+        const std::string out_path = cp_sbtl::SVDSurfaceSerializer::default_cache_path(fluid, source_backend, pair);
 
-        std::printf("  %s %s  building... ", fluid.c_str(), label.c_str());
+        std::printf("  %s/%s %s  building... ", source_backend.c_str(), fluid.c_str(), label.c_str());
         std::fflush(stdout);
 
         const auto t0 = std::chrono::steady_clock::now();
-        cp_sbtl::SurfaceSpec spec = (pair == ::CoolProp::HmassP_INPUTS) ? cp_sbtl::presets::ph_subcritical(*heos, NT, NR, rank)
-                                                                        : cp_sbtl::presets::pt_subcritical(*heos, NT, NR, rank);
-        cp_sbtl::SVDSurface surface = cp_sbtl::build_surface(*heos, std::move(spec));
+        cp_sbtl::SurfaceSpec spec = (pair == ::CoolProp::HmassP_INPUTS) ? cp_sbtl::presets::ph_subcritical(*source, NT, NR, rank)
+                                                                        : cp_sbtl::presets::pt_subcritical(*source, NT, NR, rank);
+        cp_sbtl::SVDSurface surface = cp_sbtl::build_surface(*source, std::move(spec));
         const auto t1 = std::chrono::steady_clock::now();
 
         cp_sbtl::SVDSurfaceSerializer::save_to_file(surface, out_path);
@@ -111,6 +111,23 @@ int main(int argc, char** argv) {
     const std::size_t NT = std::max<std::size_t>(2, env_size_t("SVD_NT", 200));
     const std::size_t NR = std::max<std::size_t>(2, env_size_t("SVD_NR", 800));
     const std::int32_t rank = std::max<std::int32_t>(1, env_int("SVD_RANK", 20));
+    // Source backend(s) to build tables against.  Comma-separated, no
+    // spaces.  Defaults to "HEOS" only; pass SVD_SOURCES=HEOS,REFPROP
+    // to build both side-by-side (each lands at a distinct cache path).
+    const std::string source_csv = []() {
+        const char* env = std::getenv("SVD_SOURCES");
+        return env != nullptr ? std::string(env) : std::string("HEOS");
+    }();
+    std::vector<std::string> sources;
+    {
+        std::string s = source_csv;
+        std::size_t pos = 0;
+        while ((pos = s.find(',')) != std::string::npos) {
+            sources.push_back(s.substr(0, pos));
+            s.erase(0, pos + 1);
+        }
+        if (!s.empty()) sources.push_back(s);
+    }
 
     std::vector<std::string> fluids;
     if (argc > 1) {
@@ -123,18 +140,29 @@ int main(int argc, char** argv) {
     }
 
     std::printf("SVDSBTL bulk-build  (NT=%zu  NR=%zu  rank=%d)\n", NT, NR, rank);
-    std::printf("Cache dir: %s\n\n", cp_sbtl::SVDSurfaceSerializer::default_cache_dir().c_str());
+    std::printf("Cache dir: %s\n", cp_sbtl::SVDSurfaceSerializer::default_cache_dir().c_str());
+    std::printf("Sources:   ");
+    for (std::size_t i = 0; i < sources.size(); ++i) std::printf("%s%s", i > 0 ? "," : "", sources[i].c_str());
+    std::printf("\n\n");
 
     int ok = 0;
     int failed = 0;
     const auto t_global = std::chrono::steady_clock::now();
-    for (const auto& fluid : fluids) {
-        try {
-            build_one(fluid, NT, NR, rank);
-            ++ok;
-        } catch (const std::exception& e) {
-            std::printf("  %s  ERROR: %s\n", fluid.c_str(), e.what());
-            ++failed;
+    for (const auto& source : sources) {
+        for (const auto& fluid : fluids) {
+            // IF97 is Water-only; silently skip non-Water fluids
+            // rather than erroring out the whole batch.
+            if (source == "IF97" && fluid != "Water") {
+                std::printf("  %s/%s  SKIP (IF97 is Water-only)\n", source.c_str(), fluid.c_str());
+                continue;
+            }
+            try {
+                build_one(fluid, source, NT, NR, rank);
+                ++ok;
+            } catch (const std::exception& e) {
+                std::printf("  %s/%s  ERROR: %s\n", source.c_str(), fluid.c_str(), e.what());
+                ++failed;
+            }
         }
     }
     const double total_s = std::chrono::duration<double>(std::chrono::steady_clock::now() - t_global).count();

--- a/dev/profile_svdsbtl.cpp
+++ b/dev/profile_svdsbtl.cpp
@@ -109,7 +109,7 @@ int main(int argc, char** argv) {
     const double h = heos->hmass();
     const double rho_truth = heos->rhomass();
 
-    auto svd_backend = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("SVDSBTL", "Water"));
+    auto svd_backend = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
 
     // Direct surface (skip backend wrapper) -- load the same cache
     // file SVDSBTLBackend just hit.

--- a/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
+++ b/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
@@ -193,7 +193,7 @@ class SVDSBTLBackend : public AbstractState
     [[nodiscard]] CoolPropDbl two_phase_property_(CoolProp::parameters prop) const;
 
     std::string fluid_name_;
-    std::string source_backend_;  // "HEOS" / "REFPROP" / "IF97"
+    std::string source_backend_;               // "HEOS" / "REFPROP" / "IF97"
     std::vector<CoolPropDbl> mole_fractions_;  // always {1.0}
 
     // Cache of molar mass, populated lazily on the first

--- a/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
+++ b/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
@@ -52,7 +52,22 @@ namespace CoolProp {
 class SVDSBTLBackend : public AbstractState
 {
    public:
-    explicit SVDSBTLBackend(const std::string& fluid_name);
+    // Construct an SVDSBTL backend backed by the given truth source.
+    //
+    // The source argument is required (no default) — it determines:
+    //   * which backend supplies the HEOS-style truth values when the
+    //     SVD tables are built (or loaded from cache)
+    //   * the cache key slot in <fluid>.<source>.<input_pair>.svd.bin.z
+    //     so HEOS-built and REFPROP-built tables for the same fluid
+    //     never collide
+    //   * how two-phase queries are resolved (HEOS uses SuperAncillary;
+    //     REFPROP forwards PQ/QT directly; IF97 uses psat97 + Q-blend)
+    //   * the critical-patch fallback target (always the source backend,
+    //     so the patch is "truth" by definition for each source)
+    //
+    // Supported source values: "HEOS", "REFPROP", "IF97".  Anything
+    // else throws.  IF97 is restricted to Water.
+    SVDSBTLBackend(const std::string& fluid_name, const std::string& source_backend);
 
     SVDSBTLBackend(const SVDSBTLBackend&) = delete;
     SVDSBTLBackend& operator=(const SVDSBTLBackend&) = delete;
@@ -143,7 +158,7 @@ class SVDSBTLBackend : public AbstractState
         if (ParamName == "name") {
             return fluid_name_;
         }
-        return heos_reference_()->fluid_param_string(ParamName);
+        return source_reference_()->fluid_param_string(ParamName);
     }
 
     // Test seam: exposes which surfaces were loaded vs built.  Returns
@@ -178,11 +193,12 @@ class SVDSBTLBackend : public AbstractState
     [[nodiscard]] CoolPropDbl two_phase_property_(CoolProp::parameters prop) const;
 
     std::string fluid_name_;
+    std::string source_backend_;  // "HEOS" / "REFPROP" / "IF97"
     std::vector<CoolPropDbl> mole_fractions_;  // always {1.0}
 
     // Cache of molar mass, populated lazily on the first
     // calc_molar_mass() call.  Avoids per-call shared_ptr deref +
-    // virtual dispatch through heos_reference_() on every
+    // virtual dispatch through source_reference_() on every
     // calc_hmolar / calc_rhomolar / calc_smolar.  Fluid is fixed at
     // construction so this never changes after first read.
     mutable CoolPropDbl molar_mass_cached_ = -1.0;
@@ -190,8 +206,8 @@ class SVDSBTLBackend : public AbstractState
     // Reference HEOS state for constants (critical point, triple point,
     // bounds, molar mass, R).  Lazily allocated so that backend
     // construction is cheap even when only cached blobs are loaded.
-    std::shared_ptr<CoolProp::AbstractState> heos_reference_();
-    std::shared_ptr<CoolProp::AbstractState> heos_;
+    std::shared_ptr<CoolProp::AbstractState> source_reference_();
+    std::shared_ptr<CoolProp::AbstractState> source_;
 
     // One surface per supported input pair.  Heap-allocated so the
     // ResolvedPoint pointers below stay valid across map growth.

--- a/include/CoolProp/sbtl/SVDSurfaceSerializer.h
+++ b/include/CoolProp/sbtl/SVDSurfaceSerializer.h
@@ -53,9 +53,10 @@ namespace sbtl {
 //
 // File extension convention: `.svd.bin.z`, parallel to BicubicBackend's
 // `.bin.z`.  Stored at
-// `${HOME}/.CoolProp/SVDTables/<fluid>.<input_pair>.svd.bin.z`
+// `${HOME}/.CoolProp/SVDTables/<fluid>.<source>.<input_pair>.svd.bin.z`
 // by the helper paths below — see default_cache_path() for the exact
-// composition (input_pair is the integer value of the enum).
+// composition (source is the truth-source backend name; input_pair is
+// the integer value of the enum).
 
 class SVDSurfaceSerializer
 {
@@ -67,7 +68,13 @@ class SVDSurfaceSerializer
     //          would silently fall through to NaN; bumping the rev
     //          forces a clean rebuild so the user can't trip on stale
     //          caches missing w).
-    static constexpr int kRevision = 2;
+    //   rev 3: explicit source-of-truth backend in the cache filename
+    //          ("<fluid>.<source>.<input_pair>.svd.bin.z").  No on-wire
+    //          format change, just a path change — old caches at the
+    //          rev-2 path simply won't be picked up and will be
+    //          rebuilt under the new path the first time they're
+    //          requested.
+    static constexpr int kRevision = 3;
 
     // Pack one surface into a zlib-compressed msgpack blob.
     static std::vector<char> save(const SVDSurface& surface);
@@ -92,9 +99,13 @@ class SVDSurfaceSerializer
     // existing BicubicBackend pattern (see TabularBackends.h:1035).
     static std::string default_cache_dir();
 
-    // Compose default_cache_dir() with "<fluid>.<input_pair>.svd.bin.z"
-    // so PH and PT surfaces for the same fluid get distinct files.
-    static std::string default_cache_path(const std::string& fluid_name, ::CoolProp::input_pairs input_pair);
+    // Compose default_cache_dir() with
+    //   "<fluid>.<source>.<input_pair>.svd.bin.z"
+    // so HEOS-built, REFPROP-built, and IF97-built tables for the
+    // same fluid get distinct files, and PH and PT surfaces for the
+    // same (fluid, source) get distinct files.  source_backend must
+    // be non-empty and free of path-separator characters.
+    static std::string default_cache_path(const std::string& fluid_name, const std::string& source_backend, ::CoolProp::input_pairs input_pair);
 };
 
 }  // namespace sbtl

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -138,19 +138,11 @@ class PCSAFTGenerator : public CoolProp::AbstractStateGenerator
 // NOLINTNEXTLINE(cert-err58-cpp)
 static CoolProp::GeneratorInitializer<PCSAFTGenerator> pcsaft_gen(CoolProp::PCSAFT_BACKEND_FAMILY);
 
-class SVDSBTLBackendGenerator : public CoolProp::AbstractStateGenerator
-{
-   public:
-    CoolProp::AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) {
-        if (fluid_names.size() != 1) {
-            throw ValueError("SVDSBTL backend is pure-fluid only; expected exactly one fluid name");
-        }
-        return new CoolProp::SVDSBTLBackend(fluid_names[0]);
-    };
-};
-// This static initialization will cause the generator to register
-// NOLINTNEXTLINE(cert-err58-cpp)
-static CoolProp::GeneratorInitializer<SVDSBTLBackendGenerator> svdsbtl_gen(CoolProp::SVDSBTL_BACKEND_FAMILY);
+// SVDSBTL has no AbstractStateGenerator because the standard
+// generator API only knows about (backend_family, fluid_names) — it
+// can't carry the source-backend slot SVDSBTL needs.  Instead,
+// factory() handles SVDSBTL inline below, the same pattern TTSE and
+// BICUBIC already use.
 
 AbstractState* AbstractState::factory(const std::string& backend, const std::vector<std::string>& fluid_names) {
     if (get_debug_level() > 0) {
@@ -181,6 +173,19 @@ AbstractState* AbstractState::factory(const std::string& backend, const std::vec
         // Will throw if there is a problem with this backend
         const shared_ptr<AbstractState> AS(factory(f2, fluid_names));
         return new BicubicBackend(AS);
+    } else if (f1 == SVDSBTL_BACKEND_FAMILY) {
+        // SVDSBTL requires an explicit source-of-truth backend in
+        // its name (e.g. "SVDSBTL&HEOS").  No default — see
+        // SVDSBTLBackend.h for rationale.  factory("SVDSBTL", ...)
+        // without the '&' lands here with f2 empty and throws.
+        if (f2.empty()) {
+            throw ValueError(format("SVDSBTL requires an explicit source backend, e.g. factory(\"SVDSBTL&HEOS\", \"%s\")",
+                                    fluid_names.empty() ? "<fluid>" : fluid_names[0].c_str()));
+        }
+        if (fluid_names.size() != 1) {
+            throw ValueError("SVDSBTL backend is pure-fluid only; expected exactly one fluid name");
+        }
+        return new SVDSBTLBackend(fluid_names[0], f2);
     }
 #endif
     else if (backend == "?" || backend.empty()) {

--- a/src/Backends/IF97/IF97Backend.h
+++ b/src/Backends/IF97/IF97Backend.h
@@ -26,6 +26,15 @@ class IF97Backend : public AbstractState
         return get_backend_string(IF97_BACKEND);
     }
 
+    /// The fluid this backend represents (always Water by definition).
+    /// AbstractState's default calc_fluid_names() throws — override
+    /// here so callers like the SVDSBTL adapter (which expects
+    /// fluid_names() to work on any source-of-truth backend) don't
+    /// trip on it.
+    std::vector<std::string> calc_fluid_names() override {
+        return {"Water"};
+    }
+
     // REQUIRED BUT NOT USED IN IF97 FUNCTIONS
     bool using_mole_fractions() {
         return false;

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -32,35 +32,58 @@ namespace {
 constexpr std::array<CoolProp::input_pairs, 2> kSupportedPairs = {CoolProp::HmassP_INPUTS, CoolProp::PT_INPUTS};
 
 // Sample-and-build for a given input pair using the matching preset.
-CoolProp::sbtl::SVDSurface build_surface_for_pair_(::CoolProp::AbstractState& heos, CoolProp::input_pairs pair) {
+CoolProp::sbtl::SVDSurface build_surface_for_pair_(::CoolProp::AbstractState& source, CoolProp::input_pairs pair) {
     namespace cp_sbtl = CoolProp::sbtl;
     cp_sbtl::SurfaceSpec spec;
     switch (pair) {
         case CoolProp::HmassP_INPUTS:
-            spec = cp_sbtl::presets::ph_subcritical(heos);
+            spec = cp_sbtl::presets::ph_subcritical(source);
             break;
         case CoolProp::PT_INPUTS:
-            spec = cp_sbtl::presets::pt_subcritical(heos);
+            spec = cp_sbtl::presets::pt_subcritical(source);
             break;
         default:
             throw ValueError("SVDSBTL backend: no preset registered for the requested input pair");
     }
-    return cp_sbtl::build_surface(heos, std::move(spec));
+    return cp_sbtl::build_surface(source, std::move(spec));
 }
 
 }  // namespace
 
-SVDSBTLBackend::SVDSBTLBackend(const std::string& fluid_name) : fluid_name_(fluid_name), mole_fractions_({1.0}) {
+SVDSBTLBackend::SVDSBTLBackend(const std::string& fluid_name, const std::string& source_backend)
+  : fluid_name_(fluid_name), source_backend_(source_backend), mole_fractions_({1.0}) {
+    // Validate the source backend up-front.  Anything outside the
+    // {HEOS, REFPROP, IF97} set is rejected — adding a new source
+    // (SRK, PR, etc.) needs deliberate per-backend wiring for
+    // two-phase routing and the cache-key encoding below, so failing
+    // loudly is better than silently mismatching.
+    if (source_backend_ != "HEOS" && source_backend_ != "REFPROP" && source_backend_ != "IF97") {
+        throw ValueError(format("SVDSBTL: unsupported source backend '%s' (allowed: HEOS, REFPROP, IF97)", source_backend_.c_str()));
+    }
+    // IF97 is parameterized — the only fluid it knows is Water.  Catch
+    // the obvious misuse here rather than at the first surface-build
+    // call.
+    if (source_backend_ == "IF97" && fluid_name != "Water") {
+        throw ValueError(format("SVDSBTL&IF97 is Water-only; got fluid '%s'", fluid_name.c_str()));
+    }
     for (const auto pair : kSupportedPairs) {
         ensure_surface_(pair);
     }
 }
 
-std::shared_ptr<CoolProp::AbstractState> SVDSBTLBackend::heos_reference_() {
-    if (!heos_) {
-        heos_.reset(CoolProp::AbstractState::factory("HEOS", fluid_name_));
+std::shared_ptr<CoolProp::AbstractState> SVDSBTLBackend::source_reference_() {
+    if (!source_) {
+        // The single AbstractState handle that all internal
+        // truth-source calls go through: HEOS sampling for the SVD
+        // tables, SuperAncillary (when source is HEOS), critical-
+        // patch fallback queries, and two-phase PQ/QT routing.
+        //
+        // IF97's factory takes the literal "Water" (its only fluid);
+        // the constructor already validated fluid_name_=="Water" for
+        // this source.  REFPROP and HEOS use the same fluid string.
+        source_.reset(CoolProp::AbstractState::factory(source_backend_, fluid_name_));
     }
-    return heos_;
+    return source_;
 }
 
 std::shared_ptr<superancillary::SuperAncillary<std::vector<double>>> SVDSBTLBackend::superanc_() {
@@ -71,12 +94,12 @@ std::shared_ptr<superancillary::SuperAncillary<std::vector<double>>> SVDSBTLBack
     // The SuperAncillary lives on the per-fluid CoolPropFluid record;
     // HEOSMixtureBackend wraps it via get_superanc().  Anything that's
     // not a HEOS instance simply won't have one.
-    auto* heos_ptr = dynamic_cast<CoolProp::HelmholtzEOSMixtureBackend*>(heos_reference_().get());
-    if (heos_ptr == nullptr) {
+    auto* helmholtz_ptr = dynamic_cast<CoolProp::HelmholtzEOSMixtureBackend*>(source_reference_().get());
+    if (helmholtz_ptr == nullptr) {
         return superanc_cached_;  // stays nullptr
     }
     try {
-        superanc_cached_ = heos_ptr->get_superanc();
+        superanc_cached_ = helmholtz_ptr->get_superanc();
     } catch (const std::exception&) {
         // get_superanc() throws for pseudo-pure / mixtures; SVDSBTL
         // already rejects those at construction, so this is mostly
@@ -88,7 +111,7 @@ std::shared_ptr<superancillary::SuperAncillary<std::vector<double>>> SVDSBTLBack
         // trigger them eagerly here so the first two-phase calc_*
         // doesn't pay the build cost on the hot path.  Cheap (~30 ms
         // total) and runs once per backend lifetime.
-        heos_ptr->ensure_caloric_superancillaries();
+        helmholtz_ptr->ensure_caloric_superancillaries();
     }
     return superanc_cached_;
 }
@@ -113,7 +136,7 @@ std::vector<CoolProp::input_pairs> SVDSBTLBackend::registered_input_pairs() cons
 
 void SVDSBTLBackend::ensure_surface_(CoolProp::input_pairs pair) {
     namespace cp_sbtl = CoolProp::sbtl;
-    const std::string path = cp_sbtl::SVDSurfaceSerializer::default_cache_path(fluid_name_, pair);
+    const std::string path = cp_sbtl::SVDSurfaceSerializer::default_cache_path(fluid_name_, source_backend_, pair);
     std::unique_ptr<cp_sbtl::SVDSurface> surface;
 
     if (std::filesystem::exists(path)) {
@@ -127,8 +150,8 @@ void SVDSBTLBackend::ensure_surface_(CoolProp::input_pairs pair) {
     }
 
     if (!surface) {
-        auto heos = heos_reference_();
-        surface = std::make_unique<cp_sbtl::SVDSurface>(build_surface_for_pair_(*heos, pair));
+        auto source = source_reference_();
+        surface = std::make_unique<cp_sbtl::SVDSurface>(build_surface_for_pair_(*source, pair));
         try {
             cp_sbtl::SVDSurfaceSerializer::save_to_file(*surface, path);
         } catch (const std::exception&) {
@@ -373,39 +396,39 @@ CoolPropDbl SVDSBTLBackend::calc_umolar() {
 // Constants — delegate to a lazily-allocated HEOS reference.
 CoolPropDbl SVDSBTLBackend::calc_molar_mass() {
     if (molar_mass_cached_ < 0.0) {
-        molar_mass_cached_ = heos_reference_()->molar_mass();
+        molar_mass_cached_ = source_reference_()->molar_mass();
     }
     return molar_mass_cached_;
 }
 CoolPropDbl SVDSBTLBackend::calc_gas_constant() {
-    return heos_reference_()->gas_constant();
+    return source_reference_()->gas_constant();
 }
 CoolPropDbl SVDSBTLBackend::calc_T_critical() {
-    return heos_reference_()->T_critical();
+    return source_reference_()->T_critical();
 }
 CoolPropDbl SVDSBTLBackend::calc_p_critical() {
-    return heos_reference_()->p_critical();
+    return source_reference_()->p_critical();
 }
 CoolPropDbl SVDSBTLBackend::calc_rhomass_critical() {
-    return heos_reference_()->rhomass_critical();
+    return source_reference_()->rhomass_critical();
 }
 CoolPropDbl SVDSBTLBackend::calc_rhomolar_critical() {
-    return heos_reference_()->rhomolar_critical();
+    return source_reference_()->rhomolar_critical();
 }
 CoolPropDbl SVDSBTLBackend::calc_Ttriple() {
-    return heos_reference_()->Ttriple();
+    return source_reference_()->Ttriple();
 }
 CoolPropDbl SVDSBTLBackend::calc_p_triple() {
-    return heos_reference_()->p_triple();
+    return source_reference_()->p_triple();
 }
 CoolPropDbl SVDSBTLBackend::calc_Tmax() {
-    return heos_reference_()->Tmax();
+    return source_reference_()->Tmax();
 }
 CoolPropDbl SVDSBTLBackend::calc_Tmin() {
-    return heos_reference_()->Tmin();
+    return source_reference_()->Tmin();
 }
 CoolPropDbl SVDSBTLBackend::calc_pmax() {
-    return heos_reference_()->pmax();
+    return source_reference_()->pmax();
 }
 
 }  // namespace CoolProp

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -168,33 +168,52 @@ void SVDSBTLBackend::update(CoolProp::input_pairs input_pair, double value1, dou
     _phase = iphase_not_imposed;
     two_phase_.active = false;
 
-    // Two-phase inputs go to the superancillary path immediately --
-    // no SVDSurface needed.  PQ_INPUTS and QT_INPUTS are degenerate
-    // in the surface (the dome interior is not single-phase, so the
-    // surface returns NaN) so we route around it.
+    // Two-phase inputs go to the SuperAncillary or to the source
+    // backend directly — no SVDSurface needed.  PQ_INPUTS and
+    // QT_INPUTS are degenerate in the surface (the dome interior is
+    // not single-phase, so the surface returns NaN), so we route
+    // around it.
     if (input_pair == CoolProp::PQ_INPUTS || input_pair == CoolProp::QT_INPUTS) {
         active_pair_ = input_pair;
         active_surface_ = nullptr;
         active_resolved_ = false;
-        auto sa = superanc_();
-        if (!sa) {
-            throw NotImplementedError(std::string("SVDSBTL backend: two-phase inputs require a SuperAncillary for this fluid (") + fluid_name_
-                                      + " has none).  Use a different backend (e.g. HEOS) for two-phase queries on this fluid.");
-        }
         double p_sat = 0.0;
         double T_sat = 0.0;
         double Q = 0.0;
-        if (input_pair == CoolProp::PQ_INPUTS) {
-            // value1 = p, value2 = Q.
-            p_sat = value1;
-            Q = value2;
-            T_sat = sa->get_T_from_p(p_sat);
+        auto sa = superanc_();
+        if (sa) {
+            // Fast path — HEOS-side SuperAncillary Chebyshev expansion
+            // gives sat-line state in O(1) without an HEOS flash.
+            if (input_pair == CoolProp::PQ_INPUTS) {
+                // value1 = p, value2 = Q.
+                p_sat = value1;
+                Q = value2;
+                T_sat = sa->get_T_from_p(p_sat);
+            } else {
+                // QT_INPUTS: value1 = Q, value2 = T.
+                Q = value1;
+                T_sat = value2;
+                p_sat = sa->eval_sat(T_sat, 'P', 0);
+            }
         } else {
-            // QT_INPUTS: value1 = Q, value2 = T.
-            Q = value1;
-            T_sat = value2;
-            // p_sat from the SuperAncillary's pressure expansion.
-            p_sat = sa->eval_sat(T_sat, 'P', 0);
+            // Fallback path — source backend doesn't ship a
+            // SuperAncillary (REFPROP, IF97, ...).  Route directly
+            // to its own PQ/QT_INPUTS, which it must implement.
+            auto src = source_reference_();
+            if (input_pair == CoolProp::PQ_INPUTS) {
+                p_sat = value1;
+                Q = value2;
+                // Anchor at Q=0 so the source state lands cleanly on
+                // sat,L; T_sat is invariant in Q across the dome at
+                // fixed p.
+                src->update(CoolProp::PQ_INPUTS, p_sat, 0.0);
+                T_sat = src->T();
+            } else {
+                Q = value1;
+                T_sat = value2;
+                src->update(CoolProp::QT_INPUTS, 0.0, T_sat);
+                p_sat = src->p();
+            }
         }
         if (Q < 0.0 || Q > 1.0) {
             throw ValueError("SVDSBTL backend: two-phase Q must be in [0, 1]");
@@ -243,17 +262,38 @@ void SVDSBTLBackend::update(CoolProp::input_pairs input_pair, double value1, dou
 
     if (active_point_.region_idx < 0) {
         // Out of every single-phase region.  For HmassP this typically
-        // means the (h, p) point is inside the saturation dome; route
-        // to the superancillary two-phase path and recover the user's
-        // request.  Other input pairs (PT on the sat curve) currently
-        // still surface as NaN -- two-phase PT is degenerate anyway
-        // (no unique state at T_sat unless Q is supplied).
+        // means the (h, p) point is inside the saturation dome; pull
+        // the sat-line endpoints from the SuperAncillary if available
+        // or directly from the source backend otherwise, compute Q
+        // from the lever rule, and route to the two-phase path.
+        // Other input pairs (PT on the sat curve) currently still
+        // surface as NaN — two-phase PT is degenerate anyway (no
+        // unique state at T_sat unless Q is supplied).
         if ((input_pair == CoolProp::HmassP_INPUTS || input_pair == CoolProp::HmolarP_INPUTS) && _p > 0.0) {
+            double T_sat = 0.0, hL_mol = 0.0, hV_mol = 0.0;
+            bool sat_resolved = false;
             auto sa = superanc_();
             if (sa) {
-                const double T_sat = sa->get_T_from_p(_p);
-                const double hL_mol = sa->eval_sat(T_sat, 'H', 0);
-                const double hV_mol = sa->eval_sat(T_sat, 'H', 1);
+                T_sat = sa->get_T_from_p(_p);
+                hL_mol = sa->eval_sat(T_sat, 'H', 0);
+                hV_mol = sa->eval_sat(T_sat, 'H', 1);
+                sat_resolved = true;
+            } else {
+                try {
+                    auto src = source_reference_();
+                    src->update(CoolProp::PQ_INPUTS, _p, 0.0);
+                    T_sat = src->T();
+                    hL_mol = src->hmolar();
+                    src->update(CoolProp::PQ_INPUTS, _p, 1.0);
+                    hV_mol = src->hmolar();
+                    sat_resolved = true;
+                } catch (const std::exception&) {
+                    // Source backend couldn't resolve PQ at this _p
+                    // (e.g. above its critical pressure).  Fall
+                    // through to the iphase_twophase tag below.
+                }
+            }
+            if (sat_resolved) {
                 const double h_mol = active_hmass_ * calc_molar_mass();
                 if (hL_mol <= h_mol && h_mol <= hV_mol) {
                     const double Q = (h_mol - hL_mol) / (hV_mol - hL_mol);
@@ -267,14 +307,31 @@ void SVDSBTLBackend::update(CoolProp::input_pairs input_pair, double value1, dou
 }
 
 void SVDSBTLBackend::update_two_phase_(double T_sat, double p_sat, double Q) {
-    auto sa = superanc_();
-    if (!sa) {
-        throw NotImplementedError("SVDSBTL backend: update_two_phase_ called without a SuperAncillary");
-    }
     _p = p_sat;
     _T = T_sat;
     _Q = Q;
     _phase = iphase_twophase;
+    auto sa = superanc_();
+    if (!sa) {
+        // No SuperAncillary (REFPROP / IF97 source) — pull sat-line
+        // endpoints from the source backend directly via QT_INPUTS.
+        // Two flashes (Q=0 and Q=1) at the same T_sat; slow compared
+        // to a Chebyshev eval but correct by construction.
+        auto src = source_reference_();
+        src->update(CoolProp::QT_INPUTS, 0.0, T_sat);
+        two_phase_.rhoL_mol = src->rhomolar();
+        two_phase_.hL_mol = src->hmolar();
+        two_phase_.sL_mol = src->smolar();
+        src->update(CoolProp::QT_INPUTS, 1.0, T_sat);
+        two_phase_.rhoV_mol = src->rhomolar();
+        two_phase_.hV_mol = src->hmolar();
+        two_phase_.sV_mol = src->smolar();
+        // u = h - p*v = h - p/rho; same identity as the HEOS path.
+        two_phase_.uL_mol = two_phase_.hL_mol - p_sat / two_phase_.rhoL_mol;
+        two_phase_.uV_mol = two_phase_.hV_mol - p_sat / two_phase_.rhoV_mol;
+        two_phase_.active = true;
+        return;
+    }
     two_phase_.rhoL_mol = sa->eval_sat(T_sat, 'D', 0);
     two_phase_.rhoV_mol = sa->eval_sat(T_sat, 'D', 1);
     two_phase_.hL_mol = sa->eval_sat(T_sat, 'H', 0);

--- a/src/SBTL/SVDSurfaceSerializer.cpp
+++ b/src/SBTL/SVDSurfaceSerializer.cpp
@@ -426,17 +426,25 @@ std::string SVDSurfaceSerializer::default_cache_dir() {
     return dir + "/";
 }
 
-std::string SVDSurfaceSerializer::default_cache_path(const std::string& fluid_name, ::CoolProp::input_pairs input_pair) {
+std::string SVDSurfaceSerializer::default_cache_path(const std::string& fluid_name, const std::string& source_backend, ::CoolProp::input_pairs input_pair) {
     // Defense-in-depth against path traversal.  CoolProp fluid names
     // come from the JSON catalog so this is unlikely to be hit in
     // practice, but a caller passing an attacker-controlled string
-    // (e.g. through PropsSI("...", "SVDSBTL::<weird name>")) would
-    // otherwise be able to read or write outside the cache dir.
-    if (fluid_name.empty() || fluid_name.find('/') != std::string::npos || fluid_name.find('\\') != std::string::npos
-        || fluid_name.find("..") != std::string::npos) {
+    // (e.g. through PropsSI("...", "SVDSBTL&HEOS::<weird name>"))
+    // would otherwise be able to read or write outside the cache dir.
+    auto unsafe = [](const std::string& s) {
+        return s.empty() || s.find('/') != std::string::npos || s.find('\\') != std::string::npos || s.find("..") != std::string::npos;
+    };
+    if (unsafe(fluid_name)) {
         throw std::invalid_argument("SVDSurfaceSerializer::default_cache_path: invalid fluid_name (must be a bare component name)");
     }
-    return default_cache_dir() + fluid_name + "." + std::to_string(static_cast<int>(input_pair)) + ".svd.bin.z";
+    if (unsafe(source_backend)) {
+        throw std::invalid_argument("SVDSurfaceSerializer::default_cache_path: invalid source_backend");
+    }
+    // Format: <fluid>.<source>.<input_pair>.svd.bin.z so HEOS-built
+    // and REFPROP-built (and IF97-built) tables for the same fluid
+    // never collide on disk.
+    return default_cache_dir() + fluid_name + "." + source_backend + "." + std::to_string(static_cast<int>(input_pair)) + ".svd.bin.z";
 }
 
 }  // namespace sbtl

--- a/src/SBTL/SVDSurfaceSerializer.cpp
+++ b/src/SBTL/SVDSurfaceSerializer.cpp
@@ -426,7 +426,8 @@ std::string SVDSurfaceSerializer::default_cache_dir() {
     return dir + "/";
 }
 
-std::string SVDSurfaceSerializer::default_cache_path(const std::string& fluid_name, const std::string& source_backend, ::CoolProp::input_pairs input_pair) {
+std::string SVDSurfaceSerializer::default_cache_path(const std::string& fluid_name, const std::string& source_backend,
+                                                     ::CoolProp::input_pairs input_pair) {
     // Defense-in-depth against path traversal.  CoolProp fluid names
     // come from the JSON catalog so this is unlikely to be hit in
     // practice, but a caller passing an attacker-controlled string

--- a/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
+++ b/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
@@ -173,17 +173,24 @@ TEST_CASE("SVDSurfaceSerializer::default_cache_path rejects path-traversal fluid
     // Defense-in-depth: anything that could escape the cache directory
     // must throw rather than silently writing outside ~/.CoolProp/SVDTables.
     using Catch::Matchers::ContainsSubstring;
-    REQUIRE_THROWS_WITH(cp_sbtl::SVDSurfaceSerializer::default_cache_path("../etc/passwd", ::CoolProp::HmassP_INPUTS),
+    REQUIRE_THROWS_WITH(cp_sbtl::SVDSurfaceSerializer::default_cache_path("../etc/passwd", "HEOS", ::CoolProp::HmassP_INPUTS),
                         ContainsSubstring("invalid fluid_name"));
-    REQUIRE_THROWS_WITH(cp_sbtl::SVDSurfaceSerializer::default_cache_path("foo/bar", ::CoolProp::HmassP_INPUTS),
+    REQUIRE_THROWS_WITH(cp_sbtl::SVDSurfaceSerializer::default_cache_path("foo/bar", "HEOS", ::CoolProp::HmassP_INPUTS),
                         ContainsSubstring("invalid fluid_name"));
-    REQUIRE_THROWS_WITH(cp_sbtl::SVDSurfaceSerializer::default_cache_path("foo\\bar", ::CoolProp::HmassP_INPUTS),
+    REQUIRE_THROWS_WITH(cp_sbtl::SVDSurfaceSerializer::default_cache_path("foo\\bar", "HEOS", ::CoolProp::HmassP_INPUTS),
                         ContainsSubstring("invalid fluid_name"));
-    REQUIRE_THROWS_WITH(cp_sbtl::SVDSurfaceSerializer::default_cache_path("..", ::CoolProp::HmassP_INPUTS), ContainsSubstring("invalid fluid_name"));
-    REQUIRE_THROWS_WITH(cp_sbtl::SVDSurfaceSerializer::default_cache_path("", ::CoolProp::HmassP_INPUTS), ContainsSubstring("invalid fluid_name"));
+    REQUIRE_THROWS_WITH(cp_sbtl::SVDSurfaceSerializer::default_cache_path("..", "HEOS", ::CoolProp::HmassP_INPUTS),
+                        ContainsSubstring("invalid fluid_name"));
+    REQUIRE_THROWS_WITH(cp_sbtl::SVDSurfaceSerializer::default_cache_path("", "HEOS", ::CoolProp::HmassP_INPUTS),
+                        ContainsSubstring("invalid fluid_name"));
+    // Same checks apply to the source_backend slot.
+    REQUIRE_THROWS_WITH(cp_sbtl::SVDSurfaceSerializer::default_cache_path("Water", "foo/bar", ::CoolProp::HmassP_INPUTS),
+                        ContainsSubstring("invalid source_backend"));
+    REQUIRE_THROWS_WITH(cp_sbtl::SVDSurfaceSerializer::default_cache_path("Water", "", ::CoolProp::HmassP_INPUTS),
+                        ContainsSubstring("invalid source_backend"));
     // Legitimate names pass.
-    REQUIRE_NOTHROW(cp_sbtl::SVDSurfaceSerializer::default_cache_path("Water", ::CoolProp::HmassP_INPUTS));
-    REQUIRE_NOTHROW(cp_sbtl::SVDSurfaceSerializer::default_cache_path("R134a", ::CoolProp::PT_INPUTS));
+    REQUIRE_NOTHROW(cp_sbtl::SVDSurfaceSerializer::default_cache_path("Water", "HEOS", ::CoolProp::HmassP_INPUTS));
+    REQUIRE_NOTHROW(cp_sbtl::SVDSurfaceSerializer::default_cache_path("R134a", "REFPROP", ::CoolProp::PT_INPUTS));
 }
 
 TEST_CASE("SVDSurfaceSerializer rejects corrupt input", "[SBTL][serializer]") {

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -116,7 +116,7 @@ TEST_CASE("SVDSBTL backend supports the high-level PropsSI surface", "[SVDSBTL][
     heos->update(CoolProp::PT_INPUTS, 1.0e6, 350.0);
     const double rho_truth = heos->rhomass();
 
-    const double rho_via_propsi = CoolProp::PropsSI("D", "T", 350.0, "P", 1.0e6, "SVDSBTL::Water");
+    const double rho_via_propsi = CoolProp::PropsSI("D", "T", 350.0, "P", 1.0e6, "SVDSBTL&HEOS::Water");
     INFO("PropsSI = " << rho_via_propsi << "  HEOS = " << rho_truth);
     REQUIRE(rho_via_propsi == Approx(rho_truth).epsilon(5e-3));
 }
@@ -305,6 +305,101 @@ TEST_CASE("SVDSBTL backend Q out of [0, 1] is rejected", "[SVDSBTL][twophase][re
     REQUIRE_THROWS(AS->update(CoolProp::PQ_INPUTS, 1.0e6, 1.1));
     REQUIRE_THROWS(AS->update(CoolProp::QT_INPUTS, -0.1, 350.0));
     REQUIRE_THROWS(AS->update(CoolProp::QT_INPUTS, 1.1, 350.0));
+}
+
+// -----------------------------------------------------------------------------
+// Non-HEOS source-of-truth backends
+// -----------------------------------------------------------------------------
+
+TEST_CASE("SVDSBTL backend without explicit source throws", "[SVDSBTL][source][reject]") {
+    // factory("SVDSBTL", ...) without &<source> must throw.  The error
+    // text mentions SVDSBTL&HEOS so the user has an obvious fix.
+    REQUIRE_THROWS_WITH(std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL", "Water")),
+                        Catch::Matchers::ContainsSubstring("explicit source"));
+}
+
+TEST_CASE("SVDSBTL backend rejects unsupported source names", "[SVDSBTL][source][reject]") {
+    REQUIRE_THROWS_WITH(std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&SRK", "Water")),
+                        Catch::Matchers::ContainsSubstring("unsupported source"));
+}
+
+TEST_CASE("SVDSBTL&IF97 rejects non-Water fluids", "[SVDSBTL][source][if97][reject]") {
+    REQUIRE_THROWS_WITH(std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&IF97", "CarbonDioxide")),
+                        Catch::Matchers::ContainsSubstring("Water-only"));
+}
+
+// Try-and-skip helper: REFPROP and IF97 may not be available on every
+// CI machine.  Construct once at TEST_CASE entry and SKIP if the
+// source-backend itself can't be built.
+namespace {
+bool source_backend_available(const std::string& source, const std::string& fluid) {
+    try {
+        const std::string spec = std::string("SVDSBTL&") + source;
+        auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory(spec, fluid));
+        return true;
+    } catch (const std::exception&) {
+        return false;
+    }
+}
+}  // namespace
+
+TEST_CASE("SVDSBTL&REFPROP single-phase PT lookup matches REFPROP truth", "[SVDSBTL][source][refprop][pt][slow]") {
+    if (!source_backend_available("REFPROP", "Water")) {
+        SKIP("REFPROP not available; skipping SVDSBTL&REFPROP test");
+    }
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&REFPROP", "Water"));
+    auto refprop = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("REFPROP", "Water"));
+    const double T = 0.85 * refprop->T_critical();
+    const double p = 0.50 * refprop->p_critical();
+    AS->update(CoolProp::PT_INPUTS, p, T);
+    refprop->update(CoolProp::PT_INPUTS, p, T);
+    REQUIRE(AS->rhomass() == Approx(refprop->rhomass()).epsilon(1e-3));
+    REQUIRE(AS->hmass() == Approx(refprop->hmass()).epsilon(1e-3));
+}
+
+TEST_CASE("SVDSBTL&REFPROP two-phase PQ matches REFPROP truth", "[SVDSBTL][source][refprop][twophase][slow]") {
+    if (!source_backend_available("REFPROP", "Water")) {
+        SKIP("REFPROP not available; skipping SVDSBTL&REFPROP two-phase test");
+    }
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&REFPROP", "Water"));
+    auto refprop = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("REFPROP", "Water"));
+    const double p_sat = 0.4 * refprop->p_critical();
+    AS->update(CoolProp::PQ_INPUTS, p_sat, 0.5);
+    refprop->update(CoolProp::PQ_INPUTS, p_sat, 0.5);
+    // Two-phase: SVDSBTL routes through the source backend's QT_INPUTS
+    // for sat endpoints (REFPROP has no SuperAncillary), then does the
+    // standard Q-weighted blend.  Should agree to within REFPROP's own
+    // numerical precision on the sat curves.
+    REQUIRE(AS->T() == Approx(refprop->T()).epsilon(1e-8));
+    REQUIRE(AS->rhomass() == Approx(refprop->rhomass()).epsilon(1e-6));
+    REQUIRE(AS->Q() == Approx(0.5));
+}
+
+TEST_CASE("SVDSBTL&IF97 single-phase PT lookup matches IF97 truth", "[SVDSBTL][source][if97][pt][slow]") {
+    if (!source_backend_available("IF97", "Water")) {
+        SKIP("IF97 backend not available; skipping SVDSBTL&IF97 test");
+    }
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&IF97", "Water"));
+    auto if97 = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("IF97", "Water"));
+    // 500 K, 3 MPa — IAPWS Table 5 region (compressed liquid)
+    const double T = 500.0;
+    const double p = 3.0e6;
+    AS->update(CoolProp::PT_INPUTS, p, T);
+    if97->update(CoolProp::PT_INPUTS, p, T);
+    REQUIRE(AS->rhomass() == Approx(if97->rhomass()).epsilon(1e-3));
+    REQUIRE(AS->hmass() == Approx(if97->hmass()).epsilon(1e-3));
+}
+
+TEST_CASE("SVDSBTL&HEOS and SVDSBTL&REFPROP produce distinct cache files", "[SVDSBTL][source][cache]") {
+    if (!source_backend_available("REFPROP", "Water")) {
+        SKIP("REFPROP not available; skipping cache-key disambiguation test");
+    }
+    namespace cp_sbtl = CoolProp::sbtl;
+    const std::string heos_path = cp_sbtl::SVDSurfaceSerializer::default_cache_path("Water", "HEOS", CoolProp::HmassP_INPUTS);
+    const std::string refprop_path = cp_sbtl::SVDSurfaceSerializer::default_cache_path("Water", "REFPROP", CoolProp::HmassP_INPUTS);
+    REQUIRE(heos_path != refprop_path);
+    REQUIRE(heos_path.find("Water.HEOS.") != std::string::npos);
+    REQUIRE(refprop_path.find("Water.REFPROP.") != std::string::npos);
 }
 
 #endif  // ENABLE_CATCH

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -25,16 +25,16 @@ namespace {
 // Returns true if both files at the SVDSBTL default cache path exist
 // for `fluid`.  Used as a "did the constructor populate the cache?"
 // gate without re-running the build path itself.
-bool cache_present_for(const std::string& fluid) {
+bool cache_present_for(const std::string& fluid, const std::string& source_backend = "HEOS") {
     namespace cp_sbtl = CoolProp::sbtl;
-    return std::filesystem::exists(cp_sbtl::SVDSurfaceSerializer::default_cache_path(fluid, CoolProp::HmassP_INPUTS))
-           && std::filesystem::exists(cp_sbtl::SVDSurfaceSerializer::default_cache_path(fluid, CoolProp::PT_INPUTS));
+    return std::filesystem::exists(cp_sbtl::SVDSurfaceSerializer::default_cache_path(fluid, source_backend, CoolProp::HmassP_INPUTS))
+           && std::filesystem::exists(cp_sbtl::SVDSurfaceSerializer::default_cache_path(fluid, source_backend, CoolProp::PT_INPUTS));
 }
 
 }  // namespace
 
 TEST_CASE("SVDSBTL backend constructs via AbstractState::factory", "[SVDSBTL][factory][slow]") {
-    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL", "Water"));
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
     REQUIRE(AS != nullptr);
     REQUIRE(AS->backend_name() == "SVDSBTLBackend");
     REQUIRE(AS->fluid_names().size() == 1);
@@ -50,7 +50,7 @@ TEST_CASE("SVDSBTL backend constructs via AbstractState::factory", "[SVDSBTL][fa
 }
 
 TEST_CASE("SVDSBTL backend reports critical / triple constants from HEOS reference", "[SVDSBTL][constants][slow]") {
-    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL", "Water"));
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
     auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
     REQUIRE(AS->T_critical() == Approx(heos->T_critical()).epsilon(1e-12));
     REQUIRE(AS->p_critical() == Approx(heos->p_critical()).epsilon(1e-12));
@@ -61,7 +61,7 @@ TEST_CASE("SVDSBTL backend reports critical / triple constants from HEOS referen
 }
 
 TEST_CASE("SVDSBTL backend PT lookup matches HEOS within tolerance", "[SVDSBTL][pt][water][slow]") {
-    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL", "Water"));
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
     auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
 
     // Compressed-liquid spot check matching Phase 2b's water PT preset assertion.
@@ -82,7 +82,7 @@ TEST_CASE("SVDSBTL backend PT lookup matches HEOS within tolerance", "[SVDSBTL][
 }
 
 TEST_CASE("SVDSBTL backend PH lookup matches HEOS within tolerance", "[SVDSBTL][ph][water][slow]") {
-    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL", "Water"));
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
     auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
 
     // Build a (p, T) probe via HEOS, then ask SVDSBTL for the same point via (h, p).
@@ -107,7 +107,7 @@ TEST_CASE("SVDSBTL backend PH lookup matches HEOS within tolerance", "[SVDSBTL][
 TEST_CASE("SVDSBTL backend rejects mixtures", "[SVDSBTL][reject][mixture]") {
     using Catch::Matchers::ContainsSubstring;
     REQUIRE_THROWS_WITH(
-      std::unique_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL", std::vector<std::string>{"Water", "Ethanol"})),
+      std::unique_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", std::vector<std::string>{"Water", "Ethanol"})),
       ContainsSubstring("pure-fluid"));
 }
 
@@ -123,7 +123,7 @@ TEST_CASE("SVDSBTL backend supports the high-level PropsSI surface", "[SVDSBTL][
 
 TEST_CASE("SVDSBTL backend cache reload produces the same result", "[SVDSBTL][cache][slow]") {
     // First instance populates the cache (or no-ops if already present).
-    auto first = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL", "Water"));
+    auto first = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
     if (!cache_present_for("Water")) {
         WARN("SVDSBTL cache absent after first construction (read-only home dir?); reload test will exercise rebuild path instead");
     }
@@ -131,7 +131,7 @@ TEST_CASE("SVDSBTL backend cache reload produces the same result", "[SVDSBTL][ca
     const double rho_first = first->rhomass();
 
     // Second instance hits the cache.
-    auto second = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL", "Water"));
+    auto second = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
     second->update(CoolProp::PT_INPUTS, 1.0e6, 350.0);
     const double rho_second = second->rhomass();
 
@@ -147,7 +147,7 @@ TEST_CASE("SVDSBTL backend PQ_INPUTS two-phase blend matches HEOS", "[SVDSBTL][t
     // (~1e-15 relative) are the only delta.  margin(...) lets us
     // express the tolerance in absolute terms where relative
     // comparisons break down at zero-crossing references.
-    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL", "Water"));
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
     auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
 
     // Sweep a few (p, Q) combinations across the subcritical range.
@@ -170,7 +170,7 @@ TEST_CASE("SVDSBTL backend PQ_INPUTS two-phase blend matches HEOS", "[SVDSBTL][t
 }
 
 TEST_CASE("SVDSBTL backend QT_INPUTS two-phase blend matches HEOS", "[SVDSBTL][twophase][qt][water][slow]") {
-    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL", "Water"));
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
     auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
 
     for (const double T : {280.0, 350.0, 450.0, 600.0}) {
@@ -191,7 +191,7 @@ TEST_CASE("SVDSBTL backend HmassP_INPUTS dome-hit routes to two-phase blend", "[
     // Pick a sat state, take h half-way between hL and hV at p_sat, and
     // confirm SVDSBTL recovers the same Q as HEOS via the in-dome
     // HmassP path.
-    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL", "Water"));
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
     auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
 
     for (const double p : {2.0e5, 1.0e6, 5.0e6}) {
@@ -216,7 +216,7 @@ TEST_CASE("SVDSBTL backend speed of sound matches HEOS in single phase", "[SVDSB
     // For typical single-phase Water states, SVDSBTL should agree with
     // HEOS to ~SVD fitting tolerance (median ~1e-7 relative for ρ-like
     // quantities; w roughly tracks that).
-    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL", "Water"));
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
     auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
 
     struct Pt
@@ -241,7 +241,7 @@ TEST_CASE("SVDSBTL backend speed of sound matches HEOS in single phase", "[SVDSB
 }
 
 TEST_CASE("SVDSBTL backend speed of sound throws in two-phase", "[SVDSBTL][speed_sound][twophase]") {
-    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL", "Water"));
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
     AS->update(CoolProp::PQ_INPUTS, 1.0e6, 0.5);
     REQUIRE_THROWS(AS->speed_sound());
 }
@@ -256,7 +256,7 @@ TEST_CASE("SVDSBTL backend works across the Phase 2a fluid set", "[SVDSBTL][mult
     // confirms each backend wires up correctly.
     for (const auto* fluid : {"R134a", "Ammonia", "Methane", "Propane", "CarbonDioxide", "D6"}) {
         SECTION(fluid) {
-            auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL", fluid));
+            auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", fluid));
             auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", fluid));
             REQUIRE(AS->backend_name() == "SVDSBTLBackend");
 
@@ -300,7 +300,7 @@ TEST_CASE("SVDSBTL backend works across the Phase 2a fluid set", "[SVDSBTL][mult
 }
 
 TEST_CASE("SVDSBTL backend Q out of [0, 1] is rejected", "[SVDSBTL][twophase][reject]") {
-    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL", "Water"));
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
     REQUIRE_THROWS(AS->update(CoolProp::PQ_INPUTS, 1.0e6, -0.1));
     REQUIRE_THROWS(AS->update(CoolProp::PQ_INPUTS, 1.0e6, 1.1));
     REQUIRE_THROWS(AS->update(CoolProp::QT_INPUTS, -0.1, 350.0));


### PR DESCRIPTION
## Summary

SVDSBTL's truth source for the SVD tables, SuperAncillary lookup, and (once Phase 3 lands) the critical-patch HEOS-fallback is now selected explicitly at construction time. **No default** — calling `factory(\"SVDSBTL\", \"Water\")` without an explicit `&<source>` suffix throws with a clear hint:

```cpp
factory(\"SVDSBTL\", \"Water\")           // throws: \"requires an explicit source backend\"
factory(\"SVDSBTL&HEOS\", \"Water\")      // ok
factory(\"SVDSBTL&REFPROP\", \"Water\")   // ok
factory(\"SVDSBTL&IF97\", \"Water\")      // ok (Water only)
```

Implicit defaults hide the contract; users need to know which truth source their tables were sampled from (and what conformance budget that source carries) before they trust the numbers. Same `TTSE&HEOS` / `BICUBIC&HEOS` convention CoolProp already uses for tabular backends.

## Changes

**`feat(svdsbtl): require explicit source-of-truth backend`**
- New `SVDSBTLBackend(fluid_name, source_backend)` constructor signature; validates source ∈ {HEOS, REFPROP, IF97}; IF97 restricted to Water.
- `AbstractState::factory` handles `SVDSBTL&<source>` inline (mirroring TTSE/Bicubic), drops the `SVDSBTLBackendGenerator` (the generic generator API can't carry the source slot).
- `heos_*` members and methods renamed to `source_*`; the internal handle isn't always a HEOS instance.
- Cache key now `<fluid>.<source>.<input_pair>.svd.bin.z` so HEOS-built and REFPROP-built tables don't collide; `SVDSurfaceSerializer::kRevision` bumped to 3 (path change only; on-wire format unchanged).
- `dev/build_svd_tables` honors `SVD_SOURCES=HEOS,REFPROP,IF97` env var; defaults to `HEOS`. IF97 silently skips non-Water fluids.
- All existing tests, benches, probes migrated to the explicit `SVDSBTL&HEOS` form.

**`feat(svdsbtl): two-phase routing via source backend when no SuperAncillary`**
- REFPROP / IF97 sources don't ship the per-fluid Helmholtz SuperAncillary that HEOS has, so the three two-phase paths (PQ/QT inputs, dome-hit HmassP fall-through, `update_two_phase_` sat-line endpoints) now fall back to direct `source->update(QT/PQ, ...)` flashes when `superanc_()` returns null. HEOS path is unchanged (still goes through the fast SuperAncillary Chebyshev expansion).
- New parametrized tests over source backends; REFPROP cases skip via Catch2 `SKIP()` when REFPROP isn't installed on the build machine.
- Rejection tests for `factory(\"SVDSBTL\")` (no source), `factory(\"SVDSBTL&SRK\")` (unknown source), `factory(\"SVDSBTL&IF97\", \"CarbonDioxide\")` (Water-only).
- Cache-key disambiguation test (HEOS-built and REFPROP-built Water tables get distinct paths).
- Drive-by: `IF97Backend::calc_fluid_names()` override returning `{\"Water\"}` — AbstractState's default throws and the SBTL adapter trips on it when querying the source for its fluid name.

## Test plan

- [x] `[SVDSBTL]` Catch2 suite passes locally (21 cases, 295 assertions; 3 REFPROP cases skipped because REFPROP isn't on this machine, all others run)
- [x] `dev/build_svd_tables` smoke-tested with `SVD_SOURCES=HEOS` on the existing 7-fluid set
- [x] `dev/build_svd_tables` smoke-tested with `SVD_SOURCES=IF97` for Water (skips other fluids cleanly)
- [ ] CI Windows / Linux / Catch matrix (will run on push)

## Follow-ups (separate PRs)

- IAPWS-IF97 R7-97 R1/R2/R3/R4 comprehensive conformance test suite (already drafted on `ihb/svd-iapws-conformance` off this branch — will open as a follow-up PR after this lands)
- CoolProp-ob7 — SVDSBTL&IF97 w sampling bug where IF97's wide ε-band around `p_sat` trips speed_sound() during sampling and NaN-fill produces a constant w surface. Doesn't affect HEOS source.
- CoolProp-zx1 / CoolProp-eqq closed by this PR's plumbing (this is the implementation of both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SVDSBTL can use REFPROP and IF97 as selectable source backends in addition to HEOS.
  * Table-building can target multiple source backends in one run.

* **Improvements**
  * Cache filenames now include source backend and revision bumped to avoid collisions.
  * Stronger validation for backend and cache identifiers; improved two‑phase fallback behavior.
  * IF97 reports supported fluid names correctly.

* **Tests**
  * Expanded tests for multi-backend builds, cache disambiguation, and invalid inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->