### PR TITLE
ci(deps): bump GitHub Actions deps (combines #2930-#2933)

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -71,7 +71,7 @@ jobs:
           fetch-depth: 0   # Fetch all history (especially branches)
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Run clang-format against C++ files touched by the PR
         shell: bash
@@ -213,7 +213,7 @@ jobs:
           python-version: '3.x'
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
@@ -221,7 +221,7 @@ jobs:
 
       - name: Autobuild Python
         if: ${{ matrix.language == 'python' }}
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Configure CPP
         if: ${{ matrix.language == 'cpp' }}
@@ -237,7 +237,7 @@ jobs:
                --config Release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
 

--- a/.github/workflows/gui_builder.yml
+++ b/.github/workflows/gui_builder.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm
@@ -449,7 +449,7 @@ jobs:
       contents: write
     steps:
       - name: Download all bundle artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           pattern: coolprop-gui-*

--- a/.github/workflows/javascript_builder.yml
+++ b/.github/workflows/javascript_builder.yml
@@ -35,7 +35,7 @@ jobs:
         set -x
         cmake --build build --target install -j $(nproc) --config $BUILD_TYPE
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: 24
 


### PR DESCRIPTION
## Summary
Combines four dependabot PRs into a single update so the workflow files only need to be reviewed/merged once.

| Action | From | To | Original PR |
| --- | --- | --- | --- |
| `astral-sh/setup-uv` | v5 | v7 | #2930 |
| `github/codeql-action` (init/autobuild/analyze) | v3 | v4 | #2931 |
| `actions/download-artifact` | v5 | v8 | #2932 |
| `actions/setup-node` | v4 | v6 | #2933 |

Files touched: `.github/workflows/dev_checks.yml`, `.github/workflows/gui_builder.yml`, `.github/workflows/javascript_builder.yml`.

Closes #2930, closes #2931, closes #2932, closes #2933.

## Test plan
- [ ] CI green on this PR (dev_checks, gui_builder, javascript_builder, CodeQL all exercise the bumped actions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development workflow infrastructure with newer versions of GitHub Actions components for improved build and code analysis capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->