### PR TITLE
fix(if97): clear() must flush full cache; SVDSBTL viscosity + auto-conformance docs

### DIFF
--- a/Web/fluid_properties/IF97.rst
+++ b/Web/fluid_properties/IF97.rst
@@ -194,4 +194,5 @@ A call to the top-level function ``PropsSI`` can provide: temperature, pressure,
     In [17]: PropsSI('ptriple','T',0,'P',0,'IF97::Water')
 
 
+.. include:: IF97_conformance.rst.in
 

--- a/Web/scripts/__init__.py
+++ b/Web/scripts/__init__.py
@@ -90,6 +90,7 @@ add_to_task_list("coolprop.parametric_table.py")
 add_to_task_list("coolprop.configuration.py")
 add_to_task_list("logo_2014.py")
 add_to_task_list("fluid_properties.REFPROPcomparison.py")
+add_to_task_list("fluid_properties.IF97Conformance.py")
 # Consistency.py is incremental: it skips fluids whose PNG already exists, so a
 # cache-restored run is a cheap no-op while new fluids still get their plots.
 add_to_task_list("fluid_properties.Consistency.py")

--- a/Web/scripts/fluid_properties.IF97Conformance.py
+++ b/Web/scripts/fluid_properties.IF97Conformance.py
@@ -353,6 +353,12 @@ def run_timing(backends, rng_seed=0xCAFE):
             region_of.append(region)
             accepted += 1
     N = len(T_arr)
+    # Pre-filter may reject everything if the backend set has zero
+    # joint-domain overlap on the IF97 region boxes — leave timings as
+    # NaN rather than divide by zero and abort the docs build.
+    if N == 0:
+        return {backend: {prop: float('nan') for prop in TIMING_PROPS}
+                for backend in backends}
     timings = {}
     for backend in backends:
         timings[backend] = {}

--- a/Web/scripts/fluid_properties.IF97Conformance.py
+++ b/Web/scripts/fluid_properties.IF97Conformance.py
@@ -187,14 +187,17 @@ def backend_available(factory_str):
 
 
 def run_conformance(backend):
-    """Return (results, counts).
+    """Return (results, counts, samples).
 
     results[region][prop_key] = DevAcc of (backend - reference) in the
     table's reported unit. counts[region] = in-region accepted samples.
+    samples[region] = list of dicts {'h', 'p', 'devs': {prop: |dev|}} —
+    raw per-sample record used by the failure-point figures.
     """
     rng = random.Random(SEED)
     results = {r: {p[0]: DevAcc() for p in PROPERTIES} for r in REGION_BOXES}
     counts = {r: 0 for r in REGION_BOXES}
+    samples = {r: [] for r in REGION_BOXES}
 
     prop_keys = [p[0] for p in PROPERTIES]
     kinds = {p[0]: p[3] for p in PROPERTIES}
@@ -219,15 +222,76 @@ def run_conformance(backend):
             if any(v is None for v in test_vals.values()):
                 continue
             counts[region] += 1
+            per_sample_devs = {}
             for k in prop_keys:
                 # v = 1/rho — flip so the table reports v deviation.
                 if k == 'D':
                     ref_v = 1.0 / ref_vals[k]
                     test_v = 1.0 / test_vals[k]
-                    results[region][k].add(_deviation(ref_v, test_v, kinds[k]))
+                    dev = _deviation(ref_v, test_v, kinds[k])
                 else:
-                    results[region][k].add(_deviation(ref_vals[k], test_vals[k], kinds[k]))
-    return results, counts
+                    dev = _deviation(ref_vals[k], test_vals[k], kinds[k])
+                results[region][k].add(dev)
+                per_sample_devs[k] = abs(dev) if (dev is not None and math.isfinite(dev)) else None
+            samples[region].append({'h': h, 'p': p_Pa, 'devs': per_sample_devs})
+    return results, counts, samples
+
+
+def write_failure_figures(backend, samples_per_region, out_dir):
+    """Emit one PNG per region showing sample population in PH coords
+    with budget-violating points overlaid darker.
+
+    Returns dict region → relative-path of the emitted PNG (relative to
+    Web/fluid_properties/ for inclusion in the rst.in).  When the
+    matplotlib import fails (headless CI without matplotlib), returns
+    an empty dict and the rst renderer omits the figures section.
+    """
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return {}
+
+    # Slug for the backend name so the filename is filesystem-safe.
+    slug = ''.join(c if c.isalnum() else '_' for c in backend)
+    perms = {p[0]: p[4] for p in PROPERTIES}
+    symbols = {p[0]: p[1] for p in PROPERTIES}
+    paths = {}
+
+    for region in sorted(samples_per_region):
+        samples = samples_per_region[region]
+        if not samples:
+            continue
+        # 2x3 grid: T, v, s, w, η, λ
+        fig, axes = plt.subplots(2, 3, figsize=(12, 7.5), sharex=True, sharey=True)
+        h_all = [s['h'] / 1e3 for s in samples]   # h in kJ/kg
+        p_all = [s['p'] / 1e6 for s in samples]   # p in MPa
+        prop_order = [p[0] for p in PROPERTIES]
+        for ax, prop_key in zip(axes.flat, prop_order):
+            ax.scatter(h_all, p_all, c='lightgray', s=4, edgecolors='none', label='in-region samples')
+            failing_h, failing_p = [], []
+            for s in samples:
+                d = s['devs'].get(prop_key)
+                if d is not None and d > perms[prop_key]:
+                    failing_h.append(s['h'] / 1e3)
+                    failing_p.append(s['p'] / 1e6)
+            if failing_h:
+                ax.scatter(failing_h, failing_p, c='crimson', s=8, edgecolors='none', label='over budget')
+            ax.set_yscale('log')
+            ax.set_title(r'$|\Delta {0}|>\,{1:g}$ ({2}/{3})'.format(symbols[prop_key], perms[prop_key], len(failing_h), len(samples)))
+            ax.grid(True, which='both', alpha=0.3)
+        for ax in axes[-1]:
+            ax.set_xlabel(r'$h$ [kJ/kg]')
+        for ax in axes[:, 0]:
+            ax.set_ylabel(r'$p$ [MPa]')
+        fig.suptitle(r'IF97 Region {0} — `{1}` budget-violating samples ({2} drawn)'.format(region, backend, len(samples)))
+        fig.tight_layout(rect=[0, 0, 1, 0.96])
+        out_path = os.path.join(out_dir, 'IF97_conformance_fails_{0}_R{1}.png'.format(slug, region))
+        fig.savefig(out_path, dpi=110)
+        plt.close(fig)
+        paths[region] = os.path.basename(out_path)
+    return paths
 
 
 # ---------------------------------------------------------------------------
@@ -329,7 +393,9 @@ def _fmt_ns(ns):
     return '{:.0f} ns'.format(ns)
 
 
-def render_rst(results_per_backend, counts_per_backend, timings):
+def render_rst(results_per_backend, counts_per_backend, timings, figure_paths_per_backend=None):
+    if figure_paths_per_backend is None:
+        figure_paths_per_backend = {}
     lines = []
     lines.append('')
     lines.append('.. _IF97-Conformance:')
@@ -359,11 +425,30 @@ def render_rst(results_per_backend, counts_per_backend, timings):
             lines.append('')
             continue
         results = results_per_backend[backend]
+        fig_paths = figure_paths_per_backend.get(backend, {})
 
         section_title = 'Deviation of ``{}`` from IAPWS-IF97'.format(backend)
         lines.append(section_title)
         lines.append('~' * max(60, len(section_title)))
         lines.append('')
+
+        # Failure-point figures (one per region) showing the
+        # population in PH coords with budget-violating samples
+        # overlaid in red.  Lets the reader see WHERE the SVDSBTL
+        # truncation residual exceeds the IAPWS perm budget, not
+        # just the bulk statistics.
+        if fig_paths:
+            lines.append('*Where the failures cluster (PH coords; light grey = all in-region samples, '
+                         'red = budget-violating samples for that property; one panel per property; '
+                         'pressure axis is log-scaled):*')
+            lines.append('')
+            for region in sorted(fig_paths):
+                lines.append('.. figure:: {0}'.format(fig_paths[region]))
+                lines.append('   :align: center')
+                lines.append('   :width: 90%')
+                lines.append('')
+                lines.append('   IF97 Region {0} — {1}'.format(region, backend))
+                lines.append('')
 
         for pk, sym, _unit, kind, perm, perm_unit, table_id in PROPERTIES:
             if kind == 'rel':
@@ -459,22 +544,31 @@ def main():
     print('IF97 conformance script: starting')
     results_per_backend = {}
     counts_per_backend = {}
+    figure_paths_per_backend = {}
     available = [REFERENCE]
     for backend, label in TESTED:
         if not backend_available(backend):
             print('  {} unavailable — skipping'.format(backend))
             continue
         print('  sweeping {} ({})'.format(backend, label))
-        results, counts = run_conformance(backend)
+        results, counts, samples = run_conformance(backend)
         results_per_backend[backend] = results
         counts_per_backend[backend] = counts
         available.append(backend)
         print('    in-region counts: {}'.format(counts))
+        # Emit the per-region failure-point PH figures alongside the
+        # .rst.in include.  Failures take their basename so the
+        # rst-relative path is just the file name.
+        fig_dir = os.path.dirname(OUT_PATH)
+        paths = write_failure_figures(backend, samples, fig_dir)
+        if paths:
+            figure_paths_per_backend[backend] = paths
+            print('    wrote {} failure figure(s)'.format(len(paths)))
 
     print('  timing pass over {}'.format(available))
     timings = run_timing(available)
 
-    rst = render_rst(results_per_backend, counts_per_backend, timings)
+    rst = render_rst(results_per_backend, counts_per_backend, timings, figure_paths_per_backend)
     with open(OUT_PATH, 'w') as fp:
         fp.write(rst)
     print('Wrote {}'.format(OUT_PATH))

--- a/Web/scripts/fluid_properties.IF97Conformance.py
+++ b/Web/scripts/fluid_properties.IF97Conformance.py
@@ -253,6 +253,9 @@ def run_timing(backends, rng_seed=0xCAFE):
                 try:
                     CP.PropsSI(prop, 'T', T_arr[k], 'P', p_arr[k], backend)
                 except Exception:
+                    # Warm-up sample landed outside this backend's
+                    # validity envelope; ignore — actual timing starts
+                    # below.
                     pass
             t0 = time.perf_counter()
             ok = 0
@@ -261,6 +264,8 @@ def run_timing(backends, rng_seed=0xCAFE):
                     CP.PropsSI(prop, 'T', T_arr[k], 'P', p_arr[k], backend)
                     ok += 1
                 except Exception:
+                    # Sample outside the backend's validity envelope;
+                    # don't count it toward the per-call mean.
                     pass
             t1 = time.perf_counter()
             timings[backend][prop] = ((t1 - t0) / ok * 1e9) if ok else float('nan')
@@ -317,14 +322,12 @@ def render_rst(results_per_backend, counts_per_backend, timings):
         .format(n=SAMPLES_PER_REGION))
     lines.append('')
 
-    backend_titles = dict(TESTED)
     for backend, _label in TESTED:
         if backend not in results_per_backend:
             lines.append('Backend ``{}``: not available on this build.'.format(backend))
             lines.append('')
             continue
         results = results_per_backend[backend]
-        counts = counts_per_backend[backend]
 
         section_title = 'Deviation of ``{}`` from IAPWS-IF97'.format(backend)
         lines.append(section_title)

--- a/Web/scripts/fluid_properties.IF97Conformance.py
+++ b/Web/scripts/fluid_properties.IF97Conformance.py
@@ -243,10 +243,16 @@ def run_timing(backends, rng_seed=0xCAFE):
     # Build a single (T, p) sample population using the same per-region
     # sampling + classifier as run_conformance(): draw from each region
     # box, accept only points the IF97 region atlas assigns to that
-    # region, and append to a shared list.  Result is a stratified
-    # mixture of R1/R2/R3/R5 samples — representative of real IF97
-    # usage and guaranteed in-envelope so the timed loop needs no
-    # try/except.
+    # region.  Then probe every backend in the timing set at each
+    # candidate (with every property we'll time) and KEEP only samples
+    # that succeed everywhere.  This is the right place to filter out
+    # SVDSBTL's known rank-truncation gap near the critical singularity
+    # (R3, !mayfail in the conformance tests): including those points
+    # in the timed loop would either crash or require try/except inside
+    # the inner per-call measurement.  Pre-filtering keeps the timed
+    # loop a plain for-loop and timing data is the wall-time mean over
+    # the SHARED-evaluable population for fair backend-to-backend
+    # comparison.
     T_arr = []
     p_arr = []
     region_of = []
@@ -262,8 +268,24 @@ def run_timing(backends, rng_seed=0xCAFE):
             attempts += 1
             if classify_region(T, p_MPa) != region:
                 continue
+            p_Pa = p_MPa * 1e6
+            ok = True
+            for backend in backends:
+                for prop in TIMING_PROPS:
+                    try:
+                        v = CP.PropsSI(prop, 'T', T, 'P', p_Pa, backend)
+                    except Exception:
+                        ok = False
+                        break
+                    if not math.isfinite(v):
+                        ok = False
+                        break
+                if not ok:
+                    break
+            if not ok:
+                continue
             T_arr.append(T)
-            p_arr.append(p_MPa * 1e6)
+            p_arr.append(p_Pa)
             region_of.append(region)
             accepted += 1
     N = len(T_arr)
@@ -388,7 +410,11 @@ def render_rst(results_per_backend, counts_per_backend, timings):
             'random :math:`(T, p)` samples drawn from the same per-IF97-region '
             'population the conformance sweep uses above (stratified across '
             'R1, R2, R3, R5; saturation cells filtered out by the IF97 '
-            'region classifier so every timed call is single-phase). '
+            'region classifier so every timed call is single-phase, and '
+            'samples that any tested backend cannot evaluate — e.g. cells '
+            'inside SVDSBTL\'s known rank-truncation gap near the critical '
+            'singularity — are pre-rejected during population so the timed '
+            'loop is a plain for-loop). '
             'The ratio column is :math:`t_{\\mathrm{backend}} / '
             't_{\\mathrm{IF97}}`. Lower is faster than IF97. '
             'Absolute timings depend on hardware; the **ratios** are the '

--- a/Web/scripts/fluid_properties.IF97Conformance.py
+++ b/Web/scripts/fluid_properties.IF97Conformance.py
@@ -240,35 +240,44 @@ def run_timing(backends, rng_seed=0xCAFE):
     Returns timings[backend][prop_key] = ns/call.
     """
     rng = random.Random(rng_seed)
-    N = 20000
-    # Pre-build (T, p) state vectors; restrict to a single-phase box so
-    # we don't pay the saturation-flash penalty in the timed loop.
-    T_arr = [rng.uniform(350.0, 800.0) for _ in range(N)]
-    p_arr = [rng.uniform(0.5, 20.0) * 1e6 for _ in range(N)]
+    # Build a single (T, p) sample population using the same per-region
+    # sampling + classifier as run_conformance(): draw from each region
+    # box, accept only points the IF97 region atlas assigns to that
+    # region, and append to a shared list.  Result is a stratified
+    # mixture of R1/R2/R3/R5 samples — representative of real IF97
+    # usage and guaranteed in-envelope so the timed loop needs no
+    # try/except.
+    T_arr = []
+    p_arr = []
+    region_of = []
+    for region, box in REGION_BOXES.items():
+        T_lo, T_hi = box['T']
+        p_lo, p_hi = box['p']
+        attempts = 0
+        accepted = 0
+        target = SAMPLES_PER_REGION
+        while accepted < target and attempts < 10 * target:
+            T = rng.uniform(T_lo, T_hi)
+            p_MPa = math.exp(rng.uniform(math.log(p_lo), math.log(p_hi)))
+            attempts += 1
+            if classify_region(T, p_MPa) != region:
+                continue
+            T_arr.append(T)
+            p_arr.append(p_MPa * 1e6)
+            region_of.append(region)
+            accepted += 1
+    N = len(T_arr)
     timings = {}
     for backend in backends:
         timings[backend] = {}
         for prop in TIMING_PROPS:
             for k in range(min(64, N)):  # warmup
-                try:
-                    CP.PropsSI(prop, 'T', T_arr[k], 'P', p_arr[k], backend)
-                except Exception:
-                    # Warm-up sample landed outside this backend's
-                    # validity envelope; ignore — actual timing starts
-                    # below.
-                    pass
+                CP.PropsSI(prop, 'T', T_arr[k], 'P', p_arr[k], backend)
             t0 = time.perf_counter()
-            ok = 0
             for k in range(N):
-                try:
-                    CP.PropsSI(prop, 'T', T_arr[k], 'P', p_arr[k], backend)
-                    ok += 1
-                except Exception:
-                    # Sample outside the backend's validity envelope;
-                    # don't count it toward the per-call mean.
-                    pass
+                CP.PropsSI(prop, 'T', T_arr[k], 'P', p_arr[k], backend)
             t1 = time.perf_counter()
-            timings[backend][prop] = ((t1 - t0) / ok * 1e9) if ok else float('nan')
+            timings[backend][prop] = (t1 - t0) / N * 1e9
     return timings
 
 
@@ -376,8 +385,10 @@ def render_rst(results_per_backend, counts_per_backend, timings):
         lines.append('')
         lines.append(
             'Mean wall time per ``PropsSI`` call for property look-ups at '
-            'random :math:`(T, p)` in the single-phase region '
-            ':math:`T \\in [350, 800]` K, :math:`p \\in [0.5, 20]` MPa. '
+            'random :math:`(T, p)` samples drawn from the same per-IF97-region '
+            'population the conformance sweep uses above (stratified across '
+            'R1, R2, R3, R5; saturation cells filtered out by the IF97 '
+            'region classifier so every timed call is single-phase). '
             'The ratio column is :math:`t_{\\mathrm{backend}} / '
             't_{\\mathrm{IF97}}`. Lower is faster than IF97. '
             'Absolute timings depend on hardware; the **ratios** are the '

--- a/Web/scripts/fluid_properties.IF97Conformance.py
+++ b/Web/scripts/fluid_properties.IF97Conformance.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python
+"""Generate IF97 conformance and timing tables for the docs.
+
+Emits Web/fluid_properties/IF97_conformance.rst.in, which the IF97 docs
+page ``include``s.
+
+Conformance protocol mirrors IAPWS G13-15 (Kunick et al., 2015), Tables
+8-13: for each IF97 region we draw random :math:`(p, T)` samples
+log-uniform in pressure and uniform in temperature, retain the ones the
+IF97 region classifier assigns to that region, look up the enthalpy
+:math:`h = h_\\mathrm{IF97}(p, T)` so the comparison can be expressed
+with the published-style backward arguments :math:`(p, h)`, evaluate
+each tested backend at :math:`(h, p)`, and report maximum and
+root-mean-square deviation of the tested backend from IAPWS-IF97 for
+:math:`T(p,h)`, :math:`v(p,h)`, :math:`s(p,h)`, :math:`w(p,h)`,
+:math:`\\eta(p,h)`, and :math:`\\lambda(p,h)`.
+
+Timing: per backend per property, mean wall time for ``PropsSI`` over
+the same sample population, reported as ratio relative to IF97.
+
+The script gracefully skips any backend whose factory string isn't
+available (e.g. on a CoolProp build without the SVDSBTL backend
+plumbed) — that way the docs build never breaks just because a
+backend is missing.
+"""
+from __future__ import print_function
+
+import math
+import os
+import random
+import time
+
+import CoolProp.CoolProp as CP
+
+WEB_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+OUT_PATH = os.path.join(WEB_DIR, 'fluid_properties', 'IF97_conformance.rst.in')
+
+# Truth source for the conformance comparison.
+REFERENCE = 'IF97::Water'
+
+# Backends to test against the reference.  Each entry is rendered as a
+# block of tables; if the backend can't be instantiated the block is
+# skipped (with a placeholder note in the RST).
+TESTED = [
+    ('SVDSBTL&IF97::Water', 'SVDSBTL with IF97 source'),
+]
+
+# Properties to compare.  Each entry: (CoolProp PropsSI key, math symbol,
+# unit, kind, IAPWS perm-value, IAPWS perm-unit, G13-15 table id).
+#   kind = 'rel'  -> relative deviation as %, reported in %
+#   kind = 'abs_T'-> absolute deviation, reported in mK (with x1000)
+#   kind = 'abs_s'-> absolute deviation, reported in 10^-3 J/(kg K)
+PROPERTIES = [
+    ('T', 'T',         'K',        'abs_T', 25.0,    'mK',                       8),
+    ('D', r'\rho',     'kg/m^3',   'rel',   0.001,   r'\%',                      9),
+    ('S', 's',         'J/(kg K)', 'abs_s', 1.0,     r'10^{-3}\ \mathrm{J/(kg\,K)}', 10),
+    ('A', 'w',         'm/s',      'rel',   0.001,   r'\%',                     11),
+    ('V', r'\eta',     'Pa s',     'rel',   0.001,   r'\%',                     12),
+    ('L', r'\lambda',  'W/(m K)',  'rel',   0.001,   r'\%',                     13),
+]
+
+# Property keys we time (must be a subset of the comparison properties).
+TIMING_PROPS = ['T', 'D', 'A', 'V']
+
+# Per-region (T, p) sampling box [K, MPa]. Bounds come from IAPWS-IF97.
+REGION_BOXES = {
+    1: dict(T=(273.15, 623.15), p=(1.0e-3, 100.0)),
+    2: dict(T=(273.15, 1073.15), p=(1.0e-3, 100.0)),
+    3: dict(T=(623.15, 863.15), p=(16.5292, 100.0)),
+    5: dict(T=(1073.15, 2273.15), p=(1.0e-3, 50.0)),
+}
+SAMPLES_PER_REGION = 2000
+SEED = 0xC001DAD
+
+
+# ---------------------------------------------------------------------------
+# IF97 region classifier in (p, T). Bounds + B23 boundary from IF97 Rev.
+# ---------------------------------------------------------------------------
+
+def _p_B23(T_K):
+    """B23 boundary curve p(T) in MPa."""
+    n3 = 0.10192970039326e-2
+    n4 = 0.57254459862746e3
+    n5 = 0.1391883776670e2
+    return n3 * (T_K - n4) ** 2 + n5
+
+
+def _p_sat_MPa(T_K):
+    try:
+        return CP.PropsSI('P', 'T', T_K, 'Q', 0, REFERENCE) / 1e6
+    except Exception:
+        return None
+
+
+def classify_region(T_K, p_MPa):
+    """Return IF97 region index in {1, 2, 3, 5} or None if outside."""
+    if not (273.15 <= T_K <= 2273.15):
+        return None
+    if p_MPa <= 0.0 or p_MPa > 100.0:
+        return None
+    if T_K > 1073.15:
+        return 5 if p_MPa <= 50.0 else None
+    if T_K <= 623.15:
+        psat = _p_sat_MPa(T_K)
+        if psat is None:
+            return None
+        return 1 if p_MPa > psat else 2
+    if T_K <= 863.15 and p_MPa > _p_B23(T_K):
+        return 3
+    return 2
+
+
+# ---------------------------------------------------------------------------
+# Deviation accumulator + property comparison
+# ---------------------------------------------------------------------------
+
+class DevAcc(object):
+    __slots__ = ('n', 'max_abs', 'sum_sq')
+
+    def __init__(self):
+        self.n = 0
+        self.max_abs = 0.0
+        self.sum_sq = 0.0
+
+    def add(self, delta):
+        if delta is None or not math.isfinite(delta):
+            return
+        a = abs(delta)
+        if a > self.max_abs:
+            self.max_abs = a
+        self.sum_sq += a * a
+        self.n += 1
+
+    @property
+    def rms(self):
+        if self.n == 0:
+            return float('nan')
+        return math.sqrt(self.sum_sq / self.n)
+
+
+def _deviation(ref, test, kind):
+    if ref is None or test is None:
+        return None
+    if not math.isfinite(ref) or not math.isfinite(test):
+        return None
+    if kind == 'rel':
+        if abs(ref) < 1e-30:
+            return None
+        # For density we report deviation of v = 1/rho; the table is
+        # built on v so flip the sign convention to match G13-15.
+        return 100.0 * (test - ref) / ref
+    if kind == 'abs_T':
+        return 1000.0 * (test - ref)  # K -> mK
+    if kind == 'abs_s':
+        return 1000.0 * (test - ref)  # J/(kg K) -> 10^-3 J/(kg K)
+    return test - ref
+
+
+def _safe_propssi(key, h, p, backend):
+    try:
+        return CP.PropsSI(key, 'H', h, 'P', p, backend)
+    except Exception:
+        return None
+
+
+def _safe_truth_h(T, p):
+    try:
+        return CP.PropsSI('H', 'T', T, 'P', p, REFERENCE)
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Conformance sweep
+# ---------------------------------------------------------------------------
+
+def backend_available(factory_str):
+    try:
+        CP.PropsSI('T', 'P', 1e5, 'Q', 0, factory_str)
+        return True
+    except Exception:
+        try:
+            CP.PropsSI('D', 'T', 500, 'P', 1e6, factory_str)
+            return True
+        except Exception:
+            return False
+
+
+def run_conformance(backend):
+    """Return (results, counts).
+
+    results[region][prop_key] = DevAcc of (backend - reference) in the
+    table's reported unit. counts[region] = in-region accepted samples.
+    """
+    rng = random.Random(SEED)
+    results = {r: {p[0]: DevAcc() for p in PROPERTIES} for r in REGION_BOXES}
+    counts = {r: 0 for r in REGION_BOXES}
+
+    prop_keys = [p[0] for p in PROPERTIES]
+    kinds = {p[0]: p[3] for p in PROPERTIES}
+
+    for region, box in REGION_BOXES.items():
+        T_lo, T_hi = box['T']
+        p_lo, p_hi = box['p']
+        for _ in range(SAMPLES_PER_REGION):
+            T = rng.uniform(T_lo, T_hi)
+            p_MPa = math.exp(rng.uniform(math.log(p_lo), math.log(p_hi)))
+            if classify_region(T, p_MPa) != region:
+                continue
+            p_Pa = p_MPa * 1e6
+            h = _safe_truth_h(T, p_Pa)
+            if h is None or not math.isfinite(h):
+                continue
+            # Truth values for all comparison properties.
+            ref_vals = {k: _safe_propssi(k, h, p_Pa, REFERENCE) for k in prop_keys}
+            if any(v is None for v in ref_vals.values()):
+                continue
+            test_vals = {k: _safe_propssi(k, h, p_Pa, backend) for k in prop_keys}
+            if any(v is None for v in test_vals.values()):
+                continue
+            counts[region] += 1
+            for k in prop_keys:
+                # v = 1/rho — flip so the table reports v deviation.
+                if k == 'D':
+                    ref_v = 1.0 / ref_vals[k]
+                    test_v = 1.0 / test_vals[k]
+                    results[region][k].add(_deviation(ref_v, test_v, kinds[k]))
+                else:
+                    results[region][k].add(_deviation(ref_vals[k], test_vals[k], kinds[k]))
+    return results, counts
+
+
+# ---------------------------------------------------------------------------
+# Timing sweep
+# ---------------------------------------------------------------------------
+
+def run_timing(backends, rng_seed=0xCAFE):
+    """Mean PropsSI time per (backend, property) over N timing calls.
+
+    Returns timings[backend][prop_key] = ns/call.
+    """
+    rng = random.Random(rng_seed)
+    N = 20000
+    # Pre-build (T, p) state vectors; restrict to a single-phase box so
+    # we don't pay the saturation-flash penalty in the timed loop.
+    T_arr = [rng.uniform(350.0, 800.0) for _ in range(N)]
+    p_arr = [rng.uniform(0.5, 20.0) * 1e6 for _ in range(N)]
+    timings = {}
+    for backend in backends:
+        timings[backend] = {}
+        for prop in TIMING_PROPS:
+            for k in range(min(64, N)):  # warmup
+                try:
+                    CP.PropsSI(prop, 'T', T_arr[k], 'P', p_arr[k], backend)
+                except Exception:
+                    pass
+            t0 = time.perf_counter()
+            ok = 0
+            for k in range(N):
+                try:
+                    CP.PropsSI(prop, 'T', T_arr[k], 'P', p_arr[k], backend)
+                    ok += 1
+                except Exception:
+                    pass
+            t1 = time.perf_counter()
+            timings[backend][prop] = ((t1 - t0) / ok * 1e9) if ok else float('nan')
+    return timings
+
+
+# ---------------------------------------------------------------------------
+# RST rendering
+# ---------------------------------------------------------------------------
+
+def _fmt_dev(value):
+    if value is None or not math.isfinite(value):
+        return '--'
+    return '{:.3g}'.format(value)
+
+
+def _fmt_perm(p):
+    if p >= 1.0:
+        return '{:g}'.format(p)
+    return '{:.3g}'.format(p)
+
+
+def _fmt_ns(ns):
+    if not math.isfinite(ns):
+        return '--'
+    if ns >= 1e6:
+        return '{:.2f} ms'.format(ns / 1e6)
+    if ns >= 1e3:
+        return '{:.2f} us'.format(ns / 1e3)
+    return '{:.0f} ns'.format(ns)
+
+
+def render_rst(results_per_backend, counts_per_backend, timings):
+    lines = []
+    lines.append('')
+    lines.append('.. _IF97-Conformance:')
+    lines.append('')
+    lines.append('IF97 Conformance and Timing')
+    lines.append('---------------------------')
+    lines.append('')
+    lines.append(
+        'The tables in this section are regenerated by '
+        '``Web/scripts/fluid_properties.IF97Conformance.py`` on every '
+        'docs build. The protocol mirrors '
+        ':ref:`IAPWS G13-15 Tables 8-13 <IAPWS-IF97>` '
+        '(Kunick et al., 2015): for each IF97 region we draw '
+        '{n} random :math:`(p, T)` samples log-uniform in pressure and '
+        'uniform in temperature, classify them into the IF97 region atlas, '
+        'compute :math:`h = h_\\mathrm{{IF97}}(p, T)`, evaluate each '
+        'tested backend at :math:`(h, p)`, and tabulate the maximum and '
+        'root-mean-square deviation from IAPWS-IF97 of the six properties '
+        'in G13-15: :math:`T(p,h)`, :math:`v(p,h)`, :math:`s(p,h)`, '
+        ':math:`w(p,h)`, :math:`\\eta(p,h)`, :math:`\\lambda(p,h)`.'
+        .format(n=SAMPLES_PER_REGION))
+    lines.append('')
+
+    backend_titles = dict(TESTED)
+    for backend, _label in TESTED:
+        if backend not in results_per_backend:
+            lines.append('Backend ``{}``: not available on this build.'.format(backend))
+            lines.append('')
+            continue
+        results = results_per_backend[backend]
+        counts = counts_per_backend[backend]
+
+        section_title = 'Deviation of ``{}`` from IAPWS-IF97'.format(backend)
+        lines.append(section_title)
+        lines.append('~' * max(60, len(section_title)))
+        lines.append('')
+
+        for pk, sym, _unit, kind, perm, perm_unit, table_id in PROPERTIES:
+            if kind == 'rel':
+                unit_str = r'\%'
+            elif kind == 'abs_T':
+                unit_str = 'mK'
+            elif kind == 'abs_s':
+                unit_str = r'10^{-3}\ \mathrm{J/(kg\,K)}'
+            else:
+                unit_str = perm_unit
+
+            prop_sym = sym if pk != 'D' else 'v'  # density → specific volume
+            lines.append('')
+            lines.append(
+                '*G13-15 Table {tid}* — :math:`{psym}(p,h)`, '
+                'permissible :math:`|\\Delta {psym}|_\\mathrm{{perm}} = {perm}\\ {pu}`.'
+                .format(tid=table_id, psym=prop_sym, perm=_fmt_perm(perm), pu=unit_str))
+            lines.append('')
+            lines.append('.. list-table::')
+            lines.append('   :header-rows: 1')
+            lines.append('   :widths: 12 18 22 22')
+            lines.append('')
+            lines.append('   * - IF97 Region')
+            lines.append('     - in-region samples')
+            lines.append('     - :math:`|\\Delta {0}|_{{\\max}}` [{1}]'.format(prop_sym, unit_str))
+            lines.append('     - :math:`(\\Delta {0})_{{\\mathrm{{RMS}}}}` [{1}]'.format(prop_sym, unit_str))
+            for region in sorted(REGION_BOXES):
+                acc = results[region][pk]
+                lines.append('   * - {}'.format(region))
+                lines.append('     - {}'.format(acc.n))
+                lines.append('     - {}'.format(_fmt_dev(acc.max_abs)))
+                lines.append('     - {}'.format(_fmt_dev(acc.rms)))
+        lines.append('')
+
+    # ------------------------------------------------------------------
+    # Timing table
+    # ------------------------------------------------------------------
+    if timings:
+        lines.append('Backend timing (PT inputs)')
+        lines.append('~~~~~~~~~~~~~~~~~~~~~~~~~~')
+        lines.append('')
+        lines.append(
+            'Mean wall time per ``PropsSI`` call for property look-ups at '
+            'random :math:`(T, p)` in the single-phase region '
+            ':math:`T \\in [350, 800]` K, :math:`p \\in [0.5, 20]` MPa. '
+            'The ratio column is :math:`t_{\\mathrm{backend}} / '
+            't_{\\mathrm{IF97}}`. Lower is faster than IF97. '
+            'Absolute timings depend on hardware; the **ratios** are the '
+            'load-bearing quantity. CI rebuilds these on a GitHub-hosted '
+            'runner.')
+        lines.append('')
+        lines.append('.. list-table::')
+        lines.append('   :header-rows: 1')
+        lines.append('   :widths: 22 12 12 12 12 14')
+        lines.append('')
+        header = ['   * - Backend']
+        for prop in TIMING_PROPS:
+            header.append('     - {}'.format(prop))
+        header.append('     - mean ratio vs IF97')
+        lines.extend(header)
+
+        baseline = timings.get(REFERENCE, {})
+        ordered = [REFERENCE] + [b for b, _ in TESTED if b in timings]
+        for backend in ordered:
+            bt = timings.get(backend, {})
+            if not bt:
+                continue
+            row = ['   * - ``{}``'.format(backend)]
+            ratios = []
+            for prop in TIMING_PROPS:
+                row.append('     - {}'.format(_fmt_ns(bt.get(prop, float('nan')))))
+                base = baseline.get(prop, float('nan'))
+                this = bt.get(prop, float('nan'))
+                if math.isfinite(base) and base > 0 and math.isfinite(this):
+                    ratios.append(this / base)
+            row.append('     - {:.2f}'.format(sum(ratios) / len(ratios)) if ratios else '     - --')
+            lines.extend(row)
+        lines.append('')
+    return '\n'.join(lines) + '\n'
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    print('IF97 conformance script: starting')
+    results_per_backend = {}
+    counts_per_backend = {}
+    available = [REFERENCE]
+    for backend, label in TESTED:
+        if not backend_available(backend):
+            print('  {} unavailable — skipping'.format(backend))
+            continue
+        print('  sweeping {} ({})'.format(backend, label))
+        results, counts = run_conformance(backend)
+        results_per_backend[backend] = results
+        counts_per_backend[backend] = counts
+        available.append(backend)
+        print('    in-region counts: {}'.format(counts))
+
+    print('  timing pass over {}'.format(available))
+    timings = run_timing(available)
+
+    rst = render_rst(results_per_backend, counts_per_backend, timings)
+    with open(OUT_PATH, 'w') as fp:
+        fp.write(rst)
+    print('Wrote {}'.format(OUT_PATH))
+
+
+if __name__ == '__main__':
+    main()

--- a/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
+++ b/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
@@ -139,6 +139,8 @@ class SVDSBTLBackend : public AbstractState
     CoolPropDbl calc_umolar() override;
 
     CoolPropDbl calc_speed_sound() override;
+    CoolPropDbl calc_viscosity() override;
+    CoolPropDbl calc_conductivity() override;
 
     CoolPropDbl calc_molar_mass() override;
     CoolPropDbl calc_gas_constant() override;

--- a/include/CoolProp/sbtl/SVDSurfaceSerializer.h
+++ b/include/CoolProp/sbtl/SVDSurfaceSerializer.h
@@ -80,7 +80,12 @@ class SVDSurfaceSerializer
     //          opthash over the canonical-JSON options blob.  No
     //          on-wire format change; just a path change.  Old rev-3
     //          int-keyed caches simply won't be picked up.
-    static constexpr int kRevision = 4;
+    //   rev 5: ph_properties / pt_properties extended with transport
+    //          properties (η, λ) for IAPWS G13-15 Tables 12 & 13.
+    //          Old rev-4 caches are missing two properties at the
+    //          tail; bump to force rebuild rather than try to silently
+    //          extend them in-place.
+    static constexpr int kRevision = 5;
 
     // Pack one surface into a zlib-compressed msgpack blob.
     static std::vector<char> save(const SVDSurface& surface);

--- a/src/Backends/IF97/IF97Backend.h
+++ b/src/Backends/IF97/IF97Backend.h
@@ -58,10 +58,18 @@ class IF97Backend : public AbstractState
 
     /// Override clear() function of IF97 Water
     bool clear() {
-        // Reset all instances of CachedElement and overwrite
-        // the internal double values with -_HUGE
-        // Default phase condition is no phase imposed
-        // IF97 will make phase/region determination
+        // Reset the full CachedElement registry so every cached value
+        // (speed_sound, cpmass, cvmass, umass, ...) gets invalidated
+        // alongside the IF97-specific fields the override knows about.
+        // Without `cache.clear()`, a backend instance reused across
+        // multiple update() calls would return stale property values
+        // for any CachedElement not in the manual clear-list below.
+        // This bit users of the SBTL surface sampler in particular,
+        // which reuses one AbstractState across thousands of (T, p)
+        // cells and was getting a constant speed_sound surface as a
+        // result.
+        cache.clear();
+
         this->_T = -_HUGE;
         this->_p = -_HUGE;
         this->_Q = -_HUGE;

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -493,6 +493,21 @@ CoolPropDbl SVDSBTLBackend::calc_speed_sound() {
     }
     return lookup_(ispeed_sound);
 }
+CoolPropDbl SVDSBTLBackend::calc_viscosity() {
+    if (two_phase_.active) {
+        // Viscosity has saturated-side values but no equilibrium bulk
+        // value inside the dome; G13-15 Table 12 is only defined off
+        // the saturation curve.  Mirror HEOS / IF97 and throw.
+        throw NotImplementedError("SVDSBTL backend: viscosity is not defined in the two-phase region");
+    }
+    return lookup_(iviscosity);
+}
+CoolPropDbl SVDSBTLBackend::calc_conductivity() {
+    if (two_phase_.active) {
+        throw NotImplementedError("SVDSBTL backend: conductivity is not defined in the two-phase region");
+    }
+    return lookup_(iconductivity);
+}
 CoolPropDbl SVDSBTLBackend::calc_pressure() {
     return _p;
 }

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -22,26 +22,62 @@ namespace {
 // axis), so the outputs are ρ, T, s, u, w (speed of sound).  Density
 // is log-transformed (EXP) since it varies over orders of magnitude
 // across LIQUID + VAPOR; the rest are identity-transformed.
-std::vector<PropertySpec> ph_properties() {
-    return {
+// Returns true if the source backend can compute the given transport
+// property at a benign single-phase probe point.  Used to gate
+// inclusion of η / λ in the tabulated property list — fluids whose
+// HEOS model lacks a transport correlation (e.g. some siloxanes) get
+// a slimmer table rather than an all-NaN sampling failure.
+bool source_supports_transport_(::CoolProp::AbstractState& src, ::CoolProp::parameters key) {
+    const double T = 0.85 * src.T_critical();
+    const double p = 0.50 * src.p_critical();
+    try {
+        src.update(::CoolProp::PT_INPUTS, p, T);
+        double v = (key == ::CoolProp::iviscosity) ? src.viscosity() : src.conductivity();
+        return std::isfinite(v);
+    } catch (...) {  // NOLINT(bugprone-empty-catch)
+        return false;
+    }
+}
+
+std::vector<PropertySpec> ph_properties(::CoolProp::AbstractState& src) {
+    std::vector<PropertySpec> ps = {
       {::CoolProp::iDmass, svd::OutputTransform::EXP},
       {::CoolProp::iT, svd::OutputTransform::IDENTITY},
       {::CoolProp::iSmass, svd::OutputTransform::IDENTITY},
       {::CoolProp::iUmass, svd::OutputTransform::IDENTITY},
       {::CoolProp::ispeed_sound, svd::OutputTransform::IDENTITY},
     };
+    // Transport properties — IAPWS G13-15 Tables 12 (η) and 13 (λ).
+    // Both span ~5 orders of magnitude across the (p, h) envelope so
+    // they ride the EXP transform alongside density.  Only added if
+    // the source backend actually exposes them (some fluids' HEOS
+    // models lack transport correlations entirely).
+    if (source_supports_transport_(src, ::CoolProp::iviscosity)) {
+        ps.push_back({::CoolProp::iviscosity, svd::OutputTransform::EXP});
+    }
+    if (source_supports_transport_(src, ::CoolProp::iconductivity)) {
+        ps.push_back({::CoolProp::iconductivity, svd::OutputTransform::EXP});
+    }
+    return ps;
 }
 
 // Shared property list for PT_INPUTS: T is the input (secondary
 // axis), so outputs are ρ, h, s, u, w (speed of sound).
-std::vector<PropertySpec> pt_properties() {
-    return {
+std::vector<PropertySpec> pt_properties(::CoolProp::AbstractState& src) {
+    std::vector<PropertySpec> ps = {
       {::CoolProp::iDmass, svd::OutputTransform::EXP},
       {::CoolProp::iHmass, svd::OutputTransform::IDENTITY},
       {::CoolProp::iSmass, svd::OutputTransform::IDENTITY},
       {::CoolProp::iUmass, svd::OutputTransform::IDENTITY},
       {::CoolProp::ispeed_sound, svd::OutputTransform::IDENTITY},
     };
+    if (source_supports_transport_(src, ::CoolProp::iviscosity)) {
+        ps.push_back({::CoolProp::iviscosity, svd::OutputTransform::EXP});
+    }
+    if (source_supports_transport_(src, ::CoolProp::iconductivity)) {
+        ps.push_back({::CoolProp::iconductivity, svd::OutputTransform::EXP});
+    }
+    return ps;
 }
 
 }  // namespace
@@ -61,7 +97,7 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
     spec.NT = NT;
     spec.NR = NR;
     spec.rank = rank;
-    spec.properties = ph_properties();
+    spec.properties = ph_properties(heos);
 
     // LIQUID region: primary = log p, secondary = h.
     //   b_lo = h(T_min, p) — non-isothermal floor that walks T up
@@ -113,6 +149,10 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
                 return s.umass();
             case ::CoolProp::ispeed_sound:
                 return s.speed_sound();
+            case ::CoolProp::iviscosity:
+                return s.viscosity();
+            case ::CoolProp::iconductivity:
+                return s.conductivity();
             default:
                 throw std::invalid_argument("ph_subcritical: unsupported output property");
         }
@@ -174,7 +214,7 @@ SurfaceSpec pt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
     spec.NT = NT;
     spec.NR = NR;
     spec.rank = rank;
-    spec.properties = pt_properties();
+    spec.properties = pt_properties(heos);
 
     // For PT_INPUTS the secondary axis is T (instead of h for PH).
     // The b_lo / b_hi curves return T values, not h values.  Reuse
@@ -225,6 +265,10 @@ SurfaceSpec pt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
                 return s.umass();
             case ::CoolProp::ispeed_sound:
                 return s.speed_sound();
+            case ::CoolProp::iviscosity:
+                return s.viscosity();
+            case ::CoolProp::iconductivity:
+                return s.conductivity();
             default:
                 throw std::invalid_argument("pt_subcritical: unsupported output property");
         }

--- a/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
+++ b/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
@@ -80,7 +80,11 @@ TEST_CASE("SVDSurface PH preset builds + evals against HEOS", "[SBTL][SVDSurface
     auto spec = cp_sbtl::presets::ph_subcritical(*heos, /*NT=*/40, /*NR=*/80, /*rank=*/10);
     REQUIRE(spec.input_pair == ::CoolProp::HmassP_INPUTS);
     REQUIRE(spec.regions.size() == 3);
-    REQUIRE(spec.properties.size() == 5);
+    // 5 thermodynamic properties (ρ, T, s, u, w) plus 2 optional
+    // transport properties (η, λ) when the source backend exposes them
+    // — HEOS Water does, so we expect 7 here.  Fluids without transport
+    // correlations get only the 5 thermodynamic properties.
+    REQUIRE(spec.properties.size() == 7);
 
     auto surface = cp_sbtl::build_surface(*heos, std::move(spec));
     REQUIRE(surface.sealed());

--- a/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
+++ b/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
@@ -7,6 +7,7 @@
 #if defined(ENABLE_CATCH)
 #    include <catch2/catch_all.hpp>
 
+#    include <algorithm>
 #    include <filesystem>
 #    include <memory>
 #    include <random>
@@ -85,6 +86,16 @@ TEST_CASE("SVDSurface PH preset builds + evals against HEOS", "[SBTL][SVDSurface
     // — HEOS Water does, so we expect 7 here.  Fluids without transport
     // correlations get only the 5 thermodynamic properties.
     REQUIRE(spec.properties.size() == 7);
+    auto spec_has = [&spec](::CoolProp::parameters key) {
+        return std::any_of(spec.properties.begin(), spec.properties.end(), [key](const cp_sbtl::PropertySpec& ps) { return ps.key == key; });
+    };
+    REQUIRE(spec_has(::CoolProp::iDmass));
+    REQUIRE(spec_has(::CoolProp::iT));
+    REQUIRE(spec_has(::CoolProp::iSmass));
+    REQUIRE(spec_has(::CoolProp::iUmass));
+    REQUIRE(spec_has(::CoolProp::ispeed_sound));
+    REQUIRE(spec_has(::CoolProp::iviscosity));
+    REQUIRE(spec_has(::CoolProp::iconductivity));
 
     auto surface = cp_sbtl::build_surface(*heos, std::move(spec));
     REQUIRE(surface.sealed());


### PR DESCRIPTION
## Summary

- **`fix(if97)`**: `IF97Backend::clear()` was hand-clearing five fields but skipping `cache.clear()`. `_speed_sound` (and `_cpmass`, `_cvmass`, `_umass`, ...) stayed stuck at whatever the first `update()` set on a given backend instance and was returned for every subsequent property read. Invisible when each state owns its own backend; catastrophic when the SBTL surface sampler reuses one IF97 instance across hundreds of thousands of cells (flat ≈1402.29 m/s w surface; SVDSBTL&IF97 R7-97 conformance off by 8–25 %). Adding `cache.clear()` at the top of the override flushes the full `CachedElement` registry. Closes **CoolProp-ob7**.
- **`feat(svdsbtl)`**: tabulate `η` and `λ` on both ph_subcritical and pt_subcritical presets so SVDSBTL can serve transport properties through the same SVD lookup path it already uses for `ρ / h / s / w` (IAPWS G13-15 Tables 12 & 13). Property list is built dynamically per source — fluids whose HEOS model lacks transport correlations get a slimmer table instead of an all-NaN sampling failure. `SVDSBTLBackend::calc_viscosity` / `calc_conductivity` route through `lookup_()` with the same two-phase guard as `speed_sound`. Cache `kRevision` bumped 3 → 4 to invalidate the old layout.
- **`docs(if97)`**: new `Web/scripts/fluid_properties.IF97Conformance.py` runs on every docs build and emits an `.rst.in` include for the IF97 page. Mirrors IAPWS G13-15 (Kunick et al., 2015) Tables 8–13 — per-region stochastic max/RMS deviation of each tested backend vs IF97 for `T(p,h)`, `v(p,h)`, `s(p,h)`, `w(p,h)`, `η(p,h)`, `λ(p,h)`, plus a per-backend `PropsSI` timing table with a ratio column normalised to IF97 = 1.

## Test plan

- [x] `[SVDSBTL]~[!mayfail]` Catch2 suite: 24 / 24 pass (3 REFPROP-dependent SKIPPED).
- [x] SVDSBTL&IF97 IAPWS R7-97 R1 / R2 / R4 conformance now passes (R3 still `!mayfail` for the rank-truncation reason; that's the upcoming critical-patch PR).
- [x] Docs script runs locally (degraded: SVDSBTL&IF97 unavailable in installed wheel → graceful skip + placeholder row; IF97 timing renders).
- [ ] CI build of the docs picks up the new include and renders the full table set against the freshly-built SVDSBTL&IF97 backend.
- [ ] CI `clang-format (PR diff)` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated IF97 conformance and timing tables added to docs generation; corresponding script integrated into the build pipeline.
  * Surface calculations now include transport properties (viscosity, thermal conductivity) when supported by the backend.

* **Bug Fixes**
  * Improved cache invalidation to prevent stale property values when backend instances are reused.

* **Chores**
  * On-wire surface cache revision bumped, forcing rebuild of cached surface data.

* **Tests**
  * Tests updated to account for optional transport properties in surface presets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2923?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->