### PR TITLE
feat(ci): preflight gates on signal-filtered clang-tidy + code-reviewer banner (CoolProp-y51)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,24 +97,43 @@ When changes touch files under `src/SBTL/`, `include/CoolProp/sbtl/`,
 `./dev/ci/preflight.sh` auto-selects the right umbrella tag from the
 changed-file paths; running preflight is the safe default.
 
-### Pre-PR adversarial review
+### Pre-PR adversarial review — MANDATORY
 
-Before opening a PR (`gh pr create`), run the `superpowers:code-reviewer`
-subagent against the diff with the project conventions in this file as
-the standard.  It catches the same null-deref / edge-stencil / dead-arg
-class of findings that CodeRabbit flags post-push, at zero CI-cycle
-latency.  Example invocation:
+Before any `gh pr create` invocation, **you MUST** invoke the
+`superpowers:code-reviewer` subagent against the diff.  The
+pre-push shell hook can't mechanically gate this (subagents are a
+Claude Code construct, not a CLI), so the gate is procedural — but it
+is NOT optional.  Every recent PR where CodeRabbit found a blocking
+issue (null-deref, FD-out-of-range, noexcept-on-throwing, NaN-
+absorbed-by-std::max) would have been caught by code-reviewer first
+at zero CI latency.  Skip this step and the same class of findings
+keeps recurring.
+
+**Pre-`gh pr create` checklist (MUST complete in order):**
+
+1. `./dev/ci/preflight.sh` passes (or you can explain each `--skip`).
+2. `Agent({subagent_type: "superpowers:code-reviewer", ...})` returns
+   with no blocking findings, OR you've addressed/justified each one.
+3. `git push` (the pre-push hook re-runs preflight as a safety net).
+4. THEN `gh pr create`.
+
+Canonical code-reviewer invocation:
 
 ```
 Agent({
   subagent_type: "superpowers:code-reviewer",
   description: "Pre-PR review of <branch>",
   prompt: "Adversarial review of the diff between <branch> and origin/master.
-           Check for: null-deref risk on shared_ptr inputs, FD stencils that
-           step outside their valid range, fopen without permission restriction,
-           tests that use bit-exact compare where ULP-class noise exists,
-           bot-comment-class issues that recur across the SVDSBTL PRs.
-           Report blocking findings only."
+           Project conventions are in CLAUDE.md.  Check for:
+             - null-deref risk on shared_ptr inputs
+             - noexcept on functions that can throw (resize/allocate/etc.)
+             - FD stencils that step outside their valid range
+             - non-finite values silently absorbed by std::max/std::min
+             - bit-exact compare where ULP-class noise exists
+             - fopen without permission restriction
+             - preconditions checked in the factory but not the public constructor
+             - bot-comment-class issues that recur across recent PRs
+           Report blocking findings only; skip style nits."
 })
 ```
 

--- a/dev/ci/preflight.sh
+++ b/dev/ci/preflight.sh
@@ -209,7 +209,7 @@ fi
 
 # ---------- check 5: clang-tidy diff-only ----------------------------
 
-step "clang-tidy (diff-only, informational)"
+step "clang-tidy (diff-only, signal-filtered)"
 if skip_check clang-tidy; then
     skip "clang-tidy" "--skip=clang-tidy"
 elif [ -z "$ALL_CPP" ]; then
@@ -217,33 +217,54 @@ elif [ -z "$ALL_CPP" ]; then
 elif [ ! -f build_catch/compile_commands.json ]; then
     skip "clang-tidy" "build_catch/compile_commands.json missing (cmake configure with -DCMAKE_EXPORT_COMPILE_COMMANDS=ON)"
 else
-    # Informational ONLY — mirrors CI's clang-tidy workflow which is
-    # informational by design (see .github/workflows/dev_checks.yml:
-    # `continue-on-error: true`) because .clang-tidy's
-    # WarningsAsErrors='*' triggers high-volume noise from Catch2 macros
-    # and include-cleaner that CI explicitly elected not to gate on
-    # (see issue #2926).  Preflight reports findings to stderr so I can
-    # see them in early triage but does not fail the gate.
+    # Noise filter: clang-tidy checks that CI explicitly elected NOT to
+    # gate on, per issue #2926's "Filtered as noise" section.  These
+    # dominate the raw output (Catch2 macro expansions, REFPROP C-API
+    # surface, identifier-reserved patterns from numerical-derivative
+    # naming) without delivering signal worth blocking on.  Findings
+    # matching ANY of these check names are subtracted from the gating
+    # count; preflight passes if the remaining (signal) count is zero.
     #
-    # Prefer clang-tidy-diff.py if it's already on PATH (Linux CI
-    # installs it via clang-tools-extra) — it limits analysis to lines
-    # actually touched by the PR rather than full TUs, matching CI's
-    # exact scope.  Fall back to the staged-wrapper which runs on whole
-    # .cpp files (more findings but easier to set up).
+    # Sourced from #2926 — keep in sync if that triage report updates.
+    # New noise classes that recur across PRs without yielding action
+    # belong here too.
+    CLANG_TIDY_NOISE_CHECKS=(
+        cppcoreguidelines-avoid-do-while
+        cert-err58-cpp
+        modernize-avoid-c-arrays
+        cppcoreguidelines-init-variables
+        cppcoreguidelines-pro-bounds-pointer-arithmetic
+        cert-dcl37-c
+        cert-dcl51-cpp
+        bugprone-reserved-identifier
+        cert-msc32-c
+        cert-msc51-cpp
+        clang-analyzer-optin.core.EnumCastOutOfRange
+    )
+    NOISE_PATTERN="$(IFS='|'; echo "${CLANG_TIDY_NOISE_CHECKS[*]}")"
+
     CPP_ONLY="$(printf '%s\n' "$ALL_CPP" | grep -E '\.(cpp|cc|cxx)$' || true)"
     if [ -z "$CPP_ONLY" ]; then
         skip "clang-tidy" "no .cpp files in diff (headers covered transitively)"
     else
-        if ! COOLPROP_BUILD_DIR=build_catch ./dev/ci/run-clang-tidy-staged.sh $CPP_ONLY >/tmp/preflight-clang-tidy.log 2>&1; then
-            # Don't fail — just report finding count for triage.
-            FINDING_COUNT="$(grep -cE 'warning: |error: ' /tmp/preflight-clang-tidy.log 2>/dev/null || echo 0)"
-            printf '\033[33m- clang-tidy: %s findings (informational; see /tmp/preflight-clang-tidy.log)\033[0m\n' "$FINDING_COUNT"
-            SKIP_COUNT=$((SKIP_COUNT + 1))
+        COOLPROP_BUILD_DIR=build_catch ./dev/ci/run-clang-tidy-staged.sh $CPP_ONLY >/tmp/preflight-clang-tidy.log 2>&1 || true
+        if grep -q "^warning:.*skipping" /tmp/preflight-clang-tidy.log; then
+            skip "clang-tidy" "$(grep -m1 '^warning:' /tmp/preflight-clang-tidy.log | sed 's/^warning: //')"
         else
-            if grep -q "^warning:.*skipping" /tmp/preflight-clang-tidy.log; then
-                skip "clang-tidy" "$(grep -m1 '^warning:' /tmp/preflight-clang-tidy.log | sed 's/^warning: //')"
+            RAW="$(grep -cE 'warning: |error: ' /tmp/preflight-clang-tidy.log 2>/dev/null | head -1 || echo 0)"
+            # Each finding line ends with `[<check-name>,-warnings-as-errors]`
+            # or `[<check-name>]`.  Match the bracketed check name and
+            # exclude any line whose name is in NOISE_PATTERN.
+            SIGNAL_LINES="$(grep -E 'warning: |error: ' /tmp/preflight-clang-tidy.log 2>/dev/null \
+                | grep -vE "\\[($NOISE_PATTERN)(,|\\])" || true)"
+            SIGNAL_COUNT="$(printf '%s\n' "$SIGNAL_LINES" | grep -c . || echo 0)"
+            if [ "$SIGNAL_COUNT" -gt 0 ]; then
+                printf '\n--- signal findings (noise-filtered, see #2926) ---\n'
+                printf '%s\n' "$SIGNAL_LINES" | head -30
+                printf '%s\n' "$SIGNAL_LINES" > /tmp/preflight-clang-tidy-signal.log
+                fail "clang-tidy ($SIGNAL_COUNT signal / $RAW raw findings; see /tmp/preflight-clang-tidy-signal.log)"
             else
-                ok "clang-tidy ($(printf '%s\n' "$CPP_ONLY" | wc -l | tr -d ' ') .cpp file(s); 0 findings)"
+                ok "clang-tidy ($(printf '%s\n' "$CPP_ONLY" | wc -l | tr -d ' ') .cpp file(s); 0 signal / $RAW raw findings)"
             fi
         fi
     fi
@@ -288,4 +309,23 @@ if [ $FAIL_COUNT -gt 0 ]; then
     for n in "${FAIL_NAMES[@]}"; do printf '  - %s\n' "$n"; done
     exit 1
 fi
+
+# ---------- pre-PR code-reviewer reminder ----------------------------
+#
+# Pre-push shell hooks can't mechanically invoke a Claude Code subagent
+# (subagents are an in-conversation construct, not a CLI).  Print a
+# loud reminder so the next step before `gh pr create` is clear.  See
+# CLAUDE.md "Pre-PR adversarial review" for the canonical invocation.
+#
+# This banner ALWAYS prints when preflight passes — agents and humans
+# both see it.  Skip the banner if --skip=banner is passed (useful for
+# successive iteration runs where the reviewer was already run).
+if ! skip_check banner; then
+    printf '\n\033[1;36m┌─────────────────────────────────────────────────────────┐\033[0m\n'
+    printf '\033[1;36m│  REMINDER: before `gh pr create`, run code-reviewer.   │\033[0m\n'
+    printf '\033[1;36m│  See CLAUDE.md "Pre-PR adversarial review" for the     │\033[0m\n'
+    printf '\033[1;36m│  exact Agent({subagent_type: ...}) invocation.         │\033[0m\n'
+    printf '\033[1;36m└─────────────────────────────────────────────────────────┘\033[0m\n'
+fi
+
 exit 0


### PR DESCRIPTION
## Summary

Two related changes to close the recurring "CodeRabbit caught something preflight didn't" gap from the recent SVDSBTL PRs.

Closes `CoolProp-y51`.

## 1. clang-tidy noise filter + gating

Previously preflight reported clang-tidy findings as informational ("85 findings; see log") and never failed. Issue #2926 documents that ~2000 of those raw findings are noise classes (Catch2 macro expansions, REFPROP C-API surface, identifier-reserved patterns from numerical-derivative variable names) that CI explicitly elected NOT to gate on. Filter those out via a `CLANG_TIDY_NOISE_CHECKS` list sourced from #2926, then **gate** on the remainder.

On PR #2952 the 85 raw findings would reduce to ~5 actionable; the gate would block on real issues like the `noexcept`-on-throwing-function finding CodeRabbit caught (was in the unfiltered set but invisible amid the do-while noise).

Per-finding line format the filter targets:

```
/path/file.cpp:123:5: error: ... [<check-name>,-warnings-as-errors]
```

The trailing bracketed check name is matched; lines whose name is in the noise list are subtracted from the signal count. Keep the list in sync with #2926's "Filtered as noise" section.

## 2. Pre-PR code-reviewer banner + MANDATORY CLAUDE.md rule

The pre-push shell hook can't invoke a Claude Code subagent (subagents are an in-conversation construct, not a CLI), so the mandatory adversarial review has to be procedural. Add a loud banner at the end of every successful preflight run reminding the user to invoke `superpowers:code-reviewer` before `gh pr create`.

`CLAUDE.md` "Pre-PR adversarial review" section gets strengthened to **MANDATORY** with an explicit numbered checklist (preflight → reviewer → push → `gh pr create`) and a canonical invocation template that encodes the recurring finding patterns from this week's PRs (noexcept-on-throwing, NaN-absorbed-by-`std::max`, FD stencils stepping outside valid range, etc.).

## Test plan

- [x] Self-preflight on this branch (only shell + .md edits, no C++ to gate): clean pass with banner shown.
- [ ] Re-run on a hypothetical signal-bearing branch to confirm gating triggers; will validate naturally on the next SVDSBTL PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Strengthened pre-PR review procedure with mandatory checklist and stricter code-review requirements.

* **New Features**
  * Clang-tidy preflight check now gates pushes based on filtered findings, blocking integration of code with unresolved issues.
  * Added `--skip=banner` flag to suppress pre-PR code-reviewer reminder in preflight script.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2956?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->