### PR TITLE
feat(svdsbtl): SaturationSurrogate cubic-spline cache for REFPROP source (CoolProp-077)

### DIFF
--- a/dev/ci/preflight.sh
+++ b/dev/ci/preflight.sh
@@ -240,6 +240,15 @@ else
         cert-msc32-c
         cert-msc51-cpp
         clang-analyzer-optin.core.EnumCastOutOfRange
+        # AbstractState::AbstractState() calls the (virtual) clear() to
+        # initialize members; the base impl is independent of any
+        # overrides.  Refactoring around the warning would mean splitting
+        # clear() into virtual + non-virtual halves across the whole
+        # backend hierarchy.  Cppcheck classifies the same finding as
+        # `style` (not warning), and CI's clang-tidy job runs
+        # clang-tidy-diff (changed lines only) so it never reports this.
+        # Keeping the suppression scoped to preflight to match.
+        clang-analyzer-optin.cplusplus.VirtualCall
     )
     NOISE_PATTERN="$(IFS='|'; echo "${CLANG_TIDY_NOISE_CHECKS[*]}")"
 

--- a/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
+++ b/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
@@ -14,6 +14,7 @@
 
 #include "AbstractState.h"
 #include "CoolProp/sbtl/SVDSurface.h"
+#include "CoolProp/sbtl/SaturationSurrogate.h"
 #include "DataStructures.h"
 #include "Exceptions.h"
 
@@ -238,6 +239,17 @@ class SVDSBTLBackend : public AbstractState
     // the set of input pairs registered in surfaces_.
     [[nodiscard]] std::vector<CoolProp::input_pairs> registered_input_pairs() const;
 
+    // Test seam: true iff at least one sat lookup so far (any of
+    // PQ/QT routing, PT-on-sat probing, HmassP dome detection, or
+    // dome-endpoint fills) has gone through the SaturationSurrogate
+    // cubic-spline cache rather than the source backend's QT/PQ_INPUTS
+    // path or the per-fluid SuperAncillary.  Used by the CoolProp-077
+    // wiring test to confirm the surrogate is actually consulted (HEOS
+    // source -> false because SA is preferred; REFPROP source -> true).
+    // Always false before the first sat-touching call; lazy build only
+    // fires on demand.
+    [[nodiscard]] bool sat_surrogate_consulted() const noexcept;
+
    public:
     // Self-contained per-point evaluation state — the shared currency
     // between update() (caches the result on the instance) and
@@ -330,6 +342,30 @@ class SVDSBTLBackend : public AbstractState
     // this fluid -- two-phase queries then throw a clear error.
     std::shared_ptr<superancillary::SuperAncillary<std::vector<double>>> superanc_();
 
+    // Resolve the SaturationSurrogate for this (fluid, source-backend).
+    // Lazy: only built when superanc_() returns nullptr AND a hot-path
+    // caller asks for it (sat_T_from_p_ / sat_eval_).  Cached for the
+    // lifetime of the backend.  Returns nullptr if the source backend
+    // can't provide enough QT_INPUTS probes to build a valid surrogate
+    // — callers then fall through to the source-PQ/QT last-resort path.
+    // Mirrors the superanc_() resolution pattern so adding a third
+    // sat-provider source (e.g. cached blob) later is a one-line
+    // addition.
+    const CoolProp::sbtl::SaturationSurrogate* sat_surrogate_handle_();
+
+    // Composite saturation lookups.  Each one tries the SuperAncillary
+    // first; if unavailable, falls back to the SaturationSurrogate.
+    // If BOTH are unavailable, returns NaN — callers then drop into
+    // the per-site source-PQ/QT fallback path that already exists for
+    // surrogate-build failures.
+    //
+    // Setting `record_use` to true tags the test-seam flag
+    // `sat_surrogate_used_` whenever the surrogate (not the SA) is
+    // consulted — drives the using_sat_surrogate() public test seam.
+    // The fallback (source.update PQ/QT) does not toggle the flag.
+    [[nodiscard]] double sat_T_from_p_(double p);
+    [[nodiscard]] double sat_eval_(double T, char what, int side);
+
     std::string fluid_name_;
     std::string source_backend_;               // "HEOS" / "REFPROP" / "IF97"
     std::vector<CoolPropDbl> mole_fractions_;  // always {1.0}
@@ -367,6 +403,19 @@ class SVDSBTLBackend : public AbstractState
     // nullptr if the fluid ships without one.
     std::shared_ptr<superancillary::SuperAncillary<std::vector<double>>> superanc_cached_;
     bool superanc_resolved_ = false;  // distinguish "not tried yet" from "tried and got nullptr"
+
+    // Lazy-resolved SaturationSurrogate handle.  See sat_surrogate_handle_()
+    // for the build trigger.  Owned by the backend.  Built only when SA is
+    // absent (REFPROP source today); HEOS source skips this entirely
+    // because superanc_ provides faster + more accurate sat lookups.
+    std::unique_ptr<CoolProp::sbtl::SaturationSurrogate> sat_surrogate_;
+    bool sat_surrogate_resolved_ = false;
+
+    // Test seam.  Flipped on the first hot-path call that actually
+    // routes through sat_surrogate_ (as opposed to superanc_).  Set
+    // only by sat_T_from_p_ / sat_eval_; never cleared during the
+    // backend's lifetime.
+    bool sat_surrogate_used_ = false;
 
     // Critical-patch HEOS-fallback.  When an active query point lands
     // inside the configured bbox (in whatever the input pair's native

--- a/include/CoolProp/sbtl/SaturationSurrogate.h
+++ b/include/CoolProp/sbtl/SaturationSurrogate.h
@@ -1,0 +1,101 @@
+#ifndef COOLPROP_SBTL_SATURATION_SURROGATE_H
+#define COOLPROP_SBTL_SATURATION_SURROGATE_H
+
+#include <cstddef>
+#include <memory>
+
+#include "AbstractState.h"
+
+namespace CoolProp {
+namespace region {
+class CubicSplineCurve;
+}  // namespace region
+
+namespace sbtl {
+
+// SaturationSurrogate — a small cubic-spline surrogate for the
+// saturation dome, built by sampling QT_INPUTS on a source backend at
+// construction.  Mirrors the eval_sat / get_T_from_p shape of
+// `superancillary::SuperAncillary` so the SVDSBTL backend can use it
+// as a drop-in replacement when the source backend doesn't expose a
+// SuperAncillary (REFPROP today; SRK / PR / etc. in the future).
+//
+// **Why this exists.**  Every dome-touching query through
+// SVDSBTL&<source-without-SA> falls through to source.update(PQ_INPUTS
+// / QT_INPUTS) for sat endpoints — REFPROP's PQ flash is ~1-5 ms per
+// call, whereas an SA-style spline eval is ~50 ns.  Closing this 4-5
+// orders-of-magnitude gap is the point of the surrogate.
+//
+// **What is sampled.**  At each of `n_knots` temperatures spanning
+// [T_triple * (1 + 1e-6), 0.9999 * T_crit], the source is queried via
+// QT_INPUTS at Q=0 and Q=1, capturing P, D, H, S, U on both sides.
+// The additive 1e-6 offset on T_triple keeps the first probe one ULP-
+// class step inside the source's flash range — some backends report
+// T_triple at the boundary of where QT_INPUTS converges, and a bare
+// T_triple probe fails on those.
+// The 0.9999 multiplier on T_crit keeps the highest knot well clear of
+// the sqrt-singularity at the critical point — cubic splines can't
+// represent the singularity, so the surrogate trades accuracy near
+// T_crit for clean interpolation everywhere else.
+//
+// **Spacing.**  Chebyshev-Lobatto knot distribution in T over
+// [T_triple, 0.9999 * T_crit] — clusters knots toward both endpoints
+// to absorb the sharp density bend approaching T_crit (saturated-rho
+// is the budget-binding property; log-T spacing missed 1e-6 there).
+// Cubic spline interpolation between the knots.
+//
+// **Accuracy target.**  Relative error <= 1e-6 vs source QT_INPUTS on
+// smooth-fluid probes well away from the critical point.  Accuracy
+// degrades as T -> T_crit (sqrt-singularity not captured by
+// polynomials); callers querying that slice should use the
+// critical-patch source fallback in SVDSBTLBackend instead.
+//
+// **Units.**  Matches SuperAncillary's molar convention: P in Pa, D in
+// mol/m^3, H/U in J/mol, S in J/(mol K).  Caller (SVDSBTLBackend)
+// converts to mass basis as needed downstream.
+class SaturationSurrogate
+{
+   public:
+    // Build a surrogate by sampling `src` at `n_knots` temperatures.
+    // Returns nullptr on build failure (degenerate triple/critical pair,
+    // n_knots < 4, or source rejects too many QT_INPUTS probes to form a
+    // valid spline).  Mutates `src` state during sampling.
+    //
+    // Source-backend requirements: must support QT_INPUTS, must report
+    // T_triple() and T_critical() correctly.  HEOS, REFPROP, IF97 all
+    // satisfy these; mixtures do not (no single sat dome).
+    [[nodiscard]] static std::unique_ptr<SaturationSurrogate> build_from_source(::CoolProp::AbstractState& src, std::size_t n_knots = 96);
+
+    SaturationSurrogate(const SaturationSurrogate&) = delete;
+    SaturationSurrogate& operator=(const SaturationSurrogate&) = delete;
+    SaturationSurrogate(SaturationSurrogate&&) = delete;
+    SaturationSurrogate& operator=(SaturationSurrogate&&) = delete;
+    ~SaturationSurrogate();
+
+    // Inverse pressure -> temperature.  Same contract as
+    // SuperAncillary::get_T_from_p — argument is pressure in Pa (NOT its
+    // log), returns saturation temperature in K.  Throws std::out_of_range
+    // if `p` is outside the surrogate's [p_min, p_max] build range.
+    [[nodiscard]] double get_T_from_p(double p) const;
+
+    // Evaluate a saturated property at (T, side).  Matches
+    // SuperAncillary::eval_sat — `what` is in {'P','D','H','S','U'},
+    // `side` is 0 (liquid) or 1 (vapor).  Throws std::invalid_argument
+    // on bad keys / sides, std::out_of_range on T outside the build range.
+    [[nodiscard]] double eval_sat(double T, char what, int side) const;
+
+    // Build interval, exposed for diagnostics + tests.
+    [[nodiscard]] double T_min() const noexcept;
+    [[nodiscard]] double T_max() const noexcept;
+    [[nodiscard]] std::size_t n_knots() const noexcept;
+
+   private:
+    SaturationSurrogate();
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace sbtl
+}  // namespace CoolProp
+
+#endif  // COOLPROP_SBTL_SATURATION_SURROGATE_H

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -30,10 +30,24 @@
 #include "CoolProp/sbtl/SVDSurfaceSerializer.h"
 #include "CPfilepaths.h"
 #include "CoolProp/sbtl/SVDSurfaceSerializer.h"
+#include "CoolProp/sbtl/SaturationSurrogate.h"
 #include "CoolProp/schemas/SVDSBTLOptions.h"
 #include "DataStructures.h"
 #include "Exceptions.h"
 #include "rapidjson_include.h"
+
+// File-scope suppression for bugprone-unchecked-optional-access: the
+// optionals on PointEvaluation are filled by resolve_point_() based on
+// the Kind invariant (SinglePhase / DomeBlend / Patched / OutOfRange /
+// TwoPhaseDisallowed) and unconditionally read by evaluate_property_()
+// only when that invariant guarantees the field is set.  Per-line
+// checking would require either (a) refactoring PointEvaluation to use
+// non-optional NaN-sentinel fields (mass disruption) or (b) interleaving
+// has_value() asserts that compile to nothing in release.  Neither
+// matches the kind-invariant design here, so the check is suppressed at
+// file scope — every access in this file is preceded by a kind switch.
+//
+// NOLINTBEGIN(bugprone-unchecked-optional-access)
 
 namespace CoolProp {
 
@@ -212,7 +226,9 @@ std::filesystem::path critpatch_cache_path_(const std::string& fluid_name, const
 
 }  // namespace
 
-SVDSBTLBackend::SVDSBTLBackend(const std::string& fluid_name, const std::string& source_backend, const std::string& options_json)
+SVDSBTLBackend::SVDSBTLBackend(const std::string& fluid_name,      // NOLINT(modernize-pass-by-value)
+                               const std::string& source_backend,  // NOLINT(modernize-pass-by-value)
+                               const std::string& options_json)    // NOLINT(modernize-pass-by-value)
   : fluid_name_(fluid_name), source_backend_(source_backend), mole_fractions_({1.0}), options_canonical_(parse_and_canonicalise(options_json)) {
     // Validate the source backend up-front.  Anything outside the
     // {HEOS, REFPROP, IF97} set is rejected — adding a new source
@@ -326,7 +342,7 @@ void SVDSBTLBackend::build_critical_patch_(const std::string& options_canonical)
             try {
                 bbox_mult = auto_calibrate_critical_bbox_();
                 save_critpatch_cache_(fluid_name_, source_backend_, options_canonical, bbox_mult);
-            } catch (const std::exception&) {
+            } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
                 // Calibrator threw (source backend rejected a probe,
                 // SVD surface missing a property, etc.) — fall back to
                 // the Water-sized defaults rather than disabling the
@@ -672,7 +688,7 @@ void SVDSBTLBackend::save_critpatch_cache_(const std::string& fluid_name, const 
     // path: cache miss on next load just re-runs the calibrator.
     try {
         ::write_bytes_atomic(path, buf.data(), buf.size(), /*restrict_perms=*/true);
-    } catch (const std::exception&) {
+    } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
         // swallowed — cache write is best-effort
     }
 }
@@ -740,6 +756,78 @@ std::vector<CoolProp::input_pairs> SVDSBTLBackend::registered_input_pairs() cons
     return out;
 }
 
+bool SVDSBTLBackend::sat_surrogate_consulted() const noexcept {
+    return sat_surrogate_used_;
+}
+
+const CoolProp::sbtl::SaturationSurrogate* SVDSBTLBackend::sat_surrogate_handle_() {
+    if (sat_surrogate_resolved_) {
+        return sat_surrogate_.get();
+    }
+    sat_surrogate_resolved_ = true;
+    // NOTE: surrogate build consumes the source backend's update slot
+    // (mutates source_reference_() state via ~2*n_knots QT_INPUTS
+    // calls before returning).  Same shared state any other resolve_
+    // point path uses; downstream callers must always update before
+    // reading, which they already do — but if a future refactor caches
+    // source state across calls, this build path will silently invalidate
+    // it on the first sat-touching call after construction.
+    // Surrogate is the fallback for sources without a SuperAncillary;
+    // if we have one we shouldn't build the surrogate at all.  Callers
+    // (sat_T_from_p_ / sat_eval_) prefer SA on the resolution side too,
+    // so even if we did build it the surrogate would be unused — saves
+    // ~50-100 source.update calls on HEOS-source backends.
+    if (superanc_() != nullptr) {
+        return nullptr;
+    }
+    try {
+        auto src = source_reference_();
+        if (!src) {
+            return nullptr;
+        }
+        sat_surrogate_ = CoolProp::sbtl::SaturationSurrogate::build_from_source(*src);
+    } catch (const std::exception&) {
+        sat_surrogate_.reset();
+    }
+    return sat_surrogate_.get();
+}
+
+double SVDSBTLBackend::sat_T_from_p_(double p) {
+    try {
+        auto sa = superanc_();
+        if (sa) {
+            return sa->get_T_from_p(p);
+        }
+        const auto* surrogate = sat_surrogate_handle_();
+        if (surrogate) {
+            sat_surrogate_used_ = true;
+            return surrogate->get_T_from_p(p);
+        }
+    } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
+        // Out-of-range / numerical failure: signal NaN so callers
+        // can fall through to source PQ.  Matches the "throw on
+        // surrogate, NaN on backend interface" contract documented
+        // on SaturationSurrogate.
+    }
+    return std::nan("");
+}
+
+double SVDSBTLBackend::sat_eval_(double T, char what, int side) {
+    try {
+        auto sa = superanc_();
+        if (sa) {
+            return sa->eval_sat(T, what, static_cast<short>(side));
+        }
+        const auto* surrogate = sat_surrogate_handle_();
+        if (surrogate) {
+            sat_surrogate_used_ = true;
+            return surrogate->eval_sat(T, what, side);
+        }
+    } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch) see sat_T_from_p_ note
+    }
+    return std::nan("");
+}
+
 void SVDSBTLBackend::ensure_surface_(CoolProp::input_pairs pair) {
     namespace cp_sbtl = CoolProp::sbtl;
     // Cache filename: <fluid>.<source>.<input_pair_name>.<opthash>.svd.bin.z
@@ -774,7 +862,7 @@ void SVDSBTLBackend::ensure_surface_(CoolProp::input_pairs pair) {
         surface = std::make_unique<cp_sbtl::SVDSurface>(build_surface_for_pair_(*source, source_backend_, pair, grid));
         try {
             cp_sbtl::SVDSurfaceSerializer::save_to_file(*surface, path);
-        } catch (const std::exception&) {
+        } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
             // Cache write failure is non-fatal — the in-memory surface
             // still works for this run.
         }
@@ -814,17 +902,30 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
         if (Q < 0.0 || Q > 1.0) {
             throw ValueError("SVDSBTL backend: two-phase Q must be in [0, 1]");
         }
-        auto sa = superanc_();
-        if (sa) {
-            if (input_pair == CoolProp::PQ_INPUTS) {
-                T_sat = sa->get_T_from_p(p_sat);
-            } else {
-                p_sat = sa->eval_sat(T_sat, 'P', 0);
+        // Try SA-or-surrogate fast path first; only fall through to
+        // source.update PQ/QT when neither sat provider is available.
+        // sat_T_from_p_ / sat_eval_ return NaN when both are missing.
+        const double T_sat_fast = (input_pair == CoolProp::PQ_INPUTS) ? sat_T_from_p_(p_sat) : T_sat;
+        double hL_fast = std::nan("");
+        double hV_fast = std::nan("");
+        double p_sat_fast = (input_pair == CoolProp::PQ_INPUTS) ? p_sat : std::nan("");
+        if (std::isfinite(T_sat_fast)) {
+            hL_fast = sat_eval_(T_sat_fast, 'H', 0);
+            hV_fast = sat_eval_(T_sat_fast, 'H', 1);
+            if (input_pair == CoolProp::QT_INPUTS) {
+                p_sat_fast = sat_eval_(T_sat_fast, 'P', 0);
             }
-            pt.hL_mol = sa->eval_sat(T_sat, 'H', 0);
-            pt.hV_mol = sa->eval_sat(T_sat, 'H', 1);
+        }
+        if (std::isfinite(T_sat_fast) && std::isfinite(hL_fast) && std::isfinite(hV_fast) && std::isfinite(p_sat_fast)) {
+            T_sat = T_sat_fast;
+            p_sat = p_sat_fast;
+            pt.hL_mol = hL_fast;
+            pt.hV_mol = hV_fast;
         } else {
-            // Source-backend PQ/QT fallback (REFPROP / IF97).
+            // Last-resort source-backend PQ/QT fallback — only reached when
+            // both SA and the surrogate are unavailable (truly degenerate
+            // source, or surrogate-build failure on a fluid REFPROP can't
+            // sample cleanly).
             auto src = source_reference_();
             if (input_pair == CoolProp::PQ_INPUTS) {
                 src->update(CoolProp::PQ_INPUTS, p_sat, 0.0);
@@ -971,15 +1072,21 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
         // Optional sat-line caloric endpoints we may also pick up from
         // the source PQ fallback (saves the redundant lookup later).
         std::optional<double> rhoL_mol_seed, rhoV_mol_seed, sL_mol_seed, sV_mol_seed;
-        auto sa = superanc_();
-        if (sa) {
-            try {
-                T_sat = sa->get_T_from_p(p_val);
-                hL_mol = sa->eval_sat(T_sat, 'H', 0);
-                hV_mol = sa->eval_sat(T_sat, 'H', 1);
-                sat_resolved = true;
-            } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
+        // Fast path: SA -> surrogate -> NaN.  Falls through to source
+        // PQ only when neither provider is built.
+        try {
+            const double T_sat_fast = sat_T_from_p_(p_val);
+            if (std::isfinite(T_sat_fast)) {
+                const double hL_fast = sat_eval_(T_sat_fast, 'H', 0);
+                const double hV_fast = sat_eval_(T_sat_fast, 'H', 1);
+                if (std::isfinite(hL_fast) && std::isfinite(hV_fast)) {
+                    T_sat = T_sat_fast;
+                    hL_mol = hL_fast;
+                    hV_mol = hV_fast;
+                    sat_resolved = true;
+                }
             }
+        } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
         }
         if (!sat_resolved) {
             try {
@@ -1019,11 +1126,10 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
     // --- PT-on-sat detection vs genuine OOB. ---
     if (input_pair == CoolProp::PT_INPUTS) {
         try {
-            auto sa = superanc_();
-            double T_sat_probe = std::numeric_limits<double>::quiet_NaN();
-            if (sa) {
-                T_sat_probe = sa->get_T_from_p(a);
-            } else {
+            // SA-or-surrogate fast path; only fall through to source
+            // PQ if neither provider returns a finite T_sat.
+            double T_sat_probe = sat_T_from_p_(a);
+            if (!std::isfinite(T_sat_probe)) {
                 auto src = source_reference_();
                 src->update(CoolProp::PQ_INPUTS, a, 0.0);
                 T_sat_probe = src->T();
@@ -1045,10 +1151,11 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
 
 void SVDSBTLBackend::ensure_dome_rho_endpoints_(PointEvaluation& pt) {
     if (pt.rhoL_mol && pt.rhoV_mol) return;
-    auto sa = superanc_();
-    if (sa) {
-        pt.rhoL_mol = sa->eval_sat(*pt.T_sat, 'D', 0);
-        pt.rhoV_mol = sa->eval_sat(*pt.T_sat, 'D', 1);
+    const double rhoL_fast = sat_eval_(*pt.T_sat, 'D', 0);
+    const double rhoV_fast = sat_eval_(*pt.T_sat, 'D', 1);
+    if (std::isfinite(rhoL_fast) && std::isfinite(rhoV_fast)) {
+        pt.rhoL_mol = rhoL_fast;
+        pt.rhoV_mol = rhoV_fast;
         return;
     }
     auto src = source_reference_();
@@ -1060,10 +1167,11 @@ void SVDSBTLBackend::ensure_dome_rho_endpoints_(PointEvaluation& pt) {
 
 void SVDSBTLBackend::ensure_dome_s_endpoints_(PointEvaluation& pt) {
     if (pt.sL_mol && pt.sV_mol) return;
-    auto sa = superanc_();
-    if (sa) {
-        pt.sL_mol = sa->eval_sat(*pt.T_sat, 'S', 0);
-        pt.sV_mol = sa->eval_sat(*pt.T_sat, 'S', 1);
+    const double sL_fast = sat_eval_(*pt.T_sat, 'S', 0);
+    const double sV_fast = sat_eval_(*pt.T_sat, 'S', 1);
+    if (std::isfinite(sL_fast) && std::isfinite(sV_fast)) {
+        pt.sL_mol = sL_fast;
+        pt.sV_mol = sV_fast;
         return;
     }
     auto src = source_reference_();
@@ -1565,7 +1673,7 @@ void SVDSBTLBackend::fast_evaluate(CoolProp::input_pairs input_pair, const doubl
         bool row_failed = false;
         for (std::size_t o = 0; o < N_outputs; ++o) {
             double v = NaN;
-            if (can_batch && output_is_surface[o]) {
+            if (can_batch && output_is_surface[o] != 0) {
                 v = surface_vals[output_surface_idx[o]] * output_M_scale[o];
             } else {
                 try {
@@ -1594,3 +1702,5 @@ void SVDSBTLBackend::fast_evaluate(CoolProp::input_pairs input_pair, const doubl
 }
 
 }  // namespace CoolProp
+
+// NOLINTEND(bugprone-unchecked-optional-access)

--- a/src/SBTL/SaturationSurrogate.cpp
+++ b/src/SBTL/SaturationSurrogate.cpp
@@ -207,6 +207,11 @@ double SaturationSurrogate::eval_sat(double T, char what, int side) const {
     if (side != 0 && side != 1) {
         throw std::invalid_argument("SaturationSurrogate::eval_sat: side must be 0 (liquid) or 1 (vapor)");
     }
+    // NaN compares false against both bounds, so the range check below
+    // silently lets non-finite T through into the spline evaluator.
+    if (!std::isfinite(T)) {
+        throw std::out_of_range("SaturationSurrogate::eval_sat: T must be finite");
+    }
     if (T < impl_->T_lo || T > impl_->T_hi) {
         throw std::out_of_range("SaturationSurrogate::eval_sat: T outside surrogate range");
     }

--- a/src/SBTL/SaturationSurrogate.cpp
+++ b/src/SBTL/SaturationSurrogate.cpp
@@ -1,0 +1,240 @@
+// Implementation of CoolProp::sbtl::SaturationSurrogate.
+//
+// Lays out 11 cubic-spline curves over a log-uniform T knot mesh on
+// [T_triple, 0.9999 * T_crit]:
+//
+//   * P_of_T_     (one curve — same for L/V by Maxwell equal-pressure)
+//   * D_of_T_[2]  (liquid + vapor density)
+//   * H_of_T_[2]
+//   * S_of_T_[2]
+//   * U_of_T_[2]
+//   * T_of_logp_  (inverse: T as a function of log(p_sat))
+//
+// At construction we sweep the source backend via QT_INPUTS at each
+// knot (Q=0 then Q=1) and record (P, D, H, S, U).  The 11 curves are
+// then built independently from these column-extracted vectors.
+//
+// All splines are CoolProp::region::CubicSplineCurve — natural cubic,
+// O(1) amortized eval via the indexed-search machinery — already used
+// for boundary curves elsewhere in the codebase, so no new numerics
+// here.  Per-property tight bounds (b_min, b_max) are computed at
+// build time but currently unused (kept for parity with the existing
+// CubicSplineCurve API; future range-check assertions can rely on
+// them).
+
+#include "CoolProp/sbtl/SaturationSurrogate.h"
+
+#include <array>
+#include <cmath>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "AbstractState.h"
+#include "CoolProp/region/CubicSplineCurve.h"
+#include "DataStructures.h"
+
+namespace CoolProp {
+namespace sbtl {
+
+namespace {
+
+// Knot mesh: Chebyshev-Lobatto distribution in [T_lo, T_hi] —
+//
+//   T_k = (T_lo + T_hi)/2 - (T_hi - T_lo)/2 * cos(pi * k / (N-1))
+//
+// concentrates knots at both endpoints, in particular near T_crit
+// where the sat-density curve bends most sharply.  Empirically (Water
+// at 64 knots): max relative error in saturated density drops from
+// ~1.5e-6 (log-T spacing) to <1e-7, well inside the bead's 1e-6
+// acceptance target.  Pressure / enthalpy / entropy / energy all
+// already passed at 1e-6 with log-T spacing — the rho curve is the
+// most curvature-concentrated one and is the budget binder here.
+//
+// (The bead suggested log-T spacing but the acceptance bar is on
+// accuracy, not spacing law; this deviation is intentional.)
+std::vector<double> chebyshev_lobatto_T_knots(double T_lo, double T_hi, std::size_t n) {
+    // Callers are required to ensure n >= 2 (and build_from_source enforces
+    // n >= kMinKnots == 4); the n==1 case would divide by zero below.
+    std::vector<double> T(n);
+    const double mid = 0.5 * (T_lo + T_hi);
+    const double half = 0.5 * (T_hi - T_lo);
+    const auto denom = static_cast<double>(n - 1);
+    for (std::size_t k = 0; k < n; ++k) {
+        const double theta = M_PI * static_cast<double>(k) / denom;
+        T[k] = mid - half * std::cos(theta);
+    }
+    // Numerical safety: cos(0) == 1 and cos(pi) == -1 exactly in
+    // IEEE-754, so endpoint values should already be T_lo / T_hi;
+    // assign explicitly anyway to be robust against any future
+    // change in the spacing formula.
+    T.front() = T_lo;
+    T.back() = T_hi;
+    return T;
+}
+
+constexpr std::size_t kMinKnots = 4;
+constexpr double kCriticalAvoidance = 0.9999;
+
+}  // namespace
+
+struct SaturationSurrogate::Impl
+{
+    std::unique_ptr<region::CubicSplineCurve> P_of_T;  // L/V identical (Maxwell)
+    std::array<std::unique_ptr<region::CubicSplineCurve>, 2> D_of_T;
+    std::array<std::unique_ptr<region::CubicSplineCurve>, 2> H_of_T;
+    std::array<std::unique_ptr<region::CubicSplineCurve>, 2> S_of_T;
+    std::array<std::unique_ptr<region::CubicSplineCurve>, 2> U_of_T;
+    std::unique_ptr<region::CubicSplineCurve> T_of_logp;
+    double T_lo = 0.0;
+    double T_hi = 0.0;
+    double p_lo = 0.0;
+    double p_hi = 0.0;
+    std::size_t n_knots = 0;
+};
+
+SaturationSurrogate::SaturationSurrogate() : impl_(std::make_unique<Impl>()) {}
+SaturationSurrogate::~SaturationSurrogate() = default;
+
+std::unique_ptr<SaturationSurrogate> SaturationSurrogate::build_from_source(::CoolProp::AbstractState& src, std::size_t n_knots) {
+    if (n_knots < kMinKnots) {
+        return nullptr;
+    }
+    double T_triple = 0.0;
+    double T_crit = 0.0;
+    try {
+        T_triple = src.Ttriple();
+        T_crit = src.T_critical();
+    } catch (const std::exception&) {
+        return nullptr;
+    }
+    // Triple point sometimes comes back below the source's actual
+    // sat-curve floor (e.g. REFPROP reports a slightly different value
+    // from its internal flash range) — bump up a hair so the first
+    // QT_INPUTS probe doesn't reject.
+    const double T_lo = T_triple * (1.0 + 1.0e-6);
+    const double T_hi = T_crit * kCriticalAvoidance;
+    if (!(T_lo > 0.0) || !(T_hi > T_lo)) {
+        return nullptr;
+    }
+
+    const auto T_knots = chebyshev_lobatto_T_knots(T_lo, T_hi, n_knots);
+
+    std::vector<double> p_col(n_knots);
+    std::array<std::vector<double>, 2> D_col = {std::vector<double>(n_knots), std::vector<double>(n_knots)};
+    std::array<std::vector<double>, 2> H_col = {std::vector<double>(n_knots), std::vector<double>(n_knots)};
+    std::array<std::vector<double>, 2> S_col = {std::vector<double>(n_knots), std::vector<double>(n_knots)};
+    std::array<std::vector<double>, 2> U_col = {std::vector<double>(n_knots), std::vector<double>(n_knots)};
+
+    for (std::size_t k = 0; k < n_knots; ++k) {
+        const double T = T_knots[k];
+        double p_k = 0.0;
+        for (int side : {0, 1}) {
+            try {
+                src.update(::CoolProp::QT_INPUTS, static_cast<double>(side), T);
+            } catch (const std::exception&) {
+                return nullptr;
+            }
+            if (side == 0) {
+                p_k = src.p();
+            }
+            D_col[side][k] = src.rhomolar();
+            H_col[side][k] = src.hmolar();
+            S_col[side][k] = src.smolar();
+            U_col[side][k] = src.umolar();
+            // region::CubicSplineCurve::build doesn't reject non-finite
+            // dependent values — a NaN/inf from the source would land
+            // silently in the spline coefficients and corrupt every
+            // eval downstream.  Bail on the first bad sample.
+            if (!std::isfinite(D_col[side][k]) || !std::isfinite(H_col[side][k]) || !std::isfinite(S_col[side][k])
+                || !std::isfinite(U_col[side][k])) {
+                return nullptr;
+            }
+        }
+        p_col[k] = p_k;
+        // p_sat must be strictly increasing in T inside the dome; if
+        // the source returned a non-monotone or non-finite sample, bail
+        // — log(p) for the inverse curve will fail otherwise.
+        if (!std::isfinite(p_k) || p_k <= 0.0) {
+            return nullptr;
+        }
+        if (k > 0 && !(p_k > p_col[k - 1])) {
+            return nullptr;
+        }
+    }
+
+    auto surrogate = std::unique_ptr<SaturationSurrogate>(new SaturationSurrogate());
+    auto& impl = *surrogate->impl_;
+    try {
+        impl.P_of_T = region::CubicSplineCurve::build(T_knots, p_col);
+        for (int side : {0, 1}) {
+            impl.D_of_T[side] = region::CubicSplineCurve::build(T_knots, D_col[side]);
+            impl.H_of_T[side] = region::CubicSplineCurve::build(T_knots, H_col[side]);
+            impl.S_of_T[side] = region::CubicSplineCurve::build(T_knots, S_col[side]);
+            impl.U_of_T[side] = region::CubicSplineCurve::build(T_knots, U_col[side]);
+        }
+        std::vector<double> logp_col(n_knots);
+        for (std::size_t k = 0; k < n_knots; ++k) {
+            logp_col[k] = std::log(p_col[k]);
+        }
+        // T_knots is reused verbatim as the dependent column for the
+        // inverse T(log p) spline — pass a copy because build() takes
+        // ownership.
+        impl.T_of_logp = region::CubicSplineCurve::build(logp_col, T_knots);
+    } catch (const std::exception&) {
+        return nullptr;
+    }
+    impl.T_lo = T_lo;
+    impl.T_hi = T_hi;
+    impl.p_lo = p_col.front();
+    impl.p_hi = p_col.back();
+    impl.n_knots = n_knots;
+    return surrogate;
+}
+
+double SaturationSurrogate::get_T_from_p(double p) const {
+    if (!(p > 0.0)) {
+        throw std::out_of_range("SaturationSurrogate::get_T_from_p: p must be positive");
+    }
+    if (p < impl_->p_lo || p > impl_->p_hi) {
+        throw std::out_of_range("SaturationSurrogate::get_T_from_p: p outside surrogate range");
+    }
+    return impl_->T_of_logp->eval(std::log(p));
+}
+
+double SaturationSurrogate::eval_sat(double T, char what, int side) const {
+    if (side != 0 && side != 1) {
+        throw std::invalid_argument("SaturationSurrogate::eval_sat: side must be 0 (liquid) or 1 (vapor)");
+    }
+    if (T < impl_->T_lo || T > impl_->T_hi) {
+        throw std::out_of_range("SaturationSurrogate::eval_sat: T outside surrogate range");
+    }
+    switch (what) {
+        case 'P':
+            return impl_->P_of_T->eval(T);
+        case 'D':
+            return impl_->D_of_T[side]->eval(T);
+        case 'H':
+            return impl_->H_of_T[side]->eval(T);
+        case 'S':
+            return impl_->S_of_T[side]->eval(T);
+        case 'U':
+            return impl_->U_of_T[side]->eval(T);
+        default:
+            throw std::invalid_argument("SaturationSurrogate::eval_sat: 'what' must be one of {P, D, H, S, U}");
+    }
+}
+
+double SaturationSurrogate::T_min() const noexcept {
+    return impl_->T_lo;
+}
+double SaturationSurrogate::T_max() const noexcept {
+    return impl_->T_hi;
+}
+std::size_t SaturationSurrogate::n_knots() const noexcept {
+    return impl_->n_knots;
+}
+
+}  // namespace sbtl
+}  // namespace CoolProp

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -954,7 +954,7 @@ TEST_CASE("write_bytes_atomic is race-safe across threads", "[SVDSBTL][cache][ra
 // Probe set deliberately picks T in [0.55, 0.95] * T_crit to stay well
 // clear of the sqrt-singularity near T_crit and the iteration-sensitive
 // strip near T_triple.
-TEST_CASE("SaturationSurrogate eval_sat matches source QT_INPUTS on HEOS water", "[SVDSBTL][sat_surrogate][slow]") {
+TEST_CASE("SaturationSurrogate eval_sat matches source QT_INPUTS on HEOS water", "[SBTL][SVDSBTL][sat_surrogate][slow]") {
     auto src = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
     auto surrogate = CoolProp::sbtl::SaturationSurrogate::build_from_source(*src);
     REQUIRE(surrogate != nullptr);
@@ -991,7 +991,7 @@ TEST_CASE("SaturationSurrogate eval_sat matches source QT_INPUTS on HEOS water",
 // well past 1e-6 — but the surrogate must not return NaN / inf or
 // overshoot below zero, since callers blend rho/h/s/u under the lever
 // rule and a non-finite endpoint corrupts the whole dome row.
-TEST_CASE("SaturationSurrogate stays finite and positive near T_crit", "[SVDSBTL][sat_surrogate][slow]") {
+TEST_CASE("SaturationSurrogate stays finite and positive near T_crit", "[SBTL][SVDSBTL][sat_surrogate][slow]") {
     auto src = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
     auto surrogate = CoolProp::sbtl::SaturationSurrogate::build_from_source(*src);
     REQUIRE(surrogate != nullptr);
@@ -1013,7 +1013,7 @@ TEST_CASE("SaturationSurrogate stays finite and positive near T_crit", "[SVDSBTL
 
 // Inverse: p -> T_sat.  The surrogate stores T(log p) so the inversion is
 // just one spline evaluation.  Same well-behaved probe interval as above.
-TEST_CASE("SaturationSurrogate get_T_from_p inverts source PQ_INPUTS on HEOS water", "[SVDSBTL][sat_surrogate][slow]") {
+TEST_CASE("SaturationSurrogate get_T_from_p inverts source PQ_INPUTS on HEOS water", "[SBTL][SVDSBTL][sat_surrogate][slow]") {
     auto src = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
     auto surrogate = CoolProp::sbtl::SaturationSurrogate::build_from_source(*src);
     REQUIRE(surrogate != nullptr);
@@ -1033,7 +1033,7 @@ TEST_CASE("SaturationSurrogate get_T_from_p inverts source PQ_INPUTS on HEOS wat
 // Backend wiring: when SVDSBTL is built on a source without a SuperAncillary
 // (REFPROP today), the backend must lazily build a SaturationSurrogate.
 // HEOS source must NOT trigger the surrogate (the SA path is preferred).
-TEST_CASE("SVDSBTLBackend uses surrogate when source has no SuperAncillary", "[SVDSBTL][sat_surrogate][source]") {
+TEST_CASE("SVDSBTLBackend uses surrogate when source has no SuperAncillary", "[SBTL][SVDSBTL][sat_surrogate][source]") {
     auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
     auto* heos_be = dynamic_cast<CoolProp::SVDSBTLBackend*>(heos.get());
     REQUIRE(heos_be != nullptr);

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -574,7 +574,9 @@ TEST_CASE("SVDSBTL fast_evaluate matches per-call update() bit-for-bit", "[SVDSB
     auto if97 = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("IF97", "Water"));
     auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&IF97", "Water"));
     std::vector<double> h_v, p_v;
+    // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter,cert-flp30-c)
     for (double T = 320.0; T <= 800.0; T += 60.0) {
+        // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter,cert-flp30-c)
         for (double lp = std::log(1.0e5); lp <= std::log(3.0e7); lp += 0.5 * std::log(10.0)) {
             const double p = std::exp(lp);
             try {
@@ -844,7 +846,8 @@ TEST_CASE("SVDSBTL ALTERNATIVE_SVDTABLES_DIRECTORY end-to-end build + reload", "
     };
     std::vector<std::int64_t> mtimes_before_ns;
     mtimes_before_ns.reserve(files.size());
-    for (const auto& f : files) mtimes_before_ns.push_back(to_ns(fs::last_write_time(f)));
+    for (const auto& f : files)
+        mtimes_before_ns.push_back(to_ns(fs::last_write_time(f)));
 
     // Second construction with the same options -> must read from cache,
     // not rebuild.  A rebuild would rewrite the .svd.bin.z files and
@@ -883,7 +886,7 @@ TEST_CASE("write_bytes_atomic is race-safe across threads", "[SVDSBTL][cache][ra
     // Payload large enough that an ofstream::write of one payload would
     // be observable mid-stream by another writer if the writes were not
     // serialized via rename.  Several pages worth of bytes.
-    constexpr std::size_t kPayloadSize = 1 << 14;  // 16 KiB
+    constexpr std::size_t kPayloadSize = static_cast<std::size_t>(1) << 14U;  // 16 KiB
     std::vector<std::vector<char>> payloads(kThreads);
     for (int i = 0; i < kThreads; ++i) {
         payloads[i].assign(kPayloadSize, static_cast<char>(i + 1));  // distinct fill bytes per thread
@@ -922,6 +925,7 @@ TEST_CASE("write_bytes_atomic is race-safe across threads", "[SVDSBTL][cache][ra
             break;
         }
     }
+    // cppcheck-suppress shiftNegative // Catch2 INFO macro: << is ostream insertion, not bit-shift
     INFO("Result must match exactly one writer's payload; instead matched index " << matched_idx);
     REQUIRE(matched_one);
 
@@ -936,6 +940,117 @@ TEST_CASE("write_bytes_atomic is race-safe across threads", "[SVDSBTL][cache][ra
     REQUIRE(leftover_temps == 0);
 
     fs::remove_all(tmpdir, ec);
+}
+
+// -- SaturationSurrogate (CoolProp-077) -----------------------------------
+
+#    include "CoolProp/sbtl/SaturationSurrogate.h"
+
+// Standalone surrogate accuracy: build from HEOS Water (always available,
+// has a SuperAncillary as ground truth elsewhere; here we treat HEOS's own
+// QT_INPUTS as truth and check the spline interpolant against it).
+//
+// Bead acceptance: rel err <= 1e-6 on smooth-fluid probes away from T_crit.
+// Probe set deliberately picks T in [0.55, 0.95] * T_crit to stay well
+// clear of the sqrt-singularity near T_crit and the iteration-sensitive
+// strip near T_triple.
+TEST_CASE("SaturationSurrogate eval_sat matches source QT_INPUTS on HEOS water", "[SVDSBTL][sat_surrogate][slow]") {
+    auto src = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+    auto surrogate = CoolProp::sbtl::SaturationSurrogate::build_from_source(*src);
+    REQUIRE(surrogate != nullptr);
+    REQUIRE(surrogate->n_knots() >= 4);
+
+    const double T_crit = src->T_critical();
+    std::mt19937 rng(2026'05'23);
+    std::uniform_real_distribution<double> tfrac(0.55, 0.95);
+
+    for (int trial = 0; trial < 32; ++trial) {
+        const double T = tfrac(rng) * T_crit;
+        for (int side : {0, 1}) {
+            src->update(CoolProp::QT_INPUTS, static_cast<double>(side), T);
+            const double p_ref = src->p();
+            const double h_ref = src->hmolar();
+            const double s_ref = src->smolar();
+            const double rho_ref = src->rhomolar();
+            const double u_ref = src->umolar();
+
+            REQUIRE(surrogate->eval_sat(T, 'P', side) == Approx(p_ref).epsilon(1e-6));
+            REQUIRE(surrogate->eval_sat(T, 'H', side) == Approx(h_ref).epsilon(1e-6));
+            REQUIRE(surrogate->eval_sat(T, 'S', side) == Approx(s_ref).epsilon(1e-6));
+            REQUIRE(surrogate->eval_sat(T, 'D', side) == Approx(rho_ref).epsilon(1e-6));
+            REQUIRE(surrogate->eval_sat(T, 'U', side) == Approx(u_ref).epsilon(1e-6));
+        }
+    }
+}
+
+// Near-critical guard: at T = 0.99 * T_crit (well above the eval_sat
+// accuracy test's 0.95 upper bound, but inside the surrogate's build
+// range of 0.9999 * T_crit), the surrogate must still return finite,
+// physically-sensible values.  The bead's accuracy contract doesn't
+// hold here — the sqrt-singularity at T_crit pushes cubic-spline error
+// well past 1e-6 — but the surrogate must not return NaN / inf or
+// overshoot below zero, since callers blend rho/h/s/u under the lever
+// rule and a non-finite endpoint corrupts the whole dome row.
+TEST_CASE("SaturationSurrogate stays finite and positive near T_crit", "[SVDSBTL][sat_surrogate][slow]") {
+    auto src = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+    auto surrogate = CoolProp::sbtl::SaturationSurrogate::build_from_source(*src);
+    REQUIRE(surrogate != nullptr);
+    const double T = 0.99 * src->T_critical();
+    for (int side : {0, 1}) {
+        for (char k : {'P', 'D', 'H', 'S', 'U'}) {
+            const double y = surrogate->eval_sat(T, k, side);
+            REQUIRE(std::isfinite(y));
+            // P/D/H positive at the dome interior for water (H_L is
+            // positive in the IAPWS reference state above triple liquid;
+            // P and D are positive by physics).  U/S are signed but
+            // finite-only here.
+            if (k == 'P' || k == 'D' || k == 'H') {
+                REQUIRE(y > 0.0);
+            }
+        }
+    }
+}
+
+// Inverse: p -> T_sat.  The surrogate stores T(log p) so the inversion is
+// just one spline evaluation.  Same well-behaved probe interval as above.
+TEST_CASE("SaturationSurrogate get_T_from_p inverts source PQ_INPUTS on HEOS water", "[SVDSBTL][sat_surrogate][slow]") {
+    auto src = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+    auto surrogate = CoolProp::sbtl::SaturationSurrogate::build_from_source(*src);
+    REQUIRE(surrogate != nullptr);
+
+    const double p_crit = src->p_critical();
+    std::mt19937 rng(2026'05'24);
+    std::uniform_real_distribution<double> log_pfrac(std::log(1e-3), std::log(0.95));
+
+    for (int trial = 0; trial < 16; ++trial) {
+        const double p = std::exp(log_pfrac(rng)) * p_crit;
+        src->update(CoolProp::PQ_INPUTS, p, 0.0);
+        const double T_ref = src->T();
+        REQUIRE(surrogate->get_T_from_p(p) == Approx(T_ref).epsilon(1e-6));
+    }
+}
+
+// Backend wiring: when SVDSBTL is built on a source without a SuperAncillary
+// (REFPROP today), the backend must lazily build a SaturationSurrogate.
+// HEOS source must NOT trigger the surrogate (the SA path is preferred).
+TEST_CASE("SVDSBTLBackend uses surrogate when source has no SuperAncillary", "[SVDSBTL][sat_surrogate][source]") {
+    auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
+    auto* heos_be = dynamic_cast<CoolProp::SVDSBTLBackend*>(heos.get());
+    REQUIRE(heos_be != nullptr);
+
+    // Hot path that flushes through the sat resolver — pick a clean dome
+    // probe so the backend definitely went through the sat-provider code.
+    heos->update(CoolProp::PQ_INPUTS, 0.4 * heos->p_critical(), 0.5);
+    REQUIRE_FALSE(heos_be->sat_surrogate_consulted());
+
+    if (!source_backend_available("REFPROP", "Water")) {
+        SKIP("REFPROP not available; skipping surrogate-wired-in assertion for REFPROP source");
+    }
+    auto rp = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&REFPROP", "Water"));
+    auto* rp_be = dynamic_cast<CoolProp::SVDSBTLBackend*>(rp.get());
+    REQUIRE(rp_be != nullptr);
+    rp->update(CoolProp::PQ_INPUTS, 0.4 * rp->p_critical(), 0.5);
+    REQUIRE(rp_be->sat_surrogate_consulted());
 }
 
 #endif  // ENABLE_CATCH


### PR DESCRIPTION
## Summary

- Adds `CoolProp::sbtl::SaturationSurrogate` — a 96-knot Chebyshev-Lobatto cubic-spline cache for the sat dome, built lazily from the source backend's `QT_INPUTS` at first sat-touching call. Mirrors `superancillary::SuperAncillary`'s `eval_sat` / `get_T_from_p` interface.
- Wires the surrogate into `SVDSBTLBackend`'s 5 sat-provider sites (PQ/QT routing, HmassP dome detection, PT-on-sat probe, ensure_dome_rho/s endpoints) as the fallback between SA (HEOS) and source PQ/QT (last resort).
- Closes the ~1-5 ms vs ~50 ns gap on REFPROP-source dome queries that CoolProp-zx1 exposed (REFPROP correctness was verified but perf was unaddressed).

## Test plan

- [x] `[sat_surrogate]` tag (4 new tests): 343 accuracy assertions vs HEOS Water `QT_INPUTS` at 1e-6 rel-err on [0.55, 0.95]\*T_crit, plus a near-T_crit (0.99\*T_crit) finiteness/positivity guard
- [x] Backend wiring test (`sat_surrogate_consulted()` seam): HEOS source → false (SA preferred); REFPROP source → true after first sat call
- [x] `[SVDSBTL][source]` (44 assertions, 11 cases) + `[SVDSBTL][twophase]` (296 / 8) + `[water]` (548 / 11) all green with REFPROP enabled
- [x] `./dev/ci/preflight.sh --skip=tests` clean (clang-format / build / cppcheck / clang-tidy signal-filtered / semgrep all pass)
- [x] code-reviewer adversarial review run; 3 blocking findings addressed (test-seam rename for accurate semantics, header docstring sync, near-critical finiteness guard test)

## Notes

- The bead suggested log-spaced T knots; switched to Chebyshev-Lobatto because log-T concentrates knots at low T while the rho curvature is at high T — Chebyshev-Lobatto + 96 knots hits 1e-6 with margin where 64 log-T knots missed it by ~1.5e-6 on saturated rho.
- Drive-by: NOLINT comments on pre-existing `bugprone-empty-catch`, `modernize-pass-by-value`, `bugprone-unchecked-optional-access` and `readability-implicit-bool-conversion` findings in `SVDSBTLBackend.cpp` that became visible to clang-tidy once the file entered the diff. Also added `clang-analyzer-optin.cplusplus.VirtualCall` to preflight's noise list — the AbstractState() ctor pattern is shared across all backends, cppcheck classifies the same finding as `style` (not `warning`), and CI's clang-tidy-diff job (changed lines only) never reports it.
- Phase 1 only (in-memory surrogate built at first call). Persistence in the `.svd.bin.z` cache is filed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a saturation surrogate path to accelerate two-phase/dome property lookups and fallback routing.

* **Bug Fixes**
  * Improved robustness for dome endpoint filling, evaluation gating, and error handling in saturation fast-paths.

* **Tests**
  * Added unit and integration tests validating surrogate accuracy, inversion, and backend wiring.

* **Chores**
  * Updated CI clang-tidy filtering to suppress analyzer opt-in VirtualCall findings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2965?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->