### PR TITLE
feat(wasm)!: native JS arrays via emscripten::val (replaces VectorDouble)

### DIFF
--- a/Web/coolprop/changelog.rst
+++ b/Web/coolprop/changelog.rst
@@ -11,6 +11,16 @@ Highlights:
 
 **Behavior changes (potentially breaking):**
 
+* **WASM / JavaScript wrapper:** composition vectors and phase-envelope
+  data now use **native JavaScript arrays** instead of the embind
+  ``VectorDouble`` wrapper class. Setters take a JS array directly
+  (``AS.set_mole_fractions([0.4, 0.6])``); getters return one
+  (``var z = AS.get_mole_fractions(); console.log(z[0]);``);
+  ``get_phase_envelope_data()`` returns a plain object whose fields
+  (``T``, ``p``, ...) are JS arrays (``data.T[i]``). The
+  ``VectorDouble``/``VectorString`` classes have been removed from
+  the exposed surface.
+
 * Default ``update`` for ``HmolarQ_INPUTS``, ``QSmolar_INPUTS``,
   ``DmolarQ_INPUTS`` (and their mass-input equivalents) on pure fluids
   now raises :cpapi:`CoolProp::MultipleSolutionsError` when the input

--- a/include/AbstractState.h
+++ b/include/AbstractState.h
@@ -841,21 +841,6 @@ class AbstractState
     };
 #endif
 
-#ifdef EMSCRIPTEN
-    // Emscripten cannot disambiguate the overloaded set_*_fractions members when
-    // CoolPropDbl != double, so embind takes the address of these single-arity
-    // wrappers instead of the raw virtuals.
-    void set_mole_fractions_double(const std::vector<double>& mole_fractions) {
-        set_mole_fractions(std::vector<CoolPropDbl>(mole_fractions.begin(), mole_fractions.end()));
-    };
-    void set_mass_fractions_double(const std::vector<double>& mass_fractions) {
-        set_mass_fractions(std::vector<CoolPropDbl>(mass_fractions.begin(), mass_fractions.end()));
-    };
-    void set_volu_fractions_double(const std::vector<double>& volu_fractions) {
-        set_volu_fractions(std::vector<CoolPropDbl>(volu_fractions.begin(), volu_fractions.end()));
-    };
-#endif
-
     /// Get the mole fractions of the equilibrium liquid phase
     std::vector<CoolPropDbl> mole_fractions_liquid() {
         return calc_mole_fractions_liquid();

--- a/src/emscripten_interface.cxx
+++ b/src/emscripten_interface.cxx
@@ -22,8 +22,31 @@
 /// *********************************************************************************
 
 #    include <emscripten/bind.h>
-#    include <optional>
+#    include <emscripten/val.h>
 using namespace emscripten;
+
+namespace {
+// Convert std::vector<double> → JS Array via emscripten::val.
+// Used by the JS bindings so callers get native JS arrays (with .length /
+// [i] / iterator support) instead of an embind VectorDouble wrapper, and
+// so the binding surface doesn't depend on the optional<T> registration
+// that emcc's EMBIND_AOT path doesn't currently generate invokers for
+// (upstream emscripten-core#24540).
+template <class T>
+val vec_to_js_array(const std::vector<T>& v) {
+    val arr = val::array();
+    for (const auto& x : v) arr.call<void>("push", x);
+    return arr;
+}
+
+std::vector<double> js_array_to_vec(const val& arr) {
+    const unsigned n = arr["length"].as<unsigned>();
+    std::vector<double> v;
+    v.reserve(n);
+    for (unsigned i = 0; i < n; ++i) v.push_back(arr[i].as<double>());
+    return v;
+}
+}  // namespace
 
 // Binding code
 EMSCRIPTEN_BINDINGS(coolprop_bindings) {
@@ -211,25 +234,6 @@ CoolProp::AbstractState* factory(const std::string& backend, const std::string& 
 // Binding code
 EMSCRIPTEN_BINDINGS(abstract_state_bindings) {
 
-    register_vector<double>("VectorDouble");
-    register_vector<std::string>("VectorString");
-    // Without this, VectorDouble.get(i) throws 'unbound types: optional<double>'
-    // from JS because register_vector's auto-call to register_optional<T> is
-    // an inlineable template whose body the optimizer folds to a no-op (the
-    // `thread_local bool hasRun` guard appears to be the trigger). Calling the
-    // embind internal entry-point directly preserves the wasm import.
-    internal::_embind_register_optional(
-        internal::TypeID<std::optional<double>>::get(),
-        internal::TypeID<double>::get());
-
-    value_object<CoolProp::PhaseEnvelopeData>("CoolProp::PhaseEnvelopeData")
-// Use X macros to auto-generate the variables;
-// each will look something like: .field("T", &CoolProp::PhaseEnvelopeData::T);
-#    define X(name) .field(#    name, &CoolProp::PhaseEnvelopeData::name)
-      PHASE_ENVELOPE_VECTORS
-#    undef X
-      ;
-
     function("factory", &factory, allow_raw_pointers());
 
     class_<CoolProp::AbstractState>("AbstractState")
@@ -237,13 +241,31 @@ EMSCRIPTEN_BINDINGS(abstract_state_bindings) {
       .function("using_mole_fractions", &CoolProp::AbstractState::using_mole_fractions)
       .function("using_mass_fractions", &CoolProp::AbstractState::using_mass_fractions)
       .function("using_volu_fractions", &CoolProp::AbstractState::using_volu_fractions)
-      .function("set_mass_fractions", &CoolProp::AbstractState::set_mass_fractions_double)
-      .function("set_volu_fractions", &CoolProp::AbstractState::set_volu_fractions_double)
-      .function("set_mole_fractions", &CoolProp::AbstractState::set_mole_fractions_double)
-      .function("mole_fractions_liquid", &CoolProp::AbstractState::mole_fractions_liquid_double)
-      .function("mole_fractions_vapor", &CoolProp::AbstractState::mole_fractions_vapor_double)
-      .function("get_mole_fractions", &CoolProp::AbstractState::get_mole_fractions)
-      .function("get_mass_fractions", &CoolProp::AbstractState::get_mass_fractions)
+
+      // Fraction setters/getters: accept and return native JS Arrays via
+      // emscripten::val. JS callers do `AS.set_mole_fractions([0.4, 0.6])`
+      // and read `AS.get_mole_fractions()[i]` with no VectorDouble wrapper.
+      .function("set_mass_fractions", +[](CoolProp::AbstractState& self, val arr) {
+          self.set_mass_fractions(js_array_to_vec(arr));
+      })
+      .function("set_volu_fractions", +[](CoolProp::AbstractState& self, val arr) {
+          self.set_volu_fractions(js_array_to_vec(arr));
+      })
+      .function("set_mole_fractions", +[](CoolProp::AbstractState& self, val arr) {
+          self.set_mole_fractions(js_array_to_vec(arr));
+      })
+      .function("mole_fractions_liquid", +[](CoolProp::AbstractState& self) {
+          return vec_to_js_array(self.mole_fractions_liquid_double());
+      })
+      .function("mole_fractions_vapor", +[](CoolProp::AbstractState& self) {
+          return vec_to_js_array(self.mole_fractions_vapor_double());
+      })
+      .function("get_mole_fractions", +[](CoolProp::AbstractState& self) {
+          return vec_to_js_array(self.get_mole_fractions());
+      })
+      .function("get_mass_fractions", +[](CoolProp::AbstractState& self) {
+          return vec_to_js_array(self.get_mass_fractions());
+      })
 
       .function("update", &CoolProp::AbstractState::update)
 
@@ -298,7 +320,16 @@ EMSCRIPTEN_BINDINGS(abstract_state_bindings) {
       .function("first_two_phase_deriv_splined", &CoolProp::AbstractState::first_two_phase_deriv_splined)
 
       .function("build_phase_envelope", &CoolProp::AbstractState::build_phase_envelope)
-      .function("get_phase_envelope_data", &CoolProp::AbstractState::get_phase_envelope_data)
+      .function("get_phase_envelope_data", +[](CoolProp::AbstractState& self) {
+          // Return a plain JS object with one Array per PHASE_ENVELOPE_VECTORS
+          // field (T, p, lnT, lnp, …). JS reads them as `data.T[i]` directly.
+          const CoolProp::PhaseEnvelopeData& d = self.get_phase_envelope_data();
+          val obj = val::object();
+#    define X(name) obj.set(#name, vec_to_js_array(d.name));
+          PHASE_ENVELOPE_VECTORS
+#    undef X
+          return obj;
+      })
 
       .function("melting_line", &CoolProp::AbstractState::melting_line)
       .function("saturation_ancillary", &CoolProp::AbstractState::saturation_ancillary)

--- a/wrappers/Javascript/Dockerfile
+++ b/wrappers/Javascript/Dockerfile
@@ -1,15 +1,14 @@
 ## Use docker-compose to spin up this job
 
 # Pinned to match .github/workflows/javascript_builder.yml (emcc 4.0.12).
-# emcc 5.x dropped the JS-side __embind_register_function / __embind_register_class
-# runtime dispatch from -lembind, leaving free-function and class bindings
-# inaccessible from JS (the wasm still builds and links; the resolved Module
-# instance just has no F2K / PropsSI / factory / AbstractState etc.). The
-# documented -sEMBIND_AOT=1 path was attempted but currently fails the link
-# step ('expected to find pattern in input JS: <<< EMBIND_AOT_INVOKERS >>>')
-# against our binding shape, and upstream issue emscripten-core#24540 notes
-# that AOT method-caller coverage is incomplete. Lift this pin once the 5.x
-# binding-exposure migration is sorted (tracked separately in beads).
+# emcc 5.x dropped the JS-side runtime embind dispatch from -lembind; the
+# documented `-sEMBIND_AOT=1` migration path fails the
+# `<<< EMBIND_AOT_INVOKERS >>>` substitution against our binding shape (tsgen
+# itself succeeds, but the sentinel isn't surfaced in the final JS template;
+# upstream emscripten-core#24540 notes AOT method-caller coverage is
+# incomplete). Bumping this image is gated on either upstream fixing AOT or
+# a deeper migration; bumping it also requires bumping the matching sha in
+# the CI workflow.
 FROM emscripten/emsdk@sha256:744fb6a68941970951bacf9d6632041a0398260492232691ef22bbf54b0585c6
 
 RUN apt-get -y -m update && DEBIAN_FRONTEND=noninteractive apt-get install -y dos2unix

--- a/wrappers/Javascript/test_wasm.mjs
+++ b/wrappers/Javascript/test_wasm.mjs
@@ -61,22 +61,16 @@ try {
     process.exit(1);
 }
 
-// Test mixture composition via set_mole_fractions(VectorDouble).
-// The set is verified by cross-checking the resulting density against
-// PropsSI with an explicit-composition fluid string; a bit-exact match
-// confirms the VectorDouble was correctly threaded into AbstractState.
+// Test mixture composition. Setters take a native JS array; getters return
+// a native JS array. Cross-check against PropsSI with explicit composition.
 console.log("Testing set_mole_fractions on a binary mixture...");
 try {
-    var z = new coolprop.VectorDouble();
-    z.push_back(0.4);
-    z.push_back(0.6);
-
     var ASmix = coolprop.factory("HEOS", "Methane&Ethane");
     if (!ASmix.using_mole_fractions()) {
         console.error("HEOS mixture should report using_mole_fractions() === true");
         process.exit(1);
     }
-    ASmix.set_mole_fractions(z);
+    ASmix.set_mole_fractions([0.4, 0.6]);
     ASmix.update(coolprop.input_pairs.PT_INPUTS, 1e6, 250);
 
     var rho = ASmix.rhomass();
@@ -88,21 +82,19 @@ try {
         process.exit(1);
     }
 
-    // Round-trip the composition through get_mole_fractions(). The
-    // VectorDouble::get(i) → std::optional<double> binding is registered
-    // explicitly in src/emscripten_interface.cxx; embind surfaces it as a
-    // plain JS number when the value is present.
+    // Round-trip the composition through get_mole_fractions(). Returns a
+    // native JS Array; read with [i].
     var got = ASmix.get_mole_fractions();
-    var got0 = got.get(0);
-    var got1 = got.get(1);
-    console.log("mixture composition round-trip:", got0, got1);
-    if (Math.abs(got0 - 0.4) > 1e-12 || Math.abs(got1 - 0.6) > 1e-12) {
+    console.log("mixture composition round-trip:", got);
+    if (!Array.isArray(got) || got.length !== 2) {
+        console.error("get_mole_fractions should return a JS Array of length 2; got", got);
+        process.exit(1);
+    }
+    if (Math.abs(got[0] - 0.4) > 1e-12 || Math.abs(got[1] - 0.6) > 1e-12) {
         console.error("get_mole_fractions did not round-trip composition");
         process.exit(1);
     }
-    got.delete();
 
-    z.delete();
     ASmix.delete();
     console.log("set_mole_fractions test passed!");
 } catch (e) {
@@ -137,30 +129,26 @@ try {
 }
 
 // Test the build_phase_envelope -> get_phase_envelope_data round-trip.
-// The value_object<PhaseEnvelopeData> binding (X-macro driven) is the
-// highest-risk surface from PR #2664 and was not covered by its tests.
+// get_phase_envelope_data returns a plain JS object whose fields are
+// native Arrays — read with .length and [i].
 console.log("Testing phase envelope round-trip...");
 try {
     var ASenv = coolprop.factory("HEOS", "Methane&Ethane");
-    var ze = new coolprop.VectorDouble();
-    ze.push_back(0.5);
-    ze.push_back(0.5);
-    ASenv.set_mole_fractions(ze);
+    ASenv.set_mole_fractions([0.5, 0.5]);
     ASenv.build_phase_envelope("");
     var env = ASenv.get_phase_envelope_data();
 
-    // env.T and env.p are VectorDouble fields populated by the envelope tracer.
-    var nT = env.T.size();
-    var np = env.p.size();
+    var nT = env.T.length;
+    var np = env.p.length;
     console.log("envelope points: T=" + nT + ", p=" + np);
     if (nT < 5 || np !== nT) {
         console.error("envelope returned too few points or T/p size mismatch:", nT, np);
         process.exit(1);
     }
     // Sample the middle point; both must be finite and in plausible ranges
-    // for Methane&Ethane. Exercises VectorDouble::get(i) -> optional<double>.
-    var Tmid = env.T.get(Math.floor(nT/2));
-    var pmid = env.p.get(Math.floor(np/2));
+    // for Methane&Ethane.
+    var Tmid = env.T[Math.floor(nT/2)];
+    var pmid = env.p[Math.floor(np/2)];
     console.log("envelope mid-point: T=" + Tmid + " K, p=" + pmid + " Pa");
     if (!(Number.isFinite(Tmid) && Tmid > 50 && Tmid < 400)) {
         console.error("envelope mid-T out of plausible range:", Tmid);
@@ -171,7 +159,6 @@ try {
         process.exit(1);
     }
 
-    ze.delete();
     ASenv.delete();
     console.log("Phase envelope test passed!");
 } catch (e) {


### PR DESCRIPTION
## Summary

Replaces the embind ``VectorDouble``/``VectorString`` wrapper classes on the JS binding surface with **native JavaScript arrays** via ``emscripten::val``.

### Before

```js
var v = new coolprop.VectorDouble();
v.push_back(0.4); v.push_back(0.6);
AS.set_mole_fractions(v);
v.delete();

var z = AS.get_mole_fractions();
console.log(z.get(0).value(), z.get(1).value(), z.size());
z.delete();
```

### After

```js
AS.set_mole_fractions([0.4, 0.6]);

var z = AS.get_mole_fractions();
console.log(z[0], z[1], z.length);
```

Same shape for ``get_phase_envelope_data()`` — returns a plain JS object whose fields (``T``, ``p``, …) are native arrays. No ``.delete()`` calls needed for vector returns; standard JS GC handles them.

Two thin helpers in ``src/emscripten_interface.cxx`` do the conversion:

```cpp
template <class T>
val vec_to_js_array(const std::vector<T>& v);
std::vector<double> js_array_to_vec(const val& arr);
```

Drops the ``register_vector``/``register_optional``/``value_object`` registrations, the ``#include <optional>``, and the ``set_mole_fractions_double``/``_mass_fractions_double``/``_volu_fractions_double`` EMSCRIPTEN-only wrappers from ``include/AbstractState.h`` (no longer needed — the val→vector conversion happens in the lambda). The direct ``internal::_embind_register_optional`` call from PR #2974 (CoolProp-71a.8) is also gone with this refactor — no more ``optional<double>`` registration dependency.

## Why this doesn't bump emsdk

The original motivation was to also unblock the emcc 5.x migration (CoolProp-71a.2) by removing the ``optional<double>`` dependency that breaks emcc's ``EMBIND_AOT`` path. Investigation showed AOT still fails against our binding shape at the link-time ``<<< EMBIND_AOT_INVOKERS >>>`` substitution (``tsgen.js`` itself succeeds; the sentinel is missing from the final JS template). The Dockerfile + CI workflow stay pinned to emsdk 4.0.12. **CoolProp-71a.2 stays open** with this finding documented in the bead.

## Breaking change

JS callers using the prior ``VectorDouble`` pattern will need to update (see Summary above). Changelog entry added under "Behavior changes (potentially breaking)".

## Test plan

- [x] ``cd wrappers/Javascript && docker compose run --rm runner`` against pinned emsdk 4.0.12 links cleanly
- [x] ``node test_wasm.mjs`` exits 0 with all 5 sections passing — including:
  - mixture composition round-trip: ``get_mole_fractions()`` returns ``[0.4, 0.6]`` (real JS Array)
  - envelope mid-point: ``env.T[107]`` and ``env.p[107]`` read directly
- [ ] CI ``Javascript library`` workflow green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JavaScript/WASM API now uses native JavaScript arrays for composition vectors and phase-envelope data. Setters accept arrays directly, and getters return native arrays, improving the developer experience.

* **Documentation**
  * Updated changelog documenting JavaScript API behavior changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->