### PR TITLE
refactor(headers): break two header layering violations (CoolProp-6c1)

### DIFF
--- a/include/Helmholtz.h
+++ b/include/Helmholtz.h
@@ -9,10 +9,17 @@
 //#include "Eigen/Core"
 #include "time.h"
 #include "CachedElement.h"
-#include "Backends/Cubics/GeneralizedCubic.h"
 #include <memory>
 using std::shared_ptr;
 #include "CPnumerics.h"
+
+// Forward declaration of AbstractCubic — only used via shared_ptr<AbstractCubic>
+// in this header, so the full type from Backends/Cubics/GeneralizedCubic.h is not
+// required at parse time.  Note: AbstractCubic is declared in the global namespace
+// (not CoolProp::) by GeneralizedCubic.h, so this forward decl must match.  TUs
+// that actually call methods on the pointer must include
+// "Backends/Cubics/GeneralizedCubic.h" directly.
+class AbstractCubic;
 
 #if ENABLE_CATCH
 #    include "MultiComplex/MultiComplex.hpp"

--- a/include/PolyMath.h
+++ b/include/PolyMath.h
@@ -1,7 +1,6 @@
 #ifndef POLYMATH_H
 #define POLYMATH_H
 
-#include "CoolProp.h"
 #include "CoolPropTools.h"
 #include "Exceptions.h"
 
@@ -11,6 +10,11 @@
 #include "unsupported/Eigen/Polynomials"
 
 namespace CoolProp {
+
+// Forward declaration of get_debug_level (defined in CoolProp.h / CoolProp.cpp);
+// pulled in here so PolyMath.h does not have to #include the much heavier CoolProp.h
+// just for the one-line do_debug() helper below.
+int get_debug_level();
 
 // Just a forward declaration
 class Poly2DResidual;

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -2,6 +2,7 @@
 #include "FlashRoutines.h"
 
 #include <cmath>
+#include "CoolProp.h"
 #include "HelmholtzEOSMixtureBackend.h"
 #include "HelmholtzEOSBackend.h"
 #include "PhaseEnvelopeRoutines.h"

--- a/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
+++ b/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <limits>
+#include "CoolProp.h"
 #include "DataStructures.h"
 #include "AbstractState.h"
 #include "Configuration.h"

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.h
@@ -12,6 +12,7 @@ using std::shared_ptr;
 #include <algorithm>
 #include "Configuration.h"
 #include "Backends/Cubics/CubicsLibrary.h"
+#include "Backends/Cubics/GeneralizedCubic.h"
 #include "Helmholtz.h"
 
 namespace CoolProp {

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -22,9 +22,11 @@
 #include <string>
 //#include "CoolProp.h"
 
+#include "CoolProp.h"
 #include "HelmholtzEOSMixtureBackend.h"
 #include "HelmholtzEOSBackend.h"
 #include "Fluids/FluidLibrary.h"
+#include "Backends/Cubics/GeneralizedCubic.h"
 #include "Solvers.h"
 #include "MatrixMath.h"
 #include "VLERoutines.h"

--- a/src/Backends/Incompressible/IncompressibleBackend.cpp
+++ b/src/Backends/Incompressible/IncompressibleBackend.cpp
@@ -11,7 +11,7 @@
 #endif
 
 #include <string>
-//#include "CoolProp.h"
+#include "CoolProp.h"
 
 #include "IncompressibleBackend.h"
 #include "IncompressibleFluid.h"

--- a/src/Backends/Incompressible/IncompressibleFluid.cpp
+++ b/src/Backends/Incompressible/IncompressibleFluid.cpp
@@ -1,4 +1,5 @@
 
+#include "CoolProp.h"
 #include "DataStructures.h"
 #include "IncompressibleFluid.h"
 #include "IncompressibleLibrary.h"

--- a/src/Helmholtz.cpp
+++ b/src/Helmholtz.cpp
@@ -1,5 +1,6 @@
 #include <cmath>
 #include "Helmholtz.h"
+#include "Backends/Cubics/GeneralizedCubic.h"
 
 #ifdef __ANDROID__
 #    undef _A


### PR DESCRIPTION
## Summary

Precursor cleanup for the `include/` reorganization tracked in **CoolProp-6c1** / **CoolProp-dfw** (GitHub #1280). Breaks two header-layering violations with no behavior change.

**1. `Helmholtz.h` no longer pulls `Backends/Cubics/GeneralizedCubic.h`.**
The header only uses the type via `shared_ptr<AbstractCubic>` (member + ctor param), never calling its methods, so a forward declaration suffices. `AbstractCubic` is declared in the **global** namespace by `GeneralizedCubic.h`, so the forward decl is at global scope to match. The three TUs that actually call methods on the pointer now include `GeneralizedCubic.h` directly: `src/Helmholtz.cpp`, `FluidLibrary.h`, `HelmholtzEOSMixtureBackend.cpp`.

**2. `PolyMath.h` drops a dead `#include "CoolProp.h"`.**
Its only use of that header was `get_debug_level()`, now forward-declared (matching the existing `extern int get_debug_level();` pattern already used in `FluidLibrary.h`). That include had been transitively feeding `CoolProp.h` to five `.cpp` files, which now include it directly: `Ancillaries.cpp`, `FlashRoutines.cpp`, `HelmholtzEOSMixtureBackend.cpp`, `IncompressibleFluid.cpp`, `IncompressibleBackend.cpp` (uncommented its pre-existing `//#include`).

## Why

`Helmholtz.h` (a public header) reaching into a private backend header, and `PolyMath.h` carrying a dead heavyweight include, are exactly the kind of include-graph tangles that make the include/ subfolder move (#1280) harder. Clearing them first keeps that move mechanical and reviewable.

## Test plan

- [x] CatchTestRunner builds clean
- [x] Targeted tags (`[helmholtz],[cubic],[ancillary],[ancillaries],[fluids],[IncompressibleBackend],[IncompressibleFluids],[multi_fluid]`): 2446 assertions, all pass
- [x] Broad `~[slow]` sweep: 270 cases (256 pass, 14 REFPROP-skipped), 60581 assertions, all pass
- [x] Adversarial review: shared_ptr-of-incomplete-type safety, transitive-include completeness across build configs, and forward-decl namespace/ODR correctness all verified clean

> Note: pushed with `--no-verify` (preflight skipped at author's request); CI will run the full gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal header dependencies to improve build efficiency and reduce compilation overhead.
  * Streamlined include paths across Helmholtz and backend modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2981?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->