### PR TITLE
fix(wasm): bypass register_optional<T> template to preserve _embind_register_optional import

### DIFF
--- a/src/emscripten_interface.cxx
+++ b/src/emscripten_interface.cxx
@@ -22,6 +22,7 @@
 /// *********************************************************************************
 
 #    include <emscripten/bind.h>
+#    include <optional>
 using namespace emscripten;
 
 // Binding code
@@ -212,6 +213,14 @@ EMSCRIPTEN_BINDINGS(abstract_state_bindings) {
 
     register_vector<double>("VectorDouble");
     register_vector<std::string>("VectorString");
+    // Without this, VectorDouble.get(i) throws 'unbound types: optional<double>'
+    // from JS because register_vector's auto-call to register_optional<T> is
+    // an inlineable template whose body the optimizer folds to a no-op (the
+    // `thread_local bool hasRun` guard appears to be the trigger). Calling the
+    // embind internal entry-point directly preserves the wasm import.
+    internal::_embind_register_optional(
+        internal::TypeID<std::optional<double>>::get(),
+        internal::TypeID<double>::get());
 
     value_object<CoolProp::PhaseEnvelopeData>("CoolProp::PhaseEnvelopeData")
 // Use X macros to auto-generate the variables;

--- a/wrappers/Javascript/test_wasm.mjs
+++ b/wrappers/Javascript/test_wasm.mjs
@@ -88,12 +88,19 @@ try {
         process.exit(1);
     }
 
-    // NOTE: get_mole_fractions() readback via .get(i) is gated on
-    // register_optional<double>() actually surfacing in the JS glue —
-    // currently the wasm doesn't import _embind_register_optional under
-    // emcc 4.0.12 (template body either DCE'd or not instantiated), so
-    // VectorDouble.get(i) still throws 'unbound types: optional<double>'.
-    // Round-trip test is left out until that path works; see beads.
+    // Round-trip the composition through get_mole_fractions(). The
+    // VectorDouble::get(i) → std::optional<double> binding is registered
+    // explicitly in src/emscripten_interface.cxx; embind surfaces it as a
+    // plain JS number when the value is present.
+    var got = ASmix.get_mole_fractions();
+    var got0 = got.get(0);
+    var got1 = got.get(1);
+    console.log("mixture composition round-trip:", got0, got1);
+    if (Math.abs(got0 - 0.4) > 1e-12 || Math.abs(got1 - 0.6) > 1e-12) {
+        console.error("get_mole_fractions did not round-trip composition");
+        process.exit(1);
+    }
+    got.delete();
 
     z.delete();
     ASmix.delete();
@@ -143,18 +150,24 @@ try {
     var env = ASenv.get_phase_envelope_data();
 
     // env.T and env.p are VectorDouble fields populated by the envelope tracer.
-    // We check structure (both vectors non-empty and same length) rather than
-    // element values: VectorDouble.get(i) currently returns std::optional<double>
-    // and the optional-type registration isn't taking effect in the full
-    // CoolProp build (minimal repro works; full build doesn't — pending
-    // investigation). The size check still proves the value_object binding
-    // and the X-macro field registration round-trip the data populated by
-    // build_phase_envelope().
     var nT = env.T.size();
     var np = env.p.size();
     console.log("envelope points: T=" + nT + ", p=" + np);
     if (nT < 5 || np !== nT) {
         console.error("envelope returned too few points or T/p size mismatch:", nT, np);
+        process.exit(1);
+    }
+    // Sample the middle point; both must be finite and in plausible ranges
+    // for Methane&Ethane. Exercises VectorDouble::get(i) -> optional<double>.
+    var Tmid = env.T.get(Math.floor(nT/2));
+    var pmid = env.p.get(Math.floor(np/2));
+    console.log("envelope mid-point: T=" + Tmid + " K, p=" + pmid + " Pa");
+    if (!(Number.isFinite(Tmid) && Tmid > 50 && Tmid < 400)) {
+        console.error("envelope mid-T out of plausible range:", Tmid);
+        process.exit(1);
+    }
+    if (!(Number.isFinite(pmid) && pmid > 1 && pmid < 1e8)) {
+        console.error("envelope mid-p out of plausible range:", pmid);
         process.exit(1);
     }
 


### PR DESCRIPTION
## Summary

Closes **CoolProp-71a.8** — the last open child of the WASM-updates epic except the larger emcc-5.x migration (`.2`).

PR #2971 added `register_optional<double>()` to surface `std::optional<double>` so JS callers could read `VectorDouble::get(i)`. It had no effect: the wasm imported 17 other `_embind_register_*` symbols, just not `_embind_register_optional`. A minimal one-TU repro at `-O2` worked; the full CoolProp build at `-O3 -DNDEBUG -std=gnu++17` did not, regardless of optimization level toggled on the JS target.

### Diagnosis

The `register_optional<T>()` template body is short and inlineable:
```cpp
thread_local bool hasRun;
if (hasRun) { return; }
hasRun = true;
internal::_embind_register_optional(<TypeID>, <TypeID>);
```

In the full build context, `-O3` plus LTO across the binding TU folds the body to a no-op call — presumably reasoning across the `hasRun` state machine since the extern `_embind_register_optional` declaration carries no side-effect attributes that prevent it. (`-O2` on the JS target alone didn't help; the elision happens through other means too.) Calling `internal::_embind_register_optional` directly with the same two TypeID arguments the template would generate (see `bind.h:1963-1964`) bypasses the template and preserves the wasm import.

### Diff

- `src/emscripten_interface.cxx`: +1 `#include <optional>`, +8 lines for the direct call (with comment explaining why).
- `wrappers/Javascript/test_wasm.mjs`: enable the previously-skipped `get_mole_fractions()` round-trip in the mixture section, and the previously-skipped element-value plausibility check in the phase envelope section.

`emscripten/emsdk` pin and `-O3 -DNDEBUG` build flags are unchanged.

## Test plan

- [x] `cd wrappers/Javascript && docker compose run --rm runner` against pinned emsdk 4.0.12 links cleanly
- [x] `strings coolprop.wasm | grep _embind_register_optional` → 1 hit (was 0 before)
- [x] `node test_wasm.mjs` exits 0 with all five sections passing:
  - mixture composition round-trip: `got.get(0) === 0.4`, `got.get(1) === 0.6`
  - envelope mid-point: T=263.4 K, p=4.78 MPa (Methane&Ethane 50/50)
- [x] Preflight clean (6 passed / 0 failed / 0 skipped)
- [x] Adversarial code-review pass clean
- [ ] CI `Javascript library` workflow green

## Follow-up

If/when `CoolProp-71a.2` (emcc 5.x migration) lets us bump the pin, this direct call should keep working — `_embind_register_optional` is the same internal API the embind library has used since the optional binding was introduced. If by then the embind team has fixed the template-elision issue upstream, the explicit call can be reverted to a plain `register_optional<double>()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved runtime errors in JavaScript bindings for optional type handling.

* **Tests**
  * Enhanced mixture composition round-trip validation.
  * Improved phase envelope testing with midpoint sampling checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2974?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->