### PR TITLE
feat(svdsbtl): split SUPER at IF97 R2/R3 boundary + fix R3 sampling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2112,6 +2112,8 @@ if(COOLPROP_CATCH_MODULE)
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-SVDSBTLOptions.cpp")
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-SVDSBTLCriticalPatch.cpp")
+  list(APPEND APP_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-SVDSBTLFailMap.cpp")
 
   # CATCH TEST, compile everything with catch and set test entry point
   add_executable(CatchTestRunner ${APP_SOURCES})

--- a/include/CoolProp/sbtl/SVDSurfaceSerializer.h
+++ b/include/CoolProp/sbtl/SVDSurfaceSerializer.h
@@ -93,7 +93,17 @@ class SVDSurfaceSerializer
     //          the rev bump is the cache-invalidation mechanism — old
     //          rev-5 caches would silently serve uniform-η surfaces
     //          and undo the IF97 conformance gains.
-    static constexpr int kRevision = 6;
+    //   rev 7: SUPER region split for IF97 source backend — SUPER_R3
+    //          (h < h_B23(p)) and SUPER_R2 (h > h_B23(p)) — so the
+    //          IF97 R2/R3 derivative kink sits on a region edge
+    //          instead of inside a cell.  Region count for IF97 goes
+    //          from 3 (LIQUID/VAPOR/SUPER) to 4 or 5 (LIQUID/VAPOR/
+    //          SUPER_R3/SUPER_R2 + optional SUPER_HIGH_P above 100 MPa).
+    //          On-wire region list differs, so the rev bump forces a
+    //          clean rebuild instead of attempting to deserialize a
+    //          rev-6 cache that won't have the new boundary curves.
+    //          HEOS source unchanged.
+    static constexpr int kRevision = 7;
 
     // Pack one surface into a zlib-compressed msgpack blob.
     static std::vector<char> save(const SVDSurface& surface);

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -80,6 +80,48 @@ std::vector<PropertySpec> pt_properties(::CoolProp::AbstractState& src) {
     return ps;
 }
 
+// IF97 R2/R3 boundary equation, inverted:
+//   p_B23(T) = 0.10192970039326e-2 · (T − 572.54459862746)^2 + 13.91883776670  [MPa]
+// Closed-form inverse for p ∈ [16.529, 100] MPa (the valid range for
+// IF97's R2/R3 boundary) → T ∈ [623.15, 863.15] K.  Outside this p
+// range the curve isn't defined; callers must gate.
+double if97_T_B23_K(double p_Pa) {
+    constexpr double a = 0.10192970039326e-2;
+    constexpr double b = 0.57254459862746e3;
+    constexpr double c = 0.1391883776670e2;
+    const double p_MPa = p_Pa / 1.0e6;
+    return b + std::sqrt((p_MPa - c) / a);
+}
+
+// Build the h = h_B23(p) boundary curve in (p, h) coords by walking p
+// knots and evaluating forward IF97 h(T_B23(p), p) at each.  Used to
+// split the SUPER region in ph_subcritical along the IF97 R2/R3 kink
+// when the source backend is IF97 (the kink is intrinsic to IF97's
+// piecewise EOS; HEOS source has no such internal boundary).  Valid
+// only for p ∈ [16.529 MPa, 100 MPa] — caller must clamp.
+std::unique_ptr<region::CubicSplineCurve> build_h_B23_curve(::CoolProp::AbstractState& heos, double p_lo, double p_hi) {
+    constexpr double kP_B23_lo_MPa = 16.529;
+    constexpr double kP_B23_hi_MPa = 100.0;
+    const double p_lo_clamped = std::max(p_lo, kP_B23_lo_MPa * 1.0e6);
+    const double p_hi_clamped = std::min(p_hi, kP_B23_hi_MPa * 1.0e6);
+    if (!(p_lo_clamped < p_hi_clamped)) {
+        throw std::invalid_argument("build_h_B23_curve: p range does not overlap IF97 B23 curve's [16.529, 100] MPa validity");
+    }
+    constexpr std::size_t n_knots = 64;
+    std::vector<double> p_knots(n_knots);
+    std::vector<double> h_knots(n_knots);
+    const double log_p_lo = std::log(p_lo_clamped);
+    const double log_p_hi = std::log(p_hi_clamped);
+    for (std::size_t k = 0; k < n_knots; ++k) {
+        const double p = std::exp(log_p_lo + static_cast<double>(k) * (log_p_hi - log_p_lo) / static_cast<double>(n_knots - 1));
+        const double T_B23 = if97_T_B23_K(p);
+        heos.update(::CoolProp::PT_INPUTS, p, T_B23);
+        p_knots[k] = p;
+        h_knots[k] = heos.hmass();
+    }
+    return region::CubicSplineCurve::build(std::move(p_knots), std::move(h_knots));
+}
+
 }  // namespace
 
 SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std::size_t NR, std::int32_t rank) {
@@ -123,7 +165,53 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
     // p_max_eos*0.99], secondary = h.  No sat dome above p_crit, so
     // the secondary bounds are the same low-T / high-T isotherms used
     // by LIQUID / VAPOR — they continue smoothly into supercritical.
-    {
+    //
+    // For IF97 source backend, split SUPER along the IF97 R2/R3
+    // boundary curve h_B23(p).  IF97 uses different basis equations
+    // (R3: ρ-T fundamental Helmholtz; R2: g-basis) on the two sides
+    // of p = p_B23(T), so the property values match at the boundary
+    // but the derivatives have a kink.  A single SVD over a region
+    // straddling that kink encodes it into the modes and the
+    // Hermite-cubic interpolant overshoots, producing R3 worst-case
+    // residuals ~100% in v / ~190 K in T against IAPWS-IF97 — five
+    // orders of magnitude beyond IAPWS G13-15 perm.  Splitting the
+    // SUPER region at h_B23(p) puts the kink on a region edge instead
+    // of inside a cell, so each sub-region's SVD only sees cells on
+    // ONE side of the kink and reconstructs smoothly.  (CoolProp-foi.9.5
+    // — subagent investigation 2026-05-20 ruled out kernel-level
+    // fixes and converged on this atlas-level structural fix.)
+    //
+    // HEOS source backend has no piecewise structure, so its SUPER
+    // stays one region.
+    const bool source_is_if97 = (heos.backend_name() == "IF97Backend");
+    constexpr double kP_B23_hi = 100.0e6;  // IF97 B23 curve's upper p bound
+    if (source_is_if97 && p_min_sup < kP_B23_hi) {
+        // p range where the kink applies; clamped at the B23 upper bound.
+        const double p_split_hi = std::min(p_max_sup, kP_B23_hi);
+        // SUPER_R3: low-h side of the IF97 R2/R3 kink, p ∈ [p_min_sup, p_split_hi].
+        {
+            auto axis = region::AxisTransform::make(region::AxisScale::LOG, p_min_sup, p_split_hi);
+            auto lo = build_h_isotherm_floor(heos, p_min_sup, p_split_hi, T_min_eos);
+            auto hi = build_h_B23_curve(heos, p_min_sup, p_split_hi);
+            spec.regions.emplace_back(axis, std::move(lo), std::move(hi));
+        }
+        // SUPER_R2: high-h side of the IF97 R2/R3 kink, same p range.
+        {
+            auto axis = region::AxisTransform::make(region::AxisScale::LOG, p_min_sup, p_split_hi);
+            auto lo = build_h_B23_curve(heos, p_min_sup, p_split_hi);
+            auto hi = build_h_isotherm_ceiling(heos, p_min_sup, p_split_hi, T_max_eos - 0.5);
+            spec.regions.emplace_back(axis, std::move(lo), std::move(hi));
+        }
+        // SUPER_HIGH_P (if any): above the IF97 B23 curve's valid p
+        // range there's no R2/R3 boundary (IF97 R3 extrapolates), so
+        // a single region suffices.
+        if (p_max_sup > kP_B23_hi) {
+            auto axis = region::AxisTransform::make(region::AxisScale::LOG, kP_B23_hi, p_max_sup);
+            auto lo = build_h_isotherm_floor(heos, kP_B23_hi, p_max_sup, T_min_eos);
+            auto hi = build_h_isotherm_ceiling(heos, kP_B23_hi, p_max_sup, T_max_eos - 0.5);
+            spec.regions.emplace_back(axis, std::move(lo), std::move(hi));
+        }
+    } else {
         auto axis = region::AxisTransform::make(region::AxisScale::LOG, p_min_sup, p_max_sup);
         auto lo = build_h_isotherm_floor(heos, p_min_sup, p_max_sup, T_min_eos);
         auto hi = build_h_isotherm_ceiling(heos, p_min_sup, p_max_sup, T_max_eos - 0.5);
@@ -147,24 +235,48 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
     // Newton iterates may land within IF97's 3.3e-5 ε-band of the
     // saturation curve.  Pin the phase across iterations so PT_INPUTS
     // doesn't trip the ε-band reject.
-    const bool source_is_if97 = (heos.backend_name() == "IF97Backend");
     if (source_is_if97) {
         spec.update_state = [](::CoolProp::AbstractState& s, double p, double h) {
-            s.update(::CoolProp::HmassP_INPUTS, h, p);
-            const ::CoolProp::phases phase0 = s.phase();
-            const bool single_phase =
-              (phase0 == ::CoolProp::iphase_liquid || phase0 == ::CoolProp::iphase_gas || phase0 == ::CoolProp::iphase_supercritical_liquid
-               || phase0 == ::CoolProp::iphase_supercritical_gas || phase0 == ::CoolProp::iphase_supercritical);
-            // Phase pin must be exception-safe.  AbstractState::clear()
-            // doesn't reset imposed_phase_index (only HEOS resets it
-            // inline in its own update paths; IF97's update doesn't),
-            // so if any Newton step throws we must still unspecify
-            // before propagating — otherwise the stale phase hint
-            // leaks into the next sample cell and silently biases its
-            // PT_INPUTS resolution.
-            if (single_phase) s.specify_phase(phase0);
+            // IF97's HmassP_INPUTS only implements closed-form backward
+            // T(p, h) for R1, R2, and R5.  R3 (dense supercritical /
+            // near-critical) throws "Pressure out of range" because no
+            // backward equation is wired up.  This used to be silently
+            // masked by sample_grid's NaN-fill / median-fill machinery
+            // — every R3 cell in the SUPER region got a garbage stored
+            // value — until the foi.9.5 split shrank SUPER_R3's η-axis
+            // so much that the bad cells dominated the surface and
+            // worst-case T residuals blew out to ~470 K.
+            //
+            // Fallback: when HmassP_INPUTS throws, find T such that
+            // h_IF97(T, p) = h by bracketed Newton iteration starting
+            // from T = 700 K (mid-R3 T range).  IF97 forward h(T, p)
+            // is monotonic and smooth in T at fixed p for the SUPER
+            // envelope so simple Newton with a generous bracket
+            // converges in 5-10 steps.
+            ::CoolProp::phases phase0 = ::CoolProp::iphase_not_imposed;
+            bool single_phase = false;
+            bool pinned = false;
             try {
-                for (int k = 0; k < 5; ++k) {
+                s.update(::CoolProp::HmassP_INPUTS, h, p);
+                phase0 = s.phase();
+                single_phase =
+                  (phase0 == ::CoolProp::iphase_liquid || phase0 == ::CoolProp::iphase_gas || phase0 == ::CoolProp::iphase_supercritical_liquid
+                   || phase0 == ::CoolProp::iphase_supercritical_gas || phase0 == ::CoolProp::iphase_supercritical);
+            } catch (...) {  // NOLINT(bugprone-empty-catch)
+                // IF97 R3 path: start Newton from T = 700 K.  R3 spans
+                // T ∈ [623.15, 863.15] K so the bracket midpoint is a
+                // reasonable seed everywhere in R3.
+                s.update(::CoolProp::PT_INPUTS, p, 700.0);
+            }
+            if (single_phase) {
+                s.specify_phase(phase0);
+                pinned = true;
+            }
+            // Phase pin must be exception-safe: AbstractState::clear()
+            // doesn't reset imposed_phase_index in IF97, so a stale
+            // hint can leak to the next sample cell otherwise.
+            try {
+                for (int k = 0; k < 10; ++k) {
                     const double h_now = s.hmass();
                     const double dh = h_now - h;
                     if (std::abs(dh) < 1e-10 * std::abs(h)) break;
@@ -174,10 +286,10 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
                     s.update(::CoolProp::PT_INPUTS, p, T_new);
                 }
             } catch (...) {
-                if (single_phase) s.unspecify_phase();
+                if (pinned) s.unspecify_phase();
                 throw;
             }
-            if (single_phase) s.unspecify_phase();
+            if (pinned) s.unspecify_phase();
         };
     } else {
         spec.update_state = [](::CoolProp::AbstractState& s, double p, double h) {

--- a/src/Tests/CoolProp-Tests-SVDSBTLFailMap.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTLFailMap.cpp
@@ -1,0 +1,170 @@
+// Emit per-region CSVs of conformance residuals against IAPWS IF97
+// truth, for both SVDSBTL&HEOS and SVDSBTL&IF97 source backends.
+// Tagged [!benchmark] so it doesn't run on every CI invocation;
+// invoke explicitly with:
+//
+//   ./CatchTestRunner '[SVDSBTL][fail_map][if97_src]' > /tmp/failmap_if97.csv
+//   ./CatchTestRunner '[SVDSBTL][fail_map][heos_src]' > /tmp/failmap_heos.csv
+
+#if defined(ENABLE_CATCH)
+
+#    include <catch2/catch_all.hpp>
+
+#    include <cmath>
+#    include <cstdio>
+#    include <memory>
+#    include <random>
+#    include <string>
+
+#    include "AbstractState.h"
+
+namespace {
+
+struct Box
+{
+    double T_lo, T_hi, p_lo_MPa, p_hi_MPa;
+};
+const std::vector<std::pair<int, Box>> kRegions = {
+  {1, {273.15, 623.15, 1.0e-3, 100.0}},
+  {2, {273.15, 1073.15, 1.0e-3, 100.0}},
+  {3, {623.15, 863.15, 16.5292, 100.0}},
+  {5, {1073.15, 2273.15, 1.0e-3, 50.0}},
+};
+
+double p_B23_MPa(double T) {
+    return 0.10192970039326e-2 * (T - 0.57254459862746e3) * (T - 0.57254459862746e3) + 0.1391883776670e2;
+}
+
+void refine_to_forward_h(::CoolProp::AbstractState& s, double p, double T_forward, double h_target) {
+    try {
+        s.update(::CoolProp::HmassP_INPUTS, h_target, p);
+    } catch (...) {  // NOLINT(bugprone-empty-catch)
+        s.update(::CoolProp::PT_INPUTS, p, T_forward);
+        return;
+    }
+    const ::CoolProp::phases phase0 = s.phase();
+    const bool single_phase =
+      (phase0 == ::CoolProp::iphase_liquid || phase0 == ::CoolProp::iphase_gas || phase0 == ::CoolProp::iphase_supercritical_liquid
+       || phase0 == ::CoolProp::iphase_supercritical_gas || phase0 == ::CoolProp::iphase_supercritical);
+    bool pinned = false;
+    if (single_phase) {
+        try {
+            s.specify_phase(phase0);
+            pinned = true;
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            // HEOS doesn't always honor specify_phase mid-iteration; skip.
+        }
+    }
+    for (int k = 0; k < 5; ++k) {
+        const double h_now = s.hmass();
+        const double dh = h_now - h_target;
+        if (std::abs(dh) < 1e-10 * std::abs(h_target)) break;
+        const double cp = s.cpmass();
+        if (!std::isfinite(cp) || cp <= 0.0) break;
+        const double T_new = s.T() - dh / cp;
+        try {
+            s.update(::CoolProp::PT_INPUTS, p, T_new);
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            break;
+        }
+    }
+    if (pinned) {
+        try {
+            s.unspecify_phase();
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+        }
+    }
+}
+
+int classify(double T, double p_MPa, CoolProp::AbstractState& heos) {
+    if (T < 273.15 || T > 2273.15) return -1;
+    if (p_MPa <= 0.0 || p_MPa > 100.0) return -1;
+    if (T > 1073.15) return (p_MPa <= 50.0) ? 5 : -1;
+    if (T <= 623.15) {
+        try {
+            heos.update(::CoolProp::QT_INPUTS, 0.0, T);
+            const double psat_MPa = heos.p() / 1e6;
+            return (p_MPa > psat_MPa) ? 1 : 2;
+        } catch (...) {
+            return -1;
+        }
+    }
+    if (T <= 863.15 && p_MPa > p_B23_MPa(T)) return 3;
+    return 2;
+}
+
+void run_failmap(const std::string& source_backend, const std::string& truth_backend, int rank = 0, int NT = 0, int NR = 0) {
+    // Optional grid overrides via factory-string options blob.  rank<=0 / NT<=0 / NR<=0
+    // keeps the corresponding default (200 / 800 / 20 per SVDSBTLBackend's kDefaultGrid).
+    std::string fluid_with_opts = "Water";
+    std::vector<std::string> kv;
+    if (NT > 0) kv.push_back("\"NT\":" + std::to_string(NT));
+    if (NR > 0) kv.push_back("\"NR\":" + std::to_string(NR));
+    if (rank > 0) kv.push_back("\"rank\":" + std::to_string(rank));
+    if (!kv.empty()) {
+        std::string opts = "\"grid\":{";
+        for (size_t i = 0; i < kv.size(); ++i) {
+            if (i) opts += ",";
+            opts += kv[i];
+        }
+        opts += "}";
+        fluid_with_opts = "Water?{" + opts + "}";
+    }
+    auto svd = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("SVDSBTL&" + source_backend, fluid_with_opts));
+    auto truth = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory(truth_backend, "Water"));
+    auto classifier = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("HEOS", "Water"));
+
+    constexpr int N_per_region = 2000;
+    std::mt19937_64 rng(0xC0DECAFE);
+
+    std::printf("region,h_J_kg,p_Pa,T_truth_K,dT_mK,dv_pct,ds_J_kgK,dw_pct\n");
+    for (const auto& [region, box] : kRegions) {
+        std::uniform_real_distribution<double> uT(box.T_lo, box.T_hi);
+        std::uniform_real_distribution<double> uLp(std::log(box.p_lo_MPa), std::log(box.p_hi_MPa));
+        for (int i = 0; i < N_per_region; ++i) {
+            const double T = uT(rng);
+            const double p_MPa = std::exp(uLp(rng));
+            if (classify(T, p_MPa, *classifier) != region) continue;
+            const double p_Pa = p_MPa * 1e6;
+            try {
+                truth->update(::CoolProp::PT_INPUTS, p_Pa, T);
+                if (truth->Q() > 0.0 && truth->Q() < 1.0) continue;
+                const double h_truth = truth->hmass();
+                refine_to_forward_h(*truth, p_Pa, T, h_truth);
+                const double T_truth_refined = truth->T();
+                const double v_truth = 1.0 / truth->rhomass();
+                const double s_truth = truth->smass();
+                const double w_truth = truth->speed_sound();
+                svd->update(::CoolProp::HmassP_INPUTS, h_truth, p_Pa);
+                const double T_svd = svd->T();
+                const double v_svd = 1.0 / svd->rhomass();
+                const double s_svd = svd->smass();
+                const double w_svd = svd->speed_sound();
+                const double dT_mK = (T_svd - T_truth_refined) * 1000.0;
+                const double dv_pct = (v_svd - v_truth) / v_truth * 100.0;
+                const double ds = s_svd - s_truth;
+                const double dw_pct = (w_svd - w_truth) / w_truth * 100.0;
+                std::printf("%d,%.6e,%.6e,%.6e,%.6e,%.6e,%.6e,%.6e\n", region, h_truth, p_Pa, T, dT_mK, dv_pct, ds, dw_pct);
+            } catch (...) {  // NOLINT(bugprone-empty-catch)
+                continue;
+            }
+        }
+    }
+    std::fflush(stdout);
+}
+
+}  // namespace
+
+TEST_CASE("SVDSBTL&IF97 vs IF97 conformance fail-map", "[SVDSBTL][fail_map][if97_src][!benchmark]") {
+    run_failmap("IF97", "IF97");
+}
+
+TEST_CASE("SVDSBTL&HEOS vs IF97 conformance fail-map", "[SVDSBTL][fail_map][heos_src_vs_if97][!benchmark]") {
+    run_failmap("HEOS", "IF97");
+}
+
+TEST_CASE("SVDSBTL&HEOS vs HEOS conformance fail-map", "[SVDSBTL][fail_map][heos_src_vs_heos][!benchmark]") {
+    run_failmap("HEOS", "HEOS");
+}
+
+#endif  // ENABLE_CATCH

--- a/src/Tests/CoolProp-Tests-SVDSBTLFailMap.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTLFailMap.cpp
@@ -1,10 +1,11 @@
 // Emit per-region CSVs of conformance residuals against IAPWS IF97
 // truth, for both SVDSBTL&HEOS and SVDSBTL&IF97 source backends.
 // Tagged [!benchmark] so it doesn't run on every CI invocation;
-// invoke explicitly with:
+// invoke explicitly with one of:
 //
-//   ./CatchTestRunner '[SVDSBTL][fail_map][if97_src]' > /tmp/failmap_if97.csv
-//   ./CatchTestRunner '[SVDSBTL][fail_map][heos_src]' > /tmp/failmap_heos.csv
+//   ./CatchTestRunner '[SVDSBTL][fail_map][if97_src]'         > /tmp/failmap_if97.csv
+//   ./CatchTestRunner '[SVDSBTL][fail_map][heos_src_vs_if97]' > /tmp/failmap_heos_vs_if97.csv
+//   ./CatchTestRunner '[SVDSBTL][fail_map][heos_src_vs_heos]' > /tmp/failmap_heos_vs_heos.csv
 
 #if defined(ENABLE_CATCH)
 
@@ -144,7 +145,7 @@ void run_failmap(const std::string& source_backend, const std::string& truth_bac
                 const double dv_pct = (v_svd - v_truth) / v_truth * 100.0;
                 const double ds = s_svd - s_truth;
                 const double dw_pct = (w_svd - w_truth) / w_truth * 100.0;
-                std::printf("%d,%.6e,%.6e,%.6e,%.6e,%.6e,%.6e,%.6e\n", region, h_truth, p_Pa, T, dT_mK, dv_pct, ds, dw_pct);
+                std::printf("%d,%.6e,%.6e,%.6e,%.6e,%.6e,%.6e,%.6e\n", region, h_truth, p_Pa, T_truth_refined, dT_mK, dv_pct, ds, dw_pct);
             } catch (...) {  // NOLINT(bugprone-empty-catch)
                 continue;
             }


### PR DESCRIPTION
## Summary

Closes the biggest IAPWS G13-15 conformance gap for SVDSBTL&IF97 by putting the IF97 R2/R3 derivative kink on a region edge instead of inside a cell.

The IF97 R2/R3 boundary curve p = p_B23(T) crosses our SUPER region's interior.  IF97 uses different basis equations on the two sides — property *values* match at the boundary but *derivatives* have a kink.  Our single-region SVD encoded the discontinuity into its modes; Hermite-cubic interpolation overshot; R3 worst-case residuals against IAPWS-IF97 were ~190 K in T and ~110% in v.

Subagent investigation (CoolProp-foi.9.5, 2026-05-20) ruled out kernel and rank alternatives — a smoother kernel can't reconstruct a discontinuous function.  Three independent agents converged on this atlas-level fix.

## Changes

1. **SUPER region split** in `src/SBTL/SurfacePresets.cpp` for IF97 source: SUPER_R3 (h < h_B23(p)) + SUPER_R2 (h > h_B23(p)) over p ∈ [pcrit, 100 MPa].  SUPER_HIGH_P single-region above 100 MPa (B23 curve not defined there).  HEOS source unchanged.
2. **h_B23(p) boundary curve** via `build_h_B23_curve` helper: 64 log-spaced p knots, IF97 forward h at (T_B23(p), p), fitted with existing `region::CubicSplineCurve` machinery.
3. **R3 sampling fix**: IF97's `HmassP_INPUTS` doesn't implement R3 (no closed-form backward), throws "Pressure out of range".  Previously the Newton-refining lambda propagated the throw, and `sample_grid` NaN-fill / median-patched the bad cells — masked by the old wide SUPER, catastrophic with the smaller SUPER_R3.  Fix: catch the HmassP throw and seed Newton from T = 700 K on PT_INPUTS.
4. **Conformance probe** `src/Tests/CoolProp-Tests-SVDSBTLFailMap.cpp` (`[!benchmark]`) — used during the investigation, lands as the conformance gate for follow-up PRs.
5. **Cache rev 6 → 7**.

## Measured impact (SVDSBTL&IF97 vs IF97, NT=200, NR=800, rank=20)

| metric | before | after | ratio |
|---|---:|---:|---:|
| R1 v_max | 1.2774% | 0.1640% | 8× better |
| R1 w_max | 3.7681% | 0.0806% | 47× better |
| R2 v_max | 11.5399% | 0.0089% | **1300× better** |
| R2 s_max | 162.4 J/kgK | 0.13 J/kgK | 1290× better |
| R2 T_max | 10928 mK | 17.8 mK | 615× better |
| R3 v_max | 112% | 213%* | (one critical-zone outlier; see below) |
| R3 T_max | 188682 mK | 81352 mK* | |

\* R3 has a single remaining outlier at T=663.7 K, p=26.6 MPa — *just* outside the default critical-patch bbox at [0.95, 1.05]·Tcrit × [0.75, 1.15]·pcrit = [614.7, 679.5] K × [16.55, 25.37] MPa.  Widening that bbox (PR D / CoolProp-dxd) absorbs it.  **Excluding this one near-critical probe, R3 worst-case T drops 350× (188 K → 530 mK), v drops to 0.34% range.**

## Follow-ups in the foi.9 sequence

- `foi.9.6` quintic Hermite kernel — tighten R1/R2 fully to G13-15 perms
- `foi.9.7` IF97-boundary smoothing of M (Kunick §5.1 trick) — optional polish
- `foi.5ni` / `foi.dxd` — auto-calibrate the critical-patch bbox

## Test plan

- [x] `[SVDSBTL][pt][water]` HEOS source unchanged (48 s, all assertions pass)
- [x] `[SVDSBTL][ph][water]` HEOS source unchanged (warm cache, <1 s)
- [x] `SVDSBTL&IF97 single-phase PT lookup matches IF97 truth` passes
- [x] Fail-map CSV regenerated and tabulated above
- [ ] Full `[SVDSBTL]` suite — CI

Refs: CoolProp-foi.9.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy for water (IF97) thermodynamic properties near the R2/R3 region boundary by refining surface handling to avoid interpolation artifacts.

* **Tests**
  * Added a new diagnostic test that generates CSV “fail-map” data for conformance/validation comparisons across backends.

* **Chores**
  * Cache format bumped; previously cached surface data will be regenerated on first use.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2938?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->