### PR TITLE
ci(test_catch2): cache ~/.CoolProp/SVDTables across runs

### DIFF
--- a/.github/workflows/test_catch2.yml
+++ b/.github/workflows/test_catch2.yml
@@ -21,6 +21,35 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    # The SVDSBTL Catch2 tests build per-fluid SVD surfaces on first
+    # use and persist them under ${HOME}/.CoolProp/SVDTables/ (see
+    # SVDSurfaceSerializer::default_cache_dir).  Without a persistent
+    # cache GHA rebuilds every surface on every run — currently
+    # ~9 minutes of avoidable work per push (see CoolProp-n25 for the
+    # measured impact since PR #2919 landed Phase 2c).
+    #
+    # The cache key hashes the source paths whose contents drive the
+    # on-disk SVD bytes:
+    #   - serializer header (carries kRevision)
+    #   - SVDSBTL backend (sampling / dispatch)
+    #   - SBTL presets + factory (region geometry, grid spacing,
+    #     Newton refinement)
+    #   - SVD components (Hermite slopes, decomposition)
+    #   - region atlas (axis transforms, boundary curves)
+    #   - fluid + mixture JSON (EOS data feeds the sampled values)
+    # Any of those changing bumps the key, gets a fresh build, and
+    # populates a new cache.  Everything else (docs, wrappers, CI
+    # config) leaves the cache hot.  The on-wire kRevision check in
+    # SVDSurfaceSerializer::load is the safety net if the hash ever
+    # misses an invalidation trigger.
+    - name: Cache SVDSBTL tables
+      uses: actions/cache@v4
+      with:
+        path: ~/.CoolProp/SVDTables
+        key: svdsbtl-${{ runner.os }}-${{ hashFiles('include/CoolProp/sbtl/**', 'include/CoolProp/Backends/SVDSBTL/**', 'include/CoolProp/svd/**', 'include/CoolProp/region/**', 'src/SBTL/**', 'src/Backends/SVDSBTL/**', 'src/SVD/**', 'src/Region/**', 'dev/fluids/**', 'dev/mixtures/**') }}
+        restore-keys: |
+          svdsbtl-${{ runner.os }}-
+
     - name: Build REFPROP
       if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
       shell: bash


### PR DESCRIPTION
## Summary

Adds actions/cache@v4 for \`\${HOME}/.CoolProp/SVDTables\` to the Testing Catch2 workflow.  GHA rebuilds every SVD surface from scratch on every run today, costing ~9 minutes per push since PR #2919 (Phase 2c — SVDSBTLBackend) landed.

Measured test-phase wall-clock on master:

| date | sha | tests | test phase |
|---|---|---:|---:|
| 2026-05-15 19:31 | 25936950 (pre-#2919) | 196 | ~30 s |
| 2026-05-16 14:48 | 25964661 (#2919) | 223 | ~440 s |
| 2026-05-19 13:56 | 26101976 (PR E) | 270 | ~620 s |

The 14× jump is per-fluid SVD-surface construction; subsequent same-fluid tests within one run already hit the in-process cache in ~1 s.  Persisting the disk cache across runs lets us amortize.

## Key design

Hash source paths whose contents actually drive on-disk SVD bytes:

```bash
include/CoolProp/sbtl/**           include/CoolProp/Backends/SVDSBTL/**
include/CoolProp/svd/**            include/CoolProp/region/**
src/SBTL/**                        src/Backends/SVDSBTL/**
src/SVD/**                         src/Region/**
dev/fluids/**                      dev/mixtures/**
```

A change in any of those bumps the key, the cache misses, and a fresh build populates a new entry.  Everything else leaves the cache hot.

Safety net: \`SVDSurfaceSerializer::load\` already enforces a kRevision check, so if the hash ever misses a true invalidation trigger the loader throws and \`ensure_surface_\` rebuilds cleanly.  Worst case is one extra rebuild, never silent corruption.

\`restore-keys\` lets a PR whose hash-key doesn't yet exist fall back to the most recent matching master cache, so the typical case (\"PR doesn't touch SBTL paths\") gets the master cache as-is.

Refs: CoolProp-n25

## Test plan

- [x] \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/test_catch2.yml'))\"\` — YAML parses
- [ ] First CI run on this PR: cold cache (no matching key), full ~10 min build, cache uploaded
- [ ] Push a trivial follow-up to this branch: cache hits via restore-keys, test phase drops back to ~30-60 s
- [ ] After merge to master: subsequent unrelated PRs hit the cache via restore-keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized GitHub Actions testing pipeline with caching for build artifacts, enabling faster continuous integration runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->