### PR TITLE
refactor: clang-tidy bug-finder batch (CoolProp-m1q, #2926)

### DIFF
--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -30,7 +30,6 @@ void FlashRoutines::PT_flash_mixtures(HelmholtzEOSMixtureBackend& HEOS) {
             CoolPropDbl rhomolar_guess = HEOS.solver_rho_Tp_SRK(HEOS._T, HEOS._p, iphase_gas);
 
             solver_TP_resid resid(HEOS, HEOS._T, HEOS._p);
-            std::string errstr;
             HEOS.specify_phase(iphase_gas);
             try {
                 // Try using Newton's method
@@ -234,7 +233,6 @@ void FlashRoutines::DP_flash(HelmholtzEOSMixtureBackend& HEOS) {
             }
             // Then, do the solver using the full EOS
             solver_DP_resid resid(&HEOS, HEOS.rhomolar(), HEOS.p());
-            std::string errstr;
             Halley(resid, T0, 1e-10, 100);
             HEOS._Q = -1;
             // Update the state for conditions where the state was guessed
@@ -2523,7 +2521,6 @@ void FlashRoutines::HS_flash(HelmholtzEOSMixtureBackend& HEOS) {
             return r;
         }
     } resid(HEOS, hmolar, smolar);
-    std::string errstr;
     // Find minimum temperature
     bool good_Tmin = false;
     double Tmin = HEOS.Ttriple();

--- a/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
+++ b/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
@@ -103,7 +103,6 @@ double SaturationAncillaryFunction::invert(double value, double min_bound, doubl
         }
     };
     solver_resid resid(this, value);
-    std::string errstring;
     if (min_bound < 0) {
         min_bound = Tmin - 0.01;
     }
@@ -365,7 +364,11 @@ TEST_CASE("Tests for values from melting lines", "[melting]") {
             try {
                 CoolProp::set_config_bool(DONT_CHECK_PROPERTY_LIMITS, true);
                 T_pmax_required = AS->melting_line(iT, iP, EOS_pmax);
-            } catch (...) {
+            } catch (...) {  // NOLINT(bugprone-empty-catch)
+                // Best-effort probe: T_pmax_required stays at its -1
+                // sentinel and shows up in the CAPTURE below.  The real
+                // assertion is CHECK_NOTHROW on the next melting_line
+                // call.
             }
             CoolProp::set_config_bool(DONT_CHECK_PROPERTY_LIMITS, false);
             CAPTURE(T_pmax_required);
@@ -387,8 +390,7 @@ TEST_CASE("Test that hs_anchor enthalpy/entropy agrees with EOS", "[ancillaries]
         std::ostringstream ss1;
         ss1 << "Check hs_anchor for " << fluids[i];
         SECTION(ss1.str(), "") {
-            std::string note =
-              "The enthalpy and entropy are hardcoded in the fluid JSON files.  They MUST agree with the values calculated by the EOS";
+            INFO("The enthalpy and entropy are hardcoded in the fluid JSON files.  They MUST agree with the values calculated by the EOS");
             AS->update(CoolProp::DmolarT_INPUTS, hs_anchor.rhomolar, hs_anchor.T);
             double EOS_hmolar = AS->hmolar();
             double EOS_smolar = AS->smolar();

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -1644,7 +1644,7 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
     // Maximum saturation temperature - Equal to critical pressure for pure fluids
     CoolPropDbl psat_max = calc_pmax_sat();
 
-    double T_crit_ = T_critical(), p_crit_ = p_critical(), rhomolar_crit_ = rhomolar_critical();
+    double T_crit_ = T_critical(), rhomolar_crit_ = rhomolar_critical();
     auto smolar_critical = [this, &T_crit_, &rhomolar_crit_]() { return this->calc_smolar_nocache(T_crit_, rhomolar_crit_); };
     auto hmolar_critical = [this, &T_crit_, &rhomolar_crit_]() { return this->calc_hmolar_nocache(T_crit_, rhomolar_crit_); };
     auto umolar_critical = [this, &T_crit_, &rhomolar_crit_]() { return this->calc_umolar_nocache(T_crit_, rhomolar_crit_); };
@@ -2646,7 +2646,10 @@ HelmholtzEOSBackend::StationaryPointReturnFlag HelmholtzEOSMixtureBackend::solve
                 }
                 rho *= 2;
             }
-        } catch (...) {
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            // Slow-path probe gave up; `light` stays at -1 and the
+            // light/heavy < 0 checks below classify this as
+            // ZERO_STATIONARY_POINTS.
         }
     }
 
@@ -2682,7 +2685,10 @@ HelmholtzEOSBackend::StationaryPointReturnFlag HelmholtzEOSMixtureBackend::solve
                 }
                 rho /= 1.1;
             }
-        } catch (...) {
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            // Mirror of the light-side slow path above — `heavy` stays
+            // at -1 and the classification below treats it as no
+            // stationary point.
         }
     }
 

--- a/src/Backends/Helmholtz/MixtureParameters.cpp
+++ b/src/Backends/Helmholtz/MixtureParameters.cpp
@@ -340,7 +340,10 @@ std::string get_mixture_binary_pair_data(const std::string& CAS1, const std::str
                 return format("%0.16g", v[0].get_double("betaV"));
             } else {
             }
-        } catch (...) {
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            // Dictionary lookup threw (e.g. key present but wrong type);
+            // fall through to the ValueError below so the caller sees a
+            // uniform "could not match the parameter" message.
         }
         throw ValueError(format("Could not match the parameter [%s] for the binary pair [%s,%s] - for now this is an error.", key.c_str(),
                                 CAS1.c_str(), CAS2.c_str()));

--- a/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
+++ b/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
@@ -633,7 +633,7 @@ void PhaseEnvelopeRoutines::finalize(HelmholtzEOSMixtureBackend& HEOS) {
 
                 env.insert_variables(resid.IO.T, resid.IO.p, resid.IO.rhomolar_liq, resid.IO.rhomolar_vap, resid.IO.hmolar_liq, resid.IO.hmolar_vap,
                                      resid.IO.smolar_liq, resid.IO.smolar_vap, resid.IO.x, resid.IO.y, imax);
-            } catch (...) {
+            } catch (...) {  // NOLINT(bugprone-empty-catch)
                 // Don't do the insertion
             }
         }

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -833,7 +833,13 @@ void SaturationSolvers::saturation_T_pure_Akasaka(HelmholtzEOSMixtureBackend& HE
 
         deltaL = rhoL / reduce.rhomolar;
         deltaV = rhoV / reduce.rhomolar;
-    } catch (NotImplementedError&) {
+    } catch (NotImplementedError&) {  // NOLINT(bugprone-empty-catch)
+        // Backend doesn't implement the saturation-density ancillaries
+        // (e.g. PCSAFT, incompressible) — keep the deltaL/deltaV initial
+        // guess from the caller and let the Newton iteration below
+        // converge from there.  The commented-out Soave fallback was an
+        // earlier attempt at a guess-from-Tc/pc/omega path; left in
+        // place as a hint if anyone revisits this.
         /*double Tc = crit.T;
         double pc = crit.p.Pa;
         double w = 6.67228479e-09*Tc*Tc*Tc-7.20464352e-06*Tc*Tc+3.16947758e-03*Tc-2.88760012e-01;
@@ -1024,7 +1030,10 @@ void SaturationSolvers::saturation_T_pure_Maxwell(HelmholtzEOSMixtureBackend& HE
                 }
             }
         }
-    } catch (NotImplementedError&) {
+    } catch (NotImplementedError&) {  // NOLINT(bugprone-empty-catch)
+        // SatL/SatV ancillaries not implemented for this backend — keep
+        // the input rhoL/rhoV initial guesses and let the caller's
+        // crit.rhomolar clamps below handle the dome edge.
     }
 
     if (rhoL < crit.rhomolar) {

--- a/src/Backends/IF97/IF97Backend.h
+++ b/src/Backends/IF97/IF97Backend.h
@@ -773,7 +773,7 @@ class IF97Backend : public AbstractState
                 try {
                     T_k = IF97::T_phmass(p_k, hmass_k);
                     inverse_ok = true;
-                } catch (const std::exception&) {
+                } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
                     // T_phmass throws for out-of-range inputs — fall
                     // through to the dome probe + OOB classification.
                 }

--- a/src/Backends/Incompressible/IncompressibleFluid.cpp
+++ b/src/Backends/Incompressible/IncompressibleFluid.cpp
@@ -553,11 +553,6 @@ Eigen::MatrixXd makeMatrix(const std::vector<double>& coefficients) {
 }
 
 TEST_CASE("Internal consistency checks and example use cases for the incompressible fluids", "[IncompressibleFluids]") {
-    bool PRINT = false;
-    std::string tmpStr;
-    std::vector<double> tmpVector;
-    std::vector<std::vector<double>> tmpMatrix;
-
     SECTION("Test case for \"SylthermXLT\" by Dow Chemicals") {
 
         std::vector<double> cRho;

--- a/src/Backends/PCSAFT/PCSAFTBackend.cpp
+++ b/src/Backends/PCSAFT/PCSAFTBackend.cpp
@@ -1999,8 +1999,10 @@ void PCSAFTBackend::flash_QT(PCSAFTBackend& PCSAFT) {
         p_guess = estimate_flash_p(PCSAFT);
         p = outerTQ(p_guess, PCSAFT);
         solution_found = true;
-    } catch (const SolutionError& /* ex */) {
-    } catch (const ValueError& /* ex */) {
+    } catch (const SolutionError& /* ex */) {  // NOLINT(bugprone-empty-catch)
+        // Initial-guess attempt failed; fall through to the pressure sweep below.
+    } catch (const ValueError& /* ex */) {  // NOLINT(bugprone-empty-catch)
+        // Same as above — fall through to the pressure sweep.
     }
 
     // if solution hasn't been found, try cycling through a range of pressures
@@ -2039,8 +2041,10 @@ void PCSAFTBackend::flash_PQ(PCSAFTBackend& PCSAFT) {
         t_guess = estimate_flash_t(PCSAFT);
         t = outerPQ(t_guess, PCSAFT);
         solution_found = true;
-    } catch (const SolutionError& /* ex */) {
-    } catch (const ValueError& /* ex */) {
+    } catch (const SolutionError& /* ex */) {  // NOLINT(bugprone-empty-catch)
+        // Initial-guess attempt failed; fall through to the temperature sweep below.
+    } catch (const ValueError& /* ex */) {  // NOLINT(bugprone-empty-catch)
+        // Same as above — fall through to the temperature sweep.
     }
 
     // if solution hasn't been found, try calling the flash function directly with a range of initial temperatures

--- a/src/Backends/PCSAFT/PCSAFTLibrary.cpp
+++ b/src/Backends/PCSAFT/PCSAFTLibrary.cpp
@@ -239,7 +239,9 @@ std::string PCSAFTLibraryClass::get_binary_interaction_pcsaft(const std::string&
                 }
             } else {
             }
-        } catch (...) {
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            // Dictionary lookup threw; fall through to the uniform
+            // "could not match the parameter" ValueError below.
         }
         throw ValueError(format("Could not match the parameter [%s] for the binary pair [%s,%s] - for now this is an error.", key.c_str(),
                                 CAS1.c_str(), CAS2.c_str()));
@@ -262,7 +264,9 @@ std::string PCSAFTLibraryClass::get_binary_interaction_pcsaft(const std::string&
                 }
             } else {
             }
-        } catch (...) {
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            // Dictionary lookup threw; fall through to the uniform
+            // "could not match the parameter" ValueError below.
         }
         throw ValueError(format("Could not match the parameter [%s] for the binary pair [%s,%s] - for now this is an error.", key.c_str(),
                                 CAS1.c_str(), CAS2.c_str()));

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -140,9 +140,8 @@ std::string get_REFPROP_mixtures_path_prefix() {
     std::string rpPath = refpropPath;
     // Allow the user to specify an alternative REFPROP path by configuration value
     std::string alt_refprop_path = CoolProp::get_config_string(ALTERNATIVE_REFPROP_PATH);
-    std::string separator = get_separator();
     if (!alt_refprop_path.empty()) {
-        //if (!endswith(alt_refprop_path, separator)) {
+        //if (!endswith(alt_refprop_path, get_separator())) {
         //    throw CoolProp::ValueError(format("ALTERNATIVE_REFPROP_PATH [%s] must end with a path sparator, typically a slash character", alt_refprop_path.c_str()));
         //}
         if (!path_exists(alt_refprop_path)) {
@@ -666,8 +665,7 @@ void REFPROPMixtureBackend::set_binary_interaction_double(const std::size_t i, c
     // Get the prior state
     GETKTVdll(&icomp, &jcomp, hmodij.data(), fij, hfmix.data(), hfij.data(), hbinp.data(), hmxrul.data(), 3, 255, 255, 255, 255);
 
-    std::string shmodij(hmodij.data());
-    //if (shmodij.find("KW") == 0 || shmodij.find("GE") == 0)  // Starts with KW or GE
+    //if (std::string(hmodij.data()).find("KW") == 0 || std::string(hmodij.data()).find("GE") == 0)  // Starts with KW or GE
     //{
     if (parameter == "betaT") {
         fij[0] = value;
@@ -714,8 +712,7 @@ double REFPROPMixtureBackend::get_binary_interaction_double(const std::size_t i,
     // Get the current state
     GETKTVdll(&icomp, &jcomp, hmodij.data(), fij, hfmix.data(), hfij.data(), hbinp.data(), hmxrul.data(), 3, 255, 255, 255, 255);
 
-    std::string shmodij(hmodij.data());
-    //if (shmodij.find("KW") == 0 || shmodij.find("GE") == 0)  // Starts with KW or GE
+    //if (std::string(hmodij.data()).find("KW") == 0 || std::string(hmodij.data()).find("GE") == 0)  // Starts with KW or GE
     //{
     double val = NAN;
     if (parameter == "betaT") {

--- a/src/Backends/Tabular/TabularBackends.cpp
+++ b/src/Backends/Tabular/TabularBackends.cpp
@@ -305,7 +305,7 @@ void CoolProp::SinglePhaseGriddedTableData::build(shared_ptr<CoolProp::AbstractS
             try {
                 visc[i][j] = AS->viscosity();
                 cond[i][j] = AS->conductivity();
-            } catch (std::exception&) {
+            } catch (std::exception&) {  // NOLINT(bugprone-empty-catch)
                 // Failures will remain as holes in table
             }
 

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -617,7 +617,10 @@ std::vector<std::vector<double>> PropsSImulti(const std::vector<std::string>& Ou
         if (get_debug_level() > 1) {
             std::cout << e.what() << std::endl;
         }
-    } catch (...) {
+    } catch (...) {  // NOLINT(bugprone-empty-catch)
+        // PropsSImulti is a public API and must never throw — non-
+        // std::exception escapes (e.g. ABI/external faults) are silently
+        // swallowed and surfaced via the empty return below.
     }
 #endif
     return std::vector<std::vector<double>>();

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -96,17 +96,21 @@ std::shared_ptr<CoolProp::AbstractState> get_critical_point(const std::shared_pt
     std::vector<double> masses = state->get_mass_fractions();
     if (masses.size() > 1) new_state->set_mass_fractions(masses);
 
+    // Try (p, T) first with the iphase_critical_point hint and then
+    // without; fall through to (rhomolar, T) with the same hint pair
+    // if neither works.  Each catch is a deliberate "try the next
+    // strategy" without reporting.
     if (std::isfinite(crit_state.p) && std::isfinite(crit_state.T)) {
         try {
             new_state->specify_phase(CoolProp::iphase_critical_point);
             new_state->update(CoolProp::PT_INPUTS, crit_state.p, crit_state.T);
             return new_state;
-        } catch (...) {
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
         }
         try {
             new_state->update(CoolProp::PT_INPUTS, crit_state.p, crit_state.T);
             return new_state;
-        } catch (...) {
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
         }
     }
 
@@ -115,12 +119,12 @@ std::shared_ptr<CoolProp::AbstractState> get_critical_point(const std::shared_pt
             new_state->specify_phase(CoolProp::iphase_critical_point);
             new_state->update(CoolProp::DmolarT_INPUTS, crit_state.rhomolar, crit_state.T);
             return new_state;
-        } catch (...) {
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
         }
         try {
             new_state->update(CoolProp::DmolarT_INPUTS, crit_state.rhomolar, crit_state.T);
             return new_state;
-        } catch (...) {
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
         }
     }
     throw CoolProp::ValueError("Could not calculate the critical point data.");
@@ -410,21 +414,25 @@ PropertyPlot::Range2D PropertyPlot::get_Tp_limits() const {
     else if (p.max < ID_FACTOR)
         p.max *= psat.max;
 
+    // trivial_keyed_output throws NotImplementedError on backends that
+    // don't expose iT_min / iT_max / iP_min / iP_max; in that case keep
+    // the prior limit unchanged.  Each catch is independent because we
+    // want to tighten any limit that IS available.
     try {
         t.min = std::max(t.min, state_->trivial_keyed_output(CoolProp::iT_min));
-    } catch (...) {
+    } catch (...) {  // NOLINT(bugprone-empty-catch)
     }
     try {
         t.max = std::min(t.max, state_->trivial_keyed_output(CoolProp::iT_max));
-    } catch (...) {
+    } catch (...) {  // NOLINT(bugprone-empty-catch)
     }
     try {
         p.min = std::max(p.min, state_->trivial_keyed_output(CoolProp::iP_min));
-    } catch (...) {
+    } catch (...) {  // NOLINT(bugprone-empty-catch)
     }
     try {
         p.max = std::min(p.max, state_->trivial_keyed_output(CoolProp::iP_max));
-    } catch (...) {
+    } catch (...) {  // NOLINT(bugprone-empty-catch)
     }
     return {t, p};
 }
@@ -448,7 +456,9 @@ PropertyPlot::Range2D PropertyPlot::get_axis_limits(CoolProp::parameters xkey, C
                     xrange.max = std::max(xrange.max, x);
                     yrange.min = std::min(yrange.min, y);
                     yrange.max = std::max(yrange.max, y);
-                } catch (...) {
+                } catch (...) {  // NOLINT(bugprone-empty-catch)
+                    // (T, p) outside the backend's valid region — this
+                    // corner doesn't contribute to the bounding box.
                 }
             }
         }

--- a/src/Helmholtz.cpp
+++ b/src/Helmholtz.cpp
@@ -1850,7 +1850,10 @@ TEST_CASE_METHOD(HelmholtzConsistencyFixture, "Helmholtz energy derivatives", "[
             try {
                 numerical_mcx = get_analytic_mcx(term, tau, delta, ntau, ndelta);
                 alphar_mcx = term->one_mcx(tau, delta).real();
-            } catch (std::exception& /* e */) {
+            } catch (std::exception& /* e */) {  // NOLINT(bugprone-empty-catch)
+                // one_mcx isn't implemented for every term; leave
+                // numerical_mcx/alphar_mcx at _HUGE so the CAPTURE
+                // below shows the gap rather than aborting the test.
                 //std::cout << e.what() << std::endl;
             }
             CAPTURE(alphar_mcx);

--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -2337,7 +2337,10 @@ double HAProps_Aux(const char* Name, double T, double p, double W, char* units) 
             std::cout << format("Sorry I didn't understand your input [%s] to HAProps_Aux\n", Name);
             return -1;
         }
-    } catch (...) {
+    } catch (...) {  // NOLINT(bugprone-empty-catch)
+        // HAProps_Aux is a public-facing C API and must never throw —
+        // anything that escapes the dispatch above is surfaced as
+        // _HUGE so callers see "no value" rather than a crash.
     }
     return _HUGE;
 }

--- a/src/Region/PiecewiseChebyshevCurve.cpp
+++ b/src/Region/PiecewiseChebyshevCurve.cpp
@@ -139,13 +139,12 @@ std::pair<double, double> tight_piece_bounds(const std::vector<double>& c, const
         if (prev_d == 0.0 || (prev_d * cur_d < 0.0)) {
             // Bracket [prev_s, cur_s]; bisect.
             double a_lo = prev_s, a_hi = cur_s;
-            double f_lo = prev_d, f_hi = cur_d;
+            double f_lo = prev_d;
             for (int it = 0; it < 60; ++it) {
                 const double mid = 0.5 * (a_lo + a_hi);
                 const double f_mid = eval_deriv(mid);
                 if (f_lo * f_mid <= 0.0) {
                     a_hi = mid;
-                    f_hi = f_mid;
                 } else {
                     a_lo = mid;
                     f_lo = f_mid;

--- a/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
+++ b/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
@@ -188,7 +188,7 @@ TEST_CASE("SVDSurface PH preset builds + evals against HEOS", "[SBTL][SVDSurface
             const double rel = std::abs(rho_pred - rho_truth) / rho_truth;
             max_rel = std::max(max_rel, rel);
             ++kept;
-        } catch (...) {
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
             // skip
         }
     }


### PR DESCRIPTION
## Summary

Per-site judgment fixes for the "real bugs / suspicious code" category of issue #2926. **Excluded:** virtual-in-ctor (10 sites, separate larger refactor) and float-loop-counter conversions (numerics review).

- **Dead stores (2):** drop unused `p_crit_` from `p_phase_determination_pure_or_pseudopure` (saves one `p_critical()` call per invocation; identical pattern at line 2112 is kept — `p_crit_` *is* used there). Remove unused `f_hi` from the bisection in `PiecewiseChebyshevCurve::boundary_envelope_extrema_` (only `f_lo` participates in the sign-change test).
- **Unused locals (4 + scaffolding):** three stale `errstr` strings in `FlashRoutines.cpp`; `errstring` in `Ancillaries.cpp`; convert `note = "..."` to `INFO(...)` so the explanatory text surfaces on Catch2 failure; remove the 4-line `PRINT`/`tmpStr`/`tmpVector`/`tmpMatrix` scaffold in `IncompressibleFluid.cpp`; fold REFPROP `separator` / two `shmodij` into the commented-out conditionals they fed (so anyone uncommenting them gets a compilable block).
- **Empty-catch intent (28 sites):** annotate each with `// NOLINT(bugprone-empty-catch)` matching the existing SVDSBTL convention, plus a one-line "why" comment where the prior body was empty or thin. Verified each catch is a deliberate fall-through (try-next-strategy, public-API "must not throw", or backend-doesn't-implement-this), not a swallowed bug.

After this PR, `bugprone-empty-catch`, `bugprone-unused-local-non-trivial-variable`, and `clang-analyzer-deadcode.DeadStores` all drop to **0 first-party findings**.

## Reproducibility

```bash
/opt/homebrew/opt/llvm@21/bin/run-clang-tidy -p build_catch \
  -checks='-*,bugprone-empty-catch,bugprone-unused-local-non-trivial-variable,clang-analyzer-deadcode.DeadStores' \
  -header-filter='^.../(include|src)/' -extra-arg=--sysroot=$(xcrun --show-sdk-path) -j 8
```

(Was 28 / 9 / 2 before this PR.)

## Test plan

- [x] `cmake --build build_catch --target CatchTestRunner -j8` — exit 0, no new warnings.
- [x] `./build_catch/CatchTestRunner [SBTL]` — 16 cases / 4587 assertions pass.
- [x] `./build_catch/CatchTestRunner [Helmholtz]` — 415 assertions / 1 case pass.
- [x] Local clang-tidy rescan of the three checks: 0 first-party findings.

Pre-existing 3595 `-Winconsistent-missing-override` warnings are unrelated (PR #2976 fixes those).

## Out of scope (filed for follow-up under #2926)

- virtual-in-ctor (10 sites) — needs per-class `init_*()` helper refactor.
- Float-loop-counter conversions (15 sites) — numerics review.
- `HumidAirProp` unbounded `strcpy` API — public-API signature change.
- Performance batch (`avoid-endl`, `faster-string-find`, `inefficient-vector-operation`) — separate mechanical sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused local variables across multiple backend modules.
  * Added compiler annotations and clarifying comments to empty exception handlers to suppress lint warnings and document intended error-handling behavior.
  * Minor refactoring of derivative-root bisection logic in boundary computation.
  * Cleaned up test code by removing unused test variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2978?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->