### PR TITLE
feat(fast_evaluate): batch path for SVDSBTL + dome Q-blend for IF97/SVDSBTL

### DIFF
--- a/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
+++ b/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
@@ -3,6 +3,7 @@
 
 #include <limits>
 #include <memory>
+#include <optional>
 #include <set>  // transitively needed by superancillary.h
 #include <string>
 #include <unordered_map>
@@ -125,24 +126,23 @@ class SVDSBTLBackend : public AbstractState
     void update(CoolProp::input_pairs input_pair, double value1, double value2) override;
 
     // Vectorized cache-bypassing batch evaluation — see
-    // AbstractState::fast_evaluate for the contract.  Mirrors update()'s
-    // routing (critical-patch bbox → patch_source_, otherwise SVD
-    // surface) but writes directly into the caller's out_buffer rather
-    // than touching the instance's update()-side state (_T / _p /
-    // _phase / active_point_ / active_surface_ / active_resolved_ /
-    // active_hmass_).  So back-to-back fast_evaluate calls can be
-    // interleaved with update() calls on the same instance without
-    // corrupting the most-recent update()'s state, BUT the patch
-    // routing IS stateful: it reuses the lazily-allocated patch_source_
-    // child AbstractState across all in-patch points in the batch.
-    // That makes fast_evaluate safe for single-threaded interleaving
-    // with update() but NOT thread-safe — two concurrent fast_evaluate
-    // calls on the same backend will race on patch_source_->update()
-    // for any point that falls inside the critical-patch bbox.  In-
-    // domain HmassP / HmolarP probes that fall inside the saturation
-    // dome are Q-blended in place; PT probes exactly on the sat curve
-    // and points outside every region NaN-fill with
-    // fast_evaluate_two_phase_disallowed or fast_evaluate_out_of_range.
+    // AbstractState::fast_evaluate for the contract.  Both update() and
+    // fast_evaluate() route through the same private resolve_point_()
+    // kernel; this entry point just loops over the input array, asks
+    // the kernel for a PointEvaluation per probe, then dispatches each
+    // requested output through evaluate_property_().  Writes directly
+    // into the caller's out_buffer instead of mutating active_eval_, so
+    // back-to-back fast_evaluate calls can be interleaved with update()
+    // on the same instance without corrupting the most-recent update()
+    // — BUT the patch routing is stateful (reuses the lazily-allocated
+    // patch_source_ child AbstractState across all in-patch points),
+    // which makes fast_evaluate safe for single-threaded interleaving
+    // with update() but NOT thread-safe against a concurrent
+    // fast_evaluate/update on the same backend.  HmassP / HmolarP
+    // probes inside the saturation dome are Q-blended in place; PT
+    // probes exactly on the sat curve NaN-fill with
+    // fast_evaluate_two_phase_disallowed; points outside every region
+    // NaN-fill with fast_evaluate_out_of_range.
     void fast_evaluate(CoolProp::input_pairs input_pair, const double* val1, const double* val2, std::size_t N_inputs,
                        const CoolProp::parameters* outputs, std::size_t N_outputs, double* out_buffer, std::size_t out_buffer_size, int* status_flags,
                        std::size_t status_flags_size, CoolProp::phases imposed_phase = CoolProp::iphase_not_imposed) override;
@@ -204,11 +204,88 @@ class SVDSBTLBackend : public AbstractState
     // the set of input pairs registered in surfaces_.
     [[nodiscard]] std::vector<CoolProp::input_pairs> registered_input_pairs() const;
 
+   public:
+    // Self-contained per-point evaluation state — the shared currency
+    // between update() (caches the result on the instance) and
+    // fast_evaluate() (loops, holds it locally per probe).  Public so
+    // tests + future batch callers can inspect what resolve_point_()
+    // decided.
+    struct PointEvaluation
+    {
+        enum class Kind : std::uint8_t
+        {
+            Invalid,             // never assigned
+            SinglePhase,         // atlas resolved to a surface region
+            DomeBlend,           // HmassP / HmolarP landed inside the dome OR PQ/QT input
+            Patched,             // inside the critical-patch bbox; consult patch_source_
+            OutOfRange,          // outside every region's bbox
+            TwoPhaseDisallowed,  // PT exactly on sat curve (Q ambiguous)
+            InternalError,       // per-point evaluation failure
+        };
+
+        Kind kind = Kind::Invalid;
+        int status = CoolProp::fast_evaluate_internal_error;  // fast_evaluate_status code
+
+        // The input pair this point was resolved for + the raw inputs.
+        // Lets evaluate_property_() return the supplied input verbatim
+        // (no surface round-trip) when the caller asks for it.  v1 /
+        // v2 are always set after a valid resolve_point_ call.
+        CoolProp::input_pairs input_pair = CoolProp::INPUT_PAIR_INVALID;
+        double v1 = std::numeric_limits<double>::quiet_NaN();
+        double v2 = std::numeric_limits<double>::quiet_NaN();
+
+        // Universal physical coords resolved for this point.  Filled
+        // for SinglePhase / DomeBlend / Patched; the OOB and
+        // TwoPhaseDisallowed kinds leave them as nullopt because
+        // there's no defined physical state at the input.  For
+        // DomeBlend, T == T_sat and Q is in [0, 1].
+        std::optional<double> T;
+        std::optional<double> p;
+        std::optional<double> h_mass;
+        double Q = -1.0;  // -1 sentinel for single-phase, [0, 1] in dome
+
+        // SinglePhase / Patched routing.
+        const CoolProp::sbtl::SVDSurface* surface = nullptr;
+        CoolProp::sbtl::SVDSurface::ResolvedPoint resolved{};
+
+        // DomeBlend endpoints (molar basis to match SuperAncillary's
+        // native units; h_mass / T above is what calc_* / fast_evaluate
+        // return for the row).  Sat-line h endpoints are filled at
+        // resolve time (we need them to determine Q anyway); rho and
+        // s endpoints fill lazily on first request via
+        // ensure_dome_*_endpoints_().
+        std::optional<double> T_sat;
+        std::optional<double> hL_mol;
+        std::optional<double> hV_mol;
+        std::optional<double> rhoL_mol;
+        std::optional<double> rhoV_mol;
+        std::optional<double> sL_mol;
+        std::optional<double> sV_mol;
+    };
+
    private:
-    // Returns the prop's value at the active lookup point.  Throws
-    // CoolProp::ValueError if no update() has been called or the
-    // active surface doesn't expose `prop`.
-    CoolPropDbl lookup_(CoolProp::parameters prop);
+    // Resolve an (input_pair, v1, v2) triple into a PointEvaluation
+    // without mutating any backend state.  Both update() and
+    // fast_evaluate() call this — there's exactly one place where the
+    // input-pair dispatch, critical-patch routing, atlas resolve, and
+    // dome detection live.  Two-phase PQ_INPUTS / QT_INPUTS get the
+    // same DomeBlend treatment as HmassP-inside-dome — same kernel,
+    // same fields.
+    PointEvaluation resolve_point_(CoolProp::input_pairs ip, double v1, double v2);
+
+    // Evaluate one property against a resolved PointEvaluation.  Pure;
+    // touches only the const data inside `pt` (the surface pointer or
+    // the dome endpoints) plus the lazily-populated patch_source_ for
+    // Patched rows.  Returns NaN for properties undefined in the dome
+    // (speed_sound, cp, cv, viscosity, conductivity, Prandtl) when
+    // kind == DomeBlend.  Throws when a request can't be served at all
+    // (e.g. unsupported property on a surface that doesn't expose it).
+    [[nodiscard]] double evaluate_property_(PointEvaluation& pt, CoolProp::parameters prop);
+
+    // Lazy population of dome endpoint properties — only the ones the
+    // caller actually requests are pulled from SuperAncillary / source.
+    void ensure_dome_rho_endpoints_(PointEvaluation& pt);
+    void ensure_dome_s_endpoints_(PointEvaluation& pt);
 
     // Load <fluid>.<pair>.svd.bin.z from the default cache; if absent,
     // build via the matching preset and save it.  Inserts into surfaces_.
@@ -218,18 +295,6 @@ class SVDSBTLBackend : public AbstractState
     // first call).  Returns nullptr if no SuperAncillary ships with
     // this fluid -- two-phase queries then throw a clear error.
     std::shared_ptr<superancillary::SuperAncillary<std::vector<double>>> superanc_();
-
-    // Two-phase update for PQ_INPUTS / QT_INPUTS / dome-hit HmassP /
-    // dome-hit PT.  Caches the sat-line state (T_sat, p_sat, Q, plus
-    // sat-line endpoints rho_L/V, h_L/V, s_L/V, u_L/V on a molar basis)
-    // so the calc_* virtuals can produce Q-weighted properties without
-    // re-evaluating the superancillary.
-    void update_two_phase_(double T_sat, double p_sat, double Q);
-
-    // Per-property Q-weighted blend over the cached sat-line state.
-    // Density uses 1/(Q/rho_V + (1-Q)/rho_L) (specific-volume blend);
-    // h/s/u use the linear blend.
-    [[nodiscard]] CoolPropDbl two_phase_property_(CoolProp::parameters prop) const;
 
     std::string fluid_name_;
     std::string source_backend_;               // "HEOS" / "REFPROP" / "IF97"
@@ -259,40 +324,15 @@ class SVDSBTLBackend : public AbstractState
     // ResolvedPoint pointers below stay valid across map growth.
     std::unordered_map<int /*input_pairs as int*/, std::unique_ptr<CoolProp::sbtl::SVDSurface>> surfaces_;
 
-    // State recorded by the most recent update() call.
-    CoolProp::input_pairs active_pair_ = CoolProp::INPUT_PAIR_INVALID;
-    const CoolProp::sbtl::SVDSurface* active_surface_ = nullptr;
-    CoolProp::sbtl::SVDSurface::ResolvedPoint active_point_{};
-    bool active_resolved_ = false;
-
-    // Mass-basis inputs stashed by update().  Returned verbatim when
-    // the user asks for the property they just supplied (no SVD
-    // round-trip).  _T and _p live in AbstractState already.
-    double active_hmass_ = std::numeric_limits<double>::quiet_NaN();
+    // The most recent update()'s resolved point.  All calc_*() methods
+    // dispatch through evaluate_property_(active_eval_, ...).
+    PointEvaluation active_eval_;
 
     // Lazy-resolved SuperAncillary handle.  Resolved on first call to
     // superanc_(); cached for subsequent two-phase queries.  Stays
     // nullptr if the fluid ships without one.
     std::shared_ptr<superancillary::SuperAncillary<std::vector<double>>> superanc_cached_;
     bool superanc_resolved_ = false;  // distinguish "not tried yet" from "tried and got nullptr"
-
-    // Active two-phase state, populated by update_two_phase_().  All
-    // four endpoint properties are stored on a MOLAR basis so the
-    // Q-weighted blend math doesn't need to redo the unit conversion
-    // on every calc_*.
-    struct TwoPhaseState
-    {
-        bool active = false;
-        double rhoL_mol = 0.0;
-        double rhoV_mol = 0.0;
-        double hL_mol = 0.0;
-        double hV_mol = 0.0;
-        double sL_mol = 0.0;
-        double sV_mol = 0.0;
-        double uL_mol = 0.0;
-        double uV_mol = 0.0;
-    };
-    TwoPhaseState two_phase_{};
 
     // Critical-patch HEOS-fallback.  When an active query point lands
     // inside the configured bbox (in whatever the input pair's native
@@ -316,7 +356,8 @@ class SVDSBTLBackend : public AbstractState
     };
     CriticalPatch critical_patch_{};
     std::shared_ptr<CoolProp::AbstractState> patch_source_;  // lazy
-    bool active_in_patch_ = false;
+    // active_in_patch_ removed — the patch / non-patch routing now
+    // lives on active_eval_.kind (Patched vs SinglePhase/etc.).
 
     // Configure critical_patch_ from the validated options blob.
     // Called once at construction after surfaces_ are loaded.  When

--- a/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
+++ b/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
@@ -127,12 +127,22 @@ class SVDSBTLBackend : public AbstractState
     // Vectorized cache-bypassing batch evaluation — see
     // AbstractState::fast_evaluate for the contract.  Mirrors update()'s
     // routing (critical-patch bbox → patch_source_, otherwise SVD
-    // surface) but never touches the instance's _T / _p / _phase /
-    // active_point_ slots, so back-to-back fast_evaluate batches do not
-    // interfere with each other and a concurrent update() call.  No
-    // heap allocations beyond what each in-patch point's
-    // patch_source_->update() does internally.  Two-phase / dome-hit
-    // points NaN-fill their row and set fast_evaluate_two_phase_disallowed.
+    // surface) but writes directly into the caller's out_buffer rather
+    // than touching the instance's update()-side state (_T / _p /
+    // _phase / active_point_ / active_surface_ / active_resolved_ /
+    // active_hmass_).  So back-to-back fast_evaluate calls can be
+    // interleaved with update() calls on the same instance without
+    // corrupting the most-recent update()'s state, BUT the patch
+    // routing IS stateful: it reuses the lazily-allocated patch_source_
+    // child AbstractState across all in-patch points in the batch.
+    // That makes fast_evaluate safe for single-threaded interleaving
+    // with update() but NOT thread-safe — two concurrent fast_evaluate
+    // calls on the same backend will race on patch_source_->update()
+    // for any point that falls inside the critical-patch bbox.  In-
+    // domain HmassP / HmolarP probes that fall inside the saturation
+    // dome are Q-blended in place; PT probes exactly on the sat curve
+    // and points outside every region NaN-fill with
+    // fast_evaluate_two_phase_disallowed or fast_evaluate_out_of_range.
     void fast_evaluate(CoolProp::input_pairs input_pair, const double* val1, const double* val2, std::size_t N_inputs,
                        const CoolProp::parameters* outputs, std::size_t N_outputs, double* out_buffer, std::size_t out_buffer_size, int* status_flags,
                        std::size_t status_flags_size, CoolProp::phases imposed_phase = CoolProp::iphase_not_imposed) override;

--- a/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
+++ b/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
@@ -120,9 +120,14 @@ class SVDSBTLBackend : public AbstractState
         return mole_fractions_;
     }
 
-    // Main update dispatcher.  Routes by input_pair to the matching
-    // surface and resolves the atlas-dispatch ResolvedPoint once so
-    // subsequent calc_* calls are pure SVD evaluations.
+    // Main update dispatcher.  Hands off to resolve_point_(), stores
+    // the resulting PointEvaluation as active_eval_, and copies the
+    // legacy AbstractState slots (_T / _p / _Q / _phase) for back-
+    // compat readers.  Subsequent calc_*() calls dispatch through
+    // evaluate_property_(active_eval_, ...) — which in the SinglePhase
+    // case is a single eval_with_region per output, in the DomeBlend
+    // case is a lever-rule blend with lazy sat-line endpoint fills,
+    // and in the Patched case forwards to patch_source_.
     void update(CoolProp::input_pairs input_pair, double value1, double value2) override;
 
     // Vectorized cache-bypassing batch evaluation — see
@@ -131,25 +136,34 @@ class SVDSBTLBackend : public AbstractState
     // kernel; this entry point just loops over the input array, asks
     // the kernel for a PointEvaluation per probe, then dispatches each
     // requested output through evaluate_property_().  Writes directly
-    // into the caller's out_buffer instead of mutating active_eval_, so
-    // back-to-back fast_evaluate calls can be interleaved with update()
-    // on the same instance without corrupting the most-recent update()
-    // — BUT the patch routing is stateful (reuses the lazily-allocated
-    // patch_source_ child AbstractState across all in-patch points),
-    // which makes fast_evaluate safe for single-threaded interleaving
-    // with update() but NOT thread-safe against a concurrent
-    // fast_evaluate/update on the same backend.  HmassP / HmolarP
-    // probes inside the saturation dome are Q-blended in place; PT
-    // probes exactly on the sat curve NaN-fill with
-    // fast_evaluate_two_phase_disallowed; points outside every region
-    // NaN-fill with fast_evaluate_out_of_range.
+    // into the caller's out_buffer instead of mutating active_eval_.
+    //
+    // **Thread safety / interleaving:** The backend is not thread-safe
+    // — two concurrent calls (any combination of update / fast_evaluate
+    // / property reads) on the same instance can corrupt each other's
+    // state.  Single-threaded back-to-back fast_evaluate calls and
+    // single-threaded fast_evaluate interleaved with update() are
+    // **only** safe when no probe in the batch falls inside the
+    // critical-patch bbox.  Patched probes re-update the lazily
+    // allocated patch_source_ child AbstractState in place, which
+    // means a sequence like `update(state A); fast_evaluate(...batch
+    // containing a Patched probe B...); state->T()` returns T from B
+    // rather than A.  In practice the critical-patch bbox is small
+    // (~5 % of T_c × ~30 % of p_c by default) so the corruption is
+    // local to true near-critical workloads.
+    //
+    // HmassP / HmolarP probes inside the saturation dome are
+    // Q-blended in place; PT probes exactly on the sat curve NaN-fill
+    // with fast_evaluate_two_phase_disallowed; points outside every
+    // region NaN-fill with fast_evaluate_out_of_range.
     void fast_evaluate(CoolProp::input_pairs input_pair, const double* val1, const double* val2, std::size_t N_inputs,
                        const CoolProp::parameters* outputs, std::size_t N_outputs, double* out_buffer, std::size_t out_buffer_size, int* status_flags,
                        std::size_t status_flags_size, CoolProp::phases imposed_phase = CoolProp::iphase_not_imposed) override;
 
-    // Property accessors.  Each routes through lookup_(prop), which
-    // honours the inputs the user supplied (no SVD round-trip for
-    // values the user just gave us).
+    // Property accessors.  All route through
+    // evaluate_property_(active_eval_, ...), which honours the
+    // inputs the user supplied (no SVD round-trip for values the
+    // user just gave us — h on HmassP, T on PT, etc.).
     CoolPropDbl calc_rhomass() override;
     CoolPropDbl calc_hmass() override;
     CoolPropDbl calc_smass() override;

--- a/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
+++ b/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
@@ -124,6 +124,19 @@ class SVDSBTLBackend : public AbstractState
     // subsequent calc_* calls are pure SVD evaluations.
     void update(CoolProp::input_pairs input_pair, double value1, double value2) override;
 
+    // Vectorized cache-bypassing batch evaluation — see
+    // AbstractState::fast_evaluate for the contract.  Mirrors update()'s
+    // routing (critical-patch bbox → patch_source_, otherwise SVD
+    // surface) but never touches the instance's _T / _p / _phase /
+    // active_point_ slots, so back-to-back fast_evaluate batches do not
+    // interfere with each other and a concurrent update() call.  No
+    // heap allocations beyond what each in-patch point's
+    // patch_source_->update() does internally.  Two-phase / dome-hit
+    // points NaN-fill their row and set fast_evaluate_two_phase_disallowed.
+    void fast_evaluate(CoolProp::input_pairs input_pair, const double* val1, const double* val2, std::size_t N_inputs,
+                       const CoolProp::parameters* outputs, std::size_t N_outputs, double* out_buffer, std::size_t out_buffer_size, int* status_flags,
+                       std::size_t status_flags_size, CoolProp::phases imposed_phase = CoolProp::iphase_not_imposed) override;
+
     // Property accessors.  Each routes through lookup_(prop), which
     // honours the inputs the user supplied (no SVD round-trip for
     // values the user just gave us).

--- a/src/Backends/IF97/IF97Backend.h
+++ b/src/Backends/IF97/IF97Backend.h
@@ -732,6 +732,7 @@ class IF97Backend : public AbstractState
                 case iviscosity:
                 case iconductivity:
                 case iPrandtl:
+                case iQ:
                     break;
                 default:
                     throw ValueError(
@@ -757,6 +758,9 @@ class IF97Backend : public AbstractState
             const double v2 = val2[k];
 
             double T_k, p_k;
+            const double hmass_k = is_HmassP ? v1 : (is_HmolarP ? (v1 / M) : 0.0);
+            bool dome_hit = false;
+            double T_sat_k = 0.0, Q_k = 0.0, hL_k = 0.0, hV_k = 0.0;
             if (is_PT) {
                 p_k = v1;
                 T_k = v2;
@@ -765,10 +769,37 @@ class IF97Backend : public AbstractState
                 // backward T_phmass to recover T. Both branches must produce
                 // a clean (T, p) for the forward evaluators below.
                 p_k = v2;
-                double hmass_k = is_HmolarP ? (v1 / M) : v1;
+                bool inverse_ok = false;
                 try {
                     T_k = IF97::T_phmass(p_k, hmass_k);
+                    inverse_ok = true;
                 } catch (const std::exception&) {
+                    // T_phmass throws for out-of-range inputs — fall
+                    // through to the dome probe + OOB classification.
+                }
+                // T_phmass returns Tsat for in-dome (h, p) inputs without
+                // throwing, so the dome check has to run independently of
+                // whether the inverse "succeeded".  Probing hL / hV at p
+                // and bracketing on h is the cleanest detector.
+                if (p_k > 0 && p_k <= IF97::Pcrit) {
+                    try {
+                        const double hL_probe = IF97::hliq_p(p_k);
+                        const double hV_probe = IF97::hvap_p(p_k);
+                        if (hmass_k >= hL_probe && hmass_k <= hV_probe) {
+                            T_sat_k = IF97::Tsat97(p_k);
+                            hL_k = hL_probe;
+                            hV_k = hV_probe;
+                            Q_k = (hmass_k - hL_k) / (hV_k - hL_k);
+                            dome_hit = true;
+                            T_k = T_sat_k;
+                            inverse_ok = true;
+                        }
+                    } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
+                        // Above pcrit or other IF97 envelope failure;
+                        // fall through to OOB.
+                    }
+                }
+                if (!inverse_ok) {
                     status_flags[k] = CoolProp::fast_evaluate_out_of_range;
                     fill_nan_row(k);
                     continue;
@@ -799,70 +830,156 @@ class IF97Backend : public AbstractState
             }
 
             bool eval_failed = false;
+            // Two-phase Q-blend cache (lazy fill — only touched if a
+            // property that needs sat-line endpoints is requested while
+            // dome_hit is true).
+            double rhoL_k = 0.0, rhoV_k = 0.0;
+            double sL_k = 0.0, sV_k = 0.0;
+            double uL_k = 0.0, uV_k = 0.0;
+            bool have_rho = false, have_s = false, have_u = false;
+            auto ensure_rho_sat = [&] {
+                if (have_rho) return;
+                rhoL_k = IF97::rholiq_p(p_k);
+                rhoV_k = IF97::rhovap_p(p_k);
+                have_rho = true;
+            };
+            auto ensure_s_sat = [&] {
+                if (have_s) return;
+                sL_k = IF97::sliq_p(p_k);
+                sV_k = IF97::svap_p(p_k);
+                have_s = true;
+            };
+            auto ensure_u_sat = [&] {
+                if (have_u) return;
+                uL_k = IF97::uliq_p(p_k);
+                uV_k = IF97::uvap_p(p_k);
+                have_u = true;
+            };
             for (std::size_t o = 0; o < N_outputs; ++o) {
                 const parameters out_key = outputs[o];
                 try {
                     double val;
-                    switch (out_key) {
-                        case iT:
-                            val = T_k;
-                            break;
-                        case iP:
-                            val = p_k;
-                            break;
-                        case iDmass:
-                            val = IF97::rhomass_Tp(T_k, p_k);
-                            break;
-                        case iDmolar:
-                            val = IF97::rhomass_Tp(T_k, p_k) / M;
-                            break;
-                        case iHmass:
-                            val = IF97::hmass_Tp(T_k, p_k);
-                            break;
-                        case iHmolar:
-                            val = IF97::hmass_Tp(T_k, p_k) * M;
-                            break;
-                        case iSmass:
-                            val = IF97::smass_Tp(T_k, p_k);
-                            break;
-                        case iSmolar:
-                            val = IF97::smass_Tp(T_k, p_k) * M;
-                            break;
-                        case iUmass:
-                            val = IF97::umass_Tp(T_k, p_k);
-                            break;
-                        case iUmolar:
-                            val = IF97::umass_Tp(T_k, p_k) * M;
-                            break;
-                        case iCpmass:
-                            val = IF97::cpmass_Tp(T_k, p_k);
-                            break;
-                        case iCpmolar:
-                            val = IF97::cpmass_Tp(T_k, p_k) * M;
-                            break;
-                        case iCvmass:
-                            val = IF97::cvmass_Tp(T_k, p_k);
-                            break;
-                        case iCvmolar:
-                            val = IF97::cvmass_Tp(T_k, p_k) * M;
-                            break;
-                        case ispeed_sound:
-                            val = IF97::speed_sound_Tp(T_k, p_k);
-                            break;
-                        case iviscosity:
-                            val = IF97::visc_Tp(T_k, p_k);
-                            break;
-                        case iconductivity:
-                            val = IF97::tcond_Tp(T_k, p_k);
-                            break;
-                        case iPrandtl:
-                            val = IF97::prandtl_Tp(T_k, p_k);
-                            break;
-                        default:
-                            val = NaN;
-                            eval_failed = true;
-                            break;
-                    }
+                    if (dome_hit) {
+                        // Q-weighted blend for two-phase points.  Specific
+                        // volume blends linearly (density is its reciprocal);
+                        // h/s/u blend linearly directly.  Speed of sound,
+                        // cp, cv, viscosity, conductivity have no
+                        // equilibrium bulk value in the dome — set NaN.
+                        switch (out_key) {
+                            case iT:
+                                val = T_sat_k;
+                                break;
+                            case iP:
+                                val = p_k;
+                                break;
+                            case iHmass:
+                                val = hmass_k;
+                                break;
+                            case iHmolar:
+                                val = hmass_k * M;
+                                break;
+                            case iDmass:
+                            case iDmolar: {
+                                ensure_rho_sat();
+                                const double vL = 1.0 / rhoL_k;
+                                const double vV = 1.0 / rhoV_k;
+                                const double rho_mass = 1.0 / ((1.0 - Q_k) * vL + Q_k * vV);
+                                val = (out_key == iDmass) ? rho_mass : rho_mass / M;
+                                break;
+                            }
+                            case iSmass:
+                            case iSmolar: {
+                                ensure_s_sat();
+                                const double s_mass = (1.0 - Q_k) * sL_k + Q_k * sV_k;
+                                val = (out_key == iSmass) ? s_mass : s_mass * M;
+                                break;
+                            }
+                            case iUmass:
+                            case iUmolar: {
+                                ensure_u_sat();
+                                const double u_mass = (1.0 - Q_k) * uL_k + Q_k * uV_k;
+                                val = (out_key == iUmass) ? u_mass : u_mass * M;
+                                break;
+                            }
+                            case iQ:
+                                val = Q_k;
+                                break;
+                            case iCpmass:
+                            case iCpmolar:
+                            case iCvmass:
+                            case iCvmolar:
+                            case ispeed_sound:
+                            case iviscosity:
+                            case iconductivity:
+                            case iPrandtl:
+                                val = NaN;
+                                break;
+                            default:
+                                val = NaN;
+                                eval_failed = true;
+                                break;
+                        }
+                    } else
+                        switch (out_key) {
+                            case iT:
+                                val = T_k;
+                                break;
+                            case iP:
+                                val = p_k;
+                                break;
+                            case iDmass:
+                                val = IF97::rhomass_Tp(T_k, p_k);
+                                break;
+                            case iDmolar:
+                                val = IF97::rhomass_Tp(T_k, p_k) / M;
+                                break;
+                            case iHmass:
+                                val = IF97::hmass_Tp(T_k, p_k);
+                                break;
+                            case iHmolar:
+                                val = IF97::hmass_Tp(T_k, p_k) * M;
+                                break;
+                            case iSmass:
+                                val = IF97::smass_Tp(T_k, p_k);
+                                break;
+                            case iSmolar:
+                                val = IF97::smass_Tp(T_k, p_k) * M;
+                                break;
+                            case iUmass:
+                                val = IF97::umass_Tp(T_k, p_k);
+                                break;
+                            case iUmolar:
+                                val = IF97::umass_Tp(T_k, p_k) * M;
+                                break;
+                            case iCpmass:
+                                val = IF97::cpmass_Tp(T_k, p_k);
+                                break;
+                            case iCpmolar:
+                                val = IF97::cpmass_Tp(T_k, p_k) * M;
+                                break;
+                            case iCvmass:
+                                val = IF97::cvmass_Tp(T_k, p_k);
+                                break;
+                            case iCvmolar:
+                                val = IF97::cvmass_Tp(T_k, p_k) * M;
+                                break;
+                            case ispeed_sound:
+                                val = IF97::speed_sound_Tp(T_k, p_k);
+                                break;
+                            case iviscosity:
+                                val = IF97::visc_Tp(T_k, p_k);
+                                break;
+                            case iconductivity:
+                                val = IF97::tcond_Tp(T_k, p_k);
+                                break;
+                            case iPrandtl:
+                                val = IF97::prandtl_Tp(T_k, p_k);
+                                break;
+                            default:
+                                val = NaN;
+                                eval_failed = true;
+                                break;
+                        }
                     out_buffer[k * N_outputs + o] = val;
                 } catch (const std::exception&) {
                     eval_failed = true;

--- a/src/Backends/IF97/IF97Backend.h
+++ b/src/Backends/IF97/IF97Backend.h
@@ -975,6 +975,14 @@ class IF97Backend : public AbstractState
                             case iPrandtl:
                                 val = IF97::prandtl_Tp(T_k, p_k);
                                 break;
+                            case iQ:
+                                // Single-phase by definition here — the
+                                // dome-detection branch above would have
+                                // routed two-phase points to the
+                                // Q-blend path.  Mirror update()'s
+                                // -1 sentinel for single-phase Q.
+                                val = -1.0;
+                                break;
                             default:
                                 val = NaN;
                                 eval_failed = true;

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -607,9 +607,12 @@ double SVDSBTLBackend::evaluate_property_(PointEvaluation& pt, CoolProp::paramet
     // we only short-circuit when the value was either supplied by the
     // input pair (PT case), set by the dome blend (T = T_sat), or
     // pulled from patch_source_->T() / ->p() in resolve_point_.
-    if (prop == CoolProp::iQ) {
-        return pt.Q;
-    }
+    //
+    // iQ is *not* short-circuited at top level — Patched probes
+    // delegate to patch_source_'s Q (which may itself be two-phase
+    // near the bbox edge), and OOB / TwoPhaseDisallowed / Invalid
+    // kinds return NaN through the kind switch.  Only SinglePhase
+    // and DomeBlend use the pt.Q default / blend value.
     if (prop == CoolProp::iP && pt.p) {
         return *pt.p;
     }
@@ -620,11 +623,20 @@ double SVDSBTLBackend::evaluate_property_(PointEvaluation& pt, CoolProp::paramet
         return *pt.h_mass;
     }
     if (prop == CoolProp::iHmolar && pt.h_mass) {
+        // pt.h_mass is the single source of truth: PQ/QT and HmassP-
+        // in-dome both populate it from the lever rule at resolve
+        // time, so this also handles the DomeBlend case correctly.
         return *pt.h_mass * M;
     }
 
     switch (pt.kind) {
         case PointEvaluation::Kind::SinglePhase: {
+            // Single-phase by construction (atlas resolved to a
+            // region, which excludes the dome).  Mirror the -1
+            // sentinel update()'s legacy contract uses for iQ.
+            if (prop == CoolProp::iQ) {
+                return -1.0;
+            }
             // Map molar variants to the mass-basis property the surface
             // tabulates, then scale.
             CoolProp::parameters surface_prop = prop;
@@ -661,6 +673,8 @@ double SVDSBTLBackend::evaluate_property_(PointEvaluation& pt, CoolProp::paramet
         case PointEvaluation::Kind::DomeBlend: {
             const double Q = pt.Q;
             switch (prop) {
+                case CoolProp::iQ:
+                    return Q;
                 case CoolProp::iDmass:
                 case CoolProp::iDmolar: {
                     ensure_dome_rho_endpoints_(pt);
@@ -684,8 +698,9 @@ double SVDSBTLBackend::evaluate_property_(PointEvaluation& pt, CoolProp::paramet
                     const double u_molar = (1.0 - Q) * uL_mol + Q * uV_mol;
                     return (prop == CoolProp::iUmass) ? u_molar / M : u_molar;
                 }
-                case CoolProp::iHmolar:
-                    return (1.0 - Q) * *pt.hL_mol + Q * *pt.hV_mol;
+                // iHmass / iHmolar are served by the lever-rule short-circuit
+                // above (pt.h_mass is populated in resolve_point_); no
+                // duplicate arms here.
                 case CoolProp::ispeed_sound:
                     throw NotImplementedError("SVDSBTL backend: speed_sound is not defined in the two-phase region");
                 case CoolProp::iviscosity:
@@ -698,17 +713,12 @@ double SVDSBTLBackend::evaluate_property_(PointEvaluation& pt, CoolProp::paramet
             }
         }
         case PointEvaluation::Kind::Patched: {
-            auto& src = *patch_source_;
-            switch (prop) {
-                case CoolProp::iDmolar:
-                    return src.keyed_output(CoolProp::iDmass) / M;
-                case CoolProp::iSmolar:
-                    return src.keyed_output(CoolProp::iSmass) * M;
-                case CoolProp::iUmolar:
-                    return src.keyed_output(CoolProp::iUmass) * M;
-                default:
-                    return src.keyed_output(prop);
-            }
+            // Inside the critical-patch bbox the source backend owns
+            // every answer — delegate without trying to second-guess
+            // it via mass-basis round-trips.  iQ in particular can be
+            // genuinely two-phase near the bbox edge if the patch was
+            // sized to include sat-curve excursions.
+            return patch_source_->keyed_output(prop);
         }
         case PointEvaluation::Kind::OutOfRange:
         case PointEvaluation::Kind::TwoPhaseDisallowed:
@@ -729,16 +739,43 @@ void SVDSBTLBackend::update(CoolProp::input_pairs input_pair, double value1, dou
     // class still see consistent values.
     if (active_eval_.T) _T = *active_eval_.T;
     if (active_eval_.p) _p = *active_eval_.p;
-    if (active_eval_.kind == PointEvaluation::Kind::DomeBlend) {
-        _Q = active_eval_.Q;
-        _phase = iphase_twophase;
-    } else if (active_eval_.kind == PointEvaluation::Kind::OutOfRange
-               && (input_pair == CoolProp::HmassP_INPUTS || input_pair == CoolProp::HmolarP_INPUTS)) {
-        // Legacy back-compat: when an HmassP probe misses everything
-        // (above critical pressure, etc.) we used to tag iphase_twophase
-        // as a best-effort label.  Preserve that to avoid surprising
-        // callers that check phase() in this corner case.
-        _phase = iphase_twophase;
+    // _Q is populated for every kind that has a well-defined Q so
+    // legacy callers reading state->Q() see a value consistent with
+    // what fast_evaluate(iQ) would return.  SinglePhase gets the -1
+    // sentinel (matches IF97Backend::update()); DomeBlend gets the
+    // lever-rule fraction; Patched delegates to the source backend
+    // (which can be two-phase if the bbox extends across the sat
+    // curve); OOB / TwoPhaseDisallowed / Invalid leave _Q untouched
+    // (clear() set it to -_HUGE) since there's no defined value.
+    switch (active_eval_.kind) {
+        case PointEvaluation::Kind::SinglePhase:
+            _Q = -1.0;
+            break;
+        case PointEvaluation::Kind::DomeBlend:
+            _Q = active_eval_.Q;
+            _phase = iphase_twophase;
+            break;
+        case PointEvaluation::Kind::Patched:
+            try {
+                _Q = patch_source_->keyed_output(CoolProp::iQ);
+            } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
+                _Q = -1.0;
+            }
+            break;
+        case PointEvaluation::Kind::OutOfRange:
+            // Legacy back-compat: when an HmassP probe misses
+            // everything (above critical pressure, etc.) we used to
+            // tag iphase_twophase as a best-effort label.  Preserve
+            // that to avoid surprising callers that check phase()
+            // in this corner case.
+            if (input_pair == CoolProp::HmassP_INPUTS || input_pair == CoolProp::HmolarP_INPUTS) {
+                _phase = iphase_twophase;
+            }
+            break;
+        case PointEvaluation::Kind::TwoPhaseDisallowed:
+        case PointEvaluation::Kind::Invalid:
+        case PointEvaluation::Kind::InternalError:
+            break;
     }
 }
 
@@ -838,16 +875,15 @@ CoolPropDbl SVDSBTLBackend::calc_pmax() {
 // Per-point outcome:
 //   - in-domain single-phase  → resolve + N_outputs evaluations + ok
 //   - inside critical-patch   → patch_source_->update() + property reads
-//   - out of every region     → NaN row + fast_evaluate_out_of_range
-//   - two-phase / dome hit    → NaN row + fast_evaluate_two_phase_disallowed
+//   - HmassP / HmolarP in dome → Q-weighted lever-rule blend through
+//                                 resolve_point_ + evaluate_property_
+//   - PT exactly on sat curve  → NaN row + fast_evaluate_two_phase_disallowed
+//   - out of every region      → NaN row + fast_evaluate_out_of_range
 //
-// Note that two-phase points are NOT routed through update_two_phase_'s
-// Q-weighted blend here — fast_evaluate's contract explicitly states
-// it doesn't do flash refinement; callers wanting dome behaviour use
-// update() instead.  In-patch points DO get routed through the patch
-// source (an AbstractState::update() call per point), since omitting
-// the critical-patch routing would silently degrade accuracy at points
-// the build was explicitly configured to handle.
+// In-patch points get the same patch_source_->update() routing as
+// update() does — omitting the critical-patch handoff would silently
+// degrade accuracy at the states the build was explicitly configured
+// to cover.
 void SVDSBTLBackend::fast_evaluate(CoolProp::input_pairs input_pair, const double* val1, const double* val2, std::size_t N_inputs,
                                    const CoolProp::parameters* outputs, std::size_t N_outputs, double* out_buffer, std::size_t out_buffer_size,
                                    int* status_flags, std::size_t status_flags_size, CoolProp::phases /*imposed_phase*/) {

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -341,342 +341,436 @@ void SVDSBTLBackend::ensure_surface_(CoolProp::input_pairs pair) {
     surfaces_[static_cast<int>(pair)] = std::move(surface);
 }
 
-void SVDSBTLBackend::update(CoolProp::input_pairs input_pair, double value1, double value2) {
-    clear();
-    _phase = iphase_not_imposed;
-    two_phase_.active = false;
+// resolve_point_: the shared kernel called by both update() and
+// fast_evaluate().  Maps (input_pair, v1, v2) to a PointEvaluation
+// without mutating any backend state.  The same routing logic — input-
+// pair dispatch, critical-patch bbox check, atlas resolve, dome
+// detection with sat-line lever-rule — lives in one place so any
+// future entry point (batched PropsSI, Python update_array wrapper,
+// ...) plugs in by reusing this method.
+//
+// Two-phase PQ_INPUTS / QT_INPUTS are folded into the DomeBlend kind
+// — same sat-line endpoints, same Q, same downstream property dispatch.
+SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_pairs input_pair, double value1, double value2) {
+    PointEvaluation pt;
+    pt.input_pair = input_pair;
+    pt.v1 = value1;
+    pt.v2 = value2;
 
-    // Two-phase inputs go to the SuperAncillary or to the source
-    // backend directly — no SVDSurface needed.  PQ_INPUTS and
-    // QT_INPUTS are degenerate in the surface (the dome interior is
-    // not single-phase, so the surface returns NaN), so we route
-    // around it.
+    // --- PQ / QT inputs: dome by definition, no surface needed. ---
     if (input_pair == CoolProp::PQ_INPUTS || input_pair == CoolProp::QT_INPUTS) {
-        active_pair_ = input_pair;
-        active_surface_ = nullptr;
-        active_resolved_ = false;
         double p_sat = 0.0;
         double T_sat = 0.0;
         double Q = 0.0;
-        auto sa = superanc_();
-        if (sa) {
-            // Fast path — HEOS-side SuperAncillary Chebyshev expansion
-            // gives sat-line state in O(1) without an HEOS flash.
-            if (input_pair == CoolProp::PQ_INPUTS) {
-                // value1 = p, value2 = Q.
-                p_sat = value1;
-                Q = value2;
-                T_sat = sa->get_T_from_p(p_sat);
-            } else {
-                // QT_INPUTS: value1 = Q, value2 = T.
-                Q = value1;
-                T_sat = value2;
-                p_sat = sa->eval_sat(T_sat, 'P', 0);
-            }
+        if (input_pair == CoolProp::PQ_INPUTS) {
+            p_sat = value1;
+            Q = value2;
         } else {
-            // Fallback path — source backend doesn't ship a
-            // SuperAncillary (REFPROP, IF97, ...).  Route directly
-            // to its own PQ/QT_INPUTS, which it must implement.
-            auto src = source_reference_();
-            if (input_pair == CoolProp::PQ_INPUTS) {
-                p_sat = value1;
-                Q = value2;
-                // Anchor at Q=0 so the source state lands cleanly on
-                // sat,L; T_sat is invariant in Q across the dome at
-                // fixed p.
-                src->update(CoolProp::PQ_INPUTS, p_sat, 0.0);
-                T_sat = src->T();
-            } else {
-                Q = value1;
-                T_sat = value2;
-                src->update(CoolProp::QT_INPUTS, 0.0, T_sat);
-                p_sat = src->p();
-            }
+            Q = value1;
+            T_sat = value2;
         }
         if (Q < 0.0 || Q > 1.0) {
             throw ValueError("SVDSBTL backend: two-phase Q must be in [0, 1]");
         }
-        update_two_phase_(T_sat, p_sat, Q);
-        return;
+        auto sa = superanc_();
+        if (sa) {
+            if (input_pair == CoolProp::PQ_INPUTS) {
+                T_sat = sa->get_T_from_p(p_sat);
+            } else {
+                p_sat = sa->eval_sat(T_sat, 'P', 0);
+            }
+            pt.hL_mol = sa->eval_sat(T_sat, 'H', 0);
+            pt.hV_mol = sa->eval_sat(T_sat, 'H', 1);
+        } else {
+            // Source-backend PQ/QT fallback (REFPROP / IF97).
+            auto src = source_reference_();
+            if (input_pair == CoolProp::PQ_INPUTS) {
+                src->update(CoolProp::PQ_INPUTS, p_sat, 0.0);
+                T_sat = src->T();
+                pt.hL_mol = src->hmolar();
+                src->update(CoolProp::PQ_INPUTS, p_sat, 1.0);
+                pt.hV_mol = src->hmolar();
+            } else {
+                src->update(CoolProp::QT_INPUTS, 0.0, T_sat);
+                p_sat = src->p();
+                pt.hL_mol = src->hmolar();
+                src->update(CoolProp::QT_INPUTS, 1.0, T_sat);
+                pt.hV_mol = src->hmolar();
+            }
+        }
+        pt.kind = PointEvaluation::Kind::DomeBlend;
+        pt.status = CoolProp::fast_evaluate_ok;
+        pt.T = T_sat;
+        pt.T_sat = T_sat;
+        pt.p = p_sat;
+        pt.Q = Q;
+        const double M = calc_molar_mass();
+        pt.h_mass = ((1.0 - Q) * *pt.hL_mol + Q * *pt.hV_mol) / M;
+        return pt;
     }
 
-    // HmolarP shares the HmassP surface — the molar→mass conversion
-    // happens in the switch below.  Without this normalisation the
-    // surfaces_.find() lookup would miss (we only register HmassP and
-    // PT keys) and the HmolarP switch case would be unreachable.
+    // --- Single-phase / dome routing through the surface atlas. ---
     const auto surface_key = (input_pair == CoolProp::HmolarP_INPUTS) ? CoolProp::HmassP_INPUTS : input_pair;
     const auto it = surfaces_.find(static_cast<int>(surface_key));
     if (it == surfaces_.end() || !it->second) {
         throw ValueError(std::string("SVDSBTL backend: no surface registered for this input pair (") + CoolProp::get_input_pair_short_desc(input_pair)
                          + ")");
     }
+    const auto* surface = it->second.get();
+    pt.surface = surface;
 
-    active_pair_ = input_pair;
-    active_surface_ = it->second.get();
-    active_in_patch_ = false;
-
-    // Record inputs into AbstractState's standard slots so calc_T() /
-    // calc_pressure() can return them directly without an SVD round-trip.
-    // While we're at it, ask critical_patch_ whether this state lies in
-    // its bbox; if so, every calc_* below routes through patch_source_
-    // instead of the SVD surface.  The bbox check itself is O(1).
+    // Extract (a, b) primary/secondary axes and the canonical h_mass
+    // input shortcut where applicable.
+    double a = 0.0;  // primary axis: always p for the MVP presets
+    double b = 0.0;  // secondary axis: h for HmassP/HmolarP, T for PT
     switch (input_pair) {
-        case CoolProp::HmassP_INPUTS: {
-            // (a, b) = (p, h) per ph_subcritical preset; value1=h, value2=p.
-            _p = value2;
-            active_hmass_ = value1;
-            active_in_patch_ = critical_patch_.contains(input_pair, _p, active_hmass_);
-            if (active_in_patch_) {
-                patch_source_ref_()->update(input_pair, value1, value2);
-                _T = patch_source_->T();
-            } else {
-                active_point_ = active_surface_->resolve(_p, active_hmass_);
-            }
+        case CoolProp::HmassP_INPUTS:
+            a = value2;
+            pt.p = value2;
+            pt.h_mass = value1;
+            b = value1;
             break;
-        }
-        case CoolProp::HmolarP_INPUTS: {
-            // Convert molar → mass and route to the PH surface.
-            _p = value2;
-            active_hmass_ = value1 / calc_molar_mass();
-            active_in_patch_ = critical_patch_.contains(CoolProp::HmassP_INPUTS, _p, active_hmass_);
-            if (active_in_patch_) {
-                patch_source_ref_()->update(CoolProp::HmassP_INPUTS, active_hmass_, _p);
-                _T = patch_source_->T();
-            } else {
-                active_point_ = active_surface_->resolve(_p, active_hmass_);
-            }
+        case CoolProp::HmolarP_INPUTS:
+            a = value2;
+            pt.p = value2;
+            pt.h_mass = value1 / calc_molar_mass();
+            b = *pt.h_mass;
             break;
-        }
-        case CoolProp::PT_INPUTS: {
-            // (a, b) = (p, T) per pt_subcritical preset; value1=p, value2=T.
-            _p = value1;
-            _T = value2;
-            active_in_patch_ = critical_patch_.contains(input_pair, _p, _T);
-            if (active_in_patch_) {
-                patch_source_ref_()->update(input_pair, value1, value2);
-            } else {
-                active_point_ = active_surface_->resolve(_p, _T);
-            }
+        case CoolProp::PT_INPUTS:
+            a = value1;
+            pt.p = value1;
+            pt.T = value2;
+            b = value2;
             break;
-        }
         default:
             throw ValueError(std::string("SVDSBTL backend update: unsupported input pair (") + CoolProp::get_input_pair_short_desc(input_pair) + ")");
     }
-    active_resolved_ = true;
-    if (active_in_patch_) {
-        // Patch is active: the source backend owns the answers for
-        // calc_* below.  active_point_ stays invalid but isn't read.
-        return;
+
+    // Critical-patch bbox routing.  Patch lookups defer their property
+    // reads to evaluate_property_ via patch_source_.
+    const auto patch_key = (input_pair == CoolProp::HmolarP_INPUTS) ? CoolProp::HmassP_INPUTS : input_pair;
+    if (critical_patch_.contains(patch_key, a, b)) {
+        try {
+            if (input_pair == CoolProp::HmolarP_INPUTS) {
+                patch_source_ref_()->update(CoolProp::HmassP_INPUTS, *pt.h_mass, *pt.p);
+            } else {
+                patch_source_ref_()->update(input_pair, value1, value2);
+            }
+            pt.kind = PointEvaluation::Kind::Patched;
+            pt.status = CoolProp::fast_evaluate_ok;
+            if (!pt.T) pt.T = patch_source_->T();
+            if (!pt.p) pt.p = patch_source_->p();
+            return pt;
+        } catch (const std::exception&) {
+            pt.kind = PointEvaluation::Kind::OutOfRange;
+            pt.status = CoolProp::fast_evaluate_out_of_range;
+            return pt;
+        }
     }
 
-    if (active_point_.region_idx < 0) {
-        // Out of every single-phase region.  For HmassP this typically
-        // means the (h, p) point is inside the saturation dome; pull
-        // the sat-line endpoints from the SuperAncillary if available
-        // or directly from the source backend otherwise, compute Q
-        // from the lever rule, and route to the two-phase path.
-        // Other input pairs (PT on the sat curve) currently still
-        // surface as NaN — two-phase PT is degenerate anyway (no
-        // unique state at T_sat unless Q is supplied).
-        if ((input_pair == CoolProp::HmassP_INPUTS || input_pair == CoolProp::HmolarP_INPUTS) && _p > 0.0) {
-            double T_sat = 0.0, hL_mol = 0.0, hV_mol = 0.0;
-            bool sat_resolved = false;
-            auto sa = superanc_();
-            if (sa) {
-                T_sat = sa->get_T_from_p(_p);
+    // Atlas resolve.  region_idx < 0 means the point landed inside
+    // the saturation dome (for HmassP) or outside every region's bbox
+    // (for PT or genuinely OOB HmassP).
+    pt.resolved = surface->resolve(a, b);
+    if (pt.resolved.region_idx >= 0) {
+        pt.kind = PointEvaluation::Kind::SinglePhase;
+        pt.status = CoolProp::fast_evaluate_ok;
+        return pt;
+    }
+
+    // --- Atlas miss.  For HmassP / HmolarP try dome blend. ---
+    if (input_pair == CoolProp::HmassP_INPUTS || input_pair == CoolProp::HmolarP_INPUTS) {
+        const double p_val = *pt.p;
+        const double h_mass = *pt.h_mass;
+        const double M = calc_molar_mass();
+        bool sat_resolved = false;
+        double T_sat = 0.0, hL_mol = 0.0, hV_mol = 0.0;
+        // Optional sat-line caloric endpoints we may also pick up from
+        // the source PQ fallback (saves the redundant lookup later).
+        std::optional<double> rhoL_mol_seed, rhoV_mol_seed, sL_mol_seed, sV_mol_seed;
+        auto sa = superanc_();
+        if (sa) {
+            try {
+                T_sat = sa->get_T_from_p(p_val);
                 hL_mol = sa->eval_sat(T_sat, 'H', 0);
                 hV_mol = sa->eval_sat(T_sat, 'H', 1);
                 sat_resolved = true;
-            } else {
-                try {
-                    auto src = source_reference_();
-                    src->update(CoolProp::PQ_INPUTS, _p, 0.0);
-                    T_sat = src->T();
-                    hL_mol = src->hmolar();
-                    src->update(CoolProp::PQ_INPUTS, _p, 1.0);
-                    hV_mol = src->hmolar();
-                    sat_resolved = true;
-                } catch (const std::exception&) {
-                    // Source backend couldn't resolve PQ at this _p
-                    // (e.g. above its critical pressure).  Fall
-                    // through to the iphase_twophase tag below.
-                }
-            }
-            if (sat_resolved) {
-                const double h_mol = active_hmass_ * calc_molar_mass();
-                if (hL_mol <= h_mol && h_mol <= hV_mol) {
-                    const double Q = (h_mol - hL_mol) / (hV_mol - hL_mol);
-                    update_two_phase_(T_sat, _p, Q);
-                    return;
-                }
+            } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
             }
         }
-        _phase = iphase_twophase;  // best-effort tag; users typically check via the NaN return
+        if (!sat_resolved) {
+            try {
+                auto src = source_reference_();
+                src->update(CoolProp::PQ_INPUTS, p_val, 0.0);
+                T_sat = src->T();
+                hL_mol = src->hmolar();
+                rhoL_mol_seed = src->rhomolar();
+                sL_mol_seed = src->smolar();
+                src->update(CoolProp::PQ_INPUTS, p_val, 1.0);
+                hV_mol = src->hmolar();
+                rhoV_mol_seed = src->rhomolar();
+                sV_mol_seed = src->smolar();
+                sat_resolved = true;
+            } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
+            }
+        }
+        if (sat_resolved) {
+            const double h_mol = h_mass * M;
+            if (hL_mol <= h_mol && h_mol <= hV_mol) {
+                pt.kind = PointEvaluation::Kind::DomeBlend;
+                pt.status = CoolProp::fast_evaluate_ok;
+                pt.T = T_sat;
+                pt.T_sat = T_sat;
+                pt.Q = (h_mol - hL_mol) / (hV_mol - hL_mol);
+                pt.hL_mol = hL_mol;
+                pt.hV_mol = hV_mol;
+                pt.rhoL_mol = rhoL_mol_seed;
+                pt.rhoV_mol = rhoV_mol_seed;
+                pt.sL_mol = sL_mol_seed;
+                pt.sV_mol = sV_mol_seed;
+                return pt;
+            }
+        }
     }
+
+    // --- PT-on-sat detection vs genuine OOB. ---
+    if (input_pair == CoolProp::PT_INPUTS) {
+        try {
+            auto sa = superanc_();
+            double T_sat_probe = std::numeric_limits<double>::quiet_NaN();
+            if (sa) {
+                T_sat_probe = sa->get_T_from_p(a);
+            } else {
+                auto src = source_reference_();
+                src->update(CoolProp::PQ_INPUTS, a, 0.0);
+                T_sat_probe = src->T();
+            }
+            constexpr double kSatEps = 3.3e-5;  // matches IF97Backend::set_phase
+            if (std::isfinite(T_sat_probe) && std::abs(b - T_sat_probe) <= kSatEps * T_sat_probe) {
+                pt.kind = PointEvaluation::Kind::TwoPhaseDisallowed;
+                pt.status = CoolProp::fast_evaluate_two_phase_disallowed;
+                return pt;
+            }
+        } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
+            // No sat probe available — fall through to OOB.
+        }
+    }
+    pt.kind = PointEvaluation::Kind::OutOfRange;
+    pt.status = CoolProp::fast_evaluate_out_of_range;
+    return pt;
 }
 
-void SVDSBTLBackend::update_two_phase_(double T_sat, double p_sat, double Q) {
-    _p = p_sat;
-    _T = T_sat;
-    _Q = Q;
-    _phase = iphase_twophase;
+void SVDSBTLBackend::ensure_dome_rho_endpoints_(PointEvaluation& pt) {
+    if (pt.rhoL_mol && pt.rhoV_mol) return;
     auto sa = superanc_();
-    if (!sa) {
-        // No SuperAncillary (REFPROP / IF97 source) — pull sat-line
-        // endpoints from the source backend directly via QT_INPUTS.
-        // Two flashes (Q=0 and Q=1) at the same T_sat; slow compared
-        // to a Chebyshev eval but correct by construction.
-        auto src = source_reference_();
-        src->update(CoolProp::QT_INPUTS, 0.0, T_sat);
-        two_phase_.rhoL_mol = src->rhomolar();
-        two_phase_.hL_mol = src->hmolar();
-        two_phase_.sL_mol = src->smolar();
-        src->update(CoolProp::QT_INPUTS, 1.0, T_sat);
-        two_phase_.rhoV_mol = src->rhomolar();
-        two_phase_.hV_mol = src->hmolar();
-        two_phase_.sV_mol = src->smolar();
-        // u = h - p*v = h - p/rho; same identity as the HEOS path.
-        two_phase_.uL_mol = two_phase_.hL_mol - p_sat / two_phase_.rhoL_mol;
-        two_phase_.uV_mol = two_phase_.hV_mol - p_sat / two_phase_.rhoV_mol;
-        two_phase_.active = true;
+    if (sa) {
+        pt.rhoL_mol = sa->eval_sat(*pt.T_sat, 'D', 0);
+        pt.rhoV_mol = sa->eval_sat(*pt.T_sat, 'D', 1);
         return;
     }
-    two_phase_.rhoL_mol = sa->eval_sat(T_sat, 'D', 0);
-    two_phase_.rhoV_mol = sa->eval_sat(T_sat, 'D', 1);
-    two_phase_.hL_mol = sa->eval_sat(T_sat, 'H', 0);
-    two_phase_.hV_mol = sa->eval_sat(T_sat, 'H', 1);
-    two_phase_.sL_mol = sa->eval_sat(T_sat, 'S', 0);
-    two_phase_.sV_mol = sa->eval_sat(T_sat, 'S', 1);
-    // The SuperAncillary's caloric lazy-build covers H and S but not U.
-    // Recover u via the thermodynamic identity u = h - p*v = h - p/rho.
-    // (Equivalent in mass or molar basis; the SuperAncillary is molar.)
-    two_phase_.uL_mol = two_phase_.hL_mol - p_sat / two_phase_.rhoL_mol;
-    two_phase_.uV_mol = two_phase_.hV_mol - p_sat / two_phase_.rhoV_mol;
-    two_phase_.active = true;
+    auto src = source_reference_();
+    src->update(CoolProp::QT_INPUTS, 0.0, *pt.T_sat);
+    pt.rhoL_mol = src->rhomolar();
+    src->update(CoolProp::QT_INPUTS, 1.0, *pt.T_sat);
+    pt.rhoV_mol = src->rhomolar();
 }
 
-CoolPropDbl SVDSBTLBackend::two_phase_property_(CoolProp::parameters prop) const {
-    // Specific volume blends linearly; density is its reciprocal.
-    // Caloric props blend linearly directly.  Everything here is molar.
-    const double Q = static_cast<double>(_Q);
-    switch (prop) {
-        case CoolProp::iDmolar: {
-            const double vL = 1.0 / two_phase_.rhoL_mol;
-            const double vV = 1.0 / two_phase_.rhoV_mol;
-            return 1.0 / ((1.0 - Q) * vL + Q * vV);
+void SVDSBTLBackend::ensure_dome_s_endpoints_(PointEvaluation& pt) {
+    if (pt.sL_mol && pt.sV_mol) return;
+    auto sa = superanc_();
+    if (sa) {
+        pt.sL_mol = sa->eval_sat(*pt.T_sat, 'S', 0);
+        pt.sV_mol = sa->eval_sat(*pt.T_sat, 'S', 1);
+        return;
+    }
+    auto src = source_reference_();
+    src->update(CoolProp::QT_INPUTS, 0.0, *pt.T_sat);
+    pt.sL_mol = src->smolar();
+    src->update(CoolProp::QT_INPUTS, 1.0, *pt.T_sat);
+    pt.sV_mol = src->smolar();
+}
+
+// evaluate_property_: the per-output kernel.  Pure dispatch over the
+// PointEvaluation kind — no business logic beyond input-pair
+// shortcuts, surface eval routing, dome Q-blend, and patch deref.
+//
+// Throws NotImplementedError for properties that are mathematically
+// undefined in the two-phase region (speed_sound, cp, cv, viscosity,
+// conductivity, Prandtl); fast_evaluate translates those into in-band
+// NaN values, while calc_*() lets them propagate to the caller.
+double SVDSBTLBackend::evaluate_property_(PointEvaluation& pt, CoolProp::parameters prop) {
+    const double M = calc_molar_mass();
+
+    // Always-available shortcuts directly from the resolved point.
+    // The conditional checks matter — pt.T isn't filled for HmassP /
+    // HmolarP single-phase points until we read it off the surface, so
+    // we only short-circuit when the value was either supplied by the
+    // input pair (PT case), set by the dome blend (T = T_sat), or
+    // pulled from patch_source_->T() / ->p() in resolve_point_.
+    if (prop == CoolProp::iQ) {
+        return pt.Q;
+    }
+    if (prop == CoolProp::iP && pt.p) {
+        return *pt.p;
+    }
+    if (prop == CoolProp::iT && pt.T) {
+        return *pt.T;
+    }
+    if (prop == CoolProp::iHmass && pt.h_mass) {
+        return *pt.h_mass;
+    }
+    if (prop == CoolProp::iHmolar && pt.h_mass) {
+        return *pt.h_mass * M;
+    }
+
+    switch (pt.kind) {
+        case PointEvaluation::Kind::SinglePhase: {
+            // Map molar variants to the mass-basis property the surface
+            // tabulates, then scale.
+            CoolProp::parameters surface_prop = prop;
+            bool need_div_M = false, need_mul_M = false;
+            switch (prop) {
+                case CoolProp::iDmolar:
+                    surface_prop = CoolProp::iDmass;
+                    need_div_M = true;
+                    break;
+                case CoolProp::iSmolar:
+                    surface_prop = CoolProp::iSmass;
+                    need_mul_M = true;
+                    break;
+                case CoolProp::iUmolar:
+                    surface_prop = CoolProp::iUmass;
+                    need_mul_M = true;
+                    break;
+                case CoolProp::iHmolar:
+                    surface_prop = CoolProp::iHmass;
+                    need_mul_M = true;
+                    break;
+                default:
+                    break;
+            }
+            if (!pt.surface->contains_property(surface_prop)) {
+                throw ValueError(std::string("SVDSBTL backend: active surface does not expose property '")
+                                 + CoolProp::get_parameter_information(surface_prop, "short") + "'");
+            }
+            const double v = pt.surface->eval_with_region(surface_prop, pt.resolved.region_idx, pt.resolved.svd_x, pt.resolved.svd_y);
+            if (need_div_M) return v / M;
+            if (need_mul_M) return v * M;
+            return v;
         }
-        case CoolProp::iHmolar:
-            return (1.0 - Q) * two_phase_.hL_mol + Q * two_phase_.hV_mol;
-        case CoolProp::iSmolar:
-            return (1.0 - Q) * two_phase_.sL_mol + Q * two_phase_.sV_mol;
-        case CoolProp::iUmolar:
-            return (1.0 - Q) * two_phase_.uL_mol + Q * two_phase_.uV_mol;
-        default:
-            throw ValueError(std::string("SVDSBTL backend: two-phase blend not implemented for property '")
-                             + CoolProp::get_parameter_information(prop, "short") + "'");
+        case PointEvaluation::Kind::DomeBlend: {
+            const double Q = pt.Q;
+            switch (prop) {
+                case CoolProp::iDmass:
+                case CoolProp::iDmolar: {
+                    ensure_dome_rho_endpoints_(pt);
+                    const double vL = 1.0 / *pt.rhoL_mol;
+                    const double vV = 1.0 / *pt.rhoV_mol;
+                    const double rho_molar = 1.0 / ((1.0 - Q) * vL + Q * vV);
+                    return (prop == CoolProp::iDmass) ? rho_molar * M : rho_molar;
+                }
+                case CoolProp::iSmass:
+                case CoolProp::iSmolar: {
+                    ensure_dome_s_endpoints_(pt);
+                    const double s_molar = (1.0 - Q) * *pt.sL_mol + Q * *pt.sV_mol;
+                    return (prop == CoolProp::iSmass) ? s_molar / M : s_molar;
+                }
+                case CoolProp::iUmass:
+                case CoolProp::iUmolar: {
+                    ensure_dome_rho_endpoints_(pt);
+                    // u = h - p/rho per the thermodynamic identity.
+                    const double uL_mol = *pt.hL_mol - *pt.p / *pt.rhoL_mol;
+                    const double uV_mol = *pt.hV_mol - *pt.p / *pt.rhoV_mol;
+                    const double u_molar = (1.0 - Q) * uL_mol + Q * uV_mol;
+                    return (prop == CoolProp::iUmass) ? u_molar / M : u_molar;
+                }
+                case CoolProp::iHmolar:
+                    return (1.0 - Q) * *pt.hL_mol + Q * *pt.hV_mol;
+                case CoolProp::ispeed_sound:
+                    throw NotImplementedError("SVDSBTL backend: speed_sound is not defined in the two-phase region");
+                case CoolProp::iviscosity:
+                    throw NotImplementedError("SVDSBTL backend: viscosity is not defined in the two-phase region");
+                case CoolProp::iconductivity:
+                    throw NotImplementedError("SVDSBTL backend: conductivity is not defined in the two-phase region");
+                default:
+                    throw ValueError(std::string("SVDSBTL backend: two-phase blend not implemented for property '")
+                                     + CoolProp::get_parameter_information(prop, "short") + "'");
+            }
+        }
+        case PointEvaluation::Kind::Patched: {
+            auto& src = *patch_source_;
+            switch (prop) {
+                case CoolProp::iDmolar:
+                    return src.keyed_output(CoolProp::iDmass) / M;
+                case CoolProp::iSmolar:
+                    return src.keyed_output(CoolProp::iSmass) * M;
+                case CoolProp::iUmolar:
+                    return src.keyed_output(CoolProp::iUmass) * M;
+                default:
+                    return src.keyed_output(prop);
+            }
+        }
+        case PointEvaluation::Kind::OutOfRange:
+        case PointEvaluation::Kind::TwoPhaseDisallowed:
+        case PointEvaluation::Kind::Invalid:
+        case PointEvaluation::Kind::InternalError:
+            return std::nan("");
+    }
+    return std::nan("");
+}
+
+void SVDSBTLBackend::update(CoolProp::input_pairs input_pair, double value1, double value2) {
+    clear();
+    _phase = iphase_not_imposed;
+    active_eval_ = resolve_point_(input_pair, value1, value2);
+
+    // Copy the resolved (T, p, Q) into AbstractState's standard slots
+    // so legacy callers reading _T / _p / _Q / _phase from the base
+    // class still see consistent values.
+    if (active_eval_.T) _T = *active_eval_.T;
+    if (active_eval_.p) _p = *active_eval_.p;
+    if (active_eval_.kind == PointEvaluation::Kind::DomeBlend) {
+        _Q = active_eval_.Q;
+        _phase = iphase_twophase;
+    } else if (active_eval_.kind == PointEvaluation::Kind::OutOfRange
+               && (input_pair == CoolProp::HmassP_INPUTS || input_pair == CoolProp::HmolarP_INPUTS)) {
+        // Legacy back-compat: when an HmassP probe misses everything
+        // (above critical pressure, etc.) we used to tag iphase_twophase
+        // as a best-effort label.  Preserve that to avoid surprising
+        // callers that check phase() in this corner case.
+        _phase = iphase_twophase;
     }
 }
 
-CoolPropDbl SVDSBTLBackend::lookup_(CoolProp::parameters prop) {
-    if (active_surface_ == nullptr || !active_resolved_) {
-        throw ValueError("SVDSBTL backend: lookup before update()");
-    }
-    if (active_point_.region_idx < 0) {
-        return std::nan("");
-    }
-    if (!active_surface_->contains_property(prop)) {
-        throw ValueError(std::string("SVDSBTL backend: active surface does not expose property '")
-                         + CoolProp::get_parameter_information(prop, "short") + "'");
-    }
-    return active_surface_->eval_with_region(prop, active_point_.region_idx, active_point_.svd_x, active_point_.svd_y);
-}
-
-// Mass-basis accessors — route through the active SVDSurface, OR
-// through the cached two-phase blend when the active state is inside
-// the saturation dome, OR through the critical-patch source backend
-// when the active state falls inside the per-pair bbox.
+// Property accessors — all route through evaluate_property_ over the
+// active_eval_ kernel.  The throw cases (speed_sound / viscosity /
+// conductivity in the two-phase region) propagate to the caller.
 CoolPropDbl SVDSBTLBackend::calc_rhomass() {
-    if (two_phase_.active) {
-        return two_phase_property_(iDmolar) * calc_molar_mass();
-    }
-    if (active_in_patch_) {
-        return patch_source_->rhomass();
-    }
-    return lookup_(iDmass);
+    return evaluate_property_(active_eval_, CoolProp::iDmass);
 }
 CoolPropDbl SVDSBTLBackend::calc_hmass() {
-    if (two_phase_.active) {
-        return two_phase_property_(iHmolar) / calc_molar_mass();
-    }
-    // If the user supplied h via HmassP_INPUTS, return it directly; no
-    // SVD round-trip needed.
-    if (active_pair_ == CoolProp::HmassP_INPUTS || active_pair_ == CoolProp::HmolarP_INPUTS) {
-        return active_hmass_;
-    }
-    if (active_in_patch_) {
-        return patch_source_->hmass();
-    }
-    return lookup_(iHmass);
+    return evaluate_property_(active_eval_, CoolProp::iHmass);
 }
 CoolPropDbl SVDSBTLBackend::calc_smass() {
-    if (two_phase_.active) {
-        return two_phase_property_(iSmolar) / calc_molar_mass();
-    }
-    if (active_in_patch_) {
-        return patch_source_->smass();
-    }
-    return lookup_(iSmass);
+    return evaluate_property_(active_eval_, CoolProp::iSmass);
 }
 CoolPropDbl SVDSBTLBackend::calc_umass() {
-    if (two_phase_.active) {
-        return two_phase_property_(iUmolar) / calc_molar_mass();
-    }
-    if (active_in_patch_) {
-        return patch_source_->umass();
-    }
-    return lookup_(iUmass);
+    return evaluate_property_(active_eval_, CoolProp::iUmass);
 }
-
 CoolPropDbl SVDSBTLBackend::calc_T() {
-    if (two_phase_.active || active_pair_ == CoolProp::PT_INPUTS) {
-        return _T;
-    }
-    if (active_in_patch_) {
-        return patch_source_->T();
-    }
-    return lookup_(iT);
+    return evaluate_property_(active_eval_, CoolProp::iT);
 }
 CoolPropDbl SVDSBTLBackend::calc_speed_sound() {
-    if (two_phase_.active) {
-        // Speed of sound is not uniquely defined in the two-phase
-        // region (it goes to zero at the interface; equilibrium
-        // thermodynamics doesn't give a meaningful bulk value).
-        // Mirror what HEOS does -- throw rather than return a
-        // misleading Q-weighted blend.
-        throw NotImplementedError("SVDSBTL backend: speed_sound is not defined in the two-phase region");
-    }
-    if (active_in_patch_) {
-        return patch_source_->speed_sound();
-    }
-    return lookup_(ispeed_sound);
+    return evaluate_property_(active_eval_, CoolProp::ispeed_sound);
 }
 CoolPropDbl SVDSBTLBackend::calc_viscosity() {
-    if (two_phase_.active) {
-        // Viscosity has saturated-side values but no equilibrium bulk
-        // value inside the dome; G13-15 Table 12 is only defined off
-        // the saturation curve.  Mirror HEOS / IF97 and throw.
-        throw NotImplementedError("SVDSBTL backend: viscosity is not defined in the two-phase region");
-    }
-    return lookup_(iviscosity);
+    return evaluate_property_(active_eval_, CoolProp::iviscosity);
 }
 CoolPropDbl SVDSBTLBackend::calc_conductivity() {
-    if (two_phase_.active) {
-        throw NotImplementedError("SVDSBTL backend: conductivity is not defined in the two-phase region");
-    }
-    return lookup_(iconductivity);
+    return evaluate_property_(active_eval_, CoolProp::iconductivity);
 }
 CoolPropDbl SVDSBTLBackend::calc_pressure() {
-    return _p;
+    return evaluate_property_(active_eval_, CoolProp::iP);
 }
 
 // Molar variants — defer to the mass version and scale by molar_mass.
@@ -777,392 +871,68 @@ void SVDSBTLBackend::fast_evaluate(CoolProp::input_pairs input_pair, const doubl
             status_flags[k] = CoolProp::fast_evaluate_ok;
         return;
     }
-
-    const bool is_HmassP = (input_pair == CoolProp::HmassP_INPUTS);
-    const bool is_HmolarP = (input_pair == CoolProp::HmolarP_INPUTS);
-    const bool is_PT = (input_pair == CoolProp::PT_INPUTS);
-    if (!is_HmassP && !is_HmolarP && !is_PT) {
+    if (input_pair != CoolProp::HmassP_INPUTS && input_pair != CoolProp::HmolarP_INPUTS && input_pair != CoolProp::PT_INPUTS) {
         throw ValueError(format("fast_evaluate (SVDSBTL): input_pair %s not supported (use HmassP_INPUTS, HmolarP_INPUTS, or PT_INPUTS)",
                                 get_input_pair_short_desc(input_pair).c_str()));
     }
-    const auto surface_key = is_HmolarP ? CoolProp::HmassP_INPUTS : input_pair;
-    const auto it = surfaces_.find(static_cast<int>(surface_key));
-    if (it == surfaces_.end() || !it->second) {
+    // Validate the surface exists for this input pair before the per-
+    // point loop so a malformed request fails fast (resolve_point_
+    // would otherwise throw on the first call).
+    const auto surface_key = (input_pair == CoolProp::HmolarP_INPUTS) ? CoolProp::HmassP_INPUTS : input_pair;
+    const auto sit = surfaces_.find(static_cast<int>(surface_key));
+    if (sit == surfaces_.end() || !sit->second) {
         throw ValueError(std::string("fast_evaluate (SVDSBTL): no surface registered for ") + CoolProp::get_input_pair_short_desc(input_pair));
     }
-    const auto* surface = it->second.get();
 
-    const double M = calc_molar_mass();  // pure fluid, constant
     const double NaN = std::numeric_limits<double>::quiet_NaN();
-
-    // Validate output keys up-front so we don't fail mid-loop.  Anything
-    // the SVD surface stores directly is supported, plus the per-input
-    // pair shortcuts (T/p/h that the caller just gave us) and molar
-    // variants that scale by molar mass.
-    auto is_surface_prop = [&](CoolProp::parameters prop) { return surface->contains_property(prop); };
-    for (std::size_t o = 0; o < N_outputs; ++o) {
-        switch (outputs[o]) {
-            // Always available shortcuts (no SVD eval needed) — either
-            // straight from the input pair or computed by Q-blend when
-            // the point lands in the dome.
-            case CoolProp::iT:
-            case CoolProp::iP:
-            case CoolProp::iHmass:
-            case CoolProp::iHmolar:
-            case CoolProp::iDmolar:
-            case CoolProp::iSmolar:
-            case CoolProp::iUmolar:
-            case CoolProp::iQ:
-                break;
-            default:
-                // Anything else has to be in the surface (mass-basis
-                // primary keys).  iDmass / iSmass / iUmass / ispeed_sound /
-                // iviscosity / iconductivity all land here.
-                if (!is_surface_prop(outputs[o])) {
-                    throw ValueError(format("fast_evaluate (SVDSBTL): active surface does not expose output[%zu]=%s", o,
-                                            get_parameter_information(outputs[o], "short").c_str()));
-                }
-                break;
-        }
-    }
-
     auto fill_nan_row = [&](std::size_t k) {
         for (std::size_t o = 0; o < N_outputs; ++o) {
             out_buffer[k * N_outputs + o] = NaN;
         }
     };
 
+    // Per-point loop.  The resolve_point_ / evaluate_property_ kernel
+    // does all the routing — the loop is just an adapter that turns
+    // exceptions into status flags + NaN rows.
     for (std::size_t k = 0; k < N_inputs; ++k) {
-        const double v1 = val1[k];
-        const double v2 = val2[k];
-
-        // Convert input to the surface's (a, b) coordinates and the
-        // mass-basis h we'll return as a shortcut.
-        double a;                   // primary axis: always p
-        double b;                   // secondary axis: h_mass (PH surface) or T (PT surface)
-        double h_mass_input = NaN;  // only meaningful when is_HmassP / is_HmolarP
-        double T_input = NaN;       // only meaningful when is_PT
-        if (is_HmassP) {
-            h_mass_input = v1;
-            a = v2;
-            b = v1;
-        } else if (is_HmolarP) {
-            h_mass_input = v1 / M;
-            a = v2;
-            b = h_mass_input;
-        } else {
-            // is_PT
-            T_input = v2;
-            a = v1;
-            b = v2;
-        }
-
-        // Critical-patch routing: if the point lies in the configured
-        // bbox, defer to the patch source backend.  We still pay an
-        // update() per in-patch point on the patch source — that's the
-        // cost of being "truth" inside the patch zone — but we avoid
-        // touching our own cache.
-        const auto patch_key = is_HmolarP ? CoolProp::HmassP_INPUTS : input_pair;
-        if (critical_patch_.contains(patch_key, a, b)) {
-            try {
-                if (is_HmolarP) {
-                    patch_source_ref_()->update(CoolProp::HmassP_INPUTS, h_mass_input, a);
-                } else {
-                    patch_source_ref_()->update(input_pair, v1, v2);
-                }
-            } catch (const std::exception&) {
-                status_flags[k] = CoolProp::fast_evaluate_out_of_range;
-                fill_nan_row(k);
-                continue;
-            }
-            auto& src = *patch_source_;
-            bool patch_row_failed = false;
-            for (std::size_t o = 0; o < N_outputs; ++o) {
-                const auto prop = outputs[o];
-                double v = NaN;
-                try {
-                    switch (prop) {
-                        case CoolProp::iP:
-                            v = (is_PT ? v1 : v2);
-                            break;
-                        case CoolProp::iT:
-                            v = (is_PT ? v2 : src.keyed_output(CoolProp::iT));
-                            break;
-                        case CoolProp::iHmass:
-                            v = (is_HmassP ? v1 : src.keyed_output(CoolProp::iHmass));
-                            break;
-                        case CoolProp::iHmolar:
-                            v = (is_HmolarP ? v1 : src.keyed_output(CoolProp::iHmass) * M);
-                            break;
-                        case CoolProp::iDmolar:
-                            v = src.keyed_output(CoolProp::iDmass) / M;
-                            break;
-                        case CoolProp::iSmolar:
-                            v = src.keyed_output(CoolProp::iSmass) * M;
-                            break;
-                        case CoolProp::iUmolar:
-                            v = src.keyed_output(CoolProp::iUmass) * M;
-                            break;
-                        case CoolProp::iQ:
-                            // Single-phase by definition in the patch
-                            // zone — supercritical region surrounding the
-                            // critical point.  Mirror update()'s
-                            // convention of returning -1 outside the dome.
-                            v = -1.0;
-                            break;
-                        default:
-                            v = src.keyed_output(prop);
-                            break;
-                    }
-                } catch (const std::exception&) {
-                    v = NaN;
-                    patch_row_failed = true;
-                }
-                out_buffer[k * N_outputs + o] = v;
-            }
-            // If any per-output read failed, the row no longer satisfies
-            // the all-defined contract — NaN-fill the whole row and
-            // flag it, matching IF97Backend::fast_evaluate's
-            // fast_evaluate_internal_error semantics.
-            if (patch_row_failed) {
-                status_flags[k] = CoolProp::fast_evaluate_internal_error;
-                fill_nan_row(k);
-            } else {
-                status_flags[k] = CoolProp::fast_evaluate_ok;
-            }
+        PointEvaluation pt;
+        try {
+            pt = resolve_point_(input_pair, val1[k], val2[k]);
+        } catch (const std::exception&) {
+            status_flags[k] = CoolProp::fast_evaluate_internal_error;
+            fill_nan_row(k);
             continue;
         }
-
-        // Plain SVD-surface path: resolve once, evaluate per output.
-        const auto pt = surface->resolve(a, b);
-        if (pt.region_idx < 0) {
-            // Atlas miss.  For HmassP / HmolarP this usually means the
-            // (h, p) point is inside the saturation dome; for PT it
-            // means the point straddles the sat curve (Q ambiguous) or
-            // is genuinely out of range.  Try a Q-weighted blend via
-            // the SuperAncillary for the HmassP case; fall through to
-            // out-of-range otherwise.
-            bool dome_handled = false;
-            if (is_HmassP || is_HmolarP) {
-                // Resolve sat-line endpoints in molar units.  Prefer the
-                // source backend's SuperAncillary when available (HEOS,
-                // REFPROP); fall back to source->update(PQ_INPUTS, p, Q)
-                // otherwise (IF97 source has no SA but does support PQ
-                // via psat97 + region 4).
-                double T_sat = 0.0, hL_mol = 0.0, hV_mol = 0.0;
-                double rhoL_mol = 0.0, rhoV_mol = 0.0;
-                double sL_mol = 0.0, sV_mol = 0.0;
-                bool sat_endpoints_resolved = false;
-                bool have_rho_endpoints = false;
-                bool have_s_endpoints = false;
-                auto sa = superanc_();
-                if (sa) {
-                    try {
-                        T_sat = sa->get_T_from_p(a);
-                        hL_mol = sa->eval_sat(T_sat, 'H', 0);
-                        hV_mol = sa->eval_sat(T_sat, 'H', 1);
-                        sat_endpoints_resolved = true;
-                    } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
-                    }
-                }
-                if (!sat_endpoints_resolved) {
-                    // Source-backend PQ fallback.  IF97 / REFPROP routes
-                    // come here.  We share the same patch_source-style
-                    // AbstractState across all dome probes in this batch
-                    // (lazily allocated) to avoid factory overhead.
-                    try {
-                        auto src = source_reference_();
-                        src->update(CoolProp::PQ_INPUTS, a, 0.0);
-                        T_sat = src->T();
-                        hL_mol = src->hmolar();
-                        rhoL_mol = src->rhomolar();
-                        sL_mol = src->smolar();
-                        src->update(CoolProp::PQ_INPUTS, a, 1.0);
-                        hV_mol = src->hmolar();
-                        rhoV_mol = src->rhomolar();
-                        sV_mol = src->smolar();
-                        sat_endpoints_resolved = true;
-                        have_rho_endpoints = true;
-                        have_s_endpoints = true;
-                    } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
-                        // Above pcrit or source PQ failure — fall through to OOB.
-                    }
-                }
-                if (sat_endpoints_resolved) {
-                    const double hL = hL_mol / M;
-                    const double hV = hV_mol / M;
-                    if (h_mass_input >= hL && h_mass_input <= hV) {
-                        const double Q = (h_mass_input - hL) / (hV - hL);
-                        // Lazy sat-line endpoint pulls — only touch the
-                        // source's SuperAncillary (or its PQ path) for the
-                        // endpoints that the requested output set needs.
-                        double uL_mol = 0.0, uV_mol = 0.0;
-                        bool have_u = false;
-                        auto ensure_rho = [&] {
-                            if (have_rho_endpoints) return;
-                            rhoL_mol = sa->eval_sat(T_sat, 'D', 0);
-                            rhoV_mol = sa->eval_sat(T_sat, 'D', 1);
-                            have_rho_endpoints = true;
-                        };
-                        auto ensure_s = [&] {
-                            if (have_s_endpoints) return;
-                            sL_mol = sa->eval_sat(T_sat, 'S', 0);
-                            sV_mol = sa->eval_sat(T_sat, 'S', 1);
-                            have_s_endpoints = true;
-                        };
-                        auto ensure_u = [&] {
-                            if (have_u) return;
-                            ensure_rho();
-                            // u = h - p/rho recovers internal energy
-                            // without a SuperAncillary u-table (the SA
-                            // caloric build covers H and S but not U).
-                            uL_mol = hL_mol - a / rhoL_mol;
-                            uV_mol = hV_mol - a / rhoV_mol;
-                            have_u = true;
-                        };
-                        for (std::size_t o = 0; o < N_outputs; ++o) {
-                            const auto prop = outputs[o];
-                            double v = NaN;
-                            switch (prop) {
-                                case CoolProp::iP:
-                                    v = a;
-                                    break;
-                                case CoolProp::iT:
-                                    v = T_sat;
-                                    break;
-                                case CoolProp::iHmass:
-                                    v = h_mass_input;
-                                    break;
-                                case CoolProp::iHmolar:
-                                    v = (1.0 - Q) * hL_mol + Q * hV_mol;
-                                    break;
-                                case CoolProp::iDmass:
-                                case CoolProp::iDmolar: {
-                                    ensure_rho();
-                                    const double vL = 1.0 / rhoL_mol;
-                                    const double vV = 1.0 / rhoV_mol;
-                                    const double rho_molar = 1.0 / ((1.0 - Q) * vL + Q * vV);
-                                    v = (prop == CoolProp::iDmass) ? rho_molar * M : rho_molar;
-                                    break;
-                                }
-                                case CoolProp::iSmass:
-                                case CoolProp::iSmolar: {
-                                    ensure_s();
-                                    const double s_molar = (1.0 - Q) * sL_mol + Q * sV_mol;
-                                    v = (prop == CoolProp::iSmass) ? s_molar / M : s_molar;
-                                    break;
-                                }
-                                case CoolProp::iUmass:
-                                case CoolProp::iUmolar: {
-                                    ensure_u();
-                                    const double u_molar = (1.0 - Q) * uL_mol + Q * uV_mol;
-                                    v = (prop == CoolProp::iUmass) ? u_molar / M : u_molar;
-                                    break;
-                                }
-                                case CoolProp::iQ:
-                                    v = Q;
-                                    break;
-                                case CoolProp::ispeed_sound:
-                                case CoolProp::iviscosity:
-                                case CoolProp::iconductivity:
-                                    // No equilibrium bulk value inside the
-                                    // dome.  NaN — caller can detect via
-                                    // the explicit two-phase status that
-                                    // we set below if any of these were in
-                                    // the output set.
-                                    v = NaN;
-                                    break;
-                                default:
-                                    v = NaN;
-                                    break;
-                            }
-                            out_buffer[k * N_outputs + o] = v;
-                        }
-                        status_flags[k] = CoolProp::fast_evaluate_ok;
-                        dome_handled = true;
-                    }
-                }
-            }
-            if (!dome_handled) {
-                // For PT_INPUTS, an atlas miss CAN mean "T is exactly
-                // on the saturation curve" (ambiguous Q, can't pick a
-                // single-phase side without an explicit phase hint) —
-                // that's a different failure mode from "the (T, p)
-                // point is outside every region's bbox".  Distinguish
-                // by probing Tsat(p) when a SuperAncillary or source
-                // backend can answer.  If unavailable, default to
-                // out_of_range (the conservative choice).
-                int pt_status = CoolProp::fast_evaluate_out_of_range;
-                if (is_PT) {
-                    try {
-                        auto sa = superanc_();
-                        double T_sat_probe = std::numeric_limits<double>::quiet_NaN();
-                        if (sa) {
-                            T_sat_probe = sa->get_T_from_p(a);  // a == p for PT
-                        } else {
-                            auto src = source_reference_();
-                            src->update(CoolProp::PQ_INPUTS, a, 0.0);
-                            T_sat_probe = src->T();
-                        }
-                        constexpr double kSatEps = 3.3e-5;  // matches IF97Backend::set_phase
-                        if (std::isfinite(T_sat_probe) && std::abs(b - T_sat_probe) <= kSatEps * T_sat_probe) {
-                            pt_status = CoolProp::fast_evaluate_two_phase_disallowed;
-                        }
-                    } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
-                        // No sat-line probe available — stick with OOB.
-                    }
-                }
-                status_flags[k] = pt_status;
-                fill_nan_row(k);
-            }
+        if (pt.kind == PointEvaluation::Kind::OutOfRange || pt.kind == PointEvaluation::Kind::TwoPhaseDisallowed
+            || pt.kind == PointEvaluation::Kind::Invalid || pt.kind == PointEvaluation::Kind::InternalError) {
+            status_flags[k] = pt.status;
+            fill_nan_row(k);
             continue;
         }
-
+        bool row_failed = false;
         for (std::size_t o = 0; o < N_outputs; ++o) {
-            const auto prop = outputs[o];
             double v = NaN;
-            switch (prop) {
-                // Caller-supplied inputs — no SVD eval.
-                case CoolProp::iP:
-                    v = (is_PT ? v1 : v2);
-                    break;
-                case CoolProp::iT:
-                    v = is_PT ? T_input : surface->eval_with_region(CoolProp::iT, pt.region_idx, pt.svd_x, pt.svd_y);
-                    break;
-                case CoolProp::iHmass:
-                    v = (is_HmassP || is_HmolarP) ? h_mass_input : surface->eval_with_region(CoolProp::iHmass, pt.region_idx, pt.svd_x, pt.svd_y);
-                    break;
-                case CoolProp::iHmolar:
-                    if (is_HmolarP) {
-                        v = v1;
-                    } else if (is_HmassP) {
-                        v = h_mass_input * M;
-                    } else {
-                        v = surface->eval_with_region(CoolProp::iHmass, pt.region_idx, pt.svd_x, pt.svd_y) * M;
-                    }
-                    break;
-                case CoolProp::iDmolar:
-                    v = surface->eval_with_region(CoolProp::iDmass, pt.region_idx, pt.svd_x, pt.svd_y) / M;
-                    break;
-                case CoolProp::iSmolar:
-                    v = surface->eval_with_region(CoolProp::iSmass, pt.region_idx, pt.svd_x, pt.svd_y) * M;
-                    break;
-                case CoolProp::iUmolar:
-                    v = surface->eval_with_region(CoolProp::iUmass, pt.region_idx, pt.svd_x, pt.svd_y) * M;
-                    break;
-                case CoolProp::iQ:
-                    // Single-phase by definition (atlas resolved to a
-                    // region, which excludes the dome).  Mirror the
-                    // -1 sentinel update() uses outside the dome.
-                    v = -1.0;
-                    break;
-                default:
-                    v = surface->eval_with_region(prop, pt.region_idx, pt.svd_x, pt.svd_y);
-                    break;
+            try {
+                v = evaluate_property_(pt, outputs[o]);
+            } catch (const NotImplementedError&) {
+                // Two-phase undefined property (speed_sound, viscosity,
+                // conductivity, cp, cv, Prandtl).  In-band NaN signals
+                // "no equilibrium value here"; status stays ok so the
+                // caller can still read the meaningful T / D / S / U
+                // / Q outputs from the same row.
+                v = NaN;
+            } catch (const std::exception&) {
+                v = NaN;
+                row_failed = true;
             }
             out_buffer[k * N_outputs + o] = v;
         }
-        status_flags[k] = CoolProp::fast_evaluate_ok;
+        if (row_failed) {
+            status_flags[k] = CoolProp::fast_evaluate_internal_error;
+            fill_nan_row(k);
+        } else {
+            status_flags[k] = pt.status;
+        }
     }
 }
 

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -802,7 +802,9 @@ void SVDSBTLBackend::fast_evaluate(CoolProp::input_pairs input_pair, const doubl
     auto is_surface_prop = [&](CoolProp::parameters prop) { return surface->contains_property(prop); };
     for (std::size_t o = 0; o < N_outputs; ++o) {
         switch (outputs[o]) {
-            // Always available shortcuts (no SVD eval needed).
+            // Always available shortcuts (no SVD eval needed) — either
+            // straight from the input pair or computed by Q-blend when
+            // the point lands in the dome.
             case CoolProp::iT:
             case CoolProp::iP:
             case CoolProp::iHmass:
@@ -810,6 +812,7 @@ void SVDSBTLBackend::fast_evaluate(CoolProp::input_pairs input_pair, const doubl
             case CoolProp::iDmolar:
             case CoolProp::iSmolar:
             case CoolProp::iUmolar:
+            case CoolProp::iQ:
                 break;
             default:
                 // Anything else has to be in the surface (mass-basis
@@ -915,13 +918,157 @@ void SVDSBTLBackend::fast_evaluate(CoolProp::input_pairs input_pair, const doubl
         // Plain SVD-surface path: resolve once, evaluate per output.
         const auto pt = surface->resolve(a, b);
         if (pt.region_idx < 0) {
-            // Atlas didn't find a region — either out of every region's
-            // AABB (genuinely out of range) or inside the saturation
-            // dome.  We can't distinguish here without an extra dome
-            // check, so report two-phase-disallowed which more
-            // accurately reflects the most common cause (dome hit).
-            status_flags[k] = CoolProp::fast_evaluate_two_phase_disallowed;
-            fill_nan_row(k);
+            // Atlas miss.  For HmassP / HmolarP this usually means the
+            // (h, p) point is inside the saturation dome; for PT it
+            // means the point straddles the sat curve (Q ambiguous) or
+            // is genuinely out of range.  Try a Q-weighted blend via
+            // the SuperAncillary for the HmassP case; fall through to
+            // out-of-range otherwise.
+            bool dome_handled = false;
+            if (is_HmassP || is_HmolarP) {
+                // Resolve sat-line endpoints in molar units.  Prefer the
+                // source backend's SuperAncillary when available (HEOS,
+                // REFPROP); fall back to source->update(PQ_INPUTS, p, Q)
+                // otherwise (IF97 source has no SA but does support PQ
+                // via psat97 + region 4).
+                double T_sat = 0.0, hL_mol = 0.0, hV_mol = 0.0;
+                double rhoL_mol = 0.0, rhoV_mol = 0.0;
+                double sL_mol = 0.0, sV_mol = 0.0;
+                bool sat_endpoints_resolved = false;
+                bool have_rho_endpoints = false;
+                bool have_s_endpoints = false;
+                auto sa = superanc_();
+                if (sa) {
+                    try {
+                        T_sat = sa->get_T_from_p(a);
+                        hL_mol = sa->eval_sat(T_sat, 'H', 0);
+                        hV_mol = sa->eval_sat(T_sat, 'H', 1);
+                        sat_endpoints_resolved = true;
+                    } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
+                    }
+                }
+                if (!sat_endpoints_resolved) {
+                    // Source-backend PQ fallback.  IF97 / REFPROP routes
+                    // come here.  We share the same patch_source-style
+                    // AbstractState across all dome probes in this batch
+                    // (lazily allocated) to avoid factory overhead.
+                    try {
+                        auto src = source_reference_();
+                        src->update(CoolProp::PQ_INPUTS, a, 0.0);
+                        T_sat = src->T();
+                        hL_mol = src->hmolar();
+                        rhoL_mol = src->rhomolar();
+                        sL_mol = src->smolar();
+                        src->update(CoolProp::PQ_INPUTS, a, 1.0);
+                        hV_mol = src->hmolar();
+                        rhoV_mol = src->rhomolar();
+                        sV_mol = src->smolar();
+                        sat_endpoints_resolved = true;
+                        have_rho_endpoints = true;
+                        have_s_endpoints = true;
+                    } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
+                        // Above pcrit or source PQ failure — fall through to OOB.
+                    }
+                }
+                if (sat_endpoints_resolved) {
+                    const double hL = hL_mol / M;
+                    const double hV = hV_mol / M;
+                    if (h_mass_input >= hL && h_mass_input <= hV) {
+                        const double Q = (h_mass_input - hL) / (hV - hL);
+                        // Lazy sat-line endpoint pulls — only touch the
+                        // source's SuperAncillary (or its PQ path) for the
+                        // endpoints that the requested output set needs.
+                        double uL_mol = 0.0, uV_mol = 0.0;
+                        bool have_u = false;
+                        auto ensure_rho = [&] {
+                            if (have_rho_endpoints) return;
+                            rhoL_mol = sa->eval_sat(T_sat, 'D', 0);
+                            rhoV_mol = sa->eval_sat(T_sat, 'D', 1);
+                            have_rho_endpoints = true;
+                        };
+                        auto ensure_s = [&] {
+                            if (have_s_endpoints) return;
+                            sL_mol = sa->eval_sat(T_sat, 'S', 0);
+                            sV_mol = sa->eval_sat(T_sat, 'S', 1);
+                            have_s_endpoints = true;
+                        };
+                        auto ensure_u = [&] {
+                            if (have_u) return;
+                            ensure_rho();
+                            // u = h - p/rho recovers internal energy
+                            // without a SuperAncillary u-table (the SA
+                            // caloric build covers H and S but not U).
+                            uL_mol = hL_mol - a / rhoL_mol;
+                            uV_mol = hV_mol - a / rhoV_mol;
+                            have_u = true;
+                        };
+                        for (std::size_t o = 0; o < N_outputs; ++o) {
+                            const auto prop = outputs[o];
+                            double v = NaN;
+                            switch (prop) {
+                                case CoolProp::iP:
+                                    v = a;
+                                    break;
+                                case CoolProp::iT:
+                                    v = T_sat;
+                                    break;
+                                case CoolProp::iHmass:
+                                    v = h_mass_input;
+                                    break;
+                                case CoolProp::iHmolar:
+                                    v = (1.0 - Q) * hL_mol + Q * hV_mol;
+                                    break;
+                                case CoolProp::iDmass:
+                                case CoolProp::iDmolar: {
+                                    ensure_rho();
+                                    const double vL = 1.0 / rhoL_mol;
+                                    const double vV = 1.0 / rhoV_mol;
+                                    const double rho_molar = 1.0 / ((1.0 - Q) * vL + Q * vV);
+                                    v = (prop == CoolProp::iDmass) ? rho_molar * M : rho_molar;
+                                    break;
+                                }
+                                case CoolProp::iSmass:
+                                case CoolProp::iSmolar: {
+                                    ensure_s();
+                                    const double s_molar = (1.0 - Q) * sL_mol + Q * sV_mol;
+                                    v = (prop == CoolProp::iSmass) ? s_molar / M : s_molar;
+                                    break;
+                                }
+                                case CoolProp::iUmass:
+                                case CoolProp::iUmolar: {
+                                    ensure_u();
+                                    const double u_molar = (1.0 - Q) * uL_mol + Q * uV_mol;
+                                    v = (prop == CoolProp::iUmass) ? u_molar / M : u_molar;
+                                    break;
+                                }
+                                case CoolProp::iQ:
+                                    v = Q;
+                                    break;
+                                case CoolProp::ispeed_sound:
+                                case CoolProp::iviscosity:
+                                case CoolProp::iconductivity:
+                                    // No equilibrium bulk value inside the
+                                    // dome.  NaN — caller can detect via
+                                    // the explicit two-phase status that
+                                    // we set below if any of these were in
+                                    // the output set.
+                                    v = NaN;
+                                    break;
+                                default:
+                                    v = NaN;
+                                    break;
+                            }
+                            out_buffer[k * N_outputs + o] = v;
+                        }
+                        status_flags[k] = CoolProp::fast_evaluate_ok;
+                        dome_handled = true;
+                    }
+                }
+            }
+            if (!dome_handled) {
+                status_flags[k] = CoolProp::fast_evaluate_out_of_range;
+                fill_nan_row(k);
+            }
             continue;
         }
 

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -731,4 +731,240 @@ CoolPropDbl SVDSBTLBackend::calc_pmax() {
     return source_reference_()->pmax();
 }
 
+// fast_evaluate: vectorized cache-bypassing batch path.  Mirrors
+// update()'s routing per point but writes directly to out_buffer
+// without touching any per-instance cache slot (_T, _p, _phase,
+// active_*).  All allocations live outside the loop.
+//
+// Supported pairs:
+//   HmassP_INPUTS  : val1 = h, val2 = p
+//   HmolarP_INPUTS : val1 = h_molar, val2 = p  (converted to h_mass)
+//   PT_INPUTS      : val1 = p,   val2 = T
+//
+// Per-point outcome:
+//   - in-domain single-phase  → resolve + N_outputs evaluations + ok
+//   - inside critical-patch   → patch_source_->update() + property reads
+//   - out of every region     → NaN row + fast_evaluate_out_of_range
+//   - two-phase / dome hit    → NaN row + fast_evaluate_two_phase_disallowed
+//
+// Note that two-phase points are NOT routed through update_two_phase_'s
+// Q-weighted blend here — fast_evaluate's contract explicitly states
+// it doesn't do flash refinement; callers wanting dome behaviour use
+// update() instead.  In-patch points DO get routed through the patch
+// source (an AbstractState::update() call per point), since omitting
+// the critical-patch routing would silently degrade accuracy at points
+// the build was explicitly configured to handle.
+void SVDSBTLBackend::fast_evaluate(CoolProp::input_pairs input_pair, const double* val1, const double* val2, std::size_t N_inputs,
+                                   const CoolProp::parameters* outputs, std::size_t N_outputs, double* out_buffer, std::size_t out_buffer_size,
+                                   int* status_flags, std::size_t status_flags_size, CoolProp::phases /*imposed_phase*/) {
+    // Bounds + null checks first (matches IF97Backend::fast_evaluate).
+    if (N_outputs != 0 && N_inputs > std::numeric_limits<std::size_t>::max() / N_outputs) {
+        throw ValueError(format("fast_evaluate: N_inputs * N_outputs would overflow size_t (N_inputs=%zu, N_outputs=%zu)", N_inputs, N_outputs));
+    }
+    const std::size_t required_out = N_inputs * N_outputs;
+    if (out_buffer_size < required_out) {
+        throw ValueError(format("fast_evaluate: out_buffer_size=%zu < required %zu (N_inputs * N_outputs)", out_buffer_size, required_out));
+    }
+    if (status_flags_size < N_inputs) {
+        throw ValueError(format("fast_evaluate: status_flags_size=%zu < required %zu (N_inputs)", status_flags_size, N_inputs));
+    }
+    if (N_inputs == 0) return;
+    if (val1 == nullptr || val2 == nullptr || outputs == nullptr || out_buffer == nullptr || status_flags == nullptr) {
+        throw ValueError("fast_evaluate: null pointer argument");
+    }
+    if (N_outputs == 0) {
+        for (std::size_t k = 0; k < N_inputs; ++k)
+            status_flags[k] = CoolProp::fast_evaluate_ok;
+        return;
+    }
+
+    const bool is_HmassP = (input_pair == CoolProp::HmassP_INPUTS);
+    const bool is_HmolarP = (input_pair == CoolProp::HmolarP_INPUTS);
+    const bool is_PT = (input_pair == CoolProp::PT_INPUTS);
+    if (!is_HmassP && !is_HmolarP && !is_PT) {
+        throw ValueError(format("fast_evaluate (SVDSBTL): input_pair %s not supported (use HmassP_INPUTS, HmolarP_INPUTS, or PT_INPUTS)",
+                                get_input_pair_short_desc(input_pair).c_str()));
+    }
+    const auto surface_key = is_HmolarP ? CoolProp::HmassP_INPUTS : input_pair;
+    const auto it = surfaces_.find(static_cast<int>(surface_key));
+    if (it == surfaces_.end() || !it->second) {
+        throw ValueError(std::string("fast_evaluate (SVDSBTL): no surface registered for ") + CoolProp::get_input_pair_short_desc(input_pair));
+    }
+    const auto* surface = it->second.get();
+
+    const double M = calc_molar_mass();  // pure fluid, constant
+    const double NaN = std::numeric_limits<double>::quiet_NaN();
+
+    // Validate output keys up-front so we don't fail mid-loop.  Anything
+    // the SVD surface stores directly is supported, plus the per-input
+    // pair shortcuts (T/p/h that the caller just gave us) and molar
+    // variants that scale by molar mass.
+    auto is_surface_prop = [&](CoolProp::parameters prop) { return surface->contains_property(prop); };
+    for (std::size_t o = 0; o < N_outputs; ++o) {
+        switch (outputs[o]) {
+            // Always available shortcuts (no SVD eval needed).
+            case CoolProp::iT:
+            case CoolProp::iP:
+            case CoolProp::iHmass:
+            case CoolProp::iHmolar:
+            case CoolProp::iDmolar:
+            case CoolProp::iSmolar:
+            case CoolProp::iUmolar:
+                break;
+            default:
+                // Anything else has to be in the surface (mass-basis
+                // primary keys).  iDmass / iSmass / iUmass / ispeed_sound /
+                // iviscosity / iconductivity all land here.
+                if (!is_surface_prop(outputs[o])) {
+                    throw ValueError(format("fast_evaluate (SVDSBTL): active surface does not expose output[%zu]=%s", o,
+                                            get_parameter_information(outputs[o], "short").c_str()));
+                }
+                break;
+        }
+    }
+
+    auto fill_nan_row = [&](std::size_t k) {
+        for (std::size_t o = 0; o < N_outputs; ++o) {
+            out_buffer[k * N_outputs + o] = NaN;
+        }
+    };
+
+    for (std::size_t k = 0; k < N_inputs; ++k) {
+        const double v1 = val1[k];
+        const double v2 = val2[k];
+
+        // Convert input to the surface's (a, b) coordinates and the
+        // mass-basis h we'll return as a shortcut.
+        double a;                   // primary axis: always p
+        double b;                   // secondary axis: h_mass (PH surface) or T (PT surface)
+        double h_mass_input = NaN;  // only meaningful when is_HmassP / is_HmolarP
+        double T_input = NaN;       // only meaningful when is_PT
+        if (is_HmassP) {
+            h_mass_input = v1;
+            a = v2;
+            b = v1;
+        } else if (is_HmolarP) {
+            h_mass_input = v1 / M;
+            a = v2;
+            b = h_mass_input;
+        } else {
+            // is_PT
+            T_input = v2;
+            a = v1;
+            b = v2;
+        }
+
+        // Critical-patch routing: if the point lies in the configured
+        // bbox, defer to the patch source backend.  We still pay an
+        // update() per in-patch point on the patch source — that's the
+        // cost of being "truth" inside the patch zone — but we avoid
+        // touching our own cache.
+        const auto patch_key = is_HmolarP ? CoolProp::HmassP_INPUTS : input_pair;
+        if (critical_patch_.contains(patch_key, a, b)) {
+            try {
+                if (is_HmolarP) {
+                    patch_source_ref_()->update(CoolProp::HmassP_INPUTS, h_mass_input, a);
+                } else {
+                    patch_source_ref_()->update(input_pair, v1, v2);
+                }
+            } catch (const std::exception&) {
+                status_flags[k] = CoolProp::fast_evaluate_out_of_range;
+                fill_nan_row(k);
+                continue;
+            }
+            auto& src = *patch_source_;
+            for (std::size_t o = 0; o < N_outputs; ++o) {
+                const auto prop = outputs[o];
+                double v = NaN;
+                try {
+                    switch (prop) {
+                        case CoolProp::iP:
+                            v = (is_PT ? v1 : v2);
+                            break;
+                        case CoolProp::iT:
+                            v = (is_PT ? v2 : src.keyed_output(CoolProp::iT));
+                            break;
+                        case CoolProp::iHmass:
+                            v = (is_HmassP ? v1 : src.keyed_output(CoolProp::iHmass));
+                            break;
+                        case CoolProp::iHmolar:
+                            v = (is_HmolarP ? v1 : src.keyed_output(CoolProp::iHmass) * M);
+                            break;
+                        case CoolProp::iDmolar:
+                            v = src.keyed_output(CoolProp::iDmass) / M;
+                            break;
+                        case CoolProp::iSmolar:
+                            v = src.keyed_output(CoolProp::iSmass) * M;
+                            break;
+                        case CoolProp::iUmolar:
+                            v = src.keyed_output(CoolProp::iUmass) * M;
+                            break;
+                        default:
+                            v = src.keyed_output(prop);
+                            break;
+                    }
+                } catch (const std::exception&) {
+                    v = NaN;
+                }
+                out_buffer[k * N_outputs + o] = v;
+            }
+            status_flags[k] = CoolProp::fast_evaluate_ok;
+            continue;
+        }
+
+        // Plain SVD-surface path: resolve once, evaluate per output.
+        const auto pt = surface->resolve(a, b);
+        if (pt.region_idx < 0) {
+            // Atlas didn't find a region — either out of every region's
+            // AABB (genuinely out of range) or inside the saturation
+            // dome.  We can't distinguish here without an extra dome
+            // check, so report two-phase-disallowed which more
+            // accurately reflects the most common cause (dome hit).
+            status_flags[k] = CoolProp::fast_evaluate_two_phase_disallowed;
+            fill_nan_row(k);
+            continue;
+        }
+
+        for (std::size_t o = 0; o < N_outputs; ++o) {
+            const auto prop = outputs[o];
+            double v = NaN;
+            switch (prop) {
+                // Caller-supplied inputs — no SVD eval.
+                case CoolProp::iP:
+                    v = (is_PT ? v1 : v2);
+                    break;
+                case CoolProp::iT:
+                    v = is_PT ? T_input : surface->eval_with_region(CoolProp::iT, pt.region_idx, pt.svd_x, pt.svd_y);
+                    break;
+                case CoolProp::iHmass:
+                    v = (is_HmassP || is_HmolarP) ? h_mass_input : surface->eval_with_region(CoolProp::iHmass, pt.region_idx, pt.svd_x, pt.svd_y);
+                    break;
+                case CoolProp::iHmolar:
+                    if (is_HmolarP) {
+                        v = v1;
+                    } else if (is_HmassP) {
+                        v = h_mass_input * M;
+                    } else {
+                        v = surface->eval_with_region(CoolProp::iHmass, pt.region_idx, pt.svd_x, pt.svd_y) * M;
+                    }
+                    break;
+                case CoolProp::iDmolar:
+                    v = surface->eval_with_region(CoolProp::iDmass, pt.region_idx, pt.svd_x, pt.svd_y) / M;
+                    break;
+                case CoolProp::iSmolar:
+                    v = surface->eval_with_region(CoolProp::iSmass, pt.region_idx, pt.svd_x, pt.svd_y) * M;
+                    break;
+                case CoolProp::iUmolar:
+                    v = surface->eval_with_region(CoolProp::iUmass, pt.region_idx, pt.svd_x, pt.svd_y) * M;
+                    break;
+                default:
+                    v = surface->eval_with_region(prop, pt.region_idx, pt.svd_x, pt.svd_y);
+                    break;
+            }
+            out_buffer[k * N_outputs + o] = v;
+        }
+        status_flags[k] = CoolProp::fast_evaluate_ok;
+    }
+}
+
 }  // namespace CoolProp

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -876,6 +876,7 @@ void SVDSBTLBackend::fast_evaluate(CoolProp::input_pairs input_pair, const doubl
                 continue;
             }
             auto& src = *patch_source_;
+            bool patch_row_failed = false;
             for (std::size_t o = 0; o < N_outputs; ++o) {
                 const auto prop = outputs[o];
                 double v = NaN;
@@ -902,16 +903,33 @@ void SVDSBTLBackend::fast_evaluate(CoolProp::input_pairs input_pair, const doubl
                         case CoolProp::iUmolar:
                             v = src.keyed_output(CoolProp::iUmass) * M;
                             break;
+                        case CoolProp::iQ:
+                            // Single-phase by definition in the patch
+                            // zone — supercritical region surrounding the
+                            // critical point.  Mirror update()'s
+                            // convention of returning -1 outside the dome.
+                            v = -1.0;
+                            break;
                         default:
                             v = src.keyed_output(prop);
                             break;
                     }
                 } catch (const std::exception&) {
                     v = NaN;
+                    patch_row_failed = true;
                 }
                 out_buffer[k * N_outputs + o] = v;
             }
-            status_flags[k] = CoolProp::fast_evaluate_ok;
+            // If any per-output read failed, the row no longer satisfies
+            // the all-defined contract — NaN-fill the whole row and
+            // flag it, matching IF97Backend::fast_evaluate's
+            // fast_evaluate_internal_error semantics.
+            if (patch_row_failed) {
+                status_flags[k] = CoolProp::fast_evaluate_internal_error;
+                fill_nan_row(k);
+            } else {
+                status_flags[k] = CoolProp::fast_evaluate_ok;
+            }
             continue;
         }
 
@@ -1066,7 +1084,35 @@ void SVDSBTLBackend::fast_evaluate(CoolProp::input_pairs input_pair, const doubl
                 }
             }
             if (!dome_handled) {
-                status_flags[k] = CoolProp::fast_evaluate_out_of_range;
+                // For PT_INPUTS, an atlas miss CAN mean "T is exactly
+                // on the saturation curve" (ambiguous Q, can't pick a
+                // single-phase side without an explicit phase hint) —
+                // that's a different failure mode from "the (T, p)
+                // point is outside every region's bbox".  Distinguish
+                // by probing Tsat(p) when a SuperAncillary or source
+                // backend can answer.  If unavailable, default to
+                // out_of_range (the conservative choice).
+                int pt_status = CoolProp::fast_evaluate_out_of_range;
+                if (is_PT) {
+                    try {
+                        auto sa = superanc_();
+                        double T_sat_probe = std::numeric_limits<double>::quiet_NaN();
+                        if (sa) {
+                            T_sat_probe = sa->get_T_from_p(a);  // a == p for PT
+                        } else {
+                            auto src = source_reference_();
+                            src->update(CoolProp::PQ_INPUTS, a, 0.0);
+                            T_sat_probe = src->T();
+                        }
+                        constexpr double kSatEps = 3.3e-5;  // matches IF97Backend::set_phase
+                        if (std::isfinite(T_sat_probe) && std::abs(b - T_sat_probe) <= kSatEps * T_sat_probe) {
+                            pt_status = CoolProp::fast_evaluate_two_phase_disallowed;
+                        }
+                    } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
+                        // No sat-line probe available — stick with OOB.
+                    }
+                }
+                status_flags[k] = pt_status;
                 fill_nan_row(k);
             }
             continue;
@@ -1103,6 +1149,12 @@ void SVDSBTLBackend::fast_evaluate(CoolProp::input_pairs input_pair, const doubl
                     break;
                 case CoolProp::iUmolar:
                     v = surface->eval_with_region(CoolProp::iUmass, pt.region_idx, pt.svd_x, pt.svd_y) * M;
+                    break;
+                case CoolProp::iQ:
+                    // Single-phase by definition (atlas resolved to a
+                    // region, which excludes the dome).  Mirror the
+                    // -1 sentinel update() uses outside the dome.
+                    v = -1.0;
                     break;
                 default:
                     v = surface->eval_with_region(prop, pt.region_idx, pt.svd_x, pt.svd_y);

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -519,6 +519,44 @@ TEST_CASE("SVDSBTL fast_evaluate Q-blends inside the saturation dome", "[SVDSBTL
     }
 }
 
+TEST_CASE("SVDSBTL fast_evaluate returns Q = -1 on single-phase rows", "[SVDSBTL][fast_evaluate][water]") {
+    auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&IF97", "Water"));
+    // Three solid single-phase points well inside the surface envelope:
+    // compressed liquid, sub-saturated gas, supercritical.  All should
+    // report iQ = -1.0 (matching update()'s sentinel for single-phase).
+    const std::vector<double> h_v = {5.0e5, 3.0e6, 2.0e6};
+    const std::vector<double> p_v = {1.0e7, 1.0e5, 3.0e7};
+    const std::vector<CoolProp::parameters> outputs = {CoolProp::iT, CoolProp::iQ};
+    std::vector<double> out(h_v.size() * outputs.size(), std::nan(""));
+    std::vector<int> status(h_v.size(), -1);
+    svd->fast_evaluate(CoolProp::HmassP_INPUTS, h_v.data(), p_v.data(), h_v.size(), outputs.data(), outputs.size(), out.data(), out.size(),
+                       status.data(), status.size());
+    for (std::size_t k = 0; k < h_v.size(); ++k) {
+        INFO("k=" << k << " p=" << p_v[k] << " h=" << h_v[k]);
+        REQUIRE(status[k] == CoolProp::fast_evaluate_ok);
+        REQUIRE(out[k * outputs.size() + 1] == -1.0);
+    }
+}
+
+TEST_CASE("SVDSBTL fast_evaluate flags out-of-range PT misses cleanly", "[SVDSBTL][fast_evaluate][water]") {
+    auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
+    // PT below the IF97 triple-point floor — genuinely outside every
+    // region of the atlas.  Must report fast_evaluate_out_of_range
+    // (not two-phase-disallowed, which is reserved for atlas misses
+    // that the sat-curve probe can identify; the SVDSBTL PT atlas
+    // registers LIQUID and VAPOR as adjacent at T_sat so a sat-curve
+    // hit resolves as liquid rather than missing).
+    const std::vector<double> v1 = {1.0e6};
+    const std::vector<double> v2 = {200.0};  // K, below T_triple
+    const std::vector<CoolProp::parameters> outputs = {CoolProp::iDmass};
+    std::vector<double> out(1, std::nan(""));
+    std::vector<int> status(1, -1);
+    svd->fast_evaluate(CoolProp::PT_INPUTS, v1.data(), v2.data(), 1, outputs.data(), outputs.size(), out.data(), out.size(), status.data(),
+                       status.size());
+    REQUIRE(status[0] == CoolProp::fast_evaluate_out_of_range);
+    REQUIRE(!std::isfinite(out[0]));
+}
+
 TEST_CASE("SVDSBTL fast_evaluate rejects unsupported inputs cleanly", "[SVDSBTL][fast_evaluate][reject]") {
     auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&IF97", "Water"));
     const std::vector<double> v1 = {1.0};

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -538,6 +538,52 @@ TEST_CASE("SVDSBTL fast_evaluate returns Q = -1 on single-phase rows", "[SVDSBTL
     }
 }
 
+TEST_CASE("SVDSBTL fast_evaluate routes through patch_source_ inside the critical-patch bbox", "[SVDSBTL][fast_evaluate][water][slow]") {
+    // The default auto-calibrated patch bbox for Water sits at
+    // [0.95, 1.05] * T_c x [0.75, 1.15] * p_c.  Pick a state well
+    // inside that box and assert fast_evaluate's per-output values
+    // match what patch_source_->update + property reads return on
+    // the same input.  This exercises the Patched-kind branch in
+    // resolve_point_ + evaluate_property_ that nothing else in the
+    // suite hits.
+    auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
+    auto ref = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+    const double T_c = ref->T_critical();
+    const double p_c = ref->p_critical();
+    // 99% T_c, 95% p_c — comfortably inside [0.95, 1.05] x [0.75, 1.15].
+    const double T_probe = 0.99 * T_c;
+    const double p_probe = 0.95 * p_c;
+    // Get h(p, T) from HEOS so we can route the probe through both
+    // PT_INPUTS (direct) and HmassP_INPUTS (which exercises the same
+    // bbox via the (p, h) projection).
+    ref->update(CoolProp::PT_INPUTS, p_probe, T_probe);
+    const double h_probe = ref->hmass();
+    for (const auto& routing : std::vector<std::pair<CoolProp::input_pairs, std::pair<double, double>>>{
+           {CoolProp::PT_INPUTS, {p_probe, T_probe}},
+           {CoolProp::HmassP_INPUTS, {h_probe, p_probe}},
+         }) {
+        const double v1 = routing.second.first;
+        const double v2 = routing.second.second;
+        const std::vector<CoolProp::parameters> outputs = {CoolProp::iT, CoolProp::iDmass, CoolProp::iSmass, CoolProp::iHmass, CoolProp::iQ};
+        std::vector<double> out(outputs.size(), std::nan(""));
+        std::vector<int> status(1, -1);
+        svd->fast_evaluate(routing.first, &v1, &v2, 1, outputs.data(), outputs.size(), out.data(), out.size(), status.data(), status.size());
+        REQUIRE(status[0] == CoolProp::fast_evaluate_ok);
+        // Bit-identical to update() + property reads — both code paths
+        // route through the same patch_source_ AbstractState.
+        svd->update(routing.first, v1, v2);
+        INFO("input_pair=" << routing.first << " v1=" << v1 << " v2=" << v2);
+        REQUIRE(out[0] == svd->T());
+        REQUIRE(out[1] == svd->rhomass());
+        REQUIRE(out[2] == svd->smass());
+        REQUIRE(out[3] == svd->hmass());
+        // iQ on a single-phase supercritical probe should mirror the
+        // patch_source_'s answer (typically iphase_supercritical, Q
+        // returned as a sentinel-shaped finite value from HEOS).
+        REQUIRE(out[4] == svd->Q());
+    }
+}
+
 TEST_CASE("SVDSBTL fast_evaluate flags out-of-range PT misses cleanly", "[SVDSBTL][fast_evaluate][water]") {
     auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
     // PT below the IF97 triple-point floor — genuinely outside every

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -476,6 +476,49 @@ TEST_CASE("SVDSBTL fast_evaluate matches per-call update() bit-for-bit", "[SVDSB
     }
 }
 
+TEST_CASE("SVDSBTL fast_evaluate Q-blends inside the saturation dome", "[SVDSBTL][fast_evaluate][twophase][water][slow]") {
+    // Probe inside the dome at three subcritical pressures, vary Q.
+    // fast_evaluate must (a) report fast_evaluate_ok, (b) recover Q,
+    // and (c) blend mass-basis properties linearly between the
+    // sat-line endpoints.
+    auto ref = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+    auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
+    const std::vector<double> ps = {1.0e5, 1.0e6, 5.0e6};
+    const std::vector<double> qs = {0.05, 0.25, 0.5, 0.75, 0.95};
+    std::vector<double> h_v, p_v, q_v;
+    for (double p : ps) {
+        ref->update(CoolProp::PQ_INPUTS, p, 0.0);
+        const double hL = ref->hmass();
+        ref->update(CoolProp::PQ_INPUTS, p, 1.0);
+        const double hV = ref->hmass();
+        for (double q : qs) {
+            h_v.push_back(hL + q * (hV - hL));
+            p_v.push_back(p);
+            q_v.push_back(q);
+        }
+    }
+    const std::size_t N = h_v.size();
+    const std::vector<CoolProp::parameters> outputs = {CoolProp::iT, CoolProp::iDmass, CoolProp::iSmass, CoolProp::iUmass, CoolProp::iQ};
+    std::vector<double> out(N * outputs.size(), std::nan(""));
+    std::vector<int> status(N, -1);
+    svd->fast_evaluate(CoolProp::HmassP_INPUTS, h_v.data(), p_v.data(), N, outputs.data(), outputs.size(), out.data(), out.size(), status.data(),
+                       status.size());
+    for (std::size_t k = 0; k < N; ++k) {
+        INFO("k=" << k << "  p=" << p_v[k] << "  h=" << h_v[k]);
+        REQUIRE(status[k] == CoolProp::fast_evaluate_ok);
+        // Q recovered to within a few ULP of the lever-rule construction;
+        // any residual is the HEOS sat-line round-trip noise (~1e-5).
+        REQUIRE(out[k * outputs.size() + 4] == Approx(q_v[k]).epsilon(1e-4));
+        // Q-blend matches update_two_phase_() bit-identically — both paths
+        // use the same SuperAncillary endpoints.
+        svd->update(CoolProp::HmassP_INPUTS, h_v[k], p_v[k]);
+        REQUIRE(out[k * outputs.size() + 0] == Approx(svd->T()).epsilon(1e-12));
+        REQUIRE(out[k * outputs.size() + 1] == Approx(svd->rhomass()).epsilon(1e-12));
+        REQUIRE(out[k * outputs.size() + 2] == Approx(svd->smass()).epsilon(1e-12));
+        REQUIRE(out[k * outputs.size() + 3] == Approx(svd->umass()).epsilon(1e-12));
+    }
+}
+
 TEST_CASE("SVDSBTL fast_evaluate rejects unsupported inputs cleanly", "[SVDSBTL][fast_evaluate][reject]") {
     auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&IF97", "Water"));
     const std::vector<double> v1 = {1.0};

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -431,4 +431,63 @@ TEST_CASE("SVDSBTL&HEOS and SVDSBTL&REFPROP produce distinct cache files", "[SVD
     REQUIRE(refprop_path.find("Water.REFPROP.") != std::string::npos);
 }
 
+TEST_CASE("SVDSBTL fast_evaluate matches per-call update() bit-for-bit", "[SVDSBTL][fast_evaluate][water][slow]") {
+    // Build a small (T, p) probe set via IF97, pull h(T, p), then evaluate
+    // each probe via both update() + property reads AND via fast_evaluate;
+    // assert the two paths return identical numbers (no rounding tolerance).
+    auto if97 = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("IF97", "Water"));
+    auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&IF97", "Water"));
+    std::vector<double> h_v, p_v;
+    for (double T = 320.0; T <= 800.0; T += 60.0) {
+        for (double lp = std::log(1.0e5); lp <= std::log(3.0e7); lp += 0.5 * std::log(10.0)) {
+            const double p = std::exp(lp);
+            try {
+                if97->update(CoolProp::PT_INPUTS, p, T);
+                const double h = if97->hmass();
+                if (std::isfinite(h)) {
+                    h_v.push_back(h);
+                    p_v.push_back(p);
+                }
+            } catch (...) {  // NOLINT(bugprone-empty-catch)
+            }
+        }
+    }
+    REQUIRE(h_v.size() > 10);
+    const std::size_t N = h_v.size();
+    const std::vector<CoolProp::parameters> outputs = {CoolProp::iT, CoolProp::iDmass, CoolProp::iSmass, CoolProp::ispeed_sound};
+    std::vector<double> out_fe(N * outputs.size(), std::nan(""));
+    std::vector<int> status(N, -1);
+    svd->fast_evaluate(CoolProp::HmassP_INPUTS, h_v.data(), p_v.data(), N, outputs.data(), outputs.size(), out_fe.data(), out_fe.size(),
+                       status.data(), status.size());
+    for (std::size_t k = 0; k < N; ++k) {
+        REQUIRE(status[k] == CoolProp::fast_evaluate_ok);
+        svd->update(CoolProp::HmassP_INPUTS, h_v[k], p_v[k]);
+        const double T_up = svd->T();
+        const double rho_up = svd->rhomass();
+        const double s_up = svd->smass();
+        const double w_up = svd->speed_sound();
+        // Bit-identical: both paths call the same SVDSurface::eval_with_region
+        // on the same ResolvedPoint, so there's no floating-point freedom
+        // between them.  No epsilon tolerance.
+        REQUIRE(out_fe[k * outputs.size() + 0] == T_up);
+        REQUIRE(out_fe[k * outputs.size() + 1] == rho_up);
+        REQUIRE(out_fe[k * outputs.size() + 2] == s_up);
+        REQUIRE(out_fe[k * outputs.size() + 3] == w_up);
+    }
+}
+
+TEST_CASE("SVDSBTL fast_evaluate rejects unsupported inputs cleanly", "[SVDSBTL][fast_evaluate][reject]") {
+    auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&IF97", "Water"));
+    const std::vector<double> v1 = {1.0};
+    const std::vector<double> v2 = {1.0};
+    const std::vector<CoolProp::parameters> outputs = {CoolProp::iT};
+    std::vector<double> out(1, std::nan(""));
+    std::vector<int> status(1, -1);
+    // PQ_INPUTS isn't a fast-path input — caller should get a clear error,
+    // not a NaN row.
+    REQUIRE_THROWS_AS(svd->fast_evaluate(CoolProp::PQ_INPUTS, v1.data(), v2.data(), 1, outputs.data(), outputs.size(), out.data(), out.size(),
+                                         status.data(), status.size()),
+                      CoolProp::ValueError);
+}
+
 #endif  // ENABLE_CATCH


### PR DESCRIPTION
## Summary

Two related additions to the `AbstractState::fast_evaluate` batch path, plus a kernel refactor that fixes the architectural concern the original implementation introduced.

### 1. SVDSBTL gets `fast_evaluate` (closes CoolProp-4bx)

SVDSBTL was inheriting the default that throws `NotImplementedError`. Now overridden to mirror `update()`'s routing — critical-patch bbox check → `patch_source_`, otherwise `SVDSurface::resolve` + `eval_with_region` per output — but writes directly into the caller's `out_buffer` without touching the AbstractState cache.

- Supports `HmassP_INPUTS`, `HmolarP_INPUTS`, `PT_INPUTS`.
- Supported outputs: any property the surface exposes (`iDmass / iSmass / iUmass / ispeed_sound / iviscosity / iconductivity`) plus shortcuts that don't need an SVD eval (`iT / iP / iHmass / iHmolar / iDmolar / iSmolar / iUmolar / iQ`).
- In-patch points still go through `patch_source_->update()` (rare, but correct).
- Bit-identical to per-call `update()` on in-domain probes — verified with a 30-point test at zero tolerance.

### 2. Both backends now Q-blend instead of NaN-filling dome-hit HmassP probes

The previous fast paths NaN-filled and set `fast_evaluate_two_phase_disallowed` whenever an HmassP point landed inside the saturation dome. This was unnecessarily restrictive — the lever-rule blend over sat-line endpoints is cheap (one `Tsat97` or one `SuperAncillary::get_T_from_p` lookup) and `update()` already does it.

**Blend rules** (mass-basis; molar variants follow by × / ÷ M):
- `v = (1 − Q)·v_L + Q·v_V`  so  `ρ = 1 / v` (lever rule — *specific volume* blends linearly, density is its reciprocal)
- `s = (1 − Q)·s_L + Q·s_V`
- `u = (1 − Q)·u_L + Q·u_V`
- `h = (1 − Q)·h_L + Q·h_V`  (the supplied input, modulo round-trip)
- `Q` returned directly
- `speed_sound / cp / cv / viscosity / conductivity / Prandtl` stay NaN (no equilibrium bulk value in the dome)

**IF97** — after `T_phmass` returns (it silently returns `Tsat` for in-dome inputs rather than throwing), probe `IF97::hliq_p` / `hvap_p` at p and bracket h. Sat-line endpoints come from `IF97::rholiq_p / rhovap_p / sliq_p / svap_p / uliq_p / uvap_p`.

**SVDSBTL** — after the atlas resolve returns `region_idx = -1` for HmassP / HmolarP, try the source's SuperAncillary first (HEOS / REFPROP have one); fall back to `source_reference_()->update(PQ_INPUTS, p, 0|1)` for IF97 source (no SA but PQ is fast — one `psat97` + region-4 read).

PT_INPUTS exactly on the saturation curve remains `two_phase_disallowed` because Q isn't determinable from (P, T) alone — caller should use PQ_INPUTS or supply a phase hint.

### 3. Kernel refactor — `resolve_point_` + `evaluate_property_`

The initial fast_evaluate implementation re-implemented input-pair dispatch, critical-patch routing, atlas resolve, dome detection + Q-blend, and the per-output property switch — all of which already existed in slightly different form across `update()` and the `calc_*` family. That made the two code paths drift-prone and meant any future caller (batched PropsSI, Python `update_array` wrapper, possible HEOS `fast_evaluate`, etc.) couldn't reuse the kernel.

This change pulls the routing out of both code paths:

- `resolve_point_(input_pair, v1, v2)` — pure (no instance mutation), returns a `PointEvaluation` tagged with one of `{SinglePhase, DomeBlend, Patched, OutOfRange, TwoPhaseDisallowed, InternalError}`. Two-phase `PQ_INPUTS` / `QT_INPUTS` land in `DomeBlend` with the same fields as an HmassP-in-dome row, so downstream code sees one case instead of two.
- `evaluate_property_(PointEvaluation&, parameter)` — pure dispatch with lazy sat-line endpoint fills via `ensure_dome_rho_endpoints_` / `ensure_dome_s_endpoints_`. Throws `NotImplementedError` for properties undefined in the dome; `calc_*()` lets it propagate, `fast_evaluate()` translates it into an in-band NaN.
- `update()` collapses from ~150 LOC to ~50 LOC: calls `resolve_point_`, stores the result on `active_eval_`, copies T/p/Q/phase into the AbstractState legacy slots for back-compat.
- `fast_evaluate()` collapses from ~330 LOC to ~30 LOC: loops calling the kernel per probe.
- The `TwoPhaseState` struct, `update_two_phase_()`, `two_phase_property_`, and `lookup_()` helpers all go away — their state lives on `active_eval_`, their logic lives in `evaluate_property_()`.
- Lazy / nullable doubles use `std::optional<double>` per Ian's preference.

Net diff: roughly even LOC despite adding the kernel infrastructure. A hypothetical future entry point (batched PropsSI, `update_array` wrapper, etc.) reuses the same kernel by calling `resolve_point_` + `evaluate_property_` directly.

### Adversarial-review fixes (PR-internal)

Subsequent commits address findings from a code-reviewer pass + CodeRabbit:

- **H1.** `update()` sets `_Q` for every kind (SinglePhase → -1, Patched → `patch_source_->keyed_output(iQ)`, DomeBlend → lever-rule Q). Parity with `fast_evaluate` and `IF97Backend::update()`.
- **H2.** Removed top-level `iQ` short-circuit; Patched-kind iQ forwards through `patch_source_->keyed_output(iQ)` so two-phase points near the bbox edge are reported correctly.
- **H3.** Deleted dead DomeBlend `iHmolar` arm; the `pt.h_mass`-based shortcut is the single source of truth.
- **H4.** Patched molar variants collapsed to direct `keyed_output(prop)` — HEOS computes molar quantities natively; the previous mass·M round-trip was wasted work + precision loss.
- **M1.** Stale docstrings referencing deleted `lookup_` / `update_two_phase_` rewritten.
- **M2.** Thread-safety docstring on `fast_evaluate` spells out the Patched corruption pattern explicitly.
- **M3.** New `[SVDSBTL][fast_evaluate][water][slow]` test probes (0.99 T_c, 0.95 p_c) — inside the default critical-patch bbox — through both PT and HmassP routing, asserting fast_evaluate matches `update()` + property reads on every output.

## Test plan

- [x] Full `[SVDSBTL]` suite: 42 test cases, 669 assertions, 3 skipped as before.
- [x] `[fast_evaluate]` subset: 7 test cases, 390 assertions, including the new bit-identical, lever-rule Q recovery, Q = -1 single-phase, OOB PT, and Patched-routing cases.
- [x] No regression in `[IF97]` (67/67 assertions) — the IF97 dome-blend addition lives behind the existing `fast_evaluate` test set.
- [x] Python smoke: `fast_evaluate` and `update()` produce bit-identical T / D / S / Q across single-phase and dome-blend probes via the project venv build.
- [ ] CI green across macOS / Ubuntu / Windows.

Closes CoolProp-4bx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
