### PR TITLE
feat(svdsbtl): implement ALTERNATIVE_SVDTABLES_DIRECTORY config key (CoolProp-fhp)

### DIFF
--- a/Web/coolprop/SVDSBTL.rst
+++ b/Web/coolprop/SVDSBTL.rst
@@ -132,7 +132,10 @@ compressed binary file under
 
     $HOME/.CoolProp/SVDTables/<Fluid>.<Source>.<InputPair>.<OptHash>.svd.bin.z
 
-Subsequent constructions for the same tuple load from this cache.
+(or under ``${ALTERNATIVE_SVDTABLES_DIRECTORY}/`` in place of
+``$HOME/.CoolProp/SVDTables/`` when that config key is set — see
+:ref:`SVDSBTL-config` below).  Subsequent constructions for the same
+tuple load from this cache.
 
 * **Build time:** ~10-60 s per (fluid, input pair) on a 2024-era laptop,
   HEOS-source.  REFPROP-source is several times slower (REFPROP flash
@@ -145,8 +148,10 @@ Subsequent constructions for the same tuple load from this cache.
   ``.github/workflows/test_catch2.yml`` so CI rebuilds occur
   automatically.
 
-The cache directory is ``~/.CoolProp/SVDTables/`` on all platforms.
-A configurable cache directory is tracked in bd ``CoolProp-fhp``.
+The cache directory defaults to ``~/.CoolProp/SVDTables/`` on all
+platforms.  The location is configurable via the
+``ALTERNATIVE_SVDTABLES_DIRECTORY`` configuration key — see
+:ref:`SVDSBTL-config` below.
 
 .. _SVDSBTL-regimes:
 
@@ -394,6 +399,21 @@ Configuration keys
     Gate for ``PropsSI`` routing.  See :ref:`Three performance regimes
     <SVDSBTL-regimes>`.  Set to ``true`` for interactive
     use; leave ``false`` for throughput code.
+
+``ALTERNATIVE_SVDTABLES_DIRECTORY`` (default empty)
+    Override the on-disk cache directory.  When non-empty, both the
+    ``.svd.bin.z`` surface files and the ``.critpatch.bin`` sidecars
+    are read from and written to this directory in place of the
+    default ``~/.CoolProp/SVDTables/``.  The directory is created on
+    first use.  Useful when ``$HOME`` is read-only (CI containers,
+    sandboxed processes), on shared workstations, or when a
+    centrally-managed cache is preferable.  Set via the Python API
+    like any other string-typed config key:
+
+    .. code-block:: python
+
+       import CoolProp.CoolProp as CP
+       CP.set_config_string(CP.ALTERNATIVE_SVDTABLES_DIRECTORY, "/srv/coolprop_cache")
 
 ``SVDSBTL_SAMPLING_THREADS`` (default ``1``)
     Number of worker threads for the per-grid-cell sampling phase of

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -29,6 +29,10 @@
     X(SAVE_RAW_TABLES, "SAVE_RAW_TABLES", false, "If true, the raw, uncompressed tables will also be written to file")                               \
     X(ALTERNATIVE_TABLES_DIRECTORY, "ALTERNATIVE_TABLES_DIRECTORY", "",                                                                              \
       "If provided, this path will be the root directory for the tabular data.  Otherwise, ${HOME}/.CoolProp/Tables is used")                        \
+    X(ALTERNATIVE_SVDTABLES_DIRECTORY, "ALTERNATIVE_SVDTABLES_DIRECTORY", "",                                                                        \
+      "If provided, this path will be the root directory for the SVDSBTL on-disk cache (both .svd.bin.z surfaces and .critpatch.bin sidecars).  "    \
+      "Otherwise, ${HOME}/.CoolProp/SVDTables is used.  Useful when ${HOME} is read-only (CI containers), on shared workstations, or for "           \
+      "centrally-managed cache directories.")                                                                                                        \
     X(ALTERNATIVE_REFPROP_PATH, "ALTERNATIVE_REFPROP_PATH", "",                                                                                      \
       "An alternative path to be provided to the directory that contains REFPROP's fluids and mixtures directories.  If provided, the SETPATH "      \
       "function will be called with this directory prior to calling any REFPROP functions.")                                                         \

--- a/src/SBTL/SVDSurfaceSerializer.cpp
+++ b/src/SBTL/SVDSurfaceSerializer.cpp
@@ -16,6 +16,7 @@
 #include "AbstractState.h"
 #include "Backends/Helmholtz/HelmholtzEOSMixtureBackend.h"
 #include "CPfilepaths.h"
+#include "Configuration.h"
 #include "CoolProp/region/ConstantCurve.h"
 #include "CoolProp/region/CubicSplineCurve.h"
 #include "CoolProp/region/PiecewiseChebyshevCurve.h"
@@ -489,7 +490,14 @@ SVDSurface SVDSurfaceSerializer::load_from_file(const std::string& path) {
 }
 
 std::string SVDSurfaceSerializer::default_cache_dir() {
-    const std::string dir = ::get_home_dir() + "/.CoolProp/SVDTables";
+    // ALTERNATIVE_SVDTABLES_DIRECTORY (when non-empty) overrides the
+    // default $HOME/.CoolProp/SVDTables location.  Both the .svd.bin.z
+    // surfaces and the .critpatch.bin sidecars route through this
+    // helper, so a single config key redirects both.  Motivation:
+    // read-only $HOME (CI containers), shared workstations, centrally-
+    // managed cache directories.
+    const std::string alt = ::CoolProp::get_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY);
+    std::string dir = alt.empty() ? (::get_home_dir() + "/.CoolProp/SVDTables") : alt;
     std::error_code ec;
     std::filesystem::create_directories(dir, ec);
     if (ec) {
@@ -499,7 +507,13 @@ std::string SVDSurfaceSerializer::default_cache_dir() {
         // SVDSBTL session pays the full build cost.
         std::fprintf(stderr, "SVDSurfaceSerializer: could not create cache dir %s: %s\n", dir.c_str(), ec.message().c_str());
     }
-    return dir + "/";
+    // Normalize: callers naively concatenate dir + filename, so the
+    // returned path must end with a separator regardless of whether
+    // the user supplied a trailing slash in their override.
+    if (!dir.empty() && dir.back() != '/' && dir.back() != '\\') {
+        dir.push_back('/');
+    }
+    return dir;
 }
 
 std::string SVDSurfaceSerializer::default_cache_path(const std::string& fluid_name, const std::string& source_backend,

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -8,6 +8,8 @@
 using Catch::Approx;
 
 #    include <algorithm>
+#    include <chrono>
+#    include <cstdint>
 #    include <filesystem>
 #    include <memory>
 #    include <random>
@@ -746,6 +748,117 @@ TEST_CASE("SVDSBTL fast_evaluate rejects unsupported inputs cleanly", "[SVDSBTL]
     REQUIRE_THROWS_AS(svd->fast_evaluate(CoolProp::PQ_INPUTS, v1.data(), v2.data(), 1, outputs.data(), outputs.size(), out.data(), out.size(),
                                          status.data(), status.size()),
                       CoolProp::ValueError);
+}
+
+// -----------------------------------------------------------------------------
+// ALTERNATIVE_SVDTABLES_DIRECTORY config key (CoolProp-fhp)
+// -----------------------------------------------------------------------------
+
+// Fast resolver-only test: no table build.  Verifies the contract that
+// default_cache_dir() consults the config key, creates the directory,
+// normalizes the trailing separator, and falls back to ~/.CoolProp/SVDTables
+// when the override is empty.  Both the .svd.bin.z surfaces and the
+// .critpatch.bin sidecars route through default_cache_dir(), so this single
+// check covers both file kinds by construction.
+TEST_CASE("SVDSBTL ALTERNATIVE_SVDTABLES_DIRECTORY routes default_cache_dir", "[SVDSBTL][cache][fhp]") {
+    namespace fs = std::filesystem;
+    namespace cp_sbtl = CoolProp::sbtl;
+    const std::string saved = CoolProp::get_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY);
+    const fs::path tmpdir = fs::temp_directory_path() / "coolprop_svdtables_fhp_resolver";
+    std::error_code ec;
+    fs::remove_all(tmpdir, ec);
+
+    // Override -> resolved path starts with override and ends with a separator.
+    CoolProp::set_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY, tmpdir.string());
+    const std::string resolved = cp_sbtl::SVDSurfaceSerializer::default_cache_dir();
+    REQUIRE(resolved.rfind(tmpdir.string(), 0) == 0);
+    REQUIRE_FALSE(resolved.empty());
+    REQUIRE((resolved.back() == '/' || resolved.back() == '\\'));
+    REQUIRE(fs::is_directory(tmpdir));
+
+    // Trailing separator already present in override -> no double slash.
+    const std::string with_slash = tmpdir.string() + "/";
+    CoolProp::set_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY, with_slash);
+    const std::string resolved2 = cp_sbtl::SVDSurfaceSerializer::default_cache_dir();
+    REQUIRE(resolved2.find("//") == std::string::npos);
+
+    // Empty -> default $HOME/.CoolProp/SVDTables path.
+    CoolProp::set_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY, "");
+    const std::string defaulted = cp_sbtl::SVDSurfaceSerializer::default_cache_dir();
+    REQUIRE(defaulted.find("/.CoolProp/SVDTables") != std::string::npos);
+
+    CoolProp::set_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY, saved);
+    fs::remove_all(tmpdir, ec);
+}
+
+// End-to-end test: with the override set to a fresh tmpdir, building an
+// SVDSBTL AbstractState must land its cache files inside that tmpdir (not in
+// $HOME), and a second construction with the same options must hit-and-load
+// from there (cache file's mtime must NOT advance).  Uses the smallest schema-
+// valid grid so the build is a few seconds; tagged [slow] so the default
+// preflight tag sweep doesn't pay the cost on every iteration.
+TEST_CASE("SVDSBTL ALTERNATIVE_SVDTABLES_DIRECTORY end-to-end build + reload", "[SVDSBTL][cache][fhp][slow]") {
+    namespace fs = std::filesystem;
+    const std::string saved = CoolProp::get_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY);
+    const fs::path tmpdir = fs::temp_directory_path() / "coolprop_svdtables_fhp_e2e";
+    std::error_code ec;
+    fs::remove_all(tmpdir, ec);
+    CoolProp::set_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY, tmpdir.string());
+
+    // Smallest valid grid + critical_patch off so we don't pay the
+    // bbox-calibration loop.  The options blob is the cache key (via
+    // its FNV-1a 64 opthash) so first and second construction must use
+    // an identical blob to share a cache file.
+    const std::string opts = R"({"grid":{"NT":40,"NR":80,"rank":10},"critical_patch":{"mode":"off"}})";
+    const std::string spec = "SVDSBTL&HEOS";
+    const std::string spec_with_opts = std::string("Water?") + opts;
+
+    auto cache_files_in_tmpdir = [&]() {
+        std::vector<fs::path> out;
+        if (!fs::is_directory(tmpdir, ec)) return out;
+        for (const auto& entry : fs::directory_iterator(tmpdir, ec)) {
+            const std::string name = entry.path().filename().string();
+            if (name.find(".svd.bin.z") != std::string::npos) out.push_back(entry.path());
+        }
+        return out;
+    };
+
+    // First construction -> build + write cache files into tmpdir.
+    {
+        auto first = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory(spec, spec_with_opts));
+        first->update(CoolProp::PT_INPUTS, 1.0e6, 350.0);
+    }
+    REQUIRE(fs::is_directory(tmpdir));
+    auto files = cache_files_in_tmpdir();
+    INFO("cache files in tmpdir: " << files.size());
+    REQUIRE_FALSE(files.empty());
+    // Stash mtimes as plain int64 nanoseconds: Catch2's stringifier on
+    // macOS can't print std::filesystem::file_time_type (the underlying
+    // duration uses __int128) so a failing REQUIRE on the raw type
+    // produces an ambiguous operator<< compile error.
+    auto to_ns = [](const fs::file_time_type& t) {
+        return static_cast<std::int64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(t.time_since_epoch()).count());
+    };
+    std::vector<std::int64_t> mtimes_before_ns;
+    mtimes_before_ns.reserve(files.size());
+    for (const auto& f : files) mtimes_before_ns.push_back(to_ns(fs::last_write_time(f)));
+
+    // Second construction with the same options -> must read from cache,
+    // not rebuild.  A rebuild would rewrite the .svd.bin.z files and
+    // bump their mtime.
+    {
+        auto second = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory(spec, spec_with_opts));
+        second->update(CoolProp::PT_INPUTS, 1.0e6, 350.0);
+    }
+    const auto files_after = cache_files_in_tmpdir();
+    REQUIRE(files_after.size() == files.size());
+    for (std::size_t i = 0; i < files.size(); ++i) {
+        INFO("file: " << files[i].filename().string());
+        REQUIRE(to_ns(fs::last_write_time(files[i])) == mtimes_before_ns[i]);
+    }
+
+    CoolProp::set_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY, saved);
+    fs::remove_all(tmpdir, ec);
 }
 
 #endif  // ENABLE_CATCH


### PR DESCRIPTION
## Summary

- Adds `ALTERNATIVE_SVDTABLES_DIRECTORY` config key (default empty) that overrides the SVDSBTL on-disk cache location. Mirrors the pre-existing `ALTERNATIVE_TABLES_DIRECTORY` (BICUBIC/TTSE).
- Both `.svd.bin.z` surfaces and `.critpatch.bin` sidecars inherit the override — `default_cache_dir()` is the single chokepoint both file kinds route through.
- Doc text was removed in #2959 pending implementation; this PR restores it and the bd `CoolProp-fhp` pointer becomes the actual feature.

## Why

Read-only `$HOME` (CI containers, sandboxed processes), shared workstations, and centrally-managed cache directories all need the SVDSBTL backend to read/write its ~5-15 MB-per-file cache somewhere other than `$HOME/.CoolProp/SVDTables`. Without this, every session in those environments pays the full ~10-60 s table-build cost.

## Implementation notes

- `include/Configuration.h`: register the new string key. Picked up by `COOLPROP_ALTERNATIVE_SVDTABLES_DIRECTORY` env var via the existing `possibly_set_from_env()` machinery, just like every other config key.
- `src/SBTL/SVDSurfaceSerializer.cpp`: `default_cache_dir()` consults the config before falling back to `$HOME/.CoolProp/SVDTables`, and normalizes the trailing separator so a user-supplied path without `/` still composes correctly with the filename suffix.
- `src/Backends/SVDSBTL/SVDSBTLBackend.cpp`: untouched — `critpatch_cache_path_()` already calls `SVDSurfaceSerializer::default_cache_dir()`, so the override flows through automatically.
- Defense-in-depth on `default_cache_path()` for `fluid_name` / `source_backend` / `opthash` is preserved — the override doesn't widen path-traversal exposure for the per-file components.

## Test plan

- [x] `./build_catch/CatchTestRunner [SVDSBTL][cache][fhp]` — new resolver-only test: 11 assertions / 2 cases passed.
- [x] `./build_catch/CatchTestRunner [SBTL]` — 4229 assertions / 12 cases passed (no regression in the existing serializer / multi-fluid PH preset tests).
- [x] `./build_catch/CatchTestRunner [SVDSBTL]` — full umbrella exit 0 (REFPROP source tests SKIPped in this terminal session for unrelated env reasons).
- [x] Pre-PR adversarial code review (general-purpose agent) — no blocking findings; "ship as-is".
- [ ] Preflight skipped at user's explicit request (`git push --no-verify`) — CI is the next gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable cache directory for SVD thermodynamic tables via new `ALTERNATIVE_SVDTABLES_DIRECTORY` configuration option, allowing users to override the default location for shared or read-only home directories.

* **Documentation**
  * Updated documentation with details on the new configuration option, including usage examples and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2961?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->