### PR TITLE
fix(tests): per-PID tmpdir suffix on Catch2 fixtures (CoolProp-8ft, CoolProp-3t8)

### DIFF
--- a/src/Tests/CoolProp-Tests-FactoryOptions.cpp
+++ b/src/Tests/CoolProp-Tests-FactoryOptions.cpp
@@ -15,6 +15,7 @@
 
 #    include "CoolProp/FactoryOptions.h"
 #    include "Exceptions.h"
+#    include "TestUtils.h"
 
 namespace {
 
@@ -24,7 +25,8 @@ class TempJSONFile
 {
    public:
     explicit TempJSONFile(const std::string& contents) {
-        path_ = std::filesystem::temp_directory_path() / ("cp_factopts_test_" + std::to_string(counter_++) + ".json");
+        path_ = std::filesystem::temp_directory_path()
+                / ("cp_factopts_test_" + std::to_string(CoolProp::tests::test_pid()) + "_" + std::to_string(counter_++) + ".json");
         std::ofstream(path_) << contents;
     }
     ~TempJSONFile() {

--- a/src/Tests/CoolProp-Tests-PropsSIOptions.cpp
+++ b/src/Tests/CoolProp-Tests-PropsSIOptions.cpp
@@ -23,6 +23,7 @@
 
 #    include "AbstractState.h"
 #    include "CoolProp.h"
+#    include "TestUtils.h"
 
 namespace {
 
@@ -30,7 +31,8 @@ class TempJSONFile
 {
    public:
     explicit TempJSONFile(const std::string& contents) {
-        path_ = std::filesystem::temp_directory_path() / ("cp_propssi_opts_test_" + std::to_string(counter_++) + ".json");
+        path_ = std::filesystem::temp_directory_path()
+                / ("cp_propssi_opts_test_" + std::to_string(CoolProp::tests::test_pid()) + "_" + std::to_string(counter_++) + ".json");
         std::ofstream(path_) << contents;
     }
     ~TempJSONFile() {

--- a/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
+++ b/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
@@ -21,6 +21,7 @@
 #    include "CoolProp/sbtl/SVDSurfaceSerializer.h"
 #    include "CoolProp/sbtl/SatBoundaryFactory.h"
 #    include "CoolProp/sbtl/SurfaceSpec.h"
+#    include "TestUtils.h"
 #    include "miniz.h"
 
 namespace cp_sbtl = CoolProp::sbtl;
@@ -383,9 +384,11 @@ TEST_CASE("SVDSurfaceSerializer file save/load round-trip", "[SBTL][serializer][
 
     // Save to a tmp file and load back via the file API.  Use
     // std::filesystem::temp_directory_path() rather than hard-coding
-    // /tmp -- the latter doesn't exist on Windows CI and would race
-    // when multiple test instances run concurrently.
-    const auto tmp_path = std::filesystem::temp_directory_path() / "svd_test_water_ph.svd.bin.z";
+    // /tmp -- the latter doesn't exist on Windows CI.  Suffix with the
+    // process PID (see CoolProp-8ft) so two concurrent CatchTestRunner
+    // instances don't collide on the same file.
+    const auto tmp_path = std::filesystem::temp_directory_path()
+                          / ("svd_test_water_ph_" + std::to_string(CoolProp::tests::test_pid()) + ".svd.bin.z");
     const std::string path = tmp_path.string();
     cp_sbtl::SVDSurfaceSerializer::save_to_file(surface, path);
     auto loaded = cp_sbtl::SVDSurfaceSerializer::load_from_file(path);

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -26,7 +26,25 @@ using Catch::Approx;
 #    include "CoolProp/sbtl/SVDSurfaceSerializer.h"
 #    include "DataStructures.h"
 
+#    if defined(_WIN32)
+#        include <process.h>  // _getpid
+#    else
+#        include <unistd.h>  // getpid
+#    endif
+
 namespace {
+
+// Portable PID accessor: tests that stage scratch files under
+// fs::temp_directory_path() suffix their directory name with this so
+// that two CatchTestRunner instances running concurrently (preflight
+// in two worktrees, dev + CI, etc.) don't trample each other's tmpdir.
+inline int test_pid() {
+#    if defined(_WIN32)
+    return ::_getpid();
+#    else
+    return ::getpid();
+#    endif
+}
 
 // Returns true if a cache file matching the SVDSBTL on-disk pattern
 // exists for both HmassP_INPUTS and PT_INPUTS for `fluid`.
@@ -769,7 +787,7 @@ TEST_CASE("SVDSBTL ALTERNATIVE_SVDTABLES_DIRECTORY routes default_cache_dir", "[
     namespace fs = std::filesystem;
     namespace cp_sbtl = CoolProp::sbtl;
     const std::string saved = CoolProp::get_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY);
-    const fs::path tmpdir = fs::temp_directory_path() / "coolprop_svdtables_fhp_resolver";
+    const fs::path tmpdir = fs::temp_directory_path() / ("coolprop_svdtables_fhp_resolver_" + std::to_string(test_pid()));
     std::error_code ec;
     fs::remove_all(tmpdir, ec);
 
@@ -805,7 +823,7 @@ TEST_CASE("SVDSBTL ALTERNATIVE_SVDTABLES_DIRECTORY routes default_cache_dir", "[
 TEST_CASE("SVDSBTL ALTERNATIVE_SVDTABLES_DIRECTORY end-to-end build + reload", "[SVDSBTL][cache][fhp][slow]") {
     namespace fs = std::filesystem;
     const std::string saved = CoolProp::get_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY);
-    const fs::path tmpdir = fs::temp_directory_path() / "coolprop_svdtables_fhp_e2e";
+    const fs::path tmpdir = fs::temp_directory_path() / ("coolprop_svdtables_fhp_e2e_" + std::to_string(test_pid()));
     std::error_code ec;
     fs::remove_all(tmpdir, ec);
     CoolProp::set_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY, tmpdir.string());
@@ -876,7 +894,7 @@ TEST_CASE("SVDSBTL ALTERNATIVE_SVDTABLES_DIRECTORY end-to-end build + reload", "
 // interleaved mix.
 TEST_CASE("write_bytes_atomic is race-safe across threads", "[SVDSBTL][cache][race][4no.2]") {
     namespace fs = std::filesystem;
-    const fs::path tmpdir = fs::temp_directory_path() / "coolprop_svdtables_atomic_race";
+    const fs::path tmpdir = fs::temp_directory_path() / ("coolprop_svdtables_atomic_race_" + std::to_string(test_pid()));
     std::error_code ec;
     fs::remove_all(tmpdir, ec);
     fs::create_directories(tmpdir);

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -25,26 +25,9 @@ using Catch::Approx;
 #    include "CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h"
 #    include "CoolProp/sbtl/SVDSurfaceSerializer.h"
 #    include "DataStructures.h"
-
-#    if defined(_WIN32)
-#        include <process.h>  // _getpid
-#    else
-#        include <unistd.h>  // getpid
-#    endif
+#    include "TestUtils.h"
 
 namespace {
-
-// Portable PID accessor: tests that stage scratch files under
-// fs::temp_directory_path() suffix their directory name with this so
-// that two CatchTestRunner instances running concurrently (preflight
-// in two worktrees, dev + CI, etc.) don't trample each other's tmpdir.
-inline int test_pid() {
-#    if defined(_WIN32)
-    return ::_getpid();
-#    else
-    return ::getpid();
-#    endif
-}
 
 // Returns true if a cache file matching the SVDSBTL on-disk pattern
 // exists for both HmassP_INPUTS and PT_INPUTS for `fluid`.
@@ -787,7 +770,7 @@ TEST_CASE("SVDSBTL ALTERNATIVE_SVDTABLES_DIRECTORY routes default_cache_dir", "[
     namespace fs = std::filesystem;
     namespace cp_sbtl = CoolProp::sbtl;
     const std::string saved = CoolProp::get_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY);
-    const fs::path tmpdir = fs::temp_directory_path() / ("coolprop_svdtables_fhp_resolver_" + std::to_string(test_pid()));
+    const fs::path tmpdir = fs::temp_directory_path() / ("coolprop_svdtables_fhp_resolver_" + std::to_string(CoolProp::tests::test_pid()));
     std::error_code ec;
     fs::remove_all(tmpdir, ec);
 
@@ -823,7 +806,7 @@ TEST_CASE("SVDSBTL ALTERNATIVE_SVDTABLES_DIRECTORY routes default_cache_dir", "[
 TEST_CASE("SVDSBTL ALTERNATIVE_SVDTABLES_DIRECTORY end-to-end build + reload", "[SVDSBTL][cache][fhp][slow]") {
     namespace fs = std::filesystem;
     const std::string saved = CoolProp::get_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY);
-    const fs::path tmpdir = fs::temp_directory_path() / ("coolprop_svdtables_fhp_e2e_" + std::to_string(test_pid()));
+    const fs::path tmpdir = fs::temp_directory_path() / ("coolprop_svdtables_fhp_e2e_" + std::to_string(CoolProp::tests::test_pid()));
     std::error_code ec;
     fs::remove_all(tmpdir, ec);
     CoolProp::set_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY, tmpdir.string());
@@ -894,7 +877,7 @@ TEST_CASE("SVDSBTL ALTERNATIVE_SVDTABLES_DIRECTORY end-to-end build + reload", "
 // interleaved mix.
 TEST_CASE("write_bytes_atomic is race-safe across threads", "[SVDSBTL][cache][race][4no.2]") {
     namespace fs = std::filesystem;
-    const fs::path tmpdir = fs::temp_directory_path() / ("coolprop_svdtables_atomic_race_" + std::to_string(test_pid()));
+    const fs::path tmpdir = fs::temp_directory_path() / ("coolprop_svdtables_atomic_race_" + std::to_string(CoolProp::tests::test_pid()));
     std::error_code ec;
     fs::remove_all(tmpdir, ec);
     fs::create_directories(tmpdir);

--- a/src/Tests/TestUtils.h
+++ b/src/Tests/TestUtils.h
@@ -1,0 +1,31 @@
+// Shared helpers for Catch2 test TUs.  Header-only.
+
+#ifndef COOLPROP_TESTS_TEST_UTILS_H
+#define COOLPROP_TESTS_TEST_UTILS_H
+
+#if defined(_WIN32)
+#    include <process.h>  // _getpid
+#else
+#    include <unistd.h>  // getpid
+#endif
+
+namespace CoolProp {
+namespace tests {
+
+// Portable process ID for tests that stage scratch files under
+// fs::temp_directory_path() — suffix the path with this so two
+// concurrent CatchTestRunner instances (preflight in two worktrees,
+// dev + CI, etc.) don't collide on the same hardcoded path.  See
+// CoolProp-8ft.
+inline int test_pid() {
+#if defined(_WIN32)
+    return ::_getpid();
+#else
+    return ::getpid();
+#endif
+}
+
+}  // namespace tests
+}  // namespace CoolProp
+
+#endif  // COOLPROP_TESTS_TEST_UTILS_H


### PR DESCRIPTION
## Summary

Four Catch2 test fixtures hardcoded scratch paths directly under \`fs::temp_directory_path()\`, causing cross-process races when two \`CatchTestRunner\` instances run concurrently (e.g. preflight in two worktrees, dev + CI).  Suffix each path with the process PID via a new shared helper.

- **Closes** CoolProp-8ft (three \`[SVDSBTL][cache]\` tests under \`src/Tests/CoolProp-Tests-SVDSBTL.cpp\`)
- **Closes** CoolProp-3t8 (\`SVDSurfaceSerializer\` round-trip in \`CoolProp-Tests-SBTLAdapter.cpp\`)
- Also fixes the \`TempJSONFile\` helpers in \`CoolProp-Tests-FactoryOptions.cpp\` and \`CoolProp-Tests-PropsSIOptions.cpp\` — both used a \`static inline int counter_ = 0\` that gave intra-process uniqueness but not cross-process

## What changed

| File | Change |
|---|---|
| \`src/Tests/TestUtils.h\` (new) | Header-only \`CoolProp::tests::test_pid()\` (POSIX \`getpid\` / Windows \`_getpid\`) |
| \`CoolProp-Tests-SVDSBTL.cpp\` | Lifted the local \`test_pid\` helper into \`TestUtils.h\`; suffixed the 3 \`coolprop_svdtables_*\` tmpdirs |
| \`CoolProp-Tests-SBTLAdapter.cpp\` | Suffixed \`svd_test_water_ph_<pid>.svd.bin.z\` |
| \`CoolProp-Tests-FactoryOptions.cpp\` | \`TempJSONFile\` path → \`cp_factopts_test_<pid>_<counter>.json\` |
| \`CoolProp-Tests-PropsSIOptions.cpp\` | \`TempJSONFile\` path → \`cp_propssi_opts_test_<pid>_<counter>.json\` |

The production \`write_bytes_atomic\` code is unchanged; it was already correct at the write level.  Only the test-fixture design needed fixing.

## Test plan

- [x] \`cmake --build build_catch --target CatchTestRunner -j8\` — clean
- [x] Single-instance run: \`./build_catch/CatchTestRunner "[SBTL][serializer],[FactoryOptions],[SVDSBTL][cache]"\` → 25/26 pass (1 skip on REFPROP unavailable, unrelated)
- [x] **Two concurrent CatchTestRunner instances** (the scenario that originally surfaced the race) → both pass cleanly, no leftover tmp files
- [x] \`./dev/ci/preflight.sh --skip=clang-tidy\` → 5 passed / 0 failed / 1 skipped
- [x] Adversarial code-reviewer pass → no blocking findings

## Note on \`--skip=clang-tidy\`

Preflight surfaces 4 pre-existing clang-tidy findings in \`CoolProp-Tests-SBTLAdapter.cpp\` (lines 192/289/290) from commit \`90798df4d0\` (2026-05-16), unrelated to this race fix — preflight's clang-tidy runs full-file on touched TUs.  Filed as **CoolProp-2qt** for separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability during parallel execution with enhanced temporary file and directory handling.
  * Updated test infrastructure to use system-provided temporary directories and process isolation, reducing inter-process test interference.
  * Added cross-platform test utility support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2979?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->