### PR TITLE
docs(if97-conformance): dense-knot R1/R3 isotherm + PDF emission + download link

### DIFF
--- a/Web/scripts/fluid_properties.IF97Conformance.py
+++ b/Web/scripts/fluid_properties.IF97Conformance.py
@@ -517,7 +517,11 @@ def write_failure_figures(backend, samples_per_region, out_dir):
                 pass
 
     # Isotherm overlays — walk fixed T sweeping log p, record (h, p).
-    def isotherm(T_K, p_lo_Pa, p_hi_Pa, n=64):
+    # Use dense knots (n=2000) so the sub-critical R1/R3 isotherm at
+    # T=623.15 K visually renders the near-flat plateau through the
+    # two-phase region (where p ≈ p_sat) without a visible vertical
+    # jump artifact at the dome crossing.
+    def isotherm(T_K, p_lo_Pa, p_hi_Pa, n=2000):
         hs, ps = [], []
         for i in range(n):
             p = _math.exp(_math.log(p_lo_Pa) + (i / (n - 1)) * (_math.log(p_hi_Pa) - _math.log(p_lo_Pa)))
@@ -685,6 +689,11 @@ def write_failure_figures(backend, samples_per_region, out_dir):
     fig.tight_layout(rect=[0, 0.05, 1, 0.94])
     out_path = os.path.join(out_dir, 'IF97_conformance_fails_{0}.png'.format(slug))
     fig.savefig(out_path, dpi=110)
+    # Vector PDF alongside the PNG — same figure, no second build.
+    # Useful for embedding in slides / preprints where the raster
+    # PNG would pixelate at print resolution.
+    pdf_path = os.path.join(out_dir, 'IF97_conformance_fails_{0}.pdf'.format(slug))
+    fig.savefig(pdf_path)
     plt.close(fig)
     return {'all': os.path.basename(out_path)}
 
@@ -981,6 +990,16 @@ def render_rst(results_per_backend, counts_per_backend, timings, figure_paths_pe
                 lines.append('   :width: 95%')
                 lines.append('')
                 lines.append('   {0} — IAPWS G13-15 budget violations across the full IF97 envelope.'.format(backend))
+                lines.append('')
+                # Sphinx :download: role copies the file into _downloads/
+                # at build time and renders a hyperlink in the HTML.
+                # PDF is the same figure as the PNG but vector, useful
+                # for slides / preprints where the scatter markers
+                # would pixelate at print resolution.  ~10 MB so we
+                # don't inline it; the link surfaces it for readers who
+                # want it without bloating the HTML page.
+                pdf_basename = combined.rsplit('.', 1)[0] + '.pdf'
+                lines.append('   :download:`Download the same figure as a vector PDF <{0}>` (~14 MB; useful for print / slides).'.format(pdf_basename))
                 lines.append('')
             else:
                 # Backwards-compat for any legacy per-region keys (a


### PR DESCRIPTION
## Summary

Three small docs-tooling improvements to the IF97 conformance figure generator (`Web/scripts/fluid_properties.IF97Conformance.py`):

### 1. Dense isotherm overlay (n=64 → n=2000)

The R1/R3 isotherm at T=623.15 K is sub-critical, so the (h, p) curve has a horizontal plateau at p ≈ p_sat through the two-phase dome (from h_sat,L to h_sat,V). A 64-point log-p sweep jumps OVER that plateau because p_sat sits between two knots — the rendered line shows a vertical discontinuity instead of the canonical inverted-U shape.

At n=2000 the log-p knot spacing near p_sat is dense enough that the plateau renders visually flat. The super-critical R2/R5 isotherm at T=1073.15 K has no dome and renders identically at either n.

### 2. PDF alongside the PNG

The fail-map figure ships ~250 scatter markers per panel × 6 panels. As a 110-DPI PNG it pixelates in slides / preprints; as a vector PDF (matplotlib's default backend embeds each marker as a path) it stays crisp at any size. `savefig` is called twice on the same figure — no second render.

### 3. Sphinx `:download:` link to the PDF in the rendered docs

The PDF is ~14 MB, too big to inline, but the `.. figure::` caption now gets a one-line `:download:` anchor underneath so curious readers can grab the vector version without bloating the HTML page. Sphinx copies the PDF into `_downloads/` at build time; the link works because the docs build invokes this script before `sphinx-build` (per the file's top-of-file note).

## Test plan

- [x] Run the script locally: produces both `IF97_conformance_fails_SVDSBTL_IF97__Water.{png,pdf}` in `Web/fluid_properties/`. PNG visually shows the 623.15 K isotherm flat through the dome.
- [x] `:download:` directive correctly renders in the generated `.rst.in`.
- [x] Preflight (clang-format / build / tests / cppcheck / clang-tidy / semgrep) — 2 passed / 0 failed / 4 skipped (no C++ files in diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PDF versions of failure figures for download alongside existing PNG files.
  * Added Sphinx download links in documentation for PDF access.

* **Improvements**
  * Enhanced visual quality of isothermal overlays in IF97 conformance charts through increased sampling density.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2958?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->