### PR TITLE
feat(svdsbtl): split SUPER_R3 at IF97 R1/R3 isotherm (stacked on #2938)

### DIFF
--- a/include/CoolProp/sbtl/SVDSurfaceSerializer.h
+++ b/include/CoolProp/sbtl/SVDSurfaceSerializer.h
@@ -103,7 +103,14 @@ class SVDSurfaceSerializer
     //          clean rebuild instead of attempting to deserialize a
     //          rev-6 cache that won't have the new boundary curves.
     //          HEOS source unchanged.
-    static constexpr int kRevision = 7;
+    //   rev 8: SUPER_R3 further split at the IF97 R1/R3 isotherm
+    //          h_R1R3(p) = h_IF97(623.15 K, p), so R1 territory at
+    //          p > pcrit gets its own SVD (SUPER_R1_super) separate
+    //          from R3 proper (SUPER_R3_proper).  Region count for
+    //          IF97 goes from 4-5 (post-rev-7) to 5-6.  Closes the
+    //          post-rev-7 R1 conformance gap where R1 and R3 modes
+    //          competed for SVD bandwidth in a single region.
+    static constexpr int kRevision = 8;
 
     // Pack one surface into a zlib-compressed msgpack blob.
     static std::vector<char> save(const SVDSurface& surface);

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -99,6 +99,33 @@ double if97_T_B23_K(double p_Pa) {
 // when the source backend is IF97 (the kink is intrinsic to IF97's
 // piecewise EOS; HEOS source has no such internal boundary).  Valid
 // only for p ∈ [16.529 MPa, 100 MPa] — caller must clamp.
+// Build h = h_IF97(623.15 K, p) along the IF97 R1/R3 isotherm.  Used to
+// split SUPER_R3 (above pcrit, below p_B23) into a R1-territory sub-
+// region (T < 623.15 K, compressed-liquid supercritical) and a R3-
+// proper sub-region (T >= 623.15 K, dense supercritical).  Same
+// pattern as build_h_B23_curve but on the T isotherm instead of the
+// p_B23(T) curve.  Valid for p > p_sat(623.15) = 16.529 MPa.
+std::unique_ptr<region::CubicSplineCurve> build_h_R1R3_curve(::CoolProp::AbstractState& heos, double p_lo, double p_hi) {
+    constexpr double kT_R1R3 = 623.15;
+    constexpr double kP_R1R3_lo_MPa = 16.529;
+    const double p_lo_clamped = std::max(p_lo, kP_R1R3_lo_MPa * 1.0e6);
+    if (!(p_lo_clamped < p_hi)) {
+        throw std::invalid_argument("build_h_R1R3_curve: p range does not overlap IF97 R1/R3 isotherm's validity (p > 16.529 MPa)");
+    }
+    constexpr std::size_t n_knots = 64;
+    std::vector<double> p_knots(n_knots);
+    std::vector<double> h_knots(n_knots);
+    const double log_p_lo = std::log(p_lo_clamped);
+    const double log_p_hi = std::log(p_hi);
+    for (std::size_t k = 0; k < n_knots; ++k) {
+        const double p = std::exp(log_p_lo + static_cast<double>(k) * (log_p_hi - log_p_lo) / static_cast<double>(n_knots - 1));
+        heos.update(::CoolProp::PT_INPUTS, p, kT_R1R3);
+        p_knots[k] = p;
+        h_knots[k] = heos.hmass();
+    }
+    return region::CubicSplineCurve::build(std::move(p_knots), std::move(h_knots));
+}
+
 std::unique_ptr<region::CubicSplineCurve> build_h_B23_curve(::CoolProp::AbstractState& heos, double p_lo, double p_hi) {
     constexpr double kP_B23_lo_MPa = 16.529;
     constexpr double kP_B23_hi_MPa = 100.0;
@@ -188,10 +215,26 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
     if (source_is_if97 && p_min_sup < kP_B23_hi) {
         // p range where the kink applies; clamped at the B23 upper bound.
         const double p_split_hi = std::min(p_max_sup, kP_B23_hi);
-        // SUPER_R3: low-h side of the IF97 R2/R3 kink, p ∈ [p_min_sup, p_split_hi].
+        // SUPER_R1_super: IF97 R1 territory at p > pcrit, h ∈ [h_floor(p),
+        // h_IF97(623.15 K, p)).  Separating R1 from R3 in this slab
+        // (foi.9.9) gives the R1-side compressed-liquid SVD its own η
+        // normalization — the previous combined SUPER_R3 region had
+        // R1+R3 sharing modes, and R1 conformance suffered (post-foi.9.5
+        // R1 worst v 0.164%).  Subcritical-p R1 (the LIQUID region)
+        // hits 0.008% max v with the same physics; this split brings
+        // SUPER_R3's R1 territory to that level.
         {
             auto axis = region::AxisTransform::make(region::AxisScale::LOG, p_min_sup, p_split_hi);
             auto lo = build_h_isotherm_floor(heos, p_min_sup, p_split_hi, T_min_eos);
+            auto hi = build_h_R1R3_curve(heos, p_min_sup, p_split_hi);
+            spec.regions.emplace_back(axis, std::move(lo), std::move(hi));
+        }
+        // SUPER_R3_proper: IF97 R3 territory at p > pcrit, h ∈ [h_R1R3(p),
+        // h_B23(p)).  Only the (T, p, h) region where IF97 actually
+        // evaluates R3.
+        {
+            auto axis = region::AxisTransform::make(region::AxisScale::LOG, p_min_sup, p_split_hi);
+            auto lo = build_h_R1R3_curve(heos, p_min_sup, p_split_hi);
             auto hi = build_h_B23_curve(heos, p_min_sup, p_split_hi);
             spec.regions.emplace_back(axis, std::move(lo), std::move(hi));
         }


### PR DESCRIPTION
**Stacked on PR #2938 (foi.9.5 B23 split).**  Merge that first, then rebase this onto master.

## Summary

Closes the remaining R1 conformance gap that the foi.9.5 split exposed.  R1 conformance now matches subcritical LIQUID's residual floor.

## The gap and the fix

Post-foi.9.5, SUPER_R3 still spanned both IF97 R1 (T<623.15) and IF97 R3 (T>=623.15) territory.  At p ≈ 28 MPa, R1 occupied 63% of SUPER_R3's η axis sharing SVD modes with R3.  Fail-map data:

| | R1 in subcritical LIQUID (655 probes) | R1 in SUPER_R3 (251 probes) |
|---|---:|---:|
| T fails | 0 | 91 |
| v fails | 1 (max 0.008%) | 244 (max 0.164%) |
| s fails | 9 | 247 |

Same IF97 R1 physics, two orders of magnitude worse conformance — purely because SUPER_R3 shared its SVD with R3.

This PR adds a second atlas split (mirrors foi.9.5 pattern) at the T=623.15 K isotherm:
- `SUPER_R1_super`: p > pcrit, h ∈ [h_floor(p), h_R1R3(p))
- `SUPER_R3_proper`: p > pcrit, h ∈ [h_R1R3(p), h_B23(p))

## Measured impact

| metric | foi.9.5 only | + foi.9.9 | ratio |
|---|---:|---:|---:|
| R1 T fails | 91 / 906 | **0 / 906** | full pass |
| R1 T max | 134 mK | **13 mK** | 10× — under perm |
| R1 v fails | 245 / 906 | **1 / 906** | 245× fewer |
| R1 v max | 0.164% | **0.008%** | 21× better |
| R1 s fails | 256 | 11 | 23× |
| R1 w fails | 274 | 39 | 7× |

R2 unchanged.  R3 essentially unchanged — the 213% v outlier at (T=663.7 K, p=26.6 MPa) is just outside the default critical-patch HEOS-fallback bbox, awaiting CoolProp-dxd (auto-cal) to absorb.

## Region count change

IF97 water surfaces: 4-5 regions → 5-6 regions (LIQUID, VAPOR, SUPER_R1_super, SUPER_R3_proper, SUPER_R2, optional SUPER_HIGH_P above 100 MPa).  Cache size grows ~25% per fluid.

## Test plan

- [x] Fail-map probe shows R1 conformance now matches LIQUID (1 v fail at 0.008% max; T entirely under 25 mK perm)
- [ ] Full `[SVDSBTL]` suite — CI
- [ ] HEOS-source unchanged (this PR is IF97-gated)

Refs: CoolProp-foi.9.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)