### PR TITLE
SVDSBTL critical-patch HEOS-fallback routing (PR C)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2110,6 +2110,8 @@ if(COOLPROP_CATCH_MODULE)
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-PropsSIOptions.cpp")
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-SVDSBTLOptions.cpp")
+  list(APPEND APP_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-SVDSBTLCriticalPatch.cpp")
 
   # CATCH TEST, compile everything with catch and set test entry point
   add_executable(CatchTestRunner ${APP_SOURCES})

--- a/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
+++ b/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
@@ -268,6 +268,45 @@ class SVDSBTLBackend : public AbstractState
         double uV_mol = 0.0;
     };
     TwoPhaseState two_phase_{};
+
+    // Critical-patch HEOS-fallback.  When an active query point lands
+    // inside the configured bbox (in whatever the input pair's native
+    // coords are), update() forwards the call to `patch_source_`
+    // instead of the SVD surface, and every calc_* below routes there
+    // for the duration of the current state.  Bbox is precomputed at
+    // construction per input pair so update() is a constant-time
+    // axis-aligned containment check.  Disabled when
+    // critical_patch.mode is "off" in the options blob.
+    struct CriticalPatchBbox
+    {
+        double a_lo, a_hi;  // primary axis: p for both PT and HmassP
+        double b_lo, b_hi;  // secondary axis: T for PT, h for HmassP
+    };
+    struct CriticalPatch
+    {
+        bool enabled = false;
+        std::string source;  // "HEOS" / "REFPROP" / "IF97"
+        std::unordered_map<int /*input_pairs as int*/, CriticalPatchBbox> bbox_per_pair;
+        [[nodiscard]] bool contains(::CoolProp::input_pairs pair, double a, double b) const noexcept;
+    };
+    CriticalPatch critical_patch_{};
+    std::shared_ptr<CoolProp::AbstractState> patch_source_;  // lazy
+    bool active_in_patch_ = false;
+
+    // Configure critical_patch_ from the validated options blob.
+    // Called once at construction after surfaces_ are loaded.  When
+    // mode == "auto" uses the default multipliers (PR D plugs in
+    // real auto-calibration); when "fixed" honours `bbox`; when
+    // "off" leaves enabled=false and queries always go to the SVD.
+    void build_critical_patch_(const std::string& options_canonical);
+
+    // Get the patch-side source backend, allocating on first use.
+    // The patch source can differ from the SVD truth source (set via
+    // `critical_patch.source` in the options blob) — e.g. SVDSBTL&IF97
+    // can still route patch queries through HEOS for full IAPWS-95
+    // accuracy at the critical singularity.  Defaults to the SVD
+    // truth source when null.
+    std::shared_ptr<CoolProp::AbstractState> patch_source_ref_();
 };
 
 }  // namespace CoolProp

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -116,6 +116,123 @@ SVDSBTLBackend::SVDSBTLBackend(const std::string& fluid_name, const std::string&
     for (const auto pair : kSupportedPairs) {
         ensure_surface_(pair);
     }
+    build_critical_patch_(options_canonical_);
+}
+
+bool SVDSBTLBackend::CriticalPatch::contains(::CoolProp::input_pairs pair, double a, double b) const noexcept {
+    if (!enabled) {
+        return false;
+    }
+    const auto it = bbox_per_pair.find(static_cast<int>(pair));
+    if (it == bbox_per_pair.end()) {
+        return false;
+    }
+    const auto& bb = it->second;
+    return (a >= bb.a_lo && a <= bb.a_hi && b >= bb.b_lo && b <= bb.b_hi);
+}
+
+std::shared_ptr<::CoolProp::AbstractState> SVDSBTLBackend::patch_source_ref_() {
+    if (patch_source_) {
+        return patch_source_;
+    }
+    // critical_patch_.source is empty when the options blob left it
+    // null / default — fall back to the SVD truth source so the
+    // patch IS the source by definition.
+    const std::string backend = critical_patch_.source.empty() ? source_backend_ : critical_patch_.source;
+    patch_source_.reset(::CoolProp::AbstractState::factory(backend, fluid_name_));
+    return patch_source_;
+}
+
+void SVDSBTLBackend::build_critical_patch_(const std::string& options_canonical) {
+    critical_patch_ = CriticalPatch{};  // disabled by default
+    // Default behaviour when no options are supplied (mode unset) is
+    // "auto" with the spec's hardcoded multipliers.  PR D will plug
+    // in the actual binary-search-shrink loop.
+    std::string mode = "auto";
+    std::array<double, 4> bbox_mult = {0.95, 1.05, 0.75, 1.15};  // T_lo, T_hi, p_lo, p_hi
+    std::string patch_source;
+
+    if (!options_canonical.empty()) {
+        rapidjson::Document opts;
+        opts.Parse(options_canonical.c_str(), options_canonical.size());
+        if (opts.IsObject() && opts.HasMember("critical_patch") && opts["critical_patch"].IsObject()) {
+            const auto& cp = opts["critical_patch"];
+            if (cp.HasMember("mode") && cp["mode"].IsString()) {
+                mode = cp["mode"].GetString();
+            }
+            if (cp.HasMember("source") && cp["source"].IsString()) {
+                patch_source = cp["source"].GetString();
+            }
+            if (cp.HasMember("bbox") && cp["bbox"].IsArray() && cp["bbox"].Size() == 4) {
+                for (std::size_t i = 0; i < 4; ++i) {
+                    bbox_mult[i] = cp["bbox"][static_cast<rapidjson::SizeType>(i)].GetDouble();
+                }
+            }
+        }
+    }
+    if (mode == "off") {
+        return;
+    }
+    if (mode != "auto" && mode != "fixed") {
+        // schema validation should have caught this already
+        return;
+    }
+
+    // Set the patch source up-front so an invalid `critical_patch.source`
+    // override fails at construction (factory throws on unknown backend)
+    // instead of on the first in-patch query.  Also: the bbox must be
+    // sampled from the SAME backend that will serve the patch — if a
+    // user runs SVDSBTL&IF97 with critical_patch.source="HEOS", the
+    // (p, h) envelope has to come from HEOS's h(T, p) so the in-patch
+    // (h, p) classification matches what HEOS would return.
+    critical_patch_.enabled = true;
+    critical_patch_.source = patch_source;
+    auto src = patch_source_ref_();  // factories the patch backend; throws on invalid
+
+    const double Tc = src->T_critical();
+    const double pc = src->p_critical();
+    const double T_lo = bbox_mult[0] * Tc;
+    const double T_hi = bbox_mult[1] * Tc;
+    const double p_lo = bbox_mult[2] * pc;
+    const double p_hi = bbox_mult[3] * pc;
+
+    // PT_INPUTS — native bbox is (p, T): a = p, b = T.
+    critical_patch_.bbox_per_pair[static_cast<int>(::CoolProp::PT_INPUTS)] = CriticalPatchBbox{p_lo, p_hi, T_lo, T_hi};
+
+    // HmassP_INPUTS — bbox is (p, h).  Walk the (T, p) bbox's
+    // perimeter through the PATCH backend's h(T, p) and take the
+    // conservative axis-aligned envelope of the resulting h values.
+    // Catches every (T, p) in the critical box; may include cells
+    // slightly outside (false positive → source backend used outside
+    // the strict box, correct but slightly slower; no false negatives).
+    double h_lo = std::numeric_limits<double>::infinity();
+    double h_hi = -std::numeric_limits<double>::infinity();
+    constexpr int kPerimeterSamples = 24;
+    auto try_h = [&](double T, double p) {
+        try {
+            src->update(::CoolProp::PT_INPUTS, p, T);
+            const double h = src->hmass();
+            if (std::isfinite(h)) {
+                h_lo = std::min(h_lo, h);
+                h_hi = std::max(h_hi, h);
+            }
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            // Source may reject (T, p) inside the dome at p just below
+            // pc — those cells aren't critical-supercritical anyway.
+            // Skipping them only narrows the h-bbox, which is the
+            // safer direction.
+        }
+    };
+    for (int i = 0; i <= kPerimeterSamples; ++i) {
+        const double f = static_cast<double>(i) / kPerimeterSamples;
+        try_h(T_lo + f * (T_hi - T_lo), p_lo);
+        try_h(T_lo + f * (T_hi - T_lo), p_hi);
+        try_h(T_lo, p_lo + f * (p_hi - p_lo));
+        try_h(T_hi, p_lo + f * (p_hi - p_lo));
+    }
+    if (std::isfinite(h_lo) && std::isfinite(h_hi) && h_lo < h_hi) {
+        critical_patch_.bbox_per_pair[static_cast<int>(::CoolProp::HmassP_INPUTS)] = CriticalPatchBbox{p_lo, p_hi, h_lo, h_hi};
+    }
 }
 
 std::shared_ptr<CoolProp::AbstractState> SVDSBTLBackend::source_reference_() {
@@ -283,7 +400,12 @@ void SVDSBTLBackend::update(CoolProp::input_pairs input_pair, double value1, dou
         return;
     }
 
-    const auto it = surfaces_.find(static_cast<int>(input_pair));
+    // HmolarP shares the HmassP surface — the molar→mass conversion
+    // happens in the switch below.  Without this normalisation the
+    // surfaces_.find() lookup would miss (we only register HmassP and
+    // PT keys) and the HmolarP switch case would be unreachable.
+    const auto surface_key = (input_pair == CoolProp::HmolarP_INPUTS) ? CoolProp::HmassP_INPUTS : input_pair;
+    const auto it = surfaces_.find(static_cast<int>(surface_key));
     if (it == surfaces_.end() || !it->second) {
         throw ValueError(std::string("SVDSBTL backend: no surface registered for this input pair (") + CoolProp::get_input_pair_short_desc(input_pair)
                          + ")");
@@ -291,35 +413,61 @@ void SVDSBTLBackend::update(CoolProp::input_pairs input_pair, double value1, dou
 
     active_pair_ = input_pair;
     active_surface_ = it->second.get();
+    active_in_patch_ = false;
 
     // Record inputs into AbstractState's standard slots so calc_T() /
     // calc_pressure() can return them directly without an SVD round-trip.
+    // While we're at it, ask critical_patch_ whether this state lies in
+    // its bbox; if so, every calc_* below routes through patch_source_
+    // instead of the SVD surface.  The bbox check itself is O(1).
     switch (input_pair) {
         case CoolProp::HmassP_INPUTS: {
             // (a, b) = (p, h) per ph_subcritical preset; value1=h, value2=p.
             _p = value2;
             active_hmass_ = value1;
-            active_point_ = active_surface_->resolve(_p, active_hmass_);
+            active_in_patch_ = critical_patch_.contains(input_pair, _p, active_hmass_);
+            if (active_in_patch_) {
+                patch_source_ref_()->update(input_pair, value1, value2);
+                _T = patch_source_->T();
+            } else {
+                active_point_ = active_surface_->resolve(_p, active_hmass_);
+            }
             break;
         }
         case CoolProp::HmolarP_INPUTS: {
             // Convert molar → mass and route to the PH surface.
             _p = value2;
             active_hmass_ = value1 / calc_molar_mass();
-            active_point_ = active_surface_->resolve(_p, active_hmass_);
+            active_in_patch_ = critical_patch_.contains(CoolProp::HmassP_INPUTS, _p, active_hmass_);
+            if (active_in_patch_) {
+                patch_source_ref_()->update(CoolProp::HmassP_INPUTS, active_hmass_, _p);
+                _T = patch_source_->T();
+            } else {
+                active_point_ = active_surface_->resolve(_p, active_hmass_);
+            }
             break;
         }
         case CoolProp::PT_INPUTS: {
             // (a, b) = (p, T) per pt_subcritical preset; value1=p, value2=T.
             _p = value1;
             _T = value2;
-            active_point_ = active_surface_->resolve(_p, _T);
+            active_in_patch_ = critical_patch_.contains(input_pair, _p, _T);
+            if (active_in_patch_) {
+                patch_source_ref_()->update(input_pair, value1, value2);
+            } else {
+                active_point_ = active_surface_->resolve(_p, _T);
+            }
             break;
         }
         default:
             throw ValueError(std::string("SVDSBTL backend update: unsupported input pair (") + CoolProp::get_input_pair_short_desc(input_pair) + ")");
     }
     active_resolved_ = true;
+    if (active_in_patch_) {
+        // Patch is active: the source backend owns the answers for
+        // calc_* below.  active_point_ stays invalid but isn't read.
+        return;
+    }
 
     if (active_point_.region_idx < 0) {
         // Out of every single-phase region.  For HmassP this typically
@@ -445,10 +593,14 @@ CoolPropDbl SVDSBTLBackend::lookup_(CoolProp::parameters prop) {
 
 // Mass-basis accessors — route through the active SVDSurface, OR
 // through the cached two-phase blend when the active state is inside
-// the saturation dome.
+// the saturation dome, OR through the critical-patch source backend
+// when the active state falls inside the per-pair bbox.
 CoolPropDbl SVDSBTLBackend::calc_rhomass() {
     if (two_phase_.active) {
         return two_phase_property_(iDmolar) * calc_molar_mass();
+    }
+    if (active_in_patch_) {
+        return patch_source_->rhomass();
     }
     return lookup_(iDmass);
 }
@@ -461,11 +613,17 @@ CoolPropDbl SVDSBTLBackend::calc_hmass() {
     if (active_pair_ == CoolProp::HmassP_INPUTS || active_pair_ == CoolProp::HmolarP_INPUTS) {
         return active_hmass_;
     }
+    if (active_in_patch_) {
+        return patch_source_->hmass();
+    }
     return lookup_(iHmass);
 }
 CoolPropDbl SVDSBTLBackend::calc_smass() {
     if (two_phase_.active) {
         return two_phase_property_(iSmolar) / calc_molar_mass();
+    }
+    if (active_in_patch_) {
+        return patch_source_->smass();
     }
     return lookup_(iSmass);
 }
@@ -473,12 +631,18 @@ CoolPropDbl SVDSBTLBackend::calc_umass() {
     if (two_phase_.active) {
         return two_phase_property_(iUmolar) / calc_molar_mass();
     }
+    if (active_in_patch_) {
+        return patch_source_->umass();
+    }
     return lookup_(iUmass);
 }
 
 CoolPropDbl SVDSBTLBackend::calc_T() {
     if (two_phase_.active || active_pair_ == CoolProp::PT_INPUTS) {
         return _T;
+    }
+    if (active_in_patch_) {
+        return patch_source_->T();
     }
     return lookup_(iT);
 }
@@ -490,6 +654,9 @@ CoolPropDbl SVDSBTLBackend::calc_speed_sound() {
         // Mirror what HEOS does -- throw rather than return a
         // misleading Q-weighted blend.
         throw NotImplementedError("SVDSBTL backend: speed_sound is not defined in the two-phase region");
+    }
+    if (active_in_patch_) {
+        return patch_source_->speed_sound();
     }
     return lookup_(ispeed_sound);
 }

--- a/src/Tests/CoolProp-Tests-SVDSBTLCriticalPatch.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTLCriticalPatch.cpp
@@ -1,0 +1,169 @@
+// Catch2 tests for the SVDSBTL critical-patch HEOS-fallback routing
+// (CoolProp-p0p).  At construction time, the backend computes a
+// per-input-pair bounding box around the critical point; query-time
+// update() flips a flag if the active state lies inside; every calc_*
+// then forwards to a source backend instead of the SVD surface.
+//
+// The default-mode (no options supplied) uses spec-recommended
+// multipliers [0.95, 1.05] * Tcrit  x  [0.75, 1.15] * pcrit.  PR D
+// replaces the constants with a real auto-calibration loop.
+
+#if defined(ENABLE_CATCH)
+
+#    include <catch2/catch_all.hpp>
+
+#    include <memory>
+#    include <string>
+
+#    include "AbstractState.h"
+#    include "Exceptions.h"
+
+namespace {
+
+std::shared_ptr<CoolProp::AbstractState> make_svdsbtl(const std::string& opts = "") {
+    const std::string spec = opts.empty() ? std::string("Water") : "Water?" + opts;
+    return std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", spec));
+}
+
+}  // namespace
+
+TEST_CASE("critical_patch: query inside the bbox matches source backend", "[SVDSBTL][critical_patch]") {
+    auto AS = make_svdsbtl();
+    auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+
+    // A state that lives inside the default critical bbox:
+    // T = T_crit (= 647.096 K) and p = 1.05 * p_crit.  Without the
+    // patch the rank-truncation residual is multi-percent; with the
+    // patch the answer is the source backend's value byte-for-byte.
+    const double Tc = heos->T_critical();
+    const double pc = heos->p_critical();
+    const double T = Tc;
+    const double p = 1.05 * pc;
+
+    AS->update(CoolProp::PT_INPUTS, p, T);
+    heos->update(CoolProp::PT_INPUTS, p, T);
+
+    // Patch is active → SVDSBTL must return exactly what HEOS would
+    // return (the patch source IS HEOS in this configuration).
+    REQUIRE(AS->rhomass() == Catch::Approx(heos->rhomass()).margin(1e-9));
+    REQUIRE(AS->hmass() == Catch::Approx(heos->hmass()).margin(1e-6));
+    REQUIRE(AS->smass() == Catch::Approx(heos->smass()).margin(1e-9));
+    REQUIRE(AS->speed_sound() == Catch::Approx(heos->speed_sound()).margin(1e-9));
+}
+
+TEST_CASE("critical_patch: query outside the bbox uses the SVD surface", "[SVDSBTL][critical_patch]") {
+    auto AS = make_svdsbtl();
+    auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+
+    // 0.5 * Tcrit  /  0.5 * pcrit — comfortably outside the default
+    // patch bbox in BOTH axes.  Should be within SVD-truncation
+    // accuracy (a few hundred ppm on density) of HEOS, but NOT
+    // bit-identical (which would mean the patch fired by mistake).
+    const double T = 0.5 * heos->T_critical();
+    const double p = 0.5 * heos->p_critical();
+
+    AS->update(CoolProp::PT_INPUTS, p, T);
+    heos->update(CoolProp::PT_INPUTS, p, T);
+    const double rho_svd = AS->rhomass();
+    const double rho_heos = heos->rhomass();
+    REQUIRE(std::isfinite(rho_svd));
+    REQUIRE(rho_svd == Catch::Approx(rho_heos).epsilon(2e-3));  // SVD truncation looseness
+    // Bit-identity check — if these were equal, the patch fired here.
+    if (rho_svd == rho_heos) {
+        FAIL("critical-patch fired outside its bbox at a clearly subcritical state");
+    }
+}
+
+TEST_CASE("critical_patch: mode=off disables routing", "[SVDSBTL][critical_patch]") {
+    auto AS = make_svdsbtl(R"({"critical_patch":{"mode":"off"}})");
+    auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+
+    // Same point that fires the patch in the default config; with
+    // mode=off the SVD surface answers, and the value is NOT
+    // bit-identical to HEOS (it carries SVD-truncation residual).
+    const double Tc = heos->T_critical();
+    const double pc = heos->p_critical();
+    AS->update(CoolProp::PT_INPUTS, 1.05 * pc, Tc);
+    heos->update(CoolProp::PT_INPUTS, 1.05 * pc, Tc);
+    const double rho_svd = AS->rhomass();
+    const double rho_heos = heos->rhomass();
+    REQUIRE(std::isfinite(rho_svd));
+    if (rho_svd == rho_heos) {
+        FAIL("critical-patch is supposed to be off but produced bit-identical values");
+    }
+}
+
+TEST_CASE("critical_patch: HmassP_INPUTS routing matches source backend in the bbox", "[SVDSBTL][critical_patch]") {
+    auto AS = make_svdsbtl();
+    auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+
+    // Same critical-region state as above, but expressed in (h, p).
+    const double Tc = heos->T_critical();
+    const double pc = heos->p_critical();
+    heos->update(CoolProp::PT_INPUTS, 1.05 * pc, Tc);
+    const double h = heos->hmass();
+    const double p = 1.05 * pc;
+
+    AS->update(CoolProp::HmassP_INPUTS, h, p);
+    heos->update(CoolProp::HmassP_INPUTS, h, p);
+
+    REQUIRE(AS->rhomass() == Catch::Approx(heos->rhomass()).margin(1e-9));
+    REQUIRE(AS->T() == Catch::Approx(heos->T()).margin(1e-9));
+    REQUIRE(AS->smass() == Catch::Approx(heos->smass()).margin(1e-9));
+}
+
+TEST_CASE("critical_patch: HmolarP_INPUTS reaches the surface lookup (CodeRabbit)", "[SVDSBTL][critical_patch]") {
+    // surfaces_ only registers HmassP_INPUTS and PT_INPUTS — HmolarP
+    // shares the HmassP surface via a molar→mass conversion inside
+    // update().  Without normalising the surface_key the surfaces_.find()
+    // would miss and update(HmolarP_INPUTS, ...) would throw before
+    // any of the routing logic ran.
+    auto AS = make_svdsbtl();
+    auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+    const double T = 300.0, p = 1e6;
+    heos->update(CoolProp::PT_INPUTS, p, T);
+    const double h_molar = heos->hmolar();
+    REQUIRE_NOTHROW(AS->update(CoolProp::HmolarP_INPUTS, h_molar, p));
+    REQUIRE(AS->p() == Catch::Approx(p).margin(1.0));
+    REQUIRE(AS->T() == Catch::Approx(T).epsilon(1e-3));
+}
+
+TEST_CASE("critical_patch: invalid critical_patch.source fails at construction (CodeRabbit)", "[SVDSBTL][critical_patch]") {
+    // The patch source is materialised inside build_critical_patch_()
+    // so a misconfigured source (here: IF97 patch on a non-Water
+    // fluid; IF97 is Water-only) fails immediately at construction
+    // instead of on the first in-patch query.
+    REQUIRE_THROWS(
+      std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", R"(R134a?{"critical_patch":{"source":"IF97"}})")));
+}
+
+TEST_CASE("critical_patch: mode=fixed honours an explicit bbox", "[SVDSBTL][critical_patch]") {
+    // A tight box ~ Tcrit ± 1%, pcrit ± 3% — narrower than the
+    // default; a sample inside this fires the patch, a sample just
+    // outside does not.
+    auto AS = make_svdsbtl(R"({"critical_patch":{"mode":"fixed","bbox":[0.99,1.01,0.97,1.03]}})");
+    auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+    const double Tc = heos->T_critical();
+    const double pc = heos->p_critical();
+
+    SECTION("inside narrow bbox → patch fires") {
+        AS->update(CoolProp::PT_INPUTS, pc, Tc);
+        heos->update(CoolProp::PT_INPUTS, pc, Tc);
+        REQUIRE(AS->rhomass() == Catch::Approx(heos->rhomass()).margin(1e-9));
+    }
+    SECTION("outside narrow bbox but inside default → patch off") {
+        // 1.10 * pc is inside the default [0.75, 1.15] bbox but
+        // outside this 1.03 fixed cap.  With the fixed-mode bbox the
+        // patch must NOT fire here.
+        AS->update(CoolProp::PT_INPUTS, 1.10 * pc, Tc);
+        heos->update(CoolProp::PT_INPUTS, 1.10 * pc, Tc);
+        const double rho_svd = AS->rhomass();
+        const double rho_heos = heos->rhomass();
+        REQUIRE(std::isfinite(rho_svd));
+        if (rho_svd == rho_heos) {
+            FAIL("fixed-mode patch fired outside its supplied bbox");
+        }
+    }
+}
+
+#endif  // ENABLE_CATCH

--- a/src/Tests/CoolProp-Tests-SVDSBTLCriticalPatch.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTLCriticalPatch.cpp
@@ -12,6 +12,7 @@
 
 #    include <catch2/catch_all.hpp>
 
+#    include <cmath>
 #    include <memory>
 #    include <string>
 


### PR DESCRIPTION
## Summary

Third PR in the backend-options epic.  **Stacked on #2928 (PR B) → #2927 (PR A) → master.**

### What lands

Activates the `critical_patch.*` knobs PR B already accepted in the schema and persisted in the canonical-options blob.  When the active state lands inside the per-input-pair bbox, every `calc_*` forwards to a source backend instead of the SVD surface, so the rank-truncation residual near the critical singularity goes away.

- **`SVDSBTLBackend::CriticalPatch`** holds an `enabled` flag, an optional source-backend override, and a `bbox_per_pair` map (one entry per supported input pair).  `contains()` is an O(1) axis-aligned containment check.
- **`build_critical_patch_()`** runs once at construction.  PT_INPUTS bbox is native `(p, T)`.  HmassP_INPUTS bbox is derived by walking the `(T, p)` bbox perimeter through `source->hmass()`; the resulting `(p, h)` rectangle is conservative — every `(T, p)` inside the critical box maps to an `(h, p)` inside the patch envelope, with small false-positive headroom that just means the source backend answers a few extra calls outside the strict box.
- **`update()`** flips `active_in_patch_` once per call; **`calc_rhomass / calc_hmass / calc_smass / calc_umass / calc_T / calc_speed_sound`** check the flag and forward to `patch_source_` when set.
- **`patch_source_ref_()`** lazy-allocates the patch backend so SVDSBTL&IF97 doesn't pay for a HEOS factory call unless the user opts into a HEOS-source patch via `critical_patch.source`.

### Defaults this PR ships

- `mode="auto"` (when not specified in options) — uses the spec's hardcoded multipliers `[0.95, 1.05]·Tcrit × [0.75, 1.15]·pcrit`.  PR D replaces with the binary-search-shrink auto-cal loop.
- `mode="off"` — patch disabled.
- `mode="fixed"` — honours the supplied `bbox`.
- `source=null` (default) — patch uses the SVD truth source.

### Test plan

5 new cases / 12 assertions in `CoolProp-Tests-SVDSBTLCriticalPatch.cpp`:

- Inside-bbox PT_INPUTS query is bit-identical to HEOS (patch fired).
- Outside-bbox PT_INPUTS query uses SVD (NOT bit-identical to HEOS — carries SVD truncation; explicit check that the patch did not silently fire).
- `mode=off` forces SVD even inside the would-be patch.
- Inside-bbox HmassP_INPUTS query is bit-identical to HEOS (the `(h, p) → (T, p)` hoist on the patch source works end-to-end).
- `mode=fixed` with a tight bbox: fires inside, NOT outside.

Full regression: **325 SVDSBTL assertions across 28 cases pass**.

### Beads closed

- **CoolProp-p0p** — critical-patch HEOS-fallback routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SVDSBTL backend adds a configurable "critical-patch" fallback that routes queries inside per-fluid bounding boxes to an alternate backend for improved accuracy; supports modes (on/off/fixed), optional explicit bbox, and handles PT, HmassP and HmolarP query types with lazy allocation of the patch backend.

* **Tests**
  * Added tests validating routing, accuracy inside/outside bboxes, HmolarP/HmassP handling, mode toggles, and construction-time validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2929?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->