### PR TITLE
feat(svdsbtl): R1/R3 atlas split + TOMS748 h-inversion (combines reverted #2939 + #2940)

### DIFF
--- a/include/CoolProp/sbtl/SVDSurfaceSerializer.h
+++ b/include/CoolProp/sbtl/SVDSurfaceSerializer.h
@@ -103,7 +103,14 @@ class SVDSurfaceSerializer
     //          clean rebuild instead of attempting to deserialize a
     //          rev-6 cache that won't have the new boundary curves.
     //          HEOS source unchanged.
-    static constexpr int kRevision = 7;
+    //   rev 8: SUPER_R3 further split at the IF97 R1/R3 isotherm
+    //          h_R1R3(p) = h_IF97(623.15 K, p), so R1 territory at
+    //          p > pcrit gets its own SVD (SUPER_R1_super) separate
+    //          from R3 proper (SUPER_R3_proper).  Region count for
+    //          IF97 goes from 4-5 (post-rev-7) to 5-6.  Closes the
+    //          post-rev-7 R1 conformance gap where R1 and R3 modes
+    //          competed for SVD bandwidth in a single region.
+    static constexpr int kRevision = 8;
 
     // Pack one surface into a zlib-compressed msgpack blob.
     static std::vector<char> save(const SVDSurface& surface);

--- a/include/CoolProp/sbtl/SVDSurfaceSerializer.h
+++ b/include/CoolProp/sbtl/SVDSurfaceSerializer.h
@@ -110,7 +110,15 @@ class SVDSurfaceSerializer
     //          IF97 goes from 4-5 (post-rev-7) to 5-6.  Closes the
     //          post-rev-7 R1 conformance gap where R1 and R3 modes
     //          competed for SVD bandwidth in a single region.
-    static constexpr int kRevision = 8;
+    //   rev 9: IF97 sampling-side Newton replaced with TOMS748
+    //          bracketed root-find (foi.9.10).  R3 cells whose Newton
+    //          previously failed to converge (e.g., T_target=663.7 K,
+    //          p=26.6 MPa where the T=700 fallback seed put Newton in
+    //          R2 territory and it oscillated across the R2/R3 boundary)
+    //          now sample correctly.  Stored T/s/ρ/w grid values for
+    //          those cells change, so existing rev-8 caches must
+    //          rebuild.
+    static constexpr int kRevision = 9;
 
     // Pack one surface into a zlib-compressed msgpack blob.
     static std::vector<char> save(const SVDSurface& surface);

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -71,10 +71,18 @@ void polish_patch_state_(::CoolProp::AbstractState& s, double p, double h) {
         }
     };
     const double T_seed = s.T();
-    constexpr double kT_min = 273.16;  // IF97 / IAPWS-95 lower bound
-    constexpr double kT_max = 2273.15;
-    const double T_lo = std::max(T_seed - 0.5, kT_min);
-    const double T_hi = std::min(T_seed + 0.5, kT_max);
+    // Use backend-reported T limits rather than IF97-specific constants:
+    // patch_source_ may be HEOS / REFPROP / IF97 with different envelopes,
+    // and pinning to water bounds either silently clips (HEOS with T_min
+    // > 273.16) or overshoots (backend with T_max < 2273.15).
+    const double T_lo = std::max(T_seed - 0.5, s.Tmin());
+    const double T_hi = std::min(T_seed + 0.5, s.Tmax());
+    auto restore_seed = [&s, p, T_seed]() noexcept {
+        try {
+            s.update(::CoolProp::PT_INPUTS, p, T_seed);
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+        }
+    };
     if (!(T_lo < T_hi)) {
         return;
     }
@@ -82,15 +90,20 @@ void polish_patch_state_(::CoolProp::AbstractState& s, double p, double h) {
     const double r_hi = resid(T_hi);
     if (!std::isfinite(r_lo) || !std::isfinite(r_hi) || r_lo * r_hi > 0.0) {
         // Bracket missed (rare): restore the backward seed and bail.
-        try {
-            s.update(::CoolProp::PT_INPUTS, p, T_seed);
-        } catch (...) {  // NOLINT(bugprone-empty-catch)
-        }
+        restore_seed();
         return;
     }
-    std::uintmax_t max_iter = 30;
-    const auto bracket = boost::math::tools::toms748_solve(resid, T_lo, T_hi, r_lo, r_hi, boost::math::tools::eps_tolerance<double>(40), max_iter);
-    s.update(::CoolProp::PT_INPUTS, p, 0.5 * (bracket.first + bracket.second));
+    try {
+        std::uintmax_t max_iter = 30;
+        const auto bracket =
+          boost::math::tools::toms748_solve(resid, T_lo, T_hi, r_lo, r_hi, boost::math::tools::eps_tolerance<double>(40), max_iter);
+        s.update(::CoolProp::PT_INPUTS, p, 0.5 * (bracket.first + bracket.second));
+    } catch (...) {
+        // toms748_solve / final update threw: restore the backward seed
+        // so the caller sees the ±25 mK floor instead of a half-mutated
+        // state at the last failed PT probe.
+        restore_seed();
+    }
 }
 
 // Read `grid.NT/NR/rank` out of a validated options document.  Missing

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -14,6 +14,8 @@
 #include <utility>
 #include <vector>
 
+#include "boost/math/tools/toms748_solve.hpp"
+
 #include "AbstractState.h"
 #include "Backends/Helmholtz/HelmholtzEOSMixtureBackend.h"
 #include "Configuration.h"
@@ -47,6 +49,48 @@ struct ResolvedGrid
 };
 
 constexpr ResolvedGrid kDefaultGrid = {200, 800, 20};
+
+// Polish the patch backend's T after an HmassP_INPUTS update so the
+// returned state is forward-consistent in h(T, p), not just R7-97-
+// backward-consistent.  Without this, in-bbox queries inherit the
+// patch source's backward-equation residual (±25 mK for IF97 R1/R3,
+// ±10 mK for R2/R5) — visible as ~10-20 mK / 0.1-0.4 J/(kg·K) s
+// residuals in the SVDSBTL&IF97 fail-map even inside the patch box.
+// Mirrors the polish in src/SBTL/SurfacePresets.cpp's IF97 sampling
+// lambda (foi.9.10).  Best-effort: on bracket-failure or out-of-range,
+// leaves the state as the HmassP backward seed (still functional, just
+// at the ±25 mK floor).
+void polish_patch_state_(::CoolProp::AbstractState& s, double p, double h) {
+    auto resid = [&s, p, h](double T) -> double {
+        try {
+            s.update(::CoolProp::PT_INPUTS, p, T);
+            return s.hmass() - h;
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            return std::nan("");
+        }
+    };
+    const double T_seed = s.T();
+    constexpr double kT_min = 273.16;  // IF97 / IAPWS-95 lower bound
+    constexpr double kT_max = 2273.15;
+    const double T_lo = std::max(T_seed - 0.5, kT_min);
+    const double T_hi = std::min(T_seed + 0.5, kT_max);
+    if (!(T_lo < T_hi)) {
+        return;
+    }
+    const double r_lo = resid(T_lo);
+    const double r_hi = resid(T_hi);
+    if (!std::isfinite(r_lo) || !std::isfinite(r_hi) || r_lo * r_hi > 0.0) {
+        // Bracket missed (rare): restore the backward seed and bail.
+        try {
+            s.update(::CoolProp::PT_INPUTS, p, T_seed);
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+        }
+        return;
+    }
+    boost::uintmax_t max_iter = 30;
+    const auto bracket = boost::math::tools::toms748_solve(resid, T_lo, T_hi, r_lo, r_hi, boost::math::tools::eps_tolerance<double>(40), max_iter);
+    s.update(::CoolProp::PT_INPUTS, p, 0.5 * (bracket.first + bracket.second));
+}
 
 // Read `grid.NT/NR/rank` out of a validated options document.  Missing
 // keys (and missing `grid` itself) leave the corresponding default in
@@ -460,12 +504,33 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
 
     // Critical-patch bbox routing.  Patch lookups defer their property
     // reads to evaluate_property_ via patch_source_.
+    //
+    // For HmassP / HmolarP inputs we follow the source-backend update
+    // with polish_patch_state_(): the source's HmassP_INPUTS path
+    // typically uses a backward equation (IF97 R7-97 in particular)
+    // that's only ±25 mK forward-consistent in T.  Without the polish
+    // every in-bbox query inherits that floor — visible as ~10-20 mK /
+    // 0.1-0.4 J/(kg·K) s residuals in the SVDSBTL&IF97 fail-map even
+    // inside the patch box.  The polish TOMS748-iterates on a tight
+    // bracket around T_seed so the returned state is
+    // forward-consistent (h(T_polished, p) == h_input to bracket eps).
+    // Mirrors the polish baked into ph_subcritical's IF97 sampling
+    // lambda — that's the foi.9.10 sampling-side fix; this is its
+    // query-side counterpart.  No-op for HEOS source (HEOS HmassP is
+    // already iterative + forward-consistent) modulo one extra HEOS
+    // eval per in-bbox query.
     const auto patch_key = (input_pair == CoolProp::HmolarP_INPUTS) ? CoolProp::HmassP_INPUTS : input_pair;
     if (critical_patch_.contains(patch_key, a, b)) {
         try {
             if (input_pair == CoolProp::HmolarP_INPUTS) {
                 patch_source_ref_()->update(CoolProp::HmassP_INPUTS, *pt.h_mass, *pt.p);
+                polish_patch_state_(*patch_source_, *pt.p, *pt.h_mass);
+            } else if (input_pair == CoolProp::HmassP_INPUTS) {
+                patch_source_ref_()->update(input_pair, value1, value2);
+                polish_patch_state_(*patch_source_, *pt.p, *pt.h_mass);
             } else {
+                // PT_INPUTS — source backend's PT path is already
+                // forward-consistent; no polish needed.
                 patch_source_ref_()->update(input_pair, value1, value2);
             }
             pt.kind = PointEvaluation::Kind::Patched;

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <cmath>
+#include <cstdint>
 #include <exception>
 #include <filesystem>
 #include <memory>
@@ -87,7 +88,7 @@ void polish_patch_state_(::CoolProp::AbstractState& s, double p, double h) {
         }
         return;
     }
-    boost::uintmax_t max_iter = 30;
+    std::uintmax_t max_iter = 30;
     const auto bracket = boost::math::tools::toms748_solve(resid, T_lo, T_hi, r_lo, r_hi, boost::math::tools::eps_tolerance<double>(40), max_iter);
     s.update(::CoolProp::PT_INPUTS, p, 0.5 * (bracket.first + bracket.second));
 }

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -185,7 +185,7 @@ double solve_T_from_h_toms748(::CoolProp::AbstractState& s, double p, double h_t
         // state must check *ok and skip the subsequent PT_INPUTS update.
         return (std::abs(r_lo) < std::abs(r_hi)) ? T_lo : T_hi;
     }
-    boost::uintmax_t max_iter = 30;
+    std::uintmax_t max_iter = 30;
     const auto bracket = boost::math::tools::toms748_solve(resid, T_lo, T_hi, r_lo, r_hi, boost::math::tools::eps_tolerance<double>(40), max_iter);
     if (ok != nullptr) {
         *ok = true;

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -1,7 +1,10 @@
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <stdexcept>
 #include <utility>
+
+#include "boost/math/tools/toms748_solve.hpp"
 
 #include "CoolProp/region/AxisTransform.h"
 #include "CoolProp/region/ConstantCurve.h"
@@ -149,6 +152,47 @@ std::unique_ptr<region::CubicSplineCurve> build_h_B23_curve(::CoolProp::Abstract
     return region::CubicSplineCurve::build(std::move(p_knots), std::move(h_knots));
 }
 
+// Find T such that h(T, p) = h_target via bracketed TOMS748 iteration on
+// the source backend's forward h.  Bracketed (vs Newton) so we stay
+// robust across IF97 region boundaries where cp jumps cause Newton to
+// overshoot into the wrong basin — the foi.9.10 root cause that
+// contaminated R3 cells with garbage stored T / s / ρ values up through
+// foi.9.9.  Boost's toms748_solve is already used elsewhere in CoolProp
+// (superancillary, AbstractState, FlashRoutines), so no new dependency.
+//
+// Returns the converged T.  If the bracket [T_lo, T_hi] doesn't contain
+// a root, returns the nearer endpoint and signals via `ok` so the caller
+// can fall through to the NaN-fill machinery downstream.
+double solve_T_from_h_toms748(::CoolProp::AbstractState& s, double p, double h_target, double T_lo, double T_hi, bool* ok = nullptr) {
+    auto resid = [&s, p, h_target](double T) -> double {
+        try {
+            s.update(::CoolProp::PT_INPUTS, p, T);
+            return s.hmass() - h_target;
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            // Out-of-range / ε-band rejects bubble up as NaN so the
+            // sign-bracket check below cleanly fails the bracket test.
+            return std::nan("");
+        }
+    };
+    const double r_lo = resid(T_lo);
+    const double r_hi = resid(T_hi);
+    if (!std::isfinite(r_lo) || !std::isfinite(r_hi) || r_lo * r_hi > 0.0) {
+        if (ok != nullptr) {
+            *ok = false;
+        }
+        // Returning the endpoint with smaller residual would re-mutate
+        // `s`; callers that want to fall through to the HmassP_INPUTS
+        // state must check *ok and skip the subsequent PT_INPUTS update.
+        return (std::abs(r_lo) < std::abs(r_hi)) ? T_lo : T_hi;
+    }
+    boost::uintmax_t max_iter = 30;
+    const auto bracket = boost::math::tools::toms748_solve(resid, T_lo, T_hi, r_lo, r_hi, boost::math::tools::eps_tolerance<double>(40), max_iter);
+    if (ok != nullptr) {
+        *ok = true;
+    }
+    return 0.5 * (bracket.first + bracket.second);
+}
+
 }  // namespace
 
 SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std::size_t NR, std::int32_t rank) {
@@ -290,15 +334,30 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
             // so much that the bad cells dominated the surface and
             // worst-case T residuals blew out to ~470 K.
             //
-            // Fallback: when HmassP_INPUTS throws, find T such that
-            // h_IF97(T, p) = h by bracketed Newton iteration starting
-            // from T = 700 K (mid-R3 T range).  IF97 forward h(T, p)
-            // is monotonic and smooth in T at fixed p for the SUPER
-            // envelope so simple Newton with a generous bracket
-            // converges in 5-10 steps.
+            // Two-stage h-inversion via TOMS748 (foi.9.10).  Bracketed
+            // iteration is essential — Newton from a fixed T=700 K seed
+            // overshoots across IF97 R2/R3 cp-jump boundaries when
+            // T_B23(p) < 700 K and fails to converge, leaving stored
+            // cell values wrong by tens of K (e.g., 65 K T error at
+            // T_target=663.7, p=26.6 MPa, propagating to s, ρ residuals
+            // of >20% downstream).
+            //
+            //   1. HmassP_INPUTS (R7-97 backward) seeds T to ±25 mK,
+            //      sets the phase classification.  Throws in R3 where
+            //      no backward equation is published.
+            //   2. TOMS748 polish on [T_seed − 0.5, T_seed + 0.5], clamped
+            //      to IF97's [273.16, 2273.15] T validity, closes the
+            //      ±25 mK R7-97 residual to machine precision.  Critical
+            //      for R2/R5 s conformance (cp·dT/T propagates 25 mK in
+            //      T to ~0.25 J/(kg·K) in s — over the 1e-3 perm budget).
+            //      If the clamped bracket doesn't span a sign change
+            //      (rare: HmassP already at machine precision, or
+            //      near-T_min cell with bracket clipped tight), the
+            //      helper signals via *ok and we keep the HmassP state.
+            //   3. R3 fallback: TOMS748 on [623.15 K, T_B23(p)].
             ::CoolProp::phases phase0 = ::CoolProp::iphase_not_imposed;
             bool single_phase = false;
-            bool pinned = false;
+            bool seeded_via_hmass = true;
             try {
                 s.update(::CoolProp::HmassP_INPUTS, h, p);
                 phase0 = s.phase();
@@ -306,27 +365,38 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
                   (phase0 == ::CoolProp::iphase_liquid || phase0 == ::CoolProp::iphase_gas || phase0 == ::CoolProp::iphase_supercritical_liquid
                    || phase0 == ::CoolProp::iphase_supercritical_gas || phase0 == ::CoolProp::iphase_supercritical);
             } catch (...) {  // NOLINT(bugprone-empty-catch)
-                // IF97 R3 path: start Newton from T = 700 K.  R3 spans
-                // T ∈ [623.15, 863.15] K so the bracket midpoint is a
-                // reasonable seed everywhere in R3.
-                s.update(::CoolProp::PT_INPUTS, p, 700.0);
+                seeded_via_hmass = false;
             }
+            // Phase pin (PR E mechanism) so the TOMS748 polish's
+            // PT_INPUTS evaluations near the sat dome don't trip
+            // IF97's ε-band reject.  Exception-safe — AbstractState::
+            // clear() doesn't reset imposed_phase_index in IF97.
+            bool pinned = false;
             if (single_phase) {
                 s.specify_phase(phase0);
                 pinned = true;
             }
-            // Phase pin must be exception-safe: AbstractState::clear()
-            // doesn't reset imposed_phase_index in IF97, so a stale
-            // hint can leak to the next sample cell otherwise.
             try {
-                for (int k = 0; k < 10; ++k) {
-                    const double h_now = s.hmass();
-                    const double dh = h_now - h;
-                    if (std::abs(dh) < 1e-10 * std::abs(h)) break;
-                    const double cp = s.cpmass();
-                    if (!std::isfinite(cp) || cp <= 0.0) break;
-                    const double T_new = s.T() - dh / cp;
-                    s.update(::CoolProp::PT_INPUTS, p, T_new);
+                if (!seeded_via_hmass) {
+                    // R3 fallback: bracket on [623.15 K, T_B23(p)].
+                    const double T_R3_lo = 623.15;
+                    const double T_R3_hi = if97_T_B23_K(p);
+                    const double T_R3 = solve_T_from_h_toms748(s, p, h, T_R3_lo, T_R3_hi);
+                    s.update(::CoolProp::PT_INPUTS, p, T_R3);
+                } else {
+                    // Polish R7-97 backward seed.
+                    const double T_seed = s.T();
+                    constexpr double kIF97_T_min = 273.16;
+                    constexpr double kIF97_T_max = 2273.15;
+                    const double T_lo = std::max(T_seed - 0.5, kIF97_T_min);
+                    const double T_hi = std::min(T_seed + 0.5, kIF97_T_max);
+                    if (T_lo < T_hi) {
+                        bool ok = false;
+                        const double T_polished = solve_T_from_h_toms748(s, p, h, T_lo, T_hi, &ok);
+                        if (ok) {
+                            s.update(::CoolProp::PT_INPUTS, p, T_polished);
+                        }
+                    }
                 }
             } catch (...) {
                 if (pinned) s.unspecify_phase();

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -379,9 +379,34 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
             try {
                 if (!seeded_via_hmass) {
                     // R3 fallback: bracket on [623.15 K, T_B23(p)].
+                    // if97_T_B23_K is only defined for p ∈ [16.529, 100]
+                    // MPa; outside that range its closed-form inverse
+                    // returns garbage (sub-623.15 K or NaN from the
+                    // negative-argument sqrt).  Above 100 MPa is the
+                    // SUPER_HIGH_P slab where there's no R2/R3 boundary
+                    // at all — the R3 fallback shouldn't run there in
+                    // the first place, but guard anyway.
+                    constexpr double kP_B23_lo_Pa = 16.529e6;
+                    constexpr double kP_B23_hi_Pa = 100.0e6;
+                    if (!(p >= kP_B23_lo_Pa && p <= kP_B23_hi_Pa)) {
+                        throw ::CoolProp::ValueError(
+                          "ph_subcritical IF97 sampling: R3 fallback called outside the IF97 B23 curve's [16.529, 100] MPa "
+                          "validity (the HmassP backward seed failed and no R3 bracket is defined)");
+                    }
                     const double T_R3_lo = 623.15;
                     const double T_R3_hi = if97_T_B23_K(p);
-                    const double T_R3 = solve_T_from_h_toms748(s, p, h, T_R3_lo, T_R3_hi);
+                    if (!(T_R3_lo < T_R3_hi)) {
+                        throw ::CoolProp::ValueError("ph_subcritical IF97 sampling: degenerate R3 bracket (T_B23(p) <= 623.15 K)");
+                    }
+                    bool ok = false;
+                    const double T_R3 = solve_T_from_h_toms748(s, p, h, T_R3_lo, T_R3_hi, &ok);
+                    if (!ok) {
+                        // Bracket doesn't contain h — propagate as
+                        // failure so the SurfaceFactory marks this
+                        // cell NaN, rather than committing an endpoint
+                        // T as a real state.
+                        throw ::CoolProp::ValueError("ph_subcritical IF97 sampling: R3 TOMS748 missed bracket; cell will be NaN-filled");
+                    }
                     s.update(::CoolProp::PT_INPUTS, p, T_R3);
                 } else {
                     // Polish R7-97 backward seed.
@@ -395,6 +420,22 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
                         const double T_polished = solve_T_from_h_toms748(s, p, h, T_lo, T_hi, &ok);
                         if (ok) {
                             s.update(::CoolProp::PT_INPUTS, p, T_polished);
+                        } else {
+                            // solve_T_from_h_toms748 mutates `s` via its
+                            // bracket-residual probes; on a miss the
+                            // last probe leaves s at PT_INPUTS(p, T_hi
+                            // or T_lo) instead of the HmassP seed.
+                            // Restore so callers downstream see the
+                            // backward-equation seed (±25 mK floor)
+                            // rather than a near-endpoint state.
+                            try {
+                                s.update(::CoolProp::HmassP_INPUTS, h, p);
+                            } catch (...) {  // NOLINT(bugprone-empty-catch)
+                                // Seed-restore failed (the original
+                                // HmassP at line 362 succeeded, so this
+                                // is unexpected); leave state alone and
+                                // let downstream handle as a bad cell.
+                            }
                         }
                     }
                 }

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -99,6 +99,33 @@ double if97_T_B23_K(double p_Pa) {
 // when the source backend is IF97 (the kink is intrinsic to IF97's
 // piecewise EOS; HEOS source has no such internal boundary).  Valid
 // only for p ∈ [16.529 MPa, 100 MPa] — caller must clamp.
+// Build h = h_IF97(623.15 K, p) along the IF97 R1/R3 isotherm.  Used to
+// split SUPER_R3 (above pcrit, below p_B23) into a R1-territory sub-
+// region (T < 623.15 K, compressed-liquid supercritical) and a R3-
+// proper sub-region (T >= 623.15 K, dense supercritical).  Same
+// pattern as build_h_B23_curve but on the T isotherm instead of the
+// p_B23(T) curve.  Valid for p > p_sat(623.15) = 16.529 MPa.
+std::unique_ptr<region::CubicSplineCurve> build_h_R1R3_curve(::CoolProp::AbstractState& heos, double p_lo, double p_hi) {
+    constexpr double kT_R1R3 = 623.15;
+    constexpr double kP_R1R3_lo_MPa = 16.529;
+    const double p_lo_clamped = std::max(p_lo, kP_R1R3_lo_MPa * 1.0e6);
+    if (!(p_lo_clamped < p_hi)) {
+        throw std::invalid_argument("build_h_R1R3_curve: p range does not overlap IF97 R1/R3 isotherm's validity (p > 16.529 MPa)");
+    }
+    constexpr std::size_t n_knots = 64;
+    std::vector<double> p_knots(n_knots);
+    std::vector<double> h_knots(n_knots);
+    const double log_p_lo = std::log(p_lo_clamped);
+    const double log_p_hi = std::log(p_hi);
+    for (std::size_t k = 0; k < n_knots; ++k) {
+        const double p = std::exp(log_p_lo + static_cast<double>(k) * (log_p_hi - log_p_lo) / static_cast<double>(n_knots - 1));
+        heos.update(::CoolProp::PT_INPUTS, p, kT_R1R3);
+        p_knots[k] = p;
+        h_knots[k] = heos.hmass();
+    }
+    return region::CubicSplineCurve::build(std::move(p_knots), std::move(h_knots));
+}
+
 std::unique_ptr<region::CubicSplineCurve> build_h_B23_curve(::CoolProp::AbstractState& heos, double p_lo, double p_hi) {
     constexpr double kP_B23_lo_MPa = 16.529;
     constexpr double kP_B23_hi_MPa = 100.0;
@@ -188,10 +215,26 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
     if (source_is_if97 && p_min_sup < kP_B23_hi) {
         // p range where the kink applies; clamped at the B23 upper bound.
         const double p_split_hi = std::min(p_max_sup, kP_B23_hi);
-        // SUPER_R3: low-h side of the IF97 R2/R3 kink, p ∈ [p_min_sup, p_split_hi].
+        // SUPER_R1_super: IF97 R1 territory at p > pcrit, h ∈ [h_floor(p),
+        // h_IF97(623.15 K, p)).  Separating R1 from R3 in this slab
+        // (foi.9.9) gives the R1-side compressed-liquid SVD its own η
+        // normalization — the previous combined SUPER_R3 region had
+        // R1+R3 sharing modes, and R1 conformance suffered (post-foi.9.5
+        // R1 worst v 0.164%).  Subcritical-p R1 (the LIQUID region)
+        // hits 0.008% max v with the same physics; this split brings
+        // SUPER_R3's R1 territory to that level.
         {
             auto axis = region::AxisTransform::make(region::AxisScale::LOG, p_min_sup, p_split_hi);
             auto lo = build_h_isotherm_floor(heos, p_min_sup, p_split_hi, T_min_eos);
+            auto hi = build_h_R1R3_curve(heos, p_min_sup, p_split_hi);
+            spec.regions.emplace_back(axis, std::move(lo), std::move(hi));
+        }
+        // SUPER_R3_proper: IF97 R3 territory at p > pcrit, h ∈ [h_R1R3(p),
+        // h_B23(p)).  Only the (T, p, h) region where IF97 actually
+        // evaluates R3.
+        {
+            auto axis = region::AxisTransform::make(region::AxisScale::LOG, p_min_sup, p_split_hi);
+            auto lo = build_h_R1R3_curve(heos, p_min_sup, p_split_hi);
             auto hi = build_h_B23_curve(heos, p_min_sup, p_split_hi);
             spec.regions.emplace_back(axis, std::move(lo), std::move(hi));
         }


### PR DESCRIPTION
## Context

This PR was originally just the TOMS748 h-inversion work stacked on top of #2939 (the R1/R3 atlas split). #2939 was merged and then reverted, leaving its R1/R3 split commit orphaned outside master. To recover, this PR was rebased onto current master and now carries **both** the R1/R3 split and the original TOMS748 fixes — i.e., merging this PR lands the 2939 content as well.

## Commits (4)

1. **`feat(svdsbtl): split SUPER_R3 at IF97 R1/R3 isotherm h_R1R3(p)`** (the 2939 content)
   Splits the existing \`SUPER_R3\` region along the IF97 R1/R3 boundary \`h_R1R3(p) = h_IF97(623.15 K, p)\`, so R1 territory at \`p > p_crit\` gets its own SVD (\`SUPER_R1_super\`) separate from R3 proper. Closes the post-#2938 R1 conformance gap where R1 and R3 modes were competing for SVD bandwidth in a single region.

2. **`fix(svdsbtl): replace Newton h-inversion with TOMS748 (foi.9.10)`**
   IF97's \`HmassP_INPUTS\` only implements closed-form backward T(p, h) for R1/R2/R5. In R3 the backward equation isn't wired up, and the previous Newton fallback (start at T=700 K, iterate against forward h(T, p)) silently failed at points where the seed put Newton on the wrong side of the R2/R3 boundary — e.g. T_target = 663.7 K, p = 26.6 MPa where the iterate would oscillate. Replaced with \`boost::math::tools::toms748_solve\` on \`[623.15, T_B23(p)]\` plus a \`solve_T_from_h_toms748\` helper with an \`ok\` flag so the caller can detect non-convergence cleanly.

3. **`fix(svdsbtl): TOMS748-polish patch state to forward-consistent T`**
   When the critical-patch routes a point to the patch source backend, the source's \`update(HmassP_INPUTS, h, p)\` returns IF97's backward T, which carries the ±25 mK R7-97 floor. A subsequent TOMS748 polish against forward h(T, p) brings T back to forward-consistent — closes the residual conformance gap visible at the patch perimeter in the 540k-probe failmap.

4. **`fix(svdsbtl): use std::uintmax_t for TOMS748 iteration counter (MSVC compat)`**
   \`boost::uintmax_t\` requires \`<boost/cstdint.hpp>\` on MSVC, which the Tauri-GUI build didn't pull in transitively. \`std::uintmax_t\` is the same type in modern boost and works in every toolchain.

## Test plan

- [x] Local build clean across all 4 commits.
- [x] \`./CatchTestRunner '[SVDSBTL]'\` — 332/332 assertions pass.
- [x] Dense 540k-probe failmap shows R3 v fails dropping from ~190% (broken Newton) to within IF97 R7-97 floor (~25 mK) after the TOMS748 fix.
- [x] Patch-perimeter T residuals drop from ~19 mK to ~5 mK after the patch-polish fix.
- [ ] CI green across macOS / Ubuntu / Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temperature inversion and sampling stability using more robust bracketed root solving, reducing incorrect or unstable state calculations.
  * Better handling of critical/super-region transitions to avoid NaN or misclassified states.

* **Chores**
  * On-wire cache revision bumped; existing cached data must be rebuilt.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2940?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->