### PR TITLE
docs(svdsbtl): correct 19 doc bugs uncovered by audit (CoolProp-fhp)

### DIFF
--- a/Web/coolprop/HighLevelAPI.rst
+++ b/Web/coolprop/HighLevelAPI.rst
@@ -445,6 +445,14 @@ If you have the `REFPROP library <http://www.nist.gov/srd/nist23.cfm>`_ installe
     # Using properties from REFPROP to get R410A density
     In [2]: CP.PropsSI('D','T',300,'P',101325,'REFPROP::R32[0.697615]&R125[0.302385]')
 
+The same ``backend::fluid`` selector also routes to other backends:
+``BICUBIC&HEOS::Water``, ``TTSE&HEOS::Water``, and the SVD-compressed
+tabular backend ``SVDSBTL&IF97::Water`` /
+``SVDSBTL&HEOS::<Fluid>`` (sub-microsecond per-probe; see the
+:doc:`SVDSBTL page </coolprop/SVDSBTL>` for the routing gate — SVDSBTL
+is opted *out* of ``PropsSI`` by default and must be enabled via
+``ALLOW_SVDSBTL_IN_PROPSSI``).
+
 Adding Fluids
 -------------
 

--- a/Web/coolprop/HighLevelAPI.rst
+++ b/Web/coolprop/HighLevelAPI.rst
@@ -44,7 +44,7 @@ More information:
 
 All :ref:`the wrappers <wrappers>` wrap this function in exactly the same way.
 
-For pure and pseudo-pure fluids, two state variables are required to fix the state.  The equations of state are based on :math:`T` and :math:`\rho` as state variables, so :math:`T, \rho` will always be the fastest inputs.  :math:`P,T` will be a bit slower (3-10 times), followed by input pairs where neither :math:`T` nor :math:`\rho` are specified, like :math:`P,H`; these will be much slower.  If you are only interested in Water properties, you can look into using the :ref:`IF97 <IF97>` (industrial formulation) backend.
+For pure and pseudo-pure fluids, two state variables are required to fix the state.  The equations of state are based on :math:`T` and :math:`\rho` as state variables, so :math:`T, \rho` will always be the fastest inputs.  :math:`P,T` will be a bit slower (3-10 times), followed by input pairs where neither :math:`T` nor :math:`\rho` are specified, like :math:`P,H`; these will be much slower.  If speed is an issue, you can look into table-based interpolation methods using :ref:`TTSE or bicubic interpolation <Tabular_Interpolation>`; or if you are only interested in Water properties, you can look into using the :ref:`IF97 <IF97>` (industrial formulation) backend.
 
 Vapor, Liquid, and Saturation States
 ------------------------------------

--- a/Web/coolprop/HighLevelAPI.rst
+++ b/Web/coolprop/HighLevelAPI.rst
@@ -44,7 +44,7 @@ More information:
 
 All :ref:`the wrappers <wrappers>` wrap this function in exactly the same way.
 
-For pure and pseudo-pure fluids, two state variables are required to fix the state.  The equations of state are based on :math:`T` and :math:`\rho` as state variables, so :math:`T, \rho` will always be the fastest inputs.  :math:`P,T` will be a bit slower (3-10 times), followed by input pairs where neither :math:`T` nor :math:`\rho` are specified, like :math:`P,H`; these will be much slower.  If speed is an issue, you can look into table-based interpolation methods using :ref:`TTSE or bicubic interpolation <Tabular_Interpolation>`; or if you are only interested in Water properties, you can look into using the :ref:`IF97 <IF97>` (industrial formulation) backend.
+For pure and pseudo-pure fluids, two state variables are required to fix the state.  The equations of state are based on :math:`T` and :math:`\rho` as state variables, so :math:`T, \rho` will always be the fastest inputs.  :math:`P,T` will be a bit slower (3-10 times), followed by input pairs where neither :math:`T` nor :math:`\rho` are specified, like :math:`P,H`; these will be much slower.  If you are only interested in Water properties, you can look into using the :ref:`IF97 <IF97>` (industrial formulation) backend.
 
 Vapor, Liquid, and Saturation States
 ------------------------------------
@@ -444,14 +444,6 @@ If you have the `REFPROP library <http://www.nist.gov/srd/nist23.cfm>`_ installe
 
     # Using properties from REFPROP to get R410A density
     In [2]: CP.PropsSI('D','T',300,'P',101325,'REFPROP::R32[0.697615]&R125[0.302385]')
-
-The same ``backend::fluid`` selector also routes to other backends:
-``BICUBIC&HEOS::Water``, ``TTSE&HEOS::Water``, and the SVD-compressed
-tabular backend ``SVDSBTL&IF97::Water`` /
-``SVDSBTL&HEOS::<Fluid>`` (sub-microsecond per-probe; see the
-:doc:`SVDSBTL page </coolprop/SVDSBTL>` for the routing gate — SVDSBTL
-is opted *out* of ``PropsSI`` by default and must be enabled via
-``ALLOW_SVDSBTL_IN_PROPSSI``).
 
 Adding Fluids
 -------------

--- a/Web/coolprop/HighLevelAPI.rst
+++ b/Web/coolprop/HighLevelAPI.rst
@@ -44,7 +44,7 @@ More information:
 
 All :ref:`the wrappers <wrappers>` wrap this function in exactly the same way.
 
-For pure and pseudo-pure fluids, two state variables are required to fix the state.  The equations of state are based on :math:`T` and :math:`\rho` as state variables, so :math:`T, \rho` will always be the fastest inputs.  :math:`P,T` will be a bit slower (3-10 times), followed by input pairs where neither :math:`T` nor :math:`\rho` are specified, like :math:`P,H`; these will be much slower.  If speed is an issue, you can look into table-based interpolation methods using :ref:`TTSE or bicubic interpolation <Tabular_Interpolation>`; or if you are only interested in Water properties, you can look into using the :ref:`IF97 <IF97>` (industrial formulation) backend.
+For pure and pseudo-pure fluids, two state variables are required to fix the state.  The equations of state are based on :math:`T` and :math:`\rho` as state variables, so :math:`T, \rho` will always be the fastest inputs.  :math:`P,T` will be a bit slower (3-10 times), followed by input pairs where neither :math:`T` nor :math:`\rho` are specified, like :math:`P,H`; these will be much slower.  If speed is an issue, you can look into the :ref:`SVDSBTL <SVDSBTL>` SVD-compressed tabular backend; or if you are only interested in Water properties, you can look into using the :ref:`IF97 <IF97>` (industrial formulation) backend.
 
 Vapor, Liquid, and Saturation States
 ------------------------------------

--- a/Web/coolprop/LowLevelAPI.rst
+++ b/Web/coolprop/LowLevelAPI.rst
@@ -14,7 +14,7 @@ In order to make most effective use of the low-level interface, you should insta
 
 .. warning::
 
-    While the warning about the computational overhead when generating AbstractState instances is more a recommendation, it is *required* that you allocate as few AbstractState instances as possible when using the :ref:`tabular backends (TTSE & Bicubic) <tabular_interpolation>`.
+    While the warning about the computational overhead when generating AbstractState instances is more a recommendation, it is *required* that you allocate as few AbstractState instances as possible when using the :ref:`tabular backends (TTSE & Bicubic) <tabular_interpolation>` and the :doc:`SVD-compressed tabular backend (SVDSBTL) </coolprop/SVDSBTL>` (~80-140 ms table-load per construction).
 
 .. warning::
 

--- a/Web/coolprop/REFPROP.rst
+++ b/Web/coolprop/REFPROP.rst
@@ -8,7 +8,11 @@ REFPROP Interface
 
 The thermophysical property library REFPROP developed by researchers at the National Institute of Standards and Technology in Boulder, Colorado is the gold standard in thermophysical properties.  It is mature and stable, and is currently the library most used in industry and for scientific applications.
 
-CoolProp allows for full interaction with the REFPROP library, while using the nicely abstracted C++ interface for all target languages that CoolProp supports. 
+CoolProp allows for full interaction with the REFPROP library, while using the nicely abstracted C++ interface for all target languages that CoolProp supports.
+
+.. seealso::
+
+    For throughput-bound workloads against the REFPROP backend, the :doc:`SVDSBTL </coolprop/SVDSBTL>` SVD-compressed tabular backend can sample REFPROP once at table-build time and serve subsequent ``(p, h)`` / ``(p, T)`` queries at sub-microsecond per-probe in the single-phase envelope — ``SVDSBTL&REFPROP::<Fluid>``.  Matches REFPROP truth on the sat curves within REFPROP's own numerical-noise floor; falls through to REFPROP's PQ flash for two-phase endpoints.
 
 The core difference between using CoolProp's internal routines and REFPROP's routines is that you have to change the backend from ``HEOS`` to ``REFPROP``.  In the high-level interface this is demonstrated as:
 

--- a/Web/coolprop/SVDSBTL.rst
+++ b/Web/coolprop/SVDSBTL.rst
@@ -43,11 +43,14 @@ bicubic table with three layered components that address both:
    further splits for IF97 (R1/R3, R2/R3 boundary curves).  Each
    region's secondary axis is normalised to :math:`[0, 1]` via two
    analytic boundary curves — on subcritical regions one curve is the
-   saturation dome and the other is an isotherm (low-T floor for the
-   liquid region, high-T ceiling for the vapor region); on
-   supercritical regions both curves are isotherms.  Lookups first
-   AABB-test against region bounding boxes (cheap), then evaluate the
-   precise boundary curves on the candidate.
+   saturation dome and the other is an EOS-domain floor/ceiling (for
+   the liquid region the floor walks up over the **melting curve**
+   where it binds at high p, falling back to the low-T EOS isotherm
+   where it doesn't; for the vapor region the ceiling is the high-T
+   isotherm at the EOS validity limit); on supercritical regions both
+   curves are isotherms.  Lookups first AABB-test against region
+   bounding boxes (cheap), then evaluate the precise boundary curves
+   on the candidate.
 
 2. **Per-region SVD.**  Inside each normalised region, every tabulated
    property (:math:`\rho, h, s, u, w, \eta, \lambda`) is represented
@@ -180,12 +183,18 @@ the backend.
 
        In [1]: %timeit loop()
 
-   Native C++ ``update + rhomass + T`` is ~1 µs/iter (dominated by
-   ``update()``; the cached accessors are <10 ns/pair).  The Cython
-   wrapper adds ~0.3 µs across the three FFI crossings, totaling
-   ~1.3 µs/iter from Python — still ~20× faster than HEOS's
-   :math:`(p, h)` flash on the same loop.  This is what most user
-   code should look like.
+   Native C++ ``update + rhomass + T`` is region-dependent: well
+   under 200 ns/call in single-phase (subcooled liquid, superheated
+   vapor, supercritical), and ~1-1.5 µs/call in two-phase / sat-line
+   regions where the SuperAncillary or source-backend PQ flash runs
+   per probe.  The cached accessors are <10 ns/pair on top.  The
+   Cython wrapper adds ~0.3 µs across the three FFI crossings — so
+   even a Python loop sweeping the saturation dome stays ~20× faster
+   than the same loop on HEOS.  This path is fine for ad-hoc / setup
+   code; for throughput-sensitive workloads, prefer
+   :ref:`fast_evaluate <SVDSBTL-regimes>` (next regime) which strips
+   the per-probe wrapper marshalling and amortises locate + basis
+   setup across multiple outputs.
 
 2. **fast_evaluate (batched, no instance mutation).**
    ``AbstractState.fast_evaluate(input_pair, val1[], val2[],
@@ -489,10 +498,14 @@ Accuracy envelope
 * **SVDSBTL&REFPROP::<Fluid>**: matches REFPROP truth on tested
   probes within REFPROP's own numerical-noise floor on the sat
   curves; same single-phase envelope as HEOS-source.  Two-phase
-  endpoints currently fall through to REFPROP's PQ flash (~3-5 µs
-  per probe); ``CoolProp-077`` will replace that with an on-disk
-  saturation-surrogate spline to remove the cross-DLL hop and the
-  REFPROP-thread-safety constraint that fallback inherits.
+  endpoints currently fall through to REFPROP's PQ flash; the flash
+  itself is ~1.5 µs/call native, with the SVDSBTL fallback wrapper
+  (lever rule + endpoint conversions) bringing the user-visible
+  per-probe cost to ~3-4 µs.  ``CoolProp-077`` will replace the
+  REFPROP flash with an on-disk saturation-surrogate spline to remove
+  both the cross-DLL hop and the REFPROP-thread-safety constraint
+  that fallback inherits, and reduce the wrapped cost into the
+  single-µs band.
 
 Deviation plot
 ==============

--- a/Web/coolprop/SVDSBTL.rst
+++ b/Web/coolprop/SVDSBTL.rst
@@ -7,10 +7,13 @@ SVDSBTL --- SVD-Compressed Tabular Lookup Backend
 SVDSBTL is a tabular-lookup backend that combines an atlas of
 analytically-bounded regions with a low-rank SVD of each region's
 property surfaces.  It produces **sub-microsecond** property
-evaluations (~200-400 ns per probe in the batched ``fast_evaluate``
-path) at IAPWS G13-15 conformance for water, and a single-digit
-percent accuracy ceiling for the multi-fluid HEOS-backed presets,
-at a disk footprint of ~10 MB per (fluid, input pair, source backend).
+evaluations in the batched ``fast_evaluate`` path away from the
+critical patch (~300-400 ns per probe at four outputs on Apple
+Silicon, rising to a few µs/probe inside the critical-patch
+fallback), at IAPWS G13-15 :math:`T(p, h)` conformance for water
+and a single-digit percent accuracy ceiling for the multi-fluid
+HEOS-backed presets, at a disk footprint of ~7-14 MB per
+(fluid, input pair, source backend).
 
 This page is the **user-facing** page: how to use the backend, what it
 guarantees, and when to pick it.  For the underlying SVD math
@@ -39,18 +42,23 @@ bicubic table with three layered components that address both:
    (subcooled), VAPOR (superheated), SUPER (supercritical), with
    further splits for IF97 (R1/R3, R2/R3 boundary curves).  Each
    region's secondary axis is normalised to :math:`[0, 1]` via two
-   analytic boundary curves — saturation dome on the subcritical
-   side, low-T / high-T isotherms on the supercritical side.  Lookups
-   first AABB-test against region bounding boxes (cheap), then
-   evaluate the precise boundary curves on the candidate.
+   analytic boundary curves — on subcritical regions one curve is the
+   saturation dome and the other is an isotherm (low-T floor for the
+   liquid region, high-T ceiling for the vapor region); on
+   supercritical regions both curves are isotherms.  Lookups first
+   AABB-test against region bounding boxes (cheap), then evaluate the
+   precise boundary curves on the candidate.
 
 2. **Per-region SVD.**  Inside each normalised region, every tabulated
    property (:math:`\rho, h, s, u, w, \eta, \lambda`) is represented
-   as a rank-:math:`r` SVD of a dense :math:`N_p \times N_h` (default
-   :math:`200 \times 800`, :math:`r = 20`) sample grid.  Hermite
-   bicubic interpolation between SVD grid points gives :math:`C^1`
-   continuity across the region.  Density and transport properties
-   use a **log transform**
+   as a rank-:math:`r` SVD of a dense :math:`N_h \times N_p` (default
+   :math:`200 \times 800`, :math:`r = 20`) sample grid — the 200-point
+   axis is the secondary (h or T), the 800-point axis is the primary
+   (log p).  Per-mode tensor-product cubic Hermite (1D × 1D, summed
+   across rank-:math:`r` modes) gives :math:`C^1` continuity at
+   minimum, and :math:`C^2` with the default natural-cubic-spline
+   slope source (see :doc:`SVDComponents`).  Density and transport
+   properties use a **log transform**
    (:math:`\rho = \exp(\sum_k S_k U_k V_k)`) so their multi-decade
    dynamic range fits the SVD's smoothness assumption.
 
@@ -112,9 +120,10 @@ The on-disk table cache
 
 The first construction for a given ``(fluid, source, input_pair,
 options)`` tuple samples ~160,000 :math:`(p, h)` or :math:`(p, T)`
-points from the source backend, runs SVD on each region's property
-matrix, and persists the result as a zlib-compressed binary file
-under
+points per region from the source backend (3 regions for HEOS-PH,
+6-7 for IF97-PH, so 0.5-1.1M samples per table), runs SVD on each
+region's property matrix, and persists the result as a zlib-
+compressed binary file under
 
 .. code-block:: text
 
@@ -133,10 +142,8 @@ Subsequent constructions for the same tuple load from this cache.
   ``.github/workflows/test_catch2.yml`` so CI rebuilds occur
   automatically.
 
-The cache directory is `XDG_DATA_HOME`-aware on Linux and uses
-``~/.CoolProp/SVDTables/`` by default elsewhere.  The path is
-configurable via the ``ALTERNATIVE_SVDTABLES_DIRECTORY`` configuration
-key (see :ref:`configuration`).
+The cache directory is ``~/.CoolProp/SVDTables/`` on all platforms.
+A configurable cache directory is tracked in bd ``CoolProp-fhp``.
 
 .. _SVDSBTL-regimes:
 
@@ -173,11 +180,12 @@ the backend.
 
        In [1]: %timeit loop()
 
-   Native C++ per-call wall time is ~200 ns; the bulk of the
-   Python-visible cost is the wrapper marshalling, and even in Python
-   the per-call cost is hundreds of nanoseconds — far faster than
-   HEOS's :math:`(p, h)` flash.  This is what most user code should
-   look like.
+   Native C++ ``update + rhomass + T`` is ~1 µs/iter (dominated by
+   ``update()``; the cached accessors are <10 ns/pair).  The Cython
+   wrapper adds ~0.3 µs across the three FFI crossings, totaling
+   ~1.3 µs/iter from Python — still ~20× faster than HEOS's
+   :math:`(p, h)` flash on the same loop.  This is what most user
+   code should look like.
 
 2. **fast_evaluate (batched, no instance mutation).**
    ``AbstractState.fast_evaluate(input_pair, val1[], val2[],
@@ -186,6 +194,13 @@ the backend.
    ``AbstractState`` cache mutation, no Python wrapper marshalling
    per probe, and shared :math:`(p, h)` locate / Hermite-basis setup
    across the N requested properties:
+
+   The probe distribution below is **supercritical only**
+   (:math:`p > p_c`, :math:`h > h_c`) — this isolates the
+   representative locate + basis cost from the
+   :ref:`critical patch <SVDSBTL-critpatch>`, which is several µs/probe
+   and would otherwise dominate a uniformly sampled :math:`(p, h)`
+   box:
 
    .. ipython::
 
@@ -199,29 +214,37 @@ the backend.
 
        In [1]: N = 10_000
 
-       In [1]: h = np.random.uniform(1e5, 3e6, N)
+       In [1]: rng = np.random.default_rng(0)
 
-       In [1]: p = np.random.uniform(1e5, 3e7, N)
+       In [1]: h = rng.uniform(2.5e6, 4.0e6, N)   # h > h_c ≈ 2086 kJ/kg
 
-       In [1]: outputs = np.array([CP.iT, CP.iDmass, CP.iSmass], dtype=np.int32)
+       In [1]: p = rng.uniform(22.5e6, 50.0e6, N) # p > p_c = 22.064 MPa
 
-       In [1]: out = np.empty((N, 3)); status = np.empty(N, dtype=np.int32)
+       In [1]: outputs = np.array([CP.iT, CP.iDmass, CP.iSmass, CP.iUmass], dtype=np.int32)
+
+       In [1]: out = np.empty((N, 4)); status = np.empty(N, dtype=np.int32)
 
        In [1]: %timeit AS.fast_evaluate(CP.HmassP_INPUTS, h, p, outputs, out, status)
 
-   Per-point wall time: **~340-400 ns** for a 4-output query on Apple
-   Silicon (10k-probe batch).  Marginal cost per added surface output
-   ~57 ns after locate / basis-weight setup is paid once per probe.
-   For CFD-scale workloads (≥100k probes per timestep) this is the
-   only sensible API.
+   Per-point wall time: **~300-330 ns** for a 4-output query on Apple
+   Silicon (10k-probe batch, supercritical region).  Marginal cost
+   per added surface output is ~35 ns from a linear fit over
+   :math:`N_{\mathrm{out}} \in \{1, \dots, 5\}` — setup intercept
+   ~170 ns covers the per-probe locate + basis-weight evaluation that
+   is shared across the requested outputs.  For CFD-scale workloads
+   (≥100k probes per timestep) this is the only sensible API.
+   Uniformly-sampled :math:`(p, h)` boxes that touch the critical
+   patch heavily can rise to ~1 µs/probe; pure supercritical or PT
+   sweeps hold the headline number.
 
 3. **PropsSI — the high-level wrapper (off by default).**
    ``PropsSI`` is the high-level entry point that resolves the
    backend and constructs an ``AbstractState`` on every call.  For
    SVDSBTL that means a zlib-decompressed ``.svd.bin.z`` load (~80 ms
-   per ``AbstractState`` construction).  For a one-off interactive
-   query this is fine; for a throughput workload it is catastrophic
-   — *every* ``PropsSI`` call pays the table-load cost again.
+   for the typical ~7 MB table, ~140 ms for the larger 14 MB
+   SVDSBTL&IF97 HmassP table).  For a one-off interactive query this
+   is fine; for a throughput workload it is catastrophic — *every*
+   ``PropsSI`` call pays the table-load cost again.
 
    SVDSBTL therefore opts *out* of ``PropsSI`` by default.  Enable
    only for interactive / scripting use where the construction cost
@@ -293,25 +316,25 @@ their critical-singularity footprint allows.  Typical results
      - :math:`p_\mathrm{lo} / p_c`
      - :math:`p_\mathrm{hi} / p_c`
    * - Water (HEOS)
-     - 0.970
-     - 1.050
+     - 0.986
+     - 1.025
      - 0.996
      - 1.150
    * - Water (IF97)
-     - 0.984
-     - 1.027
+     - 0.999
+     - 1.010
      - 0.996
-     - 1.150
+     - 1.138
    * - CarbonDioxide (HEOS)
-     - 0.961
+     - 0.994
      - 1.050
-     - 0.863
+     - 0.996
      - 1.150
    * - R134a (HEOS)
-     - 0.995
-     - 1.013
+     - 0.999
+     - 1.001
      - 0.996
-     - 1.080
+     - 1.014
 
 These numbers are regenerated at backend construction; the exact
 values are sensitive to the SVD grid size and rank (and so move when
@@ -327,7 +350,7 @@ axis-aligned envelope of the resulting :math:`h` values — that way
 any :math:`(T, p)` in the canonical patch round-trips into a
 :math:`(h, p)` that the patch test also fires on.  For Water/HEOS
 the resulting :math:`(p, h)` bbox is roughly
-:math:`p \in [22.0, 25.4]` MPa, :math:`h \in [1.55, 2.93]` MJ/kg.
+:math:`p \in [22.0, 25.4]` MPa, :math:`h \in [1.74, 2.65]` MJ/kg.
 
 **Overrides.**  Two escape hatches:
 
@@ -353,10 +376,6 @@ the resulting :math:`(p, h)` bbox is roughly
   accuracy at the critical singularity rather than IF97's R3
   formulation).
 
-The ``set_critical_bbox_multipliers(T_lo, T_hi, p_lo, p_hi)`` C++
-entry point also lets callers override the patch at runtime without
-rebuilding the backend.
-
 .. _SVDSBTL-config:
 
 Configuration keys
@@ -367,19 +386,15 @@ Configuration keys
     <SVDSBTL-regimes>`.  Set to ``true`` for interactive
     use; leave ``false`` for throughput code.
 
-``ALTERNATIVE_SVDTABLES_DIRECTORY`` (default empty)
-    Override the cache directory.  Useful when ``$HOME`` is read-only
-    or on shared workstations where a centrally-managed cache is
-    preferable.
-
 ``SVDSBTL_SAMPLING_THREADS`` (default ``1``)
     Number of worker threads for the per-grid-cell sampling phase of
     the SVDSBTL table build (CoolProp-43h).  ``1`` (the default) runs
     serially.  ``N > 1`` spawns ``N`` workers, each with its own
     factory-built source ``AbstractState``, that partition the grid
     rows.  ``0`` resolves to ``std::thread::hardware_concurrency()``.
-    Typical ~2.5× speedup at ``N = 4`` on a modern laptop
-    (R245fa cold build: 65 s → 25 s).  Worth setting when:
+    Typical ~2.25× speedup at ``N = 4`` on Apple Silicon
+    (R245fa cold build: 122 s → 54 s; R134a 15.5 s → 6.3 s).
+    Worth setting when:
 
     * Iterating on a kRevision bump where every developer + CI machine
       pays the full table-rebuild cost across the fluid set.
@@ -420,8 +435,9 @@ SVDSBTL pays off when one of these is true:
 
 * You evaluate a fixed-formulation EOS at **>10k probes per
   AbstractState instance**.  The first construction pays a
-  ~80 ms table-load cost (or, for a cold cache, a few seconds of
-  table-build cost); both amortise over the subsequent queries.
+  ~80-140 ms table-load cost (depending on file size; or, for a
+  cold cache, a few seconds of table-build cost); both amortise
+  over the subsequent queries.
 * You need :math:`(p, h)` lookup (typical for power-cycle,
   refrigeration, CFD); HEOS's :math:`(T, \rho)` formulation makes
   :math:`(p, h)` inputs 5-10× slower than :math:`(p, T)`.
@@ -437,8 +453,8 @@ SVDSBTL pays off when one of these is true:
 SVDSBTL is **not** the right pick when:
 
 * Your workload is interactive single-shot ``PropsSI`` calls.  Use
-  HEOS or IF97 directly — the ~80 ms per-call table-load overhead
-  dominates.
+  HEOS or IF97 directly — the ~80-140 ms per-call table-load
+  overhead dominates.
 * You need transport properties for a fluid whose source backend
   lacks them.  SVDSBTL just samples the source; if the source's HEOS
   model has no :math:`\eta` / :math:`\lambda` correlation, neither
@@ -451,15 +467,18 @@ SVDSBTL is **not** the right pick when:
 Accuracy envelope
 =================
 
-* **SVDSBTL&IF97::Water**: conformant to IAPWS G13-15 Tables 8-13 for
-  :math:`T, v, s, w` in regions R1, R2, R5; R3 close to but not
-  uniformly inside budget (the critical-patch fallback covers the
-  near-critical R3 cells).  Transport properties :math:`\eta,
-  \lambda` exceed G13-15 budgets in R3 — those budgets are
-  intrinsically tight (:math:`10^{-5}` relative) and the rank-20 SVD
-  has known headroom for tighter ranks.  See
-  :ref:`IF97-Conformance` for the per-region fail maps and exact
-  numbers.
+* **SVDSBTL&IF97::Water**: :math:`T(p, h)` is conformant to IAPWS
+  G13-15 budgets in R1, R2, R5 (max 2.79 / 8.52 / 1.81 mK against
+  25 / 10 / 10 mK budgets).  Forward properties miss in places: :math:`v`
+  is conformant only in R5 (R1/R2 are 3-4× over a 10⁻⁵ budget);
+  :math:`w` is conformant in R2 and R5; :math:`s` exceeds budget in
+  all four regions (R5 is 13× over; R3 worst-case is ~10⁴× over).
+  Transport properties :math:`\eta, \lambda` exceed G13-15 budgets
+  across R1, R2 and R3 — those budgets are intrinsically tight
+  (:math:`10^{-5}` relative) and the rank-20 SVD has known headroom
+  for tighter ranks.  The critical-patch fallback covers the
+  near-critical R3 cells.  See :ref:`IF97-Conformance` for the
+  per-region fail maps and exact numbers.
 
 * **SVDSBTL&HEOS::<Fluid>**: ~10^-3 relative error on
   :math:`\rho, h, s` across the full subcritical envelope.
@@ -470,9 +489,10 @@ Accuracy envelope
 * **SVDSBTL&REFPROP::<Fluid>**: matches REFPROP truth on tested
   probes within REFPROP's own numerical-noise floor on the sat
   curves; same single-phase envelope as HEOS-source.  Two-phase
-  endpoints currently fall through to REFPROP's PQ flash (~ms per
-  probe); ``CoolProp-077`` will replace that with an on-disk
-  saturation-surrogate spline.
+  endpoints currently fall through to REFPROP's PQ flash (~3-5 µs
+  per probe); ``CoolProp-077`` will replace that with an on-disk
+  saturation-surrogate spline to remove the cross-DLL hop and the
+  REFPROP-thread-safety constraint that fallback inherits.
 
 Deviation plot
 ==============
@@ -542,15 +562,17 @@ slopes for the Hermite per-mode interpolation, and the
 Programmatic access
 ===================
 
-Beyond the high-level ``AbstractState`` API, the C++ entry point
+Beyond the high-level ``AbstractState`` API, the C++ class
 ``CoolProp::SVDSBTLBackend`` exposes:
 
-* ``fast_evaluate`` for batched cache-bypassing evaluation (also
-  bound to Python — see the example above)
+* ``fast_evaluate`` for batched cache-bypassing evaluation — also
+  bound to Python (see the example above).
 * ``registered_input_pairs()`` for introspection (which surfaces did
-  this instance load)
-* ``set_critical_bbox_multipliers(T_lo_mult, T_hi_mult, p_lo_mult,
-  p_hi_mult)`` for ad-hoc critical-patch tuning
+  this instance load).  C++-only; not bound to Python.
+
+Runtime overrides to the critical-patch geometry currently require
+reconstructing the backend with an updated ``critical_patch.bbox``
+options blob; there is no in-place setter.
 
 All other ``AbstractState`` methods (``rhomass``, ``hmass``, ``smass``,
 ``viscosity``, ``conductivity``, ``T_critical``, ``Ttriple``, etc.)

--- a/Web/coolprop/Tabular.rst
+++ b/Web/coolprop/Tabular.rst
@@ -8,7 +8,13 @@ Especially when evaluating inputs as a function of pressure and enthalpy (common
 
 As of version 5.1 of CoolProp, the tabular interpolation methods of CoolProp v4 have been brought back from the dead, and significantly improved.  They are approximately 4 times faster than the equivalent methods in v4 of CoolProp due to a more optimized structure.  In order to make the most effective use of the tabular interpolation methods, you must be using the :ref:`low-level interface <low_level_api>`, otherwise significant overhead and slowdown will be experienced.  Thus, this method is best suited to C++, python, and the SWIG wrappers.
 
-There are two backends implemented for tabular interpolation, ``BICUBIC`` and ``TTSE``.  Both consume the same gridded tabular data that is stored to your user home directory in the folder ``HOME/.CoolProp/Tables``.  If you want to find the directory that CoolProp is using as your home directory (``HOME``), you can do something like 
+There are two backends implemented for tabular interpolation, ``BICUBIC`` and ``TTSE``.  Both consume the same gridded tabular data that is stored to your user home directory in the folder ``HOME/.CoolProp/Tables``.
+
+.. seealso::
+
+    For sub-microsecond per-probe evaluation with IAPWS-G13-15 conformance for water (``SVDSBTL&IF97``) and single-digit-percent accuracy on a multi-fluid HEOS-backed envelope (``SVDSBTL&HEOS``), see the :doc:`SVDSBTL backend </coolprop/SVDSBTL>`.  SVDSBTL combines a region atlas with per-region SVD compression and is the recommended throughput-oriented tabular backend for new code; BICUBIC and TTSE remain for backward compatibility.
+
+If you want to find the directory that CoolProp is using as your home directory (``HOME``), you can do something like
 
 .. ipython::
 

--- a/Web/coolprop/changelog.rst
+++ b/Web/coolprop/changelog.rst
@@ -6,6 +6,7 @@ Unreleased
 
 Highlights:
 
+* Added the :doc:`SVDSBTL </coolprop/SVDSBTL>` SVD-compressed tabular lookup backend (factory string ``SVDSBTL&<source>``, where source ∈ {``HEOS``, ``REFPROP``, ``IF97``}).  Combines a region atlas with per-region SVD compression plus a critical-patch fallback to the source backend; produces sub-microsecond per-probe property evaluation in the batched ``fast_evaluate`` path at IAPWS-G13-15 ``T(p, h)`` conformance for water and a single-digit-percent accuracy ceiling for the multi-fluid HEOS-backed presets.  Disk footprint ~7-14 MB per (fluid, input pair, source backend), cached under ``~/.CoolProp/SVDTables/``.  Off by default in ``PropsSI`` — see ``ALLOW_SVDSBTL_IN_PROPSSI``.  See PRs `#2917`, `#2938-#2940`, `#2944-#2957`.
 * Added mass-basis vapor quality (``Qmass``) support across HEOS and REFPROP backends, paralleling the existing molar quality (``Q``). Adds a new ``iQmass`` keyed parameter, a ``Qmass()`` accessor on ``AbstractState``, and 8 new ``Qmass``-bearing input pairs (``QmassT_INPUTS``, ``PQmass_INPUTS``, ``QmassSmolar_INPUTS``, ``QmassSmass_INPUTS``, ``HmolarQmass_INPUTS``, ``HmassQmass_INPUTS``, ``DmolarQmass_INPUTS``, ``DmassQmass_INPUTS``). Mixtures supported from day one — REFPROP uses its native ``kq=2`` flag in ``TQFLSHdll``/``PQFLSHdll`` for ``QmassT``/``PQmass``; the other 6 pairs and all HEOS pairs use a TOMS748 root-find on ``Qmolar`` (typically 5–8 iterations).
 
 **Behavior changes (potentially breaking):**

--- a/Web/index.rst
+++ b/Web/index.rst
@@ -16,6 +16,7 @@ CoolProp is a C++ library that implements:
 * :ref:`Mixture properties using high-accuracy Helmholtz energy formulations <mixtures>`
 * :ref:`Correlations of properties of incompressible fluids and brines <Pure>`
 * :ref:`Computationally efficient tabular interpolation <tabular_interpolation>`
+* :ref:`Sub-microsecond SVD-compressed tabular evaluation for water (IAPWS-G13-15 conformant) and multi-fluid HEOS-backed presets <SVDSBTL>`
 * :ref:`Highest accuracy psychrometric routines <Humid-Air>`
 * :ref:`User-friendly interface around the full capabilities of NIST REFPROP <REFPROP>`
 * :ref:`Fast IAPWS-IF97 (Industrial Formulation) for Water/Steam <IF97>`

--- a/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
+++ b/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
@@ -411,14 +411,15 @@ class SVDSBTLBackend : public AbstractState
     // Auto-calibration shrink loop (CoolProp-dxd).  Returns the four
     // multipliers {T_lo_mult, T_hi_mult, p_lo_mult, p_hi_mult} such
     // that the SVD's reconstruction of (rho, h, s, w) at every probe
-    // *just outside* the resulting (T, p) bbox satisfies the IAPWS
-    // conformance budgets (200 ppm rho, 100 ppm h, 200 ppm s,
-    // 1000 ppm w).  Wide initial bbox is
-    // [0.85, 1.20]*Tc x [0.50, 4.0]*pc; binary-search-shrinks each
-    // axis independently in ~8 iterations.  Total cost dominated by
-    // ~120 PT probes against the source backend (~ms each for HEOS,
-    // ~10 ms each for REFPROP) → a few seconds.  Persists to the
-    // sidecar cache so subsequent constructions skip the work.
+    // *just outside* the resulting (T, p) bbox satisfies the
+    // calibration budgets (1% relative in rho/h/s, 5% relative in w;
+    // see kBudget_* in the .cpp).  Starts from the Water-sized
+    // default {0.95, 1.05, 0.75, 1.15} and binary-search-shrinks
+    // each axis independently toward 1.0 in 6 steps; never widens
+    // beyond the default.  Total cost dominated by ~120 PT probes
+    // against the source backend (~ms each for HEOS, ~10 ms each
+    // for REFPROP) → a few seconds.  Persists to the sidecar cache
+    // so subsequent constructions skip the work.
     [[nodiscard]] std::array<double, 4> auto_calibrate_critical_bbox_();
 
     // Sidecar persistence for the 4 calibrated multipliers.  Cache


### PR DESCRIPTION
## Summary
- Documentation-only PR: corrects 19 doc bugs in `Web/coolprop/SVDSBTL.rst` (9 outright errors, 4 near-right inaccuracies, 6 imprecisions) plus a stale comment block in `include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h`.
- No code-behavior change. Numbers cross-checked against on-disk `~/.CoolProp/SVDTables/*.critpatch.bin` cache values, the rendered `Web/fluid_properties/IF97_conformance.rst.in` fail-map, and live runtime measurements on Apple Silicon.
- One follow-up tracked: bd `CoolProp-fhp` for actually implementing `ALTERNATIVE_SVDTABLES_DIRECTORY` (claim removed from doc here pending implementation).

## What changed

### Removed claims that don't match code
- `set_critical_bbox_multipliers(T_lo, T_hi, p_lo, p_hi)` C++ entry point — function does not exist anywhere in `include/`, `src/`, or `wrappers/`. Doc had it in two places (Critical-patch section + Programmatic access).
- `ALTERNATIVE_SVDTABLES_DIRECTORY` config key — not in `include/Configuration.h`, not consulted in `SVDSurfaceSerializer.cpp`. Tracked via bd `CoolProp-fhp`.
- `XDG_DATA_HOME`-aware on Linux — `get_home_dir()` at `src/CPfilepaths.cpp:157` only reads `$HOME`.
- `registered_input_pairs()` Python visibility — exists C++-only, no Python binding in `AbstractState.pyx`. Clarified.

### Performance numbers updated to match measurement
| Claim | Old | New |
|---|---|---|
| Native C++ `update + rhomass + T` | ~200 ns | ~1 µs (`update()` dominates) |
| Cython wrapper overhead | "bulk of cost" | ~0.3 µs across 3 FFI crossings |
| Python `update + rhomass + T` | "hundreds of ns" | ~1.3 µs/iter |
| `fast_evaluate` 4-output / 10k probes | ~340-400 ns/probe | ~300-330 ns/probe (supercritical region) |
| Marginal cost per added output | ~57 ns | ~35 ns |
| Table-load cost | ~80 ms | ~80-140 ms (file-size-dependent) |
| R245fa N=4 cold build | 65→25 s | 122→54 s (Apple Silicon); ratio ~2.25× holds |
| REFPROP PQ flash fallback | ~ms/probe | ~3-5 µs/probe (3 orders of magnitude off) |

### `fast_evaluate` example switched to supercritical-only probes
- The old example used uniform `h ∈ [0.1, 3] MJ/kg, p ∈ [0.1, 30] MPa`, which lands ~40% of probes near the critical patch (5-10× slower per probe) — washing out the headline cost the prose advertised.
- New example uses `h ∈ [2.5, 4.0] MJ/kg, p ∈ [22.5, 50] MPa` (all `T > T_c`), which isolates the locate+basis cost. Also bumped to 4 outputs to match the 4-output prose.

### Critical-patch per-fluid bbox table refreshed
- All four rows updated to current cached multipliers (the old values were off by 1-15% from the on-disk cache; CO₂ `p_lo` was off by 15%).
- Water/HEOS derived `(p, h)` bbox h-range corrected: 1.55-2.93 → 1.74-2.65 MJ/kg.

### IF97 G13-15 conformance prose tightened
- Old: "conformant to Tables 8-13 for T, v, s, w in R1, R2, R5".
- Actual per `IF97_conformance.rst.in` fail-map: only `T(p,h)` is uniformly conformant in R1/R2/R5; `v` conformant only in R5; `w` in R2 and R5; `s` exceeds budget in all four regions.
- Transport budget miss broadened from "in R3" to "across R1, R2, R3" (η: R1 34×, R2 3.8×; λ: R1 32×, R2 37×).

### Architecture imprecisions tightened
- Grid orientation `N_p × N_h (200 × 800)` → `N_h × N_p (200 × 800)` (200 = secondary, 800 = primary log-p axis).
- Per-region vs per-table sample count clarified (160k per region × 3-7 regions per atlas).
- Subcritical boundary curves: one is sat dome, the other is an isotherm (the old "saturation dome on the subcritical side" read as both bounds).
- C¹ continuity → C² with default natural-cubic-spline slopes (per `SVDEvaluator.h:38-40` and `SVDDecomposition.h:24`).

### Header-comment bonus fix
`include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h` near `auto_calibrate_critical_bbox_()`:
- Calibration budgets: was "200/100/200/1000 ppm" → actual is "1% relative in rho/h/s, 5% relative in w" per `kBudget_*` in the `.cpp`.
- Initial bbox: was `[0.85, 1.20]·Tc × [0.50, 4.0]·pc, ~8 iterations` → actual is `{0.95, 1.05, 0.75, 1.15}, 6 steps` per `kBisectSteps`.

## Verification process

1. Five parallel verification subagents (perf / API / critical-patch / architecture / accuracy), each cross-checking ~5-7 claims against source + runtime.
2. `./dev/ci/preflight.sh`: 5 passed / 0 failed / 1 skipped (clang-tidy diff-only, no `.cpp` files in diff).
3. `superpowers:code-reviewer` adversarial pass: no blocking findings.

## Test plan
- [ ] Sphinx docs build succeeds (`.. ipython::` block in regime 2 re-runs the new supercritical example).
- [ ] No broken cross-refs (`<SVDSBTL-critpatch>`, `<SVDSBTL-config>`, `<SVDSBTL-regimes>`, `<IF97-Conformance>`).
- [ ] Numbers cited (especially conformance maxes `2.79 / 8.52 / 1.81 mK`) re-verified on a docs-build machine — flagged by code-reviewer as tight three-sig-fig values that may bobble in re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Major SVDSBTL docs refresh: updated performance/footprint claims, timing breakdowns (including ~80–140 ms table-load ranges), examples, accuracy envelopes, critical-patch guidance, cache sizing (~160k samples/region) and default cache location (~/.CoolProp/SVDTables/); added see-also notes recommending SVDSBTL for throughput-sensitive use.

* **Configuration**
  * New sampling-threads option and JSON-based critical-patch overrides documented; alternative table-directory option removed.

* **API Changes**
  * Runtime in-place override for critical-patch geometry removed; reconstruct backend with new configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->