### PR TITLE
fix(svdsbtl): skip patch polish for two-phase points

### DIFF
--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -872,6 +872,17 @@ void SVDSBTLBackend::update(CoolProp::input_pairs input_pair, double value1, dou
             } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
                 _Q = -1.0;
             }
+            // Inherit the source's phase classification.  Without this
+            // a two-phase patched state (which the skip-polish path now
+            // correctly preserves) would surface as iphase_not_imposed
+            // and state.phase() would disagree with the source.  Wrap
+            // in try/catch because some sources may not report a phase
+            // for every input pair (HEOS does; defensive against
+            // REFPROP edge cases).
+            try {
+                _phase = patch_source_->phase();
+            } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
+            }
             break;
         case PointEvaluation::Kind::OutOfRange:
             // Legacy back-compat: when an HmassP probe misses

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -538,10 +538,30 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
         try {
             if (input_pair == CoolProp::HmolarP_INPUTS) {
                 patch_source_ref_()->update(CoolProp::HmassP_INPUTS, *pt.h_mass, *pt.p);
-                polish_patch_state_(*patch_source_, *pt.p, *pt.h_mass);
+                // Same dome-aware polish gating as the HmassP branch
+                // below — multi-valued h(T, p) inside the dome breaks
+                // the single-phase forward-h polish bracket.
+                if (patch_source_->phase() != CoolProp::iphase_twophase) {
+                    polish_patch_state_(*patch_source_, *pt.p, *pt.h_mass);
+                }
             } else if (input_pair == CoolProp::HmassP_INPUTS) {
                 patch_source_ref_()->update(input_pair, value1, value2);
-                polish_patch_state_(*patch_source_, *pt.p, *pt.h_mass);
+                // Skip the forward-h polish on two-phase points.
+                // polish_patch_state_ assumes a single-phase solution
+                // exists at h(T, p) = h_target on a tight T bracket
+                // around T_seed.  Inside the saturation dome h(T, p)
+                // is multi-valued (the function jumps from h_L to h_V
+                // across T = T_sat), so the bracket [T_seed-0.5,
+                // T_seed+0.5] straddles the dome and resid changes
+                // sign without any single-phase root in the range.
+                // TOMS748 silently converges to a nonsense T and the
+                // returned state classifies as supercritical_liquid
+                // with rho / Q = ±inf.  Two-phase points coming out
+                // of the patch already have correct (T_sat, Q, rho)
+                // from the source's PQ-blend; no polish needed.
+                if (patch_source_->phase() != CoolProp::iphase_twophase) {
+                    polish_patch_state_(*patch_source_, *pt.p, *pt.h_mass);
+                }
             } else {
                 // PT_INPUTS — source backend's PT path is already
                 // forward-consistent; no polish needed.


### PR DESCRIPTION
## Summary

`polish_patch_state_` runs a forward-h TOMS748 polish on every HmassP / HmolarP probe that lands inside the critical-patch bbox, on the assumption that a single-phase solution exists at `h(T, p) = h_target` on a tight T bracket around `T_seed`. Inside the saturation dome `h(T, p)` is multi-valued (it jumps from `h_L` to `h_V` across `T = T_sat`), so the bracket `[T_seed-0.5, T_seed+0.5]` straddles the dome and resid changes sign without any single-phase root in the range. TOMS748 silently converges to a nonsense T, and the returned state classifies as supercritical_liquid with `rho` / `Q` = ±inf.

The auto-calibrated patch bbox for non-water fluids whose critical region overlaps a wide h-range (R245fa, R134a, …) has its HmassP envelope straddle the saturation dome by construction, so any two-phase probe inside the patch hits the failure mode.

This skips the polish entirely when the patched state is `iphase_twophase` — two-phase points coming out of the patch already have correct `(T_sat, Q, rho)` from the source's PQ-blend; the forward-h polish was only designed for the ±25 mK backward-equation residual of IF97's single-phase formulations.

Reproducer (R245fa, **before** the fix):

```
HmassP probe: h=450.7e3 J/kg, p=2.89e6 Pa   (Q=0.5 dome point)
HEOS truth :  rho = 346.65, phase = twophase, Q = 0.500
SVDSBTL    :  rho = -inf,   phase = sc_liq,   Q = -inf
```

After the fix all 6 sweep probes (T = 0.96 … 0.999 · Tc, Q = 0.5) match HEOS within ~1e-14.

## Test plan
- [x] `CatchTestRunner "[SVDSBTL]"` — 40 passed / 6 skipped / 0 failed
- [x] Spot-checked R245fa near-critical dome at T/Tc ∈ {0.96, 0.97, 0.98, 0.99, 0.995, 0.999} — all within ~1e-14 of HEOS
- [x] No regressions on single-phase in-patch points (polish path still runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Avoided applying single-phase polishing to points originating from two-phase sources, reducing incorrect or multi-valued results near saturation boundaries.
  * Patched points now reliably inherit and report their source phase after updates, with added safeguards for sources that may not expose phase information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->