### PR TITLE
fix(wasm): pin emsdk to CI sha + add mixture set_mole_fractions test

### DIFF
--- a/wrappers/Javascript/Dockerfile
+++ b/wrappers/Javascript/Dockerfile
@@ -1,6 +1,16 @@
 ## Use docker-compose to spin up this job
 
-FROM emscripten/emsdk
+# Pinned to match .github/workflows/javascript_builder.yml (emcc 4.0.12).
+# emcc 5.x dropped the JS-side __embind_register_function / __embind_register_class
+# runtime dispatch from -lembind, leaving free-function and class bindings
+# inaccessible from JS (the wasm still builds and links; the resolved Module
+# instance just has no F2K / PropsSI / factory / AbstractState etc.). The
+# documented -sEMBIND_AOT=1 path was attempted but currently fails the link
+# step ('expected to find pattern in input JS: <<< EMBIND_AOT_INVOKERS >>>')
+# against our binding shape, and upstream issue emscripten-core#24540 notes
+# that AOT method-caller coverage is incomplete. Lift this pin once the 5.x
+# binding-exposure migration is sorted (tracked separately in beads).
+FROM emscripten/emsdk@sha256:744fb6a68941970951bacf9d6632041a0398260492232691ef22bbf54b0585c6
 
 RUN apt-get -y -m update && DEBIAN_FRONTEND=noninteractive apt-get install -y dos2unix
 

--- a/wrappers/Javascript/test_wasm.mjs
+++ b/wrappers/Javascript/test_wasm.mjs
@@ -60,3 +60,38 @@ try {
     console.error("AbstractState test failed:", e);
     process.exit(1);
 }
+
+// Test mixture composition via set_mole_fractions(VectorDouble).
+// The set is verified by cross-checking the resulting density against
+// PropsSI with an explicit-composition fluid string; a bit-exact match
+// confirms the VectorDouble was correctly threaded into AbstractState.
+console.log("Testing set_mole_fractions on a binary mixture...");
+try {
+    var z = new coolprop.VectorDouble();
+    z.push_back(0.4);
+    z.push_back(0.6);
+
+    var ASmix = coolprop.factory("HEOS", "Methane&Ethane");
+    if (!ASmix.using_mole_fractions()) {
+        console.error("HEOS mixture should report using_mole_fractions() === true");
+        process.exit(1);
+    }
+    ASmix.set_mole_fractions(z);
+    ASmix.update(coolprop.input_pairs.PT_INPUTS, 1e6, 250);
+
+    var rho = ASmix.rhomass();
+    var rhoRef = coolprop.PropsSI('D', 'P', 1e6, 'T', 250, 'HEOS::Methane[0.4]&Ethane[0.6]');
+    console.log("mixture rhomass (set_mole_fractions):", rho);
+    console.log("mixture rhomass (PropsSI ref):       ", rhoRef);
+    if (Math.abs(rho - rhoRef) > 1e-8 * Math.abs(rhoRef)) {
+        console.error("set_mole_fractions did not produce a state matching PropsSI reference");
+        process.exit(1);
+    }
+
+    z.delete();
+    ASmix.delete();
+    console.log("set_mole_fractions test passed!");
+} catch (e) {
+    console.error("set_mole_fractions test failed:", e);
+    process.exit(1);
+}


### PR DESCRIPTION
## Summary

Two-file follow-up to #2664 (Expose comprehensive AbstractState functionality and enums to WASM). Both items came up while exercising the new binding surface locally.

- **`wrappers/Javascript/Dockerfile`**: pin to the same emsdk sha (`@sha256:744fb6a6...` = emcc 4.0.12) that `.github/workflows/javascript_builder.yml` uses. Pulling `latest` (emcc 5.0.7) builds and links cleanly, but the resolved `Module` instance from `await Module()` has **zero** embind bindings — `node test_wasm.mjs` fails for every dev with `coolprop.F2K is not a function`, even though CI passes. Root cause: emcc 5.x dropped the JS-side `__embind_register_function` / `__embind_register_class` runtime dispatch from `-lembind`. `-sEMBIND_AOT=1` was tried as the forward path but fails the link step (`expected to find pattern in input JS: <<< EMBIND_AOT_INVOKERS >>>`) for our binding shape; upstream emscripten-core#24540 notes AOT method-caller coverage is incomplete. Lifting the pin is tracked separately as bead **CoolProp-71a.2**.

- **`wrappers/Javascript/test_wasm.mjs`**: adds a binary HEOS Methane&Ethane mixture test exercising the EMSCRIPTEN-only `set_mole_fractions_double` wrapper (`include/AbstractState.h:844-848`). Sets z = [0.4, 0.6], updates at PT = (1 MPa, 250 K), cross-checks `AS.rhomass()` against `PropsSI('D','P',1e6,'T',250,'HEOS::Methane[0.4]&Ethane[0.6]')`. Both paths use the same multi-fluid Helmholtz EOS so a bit-exact match is expected (and observed locally). Catches the class of regression where the composition setter silently fails to thread into the backend — not covered by #2664's tests.

Beads (parent epic **CoolProp-71a** — WASM/Javascript bindings updates):
- Closes **CoolProp-71a.1** (Dockerfile pin)
- Closes **CoolProp-71a.5** (mixture set_mole_fractions test)
- Leaves **CoolProp-71a.2** (emcc 5.x compat) open with investigation notes

## Test plan

- [x] `cd wrappers/Javascript && docker compose build --no-cache runner && docker compose run --rm runner` against the pinned sha produces `coolprop.js` (167 KB) + `coolprop.wasm` (8 MB)
- [x] `node test_wasm.mjs` exits 0 with all sections passing (basic + AbstractState + new mixture); locally observed `AS.rhomass() === PropsSI(...)` to 16 sig figs
- [x] `./dev/ci/preflight.sh` clean (2 passed / 0 failed / 4 correctly skipped — no C/C++ in diff)
- [ ] CI `Javascript library` workflow green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build configuration updated with pinned base image version.

* **Tests**
  * Added test validation for binary-mixture composition handling in JavaScript/WebAssembly builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2970?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->