### PR TITLE
feat(svdsbtl): Chebyshev η + Newton-refined IF97 + ε-band phase-pin

### DIFF
--- a/include/CoolProp/sbtl/SVDSurfaceSerializer.h
+++ b/include/CoolProp/sbtl/SVDSurfaceSerializer.h
@@ -85,7 +85,15 @@ class SVDSurfaceSerializer
     //          Old rev-4 caches are missing two properties at the
     //          tail; bump to force rebuild rather than try to silently
     //          extend them in-place.
-    static constexpr int kRevision = 5;
+    //   rev 6: Chebyshev η-spacing on the secondary axis (cells now
+    //          crowd toward the saturation curve) and IF97-source
+    //          sampling Newton-refines against forward h(T, p) at
+    //          build time.  Both change the *content* of the stored
+    //          U-matrix and slopes at the same hashed options key, so
+    //          the rev bump is the cache-invalidation mechanism — old
+    //          rev-5 caches would silently serve uniform-η surfaces
+    //          and undo the IF97 conformance gains.
+    static constexpr int kRevision = 6;
 
     // Pack one surface into a zlib-compressed msgpack blob.
     static std::vector<char> save(const SVDSurface& surface);

--- a/src/Backends/IF97/IF97Backend.h
+++ b/src/Backends/IF97/IF97Backend.h
@@ -176,10 +176,25 @@ class IF97Backend : public AbstractState
                 _T = value2;
                 _Q = -1;
                 set_phase();
-                //Two-Phase Check, with PT Inputs:
-                if (_phase == iphase_twophase)
-                    throw ValueError(format("Saturation pressure [%g Pa] corresponding to T [%g K] is within 3.3e-3 %% of given p [%Lg Pa]",
-                                            IF97::psat97(_T), _T, _p));
+                // Two-Phase Check, with PT Inputs.  set_phase()'s
+                // ε=3.3e-5 band around the saturation curve catches
+                // genuinely-ambiguous (p, T)-on-the-dome usage where
+                // the caller should be using PQ / QT inputs instead.
+                // But sampling-driven callers (SBTL surface build,
+                // Newton refinement of a forward h(T, p) = h_target
+                // iteration) legitimately land in this band through
+                // round-off and want a single-phase evaluation on
+                // the side they tell us.  Honour an explicit
+                // specify_phase() hint here; throw otherwise.
+                if (_phase == iphase_twophase) {
+                    if (imposed_phase_index == iphase_liquid || imposed_phase_index == iphase_supercritical_liquid
+                        || imposed_phase_index == iphase_gas || imposed_phase_index == iphase_supercritical_gas) {
+                        _phase = imposed_phase_index;
+                    } else {
+                        throw ValueError(format("Saturation pressure [%g Pa] corresponding to T [%g K] is within 3.3e-3 %% of given p [%Lg Pa]",
+                                                IF97::psat97(_T), _T, _p));
+                    }
+                }
                 break;
             case PQ_INPUTS:
                 _p = value1;
@@ -539,6 +554,18 @@ class IF97Backend : public AbstractState
     phases calc_phase() {
         return _phase;
     };
+
+    // Phase-hint plumbing.  AbstractState's default calc_specify_phase
+    // throws NotImplementedError; override here so callers can use
+    // specify_phase() to disambiguate (p, T) inputs that land within
+    // IF97's 3.3e-5 ε-band of the saturation curve.  The hint is read
+    // by update(PT_INPUTS) above.
+    void calc_specify_phase(phases phase) {
+        imposed_phase_index = phase;
+    }
+    void calc_unspecify_phase() {
+        imposed_phase_index = iphase_not_imposed;
+    }
 
     //
     // ************************************************************************* //

--- a/src/SBTL/SVDSurfaceFactory.cpp
+++ b/src/SBTL/SVDSurfaceFactory.cpp
@@ -17,6 +17,45 @@ namespace sbtl {
 
 namespace {
 
+// Build the per-region (xn, xi) grids returned to both the sampler and
+// the SVD builder.  Single source of truth for the secondary-axis
+// spacing — the SVD's stored y_grid MUST match the η positions where
+// the source was actually sampled, so sample_grid() and the
+// build_surface() loop below both go through here.
+//
+// Secondary axis (xn) uses Chebyshev-cosine spacing: cells crowd toward
+// both η=0 and η=1 boundaries.  In LIQUID/VAPOR regions the saturation
+// curve is one of the η boundaries, and properties have sharp curvature
+// in a thin η-strip right against it.  Uniform η spacing puts only ~1
+// grid cell of resolution into that strip — measured worst-case error
+// in SVDSBTL&HEOS R2 lives there (h_truth − h_sat,V ≈ 0.33%, η ≈ 0.005,
+// only ~1 grid cell of support at NT=200).  Chebyshev squashes bulk
+// cells toward the middle and crowds them at both ends, dropping
+// per-region failure counts by 6-9× on the SVDSBTL&HEOS conformance
+// fail-map (2026-05-18).
+//
+// Tiny pad off the literal 0 / 1 corners keeps boundary-curve evaluation
+// safe — the cubic-spline / Chebyshev sat boundaries can extrapolate
+// epsilon-outside their fit interval at the dome corners, and HmassP
+// flash failures cluster there.
+//
+// Primary axis (xi) stays on uniform spacing — its scale is handled by
+// the region's AxisTransform (linear or log) at from_normalized() time.
+std::pair<std::vector<double>, std::vector<double>> make_grid_axes(std::size_t NT, std::size_t NR) {
+    constexpr double kPadEnd = 0.001;
+    std::vector<double> xn_grid(NT);
+    std::vector<double> xi_grid(NR);
+    for (std::size_t i = 0; i < NT; ++i) {
+        const double t = static_cast<double>(i) / static_cast<double>(NT - 1);
+        const double eta_cheb = 0.5 * (1.0 - std::cos(M_PI * t));
+        xn_grid[i] = kPadEnd + (1.0 - 2.0 * kPadEnd) * eta_cheb;
+    }
+    for (std::size_t j = 0; j < NR; ++j) {
+        xi_grid[j] = static_cast<double>(j) / static_cast<double>(NR - 1);
+    }
+    return {std::move(xn_grid), std::move(xi_grid)};
+}
+
 // Walk the (xnorm, log_p_norm) ∈ [0,1] × [0,1] grid for one Region,
 // sample HEOS per cell via the spec's update_state / read_property
 // callbacks, and fill the per-property matrix dictionary.  Cells
@@ -31,32 +70,7 @@ std::vector<std::vector<double>> sample_grid(::CoolProp::AbstractState& heos, co
     const std::size_t NR = spec.NR;
     const std::size_t n_props = spec.properties.size();
 
-    std::vector<double> xn_grid(NT);
-    std::vector<double> xi_grid(NR);
-    // Chebyshev-style spacing on the secondary axis: cells crowd
-    // toward both η=0 and η=1 boundaries.  In LIQUID/VAPOR regions
-    // the saturation curve is one of the η boundaries, and properties
-    // have sharp curvature in a thin η-strip right against it.
-    // Uniform η spacing puts only ~1 grid cell of resolution into that
-    // strip — measured worst-case error in SVDSBTL&HEOS R2 lives there
-    // (h_truth − h_sat,V ≈ 0.33%, η ≈ 0.005, only ~1 grid cell of
-    // support at NT=200).  Chebyshev squashes bulk cells toward the
-    // middle and crowds them at both ends, dropping per-region failure
-    // counts by 6-9× on the SVDSBTL&HEOS conformance fail-map (2026-05-18).
-    //
-    // Tiny pad off the literal 0 / 1 corners keeps boundary-curve
-    // evaluation safe — the cubic-spline / Chebyshev sat boundaries
-    // can extrapolate epsilon-outside their fit interval at the dome
-    // corners, and HmassP flash failures cluster there.
-    constexpr double kPadEnd = 0.001;
-    for (std::size_t i = 0; i < NT; ++i) {
-        const double t = static_cast<double>(i) / static_cast<double>(NT - 1);
-        const double eta_cheb = 0.5 * (1.0 - std::cos(M_PI * t));
-        xn_grid[i] = kPadEnd + (1.0 - 2.0 * kPadEnd) * eta_cheb;
-    }
-    for (std::size_t j = 0; j < NR; ++j) {
-        xi_grid[j] = static_cast<double>(j) / static_cast<double>(NR - 1);
-    }
+    const auto [xn_grid, xi_grid] = make_grid_axes(NT, NR);
 
     // M[prop][i*NR + j] for each output property.
     std::vector<std::vector<double>> M(n_props);
@@ -162,25 +176,6 @@ std::vector<std::vector<double>> sample_grid(::CoolProp::AbstractState& heos, co
     return M;
 }
 
-// Build the per-region (xn, xi) grids returned to the SVD builder.
-// Must mirror sample_grid()'s xn formula above so the SVD's stored
-// y_grid matches the η positions where the source was actually
-// sampled.  See the comment block on sample_grid().
-std::pair<std::vector<double>, std::vector<double>> grid_axes(std::size_t NT, std::size_t NR) {
-    std::vector<double> xn_grid(NT);
-    std::vector<double> xi_grid(NR);
-    constexpr double kPadEnd = 0.001;
-    for (std::size_t i = 0; i < NT; ++i) {
-        const double t = static_cast<double>(i) / static_cast<double>(NT - 1);
-        const double eta_cheb = 0.5 * (1.0 - std::cos(M_PI * t));
-        xn_grid[i] = kPadEnd + (1.0 - 2.0 * kPadEnd) * eta_cheb;
-    }
-    for (std::size_t j = 0; j < NR; ++j) {
-        xi_grid[j] = static_cast<double>(j) / static_cast<double>(NR - 1);
-    }
-    return {xn_grid, xi_grid};
-}
-
 }  // namespace
 
 SVDSurface build_surface(::CoolProp::AbstractState& heos, SurfaceSpec spec, const BuildOptions& opts) {
@@ -211,7 +206,7 @@ SVDSurface build_surface(::CoolProp::AbstractState& heos, SurfaceSpec spec, cons
     }
     SVDSurface surface(spec.fluid_name, spec.input_pair, prop_keys);
 
-    const auto [xn_grid, xi_grid] = grid_axes(spec.NT, spec.NR);
+    const auto [xn_grid, xi_grid] = make_grid_axes(spec.NT, spec.NR);
 
     for (std::size_t r = 0; r < spec.regions.size(); ++r) {
         // Move the RegionSpec's boundary curves into a real Region,

--- a/src/SBTL/SVDSurfaceFactory.cpp
+++ b/src/SBTL/SVDSurfaceFactory.cpp
@@ -33,12 +33,26 @@ std::vector<std::vector<double>> sample_grid(::CoolProp::AbstractState& heos, co
 
     std::vector<double> xn_grid(NT);
     std::vector<double> xi_grid(NR);
-    // Step slightly off the corners — the η normalization is exact
-    // at the boundary curves but the Chebyshev / spline curves can
-    // extrapolate epsilon-outside their fit interval and HmassP can
-    // pile up flash failures near the dome corners.
+    // Chebyshev-style spacing on the secondary axis: cells crowd
+    // toward both η=0 and η=1 boundaries.  In LIQUID/VAPOR regions
+    // the saturation curve is one of the η boundaries, and properties
+    // have sharp curvature in a thin η-strip right against it.
+    // Uniform η spacing puts only ~1 grid cell of resolution into that
+    // strip — measured worst-case error in SVDSBTL&HEOS R2 lives there
+    // (h_truth − h_sat,V ≈ 0.33%, η ≈ 0.005, only ~1 grid cell of
+    // support at NT=200).  Chebyshev squashes bulk cells toward the
+    // middle and crowds them at both ends, dropping per-region failure
+    // counts by 6-9× on the SVDSBTL&HEOS conformance fail-map (2026-05-18).
+    //
+    // Tiny pad off the literal 0 / 1 corners keeps boundary-curve
+    // evaluation safe — the cubic-spline / Chebyshev sat boundaries
+    // can extrapolate epsilon-outside their fit interval at the dome
+    // corners, and HmassP flash failures cluster there.
+    constexpr double kPadEnd = 0.001;
     for (std::size_t i = 0; i < NT; ++i) {
-        xn_grid[i] = 0.001 + (0.999 - 0.001) * static_cast<double>(i) / static_cast<double>(NT - 1);
+        const double t = static_cast<double>(i) / static_cast<double>(NT - 1);
+        const double eta_cheb = 0.5 * (1.0 - std::cos(M_PI * t));
+        xn_grid[i] = kPadEnd + (1.0 - 2.0 * kPadEnd) * eta_cheb;
     }
     for (std::size_t j = 0; j < NR; ++j) {
         xi_grid[j] = static_cast<double>(j) / static_cast<double>(NR - 1);
@@ -149,11 +163,17 @@ std::vector<std::vector<double>> sample_grid(::CoolProp::AbstractState& heos, co
 }
 
 // Build the per-region (xn, xi) grids returned to the SVD builder.
+// Must mirror sample_grid()'s xn formula above so the SVD's stored
+// y_grid matches the η positions where the source was actually
+// sampled.  See the comment block on sample_grid().
 std::pair<std::vector<double>, std::vector<double>> grid_axes(std::size_t NT, std::size_t NR) {
     std::vector<double> xn_grid(NT);
     std::vector<double> xi_grid(NR);
+    constexpr double kPadEnd = 0.001;
     for (std::size_t i = 0; i < NT; ++i) {
-        xn_grid[i] = 0.001 + (0.999 - 0.001) * static_cast<double>(i) / static_cast<double>(NT - 1);
+        const double t = static_cast<double>(i) / static_cast<double>(NT - 1);
+        const double eta_cheb = 0.5 * (1.0 - std::cos(M_PI * t));
+        xn_grid[i] = kPadEnd + (1.0 - 2.0 * kPadEnd) * eta_cheb;
     }
     for (std::size_t j = 0; j < NR; ++j) {
         xi_grid[j] = static_cast<double>(j) / static_cast<double>(NR - 1);

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -155,15 +155,27 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
             const bool single_phase =
               (phase0 == ::CoolProp::iphase_liquid || phase0 == ::CoolProp::iphase_gas || phase0 == ::CoolProp::iphase_supercritical_liquid
                || phase0 == ::CoolProp::iphase_supercritical_gas || phase0 == ::CoolProp::iphase_supercritical);
+            // Phase pin must be exception-safe.  AbstractState::clear()
+            // doesn't reset imposed_phase_index (only HEOS resets it
+            // inline in its own update paths; IF97's update doesn't),
+            // so if any Newton step throws we must still unspecify
+            // before propagating — otherwise the stale phase hint
+            // leaks into the next sample cell and silently biases its
+            // PT_INPUTS resolution.
             if (single_phase) s.specify_phase(phase0);
-            for (int k = 0; k < 5; ++k) {
-                const double h_now = s.hmass();
-                const double dh = h_now - h;
-                if (std::abs(dh) < 1e-10 * std::abs(h)) break;
-                const double cp = s.cpmass();
-                if (!std::isfinite(cp) || cp <= 0.0) break;
-                const double T_new = s.T() - dh / cp;
-                s.update(::CoolProp::PT_INPUTS, p, T_new);
+            try {
+                for (int k = 0; k < 5; ++k) {
+                    const double h_now = s.hmass();
+                    const double dh = h_now - h;
+                    if (std::abs(dh) < 1e-10 * std::abs(h)) break;
+                    const double cp = s.cpmass();
+                    if (!std::isfinite(cp) || cp <= 0.0) break;
+                    const double T_new = s.T() - dh / cp;
+                    s.update(::CoolProp::PT_INPUTS, p, T_new);
+                }
+            } catch (...) {
+                if (single_phase) s.unspecify_phase();
+                throw;
             }
             if (single_phase) s.unspecify_phase();
         };

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -131,12 +131,50 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
     }
 
     // Thermodynamics glue: PH update + per-property readout.
-    spec.update_state = [](::CoolProp::AbstractState& s, double p, double h) {
-        // SurfaceSpec passes (a, b) where a is the primary axis (p) and
-        // b is the secondary axis (h).  HmassP_INPUTS takes (h, p) in
-        // that order.
-        s.update(::CoolProp::HmassP_INPUTS, h, p);
-    };
+    //
+    // For IF97-source sampling we Newton-refine the backwards-equation
+    // T(p, h) against the forward h(T, p) at build time.  The IAPWS
+    // R7-97 backwards equations carry a documented ±25 mK residual
+    // (see IF97.h's RegionOutputBackward note), which propagates to
+    // ~0.25 J/(kg·K) in s via ds ≈ cp·dT/T — well above the IAPWS
+    // perm budgets of 1e-3 J/(kg·K).  Newton-refining closes that gap
+    // so the SVD grid stores forward-consistent properties.  Costs
+    // ~3 extra forward calls per sample (build-time only); query path
+    // unchanged.  HEOS / REFPROP sources don't need refinement
+    // because their HmassP path converges to forward precision
+    // internally.
+    //
+    // Newton iterates may land within IF97's 3.3e-5 ε-band of the
+    // saturation curve.  Pin the phase across iterations so PT_INPUTS
+    // doesn't trip the ε-band reject.
+    const bool source_is_if97 = (heos.backend_name() == "IF97Backend");
+    if (source_is_if97) {
+        spec.update_state = [](::CoolProp::AbstractState& s, double p, double h) {
+            s.update(::CoolProp::HmassP_INPUTS, h, p);
+            const ::CoolProp::phases phase0 = s.phase();
+            const bool single_phase =
+              (phase0 == ::CoolProp::iphase_liquid || phase0 == ::CoolProp::iphase_gas || phase0 == ::CoolProp::iphase_supercritical_liquid
+               || phase0 == ::CoolProp::iphase_supercritical_gas || phase0 == ::CoolProp::iphase_supercritical);
+            if (single_phase) s.specify_phase(phase0);
+            for (int k = 0; k < 5; ++k) {
+                const double h_now = s.hmass();
+                const double dh = h_now - h;
+                if (std::abs(dh) < 1e-10 * std::abs(h)) break;
+                const double cp = s.cpmass();
+                if (!std::isfinite(cp) || cp <= 0.0) break;
+                const double T_new = s.T() - dh / cp;
+                s.update(::CoolProp::PT_INPUTS, p, T_new);
+            }
+            if (single_phase) s.unspecify_phase();
+        };
+    } else {
+        spec.update_state = [](::CoolProp::AbstractState& s, double p, double h) {
+            // SurfaceSpec passes (a, b) where a is the primary axis (p)
+            // and b is the secondary axis (h).  HmassP_INPUTS takes
+            // (h, p) in that order.
+            s.update(::CoolProp::HmassP_INPUTS, h, p);
+        };
+    }
     spec.read_property = [](::CoolProp::AbstractState& s, ::CoolProp::parameters key) -> double {
         switch (key) {
             case ::CoolProp::iDmass:


### PR DESCRIPTION
## Summary

Three coupled SVDSBTL build-time accuracy improvements, motivated by the
SVDSBTL&IF97 conformance fail-map against IAPWS G13-15 perm budgets (Tables
8-13).  Net effect on the SVDSBTL&IF97 fail-map (NT=200, NR=800, rank=28,
SVDSBTL&IF97 vs IF97 truth):

|                  | before | after |
|------------------|-------:|------:|
| R1 s fails       |    900 |    37 |
| R2 s fails       |   1470 |    15 |

Run cost: ~3 extra forward-h(T,p) calls per sample cell at build time only;
query path is untouched (same Hermite eval kernel).

### 1. IF97: honor specify_phase() to bypass ε-band reject (1784c20f)

IF97's PT_INPUTS resolves _phase via set_phase(), which throws inside a
3.3e-5 relative band around the saturation curve.  That's correct for
ambiguous on-the-dome usage but wrong for sampling-driven callers that
graze the band through round-off.  Adds calc_specify_phase /
calc_unspecify_phase overrides and an imposed-phase hint check; default
behavior unchanged.

### 2. SVDSBTL: Chebyshev η-spacing on the secondary axis (59a95749)

Both sample_grid() and grid_axes() switch from uniform to η = ½(1 −
cos(π·t)) on the secondary axis.  The saturation curve is one of the η
boundaries in LIQUID/VAPOR regions, and properties have sharp curvature in
a thin η-strip right against it — Chebyshev crowds ~6-9× more cells into
that strip at the same NT.  Cache rev bumped 5 → 6 so existing caches
rebuild cleanly on first use.

### 3. SVDSBTL: Newton-refine IF97 source sampling (715eb9e1)

When source backend is IF97Backend, ph_subcritical's update_state lambda
Newton-refines T(p, h) against forward h(T, p) (≤5 cp-weighted iterations,
Δh/h < 1e-10 bailout).  IAPWS R7-97 backwards equations carry a documented
±25 mK residual; in R2 at 300 K that propagates to Δs ≈ 0.17 J/(kg·K) —
well above the 1e-3 J/(kg·K) IAPWS perm budget.  HEOS and REFPROP sources
skip refinement (HmassP_INPUTS already converges to forward precision
internally).

Phase pinning (commit 1 above) keeps Newton iterates that graze IF97's
ε-band from tripping the reject path.

## Remaining

R2 |ΔT| max residual is ~11 K at the R2/R3 boundary kink near
T=725 K, p=37.6 MPa — structural to the SBTL preset's region topology
(SUPER region straddles R2/R3 boundary).  Filed as a follow-up to PR E,
not in scope here.

Refs: CoolProp-rae

## Test plan

- [x] `CatchTestRunner "SVDSBTL&IF97 single-phase PT lookup matches IF97 truth"` passes after rev=6 rebuild (70 s build, single-phase R1 probe @ 500K/3MPa, εrel < 1e-3)
- [ ] Full `[SVDSBTL]` suite (all fluids, two-phase, cache reload, multi-fluid, speed-of-sound) — CI
- [ ] Fail-map regen on master CI runner to confirm the 98× R2 s improvement reproduces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit phase-hint support for specifying phase in two-phase regions, with APIs to set/unset the hint.

* **Bug Fixes**
  * Improved handling and clearer errors for saturation-boundary (ε-band) ambiguities; single-phase hints are now accepted where appropriate.

* **Performance**
  * Switched to Chebyshev-style grid spacing for improved sampling accuracy.
  * Introduced targeted Newton refinement for pressure–enthalpy solves to improve convergence.

* **Chores**
  * Cache format/revision updated; existing cached data will be rebuilt on next use.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2934?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->