### PR TITLE
fix(svdsbtl): gate polish_patch_state_ to IF97 source only

### DIFF
--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -914,7 +914,12 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
     // polish for HEOS also drops one extra HEOS PT_INPUTS eval per
     // in-bbox query.  See the [hydrogen] regression test in
     // CoolProp-Tests-SVDSBTLCriticalPatch.cpp.
-    const bool needs_polish = (source_backend_ == "IF97");
+    // Gate on the ACTIVE patch backend, not source_backend_: when the
+    // user overrides critical_patch.source (e.g. SVDSBTL&HEOS with
+    // patch source="IF97" for Water), the polish requirement follows
+    // the backend actually serving the in-patch query.
+    const std::string& patch_backend = critical_patch_.source.empty() ? source_backend_ : critical_patch_.source;
+    const bool needs_polish = (patch_backend == "IF97");
     const auto patch_key = (input_pair == CoolProp::HmolarP_INPUTS) ? CoolProp::HmassP_INPUTS : input_pair;
     if (critical_patch_.contains(patch_key, a, b)) {
         try {

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -891,20 +891,30 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
     // Critical-patch bbox routing.  Patch lookups defer their property
     // reads to evaluate_property_ via patch_source_.
     //
-    // For HmassP / HmolarP inputs we follow the source-backend update
-    // with polish_patch_state_(): the source's HmassP_INPUTS path
-    // typically uses a backward equation (IF97 R7-97 in particular)
-    // that's only ±25 mK forward-consistent in T.  Without the polish
-    // every in-bbox query inherits that floor — visible as ~10-20 mK /
-    // 0.1-0.4 J/(kg·K) s residuals in the SVDSBTL&IF97 fail-map even
-    // inside the patch box.  The polish TOMS748-iterates on a tight
-    // bracket around T_seed so the returned state is
-    // forward-consistent (h(T_polished, p) == h_input to bracket eps).
-    // Mirrors the polish baked into ph_subcritical's IF97 sampling
-    // lambda — that's the foi.9.10 sampling-side fix; this is its
-    // query-side counterpart.  No-op for HEOS source (HEOS HmassP is
-    // already iterative + forward-consistent) modulo one extra HEOS
-    // eval per in-bbox query.
+    // For HmassP / HmolarP inputs we follow IF97's source-backend
+    // update with polish_patch_state_(): IF97's HmassP_INPUTS uses the
+    // R7-97 backward equation, which is only ±25 mK forward-consistent
+    // in T.  Without the polish every in-bbox query inherits that floor
+    // — visible as ~10-20 mK / 0.1-0.4 J/(kg·K) s residuals in the
+    // SVDSBTL&IF97 fail-map even inside the patch box.  The polish
+    // TOMS748-iterates on a tight bracket around T_seed so the returned
+    // state is forward-consistent (h(T_polished, p) == h_input to
+    // bracket eps).  Mirrors the polish baked into ph_subcritical's
+    // IF97 sampling lambda — that's the foi.9.10 sampling-side fix;
+    // this is its query-side counterpart.
+    //
+    // Polish is gated to IF97 sources only.  HEOS's HmassP_INPUTS is
+    // already iterative + forward-consistent, so the polish should be
+    // a no-op — but TOMS748 in [T_seed±0.5 K] leaves a sub-ULP T
+    // residual that, for low-Tc fluids (Hydrogen Tc=33.14 K — the
+    // bracket is ~1.5% of Tc), the critical-region stiffness amplifies
+    // into ~1e-7 ρ drift inside the patch bbox.  Visible as non-zero
+    // error in 82% of bbox cells in the SVDSBTLValidation heatmap even
+    // though the patch source IS the reference HEOS.  Skipping the
+    // polish for HEOS also drops one extra HEOS PT_INPUTS eval per
+    // in-bbox query.  See the [hydrogen] regression test in
+    // CoolProp-Tests-SVDSBTLCriticalPatch.cpp.
+    const bool needs_polish = (source_backend_ == "IF97");
     const auto patch_key = (input_pair == CoolProp::HmolarP_INPUTS) ? CoolProp::HmassP_INPUTS : input_pair;
     if (critical_patch_.contains(patch_key, a, b)) {
         try {
@@ -913,7 +923,7 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
                 // Same dome-aware polish gating as the HmassP branch
                 // below — multi-valued h(T, p) inside the dome breaks
                 // the single-phase forward-h polish bracket.
-                if (patch_source_->phase() != CoolProp::iphase_twophase) {
+                if (needs_polish && patch_source_->phase() != CoolProp::iphase_twophase) {
                     polish_patch_state_(*patch_source_, *pt.p, *pt.h_mass);
                 }
             } else if (input_pair == CoolProp::HmassP_INPUTS) {
@@ -931,7 +941,7 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
                 // with rho / Q = ±inf.  Two-phase points coming out
                 // of the patch already have correct (T_sat, Q, rho)
                 // from the source's PQ-blend; no polish needed.
-                if (patch_source_->phase() != CoolProp::iphase_twophase) {
+                if (needs_polish && patch_source_->phase() != CoolProp::iphase_twophase) {
                     polish_patch_state_(*patch_source_, *pt.p, *pt.h_mass);
                 }
             } else {

--- a/src/Tests/CoolProp-Tests-SVDSBTLCriticalPatch.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTLCriticalPatch.cpp
@@ -113,8 +113,7 @@ TEST_CASE("critical_patch: HmassP_INPUTS routing matches source backend in the b
     REQUIRE(AS->smass() == Catch::Approx(heos->smass()).margin(1e-9));
 }
 
-TEST_CASE("critical_patch: HEOS source must NOT polish (regression for low-Tc drift)",
-          "[SVDSBTL][critical_patch][hydrogen][slow]") {
+TEST_CASE("critical_patch: HEOS source must NOT polish (regression for low-Tc drift)", "[SVDSBTL][critical_patch][hydrogen][slow]") {
     // polish_patch_state_ was added (d176979e7) to fix IF97's R7-97
     // backward-equation floor (±25 mK forward-consistency).  HEOS's
     // HmassP_INPUTS is already iterative + forward-consistent, so the

--- a/src/Tests/CoolProp-Tests-SVDSBTLCriticalPatch.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTLCriticalPatch.cpp
@@ -113,6 +113,46 @@ TEST_CASE("critical_patch: HmassP_INPUTS routing matches source backend in the b
     REQUIRE(AS->smass() == Catch::Approx(heos->smass()).margin(1e-9));
 }
 
+TEST_CASE("critical_patch: HEOS source must NOT polish (regression for low-Tc drift)",
+          "[SVDSBTL][critical_patch][hydrogen][slow]") {
+    // polish_patch_state_ was added (d176979e7) to fix IF97's R7-97
+    // backward-equation floor (±25 mK forward-consistency).  HEOS's
+    // HmassP_INPUTS is already iterative + forward-consistent, so the
+    // polish should be a no-op for HEOS sources.
+    //
+    // It isn't.  For low-Tc fluids (Hydrogen, Tc=33.14 K) the polish
+    // bracket [T_seed±0.5 K] is ~1.5% of Tc, and TOMS748's eps_tolerance
+    // ≈ 1e-12 relative T leaves a sub-ULP residual which the critical-
+    // region stiffness amplifies into ~1e-7 ρ drift inside the patch
+    // bbox.  Visible as non-zero error in 82% of bbox cells in the
+    // SVDSBTLValidation heatmap, even though the patch source IS the
+    // reference HEOS and the answer should be bit-exact.
+    //
+    // Pin: every property inside the patch must equal HEOS's HmassP
+    // result bit-for-bit (margin 0) for HEOS-sourced backends.
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(
+      CoolProp::AbstractState::factory("SVDSBTL&HEOS", R"(Hydrogen?{"critical_patch":{"mode":"fixed","bbox":[0.95,1.05,0.90,1.10]}})"));
+    auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Hydrogen"));
+    const double Tc = heos->T_critical();
+    const double pc = heos->p_critical();
+
+    // (T=Tc, p=1.05*pc) — supercritical, comfortably inside the fixed
+    // bbox in (T, p).  Translate to (h, p) via HEOS to get the HmassP
+    // probe.
+    heos->update(CoolProp::PT_INPUTS, 1.05 * pc, Tc);
+    const double h = heos->hmass();
+    const double p = 1.05 * pc;
+
+    AS->update(CoolProp::HmassP_INPUTS, h, p);
+    heos->update(CoolProp::HmassP_INPUTS, h, p);
+
+    // Bit-exact (==): the patch routes to the same HEOS instance, so
+    // any difference is polish-induced drift.
+    REQUIRE(AS->rhomass() == heos->rhomass());
+    REQUIRE(AS->T() == heos->T());
+    REQUIRE(AS->smass() == heos->smass());
+}
+
 TEST_CASE("critical_patch: HmolarP_INPUTS reaches the surface lookup (CodeRabbit)", "[SVDSBTL][critical_patch]") {
     // surfaces_ only registers HmassP_INPUTS and PT_INPUTS — HmolarP
     // shares the HmassP surface via a molar→mass conversion inside


### PR DESCRIPTION
## Summary

`polish_patch_state_` (the TOMS748 forward-h-consistency polish added in d176979e7) was unconditionally executed for every non-twophase HmassP/HmolarP query inside the critical-patch bbox, regardless of source backend. The original commit message claimed the polish would be a no-op for HEOS sources since HEOS `HmassP_INPUTS` is already iterative + forward-consistent.

That claim fails for **low-Tc fluids near the critical point**. TOMS748 on the bracket `[T_seed ± 0.5 K]` (~1.5% of Tc for Hydrogen, Tc=33.14 K) leaves a sub-ULP T residual which the critical-region stiffness amplifies into **~1e-7 relative ρ drift** inside the patch bbox. Visible in the `SVDSBTLValidation` `[HP]` heatmap (PR #2964) as non-zero error in **82% of in-bbox cells for Hydrogen** — even though the patch routes through the same HEOS instance the reference uses.

Fix: `const bool needs_polish = (source_backend_ == "IF97")` gates both HmassP and HmolarP polish call sites. IF97 sources (Water) still get the polish that fixes the R7-97 backward-equation floor (±25 mK); HEOS and REFPROP skip the polish since their HmassP is already forward-consistent. Side benefit: one fewer HEOS PT_INPUTS eval per in-bbox query.

## Test plan

- [x] New regression test `critical_patch: HEOS source must NOT polish (regression for low-Tc drift)` in `src/Tests/CoolProp-Tests-SVDSBTLCriticalPatch.cpp` pins Hydrogen HmassP_INPUTS inside a fixed bbox to bit-exact (`==`, margin 0) match with HEOS reference. Failed before fix (43.0886150189**4** vs 43.0886150189**8**), passes after.
- [x] `[SBTL]` umbrella tag: 4229 assertions / 12 cases pass.
- [x] Pre-PR `superpowers:code-reviewer` adversarial review: no blocking findings. Confirmed REFPROP `HmassP_INPUTS` (via `PHFLSHdll`) is also forward-consistent, so gating to IF97-only is correct.
- [ ] CI: full SVDSBTL test sweep + IF97 fail-map regression check.
- [ ] After merge: re-render `SVDSBTLValidation.ipynb` Hydrogen `[HP]` panel (added in #2964) — in-bbox cells should flip from ~1e-7 drift to bit-exact zero (rendered white in the heatmap since `log10(0) = NaN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted critical-patch processing so source-specific polishing is applied only when appropriate, improving thermodynamic state accuracy and preventing unintended drift.

* **Tests**
  * Added a regression test to verify critical-patch routing and ensure consistent behavior across different backend sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2966?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->