### PR TITLE
refactor(clang-tidy): modernize-use-override sweep (CoolProp-7ue)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,7 +20,9 @@
 #   -cppcoreguidelines-owning-memory : we use raw pointers under Qt parent
 #   -cppcoreguidelines-avoid-non-const-global-variables : Google Tests
 #   -modernize-concat-nested-namespaces : doesn't clarify intent
-#   -modernize-use-override : project uses override+final via macros
+#   -modernize-use-override : enabled after CoolProp-7ue (no override macros);
+#       fix-it swept once across src/ + include/ with AllowOverrideAndFinal=true
+#       and IgnoreDestructors=true, keep enabled going forward.
 #   -cppcoreguidelines-narrowing-conversions / -bugprone-narrowing-conversions :
 #       WarnOnEquivalentBitWidth was added in clang-tidy 13; without it
 #       the check is too noisy on uint→int conversions, so disabled
@@ -57,7 +59,6 @@ Checks: |
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-constant-array-index,
   -modernize-concat-nested-namespaces,
-  -modernize-use-override,
   -modernize-use-trailing-return-type,
 
 WarningsAsErrors: '*'
@@ -65,6 +66,14 @@ HeaderFilterRegex: '*'
 FormatStyle:     file
 CheckOptions:
   - key:             performance-for-range-copy.WarnOnAllAutoCopies
+    value:           'true'
+  # modernize-use-override tuning (CoolProp-7ue): allow `override final`
+  # together rather than collapsing to `final` only, and don't add `override`
+  # to destructors (the project's convention; matches the historical 2uw.13
+  # configuration).
+  - key:             modernize-use-override.AllowOverrideAndFinal
+    value:           'true'
+  - key:             modernize-use-override.IgnoreDestructors
     value:           'true'
   - key:             readability-implicit-bool-conversion.AllowPointerConditions
     value:           'true'

--- a/include/Exceptions.h
+++ b/include/Exceptions.h
@@ -30,7 +30,7 @@ class CoolPropBaseError : public std::exception
     };
     CoolPropBaseError(const std::string& err, ErrCode code) throw() : m_code(code), m_err(err) {}
     ~CoolPropBaseError() throw(){};
-    virtual const char* what() const throw() {
+    const char* what() const throw() override {
         return m_err.c_str();
     }
     ErrCode code() {

--- a/include/Helmholtz.h
+++ b/include/Helmholtz.h
@@ -541,7 +541,7 @@ class ResidualHelmholtzGeneralizedExponential : public BaseHelmholtzTerm
     //void allEigen(const CoolPropDbl &tau, const CoolPropDbl &delta, HelmholtzDerivatives &derivs) throw();
 
 #if ENABLE_CATCH
-    virtual mcx::MultiComplex<double> one_mcx(const mcx::MultiComplex<double>& tau, const mcx::MultiComplex<double>& delta) const override;
+    mcx::MultiComplex<double> one_mcx(const mcx::MultiComplex<double>& tau, const mcx::MultiComplex<double>& delta) const override;
 #endif
 };
 
@@ -584,7 +584,7 @@ class ResidualHelmholtzNonAnalytic : public BaseHelmholtzTerm
     void to_json(rapidjson::Value& el, rapidjson::Document& doc);
     void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) override;
 #if ENABLE_CATCH
-    virtual mcx::MultiComplex<double> one_mcx(const mcx::MultiComplex<double>& tau, const mcx::MultiComplex<double>& delta) const override;
+    mcx::MultiComplex<double> one_mcx(const mcx::MultiComplex<double>& tau, const mcx::MultiComplex<double>& delta) const override;
 #endif
 };
 
@@ -607,7 +607,7 @@ class ResidualHelmholtzGeneralizedCubic : public BaseHelmholtzTerm
     };
 
     void to_json(rapidjson::Value& el, rapidjson::Document& doc);
-    void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) throw();
+    void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) throw() override;
 };
 
 class ResidualHelmholtzGaoB : public BaseHelmholtzTerm
@@ -635,7 +635,7 @@ class ResidualHelmholtzGaoB : public BaseHelmholtzTerm
     void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) override;
 
 #if ENABLE_CATCH
-    virtual mcx::MultiComplex<double> one_mcx(const mcx::MultiComplex<double>& tau, const mcx::MultiComplex<double>& delta) const override;
+    mcx::MultiComplex<double> one_mcx(const mcx::MultiComplex<double>& tau, const mcx::MultiComplex<double>& delta) const override;
 #endif
 };
 
@@ -656,7 +656,7 @@ class ResidualHelmholtzXiangDeiters : public BaseHelmholtzTerm
                                   const CoolPropDbl R);
     void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) override;
 #if ENABLE_CATCH
-    virtual mcx::MultiComplex<double> one_mcx(const mcx::MultiComplex<double>& tau, const mcx::MultiComplex<double>& delta) const override;
+    mcx::MultiComplex<double> one_mcx(const mcx::MultiComplex<double>& tau, const mcx::MultiComplex<double>& delta) const override;
 #endif
 };
 
@@ -716,23 +716,23 @@ class ResidualHelmholtzSAFTAssociating : public BaseHelmholtzTerm
 
     void to_json(rapidjson::Value& el, rapidjson::Document& doc);
 
-    CoolPropDbl dTau4(const CoolPropDbl& tau, const CoolPropDbl& delta) throw() {
+    CoolPropDbl dTau4(const CoolPropDbl& tau, const CoolPropDbl& delta) throw() override {
         return 1e99;
     };
-    CoolPropDbl dDelta_dTau3(const CoolPropDbl& tau, const CoolPropDbl& delta) throw() {
+    CoolPropDbl dDelta_dTau3(const CoolPropDbl& tau, const CoolPropDbl& delta) throw() override {
         return 1e99;
     };
-    CoolPropDbl dDelta2_dTau2(const CoolPropDbl& tau, const CoolPropDbl& delta) throw() {
+    CoolPropDbl dDelta2_dTau2(const CoolPropDbl& tau, const CoolPropDbl& delta) throw() override {
         return 1e99;
     };
-    CoolPropDbl dDelta3_dTau(const CoolPropDbl& tau, const CoolPropDbl& delta) throw() {
+    CoolPropDbl dDelta3_dTau(const CoolPropDbl& tau, const CoolPropDbl& delta) throw() override {
         return 1e99;
     };
-    CoolPropDbl dDelta4(const CoolPropDbl& tau, const CoolPropDbl& delta) throw() {
+    CoolPropDbl dDelta4(const CoolPropDbl& tau, const CoolPropDbl& delta) throw() override {
         return 1e99;
     };
 
-    void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& deriv) throw();
+    void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& deriv) throw() override;
 };
 
 class BaseHelmholtzContainer
@@ -843,7 +843,7 @@ class ResidualHelmholtzContainer : public BaseHelmholtzContainer
     ResidualHelmholtzXiangDeiters XiangDeiters;
     ResidualHelmholtzGaoB GaoB;
 
-    void empty_the_EOS() {
+    void empty_the_EOS() override {
         NonAnalytic = ResidualHelmholtzNonAnalytic();
         SAFT = ResidualHelmholtzSAFTAssociating();
         GenExp = ResidualHelmholtzGeneralizedExponential();
@@ -852,7 +852,7 @@ class ResidualHelmholtzContainer : public BaseHelmholtzContainer
         GaoB = ResidualHelmholtzGaoB();
     };
 
-    HelmholtzDerivatives all(const CoolPropDbl tau, const CoolPropDbl delta, bool cache_values = false) {
+    HelmholtzDerivatives all(const CoolPropDbl tau, const CoolPropDbl delta, bool cache_values = false) override {
         HelmholtzDerivatives derivs;  // zeros out the elements
         GenExp.all(tau, delta, derivs);
         NonAnalytic.all(tau, delta, derivs);
@@ -915,7 +915,7 @@ class IdealHelmholtzLead : public BaseHelmholtzTerm
         el.AddMember("a2", static_cast<double>(a2), doc.GetAllocator());
     };
 
-    void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) throw();
+    void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) throw() override;
 };
 
 /// The term in the EOS used to shift the reference state of the fluid
@@ -979,7 +979,7 @@ class IdealHelmholtzEnthalpyEntropyOffset : public BaseHelmholtzTerm
         el.AddMember("a1", static_cast<double>(a1), doc.GetAllocator());
         el.AddMember("a2", static_cast<double>(a2), doc.GetAllocator());
     };
-    void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) throw();
+    void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) throw() override;
 };
 
 /**
@@ -1008,7 +1008,7 @@ class IdealHelmholtzLogTau : public BaseHelmholtzTerm
         el.AddMember("type", "IdealHelmholtzLogTau", doc.GetAllocator());
         el.AddMember("a1", static_cast<double>(a1), doc.GetAllocator());
     };
-    void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) throw();
+    void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) throw() override;
 };
 
 /**
@@ -1038,7 +1038,7 @@ class IdealHelmholtzPower : public BaseHelmholtzTerm
         cpjson::set_long_double_array("n", n, el, doc);
         cpjson::set_long_double_array("t", t, el, doc);
     };
-    void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) throw();
+    void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) throw() override;
 };
 
 /**
@@ -1121,7 +1121,7 @@ class IdealHelmholtzPlanckEinsteinGeneralized : public BaseHelmholtzTerm
         cpjson::set_long_double_array("n", n, el, doc);
         cpjson::set_long_double_array("theta", theta, el, doc);
     };
-    void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) throw();
+    void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) throw() override;
 };
 
 class IdealHelmholtzCP0Constant : public BaseHelmholtzTerm
@@ -1157,7 +1157,7 @@ class IdealHelmholtzCP0Constant : public BaseHelmholtzTerm
         el.AddMember("T0", T0, doc.GetAllocator());
     };
 
-    void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) throw();
+    void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) throw() override;
 };
 
 class IdealHelmholtzCP0PolyT : public BaseHelmholtzTerm
@@ -1190,7 +1190,7 @@ class IdealHelmholtzCP0PolyT : public BaseHelmholtzTerm
     void to_json(rapidjson::Value& el, rapidjson::Document& doc);
     void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) override;
 #if ENABLE_CATCH
-    virtual mcx::MultiComplex<double> one_mcx(const mcx::MultiComplex<double>& tau, const mcx::MultiComplex<double>& delta) const override;
+    mcx::MultiComplex<double> one_mcx(const mcx::MultiComplex<double>& tau, const mcx::MultiComplex<double>& delta) const override;
 #endif
 };
 /**
@@ -1228,7 +1228,7 @@ class IdealHelmholtzGERG2004Sinh : public BaseHelmholtzTerm
     void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) override;
 
 #if ENABLE_CATCH
-    virtual mcx::MultiComplex<double> one_mcx(const mcx::MultiComplex<double>& tau, const mcx::MultiComplex<double>& delta) const override;
+    mcx::MultiComplex<double> one_mcx(const mcx::MultiComplex<double>& tau, const mcx::MultiComplex<double>& delta) const override;
 #endif
 };
 
@@ -1264,7 +1264,7 @@ class IdealHelmholtzGERG2004Cosh : public BaseHelmholtzTerm
     void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) override;
 
 #if ENABLE_CATCH
-    virtual mcx::MultiComplex<double> one_mcx(const mcx::MultiComplex<double>& tau, const mcx::MultiComplex<double>& delta) const override;
+    mcx::MultiComplex<double> one_mcx(const mcx::MultiComplex<double>& tau, const mcx::MultiComplex<double>& delta) const override;
 #endif
 };
 
@@ -1436,7 +1436,7 @@ class IdealHelmholtzContainer : public BaseHelmholtzContainer
         GERG2004Sinh.set_Tred(T_red);
     }
 
-    void empty_the_EOS() {
+    void empty_the_EOS() override {
         Lead = IdealHelmholtzLead();
         EnthalpyEntropyOffsetCore = IdealHelmholtzEnthalpyEntropyOffset();
         EnthalpyEntropyOffset = IdealHelmholtzEnthalpyEntropyOffset();
@@ -1449,7 +1449,7 @@ class IdealHelmholtzContainer : public BaseHelmholtzContainer
         GERG2004Sinh = IdealHelmholtzGERG2004Sinh();
     };
 
-    HelmholtzDerivatives all(const CoolPropDbl tau, const CoolPropDbl delta, bool cache_values = false) {
+    HelmholtzDerivatives all(const CoolPropDbl tau, const CoolPropDbl delta, bool cache_values = false) override {
         HelmholtzDerivatives derivs;  // zeros out the elements
         Lead.all(tau, delta, derivs);
         EnthalpyEntropyOffsetCore.all(tau, delta, derivs);

--- a/include/IdealCurves.h
+++ b/include/IdealCurves.h
@@ -34,7 +34,7 @@ class CurveTracer : public FuncWrapper1D
         return M_PI / 2.0;
     }
 
-    double call(double t) {
+    double call(double t) override {
         if (this->obj == OBJECTIVE_CIRCLE) {
             double T2, P2;
             this->TPcoords(t, lnT, lnp, T2, P2);
@@ -90,7 +90,7 @@ class IdealCurveTracer : public CurveTracer
         init();
     };
     /// Z = 1
-    double objective() {
+    double objective() override {
         return this->AS->keyed_output(iZ) - 1;
     };
 };
@@ -102,7 +102,7 @@ class BoyleCurveTracer : public CurveTracer
         init();
     };
     /// dZ/dv|T = 0
-    double objective() {
+    double objective() override {
         double r =
           (this->AS->p() - this->AS->rhomolar() * this->AS->first_partial_deriv(iP, iDmolar, iT)) / (this->AS->gas_constant() * this->AS->T());
         return r;
@@ -115,7 +115,7 @@ class JouleInversionCurveTracer : public CurveTracer
         init();
     };
     /// dZ/dT|v = 0
-    double objective() {
+    double objective() override {
         double r = (this->AS->gas_constant() * this->AS->T() * 1 / this->AS->rhomolar() * this->AS->first_partial_deriv(iP, iT, iDmolar)
                     - this->AS->p() * this->AS->gas_constant() / this->AS->rhomolar())
                    / POW2(this->AS->gas_constant() * this->AS->T());
@@ -129,7 +129,7 @@ class JouleThomsonCurveTracer : public CurveTracer
         init();
     };
     /// dZ/dT|p = 0
-    double objective() {
+    double objective() override {
         double dvdT__constp = -this->AS->first_partial_deriv(iDmolar, iT, iP) / POW2(this->AS->rhomolar());
         double r = this->AS->p() / (this->AS->gas_constant() * POW2(this->AS->T())) * (this->AS->T() * dvdT__constp - 1 / this->AS->rhomolar());
         return r;

--- a/include/PolyMath.h
+++ b/include/PolyMath.h
@@ -202,8 +202,8 @@ class Poly2DResidual : public FuncWrapper1DWithDeriv
     Poly2DResidual(Polynomial2D& poly, const Eigen::MatrixXd& coefficients, const double& in, const double& z_in, const int& axis);
     virtual ~Poly2DResidual() {};
 
-    double call(double target);
-    double deriv(double target);
+    double call(double target) override;
+    double deriv(double target) override;
 };
 
 /// A class for polynomials starting at an arbitrary degree.
@@ -421,8 +421,8 @@ class Poly2DFracResidual : public Poly2DResidual
     Poly2DFracResidual(Polynomial2DFrac& poly, const Eigen::MatrixXd& coefficients, const double& in, const double& z_in, const int& axis,
                        const int& x_exp, const int& y_exp, const double& x_base, const double& y_base);
     virtual ~Poly2DFracResidual() {};
-    double call(double target);
-    double deriv(double target);
+    double call(double target) override;
+    double deriv(double target) override;
 };
 
 class Poly2DFracIntResidual : public Poly2DFracResidual
@@ -447,8 +447,8 @@ class Poly2DFracIntResidual : public Poly2DFracResidual
     Poly2DFracIntResidual(Polynomial2DFrac& poly, const Eigen::MatrixXd& coefficients, const double& in, const double& z_in, const int& axis,
                           const int& x_exp, const int& y_exp, const double& x_base, const double& y_base, const int& int_axis);
     virtual ~Poly2DFracIntResidual() {};
-    double call(double target);
-    double deriv(double target);
+    double call(double target) override;
+    double deriv(double target) override;
 };
 
 //

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -84,7 +84,7 @@ AbstractState* AbstractStateGenerator::get_AbstractState(const std::vector<std::
 class IF97BackendGenerator : public AbstractStateGenerator
 {
    public:
-    AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) {
+    AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) override {
         if (fluid_names.size() == 1) {               // Check that fluid_names[0] has only one component
             const std::string str = fluid_names[0];  // Check that the fluid name is an alias for "Water"
             if ((upper(str) == "WATER") || (upper(str) == "H2O")) {
@@ -109,7 +109,7 @@ static GeneratorInitializer<IF97BackendGenerator> if97_gen(IF97_BACKEND_FAMILY);
 class SRKGenerator : public AbstractStateGenerator
 {
    public:
-    AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) {
+    AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) override {
         return new SRKBackend(fluid_names, get_config_double(R_U_CODATA));
     };
 };
@@ -118,7 +118,7 @@ static GeneratorInitializer<SRKGenerator> srk_gen(CoolProp::SRK_BACKEND_FAMILY);
 class PRGenerator : public AbstractStateGenerator
 {
    public:
-    AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) {
+    AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) override {
         return new PengRobinsonBackend(fluid_names, get_config_double(R_U_CODATA));
     };
 };
@@ -127,7 +127,7 @@ static GeneratorInitializer<PRGenerator> pr_gen(CoolProp::PR_BACKEND_FAMILY);
 class IncompressibleBackendGenerator : public AbstractStateGenerator
 {
    public:
-    AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) {
+    AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) override {
         if (fluid_names.size() != 1) {
             throw ValueError(format("For INCOMP backend, name vector must be one element long"));
         }
@@ -140,7 +140,7 @@ static GeneratorInitializer<IncompressibleBackendGenerator> incomp_gen(INCOMP_BA
 class VTPRGenerator : public CoolProp::AbstractStateGenerator
 {
    public:
-    CoolProp::AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) {
+    CoolProp::AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) override {
         return new CoolProp::VTPRBackend(fluid_names, CoolProp::get_config_double(R_U_CODATA));
     };
 };
@@ -151,7 +151,7 @@ static CoolProp::GeneratorInitializer<VTPRGenerator> vtpr_gen(CoolProp::VTPR_BAC
 class PCSAFTGenerator : public CoolProp::AbstractStateGenerator
 {
    public:
-    CoolProp::AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) {
+    CoolProp::AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) override {
         return new CoolProp::PCSAFTBackend(fluid_names);
     };
 };

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -414,7 +414,7 @@ class SaturationResidual : public CoolProp::FuncWrapper1D
     SaturationResidual(CoolProp::AbstractCubicBackend* ACB, CoolProp::input_pairs inputs, double imposed_variable)
       : ACB(ACB), inputs(inputs), imposed_variable(imposed_variable) {};
 
-    double call(double value) {
+    double call(double value) override {
         int Nsolns = 0;
         double rho0 = -1, rho1 = -1, rho2 = -1, T = NAN, p = NAN;
 

--- a/src/Backends/Cubics/CubicBackend.h
+++ b/src/Backends/Cubics/CubicBackend.h
@@ -50,29 +50,29 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
         return cubic;
     };
 
-    std::vector<std::string> calc_fluid_names();
+    std::vector<std::string> calc_fluid_names() override;
 
-    bool using_mole_fractions() {
+    bool using_mole_fractions() override {
         return true;
     };
-    bool using_mass_fractions() {
+    bool using_mass_fractions() override {
         return false;
     };
-    bool using_volu_fractions() {
+    bool using_volu_fractions() override {
         return false;
     };
 
-    void set_mass_fractions(const std::vector<CoolPropDbl>& mass_fractions) {
+    void set_mass_fractions(const std::vector<CoolPropDbl>& mass_fractions) override {
         throw NotImplementedError("Mass composition has not been implemented.");
     };
-    void set_volu_fractions(const std::vector<CoolPropDbl>& volu_fractions) {
+    void set_volu_fractions(const std::vector<CoolPropDbl>& volu_fractions) override {
         throw NotImplementedError("Volume composition has not been implemented.");
     };
-    const std::vector<CoolPropDbl>& get_mole_fractions() {
+    const std::vector<CoolPropDbl>& get_mole_fractions() override {
         return this->mole_fractions;
     };
 
-    const double get_fluid_constant(std::size_t i, parameters param) const {
+    const double get_fluid_constant(std::size_t i, parameters param) const override {
         switch (param) {
             case iP_critical:
                 return cubic->get_pc()[i];
@@ -98,48 +98,48 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
     }
 
     /// Return a string from the backend for the mixture/fluid
-    std::string fluid_param_string(const std::string&);
+    std::string fluid_param_string(const std::string&) override;
     /// Calculate the gas constant in J/mol/K
-    CoolPropDbl calc_gas_constant() {
+    CoolPropDbl calc_gas_constant() override {
         return cubic->get_R_u();
     };
     /// Get the reducing state to be used
-    SimpleState calc_reducing_state_nocache(const std::vector<CoolPropDbl>& mole_fractions) {
+    SimpleState calc_reducing_state_nocache(const std::vector<CoolPropDbl>& mole_fractions) override {
         SimpleState reducing;
         reducing.T = cubic->get_Tr();
         reducing.rhomolar = cubic->get_rhor();
         return reducing;
     };
-    CoolPropDbl calc_reduced_density() {
+    CoolPropDbl calc_reduced_density() override {
         return _rhomolar / get_cubic()->get_rhor();
     };
-    CoolPropDbl calc_reciprocal_reduced_temperature() {
+    CoolPropDbl calc_reciprocal_reduced_temperature() override {
         return get_cubic()->get_Tr() / _T;
     };
     std::vector<double> spinodal_densities();
 
-    CoolPropDbl calc_T_critical() {
+    CoolPropDbl calc_T_critical() override {
         if (is_pure_or_pseudopure) {
             return cubic->get_Tc()[0];
         } else {
             return HelmholtzEOSMixtureBackend::calc_T_critical();
         }
     };
-    CoolPropDbl calc_p_critical() {
+    CoolPropDbl calc_p_critical() override {
         if (is_pure_or_pseudopure) {
             return cubic->get_pc()[0];
         } else {
             return HelmholtzEOSMixtureBackend::calc_p_critical();
         }
     };
-    CoolPropDbl calc_acentric_factor() {
+    CoolPropDbl calc_acentric_factor() override {
         if (is_pure_or_pseudopure) {
             return cubic->get_acentric()[0];
         } else {
             throw ValueError("acentric factor cannot be calculated for mixtures");
         }
     }
-    CoolPropDbl calc_rhomolar_critical() {
+    CoolPropDbl calc_rhomolar_critical() override {
         if (is_pure_or_pseudopure) {
             // Curve fit from all the pure fluids in CoolProp (thanks to recommendation of A. Kazakov)
             double v_c_Lmol = 2.14107171795 * (cubic->get_Tc()[0] / cubic->get_pc()[0] * 1000) + 0.00773144012514;  // [L/mol]
@@ -154,16 +154,16 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
     void get_linear_reducing_parameters(double& rhomolar, double& T);
 
     /// Get the the starting values for the critical point evaluation routines
-    void get_critical_point_starting_values(double& delta0, double& tau0);
+    void get_critical_point_starting_values(double& delta0, double& tau0) override;
 
     /// Get the search radius in delta and tau for the tracer, scaled appropriately for cubic
-    void get_critical_point_search_radii(double& R_delta, double& R_tau);
+    void get_critical_point_search_radii(double& R_delta, double& R_tau) override;
 
     /// Checking function to see if we should stop the tracing of the critical contour
-    bool get_critical_is_terminated(double& delta, double& tau);
+    bool get_critical_is_terminated(double& delta, double& tau) override;
 
     CoolPropDbl calc_alphar_deriv_nocache(const int nTau, const int nDelta, const std::vector<CoolPropDbl>& mole_fractions, const CoolPropDbl& tau,
-                                          const CoolPropDbl& delta);
+                                          const CoolPropDbl& delta) override;
 
     /// Calculate the pressure in most computationally efficient manner
     CoolPropDbl calc_pressure_nocache(CoolPropDbl T, CoolPropDbl rhomolar);
@@ -171,7 +171,7 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
     /// Update the state for DT inputs if phase is imposed. Otherwise delegate to base class
     virtual void update_DmolarT();
 
-    virtual void update(CoolProp::input_pairs input_pair, double value1, double value2);
+    void update(CoolProp::input_pairs input_pair, double value1, double value2) override;
 
     /** Use the cubic EOS to solve for density
      *
@@ -198,7 +198,7 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
     void rho_Tp_cubic(CoolPropDbl T, CoolPropDbl p, int& Nsolns, double& rho0, double& rho1, double& rho2);
 
     /// In this class, we are already doing cubic evaluation, just delegate to our function
-    CoolPropDbl solver_rho_Tp_SRK(CoolPropDbl T, CoolPropDbl p, phases phase) {
+    CoolPropDbl solver_rho_Tp_SRK(CoolPropDbl T, CoolPropDbl p, phases phase) override {
         return solver_rho_Tp(T, p);
     };
     /**
@@ -206,9 +206,9 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
      *
      * You can often get three solutions, to overcome this problem you must either specify the phase, or provide a reasonable guess value for rho_guess, but not both
      */
-    CoolPropDbl solver_rho_Tp(CoolPropDbl T, CoolPropDbl p, CoolPropDbl rho_guess = -1);
+    CoolPropDbl solver_rho_Tp(CoolPropDbl T, CoolPropDbl p, CoolPropDbl rho_guess = -1) override;
 
-    CoolPropDbl solver_rho_Tp_global(CoolPropDbl T, CoolPropDbl p, CoolPropDbl rhomax);
+    CoolPropDbl solver_rho_Tp_global(CoolPropDbl T, CoolPropDbl p, CoolPropDbl rhomax) override;
 
     /// Update the state used to calculate the tangent-plane-distance
     void update_TPD_state() {
@@ -218,20 +218,22 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
     /// Cubic backend flashes for PQ, and QT
     void saturation(CoolProp::input_pairs inputs);
 
-    CoolPropDbl calc_molar_mass();
+    CoolPropDbl calc_molar_mass() override;
 
-    void set_binary_interaction_double(const std::size_t i1, const std::size_t i2, const std::string& parameter, const double value);
-    double get_binary_interaction_double(const std::size_t i1, const std::size_t i2, const std::string& parameter);
+    void set_binary_interaction_double(const std::size_t i1, const std::size_t i2, const std::string& parameter,
+                                       const double value) override;
+    double get_binary_interaction_double(const std::size_t i1, const std::size_t i2, const std::string& parameter) override;
 
-    void set_binary_interaction_double(const std::string& CAS1, const std::string& CAS2, const std::string& parameter, const double value) {
+    void set_binary_interaction_double(const std::string& CAS1, const std::string& CAS2, const std::string& parameter,
+                                       const double value) override {
         throw ValueError("set_binary_interaction_double not defined for AbstractCubic not defined for CAS #");
     }
-    double get_binary_interaction_double(const std::string& CAS1, const std::string& CAS2, const std::string& parameter) {
+    double get_binary_interaction_double(const std::string& CAS1, const std::string& CAS2, const std::string& parameter) override {
         throw ValueError("get_binary_interaction_double not defined for AbstractCubic not defined for CAS #");
     };
 
     // Return a 1-1 copy of this class
-    virtual HelmholtzEOSMixtureBackend* get_copy(bool generate_SatL_and_SatV = true) = 0;
+    HelmholtzEOSMixtureBackend* get_copy(bool generate_SatL_and_SatV = true) override = 0;
 
     // Copy the entire kij matrix from another instance in one shot
     void copy_k(AbstractCubicBackend* donor);
@@ -243,13 +245,13 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
     void copy_internals(AbstractCubicBackend& donor);
 
     // Set the cubic alpha function's constants:
-    void set_cubic_alpha_C(const size_t i, const std::string& parameter, const double c1, const double c2, const double c3);
+    void set_cubic_alpha_C(const size_t i, const std::string& parameter, const double c1, const double c2, const double c3) override;
 
     // Set fluid parameter (currently the volume translation parameter)
-    void set_fluid_parameter_double(const size_t i, const std::string& parameter, const double value);
+    void set_fluid_parameter_double(const size_t i, const std::string& parameter, const double value) override;
 
     // Get fluid parameter (currently the volume translation parameter)
-    double get_fluid_parameter_double(const size_t i, const std::string& parameter);
+    double get_fluid_parameter_double(const size_t i, const std::string& parameter) override;
 
     /// Return the integer code for the EOS type used in the cubic superancillary lookup.
     /// Derived classes (SRKBackend, PengRobinsonBackend) override this.
@@ -257,9 +259,9 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
         return CubicSuperAncillary::UNKNOWN_CODE;
     }
 
-    CoolPropDbl calc_saturation_ancillary(parameters param, int Q, parameters given, double value);
+    CoolPropDbl calc_saturation_ancillary(parameters param, int Q, parameters given, double value) override;
 
-    void update_QT_pure_superanc(CoolPropDbl Q, CoolPropDbl T);
+    void update_QT_pure_superanc(CoolPropDbl Q, CoolPropDbl T) override;
 
     /// Return the maximum temperature [K] supported by the cubic superancillary.
     /// Inverts Ttilde_max = R*T*b/a(T) analytically using am evaluated at T=Tc.
@@ -371,8 +373,8 @@ class CubicResidualHelmholtz : public ResidualHelmholtz
     }
 
     /// All the derivatives of the residual Helmholtz energy w.r.t. tau and delta that do not involve composition derivative
-    virtual HelmholtzDerivatives all(HelmholtzEOSMixtureBackend& HEOS, const std::vector<CoolPropDbl>& mole_fractions, double tau, double delta,
-                                     bool cache_values = false) {
+    HelmholtzDerivatives all(HelmholtzEOSMixtureBackend& HEOS, const std::vector<CoolPropDbl>& mole_fractions, double tau, double delta,
+                             bool cache_values = false) override {
         HelmholtzDerivatives a;
         std::vector<double> z = std::vector<double>(mole_fractions.begin(), mole_fractions.end());
         shared_ptr<AbstractCubic>& cubic = ACB->get_cubic();
@@ -393,74 +395,78 @@ class CubicResidualHelmholtz : public ResidualHelmholtz
         a.d4alphar_ddelta4 = cubic->alphar(tau, delta, z, 0, 4);
         return a;
     }
-    virtual CoolPropDbl dalphar_dxi(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) {
+    CoolPropDbl dalphar_dxi(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d_alphar_dxi(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 0, 0, i, xN_flag == XN_INDEPENDENT);
     }
-    virtual CoolPropDbl d2alphar_dxi_dTau(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) {
+    CoolPropDbl d2alphar_dxi_dTau(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d_alphar_dxi(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 1, 0, i, xN_flag == XN_INDEPENDENT);
     }
-    virtual CoolPropDbl d2alphar_dxi_dDelta(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) {
+    CoolPropDbl d2alphar_dxi_dDelta(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d_alphar_dxi(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 0, 1, i, xN_flag == XN_INDEPENDENT);
     }
-    virtual CoolPropDbl d3alphar_dxi_dTau2(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) {
+    CoolPropDbl d3alphar_dxi_dTau2(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d_alphar_dxi(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 2, 0, i, xN_flag == XN_INDEPENDENT);
     }
-    virtual CoolPropDbl d3alphar_dxi_dDelta_dTau(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) {
+    CoolPropDbl d3alphar_dxi_dDelta_dTau(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d_alphar_dxi(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 1, 1, i, xN_flag == XN_INDEPENDENT);
     }
-    virtual CoolPropDbl d3alphar_dxi_dDelta2(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) {
+    CoolPropDbl d3alphar_dxi_dDelta2(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d_alphar_dxi(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 0, 2, i, xN_flag == XN_INDEPENDENT);
     }
 
-    virtual CoolPropDbl d2alphardxidxj(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) {
+    CoolPropDbl d2alphardxidxj(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d2_alphar_dxidxj(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 0, 0, i, j,
                                                   xN_flag == XN_INDEPENDENT);
     }
-    virtual CoolPropDbl d3alphar_dxi_dxj_dTau(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) {
+    CoolPropDbl d3alphar_dxi_dxj_dTau(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d2_alphar_dxidxj(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 1, 0, i, j,
                                                   xN_flag == XN_INDEPENDENT);
     }
-    virtual CoolPropDbl d3alphar_dxi_dxj_dDelta(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) {
+    CoolPropDbl d3alphar_dxi_dxj_dDelta(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j,
+                                        x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d2_alphar_dxidxj(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 0, 1, i, j,
                                                   xN_flag == XN_INDEPENDENT);
     }
 
-    virtual CoolPropDbl d4alphar_dxi_dTau3(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) {
+    CoolPropDbl d4alphar_dxi_dTau3(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d_alphar_dxi(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 3, 0, i, xN_flag == XN_INDEPENDENT);
     }
-    virtual CoolPropDbl d4alphar_dxi_dDelta2_dTau(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) {
+    CoolPropDbl d4alphar_dxi_dDelta2_dTau(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d_alphar_dxi(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 1, 2, i, xN_flag == XN_INDEPENDENT);
     }
-    virtual CoolPropDbl d4alphar_dxi_dDelta_dTau2(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) {
+    CoolPropDbl d4alphar_dxi_dDelta_dTau2(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d_alphar_dxi(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 2, 1, i, xN_flag == XN_INDEPENDENT);
     }
-    virtual CoolPropDbl d4alphar_dxi_dDelta3(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) {
+    CoolPropDbl d4alphar_dxi_dDelta3(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d_alphar_dxi(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 0, 3, i, xN_flag == XN_INDEPENDENT);
     }
-    virtual CoolPropDbl d4alphar_dxi_dxj_dTau2(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) {
+    CoolPropDbl d4alphar_dxi_dxj_dTau2(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j,
+                                       x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d2_alphar_dxidxj(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 2, 0, i, j,
                                                   xN_flag == XN_INDEPENDENT);
     }
-    virtual CoolPropDbl d4alphar_dxi_dxj_dDelta_dTau(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) {
+    CoolPropDbl d4alphar_dxi_dxj_dDelta_dTau(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j,
+                                             x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d2_alphar_dxidxj(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 1, 1, i, j,
                                                   xN_flag == XN_INDEPENDENT);
     }
-    virtual CoolPropDbl d4alphar_dxi_dxj_dDelta2(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) {
+    CoolPropDbl d4alphar_dxi_dxj_dDelta2(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j,
+                                         x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d2_alphar_dxidxj(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 0, 2, i, j,
                                                   xN_flag == XN_INDEPENDENT);
     }
-    virtual CoolPropDbl d3alphardxidxjdxk(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j, std::size_t k,
-                                          x_N_dependency_flag xN_flag) {
+    CoolPropDbl d3alphardxidxjdxk(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j, std::size_t k,
+                                  x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d3_alphar_dxidxjdxk(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 0, 0, i, j, k,
                                                      xN_flag == XN_INDEPENDENT);
     }
-    virtual CoolPropDbl d4alphar_dxi_dxj_dxk_dTau(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j, std::size_t k,
-                                                  x_N_dependency_flag xN_flag) {
+    CoolPropDbl d4alphar_dxi_dxj_dxk_dTau(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j, std::size_t k,
+                                          x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d3_alphar_dxidxjdxk(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 1, 0, i, j, k,
                                                      xN_flag == XN_INDEPENDENT);
     }
-    virtual CoolPropDbl d4alphar_dxi_dxj_dxk_dDelta(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j, std::size_t k,
-                                                    x_N_dependency_flag xN_flag) {
+    CoolPropDbl d4alphar_dxi_dxj_dxk_dDelta(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j, std::size_t k,
+                                            x_N_dependency_flag xN_flag) override {
         return ACB->get_cubic()->d3_alphar_dxidxjdxk(HEOS.tau(), HEOS.delta(), HEOS.get_mole_fractions_doubleref(), 0, 1, i, j, k,
                                                      xN_flag == XN_INDEPENDENT);
     }

--- a/src/Backends/Cubics/GeneralizedCubic.h
+++ b/src/Backends/Cubics/GeneralizedCubic.h
@@ -43,7 +43,7 @@ class BasicMathiasCopemanAlphaFunction : public AbstractCubicAlphaFunction
     BasicMathiasCopemanAlphaFunction(double a0, double m_ii, double Tr_over_Tci) : AbstractCubicAlphaFunction(a0, Tr_over_Tci) {
         this->m = m_ii;
     };
-    double term(double tau, std::size_t itau);
+    double term(double tau, std::size_t itau) override;
 };
 
 /// An implementation of AbstractCubicAlphaFunction for the Twu alpha function
@@ -56,7 +56,7 @@ class TwuAlphaFunction : public AbstractCubicAlphaFunction
         c[1] = M;
         c[2] = N;
     };
-    double term(double tau, std::size_t itau);
+    double term(double tau, std::size_t itau) override;
 };
 
 /// An implementation of AbstractCubicAlphaFunction for the Mathias-Copeman alpha function
@@ -69,7 +69,7 @@ class MathiasCopemanAlphaFunction : public AbstractCubicAlphaFunction
         c[1] = c2;
         c[2] = c3;
     };
-    double term(double tau, std::size_t itau);
+    double term(double tau, std::size_t itau) override;
 };
 
 class AbstractCubic
@@ -625,9 +625,9 @@ class PengRobinson : public AbstractCubic
         set_alpha(std::vector<double>(), std::vector<double>(), std::vector<double>());
     };
 
-    double a0_ii(std::size_t i);
-    double b0_ii(std::size_t i);
-    double m_ii(std::size_t i);
+    double a0_ii(std::size_t i) override;
+    double b0_ii(std::size_t i) override;
+    double m_ii(std::size_t i) override;
 };
 
 class SRK : public AbstractCubic
@@ -643,9 +643,9 @@ class SRK : public AbstractCubic
         set_alpha(std::vector<double>(), std::vector<double>(), std::vector<double>());
     };
 
-    double a0_ii(std::size_t i);
-    double b0_ii(std::size_t i);
-    double m_ii(std::size_t i);
+    double a0_ii(std::size_t i) override;
+    double b0_ii(std::size_t i) override;
+    double m_ii(std::size_t i) override;
 };
 
 #endif

--- a/src/Backends/Cubics/VTPRBackend.h
+++ b/src/Backends/Cubics/VTPRBackend.h
@@ -57,11 +57,11 @@ class VTPRBackend : public PengRobinsonBackend
         setup(fluid_identifiers, generate_SatL_and_SatV);
     };
 
-    std::string backend_name() {
+    std::string backend_name() override {
         return get_backend_string(VTPR_BACKEND);
     }
 
-    HelmholtzEOSMixtureBackend* get_copy(bool generate_SatL_and_SatV = true) {
+    HelmholtzEOSMixtureBackend* get_copy(bool generate_SatL_and_SatV = true) override {
         AbstractCubicBackend* ACB =
           new VTPRBackend(calc_fluid_names(), cubic->get_Tc(), cubic->get_pc(), cubic->get_acentric(), cubic->get_R_u(), generate_SatL_and_SatV);
         ACB->copy_k(this);
@@ -72,7 +72,7 @@ class VTPRBackend : public PengRobinsonBackend
     void set_alpha_from_components();
 
     /// Return the fluid names
-    std::vector<std::string> calc_fluid_names() {
+    std::vector<std::string> calc_fluid_names() override {
         return m_fluid_names;
     }
 
@@ -82,22 +82,22 @@ class VTPRBackend : public PengRobinsonBackend
     /// Load the UNIFAC library if needed and get const reference to it
     const UNIFACLibrary::UNIFACParameterLibrary& LoadLibrary();
 
-    void set_mole_fractions(const std::vector<double>& z) {
+    void set_mole_fractions(const std::vector<double>& z) override {
         mole_fractions = z;
         VTPRCubic* _cubic = static_cast<VTPRCubic*>(cubic.get());
         _cubic->get_unifaq().set_mole_fractions(z);
     };
 
     /// Calculate the molar mass
-    CoolPropDbl calc_molar_mass();
+    CoolPropDbl calc_molar_mass() override;
 
     /// Allows to modify the interactions parameters aij, bij and cij
-    void set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter, const double value);
+    void set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter, const double value) override;
 
     /// Allows to modify the interactions parameters aij, bij and cij
-    double get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter);
+    double get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter) override;
 
-    CoolPropDbl calc_fugacity_coefficient(std::size_t i);
+    CoolPropDbl calc_fugacity_coefficient(std::size_t i) override;
 
     /// Modify the surface parameter Q_k of the sub group sgi
     void set_Q_k(const size_t sgi, const double value);

--- a/src/Backends/Cubics/VTPRCubic.h
+++ b/src/Backends/Cubics/VTPRCubic.h
@@ -108,7 +108,7 @@ class VTPRCubic : public PengRobinson
             }
         }
     }
-    double am_term(double tau, const std::vector<double>& x, std::size_t itau) {
+    double am_term(double tau, const std::vector<double>& x, std::size_t itau) override {
         return bm_term(x) * (sum_xi_aii_bii(tau, x, itau) + gE_R(tau, x, itau) / (-0.53087));
     }
     double sum_xi_aii_bii(double tau, const std::vector<double>& x, std::size_t itau) {
@@ -125,11 +125,11 @@ class VTPRCubic : public PengRobinson
             return aii_term(tau, i, itau) / b0_ii(i) - aii_term(tau, N - 1, itau) / b0_ii(N - 1);
         }
     }
-    double d_am_term_dxi(double tau, const std::vector<double>& x, std::size_t itau, std::size_t i, bool xN_independent) {
+    double d_am_term_dxi(double tau, const std::vector<double>& x, std::size_t itau, std::size_t i, bool xN_independent) override {
         return d_bm_term_dxi(x, i, xN_independent) * (sum_xi_aii_bii(tau, x, itau) + gE_R(tau, x, itau) / (-0.53087))
                + bm_term(x) * (d_sum_xi_aii_bii_dxi(tau, x, itau, i, xN_independent) + d_gE_R_dxi(tau, x, itau, i, xN_independent) / (-0.53087));
     }
-    double d2_am_term_dxidxj(double tau, const std::vector<double>& x, std::size_t itau, std::size_t i, std::size_t j, bool xN_independent) {
+    double d2_am_term_dxidxj(double tau, const std::vector<double>& x, std::size_t itau, std::size_t i, std::size_t j, bool xN_independent) override {
         return d2_bm_term_dxidxj(x, i, j, xN_independent) * (sum_xi_aii_bii(tau, x, itau) + gE_R(tau, x, itau) / (-0.53087))
                + d_bm_term_dxi(x, i, xN_independent)
                    * (d_sum_xi_aii_bii_dxi(tau, x, itau, i, xN_independent) + d_gE_R_dxi(tau, x, itau, i, xN_independent) / (-0.53087))
@@ -137,7 +137,7 @@ class VTPRCubic : public PengRobinson
                    * (d_sum_xi_aii_bii_dxi(tau, x, itau, i, xN_independent) + d_gE_R_dxi(tau, x, itau, i, xN_independent) / (-0.53087));
     }
     double d3_am_term_dxidxjdxk(double tau, const std::vector<double>& x, std::size_t itau, std::size_t i, std::size_t j, std::size_t k,
-                                bool xN_independent) {
+                                bool xN_independent) override {
         return d3_bm_term_dxidxjdxk(x, i, j, k, xN_independent) * (sum_xi_aii_bii(tau, x, itau) + gE_R(tau, x, itau) / (-0.53087))
                + d2_bm_term_dxidxj(x, i, k, xN_independent)
                    * (d_sum_xi_aii_bii_dxi(tau, x, itau, i, xN_independent) + d_gE_R_dxi(tau, x, itau, i, xN_independent) / (-0.53087))
@@ -145,7 +145,7 @@ class VTPRCubic : public PengRobinson
                    * (d_sum_xi_aii_bii_dxi(tau, x, itau, i, xN_independent) + d_gE_R_dxi(tau, x, itau, i, xN_independent) / (-0.53087));
     }
 
-    double bm_term(const std::vector<double>& x) {
+    double bm_term(const std::vector<double>& x) override {
         double summerbm = 0;
         for (int i = 0; i < N; ++i) {
             for (int j = 0; j < N; ++j) {
@@ -157,7 +157,7 @@ class VTPRCubic : public PengRobinson
     double bij_term(std::size_t i, std::size_t j) {
         return pow((pow(b0_ii(i), 0.75) + pow(b0_ii(j), 0.75)) / 2.0, 4.0 / 3.0);
     }
-    double d_bm_term_dxi(const std::vector<double>& x, std::size_t i, bool xN_independent) {
+    double d_bm_term_dxi(const std::vector<double>& x, std::size_t i, bool xN_independent) override {
         double summer = 0;
         if (xN_independent) {
             for (int j = N - 1; j >= 0; --j) {
@@ -171,33 +171,33 @@ class VTPRCubic : public PengRobinson
             return 2 * (summer + x[N - 1] * (bij_term(N - 1, i) - bij_term(N - 1, N - 1)));
         }
     }
-    double d2_bm_term_dxidxj(const std::vector<double>& x, std::size_t i, std::size_t j, bool xN_independent) {
+    double d2_bm_term_dxidxj(const std::vector<double>& x, std::size_t i, std::size_t j, bool xN_independent) override {
         if (xN_independent) {
             return 2 * bij_term(i, j);
         } else {
             return 2 * (bij_term(i, j) - bij_term(j, N - 1) - bij_term(N - 1, i) + bij_term(N - 1, N - 1));
         }
     }
-    double d3_bm_term_dxidxjdxk(const std::vector<double>& x, std::size_t i, std::size_t j, std::size_t k, bool xN_independent) {
+    double d3_bm_term_dxidxjdxk(const std::vector<double>& x, std::size_t i, std::size_t j, std::size_t k, bool xN_independent) override {
         return 0;
     }
     // Allows to modify the unifac interaction parameters aij, bij and cij
-    void set_interaction_parameter(const std::size_t mgi1, const std::size_t mgi2, const std::string& parameter, const double value) {
+    void set_interaction_parameter(const std::size_t mgi1, const std::size_t mgi2, const std::string& parameter, const double value) override {
         unifaq.set_interaction_parameter(mgi1, mgi2, parameter, value);
     }
 
     // Allows to modify the surface parameter Q_k of the sub group sgi
-    void set_Q_k(const size_t sgi, const double value) {
+    void set_Q_k(const size_t sgi, const double value) override {
         unifaq.set_Q_k(sgi, value);
     }
 
     // Get the surface parameter Q_k of the sub group sgi
-    double get_Q_k(const size_t sgi) const {
+    double get_Q_k(const size_t sgi) const override {
         return unifaq.get_Q_k(sgi);
     }
 
     // Allows to modify the unifac interaction parameters aij, bij and cij
-    double get_interaction_parameter(const std::size_t mgi1, const std::size_t mgi2, const std::string& parameter) {
+    double get_interaction_parameter(const std::size_t mgi1, const std::size_t mgi2, const std::string& parameter) override {
         return unifaq.get_interaction_parameter(mgi1, mgi2, parameter);
     }
     std::vector<double> ln_fugacity_coefficient(const std::vector<double>& z, double rhomolar, double p, double T) {

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -141,17 +141,17 @@ class solver_DP_resid : public FuncWrapper1DWithTwoDerivs
     HelmholtzEOSMixtureBackend* HEOS;
     CoolPropDbl rhomolar, p;
     solver_DP_resid(HelmholtzEOSMixtureBackend* HEOS, CoolPropDbl rhomolar, CoolPropDbl p) : HEOS(HEOS), rhomolar(rhomolar), p(p) {}
-    double call(double T) {
+    double call(double T) override {
         HEOS->update_DmolarT_direct(rhomolar, T);
         CoolPropDbl peos = HEOS->p();
         CoolPropDbl r = (peos - p) / p;
         return r;
     };
-    double deriv(double T) {
+    double deriv(double T) override {
         // dp/dT|rho / pspecified
         return HEOS->first_partial_deriv(iP, iT, iDmolar) / p;
     };
-    double second_deriv(double T) {
+    double second_deriv(double T) override {
         // d2p/dT2|rho / pspecified
         return HEOS->second_partial_deriv(iP, iT, iDmolar, iT, iDmolar) / p;
     };
@@ -259,17 +259,17 @@ class DQ_flash_residual : public FuncWrapper1DWithTwoDerivs
     HelmholtzEOSMixtureBackend& HEOS;
     double rhomolar, Q_target;
     DQ_flash_residual(HelmholtzEOSMixtureBackend& HEOS, double rhomolar, double Q_target) : HEOS(HEOS), rhomolar(rhomolar), Q_target(Q_target) {};
-    double call(double T) {
+    double call(double T) override {
         HEOS.update(QT_INPUTS, 0, T);  // Doesn't matter whether liquid or vapor, we are just doing a full VLE call for given T
         double rhoL = HEOS.saturated_liquid_keyed_output(iDmolar);
         double rhoV = HEOS.saturated_vapor_keyed_output(iDmolar);
         /// Error between calculated and target vapor quality based on densities
         return (1 / rhomolar - 1 / rhoL) / (1 / rhoV - 1 / rhoL) - Q_target;
     }
-    double deriv(double T) {
+    double deriv(double T) override {
         return _HUGE;
     }
-    double second_deriv(double T) {
+    double second_deriv(double T) override {
         return _HUGE;
     }
 };
@@ -1365,7 +1365,7 @@ void FlashRoutines::HSU_D_flash_twophase(HelmholtzEOSMixtureBackend& HEOS, CoolP
           : HEOS(HEOS), rhomolar_spec(rhomolar_spec), other(other), value(value) {
             Qd = _HUGE;
         };
-        double call(double T) {
+        double call(double T) override {
             HEOS.update(QT_INPUTS, 0, T);
             HelmholtzEOSMixtureBackend &SatL = HEOS.get_SatL(), &SatV = HEOS.get_SatV();
             // Quality from density
@@ -1414,7 +1414,7 @@ void FlashRoutines::HSU_D_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
         ~solver_resid() {
             HEOS->unspecify_phase();
         }
-        double call(double T) {
+        double call(double T) override {
             HEOS->update_DmolarT_direct(rhomolar, T);
             double eos = HEOS->keyed_output(other);
             if (other == iP) {
@@ -1425,19 +1425,19 @@ void FlashRoutines::HSU_D_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
                 return eos - value;
             }
         };
-        double deriv(double T) {
+        double deriv(double T) override {
             if (other == iP) {
                 return HEOS->first_partial_deriv(other, iT, iDmolar) / value;
             }
             return HEOS->first_partial_deriv(other, iT, iDmolar);
         };
-        double second_deriv(double T) {
+        double second_deriv(double T) override {
             if (other == iP) {
                 return HEOS->second_partial_deriv(other, iT, iDmolar, iT, iDmolar) / value;
             }
             return HEOS->second_partial_deriv(other, iT, iDmolar, iT, iDmolar);
         };
-        bool input_not_in_range(double T) {
+        bool input_not_in_range(double T) override {
             return (T < Tmin || T > Tmax);
         }
     };
@@ -1788,7 +1788,7 @@ void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend& HE
                     {}
             }
         }
-        double call(double T) {
+        double call(double T) override {
 
             if (iter < 2 || std::abs(rhomolar1 / rhomolar0 - 1) > 0.05) {
                 // Run the solver with T,P as inputs; but only if the last change in density was greater than a few percent
@@ -1828,13 +1828,13 @@ void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend& HE
             iter++;
             return r;
         };
-        double deriv(double T) {
+        double deriv(double T) override {
             return HEOS->first_partial_deriv(other, iT, iP);
         }
-        double second_deriv(double T) {
+        double second_deriv(double T) override {
             return HEOS->second_partial_deriv(other, iT, iP, iT, iP);
         }
-        bool input_not_in_range(double x) {
+        bool input_not_in_range(double x) override {
             return (x < Tmin || x > Tmax);
         }
     };
@@ -2105,15 +2105,15 @@ void FlashRoutines::solver_for_rho_given_T_oneof_HSU(HelmholtzEOSMixtureBackend&
 
         solver_resid(HelmholtzEOSMixtureBackend* HEOS, CoolPropDbl T, CoolPropDbl value, parameters other)
           : HEOS(HEOS), T(T), value(value), other(other) {}
-        double call(double rhomolar) {
+        double call(double rhomolar) override {
             HEOS->update_DmolarT_direct(rhomolar, T);
             double eos = HEOS->keyed_output(other);
             return eos - value;
         };
-        double deriv(double rhomolar) {
+        double deriv(double rhomolar) override {
             return HEOS->first_partial_deriv(other, iDmolar, iT);
         }
-        double second_deriv(double rhomolar) {
+        double second_deriv(double rhomolar) override {
             return HEOS->second_partial_deriv(other, iDmolar, iT, iDmolar, iT);
         }
     };
@@ -2426,7 +2426,7 @@ void FlashRoutines::HS_flash_twophase(HelmholtzEOSMixtureBackend& HEOS, CoolProp
         CoolPropDbl hmolar, smolar, Qs;
         Residual(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl hmolar_spec, CoolPropDbl smolar_spec)
           : HEOS(HEOS), hmolar(hmolar_spec), smolar(smolar_spec), Qs(_HUGE) {};
-        double call(double T) {
+        double call(double T) override {
             HEOS.update(QT_INPUTS, 0, T);
             HelmholtzEOSMixtureBackend &SatL = HEOS.get_SatL(), &SatV = HEOS.get_SatV();
             // Quality from entropy
@@ -2517,7 +2517,7 @@ void FlashRoutines::HS_flash(HelmholtzEOSMixtureBackend& HEOS) {
         CoolPropDbl hmolar, smolar;
         Residual(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl hmolar_spec, CoolPropDbl smolar_spec)
           : HEOS(HEOS), hmolar(hmolar_spec), smolar(smolar_spec) {};
-        double call(double T) {
+        double call(double T) override {
             HEOS.update(SmolarT_INPUTS, smolar, T);
             double r = HEOS.hmolar() - hmolar;
             return r;

--- a/src/Backends/Helmholtz/FlashRoutines.h
+++ b/src/Backends/Helmholtz/FlashRoutines.h
@@ -263,13 +263,13 @@ class solver_TP_resid : public FuncWrapper1DWithDeriv
         tau(HEOS.get_reducing_state().T / T),
         R_u(HEOS.gas_constant()),
         delta(-_HUGE) {}
-    double call(double rhomolar) {
+    double call(double rhomolar) override {
         delta = rhomolar / rhor;  // needed for derivative
         HEOS->update_DmolarT_direct(rhomolar, T);
         CoolPropDbl peos = HEOS->p();
         return (peos - p) / p;
     };
-    double deriv(double rhomolar) {
+    double deriv(double rhomolar) override {
         // dp/drho|T / pspecified
         return R_u * T * (1 + 2 * delta * HEOS->dalphar_dDelta() + pow(delta, 2) * HEOS->d2alphar_dDelta2()) / p;
     };
@@ -291,7 +291,7 @@ class PY_singlephase_flash_resid : public FuncWrapper1D
             HEOS.specify_phase(HEOS.phase());
         }
     };
-    double call(double T) {
+    double call(double T) override {
 
         // Run the solver with T,P as inputs;
         HEOS->update(PT_INPUTS, p, T);

--- a/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
+++ b/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
@@ -97,7 +97,7 @@ double SaturationAncillaryFunction::invert(double value, double min_bound, doubl
 
         solver_resid(SaturationAncillaryFunction* anc, CoolPropDbl value) : anc(anc), value(value) {}
 
-        double call(double T) {
+        double call(double T) override {
             CoolPropDbl current_value = anc->evaluate(T);
             return current_value - value;
         }
@@ -223,7 +223,7 @@ CoolPropDbl MeltingLineVariables::evaluate(int OF, int GIVEN, CoolPropDbl value)
                 MeltingLinePiecewisePolynomialInTrSegment* part;
                 CoolPropDbl given_p;
                 solver_resid(MeltingLinePiecewisePolynomialInTrSegment* part, CoolPropDbl p) : part(part), given_p(p) {};
-                double call(double T) {
+                double call(double T) override {
 
                     CoolPropDbl calc_p = part->evaluate(T);
 
@@ -251,7 +251,7 @@ CoolPropDbl MeltingLineVariables::evaluate(int OF, int GIVEN, CoolPropDbl value)
                 MeltingLinePiecewisePolynomialInThetaSegment* part;
                 CoolPropDbl given_p;
                 solver_resid(MeltingLinePiecewisePolynomialInThetaSegment* part, CoolPropDbl p) : part(part), given_p(p) {};
-                double call(double T) {
+                double call(double T) override {
 
                     CoolPropDbl calc_p = part->evaluate(T);
 

--- a/src/Backends/Helmholtz/HelmholtzEOSBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSBackend.h
@@ -62,7 +62,7 @@ class HelmholtzEOSBackend : public HelmholtzEOSMixtureBackend
         }
     };
     virtual ~HelmholtzEOSBackend() {};
-    std::string backend_name() {
+    std::string backend_name() override {
         return get_backend_string(HEOS_BACKEND_PURE);
     }
 };

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -48,7 +48,7 @@ namespace CoolProp {
 class HEOSGenerator : public AbstractStateGenerator
 {
    public:
-    AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) {
+    AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) override {
         if (fluid_names.size() == 1) {
             return new HelmholtzEOSBackend(fluid_names[0]);
         } else {
@@ -2049,7 +2049,7 @@ void HelmholtzEOSMixtureBackend::calc_ssat_max() {
        public:
         HelmholtzEOSMixtureBackend* HEOS;
         Residual(HelmholtzEOSMixtureBackend& HEOS) : HEOS(&HEOS) {};
-        double call(double T) {
+        double call(double T) override {
             HEOS->update(QT_INPUTS, 1, T);
             // dTdp_along_sat
             double dTdp_along_sat =
@@ -2084,7 +2084,7 @@ void HelmholtzEOSMixtureBackend::calc_hsat_max() {
        public:
         HelmholtzEOSMixtureBackend* HEOS;
         Residualhmax(HelmholtzEOSMixtureBackend& HEOS) : HEOS(&HEOS) {};
-        double call(double T) {
+        double call(double T) override {
             HEOS->update(QT_INPUTS, 1, T);
             // dTdp_along_sat
             double dTdp_along_sat =
@@ -2600,17 +2600,17 @@ HelmholtzEOSBackend::StationaryPointReturnFlag HelmholtzEOSMixtureBackend::solve
             rhor(HEOS->get_reducing_state().rhomolar),
             tau(HEOS->get_reducing_state().T / T),
             R_u(HEOS->gas_constant()) {}
-        double call(double rhomolar) {
+        double call(double rhomolar) override {
             delta = rhomolar / rhor;  // needed for derivative
             HEOS->update_DmolarT_direct(rhomolar, T);
             // dp/drho|T
             return R_u * T * (1 + 2 * delta * HEOS->dalphar_dDelta() + POW2(delta) * HEOS->d2alphar_dDelta2());
         };
-        double deriv(double rhomolar) {
+        double deriv(double rhomolar) override {
             // d2p/drho2|T
             return R_u * T / rhor * (2 * HEOS->dalphar_dDelta() + 4 * delta * HEOS->d2alphar_dDelta2() + POW2(delta) * HEOS->calc_d3alphar_dDelta3());
         };
-        double second_deriv(double rhomolar) {
+        double second_deriv(double rhomolar) override {
             // d3p/drho3|T
             return R_u * T / POW2(rhor)
                    * (6 * HEOS->d2alphar_dDelta2() + 6 * delta * HEOS->d3alphar_dDelta3() + POW2(delta) * HEOS->calc_d4alphar_dDelta4());
@@ -2720,21 +2720,21 @@ class SolverTPResid : public FuncWrapper1DWithThreeDerivs
         rhor(HEOS->get_reducing_state().rhomolar),
         tau(HEOS->get_reducing_state().T / T),
         R_u(HEOS->gas_constant()) {}
-    double call(double rhomolar) {
+    double call(double rhomolar) override {
         delta = rhomolar / rhor;  // needed for derivative
         HEOS->update_DmolarT_direct(rhomolar, T);
         CoolPropDbl peos = HEOS->p();
         return (peos - p) / p;
     };
-    double deriv(double rhomolar) {
+    double deriv(double rhomolar) override {
         // dp/drho|T / pspecified
         return R_u * T * (1 + 2 * delta * HEOS->dalphar_dDelta() + POW2(delta) * HEOS->d2alphar_dDelta2()) / p;
     };
-    double second_deriv(double rhomolar) {
+    double second_deriv(double rhomolar) override {
         // d2p/drho2|T / pspecified
         return R_u * T / rhor * (2 * HEOS->dalphar_dDelta() + 4 * delta * HEOS->d2alphar_dDelta2() + POW2(delta) * HEOS->calc_d3alphar_dDelta3()) / p;
     };
-    double third_deriv(double rhomolar) {
+    double third_deriv(double rhomolar) override {
         // d3p/drho3|T / pspecified
         return R_u * T / POW2(rhor)
                * (6 * HEOS->d2alphar_dDelta2() + 6 * delta * HEOS->d3alphar_dDelta3() + POW2(delta) * HEOS->calc_d4alphar_dDelta4()) / p;
@@ -3936,7 +3936,7 @@ CoolProp::CriticalState HelmholtzEOSMixtureBackend::calc_critical_point(double r
         double L1, M1;
         Eigen::MatrixXd Lstar, Mstar;
         Resid(HelmholtzEOSMixtureBackend& HEOS) : HEOS(HEOS), L1(_HUGE), M1(_HUGE) {};
-        std::vector<double> call(const std::vector<double>& tau_delta) {
+        std::vector<double> call(const std::vector<double>& tau_delta) override {
             double rhomolar = tau_delta[1] * HEOS.rhomolar_reducing();
             double T = HEOS.T_reducing() / tau_delta[0];
             HEOS.update(DmolarT_INPUTS, rhomolar, T);
@@ -3947,7 +3947,7 @@ CoolProp::CriticalState HelmholtzEOSMixtureBackend::calc_critical_point(double r
             o[1] = Mstar.determinant();
             return o;
         };
-        std::vector<std::vector<double>> Jacobian(const std::vector<double>& x) {
+        std::vector<std::vector<double>> Jacobian(const std::vector<double>& x) override {
             std::size_t N = x.size();
             std::vector<std::vector<double>> J(N, std::vector<double>(N, 0));
             Eigen::MatrixXd adjL = adjugate(Lstar), adjM = adjugate(Mstar), dLdTau = MixtureDerivatives::dLstar_dX(HEOS, XN_INDEPENDENT, iTau),
@@ -4024,19 +4024,19 @@ class OneDimObjective : public FuncWrapper1DWithTwoDerivs
     double _call, _deriv, _second_deriv;
     OneDimObjective(HelmholtzEOSMixtureBackend& HEOS, double delta0)
       : HEOS(HEOS), delta(delta0), _call(_HUGE), _deriv(_HUGE), _second_deriv(_HUGE) {};
-    double call(double tau) {
+    double call(double tau) override {
         double rhomolar = HEOS.rhomolar_reducing() * delta, T = HEOS.T_reducing() / tau;
         HEOS.update_DmolarT_direct(rhomolar, T);
         _call = MixtureDerivatives::Lstar(HEOS, XN_INDEPENDENT).determinant();
         return _call;
     }
-    double deriv(double tau) {
+    double deriv(double tau) override {
         Eigen::MatrixXd adjL = adjugate(MixtureDerivatives::Lstar(HEOS, XN_INDEPENDENT)),
                         dLdTau = MixtureDerivatives::dLstar_dX(HEOS, XN_INDEPENDENT, iTau);
         _deriv = (adjL * dLdTau).trace();
         return _deriv;
     };
-    double second_deriv(double tau) {
+    double second_deriv(double tau) override {
         Eigen::MatrixXd Lstar = MixtureDerivatives::Lstar(HEOS, XN_INDEPENDENT),
                         dLstardTau = MixtureDerivatives::dLstar_dX(HEOS, XN_INDEPENDENT, iTau),
                         d2LstardTau2 = MixtureDerivatives::d2Lstar_dX2(HEOS, XN_INDEPENDENT, iTau, iTau), adjL = adjugate(Lstar),
@@ -4088,7 +4088,7 @@ class L0CurveTracer : public FuncWrapper1DWithDeriv
      \brief Calculate the value of L1
      @param theta The angle
      */
-    double call(double theta) {
+    double call(double theta) override {
         double tau_new = NAN, delta_new = NAN;
         this->get_tau_delta(theta, tau, delta, tau_new, delta_new);
         double rhomolar = HEOS.rhomolar_reducing() * delta_new, T = HEOS.T_reducing() / tau_new;
@@ -4104,7 +4104,7 @@ class L0CurveTracer : public FuncWrapper1DWithDeriv
      \brief Calculate the first partial derivative of L1 with respect to the angle
      @param theta The angle
      */
-    double deriv(double theta) {
+    double deriv(double theta) override {
         double dL1_dtau = (adjLstar * dLstardTau).trace(), dL1_ddelta = (adjLstar * dLstardDelta).trace();
         return -R_tau * sin(theta) * dL1_dtau + R_delta * cos(theta) * dL1_ddelta;
     };

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
@@ -134,7 +134,7 @@ class HelmholtzEOSMixtureBackend : public AbstractState
     void sync_linked_states(const HelmholtzEOSMixtureBackend* const);
 
     virtual ~HelmholtzEOSMixtureBackend() {};
-    std::string backend_name() {
+    std::string backend_name() override {
         return get_backend_string(HEOS_BACKEND_MIX);
     }
     shared_ptr<ReducingFunction> Reducing;
@@ -144,7 +144,7 @@ class HelmholtzEOSMixtureBackend : public AbstractState
     SsatSimpleState ssat_max;
     SpinodalData spinodal_values;
 
-    bool clear() {
+    bool clear() override {
         // Clear the locally cached values for the derivatives of the Helmholtz energy
         // in each component
         for (std::vector<CoolPropFluid>::iterator it = components.begin(); it != components.end(); ++it) {
@@ -168,54 +168,55 @@ class HelmholtzEOSMixtureBackend : public AbstractState
       CorrespondingStatesTerm;  // // Allows the methods in the CorrespondingStatesTerm class to have access to all the protected members and methods of this class
 
     // Helmholtz EOS backend uses mole fractions
-    bool using_mole_fractions() {
+    bool using_mole_fractions() override {
         return true;
     }
-    bool using_mass_fractions() {
+    bool using_mass_fractions() override {
         return false;
     }
-    bool using_volu_fractions() {
+    bool using_volu_fractions() override {
         return false;
     }
     bool is_pure() {
         return components.size() == 1 && !components[0].EOS().pseudo_pure;
     }
-    bool has_melting_line() {
+    bool has_melting_line() override {
         return is_pure_or_pseudopure && components[0].ancillaries.melting_line.enabled();
     };
-    CoolPropDbl calc_melting_line(int param, int given, CoolPropDbl value);
+    CoolPropDbl calc_melting_line(int param, int given, CoolPropDbl value) override;
     /// Return a string from the backend for the mixture/fluid
-    std::string fluid_param_string(const std::string&);
+    std::string fluid_param_string(const std::string&) override;
 
     /// brief Set the reference state based on a string representation
-    virtual void set_reference_stateS(const std::string& reference_state);
+    void set_reference_stateS(const std::string& reference_state) override;
 
     /// Set the reference state based on a thermodynamic state point specified by temperature and molar density
-    virtual void set_reference_stateD(double T, double rhomolar, double hmolar0, double smolar0);
+    void set_reference_stateD(double T, double rhomolar, double hmolar0, double smolar0) override;
 
     /// Set binary mixture floating point parameter
-    virtual void set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter, const double value);
+    void set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter, const double value) override;
     /// Get binary mixture double value
-    virtual double get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter);
+    double get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter) override;
     ///// Get binary mixture string value
     //virtual std::string get_binary_interaction_string(const std::size_t &i, const std::size_t &j, const std::string &parameter);
     /// Set a binary interaction string
-    void set_binary_interaction_string(const std::size_t i, const std::size_t j, const std::string& parameter, const std::string& value);
+    void set_binary_interaction_string(const std::size_t i, const std::size_t j, const std::string& parameter,
+                                       const std::string& value) override;
     /// Apply a simple mixing rule
-    void apply_simple_mixing_rule(std::size_t i, std::size_t j, const std::string& model);
+    void apply_simple_mixing_rule(std::size_t i, std::size_t j, const std::string& model) override;
 
     // Set the cubic alpha function's constants:
-    virtual void set_cubic_alpha_C(const size_t i, const std::string& parameter, const double c1, const double c2, const double c3) {
+    void set_cubic_alpha_C(const size_t i, const std::string& parameter, const double c1, const double c2, const double c3) override {
         throw ValueError("set_cubic_alpha_C only defined for cubic backends");
     };
 
     // Set fluid parameter (currently the volume translation parameter for cubic)
-    virtual void set_fluid_parameter_double(const size_t i, const std::string& parameter, const double value) {
+    void set_fluid_parameter_double(const size_t i, const std::string& parameter, const double value) override {
         throw ValueError("set_fluid_parameter_double only defined for cubic backends");
     };
-    virtual double get_fluid_parameter_double(const size_t i, const std::string& parameter);
+    double get_fluid_parameter_double(const size_t i, const std::string& parameter) override;
 
-    phases calc_phase() {
+    phases calc_phase() override {
         return _phase;
     };
 
@@ -223,33 +224,34 @@ class HelmholtzEOSMixtureBackend : public AbstractState
      *
      * @param phase_index The index from CoolProp::phases
      */
-    void calc_specify_phase(phases phase_index) {
+    void calc_specify_phase(phases phase_index) override {
         imposed_phase_index = phase_index;
         _phase = phase_index;
     }
     /**\brief Unspecify the phase - the phase is no longer imposed, different solvers can do as they like
      */
-    void calc_unspecify_phase() {
+    void calc_unspecify_phase() override {
         imposed_phase_index = iphase_not_imposed;
     }
-    CoolPropDbl calc_saturation_ancillary(parameters param, int Q, parameters given, double value);
+    CoolPropDbl calc_saturation_ancillary(parameters param, int Q, parameters given, double value) override;
     void calc_ssat_max();
     void calc_hsat_max();
-    CoolPropDbl calc_GWP20();
-    CoolPropDbl calc_GWP500();
-    CoolPropDbl calc_GWP100();
-    CoolPropDbl calc_ODP();
+    CoolPropDbl calc_GWP20() override;
+    CoolPropDbl calc_GWP500() override;
+    CoolPropDbl calc_GWP100() override;
+    CoolPropDbl calc_ODP() override;
 
-    CoolPropDbl calc_first_saturation_deriv(parameters Of1, parameters Wrt1);
+    CoolPropDbl calc_first_saturation_deriv(parameters Of1, parameters Wrt1) override;
     CoolPropDbl calc_first_saturation_deriv(parameters Of1, parameters Wrt1, HelmholtzEOSMixtureBackend& SatL, HelmholtzEOSMixtureBackend& SatV);
-    CoolPropDbl calc_second_saturation_deriv(parameters Of1, parameters Wrt1, parameters Wrt2);
-    CoolPropDbl calc_first_two_phase_deriv(parameters Of, parameters Wrt, parameters Constant);
-    CoolPropDbl calc_second_two_phase_deriv(parameters Of, parameters Wrt1, parameters Constant1, parameters Wrt2, parameters Constant2);
-    CoolPropDbl calc_first_two_phase_deriv_splined(parameters Of, parameters Wrt, parameters Constant, CoolPropDbl x_end);
+    CoolPropDbl calc_second_saturation_deriv(parameters Of1, parameters Wrt1, parameters Wrt2) override;
+    CoolPropDbl calc_first_two_phase_deriv(parameters Of, parameters Wrt, parameters Constant) override;
+    CoolPropDbl calc_second_two_phase_deriv(parameters Of, parameters Wrt1, parameters Constant1, parameters Wrt2,
+                                            parameters Constant2) override;
+    CoolPropDbl calc_first_two_phase_deriv_splined(parameters Of, parameters Wrt, parameters Constant, CoolPropDbl x_end) override;
 
     CriticalState calc_critical_point(double rho0, double T0);
     /// An overload to make the compiler (clang in this case) happy
-    std::vector<CoolProp::CriticalState> calc_all_critical_points() {
+    std::vector<CoolProp::CriticalState> calc_all_critical_points() override {
         bool find_critical_points = true;
         return _calc_all_critical_points(find_critical_points);
     };
@@ -266,28 +268,28 @@ class HelmholtzEOSMixtureBackend : public AbstractState
     }
 
     /// Build the spinodal curve
-    virtual void calc_build_spinodal();
+    void calc_build_spinodal() override;
 
     /// Get the data from the spinodal curve
-    virtual SpinodalData calc_get_spinodal_data() {
+    SpinodalData calc_get_spinodal_data() override {
         return spinodal_values;
     };
 
     /// Calculate the values \f$\mathcal{L}_1^*\f$ and \f$\mathcal{M}_1^*\f$
-    void calc_criticality_contour_values(double& L1star, double& M1star);
+    void calc_criticality_contour_values(double& L1star, double& M1star) override;
 
     /// Calculate tangent plane distance for given trial composition w
-    double calc_tangent_plane_distance(const double T, const double p, const std::vector<double>& w, const double rhomolar_guess);
+    double calc_tangent_plane_distance(const double T, const double p, const std::vector<double>& w, const double rhomolar_guess) override;
 
     /// Calculate the phase once the state is fully calculated but you aren't sure if it is liquid or gas or ...
     void recalculate_singlephase_phase();
 
     /// Change the equation of state for one component
-    void calc_change_EOS(const std::size_t i, const std::string& EOS_name);
+    void calc_change_EOS(const std::size_t i, const std::string& EOS_name) override;
 
-    const CoolProp::SimpleState& calc_state(const std::string& state);
+    const CoolProp::SimpleState& calc_state(const std::string& state) override;
 
-    virtual const double get_fluid_constant(std::size_t i, parameters param) const {
+    const double get_fluid_constant(std::size_t i, parameters param) const override {
         const CoolPropFluid& fld = components[i];
         switch (param) {
             case iP_critical:
@@ -334,7 +336,7 @@ class HelmholtzEOSMixtureBackend : public AbstractState
         return *SatV;
     };
 
-    std::vector<CoolPropDbl> calc_mole_fractions_liquid() {
+    std::vector<CoolPropDbl> calc_mole_fractions_liquid() override {
         // SatL/SatV retain composition vectors from the most recent VLE flash
         // (or phase-envelope build) — those are not meaningful when the
         // current state is single-phase, and returning them silently surfaced
@@ -345,21 +347,21 @@ class HelmholtzEOSMixtureBackend : public AbstractState
         }
         return SatL->get_mole_fractions();
     };
-    std::vector<CoolPropDbl> calc_mole_fractions_vapor() {
+    std::vector<CoolPropDbl> calc_mole_fractions_vapor() override {
         if (_phase != iphase_twophase) {
             throw ValueError("mole_fractions_vapor is only defined in the two-phase region (current state is single-phase)");
         }
         return SatV->get_mole_fractions();
     };
 
-    const std::vector<CoolPropDbl> calc_mass_fractions();
+    const std::vector<CoolPropDbl> calc_mass_fractions() override;
 
-    const CoolProp::PhaseEnvelopeData& calc_phase_envelope_data() {
+    const CoolProp::PhaseEnvelopeData& calc_phase_envelope_data() override {
         return PhaseEnvelope;
     };
 
     /// Calculate the conformal state (unity shape factors starting point if T < 0 and rhomolar < 0)
-    void calc_conformal_state(const std::string& reference_fluid, CoolPropDbl& T, CoolPropDbl& rhomolar);
+    void calc_conformal_state(const std::string& reference_fluid, CoolPropDbl& T, CoolPropDbl& rhomolar) override;
 
     void resize(std::size_t N);
     shared_ptr<HelmholtzEOSMixtureBackend> SatL, SatV;  ///<
@@ -369,12 +371,12 @@ class HelmholtzEOSMixtureBackend : public AbstractState
      * @param value1 The first input value
      * @param value2 The second input value
      */
-    virtual void update(CoolProp::input_pairs input_pair, double value1, double value2);
+    void update(CoolProp::input_pairs input_pair, double value1, double value2) override;
 
     /** \brief Update the state using guess values
 	 *
 	 */
-    void update_with_guesses(CoolProp::input_pairs input_pair, double Value1, double Value2, const GuessesStructure& guesses);
+    void update_with_guesses(CoolProp::input_pairs input_pair, double Value1, double Value2, const GuessesStructure& guesses) override;
 
     /** \brief Update all the internal variables for a state by copying from another state
      */
@@ -388,7 +390,7 @@ class HelmholtzEOSMixtureBackend : public AbstractState
     void update_TP_guessrho(CoolPropDbl T, CoolPropDbl p, CoolPropDbl rho_guess);
     void update_DmolarT_direct(CoolPropDbl rhomolar, CoolPropDbl T);
     void update_TDmolarP_unchecked(CoolPropDbl T, CoolPropDbl rhomolarL, CoolPropDbl p);
-    void update_QT_pure_superanc(CoolPropDbl Q, CoolPropDbl T);
+    void update_QT_pure_superanc(CoolPropDbl Q, CoolPropDbl T) override;
     void update_HmolarQ_with_guessT(CoolPropDbl hmolar, CoolPropDbl Q, CoolPropDbl Tguess);
 
     /** \brief Set the components of the mixture
@@ -406,9 +408,9 @@ class HelmholtzEOSMixtureBackend : public AbstractState
      *
      * @param mf The vector of mole fractions of the components
      */
-    void set_mole_fractions(const std::vector<CoolPropDbl>& mf);
+    void set_mole_fractions(const std::vector<CoolPropDbl>& mf) override;
 
-    const std::vector<CoolPropDbl>& get_mole_fractions() {
+    const std::vector<CoolPropDbl>& get_mole_fractions() override {
         return mole_fractions;
     };
     std::vector<CoolPropDbl>& get_mole_fractions_ref() {
@@ -422,49 +424,49 @@ class HelmholtzEOSMixtureBackend : public AbstractState
      *
      * @param mass_fractions The vector of mass fractions of the components
      */
-    void set_mass_fractions(const std::vector<CoolPropDbl>& mass_fractions);
+    void set_mass_fractions(const std::vector<CoolPropDbl>& mass_fractions) override;
 
-    void calc_ideal_curve(const std::string& type, std::vector<double>& T, std::vector<double>& p);
+    void calc_ideal_curve(const std::string& type, std::vector<double>& T, std::vector<double>& p) override;
 
-    CoolPropDbl calc_molar_mass();
+    CoolPropDbl calc_molar_mass() override;
     PhaseMolarMasses calc_phase_molar_masses() override;
-    CoolPropDbl calc_gas_constant();
-    CoolPropDbl calc_acentric_factor();
+    CoolPropDbl calc_gas_constant() override;
+    CoolPropDbl calc_acentric_factor() override;
 
-    CoolPropDbl calc_Bvirial();
-    CoolPropDbl calc_Cvirial();
-    CoolPropDbl calc_dBvirial_dT();
-    CoolPropDbl calc_dCvirial_dT();
+    CoolPropDbl calc_Bvirial() override;
+    CoolPropDbl calc_Cvirial() override;
+    CoolPropDbl calc_dBvirial_dT() override;
+    CoolPropDbl calc_dCvirial_dT() override;
 
-    CoolPropDbl calc_pressure();
-    CoolPropDbl calc_cvmolar();
-    CoolPropDbl calc_cpmolar();
-    CoolPropDbl calc_gibbsmolar();
-    CoolPropDbl calc_gibbsmolar_residual() {
+    CoolPropDbl calc_pressure() override;
+    CoolPropDbl calc_cvmolar() override;
+    CoolPropDbl calc_cpmolar() override;
+    CoolPropDbl calc_gibbsmolar() override;
+    CoolPropDbl calc_gibbsmolar_residual() override {
         return gas_constant() * _T * (alphar() + delta() * dalphar_dDelta());
     }
     CoolPropDbl calc_gibbsmolar_nocache(CoolPropDbl T, CoolPropDbl rhomolar);
 
-    CoolPropDbl calc_helmholtzmolar();
-    CoolPropDbl calc_cpmolar_idealgas();
+    CoolPropDbl calc_helmholtzmolar() override;
+    CoolPropDbl calc_cpmolar_idealgas() override;
     CoolPropDbl calc_pressure_nocache(CoolPropDbl T, CoolPropDbl rhomolar);
-    CoolPropDbl calc_smolar();
-    CoolPropDbl calc_smolar_residual() {
+    CoolPropDbl calc_smolar() override;
+    CoolPropDbl calc_smolar_residual() override {
         return gas_constant() * (tau() * dalphar_dTau() - alphar());
     }
     CoolPropDbl calc_smolar_nocache(CoolPropDbl T, CoolPropDbl rhomolar);
 
-    CoolPropDbl calc_hmolar();
-    CoolPropDbl calc_hmolar_residual() {
+    CoolPropDbl calc_hmolar() override;
+    CoolPropDbl calc_hmolar_residual() override {
         return gas_constant() * _T * (tau() * dalphar_dTau() + delta() * dalphar_dDelta());
     }
     CoolPropDbl calc_hmolar_nocache(CoolPropDbl T, CoolPropDbl rhomolar);
 
     CoolPropDbl calc_umolar_nocache(CoolPropDbl T, CoolPropDbl rhomolar);
-    CoolPropDbl calc_umolar();
-    CoolPropDbl calc_speed_sound();
+    CoolPropDbl calc_umolar() override;
+    CoolPropDbl calc_speed_sound() override;
 
-    void calc_excess_properties();
+    void calc_excess_properties() override;
 
     /** \brief The phase identification parameter of Venkatarathnam et al., FPE, 2011
      *
@@ -472,71 +474,71 @@ class HelmholtzEOSMixtureBackend : public AbstractState
      */
 
     CoolPropDbl calc_phase_identification_parameter();
-    CoolPropDbl calc_fugacity(std::size_t i);
-    virtual CoolPropDbl calc_fugacity_coefficient(std::size_t i);
-    CoolPropDbl calc_chemical_potential(std::size_t i);
+    CoolPropDbl calc_fugacity(std::size_t i) override;
+    CoolPropDbl calc_fugacity_coefficient(std::size_t i) override;
+    CoolPropDbl calc_chemical_potential(std::size_t i) override;
 
     /// Using this backend, calculate the flame hazard
-    CoolPropDbl calc_flame_hazard() {
+    CoolPropDbl calc_flame_hazard() override {
         return components[0].environment.FH;
     };
     /// Using this backend, calculate the health hazard
-    CoolPropDbl calc_health_hazard() {
+    CoolPropDbl calc_health_hazard() override {
         return components[0].environment.HH;
     };
     /// Using this backend, calculate the physical hazard
-    CoolPropDbl calc_physical_hazard() {
+    CoolPropDbl calc_physical_hazard() override {
         return components[0].environment.PH;
     };
 
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r\f$ (dimensionless)
-    CoolPropDbl calc_alphar();
+    CoolPropDbl calc_alphar() override;
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta}\f$ (dimensionless)
-    CoolPropDbl calc_dalphar_dDelta();
+    CoolPropDbl calc_dalphar_dDelta() override;
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau}\f$ (dimensionless)
-    CoolPropDbl calc_dalphar_dTau();
+    CoolPropDbl calc_dalphar_dTau() override;
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta}\f$ (dimensionless)
-    CoolPropDbl calc_d2alphar_dDelta2();
+    CoolPropDbl calc_d2alphar_dDelta2() override;
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d2alphar_dDelta_dTau();
+    CoolPropDbl calc_d2alphar_dDelta_dTau() override;
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d2alphar_dTau2();
+    CoolPropDbl calc_d2alphar_dTau2() override;
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\delta}\f$ (dimensionless)
-    CoolPropDbl calc_d3alphar_dDelta3();
+    CoolPropDbl calc_d3alphar_dDelta3() override;
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d3alphar_dDelta2_dTau();
+    CoolPropDbl calc_d3alphar_dDelta2_dTau() override;
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d3alphar_dDelta_dTau2();
+    CoolPropDbl calc_d3alphar_dDelta_dTau2() override;
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d3alphar_dTau3();
+    CoolPropDbl calc_d3alphar_dTau3() override;
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\delta\delta}\f$ (dimensionless)
-    CoolPropDbl calc_d4alphar_dDelta4();
+    CoolPropDbl calc_d4alphar_dDelta4() override;
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\delta\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d4alphar_dDelta3_dTau();
+    CoolPropDbl calc_d4alphar_dDelta3_dTau() override;
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d4alphar_dDelta2_dTau2();
+    CoolPropDbl calc_d4alphar_dDelta2_dTau2() override;
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d4alphar_dDelta_dTau3();
+    CoolPropDbl calc_d4alphar_dDelta_dTau3() override;
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d4alphar_dTau4();
+    CoolPropDbl calc_d4alphar_dTau4() override;
 
-    CoolPropDbl calc_alpha0();
-    CoolPropDbl calc_dalpha0_dDelta();
-    CoolPropDbl calc_dalpha0_dTau();
-    CoolPropDbl calc_d2alpha0_dDelta2();
-    CoolPropDbl calc_d2alpha0_dDelta_dTau();
-    CoolPropDbl calc_d2alpha0_dTau2();
-    CoolPropDbl calc_d3alpha0_dDelta3();
-    CoolPropDbl calc_d3alpha0_dDelta2_dTau();
-    CoolPropDbl calc_d3alpha0_dDelta_dTau2();
-    CoolPropDbl calc_d3alpha0_dTau3();
+    CoolPropDbl calc_alpha0() override;
+    CoolPropDbl calc_dalpha0_dDelta() override;
+    CoolPropDbl calc_dalpha0_dTau() override;
+    CoolPropDbl calc_d2alpha0_dDelta2() override;
+    CoolPropDbl calc_d2alpha0_dDelta_dTau() override;
+    CoolPropDbl calc_d2alpha0_dTau2() override;
+    CoolPropDbl calc_d3alpha0_dDelta3() override;
+    CoolPropDbl calc_d3alpha0_dDelta2_dTau() override;
+    CoolPropDbl calc_d3alpha0_dDelta_dTau2() override;
+    CoolPropDbl calc_d3alpha0_dTau3() override;
 
-    CoolPropDbl calc_surface_tension();
-    CoolPropDbl calc_viscosity();
+    CoolPropDbl calc_surface_tension() override;
+    CoolPropDbl calc_viscosity() override;
     CoolPropDbl calc_viscosity_dilute();
     CoolPropDbl calc_viscosity_background();
     CoolPropDbl calc_viscosity_background(CoolPropDbl eta_dilute, CoolPropDbl& initial_density, CoolPropDbl& residual);
-    CoolPropDbl calc_conductivity();
+    CoolPropDbl calc_conductivity() override;
     CoolPropDbl calc_conductivity_background();
 
     /**
@@ -544,51 +546,53 @@ class HelmholtzEOSMixtureBackend : public AbstractState
      *
      * If the viscosity model is hardcoded or ECS is being used, there will only be one entry in critical and all others will be zero
      */
-    void calc_viscosity_contributions(CoolPropDbl& dilute, CoolPropDbl& initial_density, CoolPropDbl& residual, CoolPropDbl& critical);
+    void calc_viscosity_contributions(CoolPropDbl& dilute, CoolPropDbl& initial_density, CoolPropDbl& residual,
+                                      CoolPropDbl& critical) override;
     /**
      * \brief Calculate each of the contributions to the conductivity
      *
      * If the conductivity model is hardcoded or ECS is being used, there will only be one entry in initial_density and all others will be zero
      */
-    void calc_conductivity_contributions(CoolPropDbl& dilute, CoolPropDbl& initial_density, CoolPropDbl& residual, CoolPropDbl& critical);
+    void calc_conductivity_contributions(CoolPropDbl& dilute, CoolPropDbl& initial_density, CoolPropDbl& residual,
+                                         CoolPropDbl& critical) override;
 
-    CoolPropDbl calc_saturated_liquid_keyed_output(parameters key);
-    CoolPropDbl calc_saturated_vapor_keyed_output(parameters key);
+    CoolPropDbl calc_saturated_liquid_keyed_output(parameters key) override;
+    CoolPropDbl calc_saturated_vapor_keyed_output(parameters key) override;
 
-    CoolPropDbl calc_Tmin();
-    CoolPropDbl calc_Tmax();
-    CoolPropDbl calc_pmax();
-    CoolPropDbl calc_Ttriple();
-    CoolPropDbl calc_p_triple();
+    CoolPropDbl calc_Tmin() override;
+    CoolPropDbl calc_Tmax() override;
+    CoolPropDbl calc_pmax() override;
+    CoolPropDbl calc_Ttriple() override;
+    CoolPropDbl calc_p_triple() override;
     CoolPropDbl calc_pmax_sat();
     CoolPropDbl calc_Tmax_sat();
     void calc_Tmin_sat(CoolPropDbl& Tmin_satL, CoolPropDbl& Tmin_satV);
     void calc_pmin_sat(CoolPropDbl& pmin_satL, CoolPropDbl& pmin_satV);
 
-    virtual CoolPropDbl calc_T_critical();
-    virtual CoolPropDbl calc_p_critical();
-    virtual CoolPropDbl calc_rhomolar_critical();
+    CoolPropDbl calc_T_critical() override;
+    CoolPropDbl calc_p_critical() override;
+    CoolPropDbl calc_rhomolar_critical() override;
 
-    CoolPropDbl calc_T_reducing() {
+    CoolPropDbl calc_T_reducing() override {
         return get_reducing_state().T;
     };
-    CoolPropDbl calc_rhomolar_reducing() {
+    CoolPropDbl calc_rhomolar_reducing() override {
         return get_reducing_state().rhomolar;
     };
-    CoolPropDbl calc_p_reducing() {
+    CoolPropDbl calc_p_reducing() override {
         return get_reducing_state().p;
     };
 
     // Calculate the phase identification parameter of Venkatarathnam et al, Fluid Phase Equilibria
-    CoolPropDbl calc_PIP() {
+    CoolPropDbl calc_PIP() override {
         return 2
                - rhomolar()
                    * (second_partial_deriv(iP, iDmolar, iT, iT, iDmolar) / first_partial_deriv(iP, iT, iDmolar)
                       - second_partial_deriv(iP, iDmolar, iT, iDmolar, iT) / first_partial_deriv(iP, iDmolar, iT));
     };
 
-    std::string calc_name();
-    std::vector<std::string> calc_fluid_names();
+    std::string calc_name() override;
+    std::vector<std::string> calc_fluid_names() override;
 
     void calc_all_alphar_deriv_cache(const std::vector<CoolPropDbl>& mole_fractions, const CoolPropDbl& tau, const CoolPropDbl& delta);
     virtual CoolPropDbl calc_alphar_deriv_nocache(const int nTau, const int nDelta, const std::vector<CoolPropDbl>& mole_fractions,
@@ -624,21 +628,21 @@ class HelmholtzEOSMixtureBackend : public AbstractState
     HelmholtzDerivatives calc_all_alpha0_derivs_nocache(const std::vector<CoolPropDbl>& mole_fractions, const CoolPropDbl& tau,
                                                         const CoolPropDbl& delta, const CoolPropDbl& Tr, const CoolPropDbl& rhor);
 
-    virtual void calc_reducing_state();
+    void calc_reducing_state() override;
     virtual SimpleState calc_reducing_state_nocache(const std::vector<CoolPropDbl>& mole_fractions);
 
-    const CoolProp::SimpleState& get_reducing_state() {
+    const CoolProp::SimpleState& get_reducing_state() override {
         calc_reducing_state();
         return _reducing;
     };
 
-    void update_states();
+    void update_states() override;
 
-    CoolPropDbl calc_compressibility_factor() {
+    CoolPropDbl calc_compressibility_factor() override {
         return 1 + delta() * dalphar_dDelta();
     };
 
-    void calc_phase_envelope(const std::string& type);
+    void calc_phase_envelope(const std::string& type) override;
 
     CoolPropDbl SRK_covolume();
 

--- a/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
+++ b/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
@@ -595,7 +595,7 @@ void PhaseEnvelopeRoutines::finalize(HelmholtzEOSMixtureBackend& HEOS) {
                     this->HEOS = &HEOS, this->imax = imax;
                     this->maxima = maxima;
                 };
-                double call(double rhomolar_vap) {
+                double call(double rhomolar_vap) override {
                     PhaseEnvelopeData& env = HEOS->PhaseEnvelope;
                     IO.imposed_variable = SaturationSolvers::newton_raphson_saturation_options::RHOV_IMPOSED;
                     IO.bubble_point = false;

--- a/src/Backends/Helmholtz/ReducingFunctions.h
+++ b/src/Backends/Helmholtz/ReducingFunctions.h
@@ -179,7 +179,7 @@ class GERG2008ReducingFunction : public ReducingFunction
         }
     };
 
-    ReducingFunction* copy() {
+    ReducingFunction* copy() override {
         return new GERG2008ReducingFunction(pFluids, beta_v, gamma_v, beta_T, gamma_T);
     };
 
@@ -209,7 +209,7 @@ class GERG2008ReducingFunction : public ReducingFunction
     }
 
     /// Set a parameter
-    virtual void set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter, double value) {
+    void set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter, double value) override {
         // bound-check indices
         if (i < 0 || i >= N) {
             if (j < 0 || j >= N) {
@@ -237,7 +237,7 @@ class GERG2008ReducingFunction : public ReducingFunction
         }
     }
     /// Get a parameter
-    virtual double get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter) const {
+    double get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter) const override {
         if (parameter == "betaT") {
             return beta_T[i][j];
         } else if (parameter == "gammaT") {
@@ -254,46 +254,47 @@ class GERG2008ReducingFunction : public ReducingFunction
     /** \brief The reducing temperature
      * Calculated from \ref Yr with \f$T = Y\f$
      */
-    CoolPropDbl Tr(const std::vector<CoolPropDbl>& x) const;
+    CoolPropDbl Tr(const std::vector<CoolPropDbl>& x) const override;
 
     /** \brief The derivative of reducing temperature with respect to gammaT
      * Calculated from dYr_gamma with \f$T = Y\f$
      */
-    CoolPropDbl dTr_dgammaT(const std::vector<CoolPropDbl>& x) const;
+    CoolPropDbl dTr_dgammaT(const std::vector<CoolPropDbl>& x) const override;
 
     /** \brief The derivative of reducing temperature with respect to betaT
      * Calculated from dYr_beta with \f$T = Y\f$
      */
-    CoolPropDbl dTr_dbetaT(const std::vector<CoolPropDbl>& x) const;
+    CoolPropDbl dTr_dbetaT(const std::vector<CoolPropDbl>& x) const override;
 
     /** \brief The derivative of reducing temperature with respect to gammaT and composition
     */
-    CoolPropDbl d2Tr_dxidgammaT(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const;
+    CoolPropDbl d2Tr_dxidgammaT(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override;
 
     /** \brief The derivative of reducing temperature with respect to betaT and composition
     */
-    CoolPropDbl d2Tr_dxidbetaT(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const;
+    CoolPropDbl d2Tr_dxidbetaT(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override;
 
     /** \brief The derivative of reducing temperature with respect to component i mole fraction
      *
      * Calculated from \ref dYrdxi__constxj with \f$T = Y\f$
      */
-    CoolPropDbl dTrdxi__constxj(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const;
+    CoolPropDbl dTrdxi__constxj(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override;
     /** \brief The second derivative of reducing temperature with respect to component i mole fraction
      *
      * Calculated from \ref d2Yrdxi2__constxj with \f$T = Y\f$
      */
-    CoolPropDbl d2Trdxi2__constxj(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const;
+    CoolPropDbl d2Trdxi2__constxj(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override;
     /** \brief The second derivative of reducing temperature with respect to component i and j mole fractions
      *
      * Calculated from \ref d2Yrdxidxj with \f$T = Y\f$
      */
-    CoolPropDbl d2Trdxidxj(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) const;
+    CoolPropDbl d2Trdxidxj(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) const override;
     /** \brief The third derivative of reducing temperature with respect to component i, j and k mole fractions
 	*
 	* Calculated from \ref d3Yrdxidxjdxk with \f$T = Y\f$
 	*/
-    CoolPropDbl d3Trdxidxjdxk(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, std::size_t k, x_N_dependency_flag xN_flag) const;
+    CoolPropDbl d3Trdxidxjdxk(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, std::size_t k,
+                              x_N_dependency_flag xN_flag) const override;
 
     /** \brief The derivative of reducing molar volume with respect to component i mole fraction
      *
@@ -319,17 +320,17 @@ class GERG2008ReducingFunction : public ReducingFunction
      *
      * Given by \f$ \rho_r = 1/v_r \f$
      */
-    CoolPropDbl rhormolar(const std::vector<CoolPropDbl>& x) const;
+    CoolPropDbl rhormolar(const std::vector<CoolPropDbl>& x) const override;
 
     /** \brief The derivative of reducing density with respect to gammaV
      * Calculated from dYr_gamma with \f$v = Y\f$
      */
-    CoolPropDbl drhormolar_dgammaV(const std::vector<CoolPropDbl>& x) const;
+    CoolPropDbl drhormolar_dgammaV(const std::vector<CoolPropDbl>& x) const override;
 
     /** \brief The derivative of reducing density with respect to betaV
      * Calculated from dYr_beta with \f$v = Y\f$
      */
-    CoolPropDbl drhormolar_dbetaV(const std::vector<CoolPropDbl>& x) const;
+    CoolPropDbl drhormolar_dbetaV(const std::vector<CoolPropDbl>& x) const override;
 
     /** \brief The derivative of reducing volume with respect to gammaV and composition
     */
@@ -341,11 +342,11 @@ class GERG2008ReducingFunction : public ReducingFunction
 
     /** \brief The derivative of reducing density with respect to betaV and composition
     */
-    CoolPropDbl d2rhormolar_dxidbetaV(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const;
+    CoolPropDbl d2rhormolar_dxidbetaV(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override;
 
     /** \brief The derivative of reducing density with respect to gammaV and composition
     */
-    CoolPropDbl d2rhormolar_dxidgammaV(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const;
+    CoolPropDbl d2rhormolar_dxidgammaV(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override;
 
     /** \brief Derivative of the molar reducing density with respect to component i mole fraction
      *
@@ -354,7 +355,7 @@ class GERG2008ReducingFunction : public ReducingFunction
      * \left(\frac{\partial \rho_r}{\partial x_i}\right)_{x_{i\neq j}} = -\rho_r^2\left(\frac{\partial v_r}{\partial x_i}\right)_{x_{i\neq j}}
      * \f]
      */
-    CoolPropDbl drhormolardxi__constxj(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const;
+    CoolPropDbl drhormolardxi__constxj(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override;
     /** \brief Derivative of the molar reducing density with respect to component i mole fraction
      *
      * See also GERG 2004, Eqn. 7.58
@@ -362,7 +363,7 @@ class GERG2008ReducingFunction : public ReducingFunction
      * \left(\frac{\partial^2 \rho_r}{\partial x_i^2}\right)_{x_{i\neq j}} = 2\rho_r^3\left(\left(\frac{\partial v_r}{\partial x_i}\right)_{x_{i\neq j}}\right)^2-\rho_r\left(\left(\frac{\partial^2 v_r}{\partial x_i^2}\right)_{x_{i\neq j}}\right)
      * \f]
      */
-    CoolPropDbl d2rhormolardxi2__constxj(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const;
+    CoolPropDbl d2rhormolardxi2__constxj(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override;
     /** \brief Derivative of the molar reducing density with respect to component i  and j mole fractions
      *
      * See also GERG 2004, Eqn. 7.59
@@ -370,12 +371,13 @@ class GERG2008ReducingFunction : public ReducingFunction
      * \left(\frac{\partial^2 \rho_r}{\partial x_i\partial x_j}\right) = 2\rho_r^3\left(\left(\frac{\partial v_r}{\partial x_i}\right)_{x_{i\neq j}}\right)\left(\left(\frac{\partial v_r}{\partial x_j}\right)_{x_{i\neq j}}\right)-\rho_r^2\left(\left(\frac{\partial v_r}{\partial x_i\partial x_j}\right)\right)
      * \f]
      */
-    CoolPropDbl d2rhormolardxidxj(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) const;
+    CoolPropDbl d2rhormolardxidxj(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j,
+                                  x_N_dependency_flag xN_flag) const override;
     /** \brief Derivative of the molar reducing density with respect to component i, j, and k mole fractions
 	*
 	*/
     CoolPropDbl d3rhormolardxidxjdxk(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, std::size_t k,
-                                     x_N_dependency_flag xN_flag) const;
+                                     x_N_dependency_flag xN_flag) const override;
 
     /** \brief Generalized reducing term \f$Y_r\f$
      *
@@ -553,83 +555,85 @@ class ConstantReducingFunction : public ReducingFunction
    public:
     ConstantReducingFunction(const double T_c, const double rhomolar_c) : T_c(T_c), rhomolar_c(rhomolar_c) {};
 
-    ReducingFunction* copy() {
+    ReducingFunction* copy() override {
         return new ConstantReducingFunction(T_c, rhomolar_c);
     };
 
-    void set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter, double value) {
+    void set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter, double value) override {
         return;
     }
-    double get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter) const {
+    double get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter) const override {
         return _HUGE;
     }
 
     /// \brief The reducing temperature
-    CoolPropDbl Tr(const std::vector<CoolPropDbl>& x) const {
+    CoolPropDbl Tr(const std::vector<CoolPropDbl>& x) const override {
         return T_c;
     };
     /// \brief The derivative of reducing temperature with respect to component i mole fraction
-    CoolPropDbl dTrdxi__constxj(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const {
+    CoolPropDbl dTrdxi__constxj(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override {
         return 0;
     };
     /// \brief The second derivative of reducing temperature with respect to component i mole fraction
-    CoolPropDbl d2Trdxi2__constxj(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const {
+    CoolPropDbl d2Trdxi2__constxj(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override {
         return 0;
     };
     /// \brief The second derivative of reducing temperature with respect to component i and j mole fractions
-    CoolPropDbl d2Trdxidxj(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) const {
+    CoolPropDbl d2Trdxidxj(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) const override {
         return 0;
     };
     /// \brief The third derivative of reducing temperature with respect to component i, j and k mole fractions
-    CoolPropDbl d3Trdxidxjdxk(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, std::size_t k, x_N_dependency_flag xN_flag) const {
+    CoolPropDbl d3Trdxidxjdxk(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, std::size_t k,
+                              x_N_dependency_flag xN_flag) const override {
         return 0;
     };
 
     /// \brief The molar reducing density
-    CoolPropDbl rhormolar(const std::vector<CoolPropDbl>& x) const {
+    CoolPropDbl rhormolar(const std::vector<CoolPropDbl>& x) const override {
         return rhomolar_c;
     };
     /// \brief Derivative of the molar reducing density with respect to component i mole fraction
-    CoolPropDbl drhormolardxi__constxj(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const {
+    CoolPropDbl drhormolardxi__constxj(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override {
         return 0;
     };
     /// \brief Derivative of the molar reducing density with respect to component i mole fraction
-    CoolPropDbl d2rhormolardxi2__constxj(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const {
+    CoolPropDbl d2rhormolardxi2__constxj(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override {
         return 0;
     };
     /// \brief Derivative of the molar reducing density with respect to component i  and j mole fractions
-    CoolPropDbl d2rhormolardxidxj(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) const {
+    CoolPropDbl d2rhormolardxidxj(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j,
+                                  x_N_dependency_flag xN_flag) const override {
         return 0;
     };
     /// \brief Derivative of the molar reducing density with respect to component i, j, and k mole fractions
     CoolPropDbl d3rhormolardxidxjdxk(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, std::size_t k,
-                                     x_N_dependency_flag xN_flag) const {
+                                     x_N_dependency_flag xN_flag) const override {
         return 0;
     };
 
-    CoolPropDbl dTr_dgammaT(const std::vector<CoolPropDbl>& x) const {
+    CoolPropDbl dTr_dgammaT(const std::vector<CoolPropDbl>& x) const override {
         return 0;
     }
-    CoolPropDbl dTr_dbetaT(const std::vector<CoolPropDbl>& x) const {
+    CoolPropDbl dTr_dbetaT(const std::vector<CoolPropDbl>& x) const override {
         return 0;
     }
-    CoolPropDbl drhormolar_dgammaV(const std::vector<CoolPropDbl>& x) const {
+    CoolPropDbl drhormolar_dgammaV(const std::vector<CoolPropDbl>& x) const override {
         return 0;
     }
-    CoolPropDbl drhormolar_dbetaV(const std::vector<CoolPropDbl>& x) const {
+    CoolPropDbl drhormolar_dbetaV(const std::vector<CoolPropDbl>& x) const override {
         return 0;
     }
 
-    CoolPropDbl d2Tr_dxidgammaT(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const {
+    CoolPropDbl d2Tr_dxidgammaT(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override {
         return 0;
     }
-    CoolPropDbl d2Tr_dxidbetaT(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const {
+    CoolPropDbl d2Tr_dxidbetaT(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override {
         return 0;
     }
-    CoolPropDbl d2rhormolar_dxidgammaV(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const {
+    CoolPropDbl d2rhormolar_dxidgammaV(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override {
         return 0;
     }
-    CoolPropDbl d2rhormolar_dxidbetaV(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const {
+    CoolPropDbl d2rhormolar_dxidbetaV(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override {
         return 0;
     }
 
@@ -641,24 +645,24 @@ class ConstantReducingFunction : public ReducingFunction
     //virtual CoolPropDbl ndTrdni__constnj(const std::vector<CoolPropDbl> &x, std::size_t i, x_N_dependency_flag xN_flag){ return 0; };
 
     /// Note: this one is one, not zero
-    virtual CoolPropDbl PSI_rho(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const {
+    CoolPropDbl PSI_rho(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override {
         return 1;
     };
-    virtual CoolPropDbl d_PSI_rho_dxj(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) const {
+    CoolPropDbl d_PSI_rho_dxj(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) const override {
         return 0;
     };
-    virtual CoolPropDbl d2_PSI_rho_dxj_dxk(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, std::size_t k,
-                                           x_N_dependency_flag xN_flag) const {
+    CoolPropDbl d2_PSI_rho_dxj_dxk(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, std::size_t k,
+                                   x_N_dependency_flag xN_flag) const override {
         return 0;
     };
-    virtual CoolPropDbl PSI_T(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const {
+    CoolPropDbl PSI_T(const std::vector<CoolPropDbl>& x, std::size_t i, x_N_dependency_flag xN_flag) const override {
         return 0;
     };
-    virtual CoolPropDbl d_PSI_T_dxj(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) const {
+    CoolPropDbl d_PSI_T_dxj(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) const override {
         return 0;
     };
-    virtual CoolPropDbl d2_PSI_T_dxj_dxk(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, std::size_t k,
-                                         x_N_dependency_flag xN_flag) const {
+    CoolPropDbl d2_PSI_T_dxj_dxk(const std::vector<CoolPropDbl>& x, std::size_t i, std::size_t j, std::size_t k,
+                                 x_N_dependency_flag xN_flag) const override {
         return 0;
     };
 };

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -19,7 +19,7 @@ void SaturationSolvers::saturation_critical(HelmholtzEOSMixtureBackend& HEOS, pa
         CoolPropDbl T, desired_p;
 
         inner_resid(HelmholtzEOSMixtureBackend* HEOS, CoolPropDbl T, CoolPropDbl desired_p) : HEOS(HEOS), T(T), desired_p(desired_p) {};
-        double call(double rhomolar_liq) {
+        double call(double rhomolar_liq) override {
             HEOS->SatL->update(DmolarT_INPUTS, rhomolar_liq, T);
             CoolPropDbl calc_p = HEOS->SatL->p();
             std::cout << format("inner p: %0.16Lg; res: %0.16Lg", calc_p, calc_p - desired_p) << std::endl;
@@ -39,7 +39,7 @@ void SaturationSolvers::saturation_critical(HelmholtzEOSMixtureBackend& HEOS, pa
 
         outer_resid(HelmholtzEOSMixtureBackend& HEOS, CoolProp::parameters ykey, CoolPropDbl y)
           : HEOS(&HEOS), ykey(ykey), y(y), rhomolar_crit(HEOS.rhomolar_critical()) {};
-        double call(double rhomolar_vap) {
+        double call(double rhomolar_vap) override {
             // Calculate the other variable (T->p or p->T) for given vapor density
             CoolPropDbl T = NAN, p = NAN, rhomolar_liq = NAN;
             switch (ykey) {
@@ -86,7 +86,7 @@ void SaturationSolvers::saturation_T_pure_1D_P(HelmholtzEOSMixtureBackend& HEOS,
 
         solver_resid(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl T, CoolPropDbl rhomolar_liq_guess, CoolPropDbl rhomolar_vap_guess)
           : HEOS(&HEOS), T(T), rhomolar_liq(rhomolar_liq_guess), rhomolar_vap(rhomolar_vap_guess) {};
-        double call(double p) {
+        double call(double p) override {
             // Recalculate the densities using the current guess values
             HEOS->SatL->update_TP_guessrho(T, p, rhomolar_liq);
             HEOS->SatV->update_TP_guessrho(T, p, rhomolar_vap);
@@ -131,7 +131,7 @@ void SaturationSolvers::saturation_P_pure_1D_T(HelmholtzEOSMixtureBackend& HEOS,
 
         solver_resid(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl p, CoolPropDbl rhomolar_liq_guess, CoolPropDbl rhomolar_vap_guess)
           : HEOS(&HEOS), p(p), rhomolar_liq(rhomolar_liq_guess), rhomolar_vap(rhomolar_vap_guess) {};
-        double call(double T) {
+        double call(double T) override {
             // Recalculate the densities using the current guess values
             HEOS->SatL->update_TP_guessrho(T, p, rhomolar_liq);
             HEOS->SatV->update_TP_guessrho(T, p, rhomolar_vap);
@@ -212,7 +212,7 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend& HEOS, C
                     this->component = &component;
                     this->h = h;
                 }
-                double call(double T) {
+                double call(double T) override {
                     CoolPropDbl h_liq = component->ancillaries.hL.evaluate(T) + component->EOS().hs_anchor.hmolar;
                     return h_liq + component->ancillaries.hLV.evaluate(T) - h;
                 };
@@ -276,7 +276,7 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend& HEOS, C
                     this->component = &component;
                     this->s = s;
                 }
-                double call(double T) {
+                double call(double T) override {
                     CoolPropDbl s_liq = component->ancillaries.sL.evaluate(T) + component->EOS().hs_anchor.smolar;
                     CoolPropDbl resid = s_liq + component->ancillaries.sLV.evaluate(T) - s;
 
@@ -1731,10 +1731,10 @@ class RachfordRiceResidual : public FuncWrapper1DWithDeriv
 
    public:
     RachfordRiceResidual(const std::vector<double>& z, const std::vector<double>& lnK) : z(z), lnK(lnK) {};
-    double call(double beta) {
+    double call(double beta) override {
         return FlashRoutines::g_RachfordRice(z, lnK, beta);
     }
-    double deriv(double beta) {
+    double deriv(double beta) override {
         return FlashRoutines::dgdbeta_RachfordRice(z, lnK, beta);
     }
 };

--- a/src/Backends/Helmholtz/VLERoutines.h
+++ b/src/Backends/Helmholtz/VLERoutines.h
@@ -175,7 +175,7 @@ class WilsonK_resid : public FuncWrapper1D
         z(z),
         K(K),
         HEOS(HEOS) {}  // if input_type == imposed_T -> use T, else use p; init both
-    double call(double input_value) {
+    double call(double input_value) override {
         double summer = 0;
         if (input_type == imposed_T) {
             p = input_value;  // Iterate on pressure

--- a/src/Backends/IF97/IF97Backend.h
+++ b/src/Backends/IF97/IF97Backend.h
@@ -22,7 +22,7 @@ class IF97Backend : public AbstractState
 
    public:
     /// The name of the backend being used
-    std::string backend_name() {
+    std::string backend_name() override {
         return get_backend_string(IF97_BACKEND);
     }
 
@@ -36,28 +36,28 @@ class IF97Backend : public AbstractState
     }
 
     // REQUIRED BUT NOT USED IN IF97 FUNCTIONS
-    bool using_mole_fractions() {
+    bool using_mole_fractions() override {
         return false;
     };
-    bool using_mass_fractions() {
+    bool using_mass_fractions() override {
         return true;
     };  // But actually it doesn't matter since it is only a pure fluid
-    bool using_volu_fractions() {
+    bool using_volu_fractions() override {
         return false;
     };
-    void set_mole_fractions(const std::vector<CoolPropDbl>& mole_fractions) {
+    void set_mole_fractions(const std::vector<CoolPropDbl>& mole_fractions) override {
         throw NotImplementedError("Mole composition has not been implemented.");
     };
-    void set_mass_fractions(const std::vector<CoolPropDbl>& mass_fractions) {};  // Not implemented, but don't throw any errors
-    void set_volu_fractions(const std::vector<CoolPropDbl>& volu_fractions) {
+    void set_mass_fractions(const std::vector<CoolPropDbl>& mass_fractions) override {};  // Not implemented, but don't throw any errors
+    void set_volu_fractions(const std::vector<CoolPropDbl>& volu_fractions) override {
         throw NotImplementedError("Volume composition has not been implemented.");
     };
-    const std::vector<CoolPropDbl>& get_mole_fractions() {
+    const std::vector<CoolPropDbl>& get_mole_fractions() override {
         throw NotImplementedError("get_mole_fractions composition has not been implemented.");
     };
 
     /// Override clear() function of IF97 Water
-    bool clear() {
+    bool clear() override {
         // Reset the full CachedElement registry so every cached value
         // (speed_sound, cpmass, cvmass, umass, ...) gets invalidated
         // alongside the IF97-specific fields the override knows about.
@@ -164,7 +164,7 @@ class IF97Backend : public AbstractState
     @param value1 First input value
     @param value2 Second input value
     */
-    void update(CoolProp::input_pairs input_pair, double value1, double value2) {
+    void update(CoolProp::input_pairs input_pair, double value1, double value2) override {
 
         double H, S, hLmass, hVmass, sLmass, sVmass;
 
@@ -450,14 +450,14 @@ class IF97Backend : public AbstractState
     double rhomass() {
         return calc_rhomass();
     };
-    double calc_rhomass() {
+    double calc_rhomass() override {
         return calc_Flash(iDmass);
     };
     /// Return the molar density in mol/m³
     double rhomolar() {
         return calc_rhomolar();
     };
-    double calc_rhomolar() {
+    double calc_rhomolar() override {
         return rhomass() / molar_mass();
     };  /// kg/m³ * mol/kg = mol/m³
 
@@ -465,7 +465,7 @@ class IF97Backend : public AbstractState
     double hmass() {
         return calc_hmass();
     };
-    double calc_hmass() {
+    double calc_hmass() override {
         if (_reverse && _smass)
             return IF97::hmass_psmass(_p, _smass);  // Special IF97 function for handling reverse h(p,s) evaluation
         else
@@ -475,7 +475,7 @@ class IF97Backend : public AbstractState
     double hmolar() {
         return calc_hmolar();
     };
-    double calc_hmolar() {
+    double calc_hmolar() override {
         return hmass() * molar_mass();
     };  /// J/kg * kg/mol = J/mol
 
@@ -483,7 +483,7 @@ class IF97Backend : public AbstractState
     double smass() {
         return calc_smass();
     };
-    double calc_smass() {
+    double calc_smass() override {
         if (_reverse && _hmass)
             return IF97::smass_phmass(_p, _hmass);  // Special IF97 function for handling reverse s(p,h) evaluation
         else
@@ -493,7 +493,7 @@ class IF97Backend : public AbstractState
     double smolar() {
         return calc_smolar();
     };
-    double calc_smolar() {
+    double calc_smolar() override {
         return smass() * molar_mass();
     };  /// J/kg-K * kg/mol = J/mol-K
 
@@ -501,14 +501,14 @@ class IF97Backend : public AbstractState
     double umass() {
         return calc_umass();
     };
-    double calc_umass() {
+    double calc_umass() override {
         return calc_Flash(iUmass);
     };
     /// Return the molar internal energy in J/mol
     double umolar() {
         return calc_umolar();
     };
-    double calc_umolar() {
+    double calc_umolar() override {
         return umass() * molar_mass();
     };  /// J/kg * kg/mol = J/mol
 
@@ -516,14 +516,14 @@ class IF97Backend : public AbstractState
     double cpmass() {
         return calc_cpmass();
     };
-    double calc_cpmass() {
+    double calc_cpmass() override {
         return calc_Flash(iCpmass);
     };
     /// Return the molar-based constant pressure specific heat in J/mol/K
     double cpmolar() {
         return calc_cpmolar();
     };
-    double calc_cpmolar() {
+    double calc_cpmolar() override {
         return cpmass() * molar_mass();
     };  /// J/kg-K * kg/mol = J/mol-K
 
@@ -531,14 +531,14 @@ class IF97Backend : public AbstractState
     double cvmass() {
         return calc_cvmass();
     };
-    double calc_cvmass() {
+    double calc_cvmass() override {
         return calc_Flash(iCvmass);
     };
     /// Return the molar-based constant volume specific heat in J/mol/K
     double cvmolar() {
         return calc_cvmolar();
     };
-    double calc_cvmolar() {
+    double calc_cvmolar() override {
         return cvmass() * molar_mass();
     };  /// J/kg-K * kg/mol = J/mol-K
 
@@ -546,12 +546,12 @@ class IF97Backend : public AbstractState
     double speed_sound() {
         return calc_speed_sound();
     };
-    double calc_speed_sound() {
+    double calc_speed_sound() override {
         return calc_Flash(ispeed_sound);
     };
 
     // Return the phase
-    phases calc_phase() {
+    phases calc_phase() override {
         return _phase;
     };
 
@@ -560,10 +560,10 @@ class IF97Backend : public AbstractState
     // specify_phase() to disambiguate (p, T) inputs that land within
     // IF97's 3.3e-5 ε-band of the saturation curve.  The hint is read
     // by update(PT_INPUTS) above.
-    void calc_specify_phase(phases phase) {
+    void calc_specify_phase(phases phase) override {
         imposed_phase_index = phase;
     }
-    void calc_unspecify_phase() {
+    void calc_unspecify_phase() override {
         imposed_phase_index = iphase_not_imposed;
     }
 
@@ -573,47 +573,47 @@ class IF97Backend : public AbstractState
     // ************************************************************************* //
     //
     /// Using this backend, get the triple point temperature in K
-    double calc_Ttriple() {
+    double calc_Ttriple() override {
         return IF97::get_Ttrip();
     };
     /// Using this backend, get the triple point pressure in Pa
-    double calc_p_triple() {
+    double calc_p_triple() override {
         return IF97::get_ptrip();
     };
     /// Using this backend, get the critical point temperature in K
-    double calc_T_critical() {
+    double calc_T_critical() override {
         return IF97::get_Tcrit();
     };
     /// Using this backend, get the critical point pressure in Pa
-    double calc_p_critical() {
+    double calc_p_critical() override {
         return IF97::get_pcrit();
     };
     /// Using this backend, get the ideal gas constant in J/mol*K
     /// ==> multiplies IF97 Rgas by molar_mass() to put on molar basis per CoolProp convention
-    double calc_gas_constant() {
+    double calc_gas_constant() override {
         return IF97::get_Rgas() * molar_mass();
     };
     /// Using this backend, get the molar mass in kg/mol
-    double calc_molar_mass() {
+    double calc_molar_mass() override {
         return IF97::get_MW();
     };
     /// Using this backend, get the acentric factor (unitless)
-    double calc_acentric_factor() {
+    double calc_acentric_factor() override {
         return IF97::get_Acentric();
     };
     /// Using this backend, get the high pressure limit in Pa
     // TODO: May want to adjust this based on _T, since Region 5
     //       is limited to 50 MPa, instead of 100 MPa elsewhere.
-    double calc_pmax() {
+    double calc_pmax() override {
         return IF97::get_Pmax();
     };
     /// Note: Pmin not implemented in Abstract State or CoolProp
     /// Using this backend, get the high temperature limit in K
-    double calc_Tmax() {
+    double calc_Tmax() override {
         return IF97::get_Tmax();
     };
     /// Using this backend, get the high pressure limit in K
-    double calc_Tmin() {
+    double calc_Tmin() override {
         return IF97::get_Tmin();
     };
     /// Using this backend, get the critical point density in kg/m³
@@ -625,10 +625,10 @@ class IF97Backend : public AbstractState
         return calc_rhomass_critical();
     }
     // Overwrite the virtual calc_ functions for density
-    double calc_rhomolar_critical() {
+    double calc_rhomolar_critical() override {
         return rhomass_critical() / molar_mass();
     };
-    double calc_rhomass_critical() {
+    double calc_rhomass_critical() override {
         return IF97::get_rhocrit();
     };
     //
@@ -636,7 +636,7 @@ class IF97Backend : public AbstractState
     //                      Saturation Functions                                 //
     // ************************************************************************* //
     //
-    double calc_pressure() {
+    double calc_pressure() override {
         return _p;
     };
     //
@@ -648,21 +648,21 @@ class IF97Backend : public AbstractState
     double viscosity() {
         return calc_viscosity();
     };
-    double calc_viscosity() {
+    double calc_viscosity() override {
         return calc_Flash(iviscosity);
     };
     // Return thermal conductivity in [W/m-K]
     double conductivity() {
         return calc_conductivity();
     };
-    double calc_conductivity() {
+    double calc_conductivity() override {
         return calc_Flash(iconductivity);
     };
     // Return surface tension in [N/m]
     double surface_tension() {
         return calc_surface_tension();
     };
-    double calc_surface_tension() {
+    double calc_surface_tension() override {
         return calc_Flash(isurface_tension);
     };
     // Return Prandtl number (mu*Cp/k) [dimensionless]

--- a/src/Backends/Incompressible/IncompressibleBackend.cpp
+++ b/src/Backends/Incompressible/IncompressibleBackend.cpp
@@ -406,7 +406,7 @@ CoolPropDbl IncompressibleBackend::HmassP_flash(CoolPropDbl hmass, CoolPropDbl p
        public:
         HmassP_residual(IncompressibleBackend* backend, const double& p, const double& x, const double& h_in)
           : p(p), x(x), h_in(h_in), backend(backend) {}
-        double call(double target) {
+        double call(double target) override {
             return backend->raw_calc_hmass(target, p, x) - h_in;  //fluid.u(target,p,x)+ p / fluid.rho(target,p,x) - h_in;
         }
         //double deriv(double target);
@@ -438,7 +438,7 @@ CoolPropDbl IncompressibleBackend::PSmass_flash(CoolPropDbl p, CoolPropDbl smass
        public:
         PSmass_residual(IncompressibleBackend* backend, const double& p, const double& x, const double& s_in)
           : p(p), x(x), s_in(s_in), backend(backend) {}
-        double call(double target) {
+        double call(double target) override {
             return backend->raw_calc_smass(target, p, x) - s_in;
         }
     };

--- a/src/Backends/Incompressible/IncompressibleBackend.h
+++ b/src/Backends/Incompressible/IncompressibleBackend.h
@@ -38,7 +38,7 @@ class IncompressibleBackend : public AbstractState
    public:
     IncompressibleBackend();
     virtual ~IncompressibleBackend() {};
-    std::string backend_name() {
+    std::string backend_name() override {
         return get_backend_string(INCOMP_BACKEND);
     }
 
@@ -53,13 +53,13 @@ class IncompressibleBackend : public AbstractState
     IncompressibleBackend(const std::vector<std::string>& component_names);
 
     // Incompressible backend uses different compositions
-    bool using_mole_fractions() {
+    bool using_mole_fractions() override {
         return this->fluid->getxid() == IFRAC_MOLE;
     };
-    bool using_mass_fractions() {
+    bool using_mass_fractions() override {
         return (this->fluid->getxid() == IFRAC_MASS || this->fluid->getxid() == IFRAC_PURE);
     };
-    bool using_volu_fractions() {
+    bool using_volu_fractions() override {
         return this->fluid->getxid() == IFRAC_VOLUME;
     };
 
@@ -72,9 +72,9 @@ class IncompressibleBackend : public AbstractState
     @param value1 First input value
     @param value2 Second input value
     */
-    void update(CoolProp::input_pairs input_pair, double value1, double value2);
+    void update(CoolProp::input_pairs input_pair, double value1, double value2) override;
 
-    std::string fluid_param_string(const std::string& ParamName) {
+    std::string fluid_param_string(const std::string& ParamName) override {
         if (!ParamName.compare("long_name")) {
             return calc_name();
         } else {
@@ -83,7 +83,7 @@ class IncompressibleBackend : public AbstractState
     }
 
     /// Clear all the cached values
-    bool clear();
+    bool clear() override;
 
     /// Update the reference values and clear the state
     void set_reference_state(double T0 = 20 + 273.15, double p0 = 101325, double x0 = 0.0, double h0 = 0.0, double s0 = 0.0);
@@ -92,8 +92,8 @@ class IncompressibleBackend : public AbstractState
     /**
     @param mole_fractions The vector of mole fractions of the components
     */
-    void set_mole_fractions(const std::vector<CoolPropDbl>& mole_fractions);
-    const std::vector<CoolPropDbl>& get_mole_fractions() {
+    void set_mole_fractions(const std::vector<CoolPropDbl>& mole_fractions) override;
+    const std::vector<CoolPropDbl>& get_mole_fractions() override {
         throw NotImplementedError("get_mole_fractions not implemented for this backend");
     };
 
@@ -101,13 +101,13 @@ class IncompressibleBackend : public AbstractState
     /**
     @param mass_fractions The vector of mass fractions of the components
     */
-    void set_mass_fractions(const std::vector<CoolPropDbl>& mass_fractions);
+    void set_mass_fractions(const std::vector<CoolPropDbl>& mass_fractions) override;
 
     /// Set the volume fractions
     /**
     @param volu_fractions The vector of volume fractions of the components
     */
-    void set_volu_fractions(const std::vector<CoolPropDbl>& volu_fractions);
+    void set_volu_fractions(const std::vector<CoolPropDbl>& volu_fractions) override;
 
     /// Check if the mole fractions have been set, etc.
     void check_status();
@@ -208,35 +208,35 @@ class IncompressibleBackend : public AbstractState
     }
 
     /// We start with the functions that do not need a reference state
-    CoolPropDbl calc_rhomass() {
+    CoolPropDbl calc_rhomass() override {
         return fluid->rho(_T, _p, _fractions[0]);
     };
     CoolPropDbl calc_cmass() {
         return fluid->c(_T, _p, _fractions[0]);
     };
-    CoolPropDbl calc_cpmass() {
+    CoolPropDbl calc_cpmass() override {
         return cmass();
     };
-    CoolPropDbl calc_cvmass() {
+    CoolPropDbl calc_cvmass() override {
         return cmass();
     };
-    CoolPropDbl calc_viscosity() {
+    CoolPropDbl calc_viscosity() override {
         return fluid->visc(_T, _p, _fractions[0]);
     };
-    CoolPropDbl calc_conductivity() {
+    CoolPropDbl calc_conductivity() override {
         return fluid->cond(_T, _p, _fractions[0]);
     };
-    CoolPropDbl calc_T_freeze() {
+    CoolPropDbl calc_T_freeze() override {
         // No update is called - T_freeze is a trivial output
         fluid->checkX(_fractions[0]);
         return fluid->Tfreeze(_p, _fractions[0]);
     };
-    CoolPropDbl calc_melting_line(int param, int given, CoolPropDbl value);
-    CoolPropDbl calc_umass();
+    CoolPropDbl calc_melting_line(int param, int given, CoolPropDbl value) override;
+    CoolPropDbl calc_umass() override;
 
     /// ... and continue with the ones that depend on reference conditions.
-    CoolPropDbl calc_hmass();
-    CoolPropDbl calc_smass();
+    CoolPropDbl calc_hmass() override;
+    CoolPropDbl calc_smass() override;
 
    public:
     /// Functions that can be used with the solver, they miss the reference values!
@@ -245,7 +245,7 @@ class IncompressibleBackend : public AbstractState
 
    protected:
     /// Calculate the first partial derivative for the desired derivative
-    CoolPropDbl calc_first_partial_deriv(parameters Of, parameters Wrt, parameters Constant);
+    CoolPropDbl calc_first_partial_deriv(parameters Of, parameters Wrt, parameters Constant) override;
 
     /* Below are direct calculations of the derivatives. Nothing
 	 * special is going on, we simply use the polynomial class to
@@ -287,22 +287,22 @@ class IncompressibleBackend : public AbstractState
 
    public:
     /// Constants from the fluid object
-    CoolPropDbl calc_Tmax() {
+    CoolPropDbl calc_Tmax() override {
         return fluid->getTmax();
     };
-    CoolPropDbl calc_Tmin() {
+    CoolPropDbl calc_Tmin() override {
         return fluid->getTmin();
     };
-    CoolPropDbl calc_fraction_min() {
+    CoolPropDbl calc_fraction_min() override {
         return fluid->getxmin();
     };
-    CoolPropDbl calc_fraction_max() {
+    CoolPropDbl calc_fraction_max() override {
         return fluid->getxmax();
     };
-    std::string calc_name() {
+    std::string calc_name() override {
         return fluid->getName();
     };
-    std::string calc_description() {
+    std::string calc_description() override {
         return fluid->getDescription();
     };
 };

--- a/src/Backends/PCSAFT/PCSAFTBackend.cpp
+++ b/src/Backends/PCSAFT/PCSAFTBackend.cpp
@@ -2090,7 +2090,7 @@ double PCSAFTBackend::outerPQ(double t_guess, PCSAFTBackend& PCSAFT) {
         vector<CoolPropDbl> u;
 
         SolverInnerResid(PCSAFTBackend& PCSAFT, CoolPropDbl kb0, vector<CoolPropDbl> u) : PCSAFT(PCSAFT), kb0(kb0), u(u) {}
-        CoolPropDbl call(CoolPropDbl R) {
+        CoolPropDbl call(CoolPropDbl R) override {
             auto ncomp = PCSAFT.components.size();
             double error = 0;
 
@@ -2351,7 +2351,7 @@ double PCSAFTBackend::outerTQ(double p_guess, PCSAFTBackend& PCSAFT) {
         vector<CoolPropDbl> u;
 
         SolverInnerResid(PCSAFTBackend& PCSAFT, CoolPropDbl kb0, vector<CoolPropDbl> u) : PCSAFT(PCSAFT), kb0(kb0), u(u) {}
-        CoolPropDbl call(CoolPropDbl R) {
+        CoolPropDbl call(CoolPropDbl R) override {
             auto ncomp = PCSAFT.components.size();
             double error = 0;
 
@@ -2749,7 +2749,7 @@ CoolPropDbl PCSAFTBackend::solver_rho_Tp(CoolPropDbl T, CoolPropDbl p, phases ph
         CoolPropDbl T, p;
 
         SolverRhoResid(PCSAFTBackend& PCSAFT, CoolPropDbl T, CoolPropDbl p) : PCSAFT(PCSAFT), T(T), p(p) {}
-        CoolPropDbl call(CoolPropDbl rhomolar) {
+        CoolPropDbl call(CoolPropDbl rhomolar) override {
             CoolPropDbl peos = PCSAFT.update_DmolarT(rhomolar);
             double cost = (peos - p) / p;
             if (ValidNumber(cost)) {

--- a/src/Backends/PCSAFT/PCSAFTBackend.h
+++ b/src/Backends/PCSAFT/PCSAFTBackend.h
@@ -71,34 +71,34 @@ class PCSAFTBackend : public AbstractState
     virtual PCSAFTBackend* get_copy(bool generate_SatL_and_SatV = true);
 
     /// The name of the backend being used
-    std::string backend_name() {
+    std::string backend_name() override {
         return get_backend_string(PCSAFT_BACKEND);
     }
 
-    bool using_mole_fractions() {
+    bool using_mole_fractions() override {
         return true;
     };
-    bool using_mass_fractions() {
+    bool using_mass_fractions() override {
         return false;
     };
-    bool using_volu_fractions() {
+    bool using_volu_fractions() override {
         return false;
     };
 
-    void set_mass_fractions(const std::vector<CoolPropDbl>& mass_fractions);
-    void set_volu_fractions(const std::vector<CoolPropDbl>& volu_fractions) {
+    void set_mass_fractions(const std::vector<CoolPropDbl>& mass_fractions) override;
+    void set_volu_fractions(const std::vector<CoolPropDbl>& volu_fractions) override {
         throw NotImplementedError("Volume composition has not been implemented.");
     };
-    void set_mole_fractions(const std::vector<CoolPropDbl>& mole_fractions);
-    const std::vector<CoolPropDbl>& get_mole_fractions() {
+    void set_mole_fractions(const std::vector<CoolPropDbl>& mole_fractions) override;
+    const std::vector<CoolPropDbl>& get_mole_fractions() override {
         return this->mole_fractions;
     };
 
     void resize(std::size_t N);
 
-    virtual void update(CoolProp::input_pairs input_pair, double value1, double value2);  // %%checked
+    void update(CoolProp::input_pairs input_pair, double value1, double value2) override;  // %%checked
 
-    const double get_fluid_constant(std::size_t i, parameters param) const {
+    const double get_fluid_constant(std::size_t i, parameters param) const override {
         // const PCSAFTFluid &fld = components[i];
         // switch(param){
         //     case im: return fld.m;
@@ -121,39 +121,39 @@ class PCSAFTBackend : public AbstractState
     // ************************************************************************* //
     //
     /// Calculate the pressure
-    CoolPropDbl calc_pressure();
+    CoolPropDbl calc_pressure() override;
 
     /// Update the state for DT inputs if phase is imposed. Otherwise delegate to base class
     CoolPropDbl update_DmolarT(CoolPropDbl rho);
 
     // CoolPropDbl calc_alpha0(); // ideal gas helmholtz energy term
-    CoolPropDbl calc_alphar();  // residual helmholtz energy
+    CoolPropDbl calc_alphar() override;  // residual helmholtz energy
     CoolPropDbl calc_dadt();    // derivative of the residual helmholtz energy with respect to temperature
-    CoolPropDbl calc_hmolar_residual();
-    CoolPropDbl calc_smolar_residual();
-    vector<CoolPropDbl> calc_fugacity_coefficients();
-    CoolPropDbl calc_gibbsmolar_residual();
+    CoolPropDbl calc_hmolar_residual() override;
+    CoolPropDbl calc_smolar_residual() override;
+    vector<CoolPropDbl> calc_fugacity_coefficients() override;
+    CoolPropDbl calc_gibbsmolar_residual() override;
     // CoolPropDbl calc_cpmolar(); // TODO implement these heat capacity functions
     // CoolPropDbl calc_cp0molar();
-    CoolPropDbl calc_compressibility_factor();
+    CoolPropDbl calc_compressibility_factor() override;
 
     void flash_QT(PCSAFTBackend& PCSAFT);
     void flash_PQ(PCSAFTBackend& PCSAFT);
 
-    phases calc_phase() {
+    phases calc_phase() override {
         return _phase;
     };
     /** \brief Specify the phase - this phase will always be used in calculations
      *
      * @param phase_index The index from CoolProp::phases
      */
-    void calc_specify_phase(phases phase_index) {
+    void calc_specify_phase(phases phase_index) override {
         imposed_phase_index = phase_index;
         _phase = phase_index;
     }
     /**\brief Unspecify the phase - the phase is no longer imposed, different solvers can do as they like
      */
-    void calc_unspecify_phase() {
+    void calc_unspecify_phase() override {
         imposed_phase_index = iphase_not_imposed;
     }
     //
@@ -161,7 +161,7 @@ class PCSAFTBackend : public AbstractState
     //                         Trivial Functions                                 //
     // ************************************************************************* //
     //
-    double calc_molar_mass();
+    double calc_molar_mass() override;
     PhaseMolarMasses calc_phase_molar_masses() override;
     //
 };

--- a/src/Backends/REFPROP/REFPROPBackend.h
+++ b/src/Backends/REFPROP/REFPROPBackend.h
@@ -23,7 +23,7 @@ class REFPROPBackend : public REFPROPMixtureBackend
    public:
     REFPROPBackend();
     REFPROPBackend(const std::string& fluid_name);
-    std::string backend_name() {
+    std::string backend_name() override {
         return get_backend_string(REFPROP_BACKEND_PURE);
     }
 

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -178,7 +178,7 @@ namespace CoolProp {
 class REFPROPGenerator : public AbstractStateGenerator
 {
    public:
-    AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) {
+    AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) override {
         REFPROPMixtureBackend::REFPROP_supported();
         if (fluid_names.size() == 1) {
             return new REFPROPBackend(fluid_names[0]);
@@ -2223,7 +2223,7 @@ void REFPROPMixtureBackend::calc_true_critical_point(double& T, double& rho) {
        public:
         const std::vector<double> z;
         wrapper(const std::vector<double>& z) : z(z) {};
-        std::vector<double> call(const std::vector<double>& x) {
+        std::vector<double> call(const std::vector<double>& x) override {
             std::vector<double> r(2);
             double dpdrho__constT = _HUGE, d2pdrho2__constT = _HUGE;
             DPDDdll(const_cast<double*>(&(x[0])), const_cast<double*>(&(x[1])), const_cast<double*>(&(z[0])), &dpdrho__constT);

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.h
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.h
@@ -63,54 +63,56 @@ class REFPROPMixtureBackend : public AbstractState
     /// A function to actually do the initialization to allow it to be called in derived classes
     void construct(const std::vector<std::string>& fluid_names);
 
-    std::string backend_name() {
+    std::string backend_name() override {
         return get_backend_string(REFPROP_BACKEND_MIX);
     }
     virtual ~REFPROPMixtureBackend();
 
     static std::string version();
 
-    std::vector<std::string> calc_fluid_names() {
+    std::vector<std::string> calc_fluid_names() override {
         return fluid_names;
     };
     PhaseEnvelopeData PhaseEnvelope;
 
     /// Set binary mixture floating point parameter
-    void set_binary_interaction_double(const std::string& CAS1, const std::string& CAS2, const std::string& parameter, const double value);
+    void set_binary_interaction_double(const std::string& CAS1, const std::string& CAS2, const std::string& parameter,
+                                       const double value) override;
     /// Get binary mixture double value
-    double get_binary_interaction_double(const std::string& CAS1, const std::string& CAS2, const std::string& parameter);
+    double get_binary_interaction_double(const std::string& CAS1, const std::string& CAS2, const std::string& parameter) override;
 
     /// Get binary mixture string value
-    std::string get_binary_interaction_string(const std::string& CAS1, const std::string& CAS2, const std::string& parameter);
+    std::string get_binary_interaction_string(const std::string& CAS1, const std::string& CAS2, const std::string& parameter) override;
     /// Set binary mixture string value
-    void set_binary_interaction_string(const std::size_t i, const std::size_t j, const std::string& parameter, const std::string& value);
+    void set_binary_interaction_string(const std::size_t i, const std::size_t j, const std::string& parameter,
+                                       const std::string& value) override;
 
     /// Set binary mixture string parameter (EXPERT USE ONLY!!!)
-    void set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter, const double value);
+    void set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter, const double value) override;
     /// Get binary mixture double value (EXPERT USE ONLY!!!)
-    double get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter);
+    double get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter) override;
 
     /// Find the index (1-based for FORTRAN) of the fluid with the given CAS number
     int match_CAS(const std::string& CAS);
 
     // REFPROP backend uses mole fractions
-    bool using_mole_fractions() {
+    bool using_mole_fractions() override {
         return true;
     }
-    bool using_mass_fractions() {
+    bool using_mass_fractions() override {
         return false;
     }
-    bool using_volu_fractions() {
+    bool using_volu_fractions() override {
         return false;
     }
 
     /// Calculate the name of the fluid
-    std::string calc_name() {
+    std::string calc_name() override {
         return fluid_param_string("name");
     }
 
     // Get _phase for pure fluids only
-    phases calc_phase() {
+    phases calc_phase() override {
         if (this->Ncomp > 1) {
             throw NotImplementedError("The REFPROP backend does not implement calc_phase function for mixtures.");
         } else {
@@ -125,13 +127,13 @@ class REFPROPMixtureBackend : public AbstractState
      *
      * @param phase_index The index from CoolProp::phases
      */
-    void calc_specify_phase(phases phase_index) {
+    void calc_specify_phase(phases phase_index) override {
         imposed_phase_index = phase_index;
         _phase = phase_index;
     }
     /**\brief Unspecify the phase - the phase is no longer imposed, different solvers can do as they like
      */
-    void calc_unspecify_phase() {
+    void calc_unspecify_phase() override {
         imposed_phase_index = iphase_not_imposed;
     }
 
@@ -146,31 +148,31 @@ class REFPROPMixtureBackend : public AbstractState
     @param value1 First input value
     @param value2 Second input value
     */
-    void update(CoolProp::input_pairs, double value1, double value2);
+    void update(CoolProp::input_pairs, double value1, double value2) override;
 
     void update_Qmass_pair(CoolProp::input_pairs pair, double v1, double v2) override;
 
     /**
      * @brief Update the state, while providing guess values
      */
-    void update_with_guesses(CoolProp::input_pairs, double value1, double value2, const GuessesStructure& guesses);
+    void update_with_guesses(CoolProp::input_pairs, double value1, double value2, const GuessesStructure& guesses) override;
 
-    CoolPropDbl calc_molar_mass();
+    CoolPropDbl calc_molar_mass() override;
 
     PhaseMolarMasses calc_phase_molar_masses() override;
 
     void check_loaded_fluid();
 
-    void calc_excess_properties();
+    void calc_excess_properties() override;
 
     /// Returns true if REFPROP is supported on this platform
     static bool REFPROP_supported();
 
-    std::string fluid_param_string(const std::string& ParamName);
+    std::string fluid_param_string(const std::string& ParamName) override;
 
-    CoolPropDbl calc_PIP();
+    CoolPropDbl calc_PIP() override;
 
-    CoolPropDbl calc_cpmolar_idealgas();
+    CoolPropDbl calc_cpmolar_idealgas() override;
 
     /// Set the fluids in REFPROP DLL by calling the SETUPdll function
     /**
@@ -182,34 +184,34 @@ class REFPROPMixtureBackend : public AbstractState
     /**
     @param mole_fractions The vector of mole fractions of the components
     */
-    void set_mole_fractions(const std::vector<CoolPropDbl>& mole_fractions);
+    void set_mole_fractions(const std::vector<CoolPropDbl>& mole_fractions) override;
 
     /// Set the mass fractions
     /**
     @param mass_fractions The vector of mass fractions of the components
     */
-    void set_mass_fractions(const std::vector<CoolPropDbl>& mass_fractions);
+    void set_mass_fractions(const std::vector<CoolPropDbl>& mass_fractions) override;
 
-    const std::vector<CoolPropDbl>& get_mole_fractions() {
+    const std::vector<CoolPropDbl>& get_mole_fractions() override {
         return mole_fractions_long_double;
     };
 
-    const std::vector<CoolPropDbl> calc_mass_fractions();
+    const std::vector<CoolPropDbl> calc_mass_fractions() override;
 
-    void calc_phase_envelope(const std::string& type);
+    void calc_phase_envelope(const std::string& type) override;
 
-    CoolPropDbl calc_compressibility_factor() {
+    CoolPropDbl calc_compressibility_factor() override {
         return _p / (_rhomolar * gas_constant() * _T);
     };
 
-    const CoolProp::PhaseEnvelopeData& calc_phase_envelope_data() {
+    const CoolProp::PhaseEnvelopeData& calc_phase_envelope_data() override {
         return PhaseEnvelope;
     };
 
-    std::vector<CoolPropDbl> calc_mole_fractions_liquid() {
+    std::vector<CoolPropDbl> calc_mole_fractions_liquid() override {
         return std::vector<CoolPropDbl>(mole_fractions_liq.begin(), mole_fractions_liq.begin() + this->Ncomp);
     }
-    std::vector<CoolPropDbl> calc_mole_fractions_vapor() {
+    std::vector<CoolPropDbl> calc_mole_fractions_vapor() override {
         return std::vector<CoolPropDbl>(mole_fractions_vap.begin(), mole_fractions_vap.begin() + this->Ncomp);
     }
 
@@ -217,135 +219,135 @@ class REFPROPMixtureBackend : public AbstractState
     void check_status();
 
     /// Get the viscosity [Pa-s] (based on the temperature and density in the state class)
-    CoolPropDbl calc_viscosity();
+    CoolPropDbl calc_viscosity() override;
     /// Get the thermal conductivity [W/m/K] (based on the temperature and density in the state class)
-    CoolPropDbl calc_conductivity();
+    CoolPropDbl calc_conductivity() override;
     /// Get the surface tension [N/m] (based on the temperature in the state class).  Invalid for temperatures above critical point or below triple point temperature
-    CoolPropDbl calc_surface_tension();
+    CoolPropDbl calc_surface_tension() override;
     /// Calc the B virial coefficient
-    CoolPropDbl calc_Bvirial();
+    CoolPropDbl calc_Bvirial() override;
     /// Calc the temperature derivative of the second virial coefficient
-    CoolPropDbl calc_dBvirial_dT();
+    CoolPropDbl calc_dBvirial_dT() override;
     /// Calc the C virial coefficient
-    CoolPropDbl calc_Cvirial();
+    CoolPropDbl calc_Cvirial() override;
 
-    CoolPropDbl calc_fugacity_coefficient(std::size_t i);
-    CoolPropDbl calc_fugacity(std::size_t i);
-    CoolPropDbl calc_chemical_potential(std::size_t i);
-    CoolPropDbl calc_melting_line(int param, int given, CoolPropDbl value);
-    bool has_melting_line();
+    CoolPropDbl calc_fugacity_coefficient(std::size_t i) override;
+    CoolPropDbl calc_fugacity(std::size_t i) override;
+    CoolPropDbl calc_chemical_potential(std::size_t i) override;
+    CoolPropDbl calc_melting_line(int param, int given, CoolPropDbl value) override;
+    bool has_melting_line() override;
     double calc_melt_Tmax();
-    CoolPropDbl calc_T_critical();
-    CoolPropDbl calc_T_reducing();
-    void calc_reducing_state();
-    CoolPropDbl calc_p_critical();
-    CoolPropDbl calc_p_triple();
+    CoolPropDbl calc_T_critical() override;
+    CoolPropDbl calc_T_reducing() override;
+    void calc_reducing_state() override;
+    CoolPropDbl calc_p_critical() override;
+    CoolPropDbl calc_p_triple() override;
     CoolPropDbl calc_p_min() {
         return calc_p_triple();
     };
-    CoolPropDbl calc_rhomolar_critical();
-    CoolPropDbl calc_rhomolar_reducing();
-    CoolPropDbl calc_Ttriple();
-    CoolPropDbl calc_acentric_factor();
-    CoolPropDbl calc_gas_constant();
-    CoolPropDbl calc_dipole_moment();
+    CoolPropDbl calc_rhomolar_critical() override;
+    CoolPropDbl calc_rhomolar_reducing() override;
+    CoolPropDbl calc_Ttriple() override;
+    CoolPropDbl calc_acentric_factor() override;
+    CoolPropDbl calc_gas_constant() override;
+    CoolPropDbl calc_dipole_moment() override;
 
     /// Calculate the "true" critical point where dp/drho|T and d2p/drho2|T are zero
-    void calc_true_critical_point(double& T, double& rho);
+    void calc_true_critical_point(double& T, double& rho) override;
 
     /// Calculate the saturation properties
-    CoolPropDbl calc_saturated_liquid_keyed_output(parameters key);
-    CoolPropDbl calc_saturated_vapor_keyed_output(parameters key);
+    CoolPropDbl calc_saturated_liquid_keyed_output(parameters key) override;
+    CoolPropDbl calc_saturated_vapor_keyed_output(parameters key) override;
 
     /// Calculate an ideal curve
-    void calc_ideal_curve(const std::string& type, std::vector<double>& T, std::vector<double>& p);
+    void calc_ideal_curve(const std::string& type, std::vector<double>& T, std::vector<double>& p) override;
 
     /// A wrapper function to calculate the limits for the EOS
     void limits(double& Tmin, double& Tmax, double& rhomolarmax, double& pmax);
     /// Calculate the maximum pressure
-    CoolPropDbl calc_pmax();
+    CoolPropDbl calc_pmax() override;
     /// Calculate the maximum temperature
-    CoolPropDbl calc_Tmax();
+    CoolPropDbl calc_Tmax() override;
     /// Calculate the minimum temperature
-    CoolPropDbl calc_Tmin();
+    CoolPropDbl calc_Tmin() override;
 
     /// Call into the THERM0dll method and return outputs as a struct. REFPROP must already be setup
     THERM0dllOutputs call_THERM0dll(double T, double rho_mol_dm3, const std::vector<double>& mole_fractions);
 
     /// Calculate the residual entropy in J/mol/K (should be a uniquely negative quantity)
-    CoolPropDbl calc_smolar_residual() {
+    CoolPropDbl calc_smolar_residual() override {
         return (tau() * calc_dalphar_dTau() - calc_alphar()) * gas_constant();
     }
 
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r\f$ (dimensionless)
-    CoolPropDbl calc_alphar() {
+    CoolPropDbl calc_alphar() override {
         return call_phixdll(0, 0);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta}\f$ (dimensionless)
-    CoolPropDbl calc_dalphar_dDelta() {
+    CoolPropDbl calc_dalphar_dDelta() override {
         return call_phixdll(0, 1);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau}\f$ (dimensionless)
-    CoolPropDbl calc_dalphar_dTau() {
+    CoolPropDbl calc_dalphar_dTau() override {
         return call_phixdll(1, 0);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta}\f$ (dimensionless)
-    CoolPropDbl calc_d2alphar_dDelta2() {
+    CoolPropDbl calc_d2alphar_dDelta2() override {
         return call_phixdll(0, 2);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d2alphar_dDelta_dTau() {
+    CoolPropDbl calc_d2alphar_dDelta_dTau() override {
         return call_phixdll(1, 1);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d2alphar_dTau2() {
+    CoolPropDbl calc_d2alphar_dTau2() override {
         return call_phixdll(2, 0);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\delta}\f$ (dimensionless)
-    CoolPropDbl calc_d3alphar_dDelta3() {
+    CoolPropDbl calc_d3alphar_dDelta3() override {
         return call_phixdll(0, 3);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\delta\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d3alphar_dDelta2_dTau() {
+    CoolPropDbl calc_d3alphar_dDelta2_dTau() override {
         return call_phixdll(1, 2);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\delta\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d3alphar_dDelta_dTau2() {
+    CoolPropDbl calc_d3alphar_dDelta_dTau2() override {
         return call_phixdll(2, 1);
     };
     /// Using this backend, calculate the residual Helmholtz energy term \f$\alpha^r_{\tau\tau\tau}\f$ (dimensionless)
-    CoolPropDbl calc_d3alphar_dTau3() {
+    CoolPropDbl calc_d3alphar_dTau3() override {
         return call_phixdll(3, 0);
     };
 
-    CoolPropDbl calc_alpha0() {
+    CoolPropDbl calc_alpha0() override {
         return call_phi0dll(0, 0);
     };
-    CoolPropDbl calc_dalpha0_dDelta() {
+    CoolPropDbl calc_dalpha0_dDelta() override {
         return call_phi0dll(0, 1);
     };
-    CoolPropDbl calc_dalpha0_dTau() {
+    CoolPropDbl calc_dalpha0_dTau() override {
         return call_phi0dll(1, 0);
     };
-    CoolPropDbl calc_d2alpha0_dDelta2() {
+    CoolPropDbl calc_d2alpha0_dDelta2() override {
         return call_phi0dll(0, 2);
     };
-    CoolPropDbl calc_d2alpha0_dDelta_dTau() {
+    CoolPropDbl calc_d2alpha0_dDelta_dTau() override {
         return call_phi0dll(1, 1);
     };
-    CoolPropDbl calc_d2alpha0_dTau2() {
+    CoolPropDbl calc_d2alpha0_dTau2() override {
         return call_phi0dll(2, 0);
     };
-    CoolPropDbl calc_d3alpha0_dDelta3() {
+    CoolPropDbl calc_d3alpha0_dDelta3() override {
         return call_phi0dll(0, 3);
     };
-    CoolPropDbl calc_d3alpha0_dDelta2_dTau() {
+    CoolPropDbl calc_d3alpha0_dDelta2_dTau() override {
         return call_phi0dll(1, 2);
     };
-    CoolPropDbl calc_d3alpha0_dDelta_dTau2() {
+    CoolPropDbl calc_d3alpha0_dDelta_dTau2() override {
         return call_phi0dll(2, 1);
     };
-    CoolPropDbl calc_d3alpha0_dTau3() {
+    CoolPropDbl calc_d3alpha0_dTau3() override {
         return call_phi0dll(3, 0);
     };
 };

--- a/src/Backends/Tabular/BicubicBackend.h
+++ b/src/Backends/Tabular/BicubicBackend.h
@@ -74,7 +74,7 @@ class BicubicBackend : public TabularBackend
             is_mixture = (this->AS->get_mole_fractions().size() > 1);
         }
     };
-    void set_mole_fractions(const std::vector<CoolPropDbl>& mole_fractions) {
+    void set_mole_fractions(const std::vector<CoolPropDbl>& mole_fractions) override {
         this->AS->set_mole_fractions(mole_fractions);
         is_mixture = true;
         // Check the tables and build if necessary
@@ -86,7 +86,7 @@ class BicubicBackend : public TabularBackend
         dataset->build_coeffs(single_phase_logph, dataset->coeffs_ph);
         dataset->build_coeffs(single_phase_logpT, dataset->coeffs_pT);
     };
-    std::string backend_name() {
+    std::string backend_name() override {
         return get_backend_string(BICUBIC_BACKEND);
     }
 
@@ -105,10 +105,10 @@ class BicubicBackend : public TabularBackend
          */
     double evaluate_single_phase_derivative(SinglePhaseGriddedTableData& table, std::vector<std::vector<CellCoeffs>>& coeffs, parameters output,
                                             double x, double y, std::size_t i, std::size_t j, std::size_t Nx, std::size_t Ny);
-    double evaluate_single_phase_phmolar_derivative(parameters output, std::size_t i, std::size_t j, std::size_t Nx, std::size_t Ny) {
+    double evaluate_single_phase_phmolar_derivative(parameters output, std::size_t i, std::size_t j, std::size_t Nx, std::size_t Ny) override {
         return evaluate_single_phase_derivative(dataset->single_phase_logph, dataset->coeffs_ph, output, _hmolar, _p, i, j, Nx, Ny);
     };
-    double evaluate_single_phase_pT_derivative(parameters output, std::size_t i, std::size_t j, std::size_t Nx, std::size_t Ny) {
+    double evaluate_single_phase_pT_derivative(parameters output, std::size_t i, std::size_t j, std::size_t Nx, std::size_t Ny) override {
         return evaluate_single_phase_derivative(dataset->single_phase_logpT, dataset->coeffs_pT, output, _T, _p, i, j, Nx, Ny);
     };
 
@@ -125,20 +125,19 @@ class BicubicBackend : public TabularBackend
          */
     double evaluate_single_phase(const SinglePhaseGriddedTableData& table, const std::vector<std::vector<CellCoeffs>>& coeffs,
                                  const parameters output, const double x, const double y, const std::size_t i, const std::size_t j);
-    double evaluate_single_phase_phmolar(parameters output, std::size_t i, std::size_t j) {
+    double evaluate_single_phase_phmolar(parameters output, std::size_t i, std::size_t j) override {
         return evaluate_single_phase(dataset->single_phase_logph, dataset->coeffs_ph, output, _hmolar, _p, i, j);
     };
-    double evaluate_single_phase_pT(parameters output, std::size_t i, std::size_t j) {
+    double evaluate_single_phase_pT(parameters output, std::size_t i, std::size_t j) override {
         return evaluate_single_phase(dataset->single_phase_logpT, dataset->coeffs_pT, output, _T, _p, i, j);
     };
 
-    virtual void find_native_nearest_good_indices(SinglePhaseGriddedTableData& table, const std::vector<std::vector<CellCoeffs>>& coeffs, double x,
-                                                  double y, std::size_t& i, std::size_t& j);
+    void find_native_nearest_good_indices(SinglePhaseGriddedTableData& table, const std::vector<std::vector<CellCoeffs>>& coeffs, double x, double y,
+                                          std::size_t& i, std::size_t& j) override;
 
     /// Ask the derived class to find the nearest neighbor (pure virtual)
-    virtual void find_nearest_neighbor(SinglePhaseGriddedTableData& table, const std::vector<std::vector<CellCoeffs>>& coeffs,
-                                       const parameters variable1, const double value1, const parameters otherkey, const double otherval,
-                                       std::size_t& i, std::size_t& j);
+    void find_nearest_neighbor(SinglePhaseGriddedTableData& table, const std::vector<std::vector<CellCoeffs>>& coeffs, const parameters variable1,
+                               const double value1, const parameters otherkey, const double otherval, std::size_t& i, std::size_t& j) override;
 
     /**
          * @brief Evaluate the single-phase transport properties using linear interpolation.  Works well except for near the critical point
@@ -151,10 +150,10 @@ class BicubicBackend : public TabularBackend
          */
     double evaluate_single_phase_transport(SinglePhaseGriddedTableData& table, parameters output, double x, double y, std::size_t i, std::size_t j);
 
-    double evaluate_single_phase_phmolar_transport(parameters output, std::size_t i, std::size_t j) {
+    double evaluate_single_phase_phmolar_transport(parameters output, std::size_t i, std::size_t j) override {
         return evaluate_single_phase_transport(dataset->single_phase_logph, output, _hmolar, _p, i, j);
     };
-    double evaluate_single_phase_pT_transport(parameters output, std::size_t i, std::size_t j) {
+    double evaluate_single_phase_pT_transport(parameters output, std::size_t i, std::size_t j) override {
         return evaluate_single_phase_transport(dataset->single_phase_logpT, output, _T, _p, i, j);
     };
 
@@ -169,9 +168,9 @@ class BicubicBackend : public TabularBackend
          * @param j The y-coordinate of the cell
          */
     void invert_single_phase_x(const SinglePhaseGriddedTableData& table, const std::vector<std::vector<CellCoeffs>>& coeffs, parameters other_key,
-                               double other, double y, std::size_t i, std::size_t j);
+                               double other, double y, std::size_t i, std::size_t j) override;
     void invert_single_phase_y(const SinglePhaseGriddedTableData& table, const std::vector<std::vector<CellCoeffs>>& coeffs, parameters other_key,
-                               double other, double x, std::size_t i, std::size_t j);
+                               double other, double x, std::size_t i, std::size_t j) override;
 };
 
 }  // namespace CoolProp

--- a/src/Backends/Tabular/TTSEBackend.h
+++ b/src/Backends/Tabular/TTSEBackend.h
@@ -9,7 +9,7 @@ namespace CoolProp {
 class TTSEBackend : public TabularBackend
 {
    public:
-    std::string backend_name() {
+    std::string backend_name() override {
         return get_backend_string(TTSE_BACKEND);
     }
     /// Instantiator; base class loads or makes tables
@@ -27,36 +27,35 @@ class TTSEBackend : public TabularBackend
     }
     double evaluate_single_phase(SinglePhaseGriddedTableData& table, parameters output, double x, double y, std::size_t i, std::size_t j);
     double evaluate_single_phase_transport(SinglePhaseGriddedTableData& table, parameters output, double x, double y, std::size_t i, std::size_t j);
-    double evaluate_single_phase_phmolar(parameters output, std::size_t i, std::size_t j) {
+    double evaluate_single_phase_phmolar(parameters output, std::size_t i, std::size_t j) override {
         SinglePhaseGriddedTableData& single_phase_logph = dataset->single_phase_logph;
         return evaluate_single_phase(single_phase_logph, output, _hmolar, _p, i, j);
     }
-    double evaluate_single_phase_pT(parameters output, std::size_t i, std::size_t j) {
+    double evaluate_single_phase_pT(parameters output, std::size_t i, std::size_t j) override {
         SinglePhaseGriddedTableData& single_phase_logpT = dataset->single_phase_logpT;
         return evaluate_single_phase(single_phase_logpT, output, _T, _p, i, j);
     }
-    double evaluate_single_phase_phmolar_transport(parameters output, std::size_t i, std::size_t j) {
+    double evaluate_single_phase_phmolar_transport(parameters output, std::size_t i, std::size_t j) override {
         SinglePhaseGriddedTableData& single_phase_logph = dataset->single_phase_logph;
         return evaluate_single_phase_transport(single_phase_logph, output, _hmolar, _p, i, j);
     }
-    double evaluate_single_phase_pT_transport(parameters output, std::size_t i, std::size_t j) {
+    double evaluate_single_phase_pT_transport(parameters output, std::size_t i, std::size_t j) override {
         SinglePhaseGriddedTableData& single_phase_logpT = dataset->single_phase_logpT;
         return evaluate_single_phase_transport(single_phase_logpT, output, _T, _p, i, j);
     }
     void invert_single_phase_x(const SinglePhaseGriddedTableData& table, const std::vector<std::vector<CellCoeffs>>& coeffs, parameters output,
-                               double x, double y, std::size_t i, std::size_t j);
+                               double x, double y, std::size_t i, std::size_t j) override;
     void invert_single_phase_y(const SinglePhaseGriddedTableData& table, const std::vector<std::vector<CellCoeffs>>& coeffs, parameters output,
-                               double y, double x, std::size_t i, std::size_t j);
+                               double y, double x, std::size_t i, std::size_t j) override;
 
     /// Find the best set of i,j for native inputs.
-    virtual void find_native_nearest_good_indices(SinglePhaseGriddedTableData& table, const std::vector<std::vector<CellCoeffs>>& coeffs, double x,
-                                                  double y, std::size_t& i, std::size_t& j) {
+    void find_native_nearest_good_indices(SinglePhaseGriddedTableData& table, const std::vector<std::vector<CellCoeffs>>& coeffs, double x, double y,
+                                          std::size_t& i, std::size_t& j) override {
         return table.find_native_nearest_good_neighbor(x, y, i, j);
     };
     /// Ask the derived class to find the nearest neighbor (pure virtual)
-    virtual void find_nearest_neighbor(SinglePhaseGriddedTableData& table, const std::vector<std::vector<CellCoeffs>>& coeffs,
-                                       const parameters variable1, const double value1, const parameters otherkey, const double otherval,
-                                       std::size_t& i, std::size_t& j) {
+    void find_nearest_neighbor(SinglePhaseGriddedTableData& table, const std::vector<std::vector<CellCoeffs>>& coeffs, const parameters variable1,
+                               const double value1, const parameters otherkey, const double otherval, std::size_t& i, std::size_t& j) override {
         table.find_nearest_neighbor(variable1, value1, otherkey, otherval, cached_single_phase_i, cached_single_phase_j);
     };
 
@@ -74,11 +73,11 @@ class TTSEBackend : public TabularBackend
          */
     double evaluate_single_phase_derivative(SinglePhaseGriddedTableData& table, parameters output, double x, double y, std::size_t i, std::size_t j,
                                             std::size_t Nx, std::size_t Ny);
-    double evaluate_single_phase_phmolar_derivative(parameters output, std::size_t i, std::size_t j, std::size_t Nx, std::size_t Ny) {
+    double evaluate_single_phase_phmolar_derivative(parameters output, std::size_t i, std::size_t j, std::size_t Nx, std::size_t Ny) override {
         SinglePhaseGriddedTableData& single_phase_logph = dataset->single_phase_logph;
         return evaluate_single_phase_derivative(single_phase_logph, output, _hmolar, _p, i, j, Nx, Ny);
     };
-    double evaluate_single_phase_pT_derivative(parameters output, std::size_t i, std::size_t j, std::size_t Nx, std::size_t Ny) {
+    double evaluate_single_phase_pT_derivative(parameters output, std::size_t i, std::size_t j, std::size_t Nx, std::size_t Ny) override {
         SinglePhaseGriddedTableData& single_phase_logpT = dataset->single_phase_logpT;
         return evaluate_single_phase_derivative(single_phase_logpT, output, _T, _p, i, j, Nx, Ny);
     };

--- a/src/Backends/Tabular/TabularBackends.h
+++ b/src/Backends/Tabular/TabularBackends.h
@@ -816,7 +816,7 @@ class LogPHTable : public SinglePhaseGriddedTableData
         logy = true;
         logx = false;
     };
-    void set_limits() {
+    void set_limits() override {
         if (this->AS.get() == nullptr) {
             throw ValueError("AS is not yet set");
         }
@@ -870,7 +870,7 @@ class LogPTTable : public SinglePhaseGriddedTableData
         xmax = _HUGE;
         ymax = _HUGE;
     };
-    void set_limits() {
+    void set_limits() override {
         if (this->AS.get() == nullptr) {
             throw ValueError("AS is not yet set");
         }
@@ -1091,14 +1091,14 @@ class TabularBackend : public AbstractState
     };
 
     // None of the tabular methods are available from the high-level interface
-    bool available_in_high_level() {
+    bool available_in_high_level() override {
         return false;
     }
 
-    std::string calc_name() {
+    std::string calc_name() override {
         return AS->name();
     }
-    std::vector<std::string> calc_fluid_names() {
+    std::vector<std::string> calc_fluid_names() override {
         return AS->fluid_names();
     }
 
@@ -1181,13 +1181,13 @@ class TabularBackend : public AbstractState
         *
         * @param phase_index The index from CoolProp::phases
         */
-    void calc_specify_phase(phases phase_index) {
+    void calc_specify_phase(phases phase_index) override {
         imposed_phase_index = phase_index;
     };
 
     /**\brief Unspecify the phase - the phase is no longer imposed, different solvers can do as they like
         */
-    void calc_unspecify_phase() {
+    void calc_unspecify_phase() override {
         imposed_phase_index = iphase_not_imposed;
     };
 
@@ -1197,10 +1197,9 @@ class TabularBackend : public AbstractState
     virtual double evaluate_single_phase_pT_transport(parameters output, std::size_t i, std::size_t j) = 0;
 
     /// Vectorized direct evaluation; see AbstractState::fast_evaluate for contract.
-    virtual void fast_evaluate(CoolProp::input_pairs input_pair, const double* val1, const double* val2, std::size_t N_inputs,
-                               const CoolProp::parameters* outputs, std::size_t N_outputs, double* out_buffer, std::size_t out_buffer_size,
-                               int* status_flags, std::size_t status_flags_size,
-                               CoolProp::phases imposed_phase = CoolProp::iphase_not_imposed) override;
+    void fast_evaluate(CoolProp::input_pairs input_pair, const double* val1, const double* val2, std::size_t N_inputs,
+                       const CoolProp::parameters* outputs, std::size_t N_outputs, double* out_buffer, std::size_t out_buffer_size, int* status_flags,
+                       std::size_t status_flags_size, CoolProp::phases imposed_phase = CoolProp::iphase_not_imposed) override;
     virtual double evaluate_single_phase_phmolar_derivative(parameters output, std::size_t i, std::size_t j, std::size_t Nx, std::size_t Ny) = 0;
     virtual double evaluate_single_phase_pT_derivative(parameters output, std::size_t i, std::size_t j, std::size_t Nx, std::size_t Ny) = 0;
 
@@ -1218,62 +1217,62 @@ class TabularBackend : public AbstractState
     virtual void invert_single_phase_y(const SinglePhaseGriddedTableData& table, const std::vector<std::vector<CellCoeffs>>& coeffs,
                                        parameters output, double x, double y, std::size_t i, std::size_t j) = 0;
 
-    phases calc_phase() {
+    phases calc_phase() override {
         return _phase;
     }
-    CoolPropDbl calc_T_critical() {
+    CoolPropDbl calc_T_critical() override {
         return this->AS->T_critical();
     };
-    CoolPropDbl calc_Ttriple() {
+    CoolPropDbl calc_Ttriple() override {
         return this->AS->Ttriple();
     };
-    CoolPropDbl calc_p_triple() {
+    CoolPropDbl calc_p_triple() override {
         return this->AS->p_triple();
     };
-    CoolPropDbl calc_pmax() {
+    CoolPropDbl calc_pmax() override {
         return this->AS->pmax();
     };
-    CoolPropDbl calc_Tmax() {
+    CoolPropDbl calc_Tmax() override {
         return this->AS->Tmax();
     };
-    CoolPropDbl calc_Tmin() {
+    CoolPropDbl calc_Tmin() override {
         return this->AS->Tmin();
     };
-    CoolPropDbl calc_p_critical() {
+    CoolPropDbl calc_p_critical() override {
         return this->AS->p_critical();
     }
-    CoolPropDbl calc_rhomolar_critical() {
+    CoolPropDbl calc_rhomolar_critical() override {
         return this->AS->rhomolar_critical();
     }
-    bool using_mole_fractions() {
+    bool using_mole_fractions() override {
         return true;
     }
-    bool using_mass_fractions() {
+    bool using_mass_fractions() override {
         return false;
     }
-    bool using_volu_fractions() {
+    bool using_volu_fractions() override {
         return false;
     }
-    void update(CoolProp::input_pairs input_pair, double Value1, double Value2);
-    void set_mole_fractions(const std::vector<CoolPropDbl>& mole_fractions) {
+    void update(CoolProp::input_pairs input_pair, double Value1, double Value2) override;
+    void set_mole_fractions(const std::vector<CoolPropDbl>& mole_fractions) override {
         this->AS->set_mole_fractions(mole_fractions);
     };
-    void set_mass_fractions(const std::vector<CoolPropDbl>& mass_fractions) {
+    void set_mass_fractions(const std::vector<CoolPropDbl>& mass_fractions) override {
         throw NotImplementedError("set_mass_fractions not implemented for Tabular backends");
     };
-    const std::vector<CoolPropDbl>& get_mole_fractions() {
+    const std::vector<CoolPropDbl>& get_mole_fractions() override {
         return AS->get_mole_fractions();
     };
-    const std::vector<CoolPropDbl> calc_mass_fractions() {
+    const std::vector<CoolPropDbl> calc_mass_fractions() override {
         return AS->get_mass_fractions();
     };
 
-    CoolPropDbl calc_molar_mass() {
+    CoolPropDbl calc_molar_mass() override {
         return AS->molar_mass();
     };
 
-    [[nodiscard]] CoolPropDbl calc_saturated_liquid_keyed_output(parameters key);
-    [[nodiscard]] CoolPropDbl calc_saturated_vapor_keyed_output(parameters key);
+    [[nodiscard]] CoolPropDbl calc_saturated_liquid_keyed_output(parameters key) override;
+    [[nodiscard]] CoolPropDbl calc_saturated_vapor_keyed_output(parameters key) override;
 
     /// Returns the path to the tables that shall be written
     std::string path_to_tables();
@@ -1298,36 +1297,36 @@ class TabularBackend : public AbstractState
         CoolPropDbl yV = PhaseEnvelopeRoutines::evaluate(phase_envelope, output, iInput1, value1, cached_saturation_iV);
         return _Q * yV + (1 - _Q) * yL;
     }
-    CoolPropDbl calc_cpmolar_idealgas() {
+    CoolPropDbl calc_cpmolar_idealgas() override {
         this->AS->set_T(_T);
         return this->AS->cp0molar();
     }
     /// Calculate the surface tension using the wrapped class (fast enough)
-    CoolPropDbl calc_surface_tension() {
+    CoolPropDbl calc_surface_tension() override {
         this->AS->set_T(_T);
         return this->AS->surface_tension();
         this->AS->set_T(_HUGE);
     }
     CoolPropDbl calc_p();
-    CoolPropDbl calc_T();
-    CoolPropDbl calc_rhomolar();
-    CoolPropDbl calc_hmolar();
-    CoolPropDbl calc_smolar();
-    CoolPropDbl calc_umolar();
-    CoolPropDbl calc_cpmolar();
-    CoolPropDbl calc_cvmolar();
-    CoolPropDbl calc_viscosity();
-    CoolPropDbl calc_conductivity();
+    CoolPropDbl calc_T() override;
+    CoolPropDbl calc_rhomolar() override;
+    CoolPropDbl calc_hmolar() override;
+    CoolPropDbl calc_smolar() override;
+    CoolPropDbl calc_umolar() override;
+    CoolPropDbl calc_cpmolar() override;
+    CoolPropDbl calc_cvmolar() override;
+    CoolPropDbl calc_viscosity() override;
+    CoolPropDbl calc_conductivity() override;
     /// Calculate the speed of sound using a tabular backend [m/s]
-    CoolPropDbl calc_speed_sound();
-    CoolPropDbl calc_first_partial_deriv(parameters Of, parameters Wrt, parameters Constant);
+    CoolPropDbl calc_speed_sound() override;
+    CoolPropDbl calc_first_partial_deriv(parameters Of, parameters Wrt, parameters Constant) override;
     /** /brief calculate the derivative along the saturation curve, but only if quality is 0 or 1
         */
-    CoolPropDbl calc_first_saturation_deriv(parameters Of1, parameters Wrt1);
-    CoolPropDbl calc_first_two_phase_deriv(parameters Of, parameters Wrt, parameters Constant);
+    CoolPropDbl calc_first_saturation_deriv(parameters Of1, parameters Wrt1) override;
+    CoolPropDbl calc_first_two_phase_deriv(parameters Of, parameters Wrt, parameters Constant) override;
 
     /// If you need all three values (drho_dh__p, drho_dp__h and rho_spline), you should calculate drho_dp__h first to avoid duplicate calculations.
-    CoolPropDbl calc_first_two_phase_deriv_splined(parameters Of, parameters Wrt, parameters Constant, CoolPropDbl x_end);
+    CoolPropDbl calc_first_two_phase_deriv_splined(parameters Of, parameters Wrt, parameters Constant, CoolPropDbl x_end) override;
 
     void check_tables() {
         if (!tables_loaded) {

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -120,7 +120,7 @@ struct delim : std::numpunct<char>
 {
     char m_c;
     delim(char c) : m_c(c) {};
-    char do_decimal_point() const {
+    char do_decimal_point() const override {
         return m_c;
     }
 };

--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -404,7 +404,7 @@ static double Brent_HAProps_W(givens OutputKey, double p, givens In1Name, double
             input_vals[0] = Input1;
         };
 
-        double call(double W) {
+        double call(double W) override {
             input_vals[1] = W;
             double T = _HUGE, psi_w = _HUGE;
             _HAPropsSI_inputs(p, input_keys, input_vals, T, psi_w);
@@ -474,7 +474,7 @@ static double Brent_HAProps_T(givens OutputKey, double p, givens In1Name, double
             input_vals[0] = Input1;
         };
 
-        double call(double T_drybulb) {
+        double call(double T_drybulb) override {
             double psi_w = NAN;
             psi_w = MoleFractionWater(T_drybulb, p, input_keys[0], input_vals[0]);
             double val = _HAPropsSI_outputs(OutputKey, p, T_drybulb, psi_w);
@@ -533,7 +533,7 @@ static double Secant_Tdb_at_saturated_W(double psi_w, double p, double T_guess) 
         };
         ~BrentSolverResids() {};
 
-        double call(double T) {
+        double call(double T) override {
             double p_ws = NAN;
             if (T >= 273.16) {
                 // Saturation pressure [Pa] using IF97 formulation
@@ -1317,7 +1317,7 @@ class WetBulbSolver : public CoolProp::FuncWrapper1D
         double v_bar_w = MolarVolume(T, p, psi_w), M_ha = MM_Water() * psi_w + (1 - psi_w) * 0.028966;
         LHS = MolarEnthalpy(T, p, psi_w, v_bar_w) * (1 + _W) / M_ha;
     }
-    double call(double Twb) {
+    double call(double Twb) override {
         double epsilon = 0.621945;
         double f_wb = NAN, p_ws_wb = NAN, p_s_wb = NAN, W_s_wb = NAN, h_w = NAN, M_ha_wb = NAN, psi_wb = NAN, v_bar_wb = NAN;
 
@@ -1364,7 +1364,7 @@ class WetBulbTminSolver : public CoolProp::FuncWrapper1D
    public:
     double p, hair_dry;
     WetBulbTminSolver(double p, double hair_dry) : p(p), hair_dry(hair_dry) {}
-    double call(double Ts) {
+    double call(double Ts) override {
         //double RHS = HAPropsSI("H","T",Ts,"P",p,"R",1);
 
         double psi_w = NAN, T = Ts;
@@ -1696,7 +1696,7 @@ class HAProps_W_Residual : public CoolProp::FuncWrapper1D
         input_vals.resize(2, T);
     }
 
-    double call(double W) {
+    double call(double W) override {
         // Update inputs
         input_vals[1] = W;
         // Prepare calculation
@@ -1722,7 +1722,7 @@ class HAProps_T_Residual : public CoolProp::FuncWrapper1D
         input_vals.resize(2, W);
     }
 
-    double call(double T) {
+    double call(double T) override {
         // Update inputs
         input_vals[0] = T;
         // Prepare calculation

--- a/src/ODEIntegrators.cpp
+++ b/src/ODEIntegrators.cpp
@@ -176,25 +176,25 @@ TEST_CASE("Integrate y'=y", "[ODEIntegrator]") {
        public:
         std::vector<double> t, h, y;
 
-        virtual std::vector<double> get_initial_array() const {
+        std::vector<double> get_initial_array() const override {
             return std::vector<double>(1, 1);
         }
 
-        virtual void pre_step_callback() {};
+        void pre_step_callback() override {};
 
-        virtual void post_deriv_callback() {};
+        void post_deriv_callback() override {};
 
-        virtual void post_step_callback(double t, double h, std::vector<double>& y) {
+        void post_step_callback(double t, double h, std::vector<double>& y) override {
             this->t.push_back(t);
             this->h.push_back(h);
             this->y.push_back(y[0]);
         };
 
-        virtual bool premature_termination() {
+        bool premature_termination() override {
             return false;
         };
 
-        virtual void derivs(double t, std::vector<double>& y, std::vector<double>& yprime) {
+        void derivs(double t, std::vector<double>& y, std::vector<double>& yprime) override {
             yprime[0] = y[0];
         };
     };


### PR DESCRIPTION
## Summary

- Re-enables `modernize-use-override` in `.clang-tidy` (the previous "project uses override+final via macros" comment was stale — no such macros exist in this repo; all 92 prior usages were bare `override`).
- Runs `run-clang-tidy -checks='-*,modernize-use-override' -fix -format -j 1` across `src/` and `include/CoolProp/` with `AllowOverrideAndFinal=true` + `IgnoreDestructors=true` (matching the historical 2uw.13 plan). 34 first-party files touched.
- Adds the two new `CheckOptions` to `.clang-tidy` so the same tuning re-applies on future runs.

This closes the `modernize-use-override` follow-up from the original Tier 4.2 plan in CoolProp-2uw.13: only `nullptr` / `emplace` / `deprecated-headers` (#2805) and `init-variables` (#2808) actually landed; this fills in the gap that was still emitting `-Winconsistent-missing-override` on every local build.

## Why now

Local builds were emitting pervasive `-Winconsistent-missing-override` from clang on most backends. After this PR, that warning count drops to 0 on a clean `cmake --build build_catch --target CatchTestRunner` (the 2 remaining warnings are pre-existing `-Wc++20-extensions` on `SVDSurfaceFactory.cpp` and untouched here).

## Reproducibility

```bash
cmake -B build_catch -S . -DCOOLPROP_CATCH_MODULE=ON -DBUILD_TESTING=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
SDK=$(xcrun --show-sdk-path)
WT=$(pwd)
run-clang-tidy -p build_catch \
  -checks='-*,modernize-use-override' \
  -config="{CheckOptions: [{key: modernize-use-override.AllowOverrideAndFinal, value: 'true'}, {key: modernize-use-override.IgnoreDestructors, value: 'true'}]}" \
  -extra-arg=--sysroot="$SDK" \
  -header-filter="^${WT}/(include|src)/" \
  -fix -format -j 1
```

Note: serial (`-j 1`) is required — `run-clang-tidy` re-emits identical fix-its from every TU that includes a given header, and `clang-apply-replacements` doesn't dedupe identical replacements across TU YAML exports. A parallel run produces 314 `override override` duplicates that have to be collapsed by hand. Serial avoids that.

## Test plan

- [x] `cmake --build build_catch --target CatchTestRunner -j8` — clean build, 0 errors, 0 `-Winconsistent-missing-override` warnings.
- [x] `./build_catch/CatchTestRunner [SBTL]` — 16 cases / 4587 assertions pass (1 REFPROP-skipped, unrelated).
- [x] `./dev/ci/preflight.sh --skip=cppcheck,clang-tidy` — passes 4/4 (clang-format, build, Catch2 tag-auto-selected `[Helmholtz],[REFPROP],[!benchmark]`, semgrep).
- [x] Adversarial code-reviewer subagent pass — no blocking mechanical findings; spot-checked TU-local generators in `src/AbstractState.cpp`, `throw() override` ordering in `include/Helmholtz.h`, `virtual`-removal cases in Cubics/Helmholtz/HumidAirProp/ODEIntegrators against base class virtuals.

The two skipped preflight checks (`cppcheck`, `clang-tidy`) flag pre-existing whole-file issues unrelated to this diff (every flagged finding has a 2014–2022 blame). CI runs `clang-tidy-diff.py` and informational-mode `cppcheck`, both of which scope to changed lines only and will be clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal code structure with explicit method override specifiers for improved compile-time safety and maintainability across the project codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2976?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->