### PR TITLE
feat(ci): dev/ci/preflight.sh single-script pre-push gate (CoolProp-6r6)

### DIFF
--- a/.semgrep/cpp-file-permissions.yml
+++ b/.semgrep/cpp-file-permissions.yml
@@ -1,0 +1,47 @@
+rules:
+  # Catches the pattern that flagged CoolProp PR #2947 in CodeQL:
+  # std::fopen("...", "w*") creates the file with default permissions
+  # (0666 modified by umask, typically 0644), leaving it world-readable.
+  # On a multi-user host this is rarely actually wanted for cache files.
+  # Mitigation: follow the fopen("wb") with std::filesystem::permissions
+  # restricting to owner_read | owner_write, or use POSIX open() with
+  # explicit mode bits.
+  - id: cpp-fopen-without-restricted-permissions
+    message: >-
+      std::fopen with a write mode creates the file with default
+      permissions (typically 0644). For caches / non-public outputs
+      restrict to owner-only with std::filesystem::permissions(path,
+      perms::owner_read | perms::owner_write, replace) after the close,
+      or use POSIX open(..., O_CREAT | O_WRONLY, 0600).  See PR #2947
+      for the prior incident.
+    severity: WARNING
+    languages: [cpp, c]
+    # Semgrep's C++ string literals don't bind metavariables inside the
+    # quotes, so enumerate the common write modes explicitly.  Add new
+    # entries here if other modes show up in the codebase.
+    pattern-either:
+      - pattern: std::fopen($PATH, "w")
+      - pattern: std::fopen($PATH, "wb")
+      - pattern: std::fopen($PATH, "w+")
+      - pattern: std::fopen($PATH, "wb+")
+      - pattern: std::fopen($PATH, "a")
+      - pattern: std::fopen($PATH, "ab")
+      - pattern: std::fopen($PATH, "a+")
+      - pattern: std::fopen($PATH, "ab+")
+      - pattern: fopen($PATH, "w")
+      - pattern: fopen($PATH, "wb")
+      - pattern: fopen($PATH, "w+")
+      - pattern: fopen($PATH, "wb+")
+      - pattern: fopen($PATH, "a")
+      - pattern: fopen($PATH, "ab")
+      - pattern: fopen($PATH, "a+")
+      - pattern: fopen($PATH, "ab+")
+
+  # Note: the corresponding "getenv-into-fopen" path-injection check
+  # (the other CodeQL finding from PR #2947) is harder to express as a
+  # pure pattern rule in semgrep's C++ engine — it really needs taint-
+  # mode dataflow.  The mitigation pattern (validate caller-supplied
+  # path components for '/', '\\', "..") is documented at
+  # SVDSurfaceSerializer::default_cache_path and is the convention
+  # reviewers should look for; the file-permissions rule above catches
+  # the more frequently-recurring "write without 0600" pattern.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,18 +52,90 @@ bd close <id>         # Complete work
 
 ## Build & Test
 
-_Add your build and test commands here_
-
 ```bash
-# Example:
-# npm install
-# npm test
+# Configure (one-time)
+cmake -B build_catch -S . -DCOOLPROP_CATCH_MODULE=ON -DBUILD_TESTING=ON
+
+# Build the Catch2 runner
+cmake --build build_catch --target CatchTestRunner -j8
+
+# Run the test suite — see "Test filter discipline" below for tag scope
+./build_catch/CatchTestRunner [SBTL]            # SBTL adapter layer
+./build_catch/CatchTestRunner [SVDSBTL]         # backend-level tests
+./build_catch/CatchTestRunner "[!slow]"         # everything fast
 ```
 
-## Architecture Overview
+## Pre-Push Gate — REQUIRED before every `git push`
 
-_Add a brief overview of your project architecture_
+Run `./dev/ci/preflight.sh` before any `git push` (or install the
+pre-push hook once via `ln -s ../../dev/ci/pre-push.sample
+.git/hooks/pre-push`).  The script mirrors what CI runs:
+
+- clang-format dry-run vs `origin/master` (version pinned from `.pre-commit-config.yaml`)
+- build CatchTestRunner
+- Catch2 tests with auto-selected tag scope based on changed paths
+- cppcheck (`--enable=warning`) on changed files
+- clang-tidy diff-only (requires LLVM 18+ on PATH)
+- semgrep `p/security-audit` + local `.semgrep/` rules (uvx-resolved)
+
+If preflight passes, CI should pass with high probability.  See
+`dev/ci/README.md#preflightsh--local-pre-push-gate` for details.
+
+**`git commit --no-verify` only skips pre-commit hooks (clang-format,
+bd auto-export).  It does NOT skip the pre-push gate.**  If you must
+push without preflight, use `git push --no-verify` and document why.
 
 ## Conventions & Patterns
 
-_Add your project-specific conventions here_
+### Test filter discipline
+
+When changes touch files under `src/SBTL/`, `include/CoolProp/sbtl/`,
+`src/Backends/SVDSBTL/`, or `src/Region/`, run the **umbrella**
+`[SBTL]` tag locally — NOT just `[SVDSBTL]`.  The SBTL adapter layer
+(serializer round-trip, multi-fluid PH preset tests) lives under
+`[SBTL]` only; narrowing to `[SVDSBTL]` misses tests that bite in CI.
+`./dev/ci/preflight.sh` auto-selects the right umbrella tag from the
+changed-file paths; running preflight is the safe default.
+
+### Pre-PR adversarial review
+
+Before opening a PR (`gh pr create`), run the `superpowers:code-reviewer`
+subagent against the diff with the project conventions in this file as
+the standard.  It catches the same null-deref / edge-stencil / dead-arg
+class of findings that CodeRabbit flags post-push, at zero CI-cycle
+latency.  Example invocation:
+
+```
+Agent({
+  subagent_type: "superpowers:code-reviewer",
+  description: "Pre-PR review of <branch>",
+  prompt: "Adversarial review of the diff between <branch> and origin/master.
+           Check for: null-deref risk on shared_ptr inputs, FD stencils that
+           step outside their valid range, fopen without permission restriction,
+           tests that use bit-exact compare where ULP-class noise exists,
+           bot-comment-class issues that recur across the SVDSBTL PRs.
+           Report blocking findings only."
+})
+```
+
+### REFPROP is available locally
+
+REFPROP is installed on Ian's primary dev machine — `[refprop]`-tagged
+Catch2 tests *run* locally, they don't silently SKIP.  Don't narrow
+test filters assuming REFPROP-only tests are CI-gated; they're catchable
+locally and should be in the pre-push sweep.
+
+### `.beads/issues.jsonl` should not be in source PRs
+
+The `bd` pre-commit hook auto-exports + stages `.beads/issues.jsonl`.
+For source-code PRs, restore it explicitly before committing:
+
+```bash
+git restore --staged .beads/issues.jsonl
+git checkout .beads/issues.jsonl
+git commit --no-verify -m "..."   # --no-verify so the hook doesn't re-add it
+```
+
+The `--no-verify` here is intentional and scoped to ONE commit.  Always
+run `./dev/ci/preflight.sh` separately afterwards since `--no-verify`
+also skips clang-format checking.

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -10,10 +10,63 @@ If you're new, the **fast path** is:
 cmake -G Ninja -B build -S .                    # one-time configure
 pip install pre-commit && pre-commit install    # one-time hook setup
 cmake --build build --target format-check       # check formatting any time
+
+# Local pre-push gate (CoolProp-6r6) — mirrors what CI runs, catches
+# clang-format / cppcheck / semgrep / test failures before they hit a PR.
+# Install once by symlinking the hook (it's NOT auto-installed since
+# .git/hooks/ isn't tracked):
+ln -s ../../dev/ci/pre-push.sample .git/hooks/pre-push   # one-time
+./dev/ci/preflight.sh                                    # run any time
 ```
 
 Then commit normally — the pre-commit hook will block formatting violations
-on staged C/C++ files.
+on staged C/C++ files, and the pre-push hook will run the full preflight
+(clang-format + build + tests + cppcheck + clang-tidy + semgrep) before
+any `git push` succeeds.
+
+---
+
+## preflight.sh — local pre-push gate
+
+`dev/ci/preflight.sh` is a single script that runs the same checks CI
+runs against the diff between HEAD and the upstream branch.  Designed
+to be invoked from a pre-push git hook so a passing preflight strongly
+predicts a green CI.
+
+| Check | What it does | Skip flag |
+|---|---|---|
+| clang-format | uvx clang-format (version pinned from `.pre-commit-config.yaml`) dry-run on changed `.cpp` / `.h` files | `--skip=clang-format` |
+| build | cmake builds `CatchTestRunner` in `build_catch/` (auto-configures on first run) | `--skip=build` |
+| tests | Catch2 runner with auto-selected tag scope — `[SBTL]`, `[SVDSBTL]`, etc. picked from the changed paths | `--skip=tests` |
+| cppcheck | `--enable=warning` (real-bug-class) on changed files, `--language=c++ --std=c++17` to handle headers | `--skip=cppcheck` |
+| clang-tidy | diff-only via existing `run-clang-tidy-staged.sh`, requires `build_catch/compile_commands.json` | `--skip=clang-tidy` |
+| semgrep | `p/security-audit` + local `.semgrep/` rules (uvx-resolved, Python 3.12 pinned) | `--skip=semgrep` |
+
+Invocation:
+
+```bash
+./dev/ci/preflight.sh                          # check vs origin/master
+./dev/ci/preflight.sh --base=HEAD~1            # check vs an earlier ref
+./dev/ci/preflight.sh --skip=cppcheck,semgrep  # subset
+```
+
+Tools missing locally (`semgrep`, `clang-tidy`) are *gracefully skipped*
+rather than blocking — but the skip count is reported in the summary so
+agents see what's actually being checked.
+
+### Custom semgrep rules
+
+Rules under `.semgrep/` are loaded in addition to the public registry.
+Current local rules:
+
+- `cpp-fopen-without-restricted-permissions` — flags `std::fopen("...", "w*")`
+  patterns without an obvious permission restriction.  Suppress with
+  `// nosemgrep: cpp-fopen-without-restricted-permissions` on the line
+  when the surrounding code restricts via `std::filesystem::permissions`
+  after the close.  See PR #2947 for the originating incident.
+
+Add new rules as the CI surfaces new CodeQL-class findings that didn't
+get caught locally.
 
 ---
 

--- a/dev/ci/pre-push.sample
+++ b/dev/ci/pre-push.sample
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Sample pre-push git hook — invokes dev/ci/preflight.sh against
+# origin/master so a passing preflight predicts a green CI before
+# any `git push` succeeds.  Closes CoolProp-6r6.
+#
+# Install with:
+#
+#   ln -s ../../dev/ci/pre-push.sample .git/hooks/pre-push
+#
+# Bypass intentionally with `git push --no-verify` — agents and
+# contributors should only use that when the preflight is broken
+# (not when they want to skip a real failure).  `git commit
+# --no-verify` does NOT bypass this hook; only the explicit
+# `git push --no-verify` does.
+#
+# Override the base ref preflight compares against:
+#
+#   PREFLIGHT_BASE=upstream/main git push
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PREFLIGHT="$REPO_ROOT/dev/ci/preflight.sh"
+
+if [ ! -x "$PREFLIGHT" ]; then
+    echo "pre-push: $PREFLIGHT missing or not executable; skipping preflight" >&2
+    exit 0
+fi
+
+BASE="${PREFLIGHT_BASE:-origin/master}"
+exec "$PREFLIGHT" --base="$BASE"

--- a/dev/ci/preflight.sh
+++ b/dev/ci/preflight.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+#
+# preflight.sh — local pre-push quality gate for CoolProp.
+#
+# Runs the same checks CI runs on the diff between the current HEAD and
+# its upstream / origin/master, so a passing preflight predicts a green
+# CI.  Closes CoolProp-6r6.
+#
+# Designed to be the body of a pre-push git hook (which `git commit
+# --no-verify` does NOT bypass — only `git push --no-verify` does).
+# Invoke directly to spot-check at any time:
+#
+#   ./dev/ci/preflight.sh                # check against origin/master
+#   ./dev/ci/preflight.sh --base=HEAD~1  # check against an earlier ref
+#   ./dev/ci/preflight.sh --skip=cppcheck,clang-tidy   # subset
+#
+# Tools resolved at runtime:
+#   - clang-format     : uvx clang-format@<version-from-.pre-commit-config>
+#   - cppcheck         : system binary (graceful skip if missing)
+#   - clang-tidy       : delegates to dev/ci/run-clang-tidy-staged.sh
+#                         (which already graceful-skips when clang-tidy or
+#                          compile_commands.json isn't around)
+#   - semgrep          : uvx semgrep with p/cpp + p/security-audit rulesets
+#   - Catch2 tests     : ./build_catch/CatchTestRunner with tag scope
+#                        auto-selected from the changed paths
+#
+# Exit codes: 0 = all checks passed (or were skipped intentionally),
+# non-zero = at least one check failed.  When invoked as a pre-push hook
+# a non-zero exit will block the push; agents using `--no-verify` to skip
+# the hook are doing so deliberately and should run preflight separately.
+
+set -euo pipefail
+
+# ---------- arg parsing ----------------------------------------------
+
+BASE_REF="origin/master"
+SKIP_CHECKS=""
+for arg in "$@"; do
+    case "$arg" in
+        --base=*) BASE_REF="${arg#*=}" ;;
+        --skip=*) SKIP_CHECKS="${arg#*=}" ;;
+        --help|-h)
+            sed -n '2,30p' "$0"
+            exit 0
+            ;;
+        *)
+            echo "preflight: unknown arg '$arg' (use --base=<ref> or --skip=<csv>)" >&2
+            exit 2
+            ;;
+    esac
+done
+
+skip_check() {
+    [[ ",$SKIP_CHECKS," == *",$1,"* ]]
+}
+
+# ---------- locate repo + cd to root ---------------------------------
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# ---------- resolve diff set -----------------------------------------
+
+# Files changed on this branch vs base, restricted to extensions the
+# C-family checks care about.  Filters out deleted files (.cpp.cpp at
+# the same path would otherwise be checked even though it no longer
+# exists on disk).
+CHANGED_CPP="$(git diff --name-only --diff-filter=ACMR "$BASE_REF"...HEAD -- '*.cpp' '*.h' '*.hpp' '*.cc' '*.cxx' || true)"
+# Also pick up uncommitted changes in the working tree — preflight is
+# meant to gate pushes, but agents often run it mid-edit too.
+UNSTAGED_CPP="$(git diff --name-only --diff-filter=ACMR -- '*.cpp' '*.h' '*.hpp' '*.cc' '*.cxx' || true)"
+ALL_CPP="$(printf '%s\n%s\n' "$CHANGED_CPP" "$UNSTAGED_CPP" | sort -u | grep -v '^$' || true)"
+
+# All paths changed (any extension) — used for tag auto-selection.
+ALL_PATHS="$(git diff --name-only "$BASE_REF"...HEAD; git diff --name-only)"
+ALL_PATHS="$(printf '%s\n' "$ALL_PATHS" | sort -u | grep -v '^$' || true)"
+
+# ---------- pretty helpers -------------------------------------------
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+FAIL_NAMES=()
+
+step() {
+    printf '\n\033[1m== %s ==\033[0m\n' "$1"
+}
+
+ok() {
+    printf '\033[32m✓ %s\033[0m\n' "$1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail() {
+    printf '\033[31m✗ %s\033[0m\n' "$1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    FAIL_NAMES+=("$1")
+}
+
+skip() {
+    printf '\033[33m- %s (skipped: %s)\033[0m\n' "$1" "$2"
+    SKIP_COUNT=$((SKIP_COUNT + 1))
+}
+
+# ---------- check 1: clang-format ------------------------------------
+
+step "clang-format dry-run vs $BASE_REF"
+if skip_check clang-format; then
+    skip "clang-format" "--skip=clang-format"
+elif [ -z "$ALL_CPP" ]; then
+    skip "clang-format" "no C/C++ files in diff"
+else
+    # Read the pinned version from .pre-commit-config.yaml so CI + hook +
+    # preflight all use the same binary.
+    CF_VER="$(awk '/mirrors-clang-format/{f=1} f && /^[[:space:]]*rev:/{print $2; exit}' .pre-commit-config.yaml | tr -d 'v"' || true)"
+    if [ -z "$CF_VER" ]; then
+        CF_VER="18.1.8"
+    fi
+    # uvx caches the binary; first invocation downloads, subsequent are
+    # ~instant.  --dry-run --Werror returns non-zero on any reformatting.
+    if uvx clang-format@"$CF_VER" --dry-run --Werror $ALL_CPP 2>&1 | grep -q .; then
+        fail "clang-format (run: uvx clang-format@$CF_VER -i <files>)"
+    else
+        ok "clang-format ($CF_VER, $(printf '%s\n' "$ALL_CPP" | wc -l | tr -d ' ') file(s))"
+    fi
+fi
+
+# ---------- check 2: build CatchTestRunner ---------------------------
+
+step "build CatchTestRunner"
+if skip_check build; then
+    skip "build" "--skip=build"
+elif [ ! -d build_catch ]; then
+    # Auto-configure on first run.  Same flags as CI.
+    cmake -B build_catch -S . -DCOOLPROP_CATCH_MODULE=ON -DBUILD_TESTING=ON >/dev/null 2>&1 || {
+        fail "build (cmake configure failed; run cmake -B build_catch -S . -DCOOLPROP_CATCH_MODULE=ON -DBUILD_TESTING=ON manually)"
+    }
+fi
+if ! skip_check build && [ -d build_catch ]; then
+    if cmake --build build_catch --target CatchTestRunner -j8 2>&1 | tee /tmp/preflight-build.log | tail -5 | grep -qE "error:|FAILED"; then
+        fail "build (see /tmp/preflight-build.log)"
+    else
+        ok "build CatchTestRunner"
+    fi
+fi
+
+# ---------- check 3: Catch2 tests with auto-selected tag scope -------
+
+step "Catch2 tests"
+if skip_check tests; then
+    skip "tests" "--skip=tests"
+elif [ ! -x ./build_catch/CatchTestRunner ]; then
+    skip "tests" "CatchTestRunner not built"
+else
+    # Tag scope selection.  Path -> tag mapping mirrors how CI's broad
+    # workflow runs the full suite, but skips the expensive `[slow]`
+    # tests by default for fast local feedback.  Pass --slow to include.
+    TAG_FILTER=""
+    if printf '%s\n' "$ALL_PATHS" | grep -qE "^(src/SBTL/|include/CoolProp/sbtl/|src/Backends/SVDSBTL/|src/Region/|src/SVD/|include/CoolProp/region/|include/CoolProp/svd/)"; then
+        # SBTL/SVDSBTL surface area touched — run the umbrella tags.
+        # [SBTL] catches the adapter-layer tests (serializer round-trip,
+        # multi-fluid PH preset) that [SVDSBTL] alone misses.
+        TAG_FILTER="[SBTL],[SVDSBTL],[SVDComponents],[region],[!benchmark]"
+    elif printf '%s\n' "$ALL_PATHS" | grep -qE "^(src/Backends/Helmholtz/|src/Backends/REFPROP/)"; then
+        # HEOS / REFPROP path touched — broader sweep including transport
+        # and flash routines.
+        TAG_FILTER="[Helmholtz],[REFPROP],[!benchmark]"
+    else
+        # Default: run everything fast (skip the [slow] long tests).
+        TAG_FILTER="[!slow][!benchmark]"
+    fi
+    echo "  tag filter: $TAG_FILTER"
+    if ./build_catch/CatchTestRunner $TAG_FILTER 2>&1 | tee /tmp/preflight-tests.log | tail -3 | grep -qE "failed|Errors:"; then
+        fail "tests (see /tmp/preflight-tests.log)"
+    else
+        ok "tests ($TAG_FILTER)"
+    fi
+fi
+
+# ---------- check 4: cppcheck ----------------------------------------
+
+step "cppcheck"
+if skip_check cppcheck; then
+    skip "cppcheck" "--skip=cppcheck"
+elif ! command -v cppcheck >/dev/null 2>&1; then
+    skip "cppcheck" "cppcheck not on PATH (brew install cppcheck)"
+elif [ -z "$ALL_CPP" ]; then
+    skip "cppcheck" "no C/C++ files in diff"
+else
+    # --error-exitcode=1 surfaces any warning/style/error as a hard fail.
+    # Same rules CI's informational cppcheck job uses.
+    # --language=c++ + --std=c++17 force the C++ parser on .h files
+    # (cppcheck otherwise picks C and rejects `namespace`).  Matches
+    # the CI cppcheck workflow's invocation.
+    #
+    # --enable=warning (NOT style/performance/portability): style
+    # findings are opinion and the CI cppcheck workflow runs in
+    # "informational" mode so they don't block PRs.  Preflight mirrors
+    # that — warnings are real-bug-class (uninit vars, null deref,
+    # buffer overflow) and worth blocking.
+    if ! cppcheck --enable=warning --error-exitcode=1 --quiet --inline-suppr --language=c++ --std=c++17 \
+                  --suppress=missingIncludeSystem --suppress=unknownMacro $ALL_CPP 2>/tmp/preflight-cppcheck.log; then
+        tail -30 /tmp/preflight-cppcheck.log
+        fail "cppcheck (see /tmp/preflight-cppcheck.log)"
+    else
+        ok "cppcheck ($(printf '%s\n' "$ALL_CPP" | wc -l | tr -d ' ') file(s))"
+    fi
+fi
+
+# ---------- check 5: clang-tidy diff-only ----------------------------
+
+step "clang-tidy (diff-only)"
+if skip_check clang-tidy; then
+    skip "clang-tidy" "--skip=clang-tidy"
+elif ! command -v clang-tidy >/dev/null 2>&1; then
+    skip "clang-tidy" "clang-tidy not on PATH (install LLVM 18+)"
+elif [ -z "$ALL_CPP" ]; then
+    skip "clang-tidy" "no C/C++ files in diff"
+elif [ ! -f build_catch/compile_commands.json ]; then
+    skip "clang-tidy" "build_catch/compile_commands.json missing (cmake configure with -DCMAKE_EXPORT_COMPILE_COMMANDS=ON)"
+else
+    # Use the existing run-clang-tidy-staged.sh wrapper, point it at our
+    # build dir.  Restrict to .cpp (header analysis is implicit via TU
+    # include).
+    CPP_ONLY="$(printf '%s\n' "$ALL_CPP" | grep -E '\.(cpp|cc|cxx)$' || true)"
+    if [ -z "$CPP_ONLY" ]; then
+        skip "clang-tidy" "no .cpp files in diff (headers covered transitively)"
+    else
+        if ! COOLPROP_BUILD_DIR=build_catch ./dev/ci/run-clang-tidy-staged.sh $CPP_ONLY 2>/tmp/preflight-clang-tidy.log; then
+            tail -50 /tmp/preflight-clang-tidy.log
+            fail "clang-tidy (see /tmp/preflight-clang-tidy.log)"
+        else
+            ok "clang-tidy ($(printf '%s\n' "$CPP_ONLY" | wc -l | tr -d ' ') .cpp file(s))"
+        fi
+    fi
+fi
+
+# ---------- check 6: semgrep (CodeQL-class catches) ------------------
+
+step "semgrep (cpp + security-audit)"
+if skip_check semgrep; then
+    skip "semgrep" "--skip=semgrep"
+elif [ -z "$ALL_CPP" ]; then
+    skip "semgrep" "no C/C++ files in diff"
+else
+    # uvx-resolved semgrep with the p/security-audit ruleset.  Pin
+    # Python 3.12 so semgrep's opentelemetry dep doesn't trip on the
+    # missing pkg_resources in Python 3.9.  (p/cpp returns 404 on
+    # semgrep registry as of 2026; security-audit catches the major
+    # CodeQL-class issues that have slipped through previous PRs.
+    # Custom rules for any pattern not in p/security-audit can be
+    # added under .semgrep/ and configured here.)
+    SEMGREP_CONFIG="--config p/security-audit"
+    if [ -d ".semgrep" ]; then
+        SEMGREP_CONFIG="$SEMGREP_CONFIG --config .semgrep/"
+    fi
+    if ! uvx --python 3.12 semgrep $SEMGREP_CONFIG --error --quiet $ALL_CPP 2>/tmp/preflight-semgrep.log; then
+        tail -30 /tmp/preflight-semgrep.log
+        fail "semgrep (see /tmp/preflight-semgrep.log)"
+    else
+        ok "semgrep ($(printf '%s\n' "$ALL_CPP" | wc -l | tr -d ' ') file(s))"
+    fi
+fi
+
+# ---------- summary --------------------------------------------------
+
+echo
+echo "──────────────────────────────────────────────────────"
+echo "preflight summary: $PASS_COUNT passed / $FAIL_COUNT failed / $SKIP_COUNT skipped"
+echo "──────────────────────────────────────────────────────"
+
+if [ $FAIL_COUNT -gt 0 ]; then
+    printf '\033[31mFAIL:\033[0m\n'
+    for n in "${FAIL_NAMES[@]}"; do printf '  - %s\n' "$n"; done
+    exit 1
+fi
+exit 0

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -651,7 +651,10 @@ void SVDSBTLBackend::save_critpatch_cache_(const std::string& fluid_name, const 
         // re-runs the calibrator).
         return;
     }
-    std::FILE* f = std::fopen(path.string().c_str(), "wb");
+    // The std::filesystem::permissions() call below restricts the file
+    // to owner-only (0600); preflight's pattern-only semgrep rule
+    // can't see that mitigation across statements, so suppress.
+    std::FILE* f = std::fopen(path.string().c_str(), "wb");  // nosemgrep: cpp-fopen-without-restricted-permissions
     if (!f) {
         return;
     }


### PR DESCRIPTION
## Summary

Local-only quality gate that mirrors the CI checks against the diff between HEAD and `origin/master`. Designed to be the body of a pre-push git hook so a passing preflight strongly predicts a green CI — eliminating the push → CI-fails → fix loop that's been recurring on the SVDSBTL PRs this week.

Closes `CoolProp-6r6`.

## What runs

| Check | Notes |
|---|---|
| **clang-format** | Version pinned from `.pre-commit-config.yaml` (currently 18.1.8) via `uvx`. Catches the long-line wrap that slipped PR #2947 past `--no-verify`. |
| **build CatchTestRunner** | Auto-configures `build_catch/` on first run; catches missing source files / link errors after branch switches with stale cmake config. |
| **Catch2 tests, auto-selected tag scope** | Touching `src/SBTL/` or `include/CoolProp/sbtl/` auto-selects `[SBTL]` umbrella — PR #2951's three "unknown BoundaryCurve subclass" failures live under `[SBTL]` (not `[SVDSBTL]`) and would have been caught here. |
| **cppcheck** | `--enable=warning` + `--language=c++ --std=c++17`; real-bug class only, style excluded as informational (matches CI). |
| **clang-tidy diff-only** | Uses existing `run-clang-tidy-staged.sh` wrapper; graceful-skip when LLVM 18+ isn't on PATH. |
| **semgrep** | `p/security-audit` + local `.semgrep/` rules; uvx-resolved with `--python 3.12` pin. Custom rule `cpp-fopen-without-restricted-permissions` catches the pattern that flagged PR #2947 in CodeQL. |

## Wiring

- `dev/ci/pre-push.sample` is the canonical pre-push hook. Install once:
  ```bash
  ln -s ../../dev/ci/pre-push.sample .git/hooks/pre-push
  ```
- `git commit --no-verify` skips pre-commit hooks (bd auto-export, clang-format) but **does NOT** skip pre-push. `git push --no-verify` is the explicit bypass.
- **Local-only** — does not add anything under `.github/workflows/`. Per the discussion in this PR's parent thread, the goal is to surface failures before they hit CI, not to add another CI job.

## Custom semgrep rule

`.semgrep/cpp-file-permissions.yml` flags `std::fopen(..., "w*" | "a*")` patterns and recommends the `std::filesystem::permissions(path, owner_read | owner_write, replace)` mitigation. Suppress at known-mitigated sites with a trailing `// nosemgrep: cpp-fopen-without-restricted-permissions` (one such suppression added at the existing critpatch sidecar fopen-wb site).

## CLAUDE.md updates

Added six sections that codify the conventions which kept slipping past the gate this week:

- Build & Test commands
- Pre-Push Gate (required before every push)
- Test filter discipline ([SBTL] umbrella when touching adapter-layer code)
- Pre-PR adversarial review via `superpowers:code-reviewer` subagent (catches the CodeRabbit-class findings at zero CI-cycle latency)
- REFPROP is available locally (don't narrow filters)
- `.beads/issues.jsonl` handling for source-code PRs

## Test plan

- [x] Self-test: `./dev/ci/preflight.sh --skip=build,tests,clang-tidy` on this branch → 3 passed / 0 failed / 3 skipped
- [x] False-positive verification: semgrep rule fires on a stub `std::fopen("...", "wb")`, doesn't fire after adding the `// nosemgrep:` suppression
- [ ] Full preflight run with `tests` included is multi-minute; gated by build cache state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build, test, and project convention documentation with detailed workflow instructions and CMake-based build steps.
  * Added contributor guidance for local pre-push validation workflow and custom security checks.

* **Chores**
  * Added automated pre-push quality gate checks including code formatting, testing, static analysis, and security scanning.
  * Introduced new security linting rule for detecting insecure file permission handling in C/C++ code.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2954?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->