### PR TITLE
test(svdsbtl): relax Q bit-exact compare to Approx for REFPROP fast_evaluate

### DIFF
--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -549,9 +549,16 @@ TEST_CASE("SVDSBTL&REFPROP fast_evaluate works for mixed single-phase + dome bat
         REQUIRE(out_buffer[k * 3 + 1] == Approx(AS->rhomass()).epsilon(1e-10));  // iDmass
         // iQ: -1 sentinel for single-phase, [0,1] in dome (per
         // SVDSBTL's PointEvaluation convention; see SVDSBTLBackend.h
-        // PointEvaluation::Q docs).  -1 and Q in [0,1] are both
-        // exactly representable so direct compare is fine.
-        REQUIRE(out_buffer[k * 3 + 2] == AS->Q());
+        // PointEvaluation::Q docs).  The dome probe inherits the same
+        // last-bit divergence as T / rho via REFPROP's not-quite-
+        // order-deterministic PQ flash on the sat endpoints (see the
+        // top-of-loop comment) — Q = (h_mol - h_L_mol) / (h_V_mol -
+        // h_L_mol) is a function of those endpoints, so the bit-exact
+        // compare that worked for HEOS fails for REFPROP at ~4-ULP.
+        // The -1.0 single-phase sentinel is bit-exact under Approx
+        // with margin 0 (Approx default), so this margin only relaxes
+        // the dome case.
+        REQUIRE(out_buffer[k * 3 + 2] == Approx(AS->Q()).margin(1e-10));
     }
 }
 


### PR DESCRIPTION
## Summary

The mixed-batch REFPROP fast_evaluate test (`[SVDSBTL][source][refprop][fast_evaluate][slow]`) compared `iQ` between `fast_evaluate` and `update()` paths via direct `==`, on the comment-claimed assumption that the `-1.0` single-phase sentinel and `Q ∈ [0, 1]` are exactly representable so a bit-exact compare is fine.

Bit-exact does hold for HEOS source (deterministic at the last bit), but the same test's preamble already acknowledges (lines 534-540) that REFPROP's PQ flash on the two sat endpoints isn't quite order-deterministic at the last bits — `fast_evaluate`'s `resolve_point_` and `update()` do the two endpoints in slightly different orders across the two round-trips, and 4-ULP-class differences are observed in practice on T and rho. The same divergence flows into Q because `Q = (h_mol - h_L_mol) / (h_V_mol - h_L_mol)` is a function of those same endpoints — the dome probe inherits the last-bit noise that the comment had already conceded for T and rho one line up.

CI catches this on REFPROP-enabled runners; HEOS-only smoke tests skip the test entirely.

## Fix

Switch line 554 to `Approx(AS->Q()).margin(1e-10)`. `margin` (not `epsilon`) so the `-1.0` single-phase sentinel still compares cleanly without paying a relative tolerance against zero.

## Test plan

- [x] Local `CatchTestRunner "[SVDSBTL]"` — 40 passed / 6 skipped (REFPROP not on local box, but the type-checks compile)
- [ ] CI green on REFPROP-enabled runners (this PR's whole point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test robustness by replacing an exact equality check with a tiny tolerance for mixed single‑phase and dome evaluations, reducing false failures from ultra‑small numerical differences.
  * Clarified test comments to state that single‑phase sentinel comparisons remain strict while dome comparisons use a small tolerance to account for ~ULP‑level divergence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2950?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->