### PR TITLE
refactor: clang-tidy perf sweep + virtual-in-ctor + float-loops (CoolProp-kig, #2926)

### DIFF
--- a/include/AbstractState.h
+++ b/include/AbstractState.h
@@ -722,7 +722,11 @@ class AbstractState
 
    public:
     AbstractState() : _fluid_type(FLUID_TYPE_UNDEFINED), _phase(iphase_unknown) {
-        clear();
+        // Explicit scope: a virtual `clear()` call from the base ctor
+        // would dispatch to this class anyway (derived overrides aren't
+        // active yet), so call it directly to make that intent visible
+        // and silence clang-analyzer-optin.cplusplus.VirtualCall.
+        AbstractState::clear();
     }
     virtual ~AbstractState() {};
 

--- a/include/CPnumerics.h
+++ b/include/CPnumerics.h
@@ -67,12 +67,12 @@ class Spline
     /** A spline with x and y values */
     Spline(const std::vector<X>& x, const std::vector<Y>& y) {
         if (x.size() != y.size()) {
-            std::cerr << "X and Y must be the same size " << std::endl;
+            std::cerr << "X and Y must be the same size " << '\n';
             return;
         }
 
         if (x.size() < 3) {
-            std::cerr << "Must have at least three points for interpolation" << std::endl;
+            std::cerr << "Must have at least three points for interpolation" << '\n';
             return;
         }
 

--- a/include/CPstrings.h
+++ b/include/CPstrings.h
@@ -114,13 +114,13 @@ inline bool strstartswith(const std::string& s, const std::string& other) {
 inline double string2double(const std::string& s) {
     std::string mys = s;  //copy
     // replace D with e (FORTRAN style scientific definition)
-    if (mys.find("D") != std::string::npos) {
-        std::size_t pos = mys.find("D"), len = 1;
+    if (mys.find('D') != std::string::npos) {
+        std::size_t pos = mys.find('D'), len = 1;
         mys.replace(pos, len, "e");
     }
     // replace d with e (FORTRAN style scientific definition)
-    if (mys.find("d") != std::string::npos) {
-        std::size_t pos = mys.find("d"), len = 1;
+    if (mys.find('d') != std::string::npos) {
+        std::size_t pos = mys.find('d'), len = 1;
         mys.replace(pos, len, "e");
     }
 

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -358,7 +358,7 @@ class Configuration
                     } catch (...) {
                         auto skey = config_key_to_string(key);
                         std::string msg = "Unable to convert \"" + std::string(envval) + "\" to int for key [" + skey + "]";
-                        std::cerr << msg << std::endl;
+                        std::cerr << msg << '\n';
                         throw ValueError(msg);
                     }
                     items.erase(key);
@@ -372,7 +372,7 @@ class Configuration
                     } catch (...) {
                         auto skey = config_key_to_string(key);
                         std::string msg = "Unable to convert \"" + std::string(envval) + "\" to double for key [" + skey + "]";
-                        std::cerr << msg << std::endl;
+                        std::cerr << msg << '\n';
                         throw ValueError(msg);
                     }
                     items.erase(key);
@@ -386,7 +386,7 @@ class Configuration
                     } catch (...) {
                         auto skey = config_key_to_string(key);
                         std::string msg = "Unable to convert \"" + std::string(envval) + "\" to bool for key [" + skey + "]";
-                        std::cerr << msg << std::endl;
+                        std::cerr << msg << '\n';
                         throw ValueError(msg);
                     }
                     items.erase(key);

--- a/include/MatrixMath.h
+++ b/include/MatrixMath.h
@@ -361,7 +361,7 @@ std::string vec_to_string(const std::vector<std::vector<T>>& A, const char* fmt)
     std::stringstream out;
     out << "[ " << vec_to_string(A[0], fmt);
     for (size_t j = 1; j < A.size(); j++) {
-        out << ", " << std::endl << "  " << vec_to_string(A[j], fmt);
+        out << ", " << '\n' << "  " << vec_to_string(A[j], fmt);
     }
     out << " ]";
     return out.str();
@@ -388,7 +388,7 @@ std::string mat_to_string(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
     } else {
         out << mat_to_string(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>(A.row(0)), fmt);
         for (size_t i = 1; i < r; i++) {
-            out << ", " << std::endl << "  " << mat_to_string(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>(A.row(i)), fmt);
+            out << ", " << '\n' << "  " << mat_to_string(Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>(A.row(i)), fmt);
         }
     }
     out << " ]";
@@ -723,6 +723,7 @@ std::vector<std::vector<T>> linsolve(std::vector<std::vector<T>> const& A, std::
 template <class T>
 std::vector<T> linsolve(std::vector<std::vector<T>> const& A, std::vector<T> const& b) {
     std::vector<std::vector<T>> B;
+    B.reserve(b.size());
     for (size_t i = 0; i < b.size(); i++) {
         B.push_back(std::vector<T>(1, b[i]));
     }

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -167,7 +167,7 @@ static CoolProp::GeneratorInitializer<PCSAFTGenerator> pcsaft_gen(CoolProp::PCSA
 
 AbstractState* AbstractState::factory(const std::string& backend, const std::vector<std::string>& fluid_names) {
     if (get_debug_level() > 0) {
-        std::cout << "AbstractState::factory(" << backend << "," << stringvec_to_string(fluid_names) << ")" << std::endl;
+        std::cout << "AbstractState::factory(" << backend << "," << stringvec_to_string(fluid_names) << ")" << '\n';
     }
 
     // Split off any "?<options>" suffix once at the entry-point so the
@@ -226,7 +226,7 @@ AbstractState* AbstractState::factory(const std::string& backend, const std::vec
     get_backend_library().get_generator_iterators(f1, gen, end);
 
     if (get_debug_level() > 0) {
-        std::cout << "AbstractState::factory backend_library size: " << get_backend_library().size() << std::endl;
+        std::cout << "AbstractState::factory backend_library size: " << get_backend_library().size() << '\n';
     }
 
     if (gen != end) {
@@ -450,7 +450,7 @@ void AbstractState::mass_to_molar_inputs(CoolProp::input_pairs& input_pair, Cool
 }
 double AbstractState::trivial_keyed_output(parameters key) {
     if (get_debug_level() >= 50)
-        std::cout << format("AbstractState: trivial_keyed_output called for %s ", get_parameter_information(key, "short").c_str()) << std::endl;
+        std::cout << format("AbstractState: trivial_keyed_output called for %s ", get_parameter_information(key, "short").c_str()) << '\n';
     switch (key) {
         case imolar_mass:
             return molar_mass();
@@ -512,7 +512,7 @@ double AbstractState::trivial_keyed_output(parameters key) {
 }
 double AbstractState::keyed_output(parameters key) {
     if (get_debug_level() >= 50)
-        std::cout << format("AbstractState: keyed_output called for %s ", get_parameter_information(key, "short").c_str()) << std::endl;
+        std::cout << format("AbstractState: keyed_output called for %s ", get_parameter_information(key, "short").c_str()) << '\n';
     // Handle trivial inputs
     if (is_trivial_parameter(key)) {
         return trivial_keyed_output(key);

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -128,6 +128,7 @@ std::string CoolProp::AbstractCubicBackend::fluid_param_string(const std::string
 
 std::vector<std::string> CoolProp::AbstractCubicBackend::calc_fluid_names() {
     std::vector<std::string> out;
+    out.reserve(components.size());
     for (std::size_t i = 0; i < components.size(); ++i) {
         out.push_back(components[i].name);
     }
@@ -319,7 +320,7 @@ void CoolProp::AbstractCubicBackend::update(CoolProp::input_pairs input_pair, do
     if (get_debug_level() > 10) {
         std::cout << format("%s (%d): update called with (%d: (%s), %g, %g)", __FILE__, __LINE__, input_pair,
                             get_input_pair_short_desc(input_pair).c_str(), value1, value2)
-                  << std::endl;
+                  << '\n';
     }
 
     // Mass-quality input pair on a true mixture: solve iteratively for Qmolar

--- a/src/Backends/Cubics/CubicsLibrary.cpp
+++ b/src/Backends/Cubics/CubicsLibrary.cpp
@@ -57,7 +57,7 @@ class CubicsLibraryClass
                 fluid_map.erase(ret.first);
                 ret = fluid_map.emplace(upper(val.name), val);
                 if (get_debug_level() > 0) {
-                    std::cout << "added the cubic fluid: " + val.name << std::endl;
+                    std::cout << "added the cubic fluid: " + val.name << '\n';
                 }
                 assert(ret.second == true);
             }
@@ -78,7 +78,7 @@ class CubicsLibraryClass
                 JSONstring_map.erase(addJson.first);
                 addJson = JSONstring_map.emplace(upper(val.name), cpjson::json2string(*itr));
                 if (get_debug_level() > 0) {
-                    std::cout << "added the cubic fluid: " + val.name << std::endl;
+                    std::cout << "added the cubic fluid: " + val.name << '\n';
                 }
                 assert(addJson.second == true);
             }

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -1921,7 +1921,7 @@ void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend& HE
                 throw;
             }
             if (get_debug_level() > 0) {
-                std::cout << resid.errstring << std::endl;
+                std::cout << resid.errstring << '\n';
             }
             std::vector<double> x0 = {Tstart, rhomolarstart};
             NDNewtonRaphson_Jacobian(&solver_resid2d, x0, 1e-12, 20, 1.0);
@@ -1933,7 +1933,7 @@ void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend& HE
             HEOS.recalculate_singlephase_phase();
         } catch (...) {
             if (get_debug_level() > 0) {
-                std::cout << resid.errstring << std::endl;
+                std::cout << resid.errstring << '\n';
             }
             // Un-specify the phase of the fluid
             HEOS.unspecify_phase();

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -961,7 +961,9 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend& HEOS) {
             double increment = 0.4;
 
             try {
-                for (double omega = 1.0; omega > 0; omega -= increment) {
+                // Newton-step damping: 3 iters (omega = 1.0, 0.6, 0.2)
+                // — bounded loop, no accumulation issue worth rewriting.
+                for (double omega = 1.0; omega > 0; omega -= increment) {  // NOLINT(cert-flp30-c)
                     try {
                         options.omega = omega;
 
@@ -2469,7 +2471,10 @@ void FlashRoutines::HS_flash_singlephase(HelmholtzEOSMixtureBackend& HEOS, CoolP
         double tau0 = HEOS.tau(), delta0 = HEOS.delta();
         // Calculate the old residual after the last step
         resid_old = sqrt(POW2(HEOS.hmolar() - hmolar_spec) + POW2(HEOS.smolar() - smolar_spec));
-        for (double frac = 1.0; frac > 0.001; frac /= 2) {
+        // Geometric halving of the Newton step length (10 iters from
+        // 1.0 down to ~1/1024) — geometric, not summation; no FP
+        // counter-accumulation issue.
+        for (double frac = 1.0; frac > 0.001; frac /= 2) {  // NOLINT(cert-flp30-c)
             try {
                 // Calculate new values
                 double tau_new = tau0 + options.omega * frac * v(0);
@@ -2585,7 +2590,8 @@ TEST_CASE("Stability testing", "[stability]") {
 
     SECTION("Liquid (feed is stable)") {
         StabilityRoutines::StabilityEvaluationClass stability_tester(*HEOS);
-        for (double T = TL - 1; T >= 100; T -= 1) {
+        // Unit step over an integer range — T values are bit-exact doubles, no accumulation.
+        for (double T = TL - 1; T >= 100; T -= 1) {  // NOLINT(cert-flp30-c)
             stability_tester.set_TP(T, 101325);
             CAPTURE(T);
             CHECK_NOTHROW(stability_tester.is_stable());
@@ -2593,7 +2599,8 @@ TEST_CASE("Stability testing", "[stability]") {
     }
     SECTION("Vapor (feed is stable)") {
         StabilityRoutines::StabilityEvaluationClass stability_tester(*HEOS);
-        for (double T = TV + 1; T <= 500; T += 1) {
+        // Unit step over an integer range — see liquid section above.
+        for (double T = TV + 1; T <= 500; T += 1) {  // NOLINT(cert-flp30-c)
             stability_tester.set_TP(T, 101325);
             CAPTURE(T);
             CHECK_NOTHROW(stability_tester.is_stable());

--- a/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
+++ b/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
@@ -341,7 +341,13 @@ TEST_CASE("Tests for values from melting lines", "[melting]") {
             CHECK(pmax > pmin);
             CHECK(pmin > 0);
         }
-        for (double p = 0.1 * (pmax - pmin) + pmin; p < pmax; p += 0.2 * (pmax - pmin)) {
+        // Integer-indexed grid (cert-flp30-c): the original
+        //   for (p = 0.1*range + pmin; p < pmax; p += 0.2*range)
+        // intends 5 samples at p_i = pmin + (0.1 + 0.2*i)*range for
+        // i in {0..4}; preserve that count exactly.
+        const double p_range = pmax - pmin;
+        for (int p_i = 0; p_i < 5; ++p_i) {
+            const double p = pmin + (0.1 + 0.2 * p_i) * p_range;
             // See https://groups.google.com/forum/?fromgroups#!topic/catch-forum/mRBKqtTrITU
             std::ostringstream ss1;
             ss1 << "Melting line for " << fluids[i] << " at p=" << p;

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
@@ -55,7 +55,7 @@ void load() {
     if (getenv("COOLPROP_DISABLE_SUPERANCILLARIES_ENTIRELY")) {
         std::cout << "CoolProp: superancillaries have been disabled because the COOLPROP_DISABLE_SUPERANCILLARIES_ENTIRELY environment variable has "
                      "been defined"
-                  << std::endl;
+                  << '\n';
     }
 
     rapidjson::Document dd;
@@ -67,7 +67,7 @@ void load() {
         try {
             library.add_many(dd);
         } catch (std::exception& e) {
-            std::cout << e.what() << std::endl;
+            std::cout << e.what() << '\n';
         }
     }
 }

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.h
@@ -1176,7 +1176,7 @@ class JSONFluidLibrary
             }
         }
         if (!ValidNumber(fluid.ancillaries.sL.get_Tmin()) && get_debug_level() > 0) {
-            std::cout << "Tmin invalid for sL for " << fluid.name << std::endl;
+            std::cout << "Tmin invalid for sL for " << fluid.name << '\n';
         }
     };
 

--- a/src/Backends/Helmholtz/HelmholtzEOSBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSBackend.h
@@ -43,8 +43,8 @@ class HelmholtzEOSBackend : public HelmholtzEOSMixtureBackend
             std::vector<std::string> fluids = dict.get_string_vector("fluids");
             mole_fractions = dict.get_double_vector("mole_fractions");
             if (get_debug_level() > 0) {
-                std::cout << "Got the fluids" << vecstring_to_string(fluids) << std::endl;
-                std::cout << "Got the fractions" << vec_to_string(mole_fractions, "%g") << std::endl;
+                std::cout << "Got the fluids" << vecstring_to_string(fluids) << '\n';
+                std::cout << "Got the fractions" << vec_to_string(mole_fractions, "%g") << '\n';
             }
             for (unsigned int i = 0; i < fluids.size(); ++i) {
                 components.push_back(library.get(fluids[i]));
@@ -58,7 +58,7 @@ class HelmholtzEOSBackend : public HelmholtzEOSMixtureBackend
         // Set the mole fractions
         set_mole_fractions(std::vector<CoolPropDbl>(mole_fractions.begin(), mole_fractions.end()));
         if (get_debug_level() > 0) {
-            std::cout << "successfully set up state" << std::endl;
+            std::cout << "successfully set up state" << '\n';
         }
     };
     virtual ~HelmholtzEOSBackend() {};

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -80,8 +80,10 @@ HelmholtzEOSMixtureBackend::HelmholtzEOSMixtureBackend(const std::vector<std::st
     // Reset the residual Helmholtz energy class
     residual_helmholtz = std::make_shared<ResidualHelmholtz>();
 
-    // Set the components and associated flags
-    set_components(components, generate_SatL_and_SatV);
+    // Set the components and associated flags.  Explicit scope so the
+    // virtual-from-ctor call isn't flagged — derived overrides aren't
+    // active yet, so we want exactly THIS class's set_components.
+    HelmholtzEOSMixtureBackend::set_components(components, generate_SatL_and_SatV);
 
     // Set the phase to default unknown value
     _phase = iphase_unknown;
@@ -91,8 +93,9 @@ HelmholtzEOSMixtureBackend::HelmholtzEOSMixtureBackend(const std::vector<CoolPro
     // Reset the residual Helmholtz energy class
     residual_helmholtz = std::make_shared<ResidualHelmholtz>();
 
-    // Set the components and associated flags
-    set_components(components, generate_SatL_and_SatV);
+    // Set the components and associated flags (explicit scope — see
+    // the string-name ctor above for the rationale).
+    HelmholtzEOSMixtureBackend::set_components(components, generate_SatL_and_SatV);
 
     // Set the phase to default unknown value
     _phase = iphase_unknown;
@@ -108,8 +111,12 @@ void HelmholtzEOSMixtureBackend::set_components(const std::vector<CoolPropFluid>
         mole_fractions = std::vector<CoolPropDbl>(1, 1);
         std::vector<std::vector<double>> ones(1, std::vector<double>(1, 1));
         Reducing = std::make_shared<GERG2008ReducingFunction>(components, ones, ones, ones, ones);
-        _reducing = calc_reducing_state_nocache(mole_fractions);
-        _gas_constant = calc_gas_constant();
+        // Explicit scope: set_components is called from the ctor (see
+        // HelmholtzEOSMixtureBackend ctor above), so derived overrides
+        // aren't active yet and these virtuals would dispatch to this
+        // class anyway.  Make that explicit.
+        _reducing = HelmholtzEOSMixtureBackend::calc_reducing_state_nocache(mole_fractions);
+        _gas_constant = HelmholtzEOSMixtureBackend::calc_gas_constant();
     } else {
         // Set the mixture parameters - binary pair reducing functions, departure functions, F_ij, etc.
         set_mixture_parameters();
@@ -118,13 +125,17 @@ void HelmholtzEOSMixtureBackend::set_components(const std::vector<CoolPropFluid>
     imposed_phase_index = iphase_not_imposed;
 
     // Top-level class can hold copies of the base saturation classes,
-    // saturation classes cannot hold copies of the saturation classes
+    // saturation classes cannot hold copies of the saturation classes.
+    // Explicit scope on get_copy: this method is called from the ctor
+    // (transitively) and clang-analyzer flags the implicit virtual
+    // dispatch — but derived overrides aren't active yet, so we want
+    // exactly THIS class's get_copy regardless.
     if (generate_SatL_and_SatV) {
-        SatL.reset(get_copy(false));
+        SatL.reset(HelmholtzEOSMixtureBackend::get_copy(false));
         SatL->specify_phase(iphase_liquid);
         linked_states.push_back(SatL);
         SatL->clear();
-        SatV.reset(get_copy(false));
+        SatV.reset(HelmholtzEOSMixtureBackend::get_copy(false));
         SatV->specify_phase(iphase_gas);
         SatV->clear();
         linked_states.push_back(SatV);

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -2667,7 +2667,8 @@ HelmholtzEOSBackend::StationaryPointReturnFlag HelmholtzEOSMixtureBackend::solve
     }
 
     // First try a "normal" calculation of the stationary point on the liquid side
-    for (double omega = 0.7; omega > 0; omega -= 0.2) {
+    // 4 fixed iters (omega = 0.7, 0.5, 0.3, 0.1) — no FP accumulation concern.
+    for (double omega = 0.7; omega > 0; omega -= 0.2) {  // NOLINT(cert-flp30-c)
         try {
             resid.options.add_number("omega", omega);
             heavy = Halley(resid, rhomax, 1e-8, 100);

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -170,6 +170,7 @@ void HelmholtzEOSMixtureBackend::set_mass_fractions(const std::vector<CoolPropDb
         sum_moles += tmp;
     }
     std::vector<CoolPropDbl> mole_fractions;
+    mole_fractions.reserve(moles.size());
     for (const auto& m : moles) {
         mole_fractions.push_back(m / sum_moles);
     }
@@ -1087,6 +1088,7 @@ void HelmholtzEOSMixtureBackend::calc_ideal_curve(const std::string& type, std::
 };
 std::vector<std::string> HelmholtzEOSMixtureBackend::calc_fluid_names() {
     std::vector<std::string> out;
+    out.reserve(components.size());
     for (std::size_t i = 0; i < components.size(); ++i) {
         out.push_back(components[i].name);
     }
@@ -1406,7 +1408,7 @@ void HelmholtzEOSMixtureBackend::update(CoolProp::input_pairs input_pair, double
     if (get_debug_level() > 10) {
         std::cout << format("%s (%d): update called with (%d: (%s), %g, %g)", __FILE__, __LINE__, input_pair,
                             get_input_pair_short_desc(input_pair).c_str(), value1, value2)
-                  << std::endl;
+                  << '\n';
     }
 
     CoolPropDbl ld_value1 = value1, ld_value2 = value2;
@@ -1532,7 +1534,7 @@ void HelmholtzEOSMixtureBackend::update_with_guesses(CoolProp::input_pairs input
     if (get_debug_level() > 10) {
         std::cout << format("%s (%d): update called with (%d: (%s), %g, %g)", __FILE__, __LINE__, input_pair,
                             get_input_pair_short_desc(input_pair).c_str(), value1, value2)
-                  << std::endl;
+                  << '\n';
     }
 
     CoolPropDbl ld_value1 = value1, ld_value2 = value2;
@@ -2628,7 +2630,7 @@ HelmholtzEOSBackend::StationaryPointReturnFlag HelmholtzEOSMixtureBackend::solve
         }
     } catch (std::exception& e) {
         if (get_debug_level() > 5) {
-            std::cout << e.what() << std::endl;
+            std::cout << e.what() << '\n';
         };
         light = -1;
     }
@@ -2666,7 +2668,7 @@ HelmholtzEOSBackend::StationaryPointReturnFlag HelmholtzEOSMixtureBackend::solve
             break;  // Jump out, we got a good solution
         } catch (std::exception& e) {
             if (get_debug_level() > 5) {
-                std::cout << e.what() << std::endl;
+                std::cout << e.what() << '\n';
             };
             heavy = -1;
         }
@@ -3048,7 +3050,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_hmolar_nocache(CoolPropDbl T, CoolP
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_hmolar() {
     if (get_debug_level() >= 50)
-        std::cout << format("HelmholtzEOSMixtureBackend::calc_hmolar: 2phase: %d T: %g rhomomolar: %g", isTwoPhase(), _T, _rhomolar) << std::endl;
+        std::cout << format("HelmholtzEOSMixtureBackend::calc_hmolar: 2phase: %d T: %g rhomomolar: %g", isTwoPhase(), _T, _rhomolar) << '\n';
     if (isTwoPhase()) {
         if (!this->SatL || !this->SatV) throw ValueError(format("The saturation properties are needed for the two-phase properties"));
         if (std::abs(_Q) < DBL_EPSILON) {
@@ -3987,8 +3989,8 @@ CoolProp::CriticalState HelmholtzEOSMixtureBackend::calc_critical_point(double r
                     J[j][i] = (rplus[j] - rminus[j]) / (2 * epsilon);
                 }
             }
-            std::cout << J[0][0] << " " << J[0][1] << std::endl;
-            std::cout << J[1][0] << " " << J[1][1] << std::endl;
+            std::cout << J[0][0] << " " << J[0][1] << '\n';
+            std::cout << J[1][0] << " " << J[1][1] << '\n';
             return J;
         };
     };
@@ -4181,7 +4183,7 @@ class L0CurveTracer : public FuncWrapper1DWithDeriv
                 critical_points.push_back(crit);
                 N_critical_points++;
                 if (debug) {
-                    std::cout << HEOS.get_mole_fractions()[0] << " " << crit.rhomolar << " " << crit.T << " " << p_MPa << std::endl;
+                    std::cout << HEOS.get_mole_fractions()[0] << " " << crit.rhomolar << " " << crit.T << " " << p_MPa << '\n';
                 }
             }
 

--- a/src/Backends/Helmholtz/MixtureParameters.cpp
+++ b/src/Backends/Helmholtz/MixtureParameters.cpp
@@ -25,7 +25,7 @@ class PredefinedMixturesLibrary
         rapidjson::Document doc;
         doc.Parse<0>(str.data(), str.size());
         if (doc.HasParseError()) {
-            std::cout << str << std::endl;
+            std::cout << str << '\n';
             throw ValueError("Unable to parse predefined mixture string");
         }
         load_from_JSON(doc);
@@ -56,6 +56,7 @@ static PredefinedMixturesLibrary predefined_mixtures_library;
 
 std::string get_csv_predefined_mixtures() {
     std::vector<std::string> out;
+    out.reserve(predefined_mixtures_library.predefined_mixture_map.size());
     for (const auto& [key, val] : predefined_mixtures_library.predefined_mixture_map) {
         out.push_back(key);
     }
@@ -101,7 +102,7 @@ class MixtureBinaryPairLibrary
         rapidjson::Document doc;
         doc.Parse<0>(str.data(), str.size());
         if (doc.HasParseError()) {
-            std::cout << str << std::endl;
+            std::cout << str << '\n';
             throw ValueError("Unable to parse binary interaction function string");
         }
         load_from_JSON(doc);
@@ -175,7 +176,7 @@ class MixtureBinaryPairLibrary
                 }
             } else {
                 std::cout << "Loading error: binary pair of " << name1 << " & " << name2
-                          << "does not provide either a) xi and zeta b) gammaT, gammaV, betaT, and betaV" << std::endl;
+                          << "does not provide either a) xi and zeta b) gammaT, gammaV, betaT, and betaV" << '\n';
                 continue;
             }
 
@@ -426,7 +427,7 @@ class MixtureDepartureFunctionsLibrary
         rapidjson::Document doc;
         doc.Parse<0>(str.data(), str.size());
         if (doc.HasParseError()) {
-            std::cout << str << std::endl;
+            std::cout << str << '\n';
             throw ValueError("Unable to parse departure function string");
         }
         load_from_JSON(doc);
@@ -503,6 +504,7 @@ class MixtureDepartureFunctionsLibrary
                 //
                 // Collect all the current names for departure functions for a nicer error message
                 std::vector<std::string> names;
+                names.reserve(m_departure_function_map.size());
                 for (const auto& [name, dict] : m_departure_function_map) {
                     names.push_back(name);
                 }
@@ -698,7 +700,7 @@ void parse_HMX_BNC(const std::string& s, std::vector<REFPROP_binary_element>& BI
                 continue;
             }
             // Parse the line with the thermo BIP
-            if (lines[i].find("/") > 0) {
+            if (lines[i].find('/') > 0) {
                 // Split at ' '
                 std::vector<std::string> bits = strsplit(strstrip(lines[i]), ' ');
                 // Remove empty elements
@@ -708,7 +710,7 @@ void parse_HMX_BNC(const std::string& s, std::vector<REFPROP_binary_element>& BI
                     }
                 }
                 // Get the line that contains the thermo BIP
-                if (bits[0].find("/") > 0 && bits[1].size() == 3) {
+                if (bits[0].find('/') > 0 && bits[1].size() == 3) {
                     std::vector<std::string> theCAS = strsplit(bits[0], '/');
                     bnc.CAS1 = theCAS[0];
                     bnc.CAS2 = theCAS[1];

--- a/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
+++ b/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
@@ -248,7 +248,7 @@ void PhaseEnvelopeRoutines::build(HelmholtzEOSMixtureBackend& HEOS, const std::s
                 }
             } catch (std::exception& e) {
                 if (debug) {
-                    std::cout << e.what() << std::endl;
+                    std::cout << e.what() << '\n';
                 }
                 //std::cout << IO.T << " " << IO.p << std::endl;
                 // Try again, but with a smaller step
@@ -265,7 +265,7 @@ void PhaseEnvelopeRoutines::build(HelmholtzEOSMixtureBackend& HEOS, const std::s
             if (debug) {
                 std::cout << "dv " << IO.rhomolar_vap << " dl " << IO.rhomolar_liq << " T " << IO.T << " p " << IO.p << " hl " << IO.hmolar_liq
                           << " hv " << IO.hmolar_vap << " sl " << IO.smolar_liq << " sv " << IO.smolar_vap << " x " << vec_to_string(IO.x, "%0.10Lg")
-                          << " Ns " << IO.Nsteps << " factor " << factor << std::endl;
+                          << " Ns " << IO.Nsteps << " factor " << factor << '\n';
             }
             env.store_variables(IO.T, IO.p, IO.rhomolar_liq, IO.rhomolar_vap, IO.hmolar_liq, IO.hmolar_vap, IO.smolar_liq, IO.smolar_vap, IO.x, IO.y);
 
@@ -413,7 +413,7 @@ void PhaseEnvelopeRoutines::refine(HelmholtzEOSMixtureBackend& HEOS, const std::
                 if (debug) {
                     std::cout << "dv " << IO.rhomolar_vap << " dl " << IO.rhomolar_liq << " T " << IO.T << " p " << IO.p << " hl " << IO.hmolar_liq
                               << " hv " << IO.hmolar_vap << " sl " << IO.smolar_liq << " sv " << IO.smolar_vap << " x "
-                              << vec_to_string(IO.x, "%0.10Lg") << " Ns " << IO.Nsteps << std::endl;
+                              << vec_to_string(IO.x, "%0.10Lg") << " Ns " << IO.Nsteps << '\n';
                 }
             } catch (...) {
                 failure_count++;
@@ -783,7 +783,7 @@ bool PhaseEnvelopeRoutines::is_inside(const PhaseEnvelopeData& env, parameters i
             closest_state.Q = env.Q[iclosest];
 
             if (get_debug_level() > 5) {
-                std::cout << format("is_inside: it is not inside") << std::endl;
+                std::cout << format("is_inside: it is not inside") << '\n';
             }
             return false;
         } else {

--- a/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
+++ b/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
@@ -66,7 +66,13 @@ void PhaseEnvelopeRoutines::build(HelmholtzEOSMixtureBackend& HEOS, const std::s
         for (std::size_t i = 0; i < Tbp.size() - 1; ++i) {
             CoolPropDbl Tmin = Tbp[i], Tmax = Tbp[i + 1];
             std::size_t N = Nbp[i];
-            for (CoolPropDbl T = Tmin; is_in_closed_range(Tmin, Tmax, T); T += (Tmax - Tmin) / (N - 1)) {
+            // Integer-indexed grid (cert-flp30-c): N samples from Tmin
+            // to Tmax inclusive — exactly the count the original
+            // is_in_closed_range / `T += (Tmax-Tmin)/(N-1)` targeted,
+            // without FP roundoff dropping or duplicating the endpoint.
+            const CoolPropDbl dT_pe = (Tmax - Tmin) / static_cast<CoolPropDbl>(N - 1);
+            for (std::size_t k_pe = 0; k_pe < N; ++k_pe) {
+                const CoolPropDbl T = Tmin + static_cast<CoolPropDbl>(k_pe) * dT_pe;
                 try {
                     HEOS.update(QT_INPUTS, Qbp[i], T);
                 } catch (...) {
@@ -386,7 +392,9 @@ void PhaseEnvelopeRoutines::refine(HelmholtzEOSMixtureBackend& HEOS, const std::
         double factor = pow(rhomolar_vap_end / rhomolar_vap_start, 1.0 / N);
 
         int failure_count = 0;
-        for (double rhomolar_vap = rhomolar_vap_start * factor; rhomolar_vap < rhomolar_vap_end; rhomolar_vap *= factor) {
+        // Geometric density sweep (factor = (end/start)^(1/N)); ~N
+        // iterations, no FP accumulation issue worth converting.
+        for (double rhomolar_vap = rhomolar_vap_start * factor; rhomolar_vap < rhomolar_vap_end; rhomolar_vap *= factor) {  // NOLINT(cert-flp30-c)
             IO.rhomolar_vap = rhomolar_vap;
             IO.x.resize(IO.y.size());
             if (i < env.T.size() - 3) {

--- a/src/Backends/Helmholtz/TransportRoutines.cpp
+++ b/src/Backends/Helmholtz/TransportRoutines.cpp
@@ -1170,7 +1170,8 @@ void TransportRoutines::conformal_state_solver(HelmholtzEOSMixtureBackend& HEOS,
         double T0_init = HEOS_Reference.T(), rhomolar0_init = HEOS_Reference.rhomolar();
         // Calculate the old residual after the last step
         resid_old = sqrt(POW2(r(0)) + POW2(r(1)));
-        for (double frac = 1.0; frac > 0.001; frac /= 2) {
+        // Geometric Newton-step halving (~10 iters from 1.0 to ~1/1024).
+        for (double frac = 1.0; frac > 0.001; frac /= 2) {  // NOLINT(cert-flp30-c)
             try {
                 // Calculate new values
                 double T_new = T0_init + frac * v(0);

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -22,7 +22,7 @@ void SaturationSolvers::saturation_critical(HelmholtzEOSMixtureBackend& HEOS, pa
         double call(double rhomolar_liq) override {
             HEOS->SatL->update(DmolarT_INPUTS, rhomolar_liq, T);
             CoolPropDbl calc_p = HEOS->SatL->p();
-            std::cout << format("inner p: %0.16Lg; res: %0.16Lg", calc_p, calc_p - desired_p) << std::endl;
+            std::cout << format("inner p: %0.16Lg; res: %0.16Lg", calc_p, calc_p - desired_p) << '\n';
             return calc_p - desired_p;
         }
     };
@@ -47,7 +47,7 @@ void SaturationSolvers::saturation_critical(HelmholtzEOSMixtureBackend& HEOS, pa
                     T = y;
                     HEOS->SatV->update(DmolarT_INPUTS, rhomolar_vap, y);
                     p = HEOS->SatV->p();
-                    std::cout << format("outer p: %0.16Lg", p) << std::endl;
+                    std::cout << format("outer p: %0.16Lg", p) << '\n';
                     inner_resid inner(HEOS, T, p);
                     rhomolar_liq = Brent(inner, rhomolar_crit * 1.5, rhomolar_crit * (1 + 1e-8), LDBL_EPSILON, 1e-10, 100);
                     break;
@@ -1355,7 +1355,7 @@ void SaturationSolvers::newton_raphson_saturation::call(HelmholtzEOSMixtureBacke
     bool debug = get_debug_level() > 9 || false;
 
     if (debug) {
-        std::cout << " NRsat::call:  p " << IO.p << " T " << IO.T << " dl " << IO.rhomolar_liq << " dv " << IO.rhomolar_vap << std::endl;
+        std::cout << " NRsat::call:  p " << IO.p << " T " << IO.T << " dl " << IO.rhomolar_liq << " dv " << IO.rhomolar_vap << '\n';
     }
 
     // Reset all the variables and resize
@@ -1583,7 +1583,7 @@ void SaturationSolvers::newton_raphson_twophase::call(HelmholtzEOSMixtureBackend
     int iter = 0;
 
     if (get_debug_level() > 9) {
-        std::cout << " NRsat::call:  p" << IO.p << " T" << IO.T << " dl" << IO.rhomolar_liq << " dv" << IO.rhomolar_vap << std::endl;
+        std::cout << " NRsat::call:  p" << IO.p << " T" << IO.T << " dl" << IO.rhomolar_liq << " dv" << IO.rhomolar_vap << '\n';
     }
 
     // Reset all the variables and resize

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -515,7 +515,8 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend& HEOS, C
         // a) tau > 1
         // b) rhoL > rhoV or deltaL > deltaV
         double tau0 = tau, deltaL0 = deltaL, deltaV0 = deltaV;
-        for (double omega_local = 1.0; omega_local > 0.1; omega_local /= 1.1) {
+        // Geometric damping search (~25 iters) — no FP accumulation.
+        for (double omega_local = 1.0; omega_local > 0.1; omega_local /= 1.1) {  // NOLINT(cert-flp30-c)
             tau = tau0 + omega_local * options.omega * v[0];
             if (options.use_logdelta) {
                 deltaL = exp(log(deltaL0) + omega_local * options.omega * v[1]);
@@ -896,7 +897,8 @@ void SaturationSolvers::saturation_T_pure_Akasaka(HelmholtzEOSMixtureBackend& HE
         CoolPropDbl deltaL0 = deltaL, deltaV0 = deltaV;
         // Conditions for an acceptable step are:
         // a) rhoL > rhoV or deltaL > deltaV
-        for (double omega_local = 1.0; omega_local > 0.1; omega_local /= 1.1) {
+        // Geometric damping search (~25 iters) — no FP accumulation.
+        for (double omega_local = 1.0; omega_local > 0.1; omega_local /= 1.1) {  // NOLINT(cert-flp30-c)
             deltaL = deltaL0 + omega_local * stepL;
             deltaV = deltaV0 + omega_local * stepV;
 

--- a/src/Backends/Incompressible/IncompressibleBackend.cpp
+++ b/src/Backends/Incompressible/IncompressibleBackend.cpp
@@ -174,7 +174,11 @@ bool IncompressibleBackend::clear() {
 
 /// Update the reference values and clear the state
 void IncompressibleBackend::set_reference_state(double T0, double p0, double x0, double h0, double s0) {
-    this->clear();
+    // Explicit scope: this method is reachable from the ctor
+    // (IncompressibleBackend(IncompressibleFluid*) calls
+    // set_reference_state()), so the virtual clear() would bypass
+    // derived overrides anyway.  Make that explicit.
+    IncompressibleBackend::clear();
     /// Reference values, no need to calculate them each time
     this->_hmass_ref.clear();
     this->_smass_ref.clear();

--- a/src/Backends/Incompressible/IncompressibleBackend.cpp
+++ b/src/Backends/Incompressible/IncompressibleBackend.cpp
@@ -63,13 +63,13 @@ void IncompressibleBackend::update(CoolProp::input_pairs input_pair, double valu
 
     if (get_debug_level() >= 10) {
         //throw ValueError(format("%s (%d): You have to provide a dimension, 0 or 1, for the solver, %d is not valid. ",__FILE__,__LINE__,axis));
-        std::cout << format("Incompressible backend: Called update with %d and %f, %f ", input_pair, value1, value2) << std::endl;
+        std::cout << format("Incompressible backend: Called update with %d and %f, %f ", input_pair, value1, value2) << '\n';
     }
 
     clear();
 
     if (get_debug_level() >= 50) {
-        std::cout << format("Incompressible backend: _fractions are %s ", vec_to_string(_fractions).c_str()) << std::endl;
+        std::cout << format("Incompressible backend: _fractions are %s ", vec_to_string(_fractions).c_str()) << '\n';
     }
     if (_fractions.size() != 1) {
         throw ValueError(format("%s is an incompressible fluid, mass fractions must be set to a vector with ONE entry, not %d.", this->name().c_str(),
@@ -77,14 +77,14 @@ void IncompressibleBackend::update(CoolProp::input_pairs input_pair, double valu
     }
     if (fluid->is_pure()) {
         this->_fluid_type = FLUID_TYPE_INCOMPRESSIBLE_LIQUID;
-        if (get_debug_level() >= 50) std::cout << format("Incompressible backend: Fluid type is  %d ", this->_fluid_type) << std::endl;
+        if (get_debug_level() >= 50) std::cout << format("Incompressible backend: Fluid type is  %d ", this->_fluid_type) << '\n';
         if (_fractions[0] != 1.0) {
             throw ValueError(format("%s is a pure fluid. The composition has to be set to a vector with one entry equal to 1.0. %s is not valid.",
                                     this->name().c_str(), vec_to_string(_fractions).c_str()));
         }
     } else {
         this->_fluid_type = FLUID_TYPE_INCOMPRESSIBLE_SOLUTION;
-        if (get_debug_level() >= 50) std::cout << format("Incompressible backend: Fluid type is  %d ", this->_fluid_type) << std::endl;
+        if (get_debug_level() >= 50) std::cout << format("Incompressible backend: Fluid type is  %d ", this->_fluid_type) << '\n';
         if ((_fractions[0] < 0.0) || (_fractions[0] > 1.0)) {
             throw ValueError(
               format("%s is a solution or brine. Mass fractions must be set to a vector with one entry between 0 and 1. %s is not valid.",
@@ -93,7 +93,7 @@ void IncompressibleBackend::update(CoolProp::input_pairs input_pair, double valu
     }
 
     this->_phase = iphase_liquid;
-    if (get_debug_level() >= 50) std::cout << format("Incompressible backend: Phase type is  %d ", this->_phase) << std::endl;
+    if (get_debug_level() >= 50) std::cout << format("Incompressible backend: Phase type is  %d ", this->_phase) << '\n';
 
     switch (input_pair) {
         case PT_INPUTS: {
@@ -147,7 +147,7 @@ void IncompressibleBackend::update(CoolProp::input_pairs input_pair, double valu
     }
     if (get_debug_level() >= 50)
         std::cout << format("Incompressible backend: Update finished T=%f, p=%f, x=%s ", this->_T, this->_p, vec_to_string(_fractions).c_str())
-                  << std::endl;
+                  << '\n';
     fluid->checkTPX(_T, _p, _fractions[0]);
 }
 
@@ -192,14 +192,14 @@ void IncompressibleBackend::set_reference_state(double T0, double p0, double x0,
 */
 void IncompressibleBackend::set_fractions(const std::vector<CoolPropDbl>& fractions) {
     if (get_debug_level() >= 10)
-        std::cout << format("Incompressible backend: Called set_fractions with %s ", vec_to_string(fractions).c_str()) << std::endl;
+        std::cout << format("Incompressible backend: Called set_fractions with %s ", vec_to_string(fractions).c_str()) << '\n';
     if (fractions.size() != 1)
         throw ValueError(format("The incompressible backend only supports one entry in the fraction vector and not %d.", fractions.size()));
     if ((this->_fractions.size() != 1) || (this->_fractions[0] != fractions[0])) {  // Change it!
         if (get_debug_level() >= 20)
             std::cout << format("Incompressible backend: Updating the fractions triggered a change in reference state %s -> %s",
                                 vec_to_string(this->_fractions).c_str(), vec_to_string(fractions).c_str())
-                      << std::endl;
+                      << '\n';
         this->_fractions = fractions;
         set_reference_state(T_ref(), p_ref(), this->_fractions[0], h_ref(), s_ref());
     }
@@ -211,7 +211,7 @@ void IncompressibleBackend::set_fractions(const std::vector<CoolPropDbl>& fracti
 */
 void IncompressibleBackend::set_mole_fractions(const std::vector<CoolPropDbl>& mole_fractions) {
     if (get_debug_level() >= 10)
-        std::cout << format("Incompressible backend: Called set_mole_fractions with %s ", vec_to_string(mole_fractions).c_str()) << std::endl;
+        std::cout << format("Incompressible backend: Called set_mole_fractions with %s ", vec_to_string(mole_fractions).c_str()) << '\n';
     if (mole_fractions.size() != 1)
         throw ValueError(format("The incompressible backend only supports one entry in the mole fraction vector and not %d.", mole_fractions.size()));
     if ((fluid->getxid() == IFRAC_PURE) && true) {  //( this->_fractions[0]!=1.0 )){
@@ -219,11 +219,12 @@ void IncompressibleBackend::set_mole_fractions(const std::vector<CoolPropDbl>& m
         if (get_debug_level() >= 20)
             std::cout << format("Incompressible backend: Overwriting fractions for pure fluid with %s -> %s", vec_to_string(mole_fractions).c_str(),
                                 vec_to_string(this->_fractions).c_str())
-                      << std::endl;
+                      << '\n';
     } else if (fluid->getxid() == IFRAC_MOLE) {
         this->set_fractions(mole_fractions);
     } else {
         std::vector<CoolPropDbl> tmp_fractions;
+        tmp_fractions.reserve(mole_fractions.size());
         for (std::size_t i = 0; i < mole_fractions.size(); i++) {
             tmp_fractions.push_back((CoolPropDbl)fluid->inputFromMole(0.0, mole_fractions[i]));
         }
@@ -237,7 +238,7 @@ void IncompressibleBackend::set_mole_fractions(const std::vector<CoolPropDbl>& m
 */
 void IncompressibleBackend::set_mass_fractions(const std::vector<CoolPropDbl>& mass_fractions) {
     if (get_debug_level() >= 10)
-        std::cout << format("Incompressible backend: Called set_mass_fractions with %s ", vec_to_string(mass_fractions).c_str()) << std::endl;
+        std::cout << format("Incompressible backend: Called set_mass_fractions with %s ", vec_to_string(mass_fractions).c_str()) << '\n';
     if (mass_fractions.size() != 1)
         throw ValueError(format("The incompressible backend only supports one entry in the mass fraction vector and not %d.", mass_fractions.size()));
     if ((fluid->getxid() == IFRAC_PURE) && true) {  // ( this->_fractions[0]!=1.0 )) {
@@ -245,11 +246,12 @@ void IncompressibleBackend::set_mass_fractions(const std::vector<CoolPropDbl>& m
         if (get_debug_level() >= 20)
             std::cout << format("Incompressible backend: Overwriting fractions for pure fluid with %s -> %s", vec_to_string(mass_fractions).c_str(),
                                 vec_to_string(this->_fractions).c_str())
-                      << std::endl;
+                      << '\n';
     } else if (fluid->getxid() == IFRAC_MASS) {
         this->set_fractions(mass_fractions);
     } else {
         std::vector<CoolPropDbl> tmp_fractions;
+        tmp_fractions.reserve(mass_fractions.size());
         for (std::size_t i = 0; i < mass_fractions.size(); i++) {
             tmp_fractions.push_back((CoolPropDbl)fluid->inputFromMass(0.0, mass_fractions[i]));
         }
@@ -263,7 +265,7 @@ void IncompressibleBackend::set_mass_fractions(const std::vector<CoolPropDbl>& m
 */
 void IncompressibleBackend::set_volu_fractions(const std::vector<CoolPropDbl>& volu_fractions) {
     if (get_debug_level() >= 10)
-        std::cout << format("Incompressible backend: Called set_volu_fractions with %s ", vec_to_string(volu_fractions).c_str()) << std::endl;
+        std::cout << format("Incompressible backend: Called set_volu_fractions with %s ", vec_to_string(volu_fractions).c_str()) << '\n';
     if (volu_fractions.size() != 1)
         throw ValueError(
           format("The incompressible backend only supports one entry in the volume fraction vector and not %d.", volu_fractions.size()));
@@ -272,11 +274,12 @@ void IncompressibleBackend::set_volu_fractions(const std::vector<CoolPropDbl>& v
         if (get_debug_level() >= 20)
             std::cout << format("Incompressible backend: Overwriting fractions for pure fluid with %s -> %s", vec_to_string(volu_fractions).c_str(),
                                 vec_to_string(this->_fractions).c_str())
-                      << std::endl;
+                      << '\n';
     } else if (fluid->getxid() == IFRAC_VOLUME) {
         this->set_fractions(volu_fractions);
     } else {
         std::vector<CoolPropDbl> tmp_fractions;
+        tmp_fractions.reserve(volu_fractions.size());
         for (std::size_t i = 0; i < volu_fractions.size(); i++) {
             tmp_fractions.push_back((CoolPropDbl)fluid->inputFromVolume(0.0, volu_fractions[i]));
         }

--- a/src/Backends/Incompressible/IncompressibleLibrary.cpp
+++ b/src/Backends/Incompressible/IncompressibleLibrary.cpp
@@ -440,7 +440,7 @@ void JSONIncompressibleLibrary::add_one(rapidjson::Value& fluid_json) {
     fluid.setName("unloaded");
     try {
         fluid.setName(cpjson::get_string(fluid_json, "name"));
-        if (get_debug_level() >= 20) std::cout << format("Incompressible library: Loading base values for %s ", fluid.getName().c_str()) << std::endl;
+        if (get_debug_level() >= 20) std::cout << format("Incompressible library: Loading base values for %s ", fluid.getName().c_str()) << '\n';
         fluid.setDescription(cpjson::get_string(fluid_json, "description"));
         fluid.setReference(cpjson::get_string(fluid_json, "reference"));
         fluid.setTmax(parse_value(fluid_json, "Tmax", true, 0.0));
@@ -454,8 +454,7 @@ void JSONIncompressibleLibrary::add_one(rapidjson::Value& fluid_json) {
         fluid.setxbase(parse_value(fluid_json, "xbase", false, 0.0));
 
         /// Setters for the coefficients
-        if (get_debug_level() >= 20)
-            std::cout << format("Incompressible library: Loading coefficients for %s ", fluid.getName().c_str()) << std::endl;
+        if (get_debug_level() >= 20) std::cout << format("Incompressible library: Loading coefficients for %s ", fluid.getName().c_str()) << '\n';
         fluid.setDensity(parse_coefficients(fluid_json, "density", true));
         fluid.setSpecificHeat(parse_coefficients(fluid_json, "specific_heat", true));
         fluid.setViscosity(parse_coefficients(fluid_json, "viscosity", false));
@@ -561,7 +560,7 @@ void load_incompressible_library() {
         try {
             library.add_many(dd);
         } catch (std::exception& e) {
-            std::cout << e.what() << std::endl;
+            std::cout << e.what() << '\n';
         }
     }
     // TODO: Implement LiBr in the source code!

--- a/src/Backends/PCSAFT/PCSAFTBackend.cpp
+++ b/src/Backends/PCSAFT/PCSAFTBackend.cpp
@@ -109,9 +109,13 @@ PCSAFTBackend::PCSAFTBackend(const std::vector<std::string>& component_names, bo
 
     if (generate_SatL_and_SatV) {
         bool SatLSatV = false;
-        SatL.reset(this->get_copy(SatLSatV));
+        // Explicit scope: this runs inside the ctor; derived overrides
+        // of get_copy aren't active yet, so dispatch would resolve to
+        // PCSAFTBackend::get_copy regardless.  Make that explicit and
+        // silence clang-analyzer-optin.cplusplus.VirtualCall.
+        SatL.reset(PCSAFTBackend::get_copy(SatLSatV));
         SatL->specify_phase(iphase_liquid);
-        SatV.reset(this->get_copy(SatLSatV));
+        SatV.reset(PCSAFTBackend::get_copy(SatLSatV));
         SatV->specify_phase(iphase_gas);
     }
 
@@ -175,9 +179,13 @@ PCSAFTBackend::PCSAFTBackend(const std::vector<PCSAFTFluid>& components_in, bool
 
     if (generate_SatL_and_SatV) {
         bool SatLSatV = false;
-        SatL.reset(this->get_copy(SatLSatV));
+        // Explicit scope: this runs inside the ctor; derived overrides
+        // of get_copy aren't active yet, so dispatch would resolve to
+        // PCSAFTBackend::get_copy regardless.  Make that explicit and
+        // silence clang-analyzer-optin.cplusplus.VirtualCall.
+        SatL.reset(PCSAFTBackend::get_copy(SatLSatV));
         SatL->specify_phase(iphase_liquid);
-        SatV.reset(this->get_copy(SatLSatV));
+        SatV.reset(PCSAFTBackend::get_copy(SatLSatV));
         SatV->specify_phase(iphase_gas);
     }
 

--- a/src/Backends/PCSAFT/PCSAFTBackend.cpp
+++ b/src/Backends/PCSAFT/PCSAFTBackend.cpp
@@ -1732,7 +1732,7 @@ void PCSAFTBackend::update(CoolProp::input_pairs input_pair, double value1, doub
     if (get_debug_level() > 10) {
         std::cout << format("%s (%d): update called with (%d: (%s), %g, %g)", __FILE__, __LINE__, input_pair,
                             get_input_pair_short_desc(input_pair).c_str(), value1, value2)
-                  << std::endl;
+                  << '\n';
     }
 
     // Mass-quality input pair on a true mixture: solve iteratively for Qmolar

--- a/src/Backends/PCSAFT/PCSAFTLibrary.cpp
+++ b/src/Backends/PCSAFT/PCSAFTLibrary.cpp
@@ -39,7 +39,7 @@ void add_fluids_from_JSON_string(PCSAFTLibraryClass& dest, const std::string_vie
             try {
                 dest.add_many(dd);
             } catch (std::exception& e) {
-                std::cout << e.what() << std::endl;
+                std::cout << e.what() << '\n';
             }
         }
     } else {
@@ -360,7 +360,7 @@ void PCSAFTLibraryClass::load_from_JSON(rapidjson::Document& doc) {
         if (itr->HasMember("kij")) {
             dict.add_number("kij", cpjson::get_double(*itr, "kij"));
         } else {
-            std::cout << "Loading error: binary pair of " << name1 << " & " << name2 << "does not provide kij" << std::endl;
+            std::cout << "Loading error: binary pair of " << name1 << " & " << name2 << "does not provide kij" << '\n';
         }
         if (itr->HasMember("kijT")) {
             dict.add_number("kijT", cpjson::get_double(*itr, "kijT"));

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -484,12 +484,12 @@ void REFPROPMixtureBackend::set_REFPROP_fluids(const std::vector<std::string>& f
                 return;
             } else if (k < number_of_endings - 1) {  // Keep going
                 if (CoolProp::get_debug_level() > 5) {
-                    std::cout << format("REFPROP error/warning [ierr: %d]: %s", ierr, herr.data()) << std::endl;
+                    std::cout << format("REFPROP error/warning [ierr: %d]: %s", ierr, herr.data()) << '\n';
                 }
                 continue;
             } else {
                 if (CoolProp::get_debug_level() > 5) {
-                    std::cout << format("k: %d #endings: %d", k, number_of_endings) << std::endl;
+                    std::cout << format("k: %d #endings: %d", k, number_of_endings) << '\n';
                 }
                 throw ValueError(format("Could not load these fluids: %s", components_joined_raw.c_str()));
             }
@@ -2332,7 +2332,7 @@ bool force_load_REFPROP() {
     std::string err;
     if (!load_REFPROP(err)) {
         if (CoolProp::get_debug_level() > 5) {
-            std::cout << format("Error while loading REFPROP: %s", err) << std::endl;
+            std::cout << format("Error while loading REFPROP: %s", err) << '\n';
         }
         LoadedREFPROPRef = "";
         return false;
@@ -2345,7 +2345,7 @@ bool force_unload_REFPROP() {
     std::string err;
     if (!unload_REFPROP(err)) {
         if (CoolProp::get_debug_level() > 5) {
-            std::cout << format("Error while unloading REFPROP: %s", err) << std::endl;
+            std::cout << format("Error while unloading REFPROP: %s", err) << '\n';
         }
         LoadedREFPROPRef = "";
         return false;

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -1266,7 +1266,8 @@ void REFPROPMixtureBackend::calc_phase_envelope(const std::string& type) {
     SPLNVALdll(&isp, &iderv, &c, &rhoymax, &ierr, herr.data(), errormessagelength);
     int nc = static_cast<int>(this->Ncomp);
     double ratio = pow(rhoymax / rhoymin, 1 / double(N));
-    for (double rho_molL = rhoymin; rho_molL < rhoymax; rho_molL *= ratio) {
+    // Geometric density sweep (rho *= ratio, ~N iters by construction).
+    for (double rho_molL = rhoymin; rho_molL < rhoymax; rho_molL *= ratio) {  // NOLINT(cert-flp30-c)
         double y = NAN;
         iderv = 0;
 

--- a/src/Backends/Tabular/TabularBackends.cpp
+++ b/src/Backends/Tabular/TabularBackends.cpp
@@ -37,7 +37,7 @@ void load_table(T& table, const std::string& path_to_tables, const std::string& 
     double tic = clock();
     std::string path_to_table = path_to_tables + "/" + filename;
     if (get_debug_level() > 0) {
-        std::cout << format("Loading table: %s", path_to_table.c_str()) << std::endl;
+        std::cout << format("Loading table: %s", path_to_table.c_str()) << '\n';
     }
     std::vector<char> raw;
     try {
@@ -45,7 +45,7 @@ void load_table(T& table, const std::string& path_to_tables, const std::string& 
     } catch (...) {
         std::string err = format("Unable to load file %s", path_to_table.c_str());
         if (get_debug_level() > 0) {
-            std::cout << "err:" << err << std::endl;
+            std::cout << "err:" << err << '\n';
         }
         throw UnableToLoadError(err);
     }
@@ -62,7 +62,7 @@ void load_table(T& table, const std::string& path_to_tables, const std::string& 
         } else if (code != 0) {  // Something else, a big problem
             std::string err = format("Unable to uncompress file %s with miniz code %d", path_to_table.c_str(), code);
             if (get_debug_level() > 0) {
-                std::cout << "uncompress err:" << err << std::endl;
+                std::cout << "uncompress err:" << err << '\n';
             }
             throw UnableToLoadError(err);
         }
@@ -78,12 +78,12 @@ void load_table(T& table, const std::string& path_to_tables, const std::string& 
         table.deserialize(deserialized);
         double toc = clock();
         if (get_debug_level() > 0) {
-            std::cout << format("Loaded table: %s in %g sec.", path_to_table.c_str(), (toc - tic) / CLOCKS_PER_SEC) << std::endl;
+            std::cout << format("Loaded table: %s in %g sec.", path_to_table.c_str(), (toc - tic) / CLOCKS_PER_SEC) << '\n';
         }
     } catch (std::exception& e) {
         std::string err = format("Unable to msgpack deserialize %s; err: %s", path_to_table.c_str(), e.what());
         if (get_debug_level() > 0) {
-            std::cout << "err: " << err << std::endl;
+            std::cout << "err: " << err << '\n';
         }
         throw UnableToLoadError(err);
     }
@@ -148,7 +148,7 @@ void CoolProp::PureFluidSaturationTableData::build(shared_ptr<CoolProp::Abstract
         } catch (std::exception& e) {
             // That failed for some reason, go to the next pair
             if (debug) {
-                std::cout << " " << e.what() << std::endl;
+                std::cout << " " << e.what() << '\n';
             }
             continue;
         }
@@ -159,7 +159,7 @@ void CoolProp::PureFluidSaturationTableData::build(shared_ptr<CoolProp::Abstract
             logviscL[i] = log(viscL[i]);
         } catch (std::exception& e) {
             if (debug) {
-                std::cout << " " << e.what() << std::endl;
+                std::cout << " " << e.what() << '\n';
             }
         }
         // Saturated vapor
@@ -179,7 +179,7 @@ void CoolProp::PureFluidSaturationTableData::build(shared_ptr<CoolProp::Abstract
         } catch (std::exception& e) {
             // That failed for some reason, go to the next pair
             if (debug) {
-                std::cout << " " << e.what() << std::endl;
+                std::cout << " " << e.what() << '\n';
             }
             continue;
         }
@@ -190,7 +190,7 @@ void CoolProp::PureFluidSaturationTableData::build(shared_ptr<CoolProp::Abstract
             logviscV[i] = log(viscV[i]);
         } catch (std::exception& e) {
             if (debug) {
-                std::cout << " " << e.what() << std::endl;
+                std::cout << " " << e.what() << '\n';
             }
         }
         if (i == 0) {
@@ -258,7 +258,7 @@ void CoolProp::SinglePhaseGriddedTableData::build(shared_ptr<CoolProp::AbstractS
             yvec[j] = y;
 
             if (debug) {
-                std::cout << "x: " << x << " y: " << y << std::endl;
+                std::cout << "x: " << x << " y: " << y << '\n';
             }
 
             // Generate the input pair
@@ -276,7 +276,7 @@ void CoolProp::SinglePhaseGriddedTableData::build(shared_ptr<CoolProp::AbstractS
             } catch (std::exception& e) {
                 // That failed for some reason, go to the next pair
                 if (debug) {
-                    std::cout << " " << e.what() << std::endl;
+                    std::cout << " " << e.what() << '\n';
                 }
                 continue;
             }
@@ -284,7 +284,7 @@ void CoolProp::SinglePhaseGriddedTableData::build(shared_ptr<CoolProp::AbstractS
             // Skip two-phase states - they will remain as _HUGE holes in the table
             if (is_in_closed_range(0.0, 1.0, AS->Q())) {
                 if (debug) {
-                    std::cout << " 2Phase" << std::endl;
+                    std::cout << " 2Phase" << '\n';
                 }
                 continue;
             };
@@ -353,6 +353,7 @@ std::string CoolProp::TabularBackend::path_to_tables() {
     std::vector<std::string> fluids = AS->fluid_names();
     std::vector<CoolPropDbl> fractions = AS->get_mole_fractions();
     std::vector<std::string> components;
+    components.reserve(fluids.size());
     for (std::size_t i = 0; i < fluids.size(); ++i) {
         components.push_back(format("%s[%0.10Lf]", fluids[i].c_str(), fractions[i]));
     }
@@ -384,7 +385,7 @@ void CoolProp::TabularBackend::load_tables() {
         throw UnableToLoadError("Could not load tables");
     }
     if (get_debug_level() > 0) {
-        std::cout << "Tables loaded" << std::endl;
+        std::cout << "Tables loaded" << '\n';
     }
 }
 
@@ -1502,7 +1503,7 @@ void CoolProp::TabularDataSet::load_tables(const std::string& path_to_tables, sh
     load_table(phase_envelope, path_to_tables, "phase_envelope.bin.z");
     tables_loaded = true;
     if (get_debug_level() > 0) {
-        std::cout << "Tables loaded" << std::endl;
+        std::cout << "Tables loaded" << '\n';
     }
 };
 

--- a/src/Backends/Tabular/TabularBackends.h
+++ b/src/Backends/Tabular/TabularBackends.h
@@ -1029,6 +1029,7 @@ class TabularDataLibrary
         std::vector<std::string> fluids = AS->fluid_names();
         std::vector<CoolPropDbl> fractions = AS->get_mole_fractions();
         std::vector<std::string> components;
+        components.reserve(fluids.size());
         for (std::size_t i = 0; i < fluids.size(); ++i) {
             components.push_back(format("%s[%0.10Lf]", fluids[i].c_str(), fractions[i]));
         }

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -109,7 +109,7 @@ void extract_backend(std::string fluid_string, std::string& backend, std::string
 
 bool has_fractions_in_string(const std::string& fluid_string) {
     // If can find both "[" and "]", it must have mole fractions encoded as string
-    return (fluid_string.find("[") != std::string::npos && fluid_string.find("]") != std::string::npos);
+    return (fluid_string.find('[') != std::string::npos && fluid_string.find(']') != std::string::npos);
 }
 bool has_solution_concentration(const std::string& fluid_string) {
     // If can find "-", expect mass fractions encoded as string
@@ -363,9 +363,9 @@ void _PropsSI_outputs(shared_ptr<AbstractState>& State, const std::vector<output
     }
 
     if (get_debug_level() > 100) {
-        std::cout << format("%s (%d): input pair = %d ", __FILE__, __LINE__, input_pair) << std::endl;
-        std::cout << format("%s (%d): in1 = %s ", __FILE__, __LINE__, vec_to_string(in1).c_str()) << std::endl;
-        std::cout << format("%s (%d): in2 = %s ", __FILE__, __LINE__, vec_to_string(in2).c_str()) << std::endl;
+        std::cout << format("%s (%d): input pair = %d ", __FILE__, __LINE__, input_pair) << '\n';
+        std::cout << format("%s (%d): in1 = %s ", __FILE__, __LINE__, vec_to_string(in1).c_str()) << '\n';
+        std::cout << format("%s (%d): in2 = %s ", __FILE__, __LINE__, vec_to_string(in2).c_str()) << '\n';
     }
 
     // Get configuration variable for line tracing, see #1443
@@ -382,7 +382,7 @@ void _PropsSI_outputs(shared_ptr<AbstractState>& State, const std::vector<output
     bool success_inner = false;
 
     if (get_debug_level() > 100) {
-        std::cout << format("%s (%d): Iterating over %d input value pairs.", __FILE__, __LINE__, IO.size()) << std::endl;
+        std::cout << format("%s (%d): Iterating over %d input value pairs.", __FILE__, __LINE__, IO.size()) << '\n';
     }
 
     // Iterate over the state variable inputs
@@ -615,7 +615,7 @@ std::vector<std::vector<double>> PropsSImulti(const std::vector<std::string>& Ou
         std::cout << e.what() << std::endl;
 #    endif
         if (get_debug_level() > 1) {
-            std::cout << e.what() << std::endl;
+            std::cout << e.what() << '\n';
         }
     } catch (...) {  // NOLINT(bugprone-empty-catch)
         // PropsSImulti is a public API and must never throw — non-
@@ -652,7 +652,7 @@ double PropsSI(const std::string& Output, const std::string& Name1, double Prop1
         const double val = IO[0][0];
 
         if (get_debug_level() > 1) {
-            std::cout << format("_PropsSI will return %g", val) << std::endl;
+            std::cout << format("_PropsSI will return %g", val) << '\n';
         }
         return val;
         // END OF TRY
@@ -665,7 +665,7 @@ double PropsSI(const std::string& Output, const std::string& Name1, double Prop1
         std::cout << e.what() << std::endl;
 #    endif
         if (get_debug_level() > 1) {
-            std::cout << e.what() << std::endl;
+            std::cout << e.what() << '\n';
         }
         return _HUGE;
     } catch (...) {

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -193,11 +193,11 @@ void Isoline::calc_sat_range(int count) {
                 || (input_pair == CoolProp::PQ_INPUTS && abs(one[i] - p_crit) < 1e2)) {
                 x[i] = x_crit;
                 y[i] = y_crit;
-                std::cerr << "ERROR near critical inputs" << std::endl;
+                std::cerr << "ERROR near critical inputs" << '\n';
             } else {
                 x[i] = Detail::NaN;
                 y[i] = Detail::NaN;
-                std::cerr << "ERROR" << std::endl;
+                std::cerr << "ERROR" << '\n';
             }
         }
     }

--- a/src/DataStructures.cpp
+++ b/src/DataStructures.cpp
@@ -204,6 +204,7 @@ std::string get_parameter_information(int key, std::string_view info) {
 std::string get_csv_parameter_list() {
     auto& parameter_information = get_parameter_information();
     std::vector<std::string> strings;
+    strings.reserve(parameter_information.index_map.size());
     for (auto& it : parameter_information.index_map) {
         strings.push_back(it.first);
     }
@@ -241,15 +242,15 @@ bool is_valid_first_derivative(const std::string& name, parameters& iOf, paramet
         return false;
     }
 
-    std::size_t i0 = split_at_slash[0].find("(");
-    std::size_t i1 = split_at_slash[0].find(")", i0);
+    std::size_t i0 = split_at_slash[0].find('(');
+    std::size_t i1 = split_at_slash[0].find(')', i0);
     if (!((i0 > 0) && (i0 != std::string::npos) && (i1 > (i0 + 1)) && (i1 != std::string::npos))) {
         return false;
     }
     std::string num = split_at_slash[0].substr(i0 + 1, i1 - i0 - 1);
 
-    i0 = split_at_slash[1].find("(");
-    i1 = split_at_slash[1].find(")", i0);
+    i0 = split_at_slash[1].find('(');
+    i1 = split_at_slash[1].find(')', i0);
     if (!((i0 > 0) && (i0 != std::string::npos) && (i1 > (i0 + 1)) && (i1 != std::string::npos))) {
         return false;
     }
@@ -284,15 +285,15 @@ bool is_valid_first_saturation_derivative(const std::string& name, parameters& i
         return false;
     }
 
-    std::size_t i0 = split_at_slash[0].find("(");
-    std::size_t i1 = split_at_slash[0].find(")", i0);
+    std::size_t i0 = split_at_slash[0].find('(');
+    std::size_t i1 = split_at_slash[0].find(')', i0);
     if (!((i0 > 0) && (i0 != std::string::npos) && (i1 > (i0 + 1)) && (i1 != std::string::npos))) {
         return false;
     }
     std::string num = split_at_slash[0].substr(i0 + 1, i1 - i0 - 1);
 
-    i0 = split_at_slash[1].find("(");
-    i1 = split_at_slash[1].find(")", i0);
+    i0 = split_at_slash[1].find('(');
+    i1 = split_at_slash[1].find(')', i0);
     if (!((i0 > 0) && (i0 != std::string::npos) && (i1 > (i0 + 1)) && (i1 != std::string::npos))) {
         return false;
     }
@@ -332,8 +333,8 @@ bool is_valid_second_derivative(const std::string& name, parameters& iOf1, param
     std::string left_of_slash = left_of_bar.substr(0, i);    // "d(d(P)/d(Dmolar)|T)"
     std::string right_of_slash = left_of_bar.substr(i + 1);  // "d(Dmolar)"
 
-    i = left_of_slash.find("(");
-    std::size_t i1 = left_of_slash.rfind(")");
+    i = left_of_slash.find('(');
+    std::size_t i1 = left_of_slash.rfind(')');
     if (!((i > 0) && (i != std::string::npos) && (i1 > (i + 1)) && (i1 != std::string::npos))) {
         return false;
     }
@@ -342,8 +343,8 @@ bool is_valid_second_derivative(const std::string& name, parameters& iOf1, param
         return false;
     }
 
-    i = right_of_slash.find("(");
-    i1 = right_of_slash.rfind(")");
+    i = right_of_slash.find('(');
+    i1 = right_of_slash.rfind(')');
     if (!((i > 0) && (i != std::string::npos) && (i1 > (i + 1)) && (i1 != std::string::npos))) {
         return false;
     }
@@ -855,7 +856,7 @@ void extract_backend_families(std::string backend_string, backend_families& f1, 
     auto& backend_information = get_backend_information();
     f1 = INVALID_BACKEND_FAMILY;
     f2 = INVALID_BACKEND_FAMILY;
-    std::size_t i = backend_string.find("&");
+    std::size_t i = backend_string.find('&');
     std::map<std::string, backend_families>::const_iterator it;
     if (i != std::string::npos) {
         it = backend_information.family_name_map_r.find(backend_string.substr(0, i));  // Before "&"

--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -1208,7 +1208,7 @@ double MolarEntropy(double T, double p, double psi_w, double v_bar) {
     }
 
     if (FlagUseIdealGasEnthalpyCorrelations) {
-        std::cout << "Not implemented" << std::endl;
+        std::cout << "Not implemented" << '\n';
     } else {
         sbar_w = IdealGasMolarEntropy_Water(T, p);
         sbar_a = IdealGasMolarEntropy_Air(T, vbar_a);
@@ -1920,7 +1920,7 @@ void _HAPropsSI_inputs(double p, const std::vector<givens>& input_keys, const st
             T = Brent_HAProps_T(SecondaryInputKey, p, MainInputKey, MainInputValue, SecondaryInputValue, T_min, T_max);
         } catch (std::exception& e) {
             if (CoolProp::get_debug_level() > 0) {
-                std::cout << "ERROR: " << e.what() << std::endl;
+                std::cout << "ERROR: " << e.what() << '\n';
             }
             CoolProp::set_error_string(e.what());
             T = _HUGE;

--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -2672,9 +2672,19 @@ class ConsistencyTestData
 
         const int NT = 10, NW = 5;
         double p = 101325;
-        for (double T = 210; T < 350; T += (350 - 210) / (NT - 1)) {
+        // Integer-indexed grid (cert-flp30-c): the original
+        //   for (T = 210; T < 350; T += (350-210)/(NT-1))
+        // yields NT-1 iterations under the `<` exit (FP-roundoff
+        // sensitive at the upper bound); preserve that count exactly.
+        const double T_lo = 210.0, T_hi = 350.0;
+        const double dT = (T_hi - T_lo) / (NT - 1);
+        for (int it = 0; it < NT - 1; ++it) {
+            const double T = T_lo + dT * it;
             double Wsat = HumidAir::HAPropsSI("W", "T", T, "P", p, "R", 1.0);
-            for (double W = 1e-5; W < Wsat; W += (Wsat - 1e-5) / (NW - 1)) {
+            const double W_lo = 1e-5;
+            const double dW = (Wsat - W_lo) / (NW - 1);
+            for (int iw = 0; iw < NW - 1; ++iw) {
+                const double W = W_lo + dW * iw;
                 Dictionary vals;
                 // Calculate all the values using T, W
                 for (int i = 0; i < number_of_inputs; ++i) {

--- a/src/MatrixMath.cpp
+++ b/src/MatrixMath.cpp
@@ -30,35 +30,35 @@ TEST_CASE("Internal consistency checks and example use cases for MatrixMath.h", 
 
         Eigen::MatrixXd matrix = Eigen::MatrixXd::Random(4, 1);
         std::string tmpStr;
-        if (PRINT) std::cout << std::endl;
+        if (PRINT) std::cout << '\n';
 
         CHECK_NOTHROW(tmpStr = CoolProp::vec_to_string(cHeat[0]));
-        if (PRINT) std::cout << tmpStr << std::endl;
+        if (PRINT) std::cout << tmpStr << '\n';
         CHECK_NOTHROW(tmpStr = CoolProp::vec_to_string(cHeat));
-        if (PRINT) std::cout << tmpStr << std::endl;
+        if (PRINT) std::cout << tmpStr << '\n';
         CHECK_NOTHROW(tmpStr = CoolProp::vec_to_string(cHeat2D));
-        if (PRINT) std::cout << tmpStr << std::endl;
+        if (PRINT) std::cout << tmpStr << '\n';
 
         CHECK_NOTHROW(tmpStr = CoolProp::mat_to_string(CoolProp::vec_to_eigen(cHeat[0])));
-        if (PRINT) std::cout << tmpStr << std::endl;
+        if (PRINT) std::cout << tmpStr << '\n';
         CHECK_NOTHROW(tmpStr = CoolProp::mat_to_string(CoolProp::vec_to_eigen(cHeat, 1)));
-        if (PRINT) std::cout << tmpStr << std::endl;
+        if (PRINT) std::cout << tmpStr << '\n';
         CHECK_THROWS(tmpStr = CoolProp::mat_to_string(CoolProp::vec_to_eigen(cHeat, 2)));
-        if (PRINT) std::cout << tmpStr << std::endl;
+        if (PRINT) std::cout << tmpStr << '\n';
         CHECK_NOTHROW(tmpStr = CoolProp::mat_to_string(CoolProp::vec_to_eigen(cHeat2D)));
-        if (PRINT) std::cout << tmpStr << std::endl;
+        if (PRINT) std::cout << tmpStr << '\n';
     }
 
     SECTION("Matrix modifications") {
         Eigen::MatrixXd matrix = CoolProp::vec_to_eigen(cHeat2D);
 
-        if (PRINT) std::cout << CoolProp::mat_to_string(matrix) << std::endl;
+        if (PRINT) std::cout << CoolProp::mat_to_string(matrix) << '\n';
 
         CHECK_NOTHROW(CoolProp::removeColumn(matrix, 1));
-        if (PRINT) std::cout << CoolProp::mat_to_string(matrix) << std::endl;
+        if (PRINT) std::cout << CoolProp::mat_to_string(matrix) << '\n';
 
         CHECK_NOTHROW(CoolProp::removeRow(matrix, 1));
-        if (PRINT) std::cout << CoolProp::mat_to_string(matrix) << std::endl;
+        if (PRINT) std::cout << CoolProp::mat_to_string(matrix) << '\n';
 
         CHECK_THROWS(CoolProp::removeColumn(matrix, 10));
         CHECK_THROWS(CoolProp::removeRow(matrix, 10));

--- a/src/PolyMath.cpp
+++ b/src/PolyMath.cpp
@@ -159,7 +159,7 @@ Eigen::MatrixXd Polynomial2D::deriveCoeffs(const Eigen::MatrixXd& coefficients, 
 double Polynomial2D::evaluate(const Eigen::MatrixXd& coefficients, const double& x_in) {
     double result = Eigen::poly_eval(makeVector(coefficients), x_in);
     if (this->do_debug())
-        std::cout << "Running      1D evaluate(" << mat_to_string(coefficients) << ", x_in:" << vec_to_string(x_in) << "): " << result << std::endl;
+        std::cout << "Running      1D evaluate(" << mat_to_string(coefficients) << ", x_in:" << vec_to_string(x_in) << "): " << result << '\n';
     return result;
 }
 double Polynomial2D::evaluate(const Eigen::MatrixXd& coefficients, const double& x_in, const double& y_in) {
@@ -171,7 +171,7 @@ double Polynomial2D::evaluate(const Eigen::MatrixXd& coefficients, const double&
     }
     if (this->do_debug())
         std::cout << "Running      2D evaluate(" << mat_to_string(coefficients) << ", x_in:" << vec_to_string(x_in)
-                  << ", y_in:" << vec_to_string(y_in) << "): " << result << std::endl;
+                  << ", y_in:" << vec_to_string(y_in) << "): " << result << '\n';
     return result;
 }
 
@@ -188,12 +188,12 @@ double Polynomial2D::integral(const Eigen::MatrixXd& coefficients, const double&
 /// @param min double value that represents the minimum value
 /// @param max double value that represents the maximum value
 double Polynomial2D::solve_limits(Poly2DResidual* res, const double& min, const double& max) {
-    if (do_debug()) std::cout << format("Called solve_limits with: min=%f and max=%f", min, max) << std::endl;
+    if (do_debug()) std::cout << format("Called solve_limits with: min=%f and max=%f", min, max) << '\n';
     double macheps = DBL_EPSILON;
     double tol = DBL_EPSILON * 1e3;
     int maxiter = 10;
     double result = Brent(res, min, max, macheps, tol, maxiter);
-    if (this->do_debug()) std::cout << "Brent solver message: " << res->errstring << std::endl;
+    if (this->do_debug()) std::cout << "Brent solver message: " << res->errstring << '\n';
     return result;
 }
 
@@ -201,12 +201,12 @@ double Polynomial2D::solve_limits(Poly2DResidual* res, const double& min, const 
 /// @param res Poly2DResidual object to calculate residuals and derivatives
 /// @param guess double value that represents the start value
 double Polynomial2D::solve_guess(Poly2DResidual* res, const double& guess) {
-    if (do_debug()) std::cout << format("Called solve_guess with: guess=%f ", guess) << std::endl;
+    if (do_debug()) std::cout << format("Called solve_guess with: guess=%f ", guess) << '\n';
     //set_debug_level(1000);
     double tol = DBL_EPSILON * 1e3;
     int maxiter = 10;
     double result = Newton(res, guess, tol, maxiter);
-    if (this->do_debug()) std::cout << "Newton solver message: " << res->errstring << std::endl;
+    if (this->do_debug()) std::cout << "Newton solver message: " << res->errstring << '\n';
     return result;
 }
 
@@ -231,11 +231,11 @@ Eigen::VectorXd Polynomial2D::solve(const Eigen::MatrixXd& coefficients, const d
             break;
     }
     tmpCoefficients(0, 0) -= z_in;
-    if (this->do_debug()) std::cout << "Coefficients: " << mat_to_string(Eigen::MatrixXd(tmpCoefficients)) << std::endl;
+    if (this->do_debug()) std::cout << "Coefficients: " << mat_to_string(Eigen::MatrixXd(tmpCoefficients)) << '\n';
     Eigen::PolynomialSolver<double, Eigen::Dynamic> polySolver(tmpCoefficients);
     std::vector<double> rootsVec;
     polySolver.realRoots(rootsVec);
-    if (this->do_debug()) std::cout << "Real roots: " << vec_to_string(rootsVec) << std::endl;
+    if (this->do_debug()) std::cout << "Real roots: " << vec_to_string(rootsVec) << '\n';
     return vec_to_eigen(rootsVec);
     //return rootsVec[0]; // TODO: implement root selection algorithm
 }
@@ -261,7 +261,7 @@ double Polynomial2D::simplePolynomial(std::vector<double> const& coefficients, d
         result += coefficients[i] * pow(x, (int)i);
     }
     if (this->do_debug())
-        std::cout << "Running simplePolynomial(" << vec_to_string(coefficients) << ", " << vec_to_string(x) << "): " << result << std::endl;
+        std::cout << "Running simplePolynomial(" << vec_to_string(coefficients) << ", " << vec_to_string(x) << "): " << result << '\n';
     return result;
 }
 double Polynomial2D::simplePolynomial(std::vector<std::vector<double>> const& coefficients, double x, double y) {
@@ -271,7 +271,7 @@ double Polynomial2D::simplePolynomial(std::vector<std::vector<double>> const& co
     }
     if (this->do_debug())
         std::cout << "Running simplePolynomial(" << vec_to_string(coefficients) << ", " << vec_to_string(x) << ", " << vec_to_string(y)
-                  << "): " << result << std::endl;
+                  << "): " << result << '\n';
     return result;
 }
 
@@ -287,7 +287,7 @@ double Polynomial2D::baseHorner(std::vector<double> const& coefficients, double 
         result += coefficients[i];
     }
     if (this->do_debug())
-        std::cout << "Running       baseHorner(" << vec_to_string(coefficients) << ", " << vec_to_string(x) << "): " << result << std::endl;
+        std::cout << "Running       baseHorner(" << vec_to_string(coefficients) << ", " << vec_to_string(x) << "): " << result << '\n';
     return result;
 }
 
@@ -299,7 +299,7 @@ double Polynomial2D::baseHorner(std::vector<std::vector<double>> const& coeffici
     }
     if (this->do_debug())
         std::cout << "Running       baseHorner(" << vec_to_string(coefficients) << ", " << vec_to_string(x) << ", " << vec_to_string(y)
-                  << "): " << result << std::endl;
+                  << "): " << result << '\n';
     return result;
 }
 
@@ -470,7 +470,7 @@ double Polynomial2DFrac::evaluate(const Eigen::MatrixXd& coefficients, const dou
                                   const double& x_base, const double& y_base) {
     if ((x_exp < 0) && (std::abs(x_in - x_base) < CPPOLY_EPSILON)) {
         // throw ValueError(format("%s (%d): A fraction cannot be evaluated with zero as denominator, x_in-x_base=%f ", __FILE__, __LINE__, x_in - x_base));
-        if (this->do_debug()) std::cout << "Interpolating in x-direction for base " << x_base << " and input " << x_in << std::endl;
+        if (this->do_debug()) std::cout << "Interpolating in x-direction for base " << x_base << " and input " << x_in << '\n';
         const double x_lo = x_base - CPPOLY_DELTA;
         const double x_hi = x_base + CPPOLY_DELTA;
         const double z_lo = evaluate(coefficients, x_lo, y_in, x_exp, y_exp, x_base, y_base);
@@ -479,7 +479,7 @@ double Polynomial2DFrac::evaluate(const Eigen::MatrixXd& coefficients, const dou
     }
     if ((y_exp < 0) && (std::abs(y_in - y_base) < CPPOLY_EPSILON)) {
         // throw ValueError(format("%s (%d): A fraction cannot be evaluated with zero as denominator, y_in-y_base=%f ", __FILE__, __LINE__, y_in - y_base));
-        if (this->do_debug()) std::cout << "Interpolating in y-direction for base " << y_base << " and input " << y_in << std::endl;
+        if (this->do_debug()) std::cout << "Interpolating in y-direction for base " << y_base << " and input " << y_in << '\n';
         const double y_lo = y_base - CPPOLY_DELTA;
         const double y_hi = y_base + CPPOLY_DELTA;
         const double z_lo = evaluate(coefficients, x_in, y_lo, x_exp, y_exp, x_base, y_base);
@@ -517,11 +517,11 @@ double Polynomial2DFrac::evaluate(const Eigen::MatrixXd& coefficients, const dou
         posExp *= x_in - x_base;
         posExp += evaluate(tmpCoeffs.row(i), y_in, y_exp, y_base);
     }
-    if (this->do_debug()) std::cout << "Running      2D evaluate(" << mat_to_string(coefficients) << ", " << std::endl;
+    if (this->do_debug()) std::cout << "Running      2D evaluate(" << mat_to_string(coefficients) << ", " << '\n';
     if (this->do_debug())
         std::cout << "x_in:" << vec_to_string(x_in) << ", y_in:" << vec_to_string(y_in) << ", x_exp:" << vec_to_string(x_exp)
                   << ", y_exp:" << vec_to_string(y_exp) << ", x_base:" << vec_to_string(x_base) << ", y_base:" << vec_to_string(y_base)
-                  << "): " << negExp + posExp << std::endl;
+                  << "): " << negExp + posExp << '\n';
     return negExp + posExp;
 }
 
@@ -663,7 +663,7 @@ Eigen::VectorXd Polynomial2DFrac::solve(const Eigen::MatrixXd& coefficients, con
             break;
     }
 
-    if (this->do_debug()) std::cout << "Coefficients: " << mat_to_string(Eigen::MatrixXd(newCoefficients)) << std::endl;
+    if (this->do_debug()) std::cout << "Coefficients: " << mat_to_string(Eigen::MatrixXd(newCoefficients)) << '\n';
 
     const size_t r = newCoefficients.rows();
     for (size_t i = 0; i < r; i++) {
@@ -684,11 +684,11 @@ Eigen::VectorXd Polynomial2DFrac::solve(const Eigen::MatrixXd& coefficients, con
                                          __FILE__, __LINE__, solve_exp));
     }
 
-    if (this->do_debug()) std::cout << "Coefficients: " << mat_to_string(Eigen::MatrixXd(tmpCoefficients)) << std::endl;
+    if (this->do_debug()) std::cout << "Coefficients: " << mat_to_string(Eigen::MatrixXd(tmpCoefficients)) << '\n';
     Eigen::PolynomialSolver<double, -1> polySolver(tmpCoefficients);
     std::vector<double> rootsVec;
     polySolver.realRoots(rootsVec);
-    if (this->do_debug()) std::cout << "Real roots: " << vec_to_string(rootsVec) << std::endl;
+    if (this->do_debug()) std::cout << "Real roots: " << vec_to_string(rootsVec) << '\n';
     return vec_to_eigen(rootsVec);
     //return rootsVec[0]; // TODO: implement root selection algorithm
 }
@@ -698,7 +698,7 @@ double Polynomial2DFrac::solve_limits(const Eigen::MatrixXd& coefficients, const
                                       const int& axis, const int& x_exp, const int& y_exp, const double& x_base, const double& y_base) {
     if (do_debug())
         std::cout << format("Called solve_limits with: %f, %f, %f, %f, %d, %d, %d, %f, %f", in, z_in, min, max, axis, x_exp, y_exp, x_base, y_base)
-                  << std::endl;
+                  << '\n';
     Poly2DFracResidual res = Poly2DFracResidual(*this, coefficients, in, z_in, axis, x_exp, y_exp, x_base, y_base);
     return Polynomial2D::solve_limits(&res, min, max);
 }  //TODO: Implement tests for this solver
@@ -707,8 +707,7 @@ double Polynomial2DFrac::solve_limits(const Eigen::MatrixXd& coefficients, const
 double Polynomial2DFrac::solve_guess(const Eigen::MatrixXd& coefficients, const double& in, const double& z_in, const double& guess, const int& axis,
                                      const int& x_exp, const int& y_exp, const double& x_base, const double& y_base) {
     if (do_debug())
-        std::cout << format("Called solve_guess with: %f, %f, %f, %d, %d, %d, %f, %f", in, z_in, guess, axis, x_exp, y_exp, x_base, y_base)
-                  << std::endl;
+        std::cout << format("Called solve_guess with: %f, %f, %f, %d, %d, %d, %f, %f", in, z_in, guess, axis, x_exp, y_exp, x_base, y_base) << '\n';
     Poly2DFracResidual res = Poly2DFracResidual(*this, coefficients, in, z_in, axis, x_exp, y_exp, x_base, y_base);
     return Polynomial2D::solve_guess(&res, guess);
 }  //TODO: Implement tests for this solver
@@ -787,7 +786,7 @@ double Polynomial2DFrac::fracIntCentral(const Eigen::MatrixXd& coefficients, con
     }
     if (this->do_debug())
         std::cout << "Running   fracIntCentral(" << mat_to_string(coefficients) << ", " << vec_to_string(x_in) << ", " << vec_to_string(x_base)
-                  << "): " << result << std::endl;
+                  << "): " << result << '\n';
     return result;
 }
 
@@ -879,29 +878,29 @@ TEST_CASE("Internal consistency checks and example use cases for PolyMath.cpp", 
 
         CHECK_NOTHROW(matrix = poly.integrateCoeffs(matrix2D, 0));
         tmpStr = CoolProp::mat_to_string(matrix2D);
-        if (PRINT) std::cout << tmpStr << std::endl;
+        if (PRINT) std::cout << tmpStr << '\n';
         tmpStr = CoolProp::mat_to_string(matrix);
-        if (PRINT) std::cout << tmpStr << std::endl << std::endl;
+        if (PRINT) std::cout << tmpStr << '\n' << '\n';
 
         CHECK_NOTHROW(matrix = poly.integrateCoeffs(matrix2D, 1));
         tmpStr = CoolProp::mat_to_string(matrix2D);
-        if (PRINT) std::cout << tmpStr << std::endl;
+        if (PRINT) std::cout << tmpStr << '\n';
         tmpStr = CoolProp::mat_to_string(matrix);
-        if (PRINT) std::cout << tmpStr << std::endl << std::endl;
+        if (PRINT) std::cout << tmpStr << '\n' << '\n';
 
         CHECK_THROWS(poly.deriveCoeffs(matrix2D));
 
         CHECK_NOTHROW(matrix = poly.deriveCoeffs(matrix2D, 0));
         tmpStr = CoolProp::mat_to_string(matrix2D);
-        if (PRINT) std::cout << tmpStr << std::endl;
+        if (PRINT) std::cout << tmpStr << '\n';
         tmpStr = CoolProp::mat_to_string(matrix);
-        if (PRINT) std::cout << tmpStr << std::endl << std::endl;
+        if (PRINT) std::cout << tmpStr << '\n' << '\n';
 
         CHECK_NOTHROW(matrix = poly.deriveCoeffs(matrix2D, 1));
         tmpStr = CoolProp::mat_to_string(matrix2D);
-        if (PRINT) std::cout << tmpStr << std::endl;
+        if (PRINT) std::cout << tmpStr << '\n';
         tmpStr = CoolProp::mat_to_string(matrix);
-        if (PRINT) std::cout << tmpStr << std::endl << std::endl;
+        if (PRINT) std::cout << tmpStr << '\n' << '\n';
     }
 
     SECTION("Evaluation and test values") {

--- a/src/PolyMath.cpp
+++ b/src/PolyMath.cpp
@@ -980,7 +980,15 @@ TEST_CASE("Internal consistency checks and example use cases for PolyMath.cpp", 
 
         double acc = 0.001;
 
-        for (double T = Tmin; T < Tmax; T += Tinc) {
+        // Integer-indexed grid: preserves the original `T < Tmax` exit
+        // semantics without floating-point loop-counter accumulation
+        // (cert-flp30-c).  N_T = ceil((Tmax-Tmin)/Tinc) matches the
+        // count the original `for (T = Tmin; T < Tmax; T += Tinc)` loop
+        // produces for the current Tmin/Tmax/Tinc (223.15/523.15/200 -> 2).
+        const std::size_t N_T = static_cast<std::size_t>(std::ceil((Tmax - Tmin) / Tinc));
+
+        for (std::size_t i = 0; i < N_T; ++i) {
+            const double T = Tmin + i * Tinc;
             val1 = poly.evaluate(matrix, x, T - deltaT);
             val2 = poly.evaluate(matrix, x, T + deltaT);
             val3 = (val2 - val1) / 2 / deltaT;
@@ -995,7 +1003,8 @@ TEST_CASE("Internal consistency checks and example use cases for PolyMath.cpp", 
             CHECK(check_abs(val3, val4, acc));
         }
 
-        for (double T = Tmin; T < Tmax; T += Tinc) {
+        for (std::size_t i = 0; i < N_T; ++i) {
+            const double T = Tmin + i * Tinc;
             val1 = poly.evaluate(matrixDer, x, T - deltaT);
             val2 = poly.evaluate(matrixDer, x, T + deltaT);
             val3 = (val2 - val1) / 2 / deltaT;
@@ -1010,7 +1019,8 @@ TEST_CASE("Internal consistency checks and example use cases for PolyMath.cpp", 
             CHECK(check_abs(val3, val4, acc));
         }
 
-        for (double T = Tmin; T < Tmax; T += Tinc) {
+        for (std::size_t i = 0; i < N_T; ++i) {
+            const double T = Tmin + i * Tinc;
             val1 = poly.evaluate(matrixInt, x, T - deltaT);
             val2 = poly.evaluate(matrixInt, x, T + deltaT);
             val3 = (val2 - val1) / 2 / deltaT;
@@ -1025,7 +1035,8 @@ TEST_CASE("Internal consistency checks and example use cases for PolyMath.cpp", 
             CHECK(check_abs(val3, val4, acc));
         }
 
-        for (double T = Tmin; T < Tmax; T += Tinc) {
+        for (std::size_t i = 0; i < N_T; ++i) {
+            const double T = Tmin + i * Tinc;
             val1 = poly.evaluate(matrixInt2, x, T - deltaT);
             val2 = poly.evaluate(matrixInt2, x, T + deltaT);
             val3 = (val2 - val1) / 2 / deltaT;
@@ -1040,7 +1051,8 @@ TEST_CASE("Internal consistency checks and example use cases for PolyMath.cpp", 
             CHECK(check_abs(val3, val4, acc));
         }
 
-        for (double T = Tmin; T < Tmax; T += Tinc) {
+        for (std::size_t i = 0; i < N_T; ++i) {
+            const double T = Tmin + i * Tinc;
             val1 = poly.evaluate(matrix, x, T);
             val2 = poly.derivative(matrixInt, x, T, 1);
             CAPTURE(T);
@@ -1049,7 +1061,8 @@ TEST_CASE("Internal consistency checks and example use cases for PolyMath.cpp", 
             CHECK(check_abs(val1, val2, acc));
         }
 
-        for (double T = Tmin; T < Tmax; T += Tinc) {
+        for (std::size_t i = 0; i < N_T; ++i) {
+            const double T = Tmin + i * Tinc;
             val1 = poly.derivative(matrix, x, T, 1);
             val2 = poly.evaluate(matrixDer, x, T);
             CAPTURE(T);
@@ -1171,7 +1184,12 @@ TEST_CASE("Internal consistency checks and example use cases for PolyMath.cpp", 
         }
 
         deltaT = 0.01;
-        for (T = Tmin; T < Tmax; T += Tinc) {
+        // Integer-indexed grid (cert-flp30-c) — same N_T derivation as
+        // the loops in the previous SECTION; T is the outer-scope test
+        // variable, reuse it.
+        const std::size_t N_T_frac = static_cast<std::size_t>(std::ceil((Tmax - Tmin) / Tinc));
+        for (std::size_t i = 0; i < N_T_frac; ++i) {
+            T = Tmin + i * Tinc;
             a = poly.evaluate(matrix, T - deltaT, y);
             b = poly.evaluate(matrix, T + deltaT, y);
             c = (b - a) / 2.0 / deltaT;

--- a/src/Solvers.cpp
+++ b/src/Solvers.cpp
@@ -123,7 +123,7 @@ double Newton(FuncWrapper1DWithDeriv* f, double x0, double ftol, int maxiter) {
         };
 
         if (f->verbosity > 0) {
-            std::cout << format("i: %d, x: %0.15g, dx: %g, f: %g, dfdx: %g", f->iter, x, dx, fval, dfdx) << std::endl;
+            std::cout << format("i: %d, x: %0.15g, dx: %g, f: %g, dfdx: %g", f->iter, x, dx, fval, dfdx) << '\n';
         }
 
         x += dx;
@@ -190,7 +190,7 @@ double Halley(FuncWrapper1DWithTwoDerivs* f, double x0, double ftol, int maxiter
         dx = -omega * (2 * fval * dfdx) / (2 * POW2(dfdx) - fval * d2fdx2);
 
         if (f->verbosity > 0) {
-            std::cout << format("i: %d, x: %0.15g, dx: %g, f: %g, dfdx: %g, d2fdx2: %g", f->iter, x, dx, fval, dfdx, d2fdx2) << std::endl;
+            std::cout << format("i: %d, x: %0.15g, dx: %g, f: %g, dfdx: %g, d2fdx2: %g", f->iter, x, dx, fval, dfdx, d2fdx2) << '\n';
         }
 
         x += dx;

--- a/src/Tests/CoolProp-Tests-SVDComponents.cpp
+++ b/src/Tests/CoolProp-Tests-SVDComponents.cpp
@@ -218,6 +218,7 @@ TEST_CASE("CubicSplineCurve through known knots", "[SVDComponents][Region][bound
     // Knots from y = x^2 (a strict-convex test).
     std::vector<double> x = {0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0};
     std::vector<double> y;
+    y.reserve(x.size());
     for (double xi : x) {
         y.push_back(xi * xi);
     }

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -736,10 +736,14 @@ class ConsistencyFixture
     void subcritical_pressure_liquid() {
         // Subcritical pressure liquid
         int inputsN = sizeof(inputs) / sizeof(inputs[0]);
-        for (double p = pState->p_triple() * 1.1; p < pState->p_critical(); p *= 3) {
+        // Geometric scaling (p *= 3) — no FP-counter-accumulation issue; ~3-5 iters.
+        for (double p = pState->p_triple() * 1.1; p < pState->p_critical(); p *= 3) {  // NOLINT(cert-flp30-c)
             double Ts = PropsSI("T", "P", p, "Q", 0, "Water");
             double Tmelt = pState->melting_line(CoolProp::iT, CoolProp::iP, p);
-            for (double T = Tmelt; T < Ts - 0.1; T += 0.1) {
+            // Test scaffold: T += 0.1 over a ~100 K range gives ~1e-14
+            // cumulative error which is far below the property tolerance
+            // any of the inner CHECKs use.
+            for (double T = Tmelt; T < Ts - 0.1; T += 0.1) {  // NOLINT(cert-flp30-c)
                 CHECK_NOTHROW(set_TP(T, p));
 
                 for (int i = 0; i < inputsN; ++i) {
@@ -822,7 +826,12 @@ class HumidAirDewpointFixture
     }
     void run_p(double p) {
         CAPTURE(p);
-        for (double zH2O = 0.999; zH2O > 0; zH2O -= 0.001) {
+        // Integer-indexed sweep (cert-flp30-c): zH2O = 0.999, 0.998, ...,
+        // 0.001 (999 samples), exactly preserving the original loop's
+        // exit condition without 1e-3 step accumulation.
+        constexpr std::size_t N_z = 999;
+        for (std::size_t i = 0; i < N_z; ++i) {
+            const double zH2O = 0.999 - 0.001 * i;
             setup(zH2O);
             AS->set_mole_fractions(z);
             CAPTURE(zH2O);
@@ -1999,7 +2008,11 @@ class AncillaryFixture
         }
     }
     void do_sat(shared_ptr<CoolProp::AbstractState>& AS) {
-        for (double f = 0.1; f < 1; f += 0.4) {
+        // Integer-indexed (cert-flp30-c): f = 0.1, 0.5, 0.9 — exactly
+        // what the original `for (double f = 0.1; f < 1; f += 0.4)`
+        // produced.
+        for (std::size_t k = 0; k < 3; ++k) {
+            const double f = 0.1 + 0.4 * static_cast<double>(k);
             double Tc = AS->T_critical();
             double Tt = AS->Ttriple();
             double T = f * Tc + (1 - f) * Tt;
@@ -2188,7 +2201,9 @@ class SatTFixture
         if (AS->fluid_param_string("pure") == "true") {
             Tc = std::min(Tc, AS->T_reducing());
         }
-        for (double j = 0.1; j > 1e-10; j /= 10) {
+        // Geometric scaling (j /= 10) — not summation; 9 well-defined
+        // iters from 0.1 down to 1e-10.
+        for (double j = 0.1; j > 1e-10; j /= 10) {  // NOLINT(cert-flp30-c)
             check_QT(AS, Tc - j);
         }
     }

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -3791,7 +3791,7 @@ TEST_CASE_METHOD(SuperAncillaryOnFixture, "Performance regression; on", "[2438]"
         return AS;
     };
     AS->update(HmassP_INPUTS, 300e3, 70e5);
-    std::cout << AS->Q() << std::endl;
+    std::cout << AS->Q() << '\n';
 }
 TEST_CASE_METHOD(SuperAncillaryOffFixture, "Performance regression; off", "[2438]") {
     shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "CO2"));
@@ -3800,7 +3800,7 @@ TEST_CASE_METHOD(SuperAncillaryOffFixture, "Performance regression; off", "[2438
         return AS;
     };
     AS->update(HmassP_INPUTS, 300e3, 70e5);
-    std::cout << AS->Q() << std::endl;
+    std::cout << AS->Q() << '\n';
 }
 TEST_CASE_METHOD(SuperAncillaryOnFixture, "Performance regression for TS; on", "[2438saontime]") {
     shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "n-Propane"));


### PR DESCRIPTION
## Summary

Bundle of the remaining safe/mechanical fixes from #2926. **Excluded:** HumidAirProp `strcpy` API (public-API signature change — separate PR).

Three discrete commits — review independently:

1. **`perf(clang-tidy): mechanical sweep`** — 31 files, fully mechanical `clang-tidy --fix`:
   - `performance-avoid-endl` (136 sites): `std::endl` → `"\n"`.
   - `performance-faster-string-find` (18 sites): `s.find("x")` → `s.find('x')`.
   - `performance-inefficient-vector-operation` (13 sites): `reserve()` before `push_back` loops.

2. **`refactor: virtual-in-ctor`** — 4 files, 10 sites. Explicit scope resolution (`ClassName::method()`) instead of introducing `init_*()` helpers. Behaviorally identical — derived overrides aren't active during base construction anyway, so dispatch already resolved to THIS class; the explicit scope just documents that and silences `clang-analyzer-optin.cplusplus.VirtualCall`.

3. **`refactor: float-loop counters`** — 10 files, 26 `cert-flp30-c` sites. Per-site judgment (per #2926's "needs careful per-site review for boundary-iteration shifts"):
   - **Bounded-N grids → integer-indexed loop:** `for (T = Tmin; T < Tmax; T += step)` → `for (size_t i = 0; i < N; ++i) { T = Tmin + i*dT; }`. Sites: PolyMath × 7 (derivative tests), Tests × 2 (zH2O sweep, quality fractions), HumidAirProp × 2 (T/W grid), Ancillaries × 1, PhaseEnvelopeRoutines × 1.
   - **Geometric / short solver loops → `// NOLINT(cert-flp30-c)` with rationale:** Newton-step damping (geometric `/= 1.1`, `/= 2` or short arithmetic ≤ 4 iters), unit-step stability tests over integer ranges, geometric density sweeps. The check's "summation accumulation" failure mode doesn't apply.

After all 3 commits, `cert-flp30-c`, `clang-analyzer-optin.cplusplus.VirtualCall`, `performance-avoid-endl`, `performance-faster-string-find`, and `performance-inefficient-vector-operation` all drop to **0 first-party findings**.

## Test plan

- [x] `cmake --build build_catch --target CatchTestRunner -j8` — clean, exit 0.
- [x] `./build_catch/CatchTestRunner [SBTL]` — 16 cases / 4587 assertions pass (1 REFPROP-skip unrelated).
- [x] `./build_catch/CatchTestRunner [Helmholtz]` — 1 case / 415 assertions pass.
- [x] All 5 check counts independently rechecked via `run-clang-tidy --checks='-*,<check>'` → 0.
- [x] Branch rebased onto current master (post #2979 Catch2-fixture race-condition fix).

## Reproducibility (commit 1)

```bash
run-clang-tidy -p build_catch \
  -checks='-*,performance-avoid-endl,performance-faster-string-find,performance-inefficient-vector-operation' \
  -header-filter='^.../(include|src)/' -fix -format -j 1
```

Serial (`-j 1`) avoids the duplicate-fix-emission issue handled separately in PR #2976.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal stream handling and container memory allocations across multiple modules for improved performance.
  * Enhanced code clarity with explicit base-class method invocations during initialization to avoid virtual dispatch ambiguities.
  * Improved test determinism by replacing floating-point loop accumulation with integer-indexed iterations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2980?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->