### PR TITLE
docs(if97,svdsbtl): correct 12 claims uncovered by IF97 audit

### DIFF
--- a/Web/coolprop/SVDSBTL.rst
+++ b/Web/coolprop/SVDSBTL.rst
@@ -478,16 +478,19 @@ Accuracy envelope
 
 * **SVDSBTL&IF97::Water**: :math:`T(p, h)` is conformant to IAPWS
   G13-15 budgets in R1, R2, R5 (max 2.79 / 8.52 / 1.81 mK against
-  25 / 10 / 10 mK budgets).  Forward properties miss in places: :math:`v`
-  is conformant only in R5 (R1/R2 are 3-4× over a 10⁻⁵ budget);
-  :math:`w` is conformant in R2 and R5; :math:`s` exceeds budget in
-  all four regions (R5 is 13× over; R3 worst-case is ~10⁴× over).
-  Transport properties :math:`\eta, \lambda` exceed G13-15 budgets
-  across R1, R2 and R3 — those budgets are intrinsically tight
-  (:math:`10^{-5}` relative) and the rank-20 SVD has known headroom
-  for tighter ranks.  The critical-patch fallback covers the
-  near-critical R3 cells.  See :ref:`IF97-Conformance` for the
-  per-region fail maps and exact numbers.
+  25 / 10 / 10 mK budgets — R2 has ~15% headroom and is fragile).
+  Forward properties miss in places: :math:`v` is conformant only in
+  R5 (R1/R2 are 3-4× over a 10⁻⁵ relative budget); :math:`w` is
+  conformant only in R5 (R1 36×, R2 4.4× over budget); :math:`s`
+  exceeds budget in all four regions (R5 is 13× over; R3 worst-case
+  is ~10⁴× over).  Transport properties :math:`\eta, \lambda` exceed
+  G13-15 budgets across R1, R2 and R3; :math:`\eta` is within budget
+  in R5 (0.89×), and :math:`\lambda` is fractionally over (1.1×).
+  Those budgets are intrinsically tight (:math:`10^{-5}` relative)
+  and the rank-20 SVD has known headroom for tighter ranks.  The
+  critical-patch fallback covers the near-critical R3 cells.  See
+  :ref:`IF97-Conformance` for the per-region fail maps and exact
+  numbers.
 
 * **SVDSBTL&HEOS::<Fluid>**: ~10^-3 relative error on
   :math:`\rho, h, s` across the full subcritical envelope.

--- a/Web/fluid_properties/IF97.rst
+++ b/Web/fluid_properties/IF97.rst
@@ -48,7 +48,7 @@ fundamental equation:
 The boundaries between regions are themselves analytic curves:
 
 * The **R2/R3 boundary** is the parametric curve
-  :math:`p_{B23}(T) = 0.10193 \cdot (T - 572.545)^2 + 13.919` MPa,
+  :math:`p_{B23}(T) = 1.0193 \times 10^{-3} \cdot (T - 572.545)^2 + 13.919` MPa,
   valid for :math:`T \in [623.15, 863.15]` K (equivalently
   :math:`p \in [16.529, 100]` MPa).
 * The **R1/R3 boundary** is the isotherm :math:`T = 623.15` K.
@@ -61,9 +61,11 @@ downstream interpolator built on IF97 (the :doc:`SVDSBTL backend
 </coolprop/SVDSBTL>`, in particular) must respect this structure to
 recover G13-15-conformant accuracy.  A bilinear or bicubic table over
 a region that straddles :math:`p_{B23}` averages the kink into the
-interpolant and pays for it with ~1% structural error in :math:`v,
-s, w` near the boundary; the right fix is to split the region along
-the kink and table each side independently.
+interpolant, producing percent-class structural error in :math:`v,
+s, w` near the boundary (the SVDSBTL atlas split along
+:math:`p_{B23}` was introduced specifically to avoid this regime).
+The right fix is to split the region along the kink and table each
+side independently.
 
 A plot of the region atlas (orange = saturation curve, dashed =
 :math:`p_{B23}` and :math:`T = 1073.15` K boundaries) appears under
@@ -72,11 +74,11 @@ A plot of the region atlas (orange = saturation curve, dashed =
 IF97 Backend
 ------------
 
-The IF97 backend can be accessed the same way as the other backends, by prefixing the fluid name in calls to ``PropsSI`` and ``Props1SI``.  However, Water is the only fluid name that can be specified, as ``IF97::Water``.  Most output variables and input pairs are accepted as of CoolProp 6.1.1, with a few exceptions:
+The IF97 backend can be accessed the same way as the other backends, by prefixing the fluid name in calls to ``PropsSI`` and ``Props1SI``.  Water is the only fluid that can be specified, as ``IF97::Water`` (the alias ``IF97::H2O`` is also accepted, case-insensitively).  Most output variables and input pairs are accepted as of CoolProp 6.1.1, with a few exceptions:
 
 1. Generic Partial Derivatives are not yet supported.
 2. Mixtures are obviously not supported since this is a Water-only backend.
-3. The Reference State cannot be modified for the IF97 formulation.  *The reference state is fixed such that the specific internal energy,* :math:`U` *, and the specific entropy,* :math:`S` *, of the saturated liquid at the triple point are identically zero.*
+3. Setting the reference state has no effect on IF97 properties (top-level ``set_reference_state(...)`` silently returns; the OO ``AbstractState::set_reference_stateS`` raises ``NotImplementedError``).  *The reference state is fixed such that the specific internal energy,* :math:`U` *, and the specific entropy,* :math:`S` *, of the saturated liquid at the triple point are identically zero.*
 4. Solid properties are not supported in any of the ICE regions.
 5. The melting-sublimation curve is not used; rather, the property equations are limited uniformly at :math:`T_{min}=273.15K`.
 
@@ -143,7 +145,7 @@ Although IF97 is generally faster than the other backends, it is only applicable
     # -----------------------------
     n3 = 0.10192970039326e-2
     n4 = 0.57254459862746e3
-    n5 = 0.1391883776670e2
+    n5 = 0.13918839778870e2
     PI = 2.0*np.arcsin(1.0)
     TT = []
     PP = list(np.linspace(pb,pmax,1000))
@@ -265,9 +267,10 @@ based on cubic B-splines) already exists?
 
 * **High speed.**  The :ref:`three performance regimes <SVDSBTL-regimes>`
   cover the full single-shot-to-CFD-scale range.  The per-output
-  marginal cost in the batched ``fast_evaluate`` path is ~57 ns on
-  modern hardware — competitive with the fastest closed tabular
-  implementations.
+  marginal cost in the batched ``fast_evaluate`` path is ~35 ns on
+  Apple Silicon (supercritical region; mixes that touch the critical
+  patch heavily can rise to ~1 µs/probe) — competitive with the
+  fastest closed tabular implementations.
 
 * **Complete traceability.**  Every cell of the table is
   reproducible from the source backend at the exact build-time
@@ -280,9 +283,10 @@ based on cubic B-splines) already exists?
 
 These three properties together set SVDSBTL apart from the older
 SBTL backend and from closed-source tabulators.  The conformance
-figures above measure how close to the IAPWS-IF97 reference
-formulation the :ref:`SVDSBTL backend </coolprop/SVDSBTL>` lands
-on the four G13-15 thermodynamic properties.
+figures above characterise how the four G13-15 thermodynamic
+properties (:math:`T, v, s, w`) fare against per-region IAPWS
+budgets — see the :doc:`SVDSBTL accuracy envelope </coolprop/SVDSBTL>`
+section for the per-property/per-region pass/fail summary.
 
 IF97 vs HEOS timing — per-call and batched
 ------------------------------------------
@@ -300,11 +304,15 @@ GitHub-hosted CI runner.
 
 Per-call panels report the *median* wall time over many warm-cache
 calls (first-call cache-load cost is baked out).  Per-call numbers
-include ~1000 ns of Python-wrapper marshalling that applies equally to
-every backend — read the *ratios* as the meaningful comparison, not the
+include ~300 ns of Cython-wrapper marshalling across the three FFI
+crossings (``update`` + two accessors) that applies equally to every
+backend — read the *ratios* as the meaningful comparison, not the
 absolute nanoseconds.  ``fast_evaluate`` amortizes that overhead over
-the batch, so its per-point cost approaches native C++.  IF97's own
-dome-blend lever-rule path was added in CoolProp 7.2, so probes
+the batch, so its per-point cost approaches the native floor — sub-µs
+for the tabular backends (SVDSBTL ~300 ns/probe in the supercritical
+region), while bare IF97's own :math:`(p, h)` inversion stays
+~2 µs/probe regardless of the wrapper.  IF97's own dome-blend
+lever-rule path was added in CoolProp 7.2.1 (PR #2942), so probes
 landing inside the saturation dome no longer return NaN through
 ``fast_evaluate`` — they Q-blend between IF97's saturation endpoints.
 


### PR DESCRIPTION
## Summary
- Documentation-only PR. Five parallel verification subagents audited `Web/fluid_properties/IF97.rst` (and the just-merged `Web/coolprop/SVDSBTL.rst` from PR #2959) and found 8 outright errors, 3 soft inaccuracies, and 1 substantive carry-over bug.
- Numbers cross-checked against canonical IAPWS-IF97 constants (`build/_deps/if97-src/IF97.h`), the rendered `Web/fluid_properties/IF97_conformance.rst.in` (script `Web/scripts/fluid_properties.IF97Conformance.py` is seed-stable, `SEED=0xC001DAD`), and the authoritative SVDSBTL.rst from PR #2959.
- Two same-typo instances in code (not doc) are out of scope here — tracked via bd `CoolProp-6zl`.

## Outright errors fixed

| File:line | Was | Now |
|---|---|---|
| `IF97.rst:51` | `p_B23(T) = 0.10193 · (T-572.545)² + 13.919 MPa` (~275 MPa at T=623.15 K — factor of 1000 wrong on parabolic term) | `p_B23(T) = 1.0193 × 10⁻³ · (T-572.545)² + 13.919 MPa` |
| `IF97.rst:146` | `n5 = 0.1391883776670e2` (digits scrambled) | `n5 = 0.13918839778870e2` (matches IAPWS R7-97) |
| `IF97.rst:79` | "Reference State cannot be modified" (implies refusal) | Now states both call paths: top-level silently returns, OO method raises `NotImplementedError` |
| `IF97.rst:268` | "~57 ns marginal cost on modern hardware" | "~35 ns on Apple Silicon (supercritical region; mixes that touch the critical patch heavily can rise to ~1 µs/probe)" |
| `IF97.rst:284` | `:ref:`SVDSBTL backend </coolprop/SVDSBTL>`` (malformed Sphinx — `:ref:` doesn't take doc paths) | `:doc:`SVDSBTL accuracy envelope </coolprop/SVDSBTL>`` |
| `IF97.rst:285` | "the four G13-15 thermodynamic properties" (implies uniform pass) | "the four G13-15 thermodynamic properties (T, v, s, w) fare against per-region IAPWS budgets — see SVDSBTL accuracy envelope for the per-property/per-region pass/fail summary" |
| `IF97.rst:303` | "~1000 ns Python-wrapper marshalling" (~3× too high) | "~300 ns of Cython-wrapper marshalling across the three FFI crossings" |
| `IF97.rst:307-308` | "CoolProp 7.2" | "CoolProp 7.2.1 (PR #2942)" — dome-blend landed in commit `5fb9bb876`, 2026-05-21; v7.2.0 was tagged 2025-11-01 |

## Soft inaccuracies tightened

| File:line | Issue |
|---|---|
| `IF97.rst:75` | "Water is the only fluid name" — added "the alias `IF97::H2O` is also accepted, case-insensitively" |
| `IF97.rst:305-306` | "fast_evaluate per-point cost approaches native C++" — reworded with per-backend breakdown (SVDSBTL ~300 ns/probe supercritical; bare IF97 ~2 µs/probe HmassP regardless of wrapper) |
| `IF97.rst:62-65` | "~1% structural error in v,s,w" softened to "percent-class structural error" with SVDSBTL-atlas-split provenance (the split was introduced specifically to avoid this regime) |

## Carry-over correction from PR #2959 (substantive)

`SVDSBTL.rst:457` claimed "w is conformant in R2 and R5". **Wrong** — R2 `w` max is 0.00442% = 4.42× the 10⁻³% budget. `w` is conformant in **R5 only**. Came from an arithmetic slip by the first audit agent; the IF97 conformance re-audit (re-reading the freshly-rendered `IF97_conformance.rst.in`) caught it.

Also added the R2 T(p,h) thin-margin flag (8.52 mK against 10 mK budget — ~15% headroom — labelled "fragile") and the λ R5 fractional miss (1.1× over budget).

## Audit framework

Five parallel general-purpose subagents, each ~5-7 claims, read-only, cite file:line. Domains:
1. IF97 structural / boundary formula constants
2. IF97 backend API surface (factory, supported pairs, excluded ops)
3. IF97 timing claims (per-call, batched, profile script + figure)
4. IF97 conformance (re-read rendered `IF97_conformance.rst.in`)
5. SVDSBTL ↔ IF97 cross-page consistency post-PR #2959

Pre-PR `superpowers:code-reviewer` adversarial pass: no blocking findings. Two minor non-blocking suggestions (already incorporated). Two out-of-scope findings tracked via bd `CoolProp-6zl` (same n5 typo in `IF97Conformance.py:135` and `SurfacePresets.cpp:87,94` — ~1.45e-7 relative, below any conformance threshold).

## Out-of-scope but flagged
- `Web/fluid_properties/IF97_profile.png` (mtime 2026-05-21) predates the dome-blend / R5 extension / PR #2959. Not git-tracked. Should be regenerated before next docs release.
- `Web/scripts/fluid_properties.IF97Conformance.py:80-87` uses a uniform 10⁻³% budget for v/w/η/λ where G13-15 has per-region budgets (script's own comment admits "pending per-region verification"). Conservative direction.

## Test plan
- [ ] Sphinx docs build succeeds; `:doc:` and `:ref:` cross-refs resolve.
- [ ] The corrected `p_B23` formula in the prose round-trips numerically (T=623.15 K → ~16.529 MPa) when a reader evaluates it directly.
- [ ] The range-of-validity matplotlib plot still renders identically (the `n5` correction is below plot visibility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated water property accuracy conformance information across different calculation regions with refined conformance criteria
  * Revised IF97 region boundary equation specifications and emphasized proper table-building procedures to avoid computational errors
  * Clarified reference-state behavior and updated performance metrics with revised benchmarking data and timing analysis

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->