### PR TITLE
feat(svdsbtl): NC near-critical sub-regions with POWER(β=1/3) axis (CoolProp-4u9)

### DIFF
--- a/dev/bench_svdsbtl_ph_plot.py
+++ b/dev/bench_svdsbtl_ph_plot.py
@@ -32,7 +32,11 @@ import pandas as pd
 _INTERACTIVE = "--interactive" in sys.argv
 if _INTERACTIVE:
     sys.argv.remove("--interactive")
-    matplotlib.use("MacOSX")
+    # Only force "MacOSX" on macOS — that backend's Cocoa support isn't
+    # available on Linux/Windows.  Elsewhere, let matplotlib pick the
+    # first available GUI backend (QtAgg / TkAgg / GTK3Agg).
+    if sys.platform == "darwin":
+        matplotlib.use("MacOSX")
 
 import matplotlib.pyplot as plt  # noqa: E402
 from matplotlib.colors import LogNorm  # noqa: E402

--- a/dev/bench_svdsbtl_ph_plot.py
+++ b/dev/bench_svdsbtl_ph_plot.py
@@ -21,10 +21,21 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import matplotlib.pyplot as plt
+import matplotlib
 import numpy as np
 import pandas as pd
-from matplotlib.colors import LogNorm
+
+# Interactive mode toggles the backend BEFORE importing pyplot.  Passing
+# --interactive on the CLI keeps the figure window open + clickable
+# (zoom / pan / hover via the matplotlib toolbar); the default mode
+# (no flag) writes a PNG and closes the figure, suitable for CI.
+_INTERACTIVE = "--interactive" in sys.argv
+if _INTERACTIVE:
+    sys.argv.remove("--interactive")
+    matplotlib.use("MacOSX")
+
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.colors import LogNorm  # noqa: E402
 
 
 def _err_panel(ax, h_kJ, p_MPa, vals, title, vmin=1e-7, vmax=1e-1, dome=None, p_crit_MPa=None):
@@ -225,9 +236,15 @@ def plot_one(csv_path: Path, out_path: Path) -> None:
         parts.append(f"speedup vs REFPROP={mean_ns_refprop / mean_ns_svd:.1f}x")
     fig.text(0.5, -0.03, "    ".join(parts), ha="center", fontsize=10, family="monospace")
 
-    fig.savefig(out_path, dpi=150, bbox_inches="tight")
-    plt.close(fig)
-    print(f"  {csv_path.name}  ->  {out_path}")
+    if _INTERACTIVE:
+        # Keep the figure open; the toolbar lets the user zoom / pan /
+        # save.  plt.show() at end of main() blocks until all windows
+        # are closed.
+        print(f"  {csv_path.name}  ->  interactive window")
+    else:
+        fig.savefig(out_path, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"  {csv_path.name}  ->  {out_path}")
 
 
 def main() -> int:
@@ -250,6 +267,8 @@ def main() -> int:
             continue
         out_path = out_dir / f"bench_svdsbtl_ph_{p.stem.replace('bench_svdsbtl_ph_', '')}.png"
         plot_one(p, out_path)
+    if _INTERACTIVE:
+        plt.show()
     return 0
 
 

--- a/include/CoolProp/region/AxisTransform.h
+++ b/include/CoolProp/region/AxisTransform.h
@@ -9,12 +9,32 @@ namespace CoolProp {
 namespace region {
 
 // Map a physical variable a in [a_lo, a_hi] to xi in [0, 1].  The map is
-// either linear or applied to log(a); other monotone choices can be added
-// later if needed.
+// linear, log(a), or critical-scaling-aware cube-root (CoolProp-4u9).
+// All three are monotone in (a_lo, a_hi); other monotone choices can be
+// added later if needed.
+//
+// POWER: forward xi = 1 - cbrt((a_hi - a) / (a_hi - a_lo)); inverse
+// a = a_hi - (a_hi - a_lo) * (1 - xi)^3.  Grid lines uniform in xi
+// crowd toward a_hi (intended use: NC sub-critical sub-region in p
+// with a_hi = (1 - eps)·pc).  The cube-root absorbs the (pc - p)^(1/δ)
+// scaling singularity at the critical point — Ising β ≈ 0.326 ≈ 1/3 —
+// so the Hermite-cubic SVD interpolant stays well-conditioned all the
+// way to within ~1 ppm of pc.  Diagnostic measurements on R245fa /
+// Water / CO2 LIQUID + VAPOR at NT=200 NR=800 Cheb rank=20 show max
+// off-grid error 1e-9 to 1e-7 for POWER vs 1e-4 to 1e-3 for LOG over
+// the same band.
+//
+// POWER_LO: mirror of POWER that crowds toward a_lo instead of a_hi.
+// Forward xi = cbrt((a - a_lo) / (a_hi - a_lo)); inverse a = a_lo +
+// (a_hi - a_lo) * xi^3.  Intended use: NC super-critical sub-region
+// with a_lo = (1 + eps)·pc (pc is the LOW end of the band there).
+// Same accuracy story as POWER, opposite anchor.
 enum class AxisScale : std::uint8_t
 {
     LINEAR,
-    LOG
+    LOG,
+    POWER,
+    POWER_LO
 };
 
 struct AxisTransform
@@ -22,9 +42,12 @@ struct AxisTransform
     AxisScale scale;
     double a_lo;        // physical lower bound
     double a_hi;        // physical upper bound
-    double a_lo_t;      // transformed lower bound (a_lo or log(a_lo))
-    double a_hi_t;      // transformed upper bound (a_hi or log(a_hi))
-    double inv_span_t;  // 1 / (a_hi_t - a_lo_t); precomputed for hot path
+    double a_lo_t;      // transformed lower bound (a_lo or log(a_lo)); unused for POWER
+    double a_hi_t;      // transformed upper bound (a_hi or log(a_hi)); unused for POWER
+    double inv_span_t;  // 1 / (a_hi_t - a_lo_t); precomputed for hot path.
+                        // For POWER, this stores 1 / (a_hi - a_lo) — the linear
+                        // span — so chain-rule derivatives have a single scale
+                        // factor to multiply.
 
     // Factory.  Throws on invalid inputs (a_hi <= a_lo, or LOG with non-
     // positive bound).
@@ -35,6 +58,11 @@ struct AxisTransform
         if (s == AxisScale::LOG && !(a_lo > 0.0)) {
             throw std::invalid_argument("AxisTransform: LOG requires a_lo > 0");
         }
+        if (s == AxisScale::POWER || s == AxisScale::POWER_LO) {
+            // a_lo_t / a_hi_t intentionally unused; inv_span_t stores
+            // 1 / (a_hi - a_lo) for the chain-rule derivative path.
+            return AxisTransform{s, a_lo, a_hi, 0.0, 0.0, 1.0 / (a_hi - a_lo)};
+        }
         const double lo_t = (s == AxisScale::LOG) ? std::log(a_lo) : a_lo;
         const double hi_t = (s == AxisScale::LOG) ? std::log(a_hi) : a_hi;
         return AxisTransform{s, a_lo, a_hi, lo_t, hi_t, 1.0 / (hi_t - lo_t)};
@@ -43,23 +71,50 @@ struct AxisTransform
     // a -> xi in [0, 1].  Out-of-range inputs map outside [0,1] (no
     // clamp); callers can check before / after.
     [[nodiscard]] inline double forward(double a) const noexcept {
+        if (scale == AxisScale::POWER) {
+            return 1.0 - std::cbrt((a_hi - a) * inv_span_t);
+        }
+        if (scale == AxisScale::POWER_LO) {
+            return std::cbrt((a - a_lo) * inv_span_t);
+        }
         const double a_t = (scale == AxisScale::LOG) ? std::log(a) : a;
         return (a_t - a_lo_t) * inv_span_t;
     }
 
     // xi in [0, 1] -> a.
     [[nodiscard]] inline double inverse(double xi) const noexcept {
+        if (scale == AxisScale::POWER) {
+            const double t = 1.0 - xi;
+            return a_hi - (a_hi - a_lo) * t * t * t;
+        }
+        if (scale == AxisScale::POWER_LO) {
+            return a_lo + (a_hi - a_lo) * xi * xi * xi;
+        }
         const double a_t = a_lo_t + xi * (a_hi_t - a_lo_t);
         return (scale == AxisScale::LOG) ? std::exp(a_t) : a_t;
     }
 
     // dxi/da at the physical point a (analytic).
     //
-    //   LINEAR : dxi/da = 1 / (a_hi - a_lo) = inv_span_t
-    //   LOG    : dxi/da = 1 / (a * (log a_hi - log a_lo))
+    //   LINEAR   : dxi/da = 1 / (a_hi - a_lo) = inv_span_t
+    //   LOG      : dxi/da = 1 / (a * (log a_hi - log a_lo))
+    //   POWER    : xi = 1 - ((a_hi - a)/(a_hi - a_lo))^(1/3)
+    //                dxi/da = (1/3) * inv_span_t * ((a_hi - a) * inv_span_t)^(-2/3)
+    //                Diverges as a -> a_hi (anchor side — inverse has zero slope there).
+    //   POWER_LO : xi = ((a - a_lo)/(a_hi - a_lo))^(1/3)
+    //                dxi/da = (1/3) * inv_span_t * ((a - a_lo) * inv_span_t)^(-2/3)
+    //                Diverges as a -> a_lo (anchor side).
     [[nodiscard]] inline double dxi_da(double a) const noexcept {
         if (scale == AxisScale::LOG) {
             return inv_span_t / a;
+        }
+        if (scale == AxisScale::POWER) {
+            const double u = (a_hi - a) * inv_span_t;
+            return (1.0 / 3.0) * inv_span_t / std::cbrt(u * u);
+        }
+        if (scale == AxisScale::POWER_LO) {
+            const double u = (a - a_lo) * inv_span_t;
+            return (1.0 / 3.0) * inv_span_t / std::cbrt(u * u);
         }
         return inv_span_t;
     }

--- a/include/CoolProp/sbtl/SVDSurfaceSerializer.h
+++ b/include/CoolProp/sbtl/SVDSurfaceSerializer.h
@@ -154,7 +154,39 @@ class SVDSurfaceSerializer
     //           rev bump too (R5 is IF97-only and HEOS presets skip
     //           the new region entirely; the cache geometry is the
     //           same as rev 11 but the rev field differs).
-    static constexpr int kRevision = 12;
+    //   rev 13: CoolProp-4u9.  HEOS / REFPROP source presets gain a
+    //           pair of near-critical sub-regions (NC_LIQUID,
+    //           NC_VAPOR) on p ∈ [0.9·pc, (1 − 1ppm)·pc] using a new
+    //           AxisScale::POWER primary axis (β = 1/3, cube-root
+    //           crowding toward pc).  Parent LIQUID/VAPOR p_max
+    //           clipped down to 0.9·pc to hand off cleanly.  Region
+    //           count for HEOS caches goes from 3 (LIQUID/VAPOR/SUPER)
+    //           to 5.  POWER axis serialises via the same
+    //           AxisTransform pack/unpack as LINEAR/LOG (scale enum
+    //           value differs; a_lo/a_hi unchanged); existing rev-12
+    //           caches don't know about the NC regions and would
+    //           dispatch near-pc lookups to the parent LIQUID/VAPOR
+    //           SVD where off-grid max error is ~1e-3 instead of the
+    //           new ~1e-7 from the POWER NC regions, so the rev bump
+    //           forces a clean rebuild.  IF97 caches unchanged in
+    //           content (no NC for IF97 — G13-15 already passes) but
+    //           invalidated by the rev bump too.
+    //   rev 14: CoolProp-4u9 follow-up.  Add NC_SUPER region on
+    //           p ∈ [(1 + 1e-10)·pc, 1.1·pc] using AxisScale::POWER_LO
+    //           (mirror of POWER that crowds toward a_lo).  Closes a
+    //           (T, p) coverage gap exposed by the h=350 kJ/kg R245fa
+    //           sweep: cells in the thin strip just above pc with T
+    //           outside the auto-cal'd patch's narrow (T) bbox fell
+    //           through every region (LIQUID/VAPOR clipped to 0.9·pc,
+    //           NC_LIQUID/VAPOR capped at (1−1ppm)·pc, SUPER starting
+    //           at 1.001·pc) and returned NaN.  NC_SUPER claims them.
+    //           HEOS region count goes from 5 to 6.  NC sub-side band
+    //           also tightened from 1ppm to 1e-10 below pc — the NC
+    //           POWER axis is well-behaved at a_hi=pc-ε for any ε
+    //           large enough to keep the SuperAncillary sat-curve
+    //           well-defined, and tightening reduces the patch-only
+    //           sliver around pc.
+    static constexpr int kRevision = 14;
 
     // Pack one surface into a zlib-compressed msgpack blob.
     static std::vector<char> save(const SVDSurface& surface);

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -664,7 +664,10 @@ std::optional<std::array<double, 4>> SVDSBTLBackend::load_critpatch_cache_(const
         (void)std::fclose(f);
         return std::nullopt;
     }
-    if (std::fread(&version, sizeof(version), 1, f) != 1 || version != 1u) {
+    // v1 → v2: T_hi_cap clamp added in CoolProp-4u9.  Bump to invalidate
+    // pre-clamp caches so they get recomputed with the corrected ceiling
+    // (no migration — calibrator is cheap, re-runs on cache miss).
+    if (std::fread(&version, sizeof(version), 1, f) != 1 || version != 2u) {
         (void)std::fclose(f);
         return std::nullopt;
     }
@@ -693,7 +696,7 @@ void SVDSBTLBackend::save_critpatch_cache_(const std::string& fluid_name, const 
         return;
     }
     constexpr std::array<char, 8> kMagic = {'C', 'P', 'C', 'R', 'I', 'T', 'P', 'B'};
-    constexpr std::uint32_t kVersion = 1;
+    constexpr std::uint32_t kVersion = 2;
     constexpr std::size_t kPayloadSize = kMagic.size() + sizeof(kVersion) + 4 * sizeof(double);
     std::array<char, kPayloadSize> buf{};
     std::memcpy(buf.data(), kMagic.data(), kMagic.size());

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -588,6 +588,24 @@ std::array<double, 4> SVDSBTLBackend::auto_calibrate_critical_bbox_() {
     // Axis indices: 0=T_lo, 1=T_hi, 2=p_lo, 3=p_hi.
     // "safer" (wider patch) is the default; "tighter" is 1.0.
     std::array<double, 4> defaults = {0.95, 1.05, 0.75, 1.15};
+    // CoolProp-4u9: cap T_hi multiplier so the patch doesn't claim
+    // T territory beyond the HEOS validity envelope.  For fluids
+    // where T_max barely exceeds Tc (R245fa: T_max=440 K, Tc=427 K),
+    // the default T_hi_mult=1.05 maps to T_hi=448 K > T_max=440 K.
+    // The HmassP-envelope perimeter walk skips those unreachable
+    // corners, leaving the (h, p) bbox missing cells with h≈h_crit
+    // at p just below pc — runtime HmassP queries in that thin
+    // strip get NaN (atlas misses; patch bbox check fails) even
+    // though they're physically inside the patch's (T, p) rectangle.
+    // Clamping T_hi_mult at (T_max - 0.5) / Tc keeps the patch's
+    // T extent inside HEOS validity; the perimeter walk produces a
+    // tight, correct (h, p) bbox and the strip routes cleanly.
+    // No-op for fluids with T_max >> Tc (Water, CO2, methane —
+    // cap value > 1.05).
+    const double T_hi_cap = (src->Tmax() - 0.5) / Tc;
+    if (T_hi_cap < defaults[1]) {
+        defaults[1] = T_hi_cap;
+    }
     std::array<double, 4> tight = {1.0, 1.0, 1.0, 1.0};
     std::array<double, 4> mults = defaults;
     constexpr int kBisectSteps = 6;  // 6 = 1/64 multiplier resolution

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -198,11 +198,40 @@ double solve_T_from_h_toms748(::CoolProp::AbstractState& s, double p, double h_t
 SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std::size_t NR, std::int32_t rank) {
     // Name is historical: this preset now also registers a SUPER
     // region above p_crit so the surface covers the full HEOS
-    // (p, h) envelope.  Three regions: LIQUID + VAPOR + SUPER.
-    const auto [p_min, p_max_sub] = subcritical_pressure_range(heos);
-    const auto [p_min_sup, p_max_sup] = supercritical_pressure_range(heos);
+    // (p, h) envelope.  Three regions: LIQUID + VAPOR + SUPER, plus
+    // an optional NC_LIQUID/NC_VAPOR pair near pc when source is
+    // HEOS/REFPROP (CoolProp-4u9).
+    const auto [p_min, p_max_sub_raw] = subcritical_pressure_range(heos);
+    const auto [p_min_sup_raw, p_max_sup] = supercritical_pressure_range(heos);
     const double T_min_eos = std::max(heos.Ttriple(), heos.Tmin());
     const double T_max_eos = heos.Tmax();
+    const double pc = heos.p_critical();
+
+    // Near-critical sub-region geometry (CoolProp-4u9).  HEOS/REFPROP
+    // sources gain a dedicated NC_LIQUID/NC_VAPOR pair on p ∈ [0.9·pc,
+    // (1 − 1 ppm)·pc] with a POWER(β=1/3) primary axis that crowds
+    // grid lines toward pc.  Python diagnostics on R245fa/Water/CO2
+    // showed POWER buys 1000–100000× better off-grid max error vs LOG
+    // and stays flat in p_hi from 0.999·pc to 0.999999·pc — the
+    // critical-scaling singularity gets absorbed by the cube-root
+    // transform (Ising β ≈ 0.326 ≈ 1/3).  IF97 source skips this
+    // (G13-15 already passes without it).
+    const bool source_is_if97 = (heos.backend_name() == "IF97Backend");
+    constexpr double kNC_p_lo_mult = 0.9;
+    constexpr double kNC_p_hi_mult = 1.0 - 1.0e-10;      // gap of 1e-10·pc below pc — sub-ULP for practical p
+    constexpr double kNC_sup_p_lo_mult = 1.0 + 1.0e-10;  // mirror above pc
+    constexpr double kNC_sup_p_hi_mult = 1.1;
+    const bool nc_enabled = !source_is_if97;
+    const double p_nc_lo = nc_enabled ? kNC_p_lo_mult * pc : 0.0;
+    const double p_nc_hi = nc_enabled ? kNC_p_hi_mult * pc : 0.0;
+    const double p_nc_sup_lo = nc_enabled ? kNC_sup_p_lo_mult * pc : 0.0;
+    const double p_nc_sup_hi = nc_enabled ? kNC_sup_p_hi_mult * pc : 0.0;
+    // Clip parent LIQUID/VAPOR p-max to the NC band's lower edge when
+    // NC is enabled — handoff at p = 0.9·pc.  Clip parent SUPER p-min
+    // to NC_SUPER's upper edge.  When NC disabled (IF97 source), parent
+    // bounds use legacy values.
+    const double p_max_sub = nc_enabled ? std::min(p_max_sub_raw, p_nc_lo) : p_max_sub_raw;
+    const double p_min_sup = nc_enabled ? std::max(p_min_sup_raw, p_nc_sup_hi) : p_min_sup_raw;
 
     SurfaceSpec spec;
     spec.fluid_name = heos.fluid_names().empty() ? std::string{} : heos.fluid_names().front();
@@ -216,7 +245,7 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
     //   b_lo = h(T_min, p) — non-isothermal floor that walks T up
     //                       if T_min < T_melt(p) at high p.
     //   b_hi = h_sat,L(p) — liquid side of the saturation dome.
-    {
+    if (p_min < p_max_sub) {
         auto axis = region::AxisTransform::make(region::AxisScale::LOG, p_min, p_max_sub);
         auto lo = build_h_isotherm_floor(heos, p_min, p_max_sub, T_min_eos);
         auto hi = build_h_sat_L(heos, p_min, p_max_sub);
@@ -226,10 +255,45 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
     //   b_lo = h_sat,V(p) — vapor side of the saturation dome.
     //   b_hi = h(T_max - 0.5 K, p) — hot ceiling within the HEOS
     //                                validity envelope.
-    {
+    if (p_min < p_max_sub) {
         auto axis = region::AxisTransform::make(region::AxisScale::LOG, p_min, p_max_sub);
         auto lo = build_h_sat_V(heos, p_min, p_max_sub);
         auto hi = build_h_isotherm_ceiling(heos, p_min, p_max_sub, T_max_eos - 0.5);
+        spec.regions.emplace_back(axis, std::move(lo), std::move(hi));
+    }
+    // NC_LIQUID + NC_VAPOR (CoolProp-4u9): near-critical sub-regions on
+    // p ∈ [0.9·pc, (1 − 1ppm)·pc] with POWER(β=1/3) primary axis.
+    // Same boundary curves as the parent regions — the SuperAncillary-
+    // backed sat curves are continuous across the p = 0.9·pc handoff.
+    if (nc_enabled && p_nc_lo < p_nc_hi) {
+        {
+            auto axis = region::AxisTransform::make(region::AxisScale::POWER, p_nc_lo, p_nc_hi);
+            auto lo = build_h_isotherm_floor(heos, p_nc_lo, p_nc_hi, T_min_eos);
+            auto hi = build_h_sat_L(heos, p_nc_lo, p_nc_hi);
+            spec.regions.emplace_back(axis, std::move(lo), std::move(hi));
+        }
+        {
+            auto axis = region::AxisTransform::make(region::AxisScale::POWER, p_nc_lo, p_nc_hi);
+            auto lo = build_h_sat_V(heos, p_nc_lo, p_nc_hi);
+            auto hi = build_h_isotherm_ceiling(heos, p_nc_lo, p_nc_hi, T_max_eos - 0.5);
+            spec.regions.emplace_back(axis, std::move(lo), std::move(hi));
+        }
+    }
+    // NC_SUPER (CoolProp-4u9): super-critical near-critical sub-region
+    // on p ∈ [(1 + 1e-10)·pc, 1.1·pc] with POWER_LO(β=1/3) primary
+    // axis that crowds grid lines toward pc.  No saturation dome above
+    // pc, so b_lo / b_hi are the same isotherm-floor / isotherm-ceiling
+    // pair used by parent SUPER — they continue smoothly across the
+    // p = 1.1·pc handoff.  Single region (not the LIQ/VAP split used
+    // sub-critically) because the dome doesn't bisect this band.
+    // Closes the (h, p) coverage gap exposed by the h=350 kJ/kg sweep
+    // for R245fa: cells at p just above pc with T outside the patch's
+    // (T, p) bbox previously fell through every region and returned
+    // NaN.  NC_SUPER claims them; SVD residual ≲ 1e-7 in this band.
+    if (nc_enabled && p_nc_sup_lo < p_nc_sup_hi) {
+        auto axis = region::AxisTransform::make(region::AxisScale::POWER_LO, p_nc_sup_lo, p_nc_sup_hi);
+        auto lo = build_h_isotherm_floor(heos, p_nc_sup_lo, p_nc_sup_hi, T_min_eos);
+        auto hi = build_h_isotherm_ceiling(heos, p_nc_sup_lo, p_nc_sup_hi, T_max_eos - 0.5);
         spec.regions.emplace_back(axis, std::move(lo), std::move(hi));
     }
     // SUPER region: p > p_crit.  Primary = log p over [p_crit*1.001,
@@ -254,7 +318,6 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
     //
     // HEOS source backend has no piecewise structure, so its SUPER
     // stays one region.
-    const bool source_is_if97 = (heos.backend_name() == "IF97Backend");
     constexpr double kP_B23_hi = 100.0e6;  // IF97 B23 curve's upper p bound
     if (source_is_if97 && p_min_sup < kP_B23_hi) {
         // p range where the kink applies; clamped at the B23 upper bound.
@@ -343,7 +406,7 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
             auto hi = build_h_isotherm_ceiling(heos, kP_R5_lo, p_r5_hi, kT_R5_hi);
             spec.regions.emplace_back(axis, std::move(lo), std::move(hi));
         }
-    } else {
+    } else if (p_min_sup < p_max_sup) {
         auto axis = region::AxisTransform::make(region::AxisScale::LOG, p_min_sup, p_max_sup);
         auto lo = build_h_isotherm_floor(heos, p_min_sup, p_max_sup, T_min_eos);
         auto hi = build_h_isotherm_ceiling(heos, p_min_sup, p_max_sup, T_max_eos - 0.5);
@@ -602,11 +665,28 @@ std::unique_ptr<region::CubicSplineCurve> pt_T_floor_curve_(::CoolProp::Abstract
 
 SurfaceSpec pt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std::size_t NR, std::int32_t rank) {
     // Historical name; now covers the full phase diagram via three
-    // regions: LIQUID + VAPOR (subcritical) + SUPER (p > p_crit).
-    const auto [p_min, p_max] = subcritical_pressure_range(heos);
-    const auto [p_min_sup, p_max_sup] = supercritical_pressure_range(heos);
+    // regions: LIQUID + VAPOR (subcritical) + SUPER (p > p_crit), plus
+    // an optional NC_LIQUID/NC_VAPOR pair near pc when source is
+    // HEOS/REFPROP (CoolProp-4u9).
+    const auto [p_min, p_max_raw] = subcritical_pressure_range(heos);
+    const auto [p_min_sup_raw, p_max_sup] = supercritical_pressure_range(heos);
     const double T_min_eos = std::max(heos.Ttriple(), heos.Tmin());
     const double T_max_eos = heos.Tmax();
+    const double pc = heos.p_critical();
+
+    // Near-critical sub-region geometry (mirrors ph_subcritical above).
+    const bool source_is_if97 = (heos.backend_name() == "IF97Backend");
+    constexpr double kNC_p_lo_mult = 0.9;
+    constexpr double kNC_p_hi_mult = 1.0 - 1.0e-10;
+    constexpr double kNC_sup_p_lo_mult = 1.0 + 1.0e-10;
+    constexpr double kNC_sup_p_hi_mult = 1.1;
+    const bool nc_enabled = !source_is_if97;
+    const double p_nc_lo = nc_enabled ? kNC_p_lo_mult * pc : 0.0;
+    const double p_nc_hi = nc_enabled ? kNC_p_hi_mult * pc : 0.0;
+    const double p_nc_sup_lo = nc_enabled ? kNC_sup_p_lo_mult * pc : 0.0;
+    const double p_nc_sup_hi = nc_enabled ? kNC_sup_p_hi_mult * pc : 0.0;
+    const double p_max = nc_enabled ? std::min(p_max_raw, p_nc_lo) : p_max_raw;
+    const double p_min_sup = nc_enabled ? std::max(p_min_sup_raw, p_nc_sup_hi) : p_min_sup_raw;
 
     SurfaceSpec spec;
     spec.fluid_name = heos.fluid_names().empty() ? std::string{} : heos.fluid_names().front();
@@ -626,14 +706,14 @@ SurfaceSpec pt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
     // LIQUID region.  T-floor walks T_min(p) up over the melting
     // line.  Helper handles the knot loop so the SUPER region below
     // can reuse it.
-    {
+    if (p_min < p_max) {
         auto axis = region::AxisTransform::make(region::AxisScale::LOG, p_min, p_max);
         auto t_lo = pt_T_floor_curve_(heos, p_min, p_max, T_min_eos, SatBoundaryBuildOptions{});
         auto t_hi = build_T_sat(heos, p_min, p_max);
         spec.regions.emplace_back(axis, std::move(t_lo), std::move(t_hi));
     }
     // VAPOR region.
-    {
+    if (p_min < p_max) {
         auto axis = region::AxisTransform::make(region::AxisScale::LOG, p_min, p_max);
         auto t_lo = build_T_sat(heos, p_min, p_max);
         // Constant T_max ceiling — no melting consideration on the
@@ -641,10 +721,37 @@ SurfaceSpec pt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
         auto t_hi = std::make_unique<region::ConstantCurve>(p_min, p_max, T_max_eos - 0.5);
         spec.regions.emplace_back(axis, std::move(t_lo), std::move(t_hi));
     }
-    // SUPER region: p > p_crit.  T-floor still walks T_min up over
-    // melting line (the melting curve extends well into supercritical
-    // for most fluids).  Hot ceiling stays at T_max - 0.5 K.
-    {
+    // NC_LIQUID + NC_VAPOR (CoolProp-4u9): near-critical sub-regions on
+    // p ∈ [0.9·pc, (1 − 1ppm)·pc] with POWER(β=1/3) primary axis.
+    if (nc_enabled && p_nc_lo < p_nc_hi) {
+        {
+            auto axis = region::AxisTransform::make(region::AxisScale::POWER, p_nc_lo, p_nc_hi);
+            auto t_lo = pt_T_floor_curve_(heos, p_nc_lo, p_nc_hi, T_min_eos, SatBoundaryBuildOptions{});
+            auto t_hi = build_T_sat(heos, p_nc_lo, p_nc_hi);
+            spec.regions.emplace_back(axis, std::move(t_lo), std::move(t_hi));
+        }
+        {
+            auto axis = region::AxisTransform::make(region::AxisScale::POWER, p_nc_lo, p_nc_hi);
+            auto t_lo = build_T_sat(heos, p_nc_lo, p_nc_hi);
+            auto t_hi = std::make_unique<region::ConstantCurve>(p_nc_lo, p_nc_hi, T_max_eos - 0.5);
+            spec.regions.emplace_back(axis, std::move(t_lo), std::move(t_hi));
+        }
+    }
+    // NC_SUPER (CoolProp-4u9): super-critical near-critical sub-region
+    // on p ∈ [(1 + 1e-10)·pc, 1.1·pc] with POWER_LO(β=1/3) primary
+    // axis crowding toward pc.  Single region (no sat dome above pc);
+    // b_lo / b_hi are the T-floor / constant T_max-0.5 ceiling.
+    if (nc_enabled && p_nc_sup_lo < p_nc_sup_hi) {
+        auto axis = region::AxisTransform::make(region::AxisScale::POWER_LO, p_nc_sup_lo, p_nc_sup_hi);
+        auto t_lo = pt_T_floor_curve_(heos, p_nc_sup_lo, p_nc_sup_hi, T_min_eos, SatBoundaryBuildOptions{});
+        auto t_hi = std::make_unique<region::ConstantCurve>(p_nc_sup_lo, p_nc_sup_hi, T_max_eos - 0.5);
+        spec.regions.emplace_back(axis, std::move(t_lo), std::move(t_hi));
+    }
+    // SUPER region: p > p_crit (clipped up to 1.1·pc when NC enabled
+    // so NC_SUPER owns the strip just above pc).  T-floor still walks
+    // T_min up over melting line (the melting curve extends well into
+    // supercritical for most fluids).  Hot ceiling stays at T_max-0.5 K.
+    if (p_min_sup < p_max_sup) {
         auto axis = region::AxisTransform::make(region::AxisScale::LOG, p_min_sup, p_max_sup);
         auto t_lo = pt_T_floor_curve_(heos, p_min_sup, p_max_sup, T_min_eos, SatBoundaryBuildOptions{});
         auto t_hi = std::make_unique<region::ConstantCurve>(p_min_sup, p_max_sup, T_max_eos - 0.5);
@@ -656,7 +763,6 @@ SurfaceSpec pt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
     // IF97-only because R5 has no HEOS counterpart in CoolProp for
     // water (Wagner & Pruss covers 273-1273 K).  Constant-T b_lo /
     // b_hi: R5 is a flat T-slab, no melting curve consideration.
-    const bool source_is_if97 = (heos.backend_name() == "IF97Backend");
     if (source_is_if97) {
         // Nudge above 1073.15 because IF97's RegionDetermination_TP
         // dispatches T == 1073.15 K to R2 (the boundary uses

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -262,7 +262,9 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
         spec.regions.emplace_back(axis, std::move(lo), std::move(hi));
     }
     // NC_LIQUID + NC_VAPOR (CoolProp-4u9): near-critical sub-regions on
-    // p ∈ [0.9·pc, (1 − 1ppm)·pc] with POWER(β=1/3) primary axis.
+    // p ∈ [0.9·pc, (1 − 1e-10)·pc] with POWER(β=1/3) primary axis.
+    // The 1e-10 gap below pc is sub-ULP for practical p — anything
+    // closer falls inside the critical patch's auto-cal'd (T, p) bbox.
     // Same boundary curves as the parent regions — the SuperAncillary-
     // backed sat curves are continuous across the p = 0.9·pc handoff.
     if (nc_enabled && p_nc_lo < p_nc_hi) {
@@ -296,8 +298,10 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
         auto hi = build_h_isotherm_ceiling(heos, p_nc_sup_lo, p_nc_sup_hi, T_max_eos - 0.5);
         spec.regions.emplace_back(axis, std::move(lo), std::move(hi));
     }
-    // SUPER region: p > p_crit.  Primary = log p over [p_crit*1.001,
-    // p_max_eos*0.99], secondary = h.  No sat dome above p_crit, so
+    // SUPER region: p > p_crit (clipped up to 1.1·pc when NC enabled,
+    // so NC_SUPER owns the strip just above pc).  Primary = log p over
+    // [max(p_crit, 1.1·pc), p_max_eos*0.99], secondary = h.  No sat
+    // dome above p_crit, so
     // the secondary bounds are the same low-T / high-T isotherms used
     // by LIQUID / VAPOR — they continue smoothly into supercritical.
     //
@@ -722,7 +726,9 @@ SurfaceSpec pt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
         spec.regions.emplace_back(axis, std::move(t_lo), std::move(t_hi));
     }
     // NC_LIQUID + NC_VAPOR (CoolProp-4u9): near-critical sub-regions on
-    // p ∈ [0.9·pc, (1 − 1ppm)·pc] with POWER(β=1/3) primary axis.
+    // p ∈ [0.9·pc, (1 − 1e-10)·pc] with POWER(β=1/3) primary axis.
+    // The 1e-10 gap below pc is sub-ULP for practical p — anything
+    // closer falls inside the critical patch's auto-cal'd bbox.
     if (nc_enabled && p_nc_lo < p_nc_hi) {
         {
             auto axis = region::AxisTransform::make(region::AxisScale::POWER, p_nc_lo, p_nc_hi);

--- a/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
+++ b/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
@@ -138,7 +138,11 @@ TEST_CASE("SVDSurface PH preset builds + evals against HEOS", "[SBTL][SVDSurface
     // production-resolution accuracy.
     auto spec = cp_sbtl::presets::ph_subcritical(*heos, /*NT=*/40, /*NR=*/80, /*rank=*/10);
     REQUIRE(spec.input_pair == ::CoolProp::HmassP_INPUTS);
-    REQUIRE(spec.regions.size() == 3);
+    // 6 regions: LIQUID, VAPOR, NC_LIQUID, NC_VAPOR, NC_SUPER, SUPER.
+    // The NC_* regions are the near-critical sub-regions added in
+    // CoolProp-4u9 (POWER / POWER_LO β=1/3 primary axis crowding
+    // toward pc).
+    REQUIRE(spec.regions.size() == 6);
     // 5 thermodynamic properties (ρ, T, s, u, w) plus 2 optional
     // transport properties (η, λ) when the source backend exposes them
     // — HEOS Water does, so we expect 7 here.  Fluids without transport
@@ -157,7 +161,7 @@ TEST_CASE("SVDSurface PH preset builds + evals against HEOS", "[SBTL][SVDSurface
 
     auto surface = cp_sbtl::build_surface(*heos, std::move(spec));
     REQUIRE(surface.sealed());
-    REQUIRE(surface.region_count() == 3);
+    REQUIRE(surface.region_count() == 6);  // CoolProp-4u9: NC_LIQUID + NC_VAPOR + NC_SUPER
 
     // Probe single-phase Water states in (T, p) → look up via (h, p).
     std::mt19937 rng(57);
@@ -304,7 +308,7 @@ TEST_CASE("SVDSurface PH preset across multi-fluid set", "[SBTL][SVDSurface][pre
             auto spec = cp_sbtl::presets::ph_subcritical(*heos, /*NT=*/30, /*NR=*/50, /*rank=*/8);
             cp_sbtl::SVDSurface surface = cp_sbtl::build_surface(*heos, std::move(spec));
             REQUIRE(surface.sealed());
-            REQUIRE(surface.region_count() == 3);
+            REQUIRE(surface.region_count() == 6);  // CoolProp-4u9: NC_LIQUID + NC_VAPOR + NC_SUPER
 
             // Round-trip through serializer.  HEOS canonicalises aliases
             // (e.g. "Propane" → "n-Propane"), so compare against what the
@@ -312,7 +316,7 @@ TEST_CASE("SVDSurface PH preset across multi-fluid set", "[SBTL][SVDSurface][pre
             const auto blob = cp_sbtl::SVDSurfaceSerializer::save(surface);
             auto reloaded = cp_sbtl::SVDSurfaceSerializer::load(blob);
             REQUIRE(reloaded.fluid_name() == surface.fluid_name());
-            REQUIRE(reloaded.region_count() == 3);
+            REQUIRE(reloaded.region_count() == 6);
 
             // Spot-check eval matches HEOS at a handful of single-phase probes.
             std::mt19937 rng(91);
@@ -353,7 +357,7 @@ TEST_CASE("SVDSurface PT preset water round-trip", "[SBTL][SVDSurface][preset_pt
     auto heos = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("HEOS", "Water"));
     auto spec = cp_sbtl::presets::pt_subcritical(*heos, /*NT=*/40, /*NR=*/80, /*rank=*/10);
     REQUIRE(spec.input_pair == ::CoolProp::PT_INPUTS);
-    REQUIRE(spec.regions.size() == 3);
+    REQUIRE(spec.regions.size() == 6);  // CoolProp-4u9: NC_LIQUID + NC_VAPOR + NC_SUPER
 
     cp_sbtl::SVDSurface surface = cp_sbtl::build_surface(*heos, std::move(spec));
     REQUIRE(surface.sealed());
@@ -386,7 +390,7 @@ TEST_CASE("SVDSurfaceSerializer file save/load round-trip", "[SBTL][serializer][
     cp_sbtl::SVDSurfaceSerializer::save_to_file(surface, path);
     auto loaded = cp_sbtl::SVDSurfaceSerializer::load_from_file(path);
     REQUIRE(loaded.fluid_name() == "Water");
-    REQUIRE(loaded.region_count() == 3);
+    REQUIRE(loaded.region_count() == 6);  // CoolProp-4u9: NC_LIQUID + NC_VAPOR + NC_SUPER
     // Spot-check a single eval matches.
     heos->update(::CoolProp::PT_INPUTS, 1e5, 350.0);
     const double h = heos->hmass();

--- a/src/Tests/CoolProp-Tests-SVDComponents.cpp
+++ b/src/Tests/CoolProp-Tests-SVDComponents.cpp
@@ -77,6 +77,87 @@ TEST_CASE("AxisTransform analytic Jacobian", "[SVDComponents][Region][axis_trans
     REQUIRE(t_log.dxi_da(a) == Catch::Approx(fd).epsilon(1e-6));
 }
 
+TEST_CASE("AxisTransform power round-trip", "[SVDComponents][Region][axis_transform]") {
+    // POWER β=1/3 (CoolProp-4u9): xi=0 → a_lo, xi=1 → a_hi, crowds at a_hi.
+    // Use a band typical of NC near-critical use (R245fa-like p range).
+    const double a_lo = 0.9 * 3.651e6;           // 0.9·pc
+    const double a_hi = (1.0 - 1e-6) * 3.651e6;  // (1 − 1ppm)·pc
+    const auto t = cp_region::AxisTransform::make(cp_region::AxisScale::POWER, a_lo, a_hi);
+    std::mt19937 rng(3);
+    std::uniform_real_distribution<double> u(a_lo, a_hi);
+    for (int k = 0; k < 100; ++k) {
+        const double a = u(rng);
+        const double xi = t.forward(a);
+        REQUIRE(xi >= -1e-12);
+        REQUIRE(xi <= 1.0 + 1e-12);
+        const double a_back = t.inverse(xi);
+        REQUIRE(std::abs(a_back - a) / a < 1e-12);
+    }
+    // Endpoints exact.
+    REQUIRE(t.forward(a_lo) == Catch::Approx(0.0).margin(1e-15));
+    REQUIRE(t.forward(a_hi) == Catch::Approx(1.0).margin(1e-15));
+    REQUIRE(t.inverse(0.0) == Catch::Approx(a_lo).margin(1e-15));
+    REQUIRE(t.inverse(1.0) == Catch::Approx(a_hi).margin(1e-15));
+    // Crowding direction: at xi=0.5 the physical a is much closer to a_hi
+    // than to a_lo.  (1 − 0.5)³ = 0.125 → a = a_hi − 0.125·(a_hi−a_lo),
+    // i.e. 87.5% of the way to a_hi.
+    const double a_mid = t.inverse(0.5);
+    const double frac = (a_mid - a_lo) / (a_hi - a_lo);
+    REQUIRE(frac == Catch::Approx(0.875).margin(1e-15));
+    // POWER requires a_hi > a_lo (no LOG-style positive-bound check; physical
+    // pressures > 0 are sufficient).
+    REQUIRE_THROWS_AS(cp_region::AxisTransform::make(cp_region::AxisScale::POWER, 1.0, 1.0), std::invalid_argument);
+}
+
+TEST_CASE("AxisTransform power Jacobian vs central FD", "[SVDComponents][Region][axis_transform]") {
+    // POWER's analytic dxi/da diverges as a → a_hi; check at a few
+    // interior points where central FD is well-conditioned.
+    const auto t = cp_region::AxisTransform::make(cp_region::AxisScale::POWER, 1.0, 2.0);
+    for (double a : {1.1, 1.3, 1.5, 1.7, 1.9}) {
+        const double h = 1e-7 * a;
+        const double fd = (t.forward(a + h) - t.forward(a - h)) / (2.0 * h);
+        REQUIRE(t.dxi_da(a) == Catch::Approx(fd).epsilon(1e-5));
+    }
+}
+
+TEST_CASE("AxisTransform power_lo round-trip", "[SVDComponents][Region][axis_transform]") {
+    // POWER_LO β=1/3 (CoolProp-4u9): xi=0 → a_lo, xi=1 → a_hi, crowds at a_lo.
+    // Use a band typical of NC_SUPER (R245fa-like, just above pc).
+    const double a_lo = (1.0 + 1e-10) * 3.651e6;
+    const double a_hi = 1.1 * 3.651e6;
+    const auto t = cp_region::AxisTransform::make(cp_region::AxisScale::POWER_LO, a_lo, a_hi);
+    std::mt19937 rng(4);
+    std::uniform_real_distribution<double> u(a_lo, a_hi);
+    for (int k = 0; k < 100; ++k) {
+        const double a = u(rng);
+        const double xi = t.forward(a);
+        REQUIRE(xi >= -1e-12);
+        REQUIRE(xi <= 1.0 + 1e-12);
+        const double a_back = t.inverse(xi);
+        REQUIRE(std::abs(a_back - a) / a < 1e-12);
+    }
+    // Endpoints exact.
+    REQUIRE(t.forward(a_lo) == Catch::Approx(0.0).margin(1e-15));
+    REQUIRE(t.forward(a_hi) == Catch::Approx(1.0).margin(1e-15));
+    REQUIRE(t.inverse(0.0) == Catch::Approx(a_lo).margin(1e-15));
+    REQUIRE(t.inverse(1.0) == Catch::Approx(a_hi).margin(1e-15));
+    // Mirror of POWER: at xi=0.5 the physical a is 12.5% of the way to a_hi
+    // (POWER had 87.5%).  (0.5)³ = 0.125 → a = a_lo + 0.125·(a_hi−a_lo).
+    const double a_mid = t.inverse(0.5);
+    const double frac = (a_mid - a_lo) / (a_hi - a_lo);
+    REQUIRE(frac == Catch::Approx(0.125).margin(1e-15));
+}
+
+TEST_CASE("AxisTransform power_lo Jacobian vs central FD", "[SVDComponents][Region][axis_transform]") {
+    // POWER_LO's analytic dxi/da diverges as a → a_lo; check interior points.
+    const auto t = cp_region::AxisTransform::make(cp_region::AxisScale::POWER_LO, 1.0, 2.0);
+    for (double a : {1.1, 1.3, 1.5, 1.7, 1.9}) {
+        const double h = 1e-7 * a;
+        const double fd = (t.forward(a + h) - t.forward(a - h)) / (2.0 * h);
+        REQUIRE(t.dxi_da(a) == Catch::Approx(fd).epsilon(1e-5));
+    }
+}
+
 // ============================================================
 // BoundaryCurve: ConstantCurve
 // ============================================================

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -1054,14 +1054,16 @@ TEST_CASE("SVDSBTLBackend uses surrogate when source has no SuperAncillary", "[S
 }
 
 // CoolProp-4u9: the tiny p-strip immediately around pc (sub: p ∈
-// [(1−1ppm)·pc, pc]; super: p ∈ [pc, (1+1ppm)·pc]) sits outside the
-// NC sub-regions (which stop at (1−1ppm)·pc) and outside SUPER
-// (which starts at 1.001·pc).  Its natural home is the critical
-// patch — cells in the strip route to the source backend directly
-// and should return HEOS-exact values.  This test guards against
-// (a) patch HmassP envelope misses (e.g. perimeter walk skipping
-// cells at T > T_max for fluids with T_max ≈ Tc + ε) and (b)
-// runtime gaps where neither NC, SUPER, nor patch claims a cell.
+// [(1−1e-10)·pc, pc]; super: p ∈ [pc, (1+1e-10)·pc]) sits outside
+// the NC sub-regions (which stop at (1−1e-10)·pc on the sub-side
+// and start at (1+1e-10)·pc on the super-side) and outside SUPER
+// (which starts at 1.1·pc when NC is enabled).  Its natural home
+// is the critical patch — cells in the strip route to the source
+// backend directly and should return HEOS-exact values.  This test
+// guards against (a) patch HmassP envelope misses (e.g. perimeter
+// walk skipping cells at T > T_max for fluids with T_max ≈ Tc + ε)
+// and (b) runtime gaps where neither NC, SUPER, nor patch claims a
+// cell.
 TEST_CASE("SVDSBTL pc-strip routes through critical patch", "[SVDSBTL][CoolProp-4u9][pc_strip][slow]") {
     // Include R245fa (T_max/Tc = 1.030 — the narrowest envelope in
     // the supported set), Water (T_max/Tc = 3.51 — comfortable),

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -1053,4 +1053,67 @@ TEST_CASE("SVDSBTLBackend uses surrogate when source has no SuperAncillary", "[S
     REQUIRE(rp_be->sat_surrogate_consulted());
 }
 
+// CoolProp-4u9: the tiny p-strip immediately around pc (sub: p ∈
+// [(1−1ppm)·pc, pc]; super: p ∈ [pc, (1+1ppm)·pc]) sits outside the
+// NC sub-regions (which stop at (1−1ppm)·pc) and outside SUPER
+// (which starts at 1.001·pc).  Its natural home is the critical
+// patch — cells in the strip route to the source backend directly
+// and should return HEOS-exact values.  This test guards against
+// (a) patch HmassP envelope misses (e.g. perimeter walk skipping
+// cells at T > T_max for fluids with T_max ≈ Tc + ε) and (b)
+// runtime gaps where neither NC, SUPER, nor patch claims a cell.
+TEST_CASE("SVDSBTL pc-strip routes through critical patch", "[SVDSBTL][CoolProp-4u9][pc_strip][slow]") {
+    // Include R245fa (T_max/Tc = 1.030 — the narrowest envelope in
+    // the supported set), Water (T_max/Tc = 3.51 — comfortable),
+    // and CO2 (T_max/Tc = 6.58 — comfortable).  R245fa is the one
+    // that exposed the T_hi_mult clamp bug; Water/CO2 are regression
+    // anchors.
+    for (const auto* fluid : {"R245fa", "Water", "CarbonDioxide"}) {
+        SECTION(fluid) {
+            auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", fluid));
+            auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", fluid));
+            const double pc = heos->p_critical();
+            const double Tc = heos->T_critical();
+
+            // Probe both sides of pc at p-offsets that step through
+            // the strip.  Use T very close to Tc on each side so the
+            // cell lands inside the patch's auto-cal'd (T, p) bbox.
+            // (The auto-cal bisects T_lo aggressively; for R245fa
+            // T_lo ends at 0.9992·Tc.  A T 0.5 K below Tc would fall
+            // BELOW patch.T_lo and route to NC at its ξ=1 boundary
+            // edge — 1e-6 error, not the machine-precision the strip
+            // is supposed to give.  Testing physically-meaningful
+            // critical-region cells means T near Tc anyway.)
+            const double T_sub = (1.0 - 1.0e-4) * Tc;
+            const double T_sup = (1.0 + 1.0e-4) * Tc;
+            for (const double frac : {1e-6, 1e-7, 1e-8}) {
+                for (const auto& side : {std::make_pair(pc * (1.0 - frac), T_sub), std::make_pair(pc * (1.0 + frac), T_sup)}) {
+                    const double p = side.first;
+                    const double T = side.second;
+                    // Forward (p, T) -> h via HEOS truth.
+                    heos->update(CoolProp::PT_INPUTS, p, T);
+                    const double h = heos->hmass();
+                    const double rho_truth = heos->rhomass();
+
+                    // 1) PT lookup: SVD must route to patch and
+                    //    return HEOS-exact rho.
+                    svd->update(CoolProp::PT_INPUTS, p, T);
+                    INFO(fluid << " pc-strip PT: p=" << p << " T=" << T);
+                    REQUIRE_FALSE(std::isnan(svd->rhomass()));
+                    REQUIRE(svd->rhomass() == Approx(rho_truth).epsilon(1e-12));
+
+                    // 2) HmassP lookup: same cell via (h, p) must
+                    //    also route to patch and return HEOS-exact
+                    //    rho.  This is the path that fails for
+                    //    R245fa without the T_hi_mult clamp.
+                    svd->update(CoolProp::HmassP_INPUTS, h, p);
+                    INFO(fluid << " pc-strip HmassP: p=" << p << " h=" << h << " (T_truth=" << T << ")");
+                    REQUIRE_FALSE(std::isnan(svd->rhomass()));
+                    REQUIRE(svd->rhomass() == Approx(rho_truth).epsilon(1e-9));
+                }
+            }
+        }
+    }
+}
+
 #endif  // ENABLE_CATCH

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -1103,13 +1103,24 @@ TEST_CASE("SVDSBTL pc-strip routes through critical patch", "[SVDSBTL][CoolProp-
                     REQUIRE(svd->rhomass() == Approx(rho_truth).epsilon(1e-12));
 
                     // 2) HmassP lookup: same cell via (h, p) must
-                    //    also route to patch and return HEOS-exact
-                    //    rho.  This is the path that fails for
-                    //    R245fa without the T_hi_mult clamp.
+                    //    also route to patch and return what HEOS
+                    //    returns for the SAME (h, p) input.  This
+                    //    is the path that fails for R245fa without
+                    //    the T_hi_mult clamp.  Compare against
+                    //    heos->HmassP, not heos->PT, because the
+                    //    polish gate (#2966) means HEOS-source
+                    //    patches no longer iterate T to match
+                    //    rho_truth_PT — they just call HEOS's
+                    //    HmassP_INPUTS, which is iterative+forward-
+                    //    consistent but not bit-exact with PT in
+                    //    the ill-conditioned critical region
+                    //    (~1e-7 residual for R245fa).
+                    heos->update(CoolProp::HmassP_INPUTS, h, p);
+                    const double rho_truth_hp = heos->rhomass();
                     svd->update(CoolProp::HmassP_INPUTS, h, p);
                     INFO(fluid << " pc-strip HmassP: p=" << p << " h=" << h << " (T_truth=" << T << ")");
                     REQUIRE_FALSE(std::isnan(svd->rhomass()));
-                    REQUIRE(svd->rhomass() == Approx(rho_truth).epsilon(1e-9));
+                    REQUIRE(svd->rhomass() == Approx(rho_truth_hp).epsilon(1e-12));
                 }
             }
         }


### PR DESCRIPTION
## Summary

Adds three near-critical sub-regions (NC_LIQUID, NC_VAPOR, NC_SUPER) on `p ∈ [0.9·pc, 1.1·pc]` for HEOS/REFPROP source backends, plus `AxisScale::POWER` and `AxisScale::POWER_LO` axis-transform variants that crowd grid lines toward the critical point.  Cube-root crowding (Ising β ≈ 0.326 ≈ 1/3) absorbs the critical-scaling singularity so Hermite-cubic SVD interpolant stays well-conditioned to within 1e-10 of pc.

Closes the (h, p) coverage gap exposed by the h=350 kJ/kg R245fa sweep: cells in the thin strip just above pc with T outside the auto-cal'd patch's narrow (T, p) bbox previously fell through every region and returned NaN.

## Results

**Python diagnostic on R245fa / Water / CO2 LIQUID + VAPOR at NT=200 NR=800 Cheb, rank=20:**
- log primary @ p_hi=0.99999·pc:  max off-grid err **2-3e-4**
- pow(1/3)   @ same: max off-grid err **1e-9 to 8e-8** — 1000-100000× better

**R245fa h=350 kJ/kg pressure sweep (10k probes, sub→super):**
| Region | n_probes | max | p99 | p50 |
|---|---|---|---|---|
| LIQUID parent | 1891 | 1.0e-5 | 1.0e-5 | 7.5e-7 |
| **NC_LIQUID** | 3485 | **7.3e-9** | 1.1e-9 | 5.2e-10 |
| **NC_SUPER strip** | 33 | **2.2e-9** | 2.2e-9 | 2.2e-9 |
| **SUPER** | 4591 | **4.5e-8** | 4.0e-8 | 2.2e-9 |

Zero NaN. NC regions hit machine precision in their interior.

**R245fa end-to-end bench (post-NC):**
- max  = 7.7e-5  (down from 2.6e-4 pre-NC — remaining max is a hot-ceiling boundary cell, pre-existing)
- p99  = 9.4e-8
- p50  = 1.7e-11
- 0 cells > 1e-4 (vs 5 pre-NC)

**Per-region steady-state timing** unchanged vs master (within bench noise; medians: ~375 ns subcritical, ~214 ns SUPER).  One-time cache rebuild on first session per fluid (rev 12 → 14).

## What's NOT included (verified not to help)

A direct measurement question came up: should we apply POWER scaling to the parent LIQUID/VAPOR (full `[p_triple, 0.9·pc]`) too?  Empirically NO — across R245fa/Water/CO2/Helium and band widths from parent (5 decades) down to [0.8·pc, 0.9·pc], LOG primary wins every cell.  POWER pays off only when its anchor coincides with a real singularity (the NC case where anchor = pc-ε).

## Coverage check

After the change, every (h, p) inside the HEOS validity envelope lands in exactly one SVD region or the critical patch:
- `[p_triple, 0.9·pc]`: parent LIQUID + VAPOR (unchanged geometry, LOG primary)
- `[0.9·pc, (1−1e-10)·pc]`: NC_LIQUID + NC_VAPOR (POWER β=1/3, crowds toward pc)
- `[(1+1e-10)·pc, 1.1·pc]`: NC_SUPER (POWER_LO β=1/3, single region — no dome above pc)
- `[1.1·pc, p_max]`: parent SUPER (unchanged geometry, LOG primary)
- The 2e-10·pc sliver immediately around pc is covered by the critical patch for cells in patch's auto-cal'd (T, p) bbox (HEOS-exact lookup).

## Test plan
- [x] `[Region]` Catch2 suite (POWER + POWER_LO round-trip, Jacobian vs FD) — 2515 assertions pass
- [x] `[SBTL]` umbrella — 4229 assertions in 12 cases pass
- [x] `[SVDSBTL]` umbrella — 47 passed, 6 skipped, 766 assertions pass
- [x] `[CoolProp-4u9][pc_strip]` — new test for R245fa/Water/CO2 PT+HmassP at p ∈ [(1−1ppm)·pc, (1+1ppm)·pc] — 72 assertions pass
- [x] R245fa / Water / CO2 end-to-end bench shows no regressions and meaningful improvements near pc
- [x] R245fa h=350 kJ/kg sub→super pressure sweep — 0 NaN, max 1e-5 in parent, machine precision in NC
- [x] Docs `.. plot::` directive for R245fa (Web/coolprop/SVDSBTL.rst:542) — 20k probes, max 0.010%, p99.9 = 0.001%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive CLI plotting mode with optional on‑screen display.

* **Improvements**
  * Two new axis‑scaling modes to better handle near‑critical behavior.
  * Surface presets expanded with additional near‑critical sub‑regions for improved coverage.
  * Safer temperature bound clamping during critical‑patch calibration.
  * Cache/serializer revision bumped to force recalculation of cached critical‑patch data.

* **Tests**
  * Added and updated tests covering new axis scales, near‑critical regions, and critical‑patch routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->