### PR TITLE
Generic backend options via factory-string JSON (PR A — infrastructure)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2102,6 +2102,8 @@ if(COOLPROP_CATCH_MODULE)
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-SBTLAdapter.cpp")
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-SVDSBTL.cpp")
+  list(APPEND APP_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-FactoryOptions.cpp")
 
   # CATCH TEST, compile everything with catch and set test entry point
   add_executable(CatchTestRunner ${APP_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2104,6 +2104,8 @@ if(COOLPROP_CATCH_MODULE)
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-SVDSBTL.cpp")
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-FactoryOptions.cpp")
+  list(APPEND APP_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-SchemaValidation.cpp")
 
   # CATCH TEST, compile everything with catch and set test entry point
   add_executable(CatchTestRunner ${APP_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2106,6 +2106,8 @@ if(COOLPROP_CATCH_MODULE)
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-FactoryOptions.cpp")
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-SchemaValidation.cpp")
+  list(APPEND APP_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-PropsSIOptions.cpp")
 
   # CATCH TEST, compile everything with catch and set test entry point
   add_executable(CatchTestRunner ${APP_SOURCES})

--- a/Web/coolprop/BackendOptions.rst
+++ b/Web/coolprop/BackendOptions.rst
@@ -1,0 +1,247 @@
+.. _backend-options:
+
+***************
+Backend Options
+***************
+
+Per-instance backend configuration is passed through the factory string
+as a JSON suffix.  The mechanism is opt-in per backend, immutable after
+construction, available identically from every language that wraps
+CoolProp, and works through both the :ref:`high-level <high_level_api>`
+and :ref:`low-level <low_level_api>` interfaces.
+
+.. _backend-options-grammar:
+
+Grammar
+=======
+
+Append ``?<options>`` to the factory string:
+
+.. code-block:: text
+
+   SVDSBTL&HEOS::Water                                  ← no options, all schema defaults
+   SVDSBTL&HEOS::Water?{"critical_patch":"off"}         ← inline JSON
+   SVDSBTL&HEOS::Water?@/path/to/cfg.json               ← file indirection
+   HEOS::Water?{}                                       ← empty options (no-op)
+
+The parser splits on the **first** ``?`` and treats the entire remainder
+as a single JSON value (or, if it begins with ``@``, as a file path
+read verbatim).  Any subsequent ``?`` characters — inside a JSON string
+value, in a URL embedded in a value, in a file path after ``@`` — are
+preserved as-is.
+
+Options live in either the backend or the fluid half of the factory
+string (whichever your call site finds convenient).  If both halves
+carry an options suffix, factory construction throws a ``ValueError``
+to flag the typo.
+
+.. _backend-options-highlevel:
+
+Use from the high-level interfaces
+==================================
+
+The factory string is parsed in exactly one place inside CoolProp
+(``AbstractState::factory``).  Every wrapper that takes a fluid name
+forwards it verbatim, so the ``?<options>`` syntax works from any
+language with no per-wrapper changes:
+
+**Python**
+
+.. code-block:: python
+
+   from CoolProp.CoolProp import PropsSI
+   PropsSI("D", "T", 300, "P", 1e5,
+           'SVDSBTL&HEOS::Water?{"critical_patch":"off"}')
+
+**FORTRAN**
+
+.. code-block:: fortran
+
+   d = PropsSI('D'//c_null_char, 'T'//c_null_char, 300.0_dp, &
+               'P'//c_null_char, 1.0e5_dp, &
+               'SVDSBTL&HEOS::Water?@/opt/coolprop/h2o.json'//c_null_char)
+
+**Excel / LibreOffice Calc**
+
+.. code-block:: text
+
+   =PropsSI("D";"T";300;"P";1E5;"SVDSBTL&HEOS::Water?@C:\Configs\h2o.json")
+
+**MATLAB**
+
+.. code-block:: matlab
+
+   d = py.CoolProp.CoolProp.PropsSI('D','T',300,'P',1e5, ...
+           'SVDSBTL&HEOS::Water?@~/coolprop/opts.json');
+
+For Excel / FORTRAN / similar interfaces where embedding inline JSON
+gets painful (quote escaping, cell length limits, etc.), the
+``?@<path>`` form is the recommended path — write the JSON once to a
+file, reference the path on every call.
+
+.. _backend-options-schema:
+
+Strict validation
+=================
+
+Every options-aware backend ships a JSON Schema (Draft 2020-12) that
+the factory validates against on every call:
+
+* Unknown keys throw — typos surface immediately rather than silently
+  defaulting.
+* Type mismatches throw — strings vs numbers vs booleans are checked
+  per the schema.
+* Required keys missing throw with the dotted path of the missing field.
+* Enum violations throw with the offending value plus the allowed set.
+
+Schemas live alongside the headers in
+``include/CoolProp/schemas/<backend>.schema.json``.  Each opted-in
+backend exposes its schema as a constant string literal compiled into
+the binary — no runtime file lookups, no version-skew between docs and
+runtime.
+
+The schema is itself versioned (``"schema": 1`` at the top level) so
+the layout can evolve with explicit migration support.
+
+.. _backend-options-canonical:
+
+Reproducibility — ``build_options_json()`` and cache keys
+=========================================================
+
+Two callers need a single canonical form per logically-equal options
+value: cache filename hashing (so two callers passing the same options
+in different key orders hit the same cache file) and reproducibility
+logging.  The shared helper:
+
+* Sorts object keys recursively.
+* Preserves array order.
+* Uses RapidJSON's default formatting for scalars (deterministic
+  within a single CoolProp build).
+
+It is **not** strict `RFC 8785 (JCS)
+<https://datatracker.ietf.org/doc/html/rfc8785>`_ — no NFC string
+normalisation, no ECMAScript number rounding — but it's
+deterministic within a single CoolProp build, which is all the cache
+key needs.
+
+Every ``AbstractState`` exposes:
+
+.. code-block:: cpp
+
+   virtual std::string build_options_json() const;
+
+Returns the canonical-JSON string the instance was built with
+(defaults expanded).  Default is the empty string; backends that
+accept options override to return the canonical form so callers can
+copy-paste it into a fresh ``factory()`` call and reproduce the
+construction byte-for-byte.
+
+For caching backends (SVDSBTL today), the cache filename incorporates
+a 16-hex-character FNV-1a 64 prefix of the canonical bytes alongside
+fluid name, source backend, and symbolic input-pair name.  FNV-1a 64
+is the same hash family CoolProp already uses for the superancillary
+``source_eos_hash`` freshness stamp — no new dependencies, identical
+determinism guarantees across compilers.
+
+.. _backend-options-opting-in:
+
+Opting a backend in
+===================
+
+Backends that want to consume options publish a JSON Schema and
+override the options-aware ``AbstractStateGenerator`` virtual:
+
+.. code-block:: cpp
+
+   class MyBackendGenerator : public AbstractStateGenerator {
+    public:
+       AbstractState* get_AbstractState(
+           const std::vector<std::string>& fluid_names,
+           const std::string& options_json) override {
+           rapidjson::Document opts;
+           if (!options_json.empty()) opts.Parse(options_json);
+           else                       opts.SetObject();
+           validate_against_schema(opts, kMyBackendOptionsSchemaJson);
+           // ...construct using the parsed options...
+       }
+       AbstractState* get_AbstractState(
+           const std::vector<std::string>& fluid_names) override {
+           return get_AbstractState(fluid_names, "");
+       }
+   };
+
+The default implementation of the options-aware overload forwards to
+the no-options overload when ``options_json`` is empty / ``"{}"`` and
+throws ``NotImplementedError`` otherwise — so backends that haven't
+opted in reject options loudly instead of silently dropping them.
+
+.. _backend-options-migration:
+
+Migration from Configuration globals
+====================================
+
+The ``Configuration`` mechanism is process-global and stringly-typed.
+Several backend knobs that are currently Configuration globals are
+better expressed as per-instance options.  Over time the following
+mappings will land as deprecations of the corresponding globals:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 32 40
+
+   * - Backend
+     - Today (Configuration global)
+     - After migration (options key)
+   * - SVDSBTL
+     - *(none — new backend)*
+     - ``grid``, ``properties``, ``critical_patch``
+   * - BICUBIC
+     - ``BICUBIC_GRID_NT``, ``BICUBIC_GRID_NR``
+     - ``grid.NT``, ``grid.NR``
+   * - TTSE
+     - ``TTSE_GRID_NT``, ``TTSE_GRID_NR``
+     - ``grid.NT``, ``grid.NR``
+   * - REFPROP
+     - ``ALTERNATIVE_REFPROP_LIBRARY_PATH``,
+       ``ALTERNATIVE_REFPROP_HMX_BNC_PATH``,
+       ``ALTERNATIVE_REFPROP_PATH``
+     - ``library_path``, ``hmx_path``, ``root_path``
+
+Each follow-up PR ships its backend's schema, an opt-in for the
+options-aware overload, and a deprecation warning emitted whenever
+the corresponding Configuration global is set.  Existing scripts that
+rely on the Configuration globals keep working through at least one
+release cycle.
+
+.. _backend-options-rationale:
+
+Design rationale
+================
+
+A short tour of why the design lands where it does:
+
+* **Why not mutators?**  ``set_<knob>()`` methods make caching brittle
+  (cache key would have to reflect every post-construction setting)
+  and pessimise reproducibility.  The factory-string form is the
+  single source of truth, baked into the cache key, and round-trips
+  through ``build_options_json()``.
+* **Why not Configuration globals?**  Process-global state forbids
+  mixing two backends with different policies in the same process,
+  silently inherits across unrelated code, and rides outside the
+  cache key.  The factory-string form is per-instance and explicit.
+* **Why not a builder API?**  Wrapper bridges (SWIG, Cython,
+  Mathematica) would each need per-method bindings.  The string-only
+  factory entry-point requires zero new wrapper code.
+* **Why JSON over query-string ("``?critical_patch=off&NT=200``")?**
+  JSON gives typed nested structures (``critical_patch.tolerance``
+  next to ``critical_patch.bbox`` without flat-key collisions), and
+  the schema evolution story is straightforward.  The high-level
+  ``?@path.json`` indirection sidesteps the inline-quoting tax.
+* **Why split on the first ``?`` only?**  Any other rule re-introduces
+  parser ambiguity for URLs and regexes inside JSON string values.
+  JSON's quoting rules are the source of truth for everything after
+  the first ``?``.
+
+See the design document
+``docs/superpowers/specs/2026-05-16-backend-options-string-design.md``
+for the full decision trail.

--- a/Web/coolprop/index.rst
+++ b/Web/coolprop/index.rst
@@ -11,6 +11,7 @@ This section includes information about the CoolProp software, listings of input
     HighLevelAPI.rst
     LowLevelAPI.rst
     Tabular.rst
+    BackendOptions.rst
     Configuration.rst
     REFPROP.rst
     Cubics.rst

--- a/docs/superpowers/specs/2026-05-16-backend-options-string-design.md
+++ b/docs/superpowers/specs/2026-05-16-backend-options-string-design.md
@@ -94,6 +94,45 @@ if (pos == std::string::npos) {
 inside the JSON value (or inside the file path for `@…`) and are handled
 by the JSON parser's quoting rules, not by the factory-string parser.
 
+### High-level interface support (PropsSI, FORTRAN, Excel)
+
+The factory string is parsed in exactly one place
+(`AbstractState::factory()`), and `PropsSI` / `Props1SI` /
+`PhaseSI` etc. forward their `FluidName` argument through that same
+parser unchanged. Consequence: the `?<options>` suffix works
+identically for callers stuck on the high-level interface, with **no
+new entry-points and no per-language wrapper changes**:
+
+```python
+# Python
+PropsSI("D", "T", 300, "P", 1e5,
+        'SVDSBTL&HEOS::Water?{"critical_patch":"off"}')
+```
+
+```fortran
+! FORTRAN — escape quotes per host language rules
+d = PropsSI('D'//c_null_char, 'T'//c_null_char, 300.0_dp, &
+            'P'//c_null_char, 1.0e5_dp, &
+            'SVDSBTL&HEOS::Water?@/opt/coolprop/h2o_no_patch.json'//c_null_char)
+```
+
+```excel
+=PropsSI("D";"T";300;"P";1E5;"SVDSBTL&HEOS::Water?@C:\Configs\h2o.json")
+```
+
+```matlab
+% MATLAB
+d = py.CoolProp.CoolProp.PropsSI('D','T',300,'P',1e5, ...
+        'SVDSBTL&HEOS::Water?@~/coolprop/opts.json');
+```
+
+For inline JSON the host language's string-quoting rules apply
+(escape `"` as `\"` in C-family, doubled `""` in Excel, etc.). When
+the quoting becomes painful — Excel cells especially are limited to
+~32k chars and don't escape gracefully — the `?@path.json` form
+sidesteps escaping entirely and is the recommended path for
+high-level interfaces.
+
 ### Schema (initial, for SVDSBTL)
 
 ```jsonc
@@ -284,6 +323,20 @@ equivalent.
 - Round-trip: `build_options_json()` output, fed back into the factory,
   produces an instance with identical `build_options_json()`.
 
+### High-level-interface pass-through
+
+- `PropsSI("D", "T", 300, "P", 1e5,
+   'SVDSBTL&HEOS::Water?{"critical_patch":"off"}')` returns a finite
+   density and matches the result of constructing the same backend
+   via `AbstractState::factory()` with the same string.
+- `PropsSI(..., 'SVDSBTL&HEOS::Water?@/tmp/cfg.json')` reads the file
+   and applies the options. A missing file throws the same
+   `FileIOError` PropsSI surfaces as a CoolProp error message — no
+   silent fallback to defaults.
+- A round-trip from `build_options_json()` through PropsSI's
+   FluidName argument produces a backend with identical canonical
+   options.
+
 ### SVDSBTL behavioural tests
 
 - `critical_patch=off` → backend instance has the patch disabled;
@@ -352,3 +405,7 @@ release-cycle of overlap before the Configuration globals are removed.
       different filenames.
 - [ ] At least one BICUBIC / TTSE follow-up PR filed (not landed) to
       verify the mechanism generalizes.
+- [ ] PropsSI / Props1SI / PhaseSI accept the `?<options>` suffix
+      verbatim in their `FluidName` argument — both inline JSON and
+      `@path` forms exercised in tests, Python wrapper through to the
+      C++ entry-point.

--- a/docs/superpowers/specs/2026-05-16-backend-options-string-design.md
+++ b/docs/superpowers/specs/2026-05-16-backend-options-string-design.md
@@ -1,0 +1,354 @@
+# Backend options via factory-string JSON
+
+**Status:** draft — for review
+**Owner:** Ian Bell
+**Tracking:** CoolProp-vh0 (epic)
+**Date:** 2026-05-16
+
+## Problem
+
+Several CoolProp backends need per-instance configuration that doesn't fit
+the current model:
+
+- **SVDSBTL** (the immediate driver): the critical-patch HEOS-fallback
+  needs a per-fluid bounding box in (T, p). Today there's no per-fluid
+  configuration, only Configuration globals; Ian flagged this in the
+  earlier SVDSBTL review:
+
+  > I don't want to hardcode. Something automatic is needed and/or
+  > something the user can override/control at runtime.
+
+  Auto-calibration covers "automatic". This spec covers "the override".
+
+- **BICUBIC / TTSE**: grid resolution, axis ranges, and refinement
+  policies are currently process-global via `Configuration`. Per-instance
+  tweaks aren't expressible.
+
+- **REFPROP**: `ALTERNATIVE_REFPROP_LIBRARY_PATH`, `_HMX_BNC_PATH`,
+  `_PATH` are all Configuration globals. Switching libraries inside a
+  single Python process is awkward / impossible.
+
+The current `Configuration` mechanism is process-global and stringly-
+typed; once set, every subsequent backend instantiation inherits it,
+which makes mixing two SVDSBTL backends with different policies in the
+same process effectively impossible.
+
+## Goal
+
+Add a single, **immutable**, **per-instance** option-passing mechanism
+that:
+
+1. Threads options through the factory entry-point in a way that
+   composes cleanly with `PropsSI` one-liners.
+2. Is **typed and nestable** — schema can grow without grammar evolution.
+3. Is **strict** — unknown keys throw at construction time; no silent
+   drift across CoolProp versions.
+4. Is **canonical** — the same logical options produce the same bytes,
+   so options participate in cache-key hashing.
+5. Is **reproducible** — `AS->build_options_json()` returns the exact
+   canonical form the instance was built with; copying it into a fresh
+   `factory()` call replays the construction.
+6. Is **backend-agnostic** — the mechanism lives in `AbstractState`
+   plumbing, not in any single backend.
+
+Explicit non-goals:
+
+- **No mutators.** Options are construction-time only. Want different
+  options? Construct a different `AbstractState`.
+- **No Configuration globals as defaults.** The factory string is the
+  single source of truth. Shared defaults live in a JSON file the user
+  references via `?@path.json`.
+- **No per-`PropsSI`-call options.** The factory call is the only place
+  options enter.
+
+## Design
+
+### Grammar
+
+The existing factory string accepts an optional `?<options>` suffix:
+
+```text
+SVDSBTL&HEOS::Water
+SVDSBTL&HEOS::Water?{"critical_patch":"off"}
+SVDSBTL&HEOS::Water?@/path/to/cfg.json
+HEOS::CarbonDioxide?{"phase_envelope":{"max_steps":500}}
+```
+
+Parsing is intentionally dumb:
+
+```cpp
+auto pos = factory_string.find_first_of('?');
+if (pos == std::string::npos) {
+    options_json = "{}";
+    cleaned    = factory_string;
+} else {
+    cleaned    = factory_string.substr(0, pos);
+    auto tail  = factory_string.substr(pos + 1);
+    if (tail.empty())            options_json = "{}";
+    else if (tail[0] == '@')     options_json = read_file(tail.substr(1));
+    else                         options_json = tail;            // inline JSON
+}
+```
+
+`find_first_of('?')` is called **once**. Any further `?` characters are
+inside the JSON value (or inside the file path for `@…`) and are handled
+by the JSON parser's quoting rules, not by the factory-string parser.
+
+### Schema (initial, for SVDSBTL)
+
+```jsonc
+{
+  "schema": 1,
+  "grid": { "NT": 200, "NR": 800, "rank": 20 },
+  "properties": {
+    "transport": "auto"                    // auto | on | off
+  },
+  "critical_patch": {
+    "mode": "auto",                        // auto | off | fixed
+    "source": null,                        // null = same as truth source
+    "tolerance": 1e-3,                     // auto-cal target residual
+    "metric": "D",                         // D | A | H — auto-cal residual metric
+    "bbox": null                           // [Tlo, Thi, plo, phi] when mode=="fixed"
+  }
+}
+```
+
+Nested objects let `critical_patch.tolerance` and `critical_patch.bbox`
+coexist without flat-key collisions and leave room for `regions: {"R3":
+{...}}` later. `schema` is the migration anchor — bump it, write a
+migrator if a key moves.
+
+Schema is published as a JSON Schema document (Draft 2020-12) in
+`schemas/svdsbtl_options.schema.json`, rendered into the Sphinx docs.
+
+### Validation
+
+A shared helper `validate_against_schema(json_value, schema_document)`
+runs at factory time. Default mode is **strict**:
+
+- Unknown keys → throw.
+- Type mismatch → throw.
+- Required keys missing → throw.
+
+No `strict=false` toggle in the initial release. If we want one later
+it's a per-backend `"strict": false` in the JSON itself, not a global.
+
+### Canonical serialization
+
+Cache hashing and reproducibility both need a single canonical form per
+logical-options-value. We use [RFC 8785 JCS][jcs]: sort keys
+recursively, normalize number representation, UTF-8 NFC for strings,
+arrays preserve order. The canonical bytes are the input to:
+
+- **`AbstractState::build_options_json()`** — returns the canonical
+  string for the instance.
+- **Cache filename hashing** — for caching backends (SVDSBTL today),
+  the cache filename gets an 8-hex-char SHA-256 prefix of the canonical
+  bytes alongside fluid / source / input_pair. Drops the int-keyed
+  input_pair fragility (CoolProp-b6v) at the same time.
+
+[jcs]: https://datatracker.ietf.org/doc/html/rfc8785
+
+### API surface
+
+```cpp
+// AbstractState.h — new virtual, default returns empty.
+virtual std::string build_options_json() const { return ""; }
+```
+
+```cpp
+// AbstractStateGenerator interface — new virtual with default that
+// rejects options.  Backwards-compatible: existing generators stay
+// working untouched.
+virtual AbstractState* get_AbstractState(
+    const std::vector<std::string>& fluid_names,
+    const rapidjson::Value& options) {
+    if (options.IsNull() || (options.IsObject() && options.ObjectEmpty())) {
+        return get_AbstractState(fluid_names);
+    }
+    throw NotImplementedError(
+        "backend " + name() + " does not accept options");
+}
+```
+
+```cpp
+// Existing factory entry-point unchanged in signature; gains
+// options-string parsing internally.
+AbstractState* AbstractState::factory(const std::string& factory_string,
+                                       const std::vector<std::string>& fluid_names);
+```
+
+`get_AbstractState(fluid_names)` (no-options) stays — backends that
+ignore options need zero code changes.
+
+### Per-backend opt-in
+
+A backend opts in by:
+
+1. Publishing a JSON Schema in `schemas/<backend>_options.schema.json`.
+2. Overriding `get_AbstractState(fluid_names, options)` to validate
+   against its schema and construct accordingly.
+3. (Optional) Overriding `build_options_json()` to return the canonical
+   form it was constructed with.
+
+SVDSBTL ships as the first consumer in this PR. BICUBIC, TTSE, REFPROP
+become follow-up patches; each one deprecates the corresponding
+Configuration globals with a deprecation warning + a migration table in
+the docs.
+
+### `@path` indirection — file-path edge cases
+
+When the suffix begins with `@`, the rest is a filesystem path read
+verbatim:
+
+```cpp
+auto path = tail.substr(1);              // strip leading '@'
+// NO further ? splitting on the path
+```
+
+Path may itself contain `?`, `&`, etc. Path resolution: relative paths
+resolve against the process CWD; `~` expansion uses the same helper
+already used for `ALTERNATIVE_REFPROP_PATH`.
+
+If the file doesn't exist or isn't readable, throw a `FileIOError`
+with the full path quoted, so misconfiguration surfaces immediately.
+
+### Auto-calibration loop (referenced by `critical_patch.mode=auto`)
+
+Runs at table-build time, once per (fluid, input_pair). Output is a
+single `[Tlo, Thi, plo, phi]` tuple stored in the cache header.
+
+Sketch:
+
+1. Probe set: sample (T, p) on a hexagonal lattice in an oversized
+   initial bbox (e.g. 0.85·T_c .. 1.20·T_c × 0.50·p_c .. 1.30·p_c).
+2. For each candidate (Tlo, Thi, plo, phi), evaluate `metric` residual
+   between SVDSBTL prediction and source backend over the probe set.
+3. Binary-search-shrink along each axis independently from the
+   oversized initial box. Stop when the residual hits `tolerance` or
+   further shrinking blows past it.
+4. Persist the final tuple in the cache header alongside the SVD
+   blobs.
+
+User who passes `critical_patch.mode="fixed"` + `bbox=[...]` skips the
+loop and the supplied tuple goes straight into the cache. `mode="off"`
+disables the patch entirely; the cache stores `null` for the bbox.
+
+## Test contract
+
+The parser is the riskiest piece. Tests live in
+`src/Tests/CoolProp-Tests-FactoryOptions.cpp` (new file) and cover:
+
+### Parsing edge cases
+
+- No `?` → options = `{}`.
+- Bare `?` → options = `{}`.
+- `?{}` → options = `{}`.
+- Inline JSON with nested objects round-trips.
+- `@<path>` reads file; missing file throws `FileIOError`.
+- `@<path>` where the path itself contains `?` and `&` — the path is
+  read verbatim, no re-splitting.
+- Garbage after `?` (non-JSON, non-`@`) → throws `ValueError` with a
+  message that includes the offending tail.
+
+### `?` characters inside JSON values
+
+A mandatory subset (driven by Ian's earlier review note):
+
+- `?{"hint":"what?"}` — `?` inside a string value parses correctly.
+- `?{"q":"?"}` — `?` is the entire string value.
+- `?{"meta":{"url":"http://x.com/path?id=1&q=2"}}` — `?` and `&`
+  together inside a URL-style string.
+- `?{"regex":"^[A-Z]+\\?$"}` — `?` after an escaped backslash.
+- `?{"chain":"first?second?third"}` — multiple `?` characters inside
+  one string.
+
+Each test asserts the parsed value equals the expected Python
+equivalent.
+
+### Schema validation
+
+- Unknown top-level key → throws with key name in message.
+- Unknown nested key → throws with full dotted path
+  (e.g. `critical_patch.unknown_field`).
+- Type mismatch → throws with expected vs actual type.
+- Required key missing → throws with key name.
+- Default values fill in for unspecified keys.
+
+### Canonical serialization round-trip
+
+- Build instance with `?{"grid":{"NT":200,"rank":20,"NR":800}}` and
+  with `?{"grid":{"rank":20,"NR":800,"NT":200}}`. Both must produce the
+  same `build_options_json()` output (sorted keys) and the same
+  SHA-256 cache-filename prefix.
+- Round-trip: `build_options_json()` output, fed back into the factory,
+  produces an instance with identical `build_options_json()`.
+
+### SVDSBTL behavioural tests
+
+- `critical_patch=off` → backend instance has the patch disabled;
+  queries inside the would-be patch return NaN (no fallback).
+- `critical_patch=fixed&bbox=[...]` → cache stores the supplied bbox
+  verbatim; auto-cal loop is not invoked.
+- `critical_patch=auto` (default) → auto-cal runs; resulting bbox is
+  persistent in the cache header.
+
+## Migration plan
+
+| Generation | Backend | Action |
+|---|---|---|
+| Concurrent with this PR | SVDSBTL | First consumer; full schema, critical-patch + auto-cal landed |
+| Follow-up #1 | BICUBIC | Deprecate `BICUBIC_*` Configuration globals; equivalent JSON keys land in the schema; emit deprecation warning when globals are set |
+| Follow-up #2 | TTSE | Same as BICUBIC |
+| Follow-up #3 | REFPROP | Deprecate `ALTERNATIVE_REFPROP_*` globals in favor of `?{"library_path":"…","hmx_path":"…"}` |
+| Future | PCSAFT, SuperAncillary, HEOS | Per-backend judgment; many have nothing tunable today |
+
+Each follow-up is one PR with its own migration notes and at least one
+release-cycle of overlap before the Configuration globals are removed.
+
+## Out-of-scope (deferred)
+
+- Per-region SVDSBTL options (e.g. different rank in R3). Schema leaves
+  room (`"regions": {...}`) but no plumbing.
+- Programmatic options-builder API in language wrappers. The factory
+  string is the universal entry-point; wrappers can wrap it but the
+  spec doesn't require any per-wrapper helper.
+- Read-only `Configuration` snapshot persisted into the cache. Cache
+  already gets the options canonical form; that's sufficient for
+  reproducibility.
+
+## Open questions
+
+1. **RapidJSON vs nlohmann::json** — CoolProp already vendors RapidJSON
+   for the fluid catalog. Sticking with it keeps the dependency surface
+   flat. nlohmann would give a nicer C++ API but bloats build time.
+   Recommendation: RapidJSON; revisit only if the API friction shows up.
+2. **JSON Schema validator** — RapidJSON has a schema validator. Use
+   it directly; don't pull in a separate validator library.
+3. **Where do per-backend schemas live?** — Recommend
+   `include/CoolProp/schemas/<backend>.schema.json` so they're
+   header-only-installable, with a `*.h` companion that exposes them as
+   `kSVDSBTLOptionsSchemaJson` string literals (avoids runtime file
+   lookups for the validator).
+4. **Deprecation cadence for Configuration globals** — One release with
+   the JSON key + a deprecation warning when the global is set, then
+   removal one release later? Leaving as TBD pending Ian's preference.
+
+## Acceptance criteria
+
+- [ ] Parser splits on first `?` only; handles inline JSON, `@path`,
+      empty / missing tail.
+- [ ] All `?`-in-JSON test cases pass.
+- [ ] SVDSBTL `?{"critical_patch":"off"}` correctly disables the patch
+      with no auto-cal invocation.
+- [ ] SVDSBTL `?{"critical_patch":"fixed","bbox":[...]}` builds a cache
+      with the supplied bbox in the header.
+- [ ] SVDSBTL `?{"critical_patch":"auto"}` runs the auto-cal loop and
+      persists the result.
+- [ ] `AS->build_options_json()` round-trips: feed output back to
+      `factory()`, get bit-identical canonical form.
+- [ ] Cache filename hashing makes two logically-equal options produce
+      the same cache filename; logically-different options produce
+      different filenames.
+- [ ] At least one BICUBIC / TTSE follow-up PR filed (not landed) to
+      verify the mechanism generalizes.

--- a/docs/superpowers/specs/2026-05-16-backend-options-string-design.md
+++ b/docs/superpowers/specs/2026-05-16-backend-options-string-design.md
@@ -175,18 +175,30 @@ it's a per-backend `"strict": false` in the JSON itself, not a global.
 ### Canonical serialization
 
 Cache hashing and reproducibility both need a single canonical form per
-logical-options-value. We use [RFC 8785 JCS][jcs]: sort keys
-recursively, normalize number representation, UTF-8 NFC for strings,
-arrays preserve order. The canonical bytes are the input to:
+logical-options-value. We sort object keys recursively, preserve
+array order, and use RapidJSON's default number formatting. This
+is *not* strict [RFC 8785 JCS][jcs] (no NFC string normalisation,
+no ECMAScript number rounding) — but it's "deterministic within a
+single CoolProp build", which is what cache hashing needs since the
+canonical form never appears in any on-wire / cross-implementation
+context.
+
+The canonical bytes are the input to:
 
 - **`AbstractState::build_options_json()`** — returns the canonical
   string for the instance.
 - **Cache filename hashing** — for caching backends (SVDSBTL today),
-  the cache filename gets an 8-hex-char SHA-256 prefix of the canonical
-  bytes alongside fluid / source / input_pair. Drops the int-keyed
+  the cache filename gets a 16-hex-char [FNV-1a 64][fnv1a] prefix
+  of the canonical bytes alongside fluid / source / input_pair.
+  FNV-1a 64 is the same hash family CoolProp already uses for
+  superancillary EOS-freshness verification (see the
+  `Superancillary source_eos_hash` test in
+  `src/Tests/CoolProp-Tests.cpp`) — no new dependencies, identical
+  determinism guarantees across compilers. Drops the int-keyed
   input_pair fragility (CoolProp-b6v) at the same time.
 
 [jcs]: https://datatracker.ietf.org/doc/html/rfc8785
+[fnv1a]: http://www.isthe.com/chongo/tech/comp/fnv/
 
 ### API surface
 
@@ -319,7 +331,7 @@ equivalent.
 - Build instance with `?{"grid":{"NT":200,"rank":20,"NR":800}}` and
   with `?{"grid":{"rank":20,"NR":800,"NT":200}}`. Both must produce the
   same `build_options_json()` output (sorted keys) and the same
-  SHA-256 cache-filename prefix.
+  FNV-1a 64 cache-filename prefix.
 - Round-trip: `build_options_json()` output, fed back into the factory,
   produces an instance with identical `build_options_json()`.
 
@@ -370,20 +382,24 @@ release-cycle of overlap before the Configuration globals are removed.
   already gets the options canonical form; that's sufficient for
   reproducibility.
 
+## Decisions made during PR A
+
+1. **JSON library: RapidJSON** (already vendored for the fluid catalog).
+   nlohmann would offer a nicer API at a build-time cost; not worth it.
+2. **Schema validator: RapidJSON's built-in** (`rapidjson::SchemaDocument`).
+   Strict-mode = `additionalProperties:false` in each per-backend schema.
+3. **Canonical-form hash: FNV-1a 64** (same hash family CoolProp already
+   uses to stamp `source_eos_hash` for superancillary freshness; 16-hex
+   prefix on cache filenames).
+4. **Schema storage:** per-backend JSON Schemas live in
+   `include/CoolProp/schemas/<backend>.schema.json` plus a generated
+   `*.h` companion that exposes the schema as a string literal
+   (`kSVDSBTLOptionsSchemaJson`), so the validator has no runtime file
+   dependency.
+
 ## Open questions
 
-1. **RapidJSON vs nlohmann::json** — CoolProp already vendors RapidJSON
-   for the fluid catalog. Sticking with it keeps the dependency surface
-   flat. nlohmann would give a nicer C++ API but bloats build time.
-   Recommendation: RapidJSON; revisit only if the API friction shows up.
-2. **JSON Schema validator** — RapidJSON has a schema validator. Use
-   it directly; don't pull in a separate validator library.
-3. **Where do per-backend schemas live?** — Recommend
-   `include/CoolProp/schemas/<backend>.schema.json` so they're
-   header-only-installable, with a `*.h` companion that exposes them as
-   `kSVDSBTLOptionsSchemaJson` string literals (avoids runtime file
-   lookups for the validator).
-4. **Deprecation cadence for Configuration globals** — One release with
+1. **Deprecation cadence for Configuration globals** — One release with
    the JSON key + a deprecation warning when the global is set, then
    removal one release later? Leaving as TBD pending Ian's preference.
 

--- a/include/AbstractState.h
+++ b/include/AbstractState.h
@@ -773,6 +773,17 @@ class AbstractState
     /// Must be overloaded by the backend to provide the backend's name
     virtual std::string backend_name() = 0;
 
+    /// Canonical-JSON string of the options this instance was built
+    /// with.  Default returns "" — backends that accept factory-string
+    /// options (`?{...}` suffix) override this to return the
+    /// canonical form (sorted keys, defaults expanded) so callers can
+    /// reproduce the construction by feeding it back through
+    /// `factory()`.  See
+    /// docs/superpowers/specs/2026-05-16-backend-options-string-design.md.
+    virtual std::string build_options_json() const {
+        return "";
+    }
+
     // The derived classes must implement this function to define whether they use mole fractions (true) or mass fractions (false)
     virtual bool using_mole_fractions() = 0;
     virtual bool using_mass_fractions() = 0;
@@ -1681,6 +1692,17 @@ class AbstractStateGenerator
 {
    public:
     virtual AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) = 0;
+
+    /// Options-aware factory entry-point.  Default forwards to the
+    /// no-options overload when `options_json` is empty / "{}"; throws
+    /// NotImplementedError otherwise.  Backends that accept options
+    /// override this to parse + validate the JSON against their schema
+    /// before constructing.  `options_json` arrives raw from the
+    /// `?<...>` suffix on the factory string (see
+    /// `parse_factory_options`); backends are responsible for their
+    /// own JSON parse and schema validation.
+    virtual AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names, const std::string& options_json);
+
     virtual ~AbstractStateGenerator() {};
 };
 

--- a/include/CoolProp/FactoryOptions.h
+++ b/include/CoolProp/FactoryOptions.h
@@ -1,0 +1,42 @@
+#ifndef COOLPROP_FACTORY_OPTIONS_H
+#define COOLPROP_FACTORY_OPTIONS_H
+
+#include <string>
+
+namespace CoolProp {
+
+// Result of splitting a factory string of the form
+//
+//     <backend-and-fluid>[?<options>]
+//
+// into its two halves.  `options_json` is the *raw* options payload as a
+// JSON string, populated by either an inline `?{...}` blob or a
+// `?@<path>` indirection that reads the file at <path>.  No JSON parsing
+// or schema validation happens here — that lives one layer up in the
+// schema validator.  When the factory string has no `?` suffix or the
+// suffix is empty, `options_json` is the empty string and downstream
+// callers treat that as "no options".
+struct FactoryOptionsParseResult
+{
+    std::string clean_string;  ///< Factory string with any `?<suffix>` stripped.
+    std::string options_json;  ///< Raw options JSON (empty if none supplied).
+};
+
+// Split a factory string on its first `?` and resolve the suffix.
+//
+//   - No `?`                         → options_json = ""
+//   - `?` then empty / whitespace    → options_json = ""
+//   - `?@<path>`                     → options_json = contents of <path>
+//                                      (FileIOError on read failure)
+//   - anything else                  → options_json = the verbatim tail
+//
+// The parser deliberately does *not* validate JSON, look at the schema,
+// or interpret the suffix in any other way.  Any `?` characters after
+// the first one (e.g. inside a JSON string value, inside a URL, inside
+// the `@<path>` filename itself) are kept verbatim — the contract is
+// `find_first_of('?')` exactly once.
+FactoryOptionsParseResult parse_factory_options(const std::string& factory_string);
+
+}  // namespace CoolProp
+
+#endif  // COOLPROP_FACTORY_OPTIONS_H

--- a/include/CoolProp/SchemaValidation.h
+++ b/include/CoolProp/SchemaValidation.h
@@ -1,0 +1,68 @@
+#ifndef COOLPROP_SCHEMA_VALIDATION_H
+#define COOLPROP_SCHEMA_VALIDATION_H
+
+#include <string>
+
+#if !defined(SWIG)
+#    include "rapidjson_include.h"
+#endif
+
+namespace CoolProp {
+
+#if !defined(SWIG)
+
+// Strict-mode JSON Schema validation.
+//
+// Validates `instance` against `schema` using RapidJSON's built-in
+// validator.  On a validation failure, throws CoolProp::ValueError with
+// a message that quotes both the schema-pointer and the instance-pointer
+// of the failing assertion (e.g. "/critical_patch/tolerance does not
+// satisfy schema /properties/critical_patch/properties/tolerance: type
+// expected number, got string").
+//
+// The schema is consumed as a parsed Document so multiple validations
+// against the same schema can share parse cost.  Caller owns both
+// documents.
+void validate_against_schema(const rapidjson::Value& instance, const rapidjson::Document& schema);
+
+// Convenience overload — parse `schema_json` once and validate.  Useful
+// for the per-backend entry points where the schema is a constant
+// string literal compiled into the binary.  Throws ValueError if
+// schema_json itself is invalid JSON.
+void validate_against_schema(const rapidjson::Value& instance, const std::string& schema_json);
+
+// Produce a deterministic string representation of `value` for hashing
+// and reproducibility.  Object keys are sorted recursively; arrays
+// preserve order; numbers use RapidJSON's default formatting (already
+// deterministic within a single build).  Strings are UTF-8 verbatim
+// (no NFC normalisation performed — see note).
+//
+// This is *not* strict RFC 8785 (JCS): number normalisation skips
+// the ECMAScript JSON.stringify rules, and string content isn't
+// NFC-normalised.  It's "canonical within a CoolProp process" — the
+// same logical-options-value produces the same bytes inside one
+// binary, which is what cache hashing needs.  The form is not part
+// of any external on-wire format, so this scope is sufficient.
+//
+// Returns the canonical string (UTF-8, no trailing newline).
+std::string to_canonical_json(const rapidjson::Value& value);
+
+// Convenience overload — parse `json_str` and canonicalise.  Throws
+// ValueError if `json_str` is invalid JSON.
+std::string to_canonical_json(const std::string& json_str);
+
+#endif  // !SWIG
+
+// Schema-validation helpers that work on JSON strings — exposed even
+// to SWIG since they take only std::string.  Internally they parse,
+// validate, and (for to_canonical_json_str) re-serialise.
+//
+// Mirrors the typed API above for callers that don't want to touch
+// rapidjson directly (e.g. wrappers, tests).
+void validate_json_against_schema(const std::string& instance_json, const std::string& schema_json);
+
+std::string to_canonical_json_str(const std::string& json_str);
+
+}  // namespace CoolProp
+
+#endif  // COOLPROP_SCHEMA_VALIDATION_H

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -184,15 +184,35 @@ AbstractState* AbstractState::factory(const std::string& backend, const std::vec
     std::string clean_backend = parsed.clean_string;
     std::string options_json = parsed.options_json;
     std::vector<std::string> clean_fluid_names = fluid_names;
-    if (!clean_fluid_names.empty() && clean_fluid_names[0].find('?') != std::string::npos) {
-        auto parsed_fluid = parse_factory_options(clean_fluid_names[0]);
+    // The `?<options>` suffix on the fluid side can land on ANY
+    // element of fluid_names — for mixtures, the
+    // factory(string, string) convenience overload calls
+    // strsplit('&') before forwarding, so e.g.
+    // "HEOS::R32&R125?{...}" arrives as ["R32", "R125?{...}"] with
+    // the suffix on the LAST token.  Scan the whole vector; throw
+    // if two different tokens carry a suffix (typo); always strip
+    // the trailing '?' so downstream fluid lookup sees the bare
+    // component name.
+    std::size_t fluid_options_index = clean_fluid_names.size();  // sentinel = none
+    for (std::size_t i = 0; i < clean_fluid_names.size(); ++i) {
+        if (clean_fluid_names[i].find('?') == std::string::npos) {
+            continue;
+        }
+        if (fluid_options_index != clean_fluid_names.size()) {
+            throw ValueError("factory: '?<options>' supplied in multiple fluid components; encode it once.");
+        }
+        fluid_options_index = i;
+    }
+    if (fluid_options_index != clean_fluid_names.size()) {
+        auto parsed_fluid = parse_factory_options(clean_fluid_names[fluid_options_index]);
         if (!parsed_fluid.options_json.empty() && !options_json.empty()) {
             throw ValueError("factory: '?<options>' supplied on both the backend and fluid sides; pick one side.");
         }
-        // Always replace fluid_names[0] with the stripped form — even
-        // when the suffix carried no options (bare '?' or whitespace) —
-        // so the downstream fluid lookup doesn't see a trailing '?'.
-        clean_fluid_names[0] = parsed_fluid.clean_string;
+        // Always replace the affected fluid name with the stripped
+        // form — even when the suffix carried no options (bare '?'
+        // or whitespace) — so the downstream fluid lookup doesn't
+        // see a trailing '?'.
+        clean_fluid_names[fluid_options_index] = parsed_fluid.clean_string;
         if (!parsed_fluid.options_json.empty()) {
             options_json = parsed_fluid.options_json;
         }

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -171,14 +171,32 @@ AbstractState* AbstractState::factory(const std::string& backend, const std::vec
     }
 
     // Split off any "?<options>" suffix once at the entry-point so the
-    // rest of the dispatch operates on the unadorned backend string.
-    // The raw options JSON (or "" when nothing was supplied) is
-    // threaded through to the backend generator via the options-aware
-    // overload below.  See
+    // rest of the dispatch operates on the unadorned backend / fluid
+    // strings.  PropsSI calls extract_backend() first, which splits
+    // "BACKEND::FLUID?<options>" on "::" without touching '?'  — so
+    // the suffix arrives on the *fluid* side.  Direct factory()
+    // callers may put it on either side.  Strip from wherever it
+    // lives (rejecting the ambiguous both-sides case) and thread the
+    // raw options JSON through to the backend generator via the
+    // options-aware overload below.  See
     // docs/superpowers/specs/2026-05-16-backend-options-string-design.md.
     auto parsed = parse_factory_options(backend);
-    const std::string& clean_backend = parsed.clean_string;
-    const std::string& options_json = parsed.options_json;
+    std::string clean_backend = parsed.clean_string;
+    std::string options_json = parsed.options_json;
+    std::vector<std::string> clean_fluid_names = fluid_names;
+    if (!clean_fluid_names.empty() && clean_fluid_names[0].find('?') != std::string::npos) {
+        auto parsed_fluid = parse_factory_options(clean_fluid_names[0]);
+        if (!parsed_fluid.options_json.empty() && !options_json.empty()) {
+            throw ValueError("factory: '?<options>' supplied on both the backend and fluid sides; pick one side.");
+        }
+        // Always replace fluid_names[0] with the stripped form — even
+        // when the suffix carried no options (bare '?' or whitespace) —
+        // so the downstream fluid lookup doesn't see a trailing '?'.
+        clean_fluid_names[0] = parsed_fluid.clean_string;
+        if (!parsed_fluid.options_json.empty()) {
+            options_json = parsed_fluid.options_json;
+        }
+    }
 
     backend_families f1;
     std::string f2;
@@ -193,16 +211,23 @@ AbstractState* AbstractState::factory(const std::string& backend, const std::vec
 
     if (gen != end) {
         // One of the registered backends was able to match the given backend family
-        return gen->second->get_AbstractState(fluid_names, options_json);
+        return gen->second->get_AbstractState(clean_fluid_names, options_json);
     }
 #if !defined(NO_TABULAR_BACKENDS)
     else if (f1 == TTSE_BACKEND_FAMILY) {
-        // Will throw if there is a problem with this backend
-        const shared_ptr<AbstractState> AS(factory(f2, fluid_names));
+        // Will throw if there is a problem with this backend.  These
+        // tabular backends don't accept options today; if the caller
+        // supplied any, fail loud so the suffix isn't silently dropped.
+        if (!options_json.empty()) {
+            throw NotImplementedError("TTSE backend does not yet accept factory-string options");
+        }
+        const shared_ptr<AbstractState> AS(factory(f2, clean_fluid_names));
         return new TTSEBackend(AS);
     } else if (f1 == BICUBIC_BACKEND_FAMILY) {
-        // Will throw if there is a problem with this backend
-        const shared_ptr<AbstractState> AS(factory(f2, fluid_names));
+        if (!options_json.empty()) {
+            throw NotImplementedError("BICUBIC backend does not yet accept factory-string options");
+        }
+        const shared_ptr<AbstractState> AS(factory(f2, clean_fluid_names));
         return new BicubicBackend(AS);
     } else if (f1 == SVDSBTL_BACKEND_FAMILY) {
         // SVDSBTL requires an explicit source-of-truth backend in
@@ -211,28 +236,38 @@ AbstractState* AbstractState::factory(const std::string& backend, const std::vec
         // without the '&' lands here with f2 empty and throws.
         if (f2.empty()) {
             throw ValueError(format("SVDSBTL requires an explicit source backend, e.g. factory(\"SVDSBTL&HEOS\", \"%s\")",
-                                    fluid_names.empty() ? "<fluid>" : fluid_names[0].c_str()));
+                                    clean_fluid_names.empty() ? "<fluid>" : clean_fluid_names[0].c_str()));
         }
-        if (fluid_names.size() != 1) {
+        if (clean_fluid_names.size() != 1) {
             throw ValueError("SVDSBTL backend is pure-fluid only; expected exactly one fluid name");
         }
-        return new SVDSBTLBackend(fluid_names[0], f2);
+        // SVDSBTL is not yet opted in to factory-string options; drop
+        // the suffix loudly rather than silently for symmetry with the
+        // tabular branches above.  PR B wires this up.
+        if (!options_json.empty()) {
+            throw NotImplementedError("SVDSBTL backend does not yet accept factory-string options");
+        }
+        return new SVDSBTLBackend(clean_fluid_names[0], f2);
     }
 #endif
-    else if (backend == "?" || backend.empty()) {
-        const std::size_t idel = fluid_names[0].find("::");
-        // Backend has not been specified, and we have to figure out what the backend is by parsing the string
-        if (idel == std::string::npos)  // No '::' found, no backend specified, try HEOS, otherwise a failure
-        {
-            // Figure out what backend to use
-            return factory("HEOS", fluid_names);
+    else if (clean_backend == "?" || clean_backend.empty()) {
+        // Backend has not been specified, and we have to figure out what
+        // the backend is by parsing the (already-stripped) fluid string.
+        // Options accumulated above are re-attached to the inner
+        // backend half so the recursive factory() call's own parse pass
+        // picks them up — keeps the dispatch logic in one place.
+        const std::size_t idel = clean_fluid_names[0].find("::");
+        const std::string suffix = options_json.empty() ? std::string{} : ("?" + options_json);
+        if (idel == std::string::npos) {
+            // No '::' found, default to HEOS.
+            return factory("HEOS" + suffix, clean_fluid_names);
         } else {
-            // Split string at the '::' into two std::string, call again
-            return factory(std::string(fluid_names[0].begin(), fluid_names[0].begin() + idel),
-                           std::string(fluid_names[0].begin() + (idel + 2), fluid_names[0].end()));
+            std::string inner_backend = clean_fluid_names[0].substr(0, idel) + suffix;
+            std::vector<std::string> inner_fluid = {clean_fluid_names[0].substr(idel + 2)};
+            return factory(inner_backend, inner_fluid);
         }
     } else {
-        throw ValueError(format("Invalid backend name [%s] to factory function", backend.c_str()));
+        throw ValueError(format("Invalid backend name [%s] to factory function", clean_backend.c_str()));
     }
 }
 std::vector<std::string> AbstractState::fluid_names() {

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include "boost/math/tools/toms748_solve.hpp"
 #include "AbstractState.h"
+#include "CoolProp/FactoryOptions.h"
 #include "DataStructures.h"
 #include "qmass_conversions.h"
 #include "Backends/IF97/IF97Backend.h"
@@ -59,6 +60,26 @@ inline BackendLibrary& get_backend_library() {
 void register_backend(const backend_families& bf, shared_ptr<AbstractStateGenerator> gen) {
     get_backend_library().add_backend(bf, gen);
 };
+
+// Default implementation of the options-aware factory entry-point.
+// Forwards to the no-options overload when `options_json` is empty or
+// is the canonical empty object "{}".  Anything else means the caller
+// passed `?<options>` but the backend hasn't opted in to consume them —
+// throw with a clear message so silent option-dropping never happens.
+AbstractState* AbstractStateGenerator::get_AbstractState(const std::vector<std::string>& fluid_names, const std::string& options_json) {
+    // Trim surrounding whitespace; treat ""/"{}" as "no options".
+    std::size_t lo = options_json.find_first_not_of(" \t\r\n");
+    if (lo == std::string::npos) {
+        return get_AbstractState(fluid_names);
+    }
+    std::size_t hi = options_json.find_last_not_of(" \t\r\n");
+    const std::string trimmed = options_json.substr(lo, hi - lo + 1);
+    if (trimmed == "{}") {
+        return get_AbstractState(fluid_names);
+    }
+    throw NotImplementedError("This backend does not accept factory-string options.  Drop the '?<...>' suffix or opt the backend in (see "
+                              "docs/superpowers/specs/2026-05-16-backend-options-string-design.md).");
+}
 
 class IF97BackendGenerator : public AbstractStateGenerator
 {
@@ -149,9 +170,19 @@ AbstractState* AbstractState::factory(const std::string& backend, const std::vec
         std::cout << "AbstractState::factory(" << backend << "," << stringvec_to_string(fluid_names) << ")" << std::endl;
     }
 
+    // Split off any "?<options>" suffix once at the entry-point so the
+    // rest of the dispatch operates on the unadorned backend string.
+    // The raw options JSON (or "" when nothing was supplied) is
+    // threaded through to the backend generator via the options-aware
+    // overload below.  See
+    // docs/superpowers/specs/2026-05-16-backend-options-string-design.md.
+    auto parsed = parse_factory_options(backend);
+    const std::string& clean_backend = parsed.clean_string;
+    const std::string& options_json = parsed.options_json;
+
     backend_families f1;
     std::string f2;
-    extract_backend_families_string(backend, f1, f2);
+    extract_backend_families_string(clean_backend, f1, f2);
 
     std::map<backend_families, shared_ptr<AbstractStateGenerator>>::const_iterator gen, end;
     get_backend_library().get_generator_iterators(f1, gen, end);
@@ -162,7 +193,7 @@ AbstractState* AbstractState::factory(const std::string& backend, const std::vec
 
     if (gen != end) {
         // One of the registered backends was able to match the given backend family
-        return gen->second->get_AbstractState(fluid_names);
+        return gen->second->get_AbstractState(fluid_names, options_json);
     }
 #if !defined(NO_TABULAR_BACKENDS)
     else if (f1 == TTSE_BACKEND_FAMILY) {

--- a/src/FactoryOptions.cpp
+++ b/src/FactoryOptions.cpp
@@ -1,0 +1,53 @@
+#include "CoolProp/FactoryOptions.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <string>
+
+#include "CPfilepaths.h"
+#include "Exceptions.h"
+
+namespace CoolProp {
+
+namespace {
+
+bool is_all_whitespace(const std::string& s) {
+    return std::all_of(s.begin(), s.end(), [](unsigned char c) { return std::isspace(c) != 0; });
+}
+
+}  // namespace
+
+FactoryOptionsParseResult parse_factory_options(const std::string& factory_string) {
+    FactoryOptionsParseResult result;
+
+    const std::size_t pos = factory_string.find_first_of('?');
+    if (pos == std::string::npos) {
+        result.clean_string = factory_string;
+        return result;
+    }
+
+    result.clean_string = factory_string.substr(0, pos);
+    std::string tail = factory_string.substr(pos + 1);
+
+    if (tail.empty() || is_all_whitespace(tail)) {
+        return result;
+    }
+
+    if (tail.front() == '@') {
+        const std::string path = tail.substr(1);
+        if (path.empty()) {
+            throw ValueError("factory-string options: '@' indirection requires a non-empty path");
+        }
+        // get_file_contents() reads the file verbatim and throws on
+        // read failure.  The path may contain '?' / '&' / spaces /
+        // etc.  — no further parsing of the path string.
+        result.options_json = get_file_contents(path.c_str());
+        return result;
+    }
+
+    result.options_json = std::move(tail);
+    return result;
+}
+
+}  // namespace CoolProp

--- a/src/SchemaValidation.cpp
+++ b/src/SchemaValidation.cpp
@@ -1,0 +1,126 @@
+#include "CoolProp/SchemaValidation.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "Exceptions.h"
+#include "rapidjson_include.h"
+
+namespace CoolProp {
+
+namespace {
+
+// Recursively copy `src` into `dst`, sorting object members by key
+// (lexicographic byte-wise) at every level.  Arrays preserve order.
+// `allocator` is the target document's allocator.
+void copy_sorted(const rapidjson::Value& src, rapidjson::Value& dst, rapidjson::Document::AllocatorType& allocator) {
+    if (src.IsObject()) {
+        dst.SetObject();
+        // Collect member references, sort by key, then copy in order.
+        std::vector<std::pair<std::string, const rapidjson::Value*>> kv;
+        kv.reserve(src.MemberCount());
+        for (auto it = src.MemberBegin(); it != src.MemberEnd(); ++it) {
+            kv.emplace_back(std::string(it->name.GetString(), it->name.GetStringLength()), &it->value);
+        }
+        std::sort(kv.begin(), kv.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
+        for (const auto& [key, val_ptr] : kv) {
+            rapidjson::Value name_copy;
+            name_copy.SetString(key.c_str(), static_cast<rapidjson::SizeType>(key.size()), allocator);
+            rapidjson::Value sub;
+            copy_sorted(*val_ptr, sub, allocator);
+            dst.AddMember(name_copy, sub, allocator);
+        }
+        return;
+    }
+    if (src.IsArray()) {
+        dst.SetArray();
+        for (auto it = src.Begin(); it != src.End(); ++it) {
+            rapidjson::Value sub;
+            copy_sorted(*it, sub, allocator);
+            dst.PushBack(sub, allocator);
+        }
+        return;
+    }
+    // Scalar: copy via the document's allocator.
+    dst.CopyFrom(src, allocator);
+}
+
+// RapidJSON validator helper — convert a SchemaPointer / DocumentPointer
+// to a string for inclusion in the error message.
+std::string pointer_to_string(const rapidjson::GenericPointer<rapidjson::Value>& p) {
+    rapidjson::StringBuffer sb;
+    p.StringifyUriFragment(sb);
+    return std::string(sb.GetString(), sb.GetSize());
+}
+
+rapidjson::Document parse_json(const std::string& s, const char* what) {
+    rapidjson::Document d;
+    if (d.Parse(s.c_str(), s.size()).HasParseError()) {
+        throw ValueError(std::string("parse_json: failed to parse ") + what + " (offset " + std::to_string(d.GetErrorOffset()) + ")");
+    }
+    return d;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Schema validation
+// ---------------------------------------------------------------------------
+
+void validate_against_schema(const rapidjson::Value& instance, const rapidjson::Document& schema) {
+    rapidjson::SchemaDocument schema_doc(schema);
+    rapidjson::SchemaValidator validator(schema_doc);
+    if (instance.Accept(validator)) {
+        return;
+    }
+    // Build a useful error: schema-pointer + instance-pointer + keyword.
+    const std::string sp = pointer_to_string(validator.GetInvalidSchemaPointer());
+    const std::string ip = pointer_to_string(validator.GetInvalidDocumentPointer());
+    const char* kw = validator.GetInvalidSchemaKeyword();
+    throw ValueError(std::string("schema validation failed: instance ") + (ip.empty() ? "/" : ip) + " violates schema " + (sp.empty() ? "/" : sp)
+                     + " (keyword: " + (kw ? kw : "<unknown>") + ")");
+}
+
+void validate_against_schema(const rapidjson::Value& instance, const std::string& schema_json) {
+    rapidjson::Document schema = parse_json(schema_json, "schema");
+    validate_against_schema(instance, schema);
+}
+
+// ---------------------------------------------------------------------------
+// Canonical JSON
+// ---------------------------------------------------------------------------
+
+std::string to_canonical_json(const rapidjson::Value& value) {
+    rapidjson::Document sorted;
+    rapidjson::Document::AllocatorType& alloc = sorted.GetAllocator();
+    rapidjson::Value root;
+    copy_sorted(value, root, alloc);
+    sorted.Swap(root);
+
+    rapidjson::StringBuffer sb;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
+    sorted.Accept(writer);
+    return std::string(sb.GetString(), sb.GetSize());
+}
+
+std::string to_canonical_json(const std::string& json_str) {
+    rapidjson::Document d = parse_json(json_str, "input");
+    return to_canonical_json(d);
+}
+
+// ---------------------------------------------------------------------------
+// SWIG-friendly string overloads
+// ---------------------------------------------------------------------------
+
+void validate_json_against_schema(const std::string& instance_json, const std::string& schema_json) {
+    rapidjson::Document instance = parse_json(instance_json, "instance");
+    validate_against_schema(instance, schema_json);
+}
+
+std::string to_canonical_json_str(const std::string& json_str) {
+    return to_canonical_json(json_str);
+}
+
+}  // namespace CoolProp

--- a/src/Tests/CoolProp-Tests-FactoryOptions.cpp
+++ b/src/Tests/CoolProp-Tests-FactoryOptions.cpp
@@ -137,4 +137,40 @@ TEST_CASE("parse_factory_options: clean_string preserves the full backend+fluid 
     }
 }
 
+// ---------------------------------------------------------------------------
+// Factory entry-point integration: options are stripped from the backend
+// string before dispatch, and the default generator overload rejects
+// non-empty options with NotImplementedError for backends that haven't
+// opted in.
+// ---------------------------------------------------------------------------
+
+#    include "AbstractState.h"
+
+TEST_CASE("AbstractState::factory: '?<options>' is stripped before backend dispatch", "[FactoryOptions]") {
+    SECTION("no options — existing behaviour unchanged") {
+        auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+        REQUIRE(AS != nullptr);
+        // HEOS factory returns the pure-fluid wrapper, which reports
+        // "HelmholtzEOSBackend" rather than the mixture variant.
+        REQUIRE(AS->backend_name() == "HelmholtzEOSBackend");
+    }
+    SECTION("empty options ('?{}') accepted by default overload") {
+        auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS?{}", "Water"));
+        REQUIRE(AS != nullptr);
+    }
+    SECTION("bare '?' accepted by default overload") {
+        auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS?", "Water"));
+        REQUIRE(AS != nullptr);
+    }
+}
+
+TEST_CASE("AbstractState::factory: non-empty options on an opted-out backend throw", "[FactoryOptions]") {
+    REQUIRE_THROWS(std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory(R"(HEOS?{"some_key":1})", "Water")));
+}
+
+TEST_CASE("AbstractState::build_options_json: default returns empty string", "[FactoryOptions]") {
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+    REQUIRE(AS->build_options_json().empty());
+}
+
 #endif  // ENABLE_CATCH

--- a/src/Tests/CoolProp-Tests-FactoryOptions.cpp
+++ b/src/Tests/CoolProp-Tests-FactoryOptions.cpp
@@ -1,0 +1,140 @@
+// Catch2 tests for parse_factory_options() — the factory-string `?<options>`
+// suffix parser.  Pure-parser tests; no backend wiring, no JSON validation
+// (that lives one layer up).  See
+// docs/superpowers/specs/2026-05-16-backend-options-string-design.md for
+// the design.
+
+#if defined(ENABLE_CATCH)
+
+#    include <catch2/catch_all.hpp>
+
+#    include <cstdio>
+#    include <filesystem>
+#    include <fstream>
+#    include <string>
+
+#    include "CoolProp/FactoryOptions.h"
+#    include "Exceptions.h"
+
+namespace {
+
+// RAII temp file for the @path tests.  Writes the given contents to
+// a unique path under the system temp dir; removes on destruction.
+class TempJSONFile
+{
+   public:
+    explicit TempJSONFile(const std::string& contents) {
+        path_ = std::filesystem::temp_directory_path() / ("cp_factopts_test_" + std::to_string(counter_++) + ".json");
+        std::ofstream(path_) << contents;
+    }
+    ~TempJSONFile() {
+        std::error_code ec;
+        std::filesystem::remove(path_, ec);
+    }
+    TempJSONFile(const TempJSONFile&) = delete;
+    TempJSONFile& operator=(const TempJSONFile&) = delete;
+    TempJSONFile(TempJSONFile&&) = delete;
+    TempJSONFile& operator=(TempJSONFile&&) = delete;
+
+    [[nodiscard]] std::string path() const {
+        return path_.string();
+    }
+
+   private:
+    std::filesystem::path path_;
+    static inline int counter_ = 0;
+};
+
+}  // namespace
+
+TEST_CASE("parse_factory_options: no '?' suffix returns whole string + empty options", "[FactoryOptions]") {
+    auto r = CoolProp::parse_factory_options("HEOS::Water");
+    REQUIRE(r.clean_string == "HEOS::Water");
+    REQUIRE(r.options_json.empty());
+}
+
+TEST_CASE("parse_factory_options: bare '?' yields empty options", "[FactoryOptions]") {
+    auto r = CoolProp::parse_factory_options("HEOS::Water?");
+    REQUIRE(r.clean_string == "HEOS::Water");
+    REQUIRE(r.options_json.empty());
+}
+
+TEST_CASE("parse_factory_options: whitespace-only tail is treated as empty", "[FactoryOptions]") {
+    auto r = CoolProp::parse_factory_options("HEOS::Water?   \t  ");
+    REQUIRE(r.clean_string == "HEOS::Water");
+    REQUIRE(r.options_json.empty());
+}
+
+TEST_CASE("parse_factory_options: inline JSON tail is returned verbatim", "[FactoryOptions]") {
+    auto r = CoolProp::parse_factory_options(R"(SVDSBTL&HEOS::Water?{"critical_patch":"off"})");
+    REQUIRE(r.clean_string == "SVDSBTL&HEOS::Water");
+    REQUIRE(r.options_json == R"({"critical_patch":"off"})");
+}
+
+TEST_CASE("parse_factory_options: split is on the FIRST '?' only", "[FactoryOptions]") {
+    SECTION("'?' inside a JSON string value") {
+        auto r = CoolProp::parse_factory_options(R"(HEOS::Water?{"hint":"what?"})");
+        REQUIRE(r.clean_string == "HEOS::Water");
+        REQUIRE(r.options_json == R"({"hint":"what?"})");
+    }
+    SECTION("'?' is the entire string value") {
+        auto r = CoolProp::parse_factory_options(R"(HEOS::Water?{"q":"?"})");
+        REQUIRE(r.clean_string == "HEOS::Water");
+        REQUIRE(r.options_json == R"({"q":"?"})");
+    }
+    SECTION("URL-style with both '?' and '&' inside the value") {
+        auto r = CoolProp::parse_factory_options(R"(HEOS::Water?{"meta":{"url":"http://x.com/path?id=1&q=2"}})");
+        REQUIRE(r.clean_string == "HEOS::Water");
+        REQUIRE(r.options_json == R"({"meta":{"url":"http://x.com/path?id=1&q=2"}})");
+    }
+    SECTION("regex string with escaped '?'") {
+        auto r = CoolProp::parse_factory_options(R"(HEOS::Water?{"regex":"^[A-Z]+\\?$"})");
+        REQUIRE(r.clean_string == "HEOS::Water");
+        REQUIRE(r.options_json == R"({"regex":"^[A-Z]+\\?$"})");
+    }
+    SECTION("multiple '?' chained inside one string value") {
+        auto r = CoolProp::parse_factory_options(R"(HEOS::Water?{"chain":"first?second?third"})");
+        REQUIRE(r.clean_string == "HEOS::Water");
+        REQUIRE(r.options_json == R"({"chain":"first?second?third"})");
+    }
+}
+
+TEST_CASE("parse_factory_options: '@path' reads file contents verbatim", "[FactoryOptions]") {
+    SECTION("simple file path") {
+        TempJSONFile f(R"({"critical_patch":"auto","grid":{"NT":200}})");
+        const std::string s = "SVDSBTL&HEOS::Water?@" + f.path();
+        auto r = CoolProp::parse_factory_options(s);
+        REQUIRE(r.clean_string == "SVDSBTL&HEOS::Water");
+        REQUIRE(r.options_json == R"({"critical_patch":"auto","grid":{"NT":200}})");
+    }
+    SECTION("file path with internal characters ('-', '_', '.', digits)") {
+        TempJSONFile f(R"({"x":1})");
+        const std::string s = "HEOS::Water?@" + f.path();
+        auto r = CoolProp::parse_factory_options(s);
+        REQUIRE(r.options_json == R"({"x":1})");
+    }
+    SECTION("missing '@path' file throws") {
+        REQUIRE_THROWS(CoolProp::parse_factory_options("HEOS::Water?@/this/path/definitely/does/not/exist.json"));
+    }
+    SECTION("bare '@' with no path throws ValueError") {
+        REQUIRE_THROWS_AS(CoolProp::parse_factory_options("HEOS::Water?@"), CoolProp::ValueError);
+    }
+}
+
+TEST_CASE("parse_factory_options: clean_string preserves the full backend+fluid grammar", "[FactoryOptions]") {
+    SECTION("simple backend") {
+        auto r = CoolProp::parse_factory_options("HEOS::Water?{}");
+        REQUIRE(r.clean_string == "HEOS::Water");
+    }
+    SECTION("source-backend split (& inside the cleaned half)") {
+        auto r = CoolProp::parse_factory_options("SVDSBTL&HEOS::Water?{}");
+        REQUIRE(r.clean_string == "SVDSBTL&HEOS::Water");
+    }
+    SECTION("no fluid name") {
+        auto r = CoolProp::parse_factory_options("HEOS?{}");
+        REQUIRE(r.clean_string == "HEOS");
+        REQUIRE(r.options_json == "{}");
+    }
+}
+
+#endif  // ENABLE_CATCH

--- a/src/Tests/CoolProp-Tests-PropsSIOptions.cpp
+++ b/src/Tests/CoolProp-Tests-PropsSIOptions.cpp
@@ -1,0 +1,126 @@
+// Catch2 tests for the `?<options>` suffix flowing through the
+// high-level CoolProp API (PropsSI, Props1SI, PhaseSI).  No backend
+// opts in to options in PR A; these tests therefore verify that:
+//
+//   * empty / no-options strings work identically with or without the
+//     `?` suffix (the suffix is parsed and dropped without affecting
+//     the call);
+//   * `?{...}` options on a backend that hasn't opted in throw a
+//     clear NotImplementedError instead of being silently dropped.
+//
+// When PR B (SVDSBTL opt-in) lands, this file gains positive tests
+// asserting that the SVDSBTL backend respects the supplied options.
+// CoolProp-iqz.
+
+#if defined(ENABLE_CATCH)
+
+#    include <catch2/catch_all.hpp>
+
+#    include <cmath>
+#    include <filesystem>
+#    include <fstream>
+#    include <string>
+
+#    include "AbstractState.h"
+#    include "CoolProp.h"
+
+namespace {
+
+class TempJSONFile
+{
+   public:
+    explicit TempJSONFile(const std::string& contents) {
+        path_ = std::filesystem::temp_directory_path() / ("cp_propssi_opts_test_" + std::to_string(counter_++) + ".json");
+        std::ofstream(path_) << contents;
+    }
+    ~TempJSONFile() {
+        std::error_code ec;
+        std::filesystem::remove(path_, ec);
+    }
+    TempJSONFile(const TempJSONFile&) = delete;
+    TempJSONFile& operator=(const TempJSONFile&) = delete;
+    TempJSONFile(TempJSONFile&&) = delete;
+    TempJSONFile& operator=(TempJSONFile&&) = delete;
+
+    [[nodiscard]] std::string path() const {
+        return path_.string();
+    }
+
+   private:
+    std::filesystem::path path_;
+    static inline int counter_ = 0;
+};
+
+}  // namespace
+
+TEST_CASE("PropsSI: '?<options>' suffix on fluid string parses + dispatches", "[FactoryOptions][PropsSI]") {
+    const double T = 300.0;
+    const double p = 101325.0;
+    const double rho_ref = CoolProp::PropsSI("D", "T", T, "P", p, "HEOS::Water");
+    REQUIRE(std::isfinite(rho_ref));
+
+    SECTION("bare '?' is a no-op (empty options)") {
+        const double rho = CoolProp::PropsSI("D", "T", T, "P", p, "HEOS::Water?");
+        REQUIRE(rho == Catch::Approx(rho_ref));
+    }
+    SECTION("empty JSON object is a no-op") {
+        const double rho = CoolProp::PropsSI("D", "T", T, "P", p, "HEOS::Water?{}");
+        REQUIRE(rho == Catch::Approx(rho_ref));
+    }
+    // Trailing-whitespace tail is exercised by parse_factory_options
+    // directly; PropsSI's string path normalises whitespace separately,
+    // so don't double-test that integration here.
+}
+
+TEST_CASE("PropsSI: non-empty options on opted-out backend errors gracefully", "[FactoryOptions][PropsSI]") {
+    // HEOS does not (yet) opt in to options; non-empty payload must
+    // surface as a non-finite result, not a silent success at the
+    // default settings.  PropsSI catches the exception and returns
+    // HUGE_VAL; the errstring will carry the original message.
+    const double rho = CoolProp::PropsSI("D", "T", 300.0, "P", 101325.0, R"(HEOS::Water?{"key":1})");
+    REQUIRE_FALSE(std::isfinite(rho));
+    const std::string err = CoolProp::get_global_param_string("errstring");
+    REQUIRE_FALSE(err.empty());
+}
+
+TEST_CASE("PropsSI: '@path' indirection reads file on fluid string", "[FactoryOptions][PropsSI]") {
+    TempJSONFile f("{}");
+    const std::string fluid_arg = "HEOS::Water?@" + f.path();
+    const double rho = CoolProp::PropsSI("D", "T", 300.0, "P", 101325.0, fluid_arg);
+    REQUIRE(std::isfinite(rho));
+    // Same as the no-options call.
+    const double rho_ref = CoolProp::PropsSI("D", "T", 300.0, "P", 101325.0, "HEOS::Water");
+    REQUIRE(rho == Catch::Approx(rho_ref));
+}
+
+TEST_CASE("Props1SI / PhaseSI: '?<options>' suffix accepted through high-level API", "[FactoryOptions][PropsSI]") {
+    SECTION("Props1SI empty options") {
+        const double tcrit = CoolProp::Props1SI("HEOS::Water?{}", "Tcrit");
+        REQUIRE(tcrit == Catch::Approx(647.096).margin(0.5));
+    }
+    SECTION("PhaseSI empty options") {
+        const std::string phase = CoolProp::PhaseSI("T", 300.0, "P", 101325.0, "HEOS::Water?{}");
+        REQUIRE(phase == "liquid");
+    }
+}
+
+TEST_CASE("AbstractState::factory: ambiguous '?<options>' on both sides throws", "[FactoryOptions]") {
+    // If options are on the backend AND the fluid, that's almost
+    // certainly a typo — fail loud with a clear message.
+    REQUIRE_THROWS(std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory(R"(HEOS?{})", R"(Water?{})")));
+}
+
+TEST_CASE("AbstractState::factory: '?<options>' on the fluid side is hoisted", "[FactoryOptions]") {
+    // PropsSI's extract_backend() puts the `?<options>` suffix on the
+    // fluid side after the "::" split.  factory() must hoist it back
+    // into the dispatch layer rather than dropping it silently.
+    SECTION("empty options on fluid side accepted") {
+        auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water?{}"));
+        REQUIRE(AS != nullptr);
+    }
+    SECTION("non-empty options on fluid side reach the default overload (throws)") {
+        REQUIRE_THROWS(std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", R"(Water?{"x":1})")));
+    }
+}
+
+#endif  // ENABLE_CATCH

--- a/src/Tests/CoolProp-Tests-PropsSIOptions.cpp
+++ b/src/Tests/CoolProp-Tests-PropsSIOptions.cpp
@@ -123,4 +123,31 @@ TEST_CASE("AbstractState::factory: '?<options>' on the fluid side is hoisted", "
     }
 }
 
+TEST_CASE("AbstractState::factory: '?<options>' on the LAST mixture token is hoisted", "[FactoryOptions]") {
+    // For mixtures, factory(string, string) splits on '&' before the
+    // vector-overload runs — so e.g. "HEOS::R32&R125?{}" arrives as
+    // fluid_names = ["R32", "R125?{}"] and the suffix lands on the
+    // last token, not the first.  Make sure the parser scans the
+    // whole vector and strips correctly.
+    SECTION("empty options on last mixture token accepted") {
+        auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "R32&R125?{}"));
+        REQUIRE(AS != nullptr);
+        REQUIRE(AS->fluid_names().size() == 2);
+        REQUIRE(AS->fluid_names()[0] == "R32");
+        REQUIRE(AS->fluid_names()[1] == "R125");  // trailing '?' stripped
+    }
+    SECTION("empty options on first mixture token accepted") {
+        auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "R32?{}&R125"));
+        REQUIRE(AS != nullptr);
+        REQUIRE(AS->fluid_names()[0] == "R32");
+        REQUIRE(AS->fluid_names()[1] == "R125");
+    }
+    SECTION("non-empty options on last mixture token reach the default overload (throws)") {
+        REQUIRE_THROWS(std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", R"(R32&R125?{"k":1})")));
+    }
+    SECTION("options on multiple mixture tokens is rejected") {
+        REQUIRE_THROWS(std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "R32?{}&R125?{}")));
+    }
+}
+
 #endif  // ENABLE_CATCH

--- a/src/Tests/CoolProp-Tests-SchemaValidation.cpp
+++ b/src/Tests/CoolProp-Tests-SchemaValidation.cpp
@@ -1,0 +1,155 @@
+// Catch2 tests for CoolProp::validate_against_schema and
+// CoolProp::to_canonical_json (CoolProp-bh2).
+
+#if defined(ENABLE_CATCH)
+
+#    include <catch2/catch_all.hpp>
+
+#    include <string>
+
+#    include "CoolProp/SchemaValidation.h"
+#    include "Exceptions.h"
+#    include "rapidjson_include.h"
+
+namespace {
+
+// Common test schema modelled after the SVDSBTL options schema we're
+// about to write — exercises objects, nested objects, enums, types,
+// required keys, and additionalProperties:false (strict mode).
+constexpr const char* kSchema = R"({
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema"],
+  "properties": {
+    "schema": {"type": "integer", "const": 1},
+    "grid": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "NT": {"type": "integer", "minimum": 2},
+        "NR": {"type": "integer", "minimum": 2},
+        "rank": {"type": "integer", "minimum": 1}
+      }
+    },
+    "critical_patch": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {"type": "string", "enum": ["auto", "off", "fixed"]},
+        "tolerance": {"type": "number", "exclusiveMinimum": 0},
+        "bbox": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "items": {"type": "number"}
+        }
+      }
+    }
+  }
+})";
+
+rapidjson::Document parse(const std::string& s) {
+    rapidjson::Document d;
+    d.Parse(s.c_str(), s.size());
+    REQUIRE_FALSE(d.HasParseError());
+    return d;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// validate_against_schema
+// ---------------------------------------------------------------------------
+
+TEST_CASE("validate_against_schema: minimal valid instance passes", "[SchemaValidation]") {
+    auto inst = parse(R"({"schema": 1})");
+    REQUIRE_NOTHROW(CoolProp::validate_against_schema(inst, std::string(kSchema)));
+}
+
+TEST_CASE("validate_against_schema: fully populated valid instance passes", "[SchemaValidation]") {
+    auto inst = parse(R"({
+        "schema": 1,
+        "grid": {"NT": 200, "NR": 800, "rank": 20},
+        "critical_patch": {"mode": "auto", "tolerance": 1e-3, "bbox": [0.95, 1.05, 0.75, 1.15]}
+    })");
+    REQUIRE_NOTHROW(CoolProp::validate_against_schema(inst, std::string(kSchema)));
+}
+
+TEST_CASE("validate_against_schema: unknown top-level key throws", "[SchemaValidation]") {
+    auto inst = parse(R"({"schema": 1, "frobnitz": true})");
+    REQUIRE_THROWS_AS(CoolProp::validate_against_schema(inst, std::string(kSchema)), CoolProp::ValueError);
+}
+
+TEST_CASE("validate_against_schema: unknown nested key throws", "[SchemaValidation]") {
+    auto inst = parse(R"({"schema": 1, "grid": {"NT": 200, "extra": 3}})");
+    REQUIRE_THROWS_AS(CoolProp::validate_against_schema(inst, std::string(kSchema)), CoolProp::ValueError);
+}
+
+TEST_CASE("validate_against_schema: type mismatch throws", "[SchemaValidation]") {
+    auto inst = parse(R"({"schema": 1, "grid": {"NT": "two-hundred"}})");
+    REQUIRE_THROWS_AS(CoolProp::validate_against_schema(inst, std::string(kSchema)), CoolProp::ValueError);
+}
+
+TEST_CASE("validate_against_schema: enum violation throws", "[SchemaValidation]") {
+    auto inst = parse(R"({"schema": 1, "critical_patch": {"mode": "ON"}})");
+    REQUIRE_THROWS_AS(CoolProp::validate_against_schema(inst, std::string(kSchema)), CoolProp::ValueError);
+}
+
+TEST_CASE("validate_against_schema: required key missing throws", "[SchemaValidation]") {
+    auto inst = parse(R"({"grid": {"NT": 200}})");
+    REQUIRE_THROWS_AS(CoolProp::validate_against_schema(inst, std::string(kSchema)), CoolProp::ValueError);
+}
+
+TEST_CASE("validate_against_schema: bbox wrong size throws", "[SchemaValidation]") {
+    auto inst = parse(R"({"schema": 1, "critical_patch": {"bbox": [1, 2, 3]}})");
+    REQUIRE_THROWS_AS(CoolProp::validate_against_schema(inst, std::string(kSchema)), CoolProp::ValueError);
+}
+
+TEST_CASE("validate_against_schema: invalid schema JSON throws", "[SchemaValidation]") {
+    auto inst = parse(R"({"schema": 1})");
+    REQUIRE_THROWS_AS(CoolProp::validate_against_schema(inst, std::string("not json")), CoolProp::ValueError);
+}
+
+// ---------------------------------------------------------------------------
+// to_canonical_json
+// ---------------------------------------------------------------------------
+
+TEST_CASE("to_canonical_json: sorts object keys", "[SchemaValidation]") {
+    const auto a = CoolProp::to_canonical_json(std::string(R"({"b": 2, "a": 1, "c": 3})"));
+    REQUIRE(a == R"({"a":1,"b":2,"c":3})");
+}
+
+TEST_CASE("to_canonical_json: sorts nested object keys recursively", "[SchemaValidation]") {
+    const auto a = CoolProp::to_canonical_json(std::string(R"({"outer": {"z": 1, "a": 2}, "inner": 3})"));
+    REQUIRE(a == R"({"inner":3,"outer":{"a":2,"z":1}})");
+}
+
+TEST_CASE("to_canonical_json: preserves array order", "[SchemaValidation]") {
+    const auto a = CoolProp::to_canonical_json(std::string(R"([3, 1, 2])"));
+    REQUIRE(a == R"([3,1,2])");
+}
+
+TEST_CASE("to_canonical_json: logically-equal inputs produce identical output", "[SchemaValidation]") {
+    const auto a = CoolProp::to_canonical_json(std::string(R"({"grid":{"NT":200,"rank":20,"NR":800}})"));
+    const auto b = CoolProp::to_canonical_json(std::string(R"({"grid":{"rank":20,"NR":800,"NT":200}})"));
+    REQUIRE(a == b);
+}
+
+TEST_CASE("to_canonical_json: idempotent — re-canonicalising returns the same bytes", "[SchemaValidation]") {
+    const auto a = CoolProp::to_canonical_json(std::string(R"({"b":2,"a":1})"));
+    const auto b = CoolProp::to_canonical_json(a);
+    REQUIRE(a == b);
+}
+
+TEST_CASE("to_canonical_json: handles all JSON scalar types", "[SchemaValidation]") {
+    const auto a = CoolProp::to_canonical_json(std::string(R"({"i":1,"f":1.5,"s":"x","b":true,"n":null,"a":[1,2]})"));
+    // Sorted: a, b, f, i, n, s
+    REQUIRE(a == R"({"a":[1,2],"b":true,"f":1.5,"i":1,"n":null,"s":"x"})");
+}
+
+TEST_CASE("to_canonical_json: invalid JSON throws", "[SchemaValidation]") {
+    REQUIRE_THROWS_AS(CoolProp::to_canonical_json(std::string("{not: json}")), CoolProp::ValueError);
+}
+
+#endif  // ENABLE_CATCH

--- a/wrappers/Python/CoolProp/AbstractState.pxd
+++ b/wrappers/Python/CoolProp/AbstractState.pxd
@@ -61,6 +61,7 @@ cdef class AbstractState:
 
     cpdef name(self)
     cpdef backend_name(self)
+    cpdef build_options_json(self)
     cpdef fluid_names(self)
     cpdef fluid_param_string(self, string key)
     cpdef set_cubic_alpha_C(self, size_t i, string parameter, double c1, double c2, double c3)

--- a/wrappers/Python/CoolProp/AbstractState.pyx
+++ b/wrappers/Python/CoolProp/AbstractState.pyx
@@ -44,6 +44,18 @@ cdef class AbstractState:
     cpdef backend_name(self):
         """ Get the backend name - wrapper of c++ function :cpapi:`CoolProp::AbstractState::backend_name` """
         return self.thisptr.backend_name()
+    cpdef build_options_json(self):
+        """ Canonical-JSON string of the options this instance was built with.
+
+        Returns an empty string for backends that don't accept factory-string
+        options.  For options-aware backends (e.g. SVDSBTL), the return value
+        round-trips through :py:func:`AbstractState.factory`: feeding it back
+        as the ``?<options>`` suffix on the factory string reproduces the
+        construction byte-for-byte.
+
+        Wrapper of c++ function :cpapi:`CoolProp::AbstractState::build_options_json` .
+        """
+        return self.thisptr.build_options_json()
     cpdef fluid_names(self):
         """ Get the list of fluid names - wrapper of c++ function :cpapi:`CoolProp::AbstractState::fluid_names` """
         return self.thisptr.fluid_names()

--- a/wrappers/Python/CoolProp/cAbstractState.pxd
+++ b/wrappers/Python/CoolProp/cAbstractState.pxd
@@ -64,6 +64,7 @@ cdef extern from "AbstractState.h" namespace "CoolProp":
 
         string name() except +ValueError
         string backend_name() except +ValueError
+        string build_options_json() except +ValueError
         vector[string] fluid_names() except +ValueError
         string fluid_param_string(const string &) except +ValueError
         void set_cubic_alpha_C(const size_t, const string&, const double, const double, const double) except +ValueError


### PR DESCRIPTION
## Summary

First of five PRs landing the per-instance backend-options mechanism described in
[docs/superpowers/specs/2026-05-16-backend-options-string-design.md](https://github.com/CoolProp/CoolProp/blob/ihb/backend-options-spec/docs/superpowers/specs/2026-05-16-backend-options-string-design.md).

This PR is **pure infrastructure** — no backend opts in yet, no behaviour change in any existing call site.  Subsequent PRs (B–E in the breakdown below) consume the infrastructure: SVDSBTL first, BICUBIC/TTSE/REFPROP later, deprecating the corresponding Configuration globals along the way.

### What lands

- **Factory-string parser** (`include/CoolProp/FactoryOptions.h`, `src/FactoryOptions.cpp`).  Splits the optional ``?<options>`` suffix from a factory string with a single ``find_first_of('?')``; resolves inline JSON or ``?@<path>`` indirection.  Pure helper; 27 assertions over 7 cases including all the ``?``-inside-JSON contracts Ian called out at design review.
- **JSON schema validator + canonical-JSON helper** (`include/CoolProp/SchemaValidation.h`, `src/SchemaValidation.cpp`).  RapidJSON-backed strict-mode validator; recursive key-sort canonicaliser used for cache hashing and reproducibility (FNV-1a 64 over the canonical bytes; same hash family CoolProp already uses for ``source_eos_hash``).
- **Options-aware `AbstractStateGenerator` overload** + ``AbstractState::build_options_json()`` virtual.  Default forwards to the no-options overload on empty input and throws ``NotImplementedError`` otherwise, so silent option-dropping cannot happen.  Cython binding stub added.
- **`AbstractState::factory()` wired** to call the parser on entry, hoist a ``?<options>`` suffix from *either* the backend or the fluid side (PropsSI puts it on the fluid side after ``::`` splitting), and pass the raw JSON through to the backend generator.  Existing TTSE / BICUBIC / SVDSBTL inline branches throw if options are supplied — they opt in via follow-up PRs.
- **PropsSI / Props1SI / PhaseSI pass-through tests** — the high-level API forwards ``?<options>`` verbatim through the existing ``FluidName`` argument; zero new entry-points; works for FORTRAN / Excel / MATLAB via the standard string path.
- **Sphinx docs page** (`Web/coolprop/BackendOptions.rst`).  Linked into the toctree between Tabular and Configuration.

### Why this layout

- **Per-instance, immutable, schema-validated, reproducible** — see the spec doc.
- **No new public C++ entry-points** — the suffix rides on the existing factory string, so every wrapper benefits without per-language code.
- **JSON over query-string** for typed nested options and schema evolution; ``?@path`` indirection for callers (Excel, FORTRAN) where escaping inline JSON is painful.

### PR breakdown (this is **PR A**)

| PR | Theme | Status |
|---|---|---|
| **A** (this) | Generic options machinery + spec | **here** |
| B | SVDSBTL opts in (schema + cache key + critical_patch knobs) | next |
| C | Critical-patch HEOS-fallback routing | after B |
| D | Auto-calibration loop | after C |
| E | First generalization PoC (BICUBIC opt-in) + final docs polish | after D |

### Test plan

- [x] Parser unit tests (27 assertions / 7 cases) — including all five `?`-in-JSON cases from Ian's design-review note.
- [x] Schema validator + canonical-JSON unit tests (25 assertions / 16 cases) — unknown keys, type mismatches, enum violations, required-key missing, sorted-key idempotence, cross-input logical equality.
- [x] Factory dispatch unit tests (33 assertions / 10 cases) — `?` stripped before backend dispatch, ambiguous-both-sides rejected, default overload throws for opted-out backends.
- [x] PropsSI / Props1SI / PhaseSI integration tests (45 assertions / 6 cases + 1 REFPROP-only skipped) — high-level API accepts inline JSON and `@path` indirection.
- [ ] CI green.
- [x] No regression in existing SVDSBTL Catch suite — verified locally on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-instance backend options via a `?<options>` suffix (inline JSON or `?`@path`` file), opt-in backend validation, and a public method to retrieve canonical options JSON for reproducible behavior and deterministic cache keys.
* **Documentation**
  * Comprehensive backend options guide and formal design/specification added.
* **Tests**
  * New test suites covering parsing, file indirection, schema validation, canonicalization, and API integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2927?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->