### PR TITLE
feat(svdsbtl): DT-indexed surface for native (ρ,T) lookups (CoolProp-i7j)

### DIFF
--- a/Web/coolprop/_gen/gen_DT_validation_fig1301.py
+++ b/Web/coolprop/_gen/gen_DT_validation_fig1301.py
@@ -1,0 +1,140 @@
+"""Reproduce yufang67's (T, ρ) error scatter from issue #1301 for the
+DT-indexed SVDSBTL preset (CoolProp-i7j), fully in Python — does its
+own (T, ρ) sweep via CoolProp (no C++/CSV dependency) and renders the
+two-panel figure in the ORIGINAL report's format.
+
+Requires a CoolProp Python wrapper built from THIS branch (so the
+SVDSBTL backend understands DmassT_INPUTS).  Build it with, e.g.:
+
+    cmake --build build_catch --target CoolProp   # or the Python target
+    pip install -e wrappers/Python                 # editable wrapper
+
+Figure format (matches #1301):
+  * x = T [K] over [220, 500], y = ρ [kg/m³] over [0, 1200] (linear)
+  * color = |P_backend − P_EOS| / P_EOS · 100  [%], jet, log-normed
+  * left  = BICUBIC&HEOS  (reproduces the near-saturation error band
+            + negative-pressure cells)
+  * right = SVDSBTL&HEOS DT-indexed (the fix)
+  * P < 0 cells overplotted as black ×
+
+Usage:
+    python3 Web/coolprop/_gen/gen_DT_validation_fig1301.py
+    python3 ... --n 200000        # denser scatter (default 20000)
+    python3 ... --grid 400,1600,30  # bump SVDSBTL NT,NR,rank via options
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.colors import LogNorm
+
+# yufang67's bounds from #1301.
+T_LO, T_HI = 220.0, 500.0
+RHO_LO, RHO_HI = 1.0e-2, 1200.0
+OUT_DEFAULT = Path(__file__).resolve().parents[1] / "fig1301_dt_validation.png"
+
+
+def _sweep(n_samples: int, grid: str | None):
+    import CoolProp.CoolProp as CP
+
+    svd_fluid = "CarbonDioxide"
+    if grid:
+        nt, nr, rank = (int(x) for x in grid.split(","))
+        svd_fluid = f'CarbonDioxide?{{"grid":{{"NT":{nt},"NR":{nr},"rank":{rank}}}}}'
+
+    heos = CP.AbstractState("HEOS", "CarbonDioxide")
+    svd = CP.AbstractState("SVDSBTL&HEOS", svd_fluid)
+    bic = CP.AbstractState("BICUBIC&HEOS", "CarbonDioxide")
+
+    rng = np.random.default_rng(1301)
+    T = rng.uniform(T_LO, T_HI, n_samples)
+    rho = rng.uniform(RHO_LO, RHO_HI, n_samples)
+
+    # SVDSBTL: vectorized via fast_evaluate (DmassT) — bypasses the
+    # per-call cache overhead that dominates a 200k point-by-point
+    # sweep.  val1 = D, val2 = T for DmassT_INPUTS.  out[:,0] = p.
+    out = np.full((n_samples, 1), np.nan)
+    status = np.zeros(n_samples, dtype=np.int32)
+    svd.fast_evaluate(
+        CP.DmassT_INPUTS,
+        np.ascontiguousarray(rho), np.ascontiguousarray(T),
+        np.array([CP.iP], dtype=np.int32),
+        out, status,
+    )
+    p_svd = np.where(status == 0, out[:, 0], np.nan)
+
+    # HEOS (truth) and BICUBIC have no DmassT fast path (HEOS has none;
+    # tabular fast_evaluate only does PT / HmolarP), so they go
+    # point-by-point.  Both are cheap per call relative to SVDSBTL's
+    # cache check, so this is no longer the bottleneck.
+    p_heos = np.full(n_samples, np.nan)
+    p_bic = np.full(n_samples, np.nan)
+    for i in range(n_samples):
+        for state, arr in ((heos, p_heos), (bic, p_bic)):
+            try:
+                state.update(CP.DmassT_INPUTS, rho[i], T[i])
+                arr[i] = state.p()
+            except Exception:
+                pass  # leave NaN — outside this backend's validity envelope
+    return T, rho, p_heos, p_svd, p_bic
+
+
+def _panel(ax, T, rho, p_heos, p_bk, title):
+    valid = np.isfinite(p_heos) & np.isfinite(p_bk) & (p_heos != 0.0)
+    pct = np.full_like(p_heos, np.nan)
+    pct[valid] = np.abs(p_bk[valid] - p_heos[valid]) / np.abs(p_heos[valid]) * 100.0
+    vals = np.maximum(pct, 1e-10)
+    finite = np.isfinite(vals)
+    sc = ax.scatter(
+        T[finite], rho[finite], c=vals[finite], s=6, edgecolor="none",
+        cmap="jet", norm=LogNorm(vmin=1e-8, vmax=1e2),
+    )
+    neg = np.isfinite(p_heos) & (p_heos > 0) & np.isfinite(p_bk) & (p_bk <= 0)
+    if neg.any():
+        ax.scatter(T[neg], rho[neg], s=22, marker="x", color="black", linewidths=1.1, label="P < 0 (sign flip)")
+        ax.legend(loc="upper right", fontsize=8, framealpha=0.9)
+    ax.set_xlim(T_LO, T_HI)
+    ax.set_ylim(0.0, RHO_HI)
+    ax.set_xlabel("Temperature  [K]")
+    ax.set_ylabel("density  [kg/m³]")
+    ax.set_title(f"{title}  ({int(neg.sum())} cells P<0)")
+    plt.colorbar(sc, ax=ax, label="Error in pressure  [%]")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=20000, help="number of random (T, ρ) draws")
+    ap.add_argument("--grid", type=str, default=None, help="SVDSBTL grid as NT,NR,rank (e.g. 400,1600,30)")
+    ap.add_argument("--out", type=Path, default=OUT_DEFAULT)
+    args = ap.parse_args(argv)
+
+    try:
+        T, rho, p_heos, p_svd, p_bic = _sweep(args.n, args.grid)
+    except ImportError:
+        sys.stderr.write(
+            "CoolProp Python wrapper not importable — build it from this branch first "
+            "(SVDSBTL DmassT support is required).\n"
+        )
+        return 1
+
+    fig, axes = plt.subplots(1, 2, figsize=(15, 6), constrained_layout=True)
+    fig.suptitle(
+        f"CO₂ P(ρ, T) error vs HEOS — issue #1301 reproduction (CoolProp-i7j, N={args.n} random draws)",
+        fontsize=13,
+    )
+    _panel(axes[0], T, rho, p_heos, p_bic, "BICUBIC&HEOS")
+    _panel(axes[1], T, rho, p_heos, p_svd, "SVDSBTL&HEOS (DT-indexed)")
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(args.out, dpi=140, bbox_inches="tight")
+    print(f"Wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Web/coolprop/_gen/gen_DT_water_anomaly.py
+++ b/Web/coolprop/_gen/gen_DT_water_anomaly.py
@@ -1,0 +1,150 @@
+"""Water density-anomaly validation for the DT-indexed SVDSBTL surface
+(CoolProp-i7j).  Companion to gen_DT_validation_fig1301.py, focused on
+the compressed-liquid band just above the saturation dome, bracketing
+the 4 degC density maximum (T_anom ~277.13 K) and running up to the
+melting / HEOS-validity boundary.
+
+This is the region the LIQUID_LO / LIQUID_HI anomaly split exists for:
+rho_sat,L(T) is non-monotone here (peaks at T_anom), so a single LIQUID
+region would straddle the density-maximum hairpin.  The figure shows
+the split keeps P(rho,T) clean across it.
+
+Requires a CoolProp Python wrapper built from this branch (DmassT
+SVDSBTL support).
+
+Format mirrors the #1301 figure:
+  * x = T [K], y = rho [kg/m3] (linear)
+  * color = |P_backend - P_EOS| / P_EOS * 100  [%], jet, log-normed
+  * left = BICUBIC&HEOS, right = SVDSBTL&HEOS (DT-indexed)
+  * rho_sat,L(T) overlaid (white); T_anom marked (dashed)
+
+Usage:
+    python3 Web/coolprop/_gen/gen_DT_water_anomaly.py
+    python3 ... --n 100000
+    python3 ... --interactive      # live zoom/pan/inspect window
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import matplotlib
+
+# Interactive mode must pick a GUI backend BEFORE importing pyplot.
+# Detect the flag from argv directly (argparse runs later).  Only force
+# "MacOSX" on darwin — that backend's Cocoa support isn't available on
+# Linux/Windows; elsewhere let matplotlib auto-select a GUI backend.
+_INTERACTIVE = "--interactive" in sys.argv
+if _INTERACTIVE and sys.platform == "darwin":
+    matplotlib.use("MacOSX")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+from matplotlib.colors import LogNorm  # noqa: E402
+
+# Band brackets the anomaly (277.13 K) with compressed-liquid densities
+# from just above rho_sat,L up to the melting/validity ceiling.
+T_LO, T_HI = 273.2, 300.0
+RHO_LO, RHO_HI = 996.0, 1090.0
+OUT_DEFAULT = Path(__file__).resolve().parents[1] / "fig_dt_water_anomaly.png"
+
+
+def _sweep(n_samples: int):
+    import CoolProp.CoolProp as CP
+
+    heos = CP.AbstractState("HEOS", "Water")
+    svd = CP.AbstractState("SVDSBTL&HEOS", "Water")
+    bic = CP.AbstractState("BICUBIC&HEOS", "Water")
+
+    rng = np.random.default_rng(277)
+    T = rng.uniform(T_LO, T_HI, n_samples)
+    rho = rng.uniform(RHO_LO, RHO_HI, n_samples)
+
+    # SVDSBTL via fast_evaluate (DmassT): val1=rho, val2=T, out=[iP].
+    out = np.full((n_samples, 1), np.nan)
+    status = np.zeros(n_samples, dtype=np.int32)
+    svd.fast_evaluate(CP.DmassT_INPUTS, np.ascontiguousarray(rho), np.ascontiguousarray(T),
+                      np.array([CP.iP], dtype=np.int32), out, status)
+    p_svd = np.where(status == 0, out[:, 0], np.nan)
+
+    p_heos = np.full(n_samples, np.nan)
+    p_bic = np.full(n_samples, np.nan)
+    for i in range(n_samples):
+        for state, arr in ((heos, p_heos), (bic, p_bic)):
+            try:
+                state.update(CP.DmassT_INPUTS, rho[i], T[i])
+                arr[i] = state.p()
+            except Exception:  # noqa: BLE001
+                # (rho, T) outside this backend's validity (below the
+                # melting line, or off BICUBIC's rectangular grid) —
+                # keep the pre-filled NaN; _panel masks non-finite cells.
+                pass
+
+    # rho_sat,L(T) overlay — shows the anomaly hairpin (peak at ~277 K).
+    Tcurve = np.linspace(T_LO, T_HI, 200)
+    rho_satL = np.full_like(Tcurve, np.nan)
+    for i, Tc in enumerate(Tcurve):
+        try:
+            heos.update(CP.QT_INPUTS, 0.0, Tc)
+            rho_satL[i] = heos.rhomass()
+        except Exception:  # noqa: BLE001
+            # No saturation point at this T (e.g. above Tc) — leave the
+            # overlay NaN so the curve simply doesn't plot there.
+            pass
+    return T, rho, p_heos, p_svd, p_bic, Tcurve, rho_satL
+
+
+def _panel(ax, T, rho, p_heos, p_bk, Tcurve, rho_satL, title):
+    valid = np.isfinite(p_heos) & np.isfinite(p_bk) & (p_heos != 0.0)
+    pct = np.full_like(p_heos, np.nan)
+    pct[valid] = np.abs(p_bk[valid] - p_heos[valid]) / np.abs(p_heos[valid]) * 100.0
+    vals = np.maximum(pct, 1e-10)
+    finite = np.isfinite(vals)
+    sc = ax.scatter(T[finite], rho[finite], c=vals[finite], s=6, edgecolor="none",
+                    cmap="jet", norm=LogNorm(vmin=1e-8, vmax=1e2))
+    neg = np.isfinite(p_heos) & (p_heos > 0) & np.isfinite(p_bk) & (p_bk <= 0)
+    if neg.any():
+        ax.scatter(T[neg], rho[neg], s=22, marker="x", color="black", linewidths=1.1, label="P < 0")
+    ax.plot(Tcurve, rho_satL, color="white", lw=1.4, label=r"$\rho_{sat,L}(T)$")
+    ax.axvline(277.13, color="white", ls="--", lw=0.8, alpha=0.7, label=r"$T_{anom}\approx277$ K")
+    ax.legend(loc="lower right", fontsize=8, framealpha=0.85)
+    ax.set_xlim(T_LO, T_HI)
+    ax.set_ylim(RHO_LO, RHO_HI)
+    ax.set_xlabel("Temperature  [K]")
+    ax.set_ylabel("density  [kg/m³]")
+    ax.set_title(f"{title}  ({int(neg.sum())} cells P<0)")
+    plt.colorbar(sc, ax=ax, label="Error in pressure  [%]")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=50000)
+    ap.add_argument("--out", type=Path, default=OUT_DEFAULT)
+    ap.add_argument("--interactive", action="store_true",
+                    help="open a live GUI window (zoom/pan/inspect) instead of only writing the PNG")
+    args = ap.parse_args(argv)
+    try:
+        T, rho, p_heos, p_svd, p_bic, Tcurve, rho_satL = _sweep(args.n)
+    except ImportError:
+        sys.stderr.write("CoolProp wrapper not importable — build from this branch first.\n")
+        return 1
+    fig, axes = plt.subplots(1, 2, figsize=(15, 6), constrained_layout=True)
+    fig.suptitle(
+        f"Water P(ρ,T) error vs HEOS near the 4 °C density anomaly, sat → melting "
+        f"(CoolProp-i7j, N={args.n})", fontsize=13)
+    _panel(axes[0], T, rho, p_heos, p_bic, Tcurve, rho_satL, "BICUBIC&HEOS")
+    _panel(axes[1], T, rho, p_heos, p_svd, Tcurve, rho_satL, "SVDSBTL&HEOS (DT-indexed)")
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(args.out, dpi=140, bbox_inches="tight")
+    print(f"Wrote {args.out}")
+    if args.interactive:
+        # Live window: matplotlib's nav toolbar gives zoom/pan/cursor
+        # readout.  Blocks until the window is closed.
+        plt.show()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
+++ b/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
@@ -288,6 +288,10 @@ class SVDSBTLBackend : public AbstractState
         std::optional<double> T;
         std::optional<double> p;
         std::optional<double> h_mass;
+        // Mass density input shortcut for DmassT / DmolarT inputs.
+        // Lets evaluate_property_ return iDmass directly without a
+        // surface eval (D is the input, not a stored property).
+        std::optional<double> rho_mass;
         double Q = -1.0;  // -1 sentinel for single-phase, [0, 1] in dome
 
         // SinglePhase / Patched routing.

--- a/include/CoolProp/region/SuperancillaryTemperatureBoundaryCurve.h
+++ b/include/CoolProp/region/SuperancillaryTemperatureBoundaryCurve.h
@@ -1,0 +1,227 @@
+#ifndef COOLPROP_REGION_SUPERANCILLARY_TEMPERATURE_BOUNDARY_CURVE_H
+#define COOLPROP_REGION_SUPERANCILLARY_TEMPERATURE_BOUNDARY_CURVE_H
+
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <set>  // transitively needed by superancillary.h
+#include <utility>
+#include <vector>
+
+#include "CoolProp/region/BoundaryCurve.h"
+#include "superancillary/superancillary.h"
+
+namespace CoolProp {
+namespace region {
+
+// 1D boundary curve b = f(T) backed by the source backend's SuperAncillary.
+// T-parameterized sibling of SuperancillaryBoundaryCurve — that one
+// composes get_T_from_p with eval_sat for p-axis presets (PH, PT); this
+// one calls eval_sat(T, prop, Q) directly because the DT-indexed preset
+// uses T as the primary axis and needs no inversion.
+//
+// SCOPE.  Sat dome curves only (Q in {0, 1}, prop_key in {'D','P','H',
+// 'S','U'}).  Same scope as the pressure-parameterized sibling.
+//
+// EVAL_DA.  Central FD on eval(T) with relative step h = max(1e-7*T, 1)
+// K — well inside the smooth interior of every property's Cheb
+// expansion.  Endpoints clamped to [T_min, T_max] so a query at the
+// build edge doesn't step out into the SA's invalid region.
+//
+// EVAL_FAST.  1024-point linear-T table (no log scaling — T span is at
+// most factor ~3 from triple to critical).  ~8 KB per curve.
+class SuperancillaryTemperatureBoundaryCurve final : public BoundaryCurve
+{
+   public:
+    using SuperAncillary_t = superancillary::SuperAncillary<std::vector<double>>;
+
+    SuperancillaryTemperatureBoundaryCurve(std::shared_ptr<SuperAncillary_t> sa, double T_min, double T_max, char prop_key, short Q,
+                                           double output_scale, double b_min, double b_max)
+      : sa_(std::move(sa)), T_min_(T_min), T_max_(T_max), prop_key_(prop_key), Q_(Q), output_scale_(output_scale), b_min_(b_min), b_max_(b_max) {
+        // Fail fast: every public eval / eval_da / eval_fast path
+        // dereferences sa_ unchecked.  Both factory build() and
+        // from_state() null-guard; the direct-construction path also
+        // needs the guard.
+        if (!sa_) {
+            throw std::invalid_argument("SuperancillaryTemperatureBoundaryCurve: null SuperAncillary handle");
+        }
+        if (!(T_min_ > 0.0) || !(T_max_ > T_min_)) {
+            throw std::invalid_argument("SuperancillaryTemperatureBoundaryCurve: need 0 < T_min < T_max");
+        }
+        // Validate the deserialization-reachable invariants here, not
+        // only in build(): from_state() constructs directly, so a bad
+        // Q / prop_key from a corrupt blob must fail fast rather than
+        // silently produce a NaN-backed curve.  Mirrors the SCOPE doc.
+        if (Q_ != 0 && Q_ != 1) {
+            throw std::invalid_argument("SuperancillaryTemperatureBoundaryCurve: Q must be 0 (liquid) or 1 (vapor)");
+        }
+        switch (prop_key_) {
+            case 'D':
+            case 'P':
+            case 'H':
+            case 'S':
+            case 'U':
+                break;
+            default:
+                throw std::invalid_argument("SuperancillaryTemperatureBoundaryCurve: unsupported prop_key (expect one of D,P,H,S,U)");
+        }
+        build_surrogate_();
+    }
+
+    // Factory: probes the SA across [T_min, T_max] to pre-compute b_min
+    // / b_max for the AABB cheap-reject.  Throws if the SuperAncillary
+    // rejects the property key or the entire requested range.
+    //
+    // SuperAncillary returns properties in MOLAR units (mol/m^3 for D,
+    // J/mol for H, J/(mol K) for S).  For mass-basis density consumers
+    // pass `output_scale = M` (kg/mol); for molar-basis pass 1.0.
+    static std::unique_ptr<SuperancillaryTemperatureBoundaryCurve> build(std::shared_ptr<SuperAncillary_t> sa, double T_min, double T_max,
+                                                                         char prop_key, short Q, double output_scale);
+
+    [[nodiscard]] double eval(double T) const noexcept override {
+        try {
+            return sa_->eval_sat(T, prop_key_, Q_) * output_scale_;
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            return std::nan("");
+        }
+    }
+
+    [[nodiscard]] double eval_da(double T) const noexcept override {
+        // Central FD on eval(T).  Relative step h = max(1e-7*T, 1 K)
+        // gives ~1e-13 relative error in the derivative — Cheb
+        // expansions are C^infinity in the interior.  Clamp the
+        // stencil to [T_min_, T_max_] so an endpoint query doesn't
+        // step into the SA's invalid range.  Asymmetric stencils
+        // still divide by the actual span, preserving slope accuracy.
+        const double h = std::max(1e-7 * std::abs(T), 1.0);
+        const double T_hi = std::min(T + h, T_max_);
+        const double T_lo = std::max(T - h, T_min_);
+        if (!(T_hi > T_lo)) {
+            return std::nan("");
+        }
+        const double y_plus = eval(T_hi);
+        const double y_minus = eval(T_lo);
+        if (!std::isfinite(y_plus) || !std::isfinite(y_minus)) {
+            return std::nan("");
+        }
+        return (y_plus - y_minus) / (T_hi - T_lo);
+    }
+
+    // Fast 1e-6-accurate surrogate via 1024-point linear-T table.  Used
+    // by Region::curve_contains for atlas dispatch.  Out-of-range clamps
+    // to the nearest endpoint.
+    [[nodiscard]] double eval_fast(double T) const noexcept override {
+        const double idx_f = (T - T_min_) * inv_T_step_;
+        if (!(idx_f > 0.0)) {
+            return surrogate_table_.front();
+        }
+        const auto last = static_cast<double>(kSurrogatePoints - 1);
+        if (idx_f >= last) {
+            return surrogate_table_.back();
+        }
+        const auto i = static_cast<std::size_t>(idx_f);
+        const double frac = idx_f - static_cast<double>(i);
+        const double y0 = surrogate_table_[i];
+        const double y1 = surrogate_table_[i + 1];
+        return y0 + frac * (y1 - y0);
+    }
+
+    [[nodiscard]] std::pair<double, double> bounds() const noexcept override {
+        return {b_min_, b_max_};
+    }
+    [[nodiscard]] std::pair<double, double> a_range() const noexcept override {
+        return {T_min_, T_max_};
+    }
+
+    // State / from_state for the serializer.  Only primitive scalars
+    // are stored; deserialization re-attaches the live SuperAncillary
+    // handle (typically the same instance the SVDSBTL backend owns).
+    struct State
+    {
+        double T_min;
+        double T_max;
+        char prop_key;
+        short Q;
+        double output_scale;
+        double b_min;
+        double b_max;
+    };
+    [[nodiscard]] State state() const {
+        return State{T_min_, T_max_, prop_key_, Q_, output_scale_, b_min_, b_max_};
+    }
+    static std::unique_ptr<SuperancillaryTemperatureBoundaryCurve> from_state(State s, std::shared_ptr<SuperAncillary_t> sa) {
+        if (!sa) {
+            throw std::invalid_argument("SuperancillaryTemperatureBoundaryCurve::from_state: null SuperAncillary handle");
+        }
+        return std::make_unique<SuperancillaryTemperatureBoundaryCurve>(std::move(sa), s.T_min, s.T_max, s.prop_key, s.Q, s.output_scale, s.b_min,
+                                                                        s.b_max);
+    }
+
+   private:
+    static constexpr std::size_t kSurrogatePoints = 1024;
+
+    // Build the 1024-point linear-T surrogate table.  NOT noexcept:
+    // surrogate_table_.resize can throw std::bad_alloc.
+    void build_surrogate_() {
+        surrogate_table_.resize(kSurrogatePoints);
+        const double T_step = (T_max_ - T_min_) / static_cast<double>(kSurrogatePoints - 1);
+        inv_T_step_ = 1.0 / T_step;
+        bool any_finite = false;
+        for (std::size_t k = 0; k < kSurrogatePoints; ++k) {
+            const double T = T_min_ + static_cast<double>(k) * T_step;
+            surrogate_table_[k] = eval(T);
+            any_finite = any_finite || std::isfinite(surrogate_table_[k]);
+        }
+        // The backfill below assumes ≥1 finite sample exists.  build()'s
+        // probe guarantees that, but from_state() can construct directly
+        // with a handle whose valid range doesn't overlap [T_min, T_max]
+        // — every sample non-finite.  Fail fast rather than returning an
+        // all-NaN table that eval_fast() would silently interpolate.
+        if (!any_finite) {
+            throw std::runtime_error("SuperancillaryTemperatureBoundaryCurve: no finite samples in surrogate build range");
+        }
+        // Backfill any non-finite samples (rare: SA can reject a probe
+        // exotically close to the critical point) from the nearest
+        // finite neighbour.  Storing a raw NaN would let eval_fast()
+        // interpolate through it and make Region::curve_contains
+        // false-miss valid points even though the exact eval() path
+        // still works.  The factory's b_min/b_max probe already
+        // guarantees ≥1 finite sample exists, so the backward+forward
+        // scan always resolves.
+        for (std::size_t k = 0; k < kSurrogatePoints; ++k) {
+            if (std::isfinite(surrogate_table_[k])) continue;
+            double fill = std::nan("");
+            for (std::size_t j = k; j-- > 0;) {
+                if (std::isfinite(surrogate_table_[j])) {
+                    fill = surrogate_table_[j];
+                    break;
+                }
+            }
+            if (!std::isfinite(fill)) {
+                for (std::size_t j = k + 1; j < kSurrogatePoints; ++j) {
+                    if (std::isfinite(surrogate_table_[j])) {
+                        fill = surrogate_table_[j];
+                        break;
+                    }
+                }
+            }
+            surrogate_table_[k] = fill;  // finite by the factory's probe guarantee
+        }
+    }
+
+    std::shared_ptr<SuperAncillary_t> sa_;
+    double T_min_;
+    double T_max_;
+    char prop_key_;
+    short Q_;
+    double output_scale_;
+    double b_min_;
+    double b_max_;
+    std::vector<double> surrogate_table_;
+    double inv_T_step_ = 0.0;
+};
+
+}  // namespace region
+}  // namespace CoolProp
+
+#endif  // COOLPROP_REGION_SUPERANCILLARY_TEMPERATURE_BOUNDARY_CURVE_H

--- a/include/CoolProp/sbtl/SVDSurfaceFactory.h
+++ b/include/CoolProp/sbtl/SVDSurfaceFactory.h
@@ -54,6 +54,29 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT = 200
 // PT_INPUTS preset.  (a, b) = (p, T).  Output properties: rho, h, s, u.
 SurfaceSpec pt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT = 200, std::size_t NR = 800, std::int32_t rank = 20);
 
+// DmassT_INPUTS preset.  (a, b) = (T, D).  Output properties: p, h, s, u.
+//
+// Primary advantage over PT/PH: (D, T) is the Helmholtz EOS's native
+// coordinate, so every output property is a direct evaluation — no
+// inversion, no critical-region stiffness, no "cells with -760 MPa"
+// failure modes like BICUBIC's invert_single_phase_y on #1301.
+//
+// Geometry mirrors ph_subcritical: LIQUID + VAPOR sub-critical (T <
+// T_critical * 0.999), SUPER super-critical (T > T_critical * 1.001).
+// Secondary axis D bounded by rho_sat,L(T) / rho_sat,V(T) and
+// per-fluid HEOS-validity D-extents on the non-dome side.
+//
+// Anomaly handling: for fluids whose ρ_sat,L(T) curve has interior
+// extrema (water at T_anom ≈ 277 K, heavy water at ≈ 284 K), the
+// LIQUID region is split into N+1 sub-regions where N is the number
+// of extrema — each sub-region's T span lies inside one monotonic
+// piece of ρ_sat,L(T).  Auto-detected via the source backend's
+// SuperAncillary `get_x_at_extrema()` on the rho_sat,L expansion;
+// gracefully falls back to a single LIQUID region when no SA is
+// available (REFPROP / IF97 sources, or fluids without a SA in
+// HEOS).
+SurfaceSpec dt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT = 200, std::size_t NR = 800, std::int32_t rank = 20);
+
 }  // namespace presets
 
 }  // namespace sbtl

--- a/include/CoolProp/sbtl/SVDSurfaceSerializer.h
+++ b/include/CoolProp/sbtl/SVDSurfaceSerializer.h
@@ -186,7 +186,7 @@ class SVDSurfaceSerializer
     //           large enough to keep the SuperAncillary sat-curve
     //           well-defined, and tightening reduces the patch-only
     //           sliver around pc.
-    static constexpr int kRevision = 14;
+    static constexpr int kRevision = 15;
 
     // Pack one surface into a zlib-compressed msgpack blob.
     static std::vector<char> save(const SVDSurface& surface);

--- a/include/CoolProp/sbtl/SatBoundaryFactory.h
+++ b/include/CoolProp/sbtl/SatBoundaryFactory.h
@@ -2,6 +2,7 @@
 #define COOLPROP_SBTL_SAT_BOUNDARY_FACTORY_H
 
 #include <memory>
+#include <vector>
 
 #include "AbstractState.h"
 #include "CoolProp/region/BoundaryCurve.h"
@@ -74,6 +75,33 @@ std::unique_ptr<region::BoundaryCurve> build_h_sat_V(::CoolProp::AbstractState& 
 std::unique_ptr<region::BoundaryCurve> build_T_sat(::CoolProp::AbstractState& heos, double p_min, double p_max,
                                                    const SatBoundaryBuildOptions& opts = {});
 
+// rho_sat,L(T) — mass density on the saturated-liquid side of the
+// dome, parameterized on temperature.  Used by the DT-indexed preset
+// where the secondary axis (D) is bounded below by rho_sat,V(T) and
+// above by rho_sat,L(T) at fixed T.
+//
+// When the source backend exposes a SuperAncillary, returns a
+// SuperancillaryTemperatureBoundaryCurve calling eval_sat('D', 0, T)
+// directly (no inversion, machine-precision residual).  Otherwise
+// falls back to a CubicSplineCurve sampled via QT_INPUTS with Q=0
+// at `n_knots` linear-uniform T values across [T_min, T_max].
+//
+// NOTE: for fluids with a density anomaly (water at T_anom ≈ 277 K,
+// heavy water at ≈ 284 K) the caller MUST split the LIQUID region so
+// each sub-region's [T_min, T_max] stays inside one monotonic piece of
+// rho_sat,L(T).  Querying piece boundaries on the SuperAncillary via
+// `get_approx1d('D', 0).get_x_at_extrema()` is the supported way.
+std::unique_ptr<region::BoundaryCurve> build_rho_sat_L(::CoolProp::AbstractState& heos, double T_min, double T_max,
+                                                       const SatBoundaryBuildOptions& opts = {});
+
+// rho_sat,V(T) — mass density on the saturated-vapor side of the
+// dome, parameterized on temperature.  Same dispatch as
+// build_rho_sat_L; QT_INPUTS with Q=1 in the spline fallback.  No
+// anomaly handling needed — rho_sat,V is monotone in T for every
+// known fluid.
+std::unique_ptr<region::BoundaryCurve> build_rho_sat_V(::CoolProp::AbstractState& heos, double T_min, double T_max,
+                                                       const SatBoundaryBuildOptions& opts = {});
+
 // Isobar h-floor: h on the cold-isotherm boundary.  For fluids with
 // steep melting curves (Methane / Propane / CO2 LIQUID at high p),
 // T_min may fall below T_melt(p) at part of the pressure range;
@@ -87,6 +115,30 @@ std::unique_ptr<region::CubicSplineCurve> build_h_isotherm_floor(::CoolProp::Abs
 // so we stay strictly inside the HEOS validity envelope).
 std::unique_ptr<region::CubicSplineCurve> build_h_isotherm_ceiling(::CoolProp::AbstractState& heos, double p_min, double p_max, double T_max,
                                                                    const SatBoundaryBuildOptions& opts = {});
+
+// Locate the interior extrema of rho_sat,L(T) inside [T_min, T_max] —
+// i.e., the T values where drho_sat,L/dT = 0.  For most fluids the
+// returned vector is empty (rho_sat,L is monotone decreasing in T from
+// triple to critical).  Water and heavy water each have one extremum
+// (the density anomaly at ~277 K and ~284 K respectively); any future
+// fluid with N extrema returns N entries.
+//
+// Used by the DT-indexed SVDSBTL preset (CoolProp-i7j) to split the
+// LIQUID region into monotonic sub-regions — required because a
+// non-monotone rho_sat,L(T) creates a non-simply-connected LIQUID
+// region in (D, T) space (cells straddling the anomaly contain a
+// discontinuity the SVD can't represent).
+//
+// Dispatch:
+//   1. Source has SuperAncillary: query
+//      `get_approx1d('D', 0).get_x_at_extrema()` — exact, zero compute.
+//   2. Else: walk QT_INPUTS on a coarse T grid (~64 points), find any
+//      sign change in dρ_sat,L/dT via central difference, bisect each
+//      bracket with TOMS748 to locate the extremum.
+//
+// Returned T values are sorted ascending and lie strictly inside
+// (T_min, T_max).
+std::vector<double> find_rho_satL_extrema_T(::CoolProp::AbstractState& heos, double T_min, double T_max);
 
 // Convenience: subcritical pressure range for `fluid`.  Returns
 // (p_min, p_max) ≈ (p_triple * 1.01, p_crit * 0.999) so PQ flashes

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -56,7 +56,7 @@ namespace {
 // The MVP set of input pairs.  Adding DU / HS / etc. in a follow-up
 // is a one-line append here plus the matching preset + load helpers
 // in `build_surface_for_pair_`.
-constexpr std::array<CoolProp::input_pairs, 2> kSupportedPairs = {CoolProp::HmassP_INPUTS, CoolProp::PT_INPUTS};
+constexpr std::array<CoolProp::input_pairs, 3> kSupportedPairs = {CoolProp::HmassP_INPUTS, CoolProp::PT_INPUTS, CoolProp::DmassT_INPUTS};
 
 // Resolved grid-shape knobs extracted from the validated options
 // document.  Used both to size the per-input-pair surfaces and to
@@ -155,6 +155,9 @@ CoolProp::sbtl::SVDSurface build_surface_for_pair_(::CoolProp::AbstractState& so
         case CoolProp::PT_INPUTS:
             spec = cp_sbtl::presets::pt_subcritical(source, g.NT, g.NR, g.rank);
             break;
+        case CoolProp::DmassT_INPUTS:
+            spec = cp_sbtl::presets::dt_subcritical(source, g.NT, g.NR, g.rank);
+            break;
         default:
             throw ValueError("SVDSBTL backend: no preset registered for the requested input pair");
     }
@@ -245,6 +248,17 @@ SVDSBTLBackend::SVDSBTLBackend(const std::string& fluid_name,      // NOLINT(mod
         throw ValueError(format("SVDSBTL&IF97 is Water-only; got fluid '%s'", fluid_name.c_str()));
     }
     for (const auto pair : kSupportedPairs) {
+        // DmassT/DmolarT share the DmassT_INPUTS surface, built lazily on
+        // the first density-input query (see update()/fast_evaluate()).
+        // Building it eagerly here would (a) make HmassP/PT-only consumers
+        // pay for the heavy dt_subcritical dense SVD, and (b) THROW for an
+        // IF97 source — dt_subcritical can't be sampled on a (D,T) grid
+        // from IF97, producing an all-NaN matrix (this broke the
+        // SVDSBTL&IF97 docs example at construction).  (CoolProp-eal will
+        // generalize lazy loading to every pair.)
+        if (pair == ::CoolProp::DmassT_INPUTS) {
+            continue;
+        }
         ensure_surface_(pair);
     }
     build_critical_patch_(options_canonical_);
@@ -408,6 +422,16 @@ void SVDSBTLBackend::build_critical_patch_(const std::string& options_canonical)
     if (std::isfinite(h_lo) && std::isfinite(h_hi) && h_lo < h_hi) {
         critical_patch_.bbox_per_pair[static_cast<int>(::CoolProp::HmassP_INPUTS)] = CriticalPatchBbox{p_lo, p_hi, h_lo, h_hi};
     }
+
+    // NOTE: DmassT / DmolarT are intentionally NOT critical-patched yet.
+    // A DT bbox would route the whole critical box to patch_source_, but
+    // the patch source isn't guaranteed to serve DmassT_INPUTS (IF97 in
+    // particular), so an unconditional DT bbox would turn atlas-servable
+    // near-critical DT cells into OOB for SVDSBTL&IF97.  Doing it safely
+    // needs a patch-source DmassT capability probe + dedicated tests —
+    // tracked as a follow-up (PR #2984 / CoolProp-i7j).  Until then DT
+    // states in the [0.999, 1.001]·Tc gap fall through to the DT-dome
+    // path or OOB, same as the no-critical-patch default.
 }
 
 std::array<double, 4> SVDSBTLBackend::auto_calibrate_critical_bbox_() {
@@ -850,6 +874,12 @@ double SVDSBTLBackend::sat_eval_(double T, char what, int side) {
 }
 
 void SVDSBTLBackend::ensure_surface_(CoolProp::input_pairs pair) {
+    // Idempotent: the lazy DmassT/DmolarT callers in update() /
+    // fast_evaluate() may invoke this on every query, so skip the
+    // load/build when the surface is already resident.
+    if (surfaces_.find(static_cast<int>(pair)) != surfaces_.end()) {
+        return;
+    }
     namespace cp_sbtl = CoolProp::sbtl;
     // Cache filename: <fluid>.<source>.<input_pair_name>.<opthash>.svd.bin.z
     //  - input_pair_name (e.g. "PT_INPUTS", "HmassP_INPUTS") instead
@@ -974,7 +1004,14 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
     }
 
     // --- Single-phase / dome routing through the surface atlas. ---
-    const auto surface_key = (input_pair == CoolProp::HmolarP_INPUTS) ? CoolProp::HmassP_INPUTS : input_pair;
+    // Molar input pairs share a surface with their mass-basis sibling;
+    // the conversion happens in the (a, b) extraction below.
+    auto surface_key = input_pair;
+    if (input_pair == CoolProp::HmolarP_INPUTS) {
+        surface_key = CoolProp::HmassP_INPUTS;
+    } else if (input_pair == CoolProp::DmolarT_INPUTS) {
+        surface_key = CoolProp::DmassT_INPUTS;
+    }
     const auto it = surfaces_.find(static_cast<int>(surface_key));
     if (it == surfaces_.end() || !it->second) {
         throw ValueError(std::string("SVDSBTL backend: no surface registered for this input pair (") + CoolProp::get_input_pair_short_desc(input_pair)
@@ -1005,6 +1042,22 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
             pt.p = value1;
             pt.T = value2;
             b = value2;
+            break;
+        case CoolProp::DmassT_INPUTS:
+            // DmassT_INPUTS: value1 = D (kg/m^3), value2 = T (K).
+            // DT preset uses T as primary, D as secondary.
+            a = value2;
+            pt.T = value2;
+            pt.rho_mass = value1;
+            b = value1;
+            break;
+        case CoolProp::DmolarT_INPUTS:
+            // DmolarT_INPUTS: value1 = D_molar (mol/m^3), value2 = T.
+            // Convert D_molar -> D_mass via M for surface lookup.
+            a = value2;
+            pt.T = value2;
+            pt.rho_mass = value1 * calc_molar_mass();
+            b = *pt.rho_mass;
             break;
         default:
             throw ValueError(std::string("SVDSBTL backend update: unsupported input pair (") + CoolProp::get_input_pair_short_desc(input_pair) + ")");
@@ -1180,6 +1233,82 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
             // No sat probe available — fall through to OOB.
         }
     }
+
+    // --- DT dome routing.  For DmassT / DmolarT an atlas miss inside
+    // the subcritical envelope means the (D, T) point landed in the
+    // two-phase dome (rho_sat,V(T) < D < rho_sat,L(T)).  The LIQUID /
+    // VAPOR sub-regions stop at the dome boundary by construction, so
+    // any miss with T < T_critical and D between the sat densities is
+    // two-phase.  P is well-defined (= P_sat(T)); Q comes from the
+    // lever rule on specific volume (NOT density — v is the additive
+    // quantity).  Routes through the same DomeBlend machinery the
+    // HmassP path uses; evaluate_property_ reads p / Q / blended
+    // caloric props off the endpoints. ---
+    if (input_pair == CoolProp::DmassT_INPUTS || input_pair == CoolProp::DmolarT_INPUTS) {
+        const double T_query = *pt.T;
+        const double M = calc_molar_mass();
+        const double rho_mol_query = *pt.rho_mass / M;
+        try {
+            auto src = source_reference_();
+            if (T_query < src->T_critical()) {
+                // rho_sat endpoints at T.  sat_eval_('D', ...) returns
+                // MOLAR density (mol/m^3) — same basis as the HmassP
+                // dome path's rhoL_mol / rhoV_mol.  Mirror that path's
+                // source-QT fallback: when the SA/surrogate sat provider
+                // can't supply an endpoint, take it from the source QT
+                // flash so DT two-phase queries still resolve on sources
+                // without a usable saturation provider.
+                double rhoL_mol = sat_eval_(T_query, 'D', 0);
+                double rhoV_mol = sat_eval_(T_query, 'D', 1);
+                if (!std::isfinite(rhoL_mol) || !std::isfinite(rhoV_mol)) {
+                    src->update(CoolProp::QT_INPUTS, 0.0, T_query);
+                    rhoL_mol = src->rhomolar();
+                    src->update(CoolProp::QT_INPUTS, 1.0, T_query);
+                    rhoV_mol = src->rhomolar();
+                }
+                if (std::isfinite(rhoL_mol) && std::isfinite(rhoV_mol) && rhoV_mol < rho_mol_query && rho_mol_query < rhoL_mol) {
+                    // Two-phase.  P_sat(T) from the source QT flash.
+                    src->update(CoolProp::QT_INPUTS, 0.0, T_query);
+                    const double p_sat = src->p();
+                    pt.kind = PointEvaluation::Kind::DomeBlend;
+                    pt.status = CoolProp::fast_evaluate_ok;
+                    pt.p = p_sat;
+                    pt.T = T_query;
+                    pt.T_sat = T_query;
+                    // Lever rule on specific volume (the additive
+                    // quantity): v = (1-Q)*vL + Q*vV.  Q is basis-
+                    // independent, so molar volumes give the same Q.
+                    const double v = 1.0 / rho_mol_query;
+                    const double vL = 1.0 / rhoL_mol;
+                    const double vV = 1.0 / rhoV_mol;
+                    pt.Q = (v - vL) / (vV - vL);
+                    // sat_eval_('H', ...) is already molar — don't scale.
+                    // Same source-QT fallback as the rho endpoints above.
+                    double hL_mol = sat_eval_(T_query, 'H', 0);
+                    double hV_mol = sat_eval_(T_query, 'H', 1);
+                    if (!std::isfinite(hL_mol) || !std::isfinite(hV_mol)) {
+                        src->update(CoolProp::QT_INPUTS, 0.0, T_query);
+                        hL_mol = src->hmolar();
+                        src->update(CoolProp::QT_INPUTS, 1.0, T_query);
+                        hV_mol = src->hmolar();
+                    }
+                    pt.hL_mol = hL_mol;
+                    pt.hV_mol = hV_mol;
+                    pt.rhoL_mol = rhoL_mol;
+                    pt.rhoV_mol = rhoV_mol;
+                    // Fill h_mass from the lever rule so iHmass/iHmolar
+                    // resolve via the top-level short-circuit (the
+                    // DomeBlend switch has no enthalpy arm — it
+                    // delegates to pt.h_mass, which the HmassP dome
+                    // path sets at resolve time and we must mirror).
+                    pt.h_mass = ((1.0 - pt.Q) * *pt.hL_mol + pt.Q * *pt.hV_mol) / M;
+                    return pt;
+                }
+            }
+        } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
+            // Sat endpoints / source unavailable — fall through to OOB.
+        }
+    }
     pt.kind = PointEvaluation::Kind::OutOfRange;
     pt.status = CoolProp::fast_evaluate_out_of_range;
     return pt;
@@ -1254,6 +1383,15 @@ double SVDSBTLBackend::evaluate_property_(PointEvaluation& pt, CoolProp::paramet
         // in-dome both populate it from the lever rule at resolve
         // time, so this also handles the DomeBlend case correctly.
         return *pt.h_mass * M;
+    }
+    // DmassT / DmolarT input shortcut — density is the input, not a
+    // surface-tabulated property, so return it directly.  Same
+    // single-source-of-truth pattern as h_mass above.
+    if (prop == CoolProp::iDmass && pt.rho_mass) {
+        return *pt.rho_mass;
+    }
+    if (prop == CoolProp::iDmolar && pt.rho_mass) {
+        return *pt.rho_mass / M;
     }
 
     switch (pt.kind) {
@@ -1357,6 +1495,12 @@ double SVDSBTLBackend::evaluate_property_(PointEvaluation& pt, CoolProp::paramet
 }
 
 void SVDSBTLBackend::update(CoolProp::input_pairs input_pair, double value1, double value2) {
+    // Lazily build the DmassT surface on first density-input query (it is
+    // deliberately kept out of the constructor's eager loop — see there).
+    // ensure_surface_ is idempotent, so this is a cheap no-op afterwards.
+    if (input_pair == CoolProp::DmassT_INPUTS || input_pair == CoolProp::DmolarT_INPUTS) {
+        ensure_surface_(CoolProp::DmassT_INPUTS);
+    }
     clear();
     _phase = iphase_not_imposed;
     active_eval_ = resolve_point_(input_pair, value1, value2);
@@ -1366,6 +1510,24 @@ void SVDSBTLBackend::update(CoolProp::input_pairs input_pair, double value1, dou
     // class still see consistent values.
     if (active_eval_.T) _T = *active_eval_.T;
     if (active_eval_.p) _p = *active_eval_.p;
+    // AbstractState::p() returns the cached _p directly (skipping
+    // calc_pressure / calc_p), so for input pairs where p is computed
+    // by the surface rather than supplied as input (currently:
+    // DmassT / DmolarT), we must populate _p here.  Single-phase
+    // only — Dome / Patched / OOB paths intentionally leave _p alone
+    // since they have their own ->p() routing.
+    if (!active_eval_.p && active_eval_.kind == PointEvaluation::Kind::SinglePhase
+        && (input_pair == CoolProp::DmassT_INPUTS || input_pair == CoolProp::DmolarT_INPUTS)) {
+        try {
+            const double p_surface = evaluate_property_(active_eval_, CoolProp::iP);
+            if (std::isfinite(p_surface) && p_surface > 0.0) {
+                _p = p_surface;
+                active_eval_.p = p_surface;  // also cache on the eval for AbstractState::T() and friends
+            }
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            // Surface eval failed; leave _p at its default (caller will see NaN/-inf which signals an OOB cell).
+        }
+    }
     // _Q is populated for every kind that has a well-defined Q so
     // legacy callers reading state->Q() see a value consistent with
     // what fast_evaluate(iQ) would return.  SinglePhase gets the -1
@@ -1540,19 +1702,33 @@ void SVDSBTLBackend::fast_evaluate(CoolProp::input_pairs input_pair, const doubl
     if (val1 == nullptr || val2 == nullptr || outputs == nullptr || out_buffer == nullptr || status_flags == nullptr) {
         throw ValueError("fast_evaluate: null pointer argument");
     }
+    // Lazily build the DmassT surface (kept out of the constructor's eager
+    // loop — see there).  fast_evaluate is an independent entry point, so it
+    // needs the same lazy ensure as update().  Idempotent.
+    if (input_pair == CoolProp::DmassT_INPUTS || input_pair == CoolProp::DmolarT_INPUTS) {
+        ensure_surface_(CoolProp::DmassT_INPUTS);
+    }
     if (N_outputs == 0) {
         for (std::size_t k = 0; k < N_inputs; ++k)
             status_flags[k] = CoolProp::fast_evaluate_ok;
         return;
     }
-    if (input_pair != CoolProp::HmassP_INPUTS && input_pair != CoolProp::HmolarP_INPUTS && input_pair != CoolProp::PT_INPUTS) {
-        throw ValueError(format("fast_evaluate (SVDSBTL): input_pair %s not supported (use HmassP_INPUTS, HmolarP_INPUTS, or PT_INPUTS)",
+    if (input_pair != CoolProp::HmassP_INPUTS && input_pair != CoolProp::HmolarP_INPUTS && input_pair != CoolProp::PT_INPUTS
+        && input_pair != CoolProp::DmassT_INPUTS && input_pair != CoolProp::DmolarT_INPUTS) {
+        throw ValueError(format("fast_evaluate (SVDSBTL): input_pair %s not supported "
+                                "(use HmassP_INPUTS, HmolarP_INPUTS, PT_INPUTS, DmassT_INPUTS, or DmolarT_INPUTS)",
                                 get_input_pair_short_desc(input_pair).c_str()));
     }
     // Validate the surface exists for this input pair before the per-
     // point loop so a malformed request fails fast (resolve_point_
-    // would otherwise throw on the first call).
-    const auto surface_key = (input_pair == CoolProp::HmolarP_INPUTS) ? CoolProp::HmassP_INPUTS : input_pair;
+    // would otherwise throw on the first call).  Molar input pairs
+    // share a surface with their mass-basis sibling.
+    auto surface_key = input_pair;
+    if (input_pair == CoolProp::HmolarP_INPUTS) {
+        surface_key = CoolProp::HmassP_INPUTS;
+    } else if (input_pair == CoolProp::DmolarT_INPUTS) {
+        surface_key = CoolProp::DmassT_INPUTS;
+    }
     const auto sit = surfaces_.find(static_cast<int>(surface_key));
     if (sit == surfaces_.end() || !sit->second) {
         throw ValueError(std::string("fast_evaluate (SVDSBTL): no surface registered for ") + CoolProp::get_input_pair_short_desc(input_pair));
@@ -1590,6 +1766,7 @@ void SVDSBTLBackend::fast_evaluate(CoolProp::input_pairs input_pair, const doubl
     // by the input pair.
     const bool input_is_PT = (input_pair == CoolProp::PT_INPUTS);
     const bool input_has_h = (input_pair == CoolProp::HmassP_INPUTS || input_pair == CoolProp::HmolarP_INPUTS);
+    const bool input_has_D = (input_pair == CoolProp::DmassT_INPUTS || input_pair == CoolProp::DmolarT_INPUTS);
 
     // N_outputs is bounded by the caller's output schema (typically <
     // 10 for thermo-property batches), so a single heap allocation
@@ -1607,17 +1784,31 @@ void SVDSBTLBackend::fast_evaluate(CoolProp::input_pairs input_pair, const doubl
         switch (outputs[o]) {
             case CoolProp::iP:
             case CoolProp::iQ:
-                // Always-available shortcuts: iP comes off the input
-                // pair; iQ resolves trivially (-1 for SinglePhase, Q
-                // for DomeBlend) inside evaluate_property_.
+                // Resolved inside evaluate_property_, not via the
+                // batched surface multi-eval: iP is the input for
+                // PT/HmassP (and a per-point surface eval for DmassT,
+                // handled there); iQ resolves trivially (-1 for
+                // SinglePhase, Q for DomeBlend).  Either way these
+                // don't join the surface_props batch.
                 output_is_surface[o] = 0;
                 continue;
             case CoolProp::iT:
-                if (input_is_PT) {
+                if (input_is_PT || input_has_D) {
+                    // T is supplied directly by PT and DmassT/DmolarT.
                     output_is_surface[o] = 0;
                     continue;
                 }
                 // Falls through to surface eval (mass_prop = iT, scale = 1).
+                break;
+            case CoolProp::iDmass:
+                if (input_has_D) {
+                    // Density is the input, not a tabulated property —
+                    // evaluate_property_'s pt.rho_mass short-circuit
+                    // returns it.  (For non-D inputs, falls through to
+                    // surface eval via default below.)
+                    output_is_surface[o] = 0;
+                    continue;
+                }
                 break;
             case CoolProp::iHmass:
                 if (input_has_h) {
@@ -1638,6 +1829,11 @@ void SVDSBTLBackend::fast_evaluate(CoolProp::input_pairs input_pair, const doubl
                 scale = M;
                 break;
             case CoolProp::iDmolar:
+                if (input_has_D) {
+                    // evaluate_property_ shortcut: *pt.rho_mass / M.
+                    output_is_surface[o] = 0;
+                    continue;
+                }
                 mass_prop = CoolProp::iDmass;
                 scale = 1.0 / M;
                 break;

--- a/src/Region/SuperancillaryTemperatureBoundaryCurve.cpp
+++ b/src/Region/SuperancillaryTemperatureBoundaryCurve.cpp
@@ -1,0 +1,60 @@
+#include "CoolProp/region/SuperancillaryTemperatureBoundaryCurve.h"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+namespace CoolProp {
+namespace region {
+
+std::unique_ptr<SuperancillaryTemperatureBoundaryCurve> SuperancillaryTemperatureBoundaryCurve::build(std::shared_ptr<SuperAncillary_t> sa,
+                                                                                                      double T_min, double T_max, char prop_key,
+                                                                                                      short Q, double output_scale) {
+    if (!sa) {
+        throw std::invalid_argument("SuperancillaryTemperatureBoundaryCurve::build: null SuperAncillary handle");
+    }
+    if (!(T_min > 0.0) || !(T_max > T_min)) {
+        throw std::invalid_argument("SuperancillaryTemperatureBoundaryCurve::build: need 0 < T_min < T_max");
+    }
+    if (Q != 0 && Q != 1) {
+        throw std::invalid_argument("SuperancillaryTemperatureBoundaryCurve::build: Q must be 0 (liquid) or 1 (vapor)");
+    }
+
+    // Probe the curve at linear-T sample points to pre-compute the
+    // (b_min, b_max) AABB.  32 probes give a tight bound for smooth
+    // boundary curves.  T span is at most factor ~3, so log spacing
+    // wouldn't help — linear is the right default.
+    constexpr std::size_t kProbes = 32;
+    double b_min = std::numeric_limits<double>::infinity();
+    double b_max = -std::numeric_limits<double>::infinity();
+    std::size_t finite_probe_count = 0;
+    for (std::size_t k = 0; k < kProbes; ++k) {
+        const double f = static_cast<double>(k) / static_cast<double>(kProbes - 1);
+        const double T = T_min + f * (T_max - T_min);
+        try {
+            const double y = sa->eval_sat(T, prop_key, Q) * output_scale;
+            if (std::isfinite(y)) {
+                ++finite_probe_count;
+                b_min = std::min(b_min, y);
+                b_max = std::max(b_max, y);
+            }
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            // SA may reject queries exotically close to the critical
+            // point.  Skip and keep surrounding probes.
+        }
+    }
+    if (finite_probe_count == 0) {
+        throw std::runtime_error("SuperancillaryTemperatureBoundaryCurve::build: SuperAncillary rejected all probes in the requested T range");
+    }
+    if (!(b_max > b_min)) {  // CodeQL-safe form of b_min == b_max (b_min <= b_max always holds here)
+        // Degenerate near-flat curve; inflate by 1 ULP per side so the
+        // AABB has non-zero b-extent and Region machinery doesn't trip.
+        const double eps = std::max(std::abs(b_min) * std::numeric_limits<double>::epsilon(), std::numeric_limits<double>::min());
+        b_min -= eps;
+        b_max += eps;
+    }
+    return std::make_unique<SuperancillaryTemperatureBoundaryCurve>(std::move(sa), T_min, T_max, prop_key, Q, output_scale, b_min, b_max);
+}
+
+}  // namespace region
+}  // namespace CoolProp

--- a/src/SBTL/SVDSurfaceSerializer.cpp
+++ b/src/SBTL/SVDSurfaceSerializer.cpp
@@ -22,6 +22,7 @@
 #include "CoolProp/region/PiecewiseChebyshevCurve.h"
 #include "CoolProp/region/Region.h"
 #include "CoolProp/region/SuperancillaryBoundaryCurve.h"
+#include "CoolProp/region/SuperancillaryTemperatureBoundaryCurve.h"
 #include "CoolProp/svd/SVDDecomposition.h"
 #include "miniz.h"
 
@@ -42,6 +43,12 @@ enum class CurveKind : std::uint8_t
     // (no piecewise tables); the SuperAncillary handle itself is
     // re-acquired at load time from the source HEOS for the fluid.
     SUPERANCILLARY = 3,
+    // SuperancillaryTemperatureBoundaryCurve — T-parameterized sibling
+    // of SUPERANCILLARY used by the DT-indexed preset for its
+    // rho_sat,L / rho_sat,V dome boundaries.  Same POD-only scheme
+    // (T_min/T_max in place of p_min/p_max); SA handle re-acquired at
+    // load time.
+    SUPERANCILLARY_T = 4,
 };
 
 // ---------- packing helpers -------------------------------------------
@@ -101,6 +108,22 @@ void pack_curve(Packer& pk, const region::BoundaryCurve& curve) {
         pk.pack(static_cast<std::uint8_t>(CurveKind::SUPERANCILLARY));
         pk.pack(s.p_min);
         pk.pack(s.p_max);
+        pk.pack(static_cast<std::int8_t>(s.prop_key));
+        pk.pack(static_cast<std::int16_t>(s.Q));
+        pk.pack(s.output_scale);
+        pk.pack(s.b_min);
+        pk.pack(s.b_max);
+        return;
+    }
+    if (const auto* c = dynamic_cast<const region::SuperancillaryTemperatureBoundaryCurve*>(&curve)) {
+        const auto s = c->state();
+        // T-parameterized sibling of SUPERANCILLARY (DT-preset dome
+        // boundaries).  Same POD-only scheme; the SuperAncillary handle
+        // is re-acquired from the fluid HEOS at load time.
+        pk.pack_array(8);
+        pk.pack(static_cast<std::uint8_t>(CurveKind::SUPERANCILLARY_T));
+        pk.pack(s.T_min);
+        pk.pack(s.T_max);
         pk.pack(static_cast<std::int8_t>(s.prop_key));
         pk.pack(static_cast<std::int16_t>(s.Q));
         pk.pack(s.output_scale);
@@ -256,7 +279,7 @@ std::unique_ptr<region::BoundaryCurve> unpack_curve(const msgpack::object& o,
                 throw std::runtime_error("SVDSurfaceSerializer: stream contains a SuperAncillary-backed curve but no SuperAncillary handle is "
                                          "available for the fluid (source backend must be HEOS for re-hydration)");
             }
-            region::SuperancillaryBoundaryCurve::State s;
+            region::SuperancillaryBoundaryCurve::State s{};
             s.p_min = as<double>(o.via.array.ptr[1]);
             s.p_max = as<double>(o.via.array.ptr[2]);
             s.prop_key = static_cast<char>(as<std::int8_t>(o.via.array.ptr[3]));
@@ -264,7 +287,23 @@ std::unique_ptr<region::BoundaryCurve> unpack_curve(const msgpack::object& o,
             s.output_scale = as<double>(o.via.array.ptr[5]);
             s.b_min = as<double>(o.via.array.ptr[6]);
             s.b_max = as<double>(o.via.array.ptr[7]);
-            return region::SuperancillaryBoundaryCurve::from_state(std::move(s), sa);
+            return region::SuperancillaryBoundaryCurve::from_state(s, sa);
+        }
+        case CurveKind::SUPERANCILLARY_T: {
+            check_array(o, 8, "superancillary-T curve");
+            if (!sa) {
+                throw std::runtime_error("SVDSurfaceSerializer: stream contains a SuperAncillary-backed curve but no SuperAncillary handle is "
+                                         "available for the fluid (source backend must be HEOS for re-hydration)");
+            }
+            region::SuperancillaryTemperatureBoundaryCurve::State s{};
+            s.T_min = as<double>(o.via.array.ptr[1]);
+            s.T_max = as<double>(o.via.array.ptr[2]);
+            s.prop_key = static_cast<char>(as<std::int8_t>(o.via.array.ptr[3]));
+            s.Q = static_cast<short>(as<std::int16_t>(o.via.array.ptr[4]));
+            s.output_scale = as<double>(o.via.array.ptr[5]);
+            s.b_min = as<double>(o.via.array.ptr[6]);
+            s.b_max = as<double>(o.via.array.ptr[7]);
+            return region::SuperancillaryTemperatureBoundaryCurve::from_state(s, sa);
         }
     }
     throw std::runtime_error("SVDSurfaceSerializer: unknown curve kind");
@@ -380,7 +419,10 @@ std::vector<char> zlib_compress(const msgpack::sbuffer& sbuf) {
     // Z_OK when it fits.
     std::vector<char> out(sbuf.size() + (sbuf.size() / 1000) + 128);
     auto out_size = static_cast<mz_ulong>(out.size());
-    const int code = compress((unsigned char*)out.data(), &out_size, (const unsigned char*)sbuf.data(), static_cast<mz_ulong>(sbuf.size()));
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast) — zlib's C API takes unsigned char*; our buffers are char (pre-existing glue).
+    const int code = compress(reinterpret_cast<unsigned char*>(out.data()), &out_size, reinterpret_cast<const unsigned char*>(sbuf.data()),
+                              static_cast<mz_ulong>(sbuf.size()));
+    // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
     if (code != Z_OK) {
         throw std::runtime_error(std::string("SVDSurfaceSerializer: zlib compress failed (code ") + std::to_string(code) + ")");
     }
@@ -397,7 +439,10 @@ std::vector<char> zlib_uncompress(const std::vector<char>& compressed) {
     int code = 0;
     int retries = 0;
     do {
-        code = uncompress((unsigned char*)out.data(), &out_size, (const unsigned char*)compressed.data(), in_size);
+        // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast) — zlib C API takes unsigned char* (pre-existing glue).
+        code =
+          uncompress(reinterpret_cast<unsigned char*>(out.data()), &out_size, reinterpret_cast<const unsigned char*>(compressed.data()), in_size);
+        // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
         if (code == Z_BUF_ERROR) {
             if (++retries > 8) {
                 throw std::runtime_error("SVDSurfaceSerializer: zlib uncompress would not fit after 8 retries");
@@ -498,6 +543,7 @@ std::string SVDSurfaceSerializer::default_cache_dir() {
         // Surface the error to stderr so a user with an unwritable
         // home dir (CI sandboxes, read-only mounts) sees *why* every
         // SVDSBTL session pays the full build cost.
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,cert-err33-c) — deliberate diagnostic-only stderr write (pre-existing)
         std::fprintf(stderr, "SVDSurfaceSerializer: could not create cache dir %s: %s\n", dir.c_str(), ec.message().c_str());
     }
     // Normalize: callers naively concatenate dir + filename, so the

--- a/src/SBTL/SatBoundaryFactory.cpp
+++ b/src/SBTL/SatBoundaryFactory.cpp
@@ -1,12 +1,16 @@
 #include "CoolProp/sbtl/SatBoundaryFactory.h"
 
+#include <algorithm>  // std::sort / std::min / std::max in find_rho_satL_extrema_T
 #include <cmath>
 #include <functional>
 #include <stdexcept>
 #include <vector>
 
+#include "boost/math/tools/toms748_solve.hpp"
+
 #include "Backends/Helmholtz/HelmholtzEOSMixtureBackend.h"
 #include "CoolProp/region/SuperancillaryBoundaryCurve.h"
+#include "CoolProp/region/SuperancillaryTemperatureBoundaryCurve.h"
 #include "DataStructures.h"
 
 namespace CoolProp {
@@ -103,6 +107,60 @@ std::unique_ptr<region::BoundaryCurve> build_h_sat_V(::CoolProp::AbstractState& 
     });
 }
 
+namespace {
+// T-parameterized cubic-spline sampler.  Mirror of
+// spline_through_log_p_samples, but linear-T spacing since the T span
+// over a dome arc is at most factor ~3 and log spacing would over-
+// concentrate knots at low T where rho_sat curves are nearly linear.
+std::unique_ptr<region::CubicSplineCurve> spline_through_linear_T_samples(double T_min, double T_max, std::size_t n_knots,
+                                                                          const std::function<double(double)>& f) {
+    if (!(T_min > 0.0) || !(T_max > T_min) || n_knots < 2) {
+        throw std::invalid_argument("SatBoundaryFactory: invalid T range or n_knots (need 0 < T_min < T_max and n_knots >= 2)");
+    }
+    std::vector<double> T_knots(n_knots);
+    std::vector<double> y(n_knots);
+    const double dT = (T_max - T_min) / static_cast<double>(n_knots - 1);
+    for (std::size_t k = 0; k < n_knots; ++k) {
+        T_knots[k] = T_min + static_cast<double>(k) * dT;
+        y[k] = f(T_knots[k]);
+    }
+    return region::CubicSplineCurve::build(std::move(T_knots), std::move(y));
+}
+}  // namespace
+
+std::unique_ptr<region::BoundaryCurve> build_rho_sat_L(::CoolProp::AbstractState& heos, double T_min, double T_max,
+                                                       const SatBoundaryBuildOptions& opts) {
+    if (auto sa = try_get_superanc(heos, /*need_caloric=*/false)) {
+        try {
+            // SuperAncillary returns molar density (mol/m^3); SBTL
+            // stores mass-basis (kg/m^3).  rho_mass = rho_mol * M.
+            const double M = heos.molar_mass();
+            return region::SuperancillaryTemperatureBoundaryCurve::build(sa, T_min, T_max, 'D', 0, M);
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            // Fall through to the spline path on SA range mismatch.
+        }
+    }
+    return spline_through_linear_T_samples(T_min, T_max, opts.n_knots, [&](double T) {
+        heos.update(::CoolProp::QT_INPUTS, 0.0, T);
+        return heos.rhomass();
+    });
+}
+
+std::unique_ptr<region::BoundaryCurve> build_rho_sat_V(::CoolProp::AbstractState& heos, double T_min, double T_max,
+                                                       const SatBoundaryBuildOptions& opts) {
+    if (auto sa = try_get_superanc(heos, /*need_caloric=*/false)) {
+        try {
+            const double M = heos.molar_mass();
+            return region::SuperancillaryTemperatureBoundaryCurve::build(sa, T_min, T_max, 'D', 1, M);
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+        }
+    }
+    return spline_through_linear_T_samples(T_min, T_max, opts.n_knots, [&](double T) {
+        heos.update(::CoolProp::QT_INPUTS, 1.0, T);
+        return heos.rhomass();
+    });
+}
+
 std::unique_ptr<region::BoundaryCurve> build_T_sat(::CoolProp::AbstractState& heos, double p_min, double p_max, const SatBoundaryBuildOptions& opts) {
     // No prop_key in the SuperAncillary for T directly — it's the
     // *result* of get_T_from_p, not a tabulated property.  Build a
@@ -156,6 +214,97 @@ std::pair<double, double> supercritical_pressure_range(::CoolProp::AbstractState
     const double p_crit = heos.p_critical();
     const double p_max_eos = heos.pmax();
     return {1.001 * p_crit, 0.99 * p_max_eos};
+}
+
+std::vector<double> find_rho_satL_extrema_T(::CoolProp::AbstractState& heos, double T_min, double T_max) {
+    if (!(T_max > T_min)) {
+        return {};
+    }
+    // SuperAncillary path — pieces are constructed to be monotonic in
+    // the dependent variable, so get_x_at_extrema() returns precisely
+    // the T values where drho_sat,L/dT = 0.
+    if (auto sa = try_get_superanc(heos, /*need_caloric=*/false)) {
+        try {
+            const auto& approx = sa->get_approx1d('D', /*Q=*/0);
+            std::vector<double> hits;
+            for (double T : approx.get_x_at_extrema()) {
+                if (T > T_min && T < T_max) {
+                    hits.push_back(T);
+                }
+            }
+            std::sort(hits.begin(), hits.end());
+            return hits;
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            // SA may reject the property key (no rhoL expansion).
+            // Fall through to the QT_INPUTS walk.
+        }
+    }
+    // Fallback: walk QT_INPUTS at 64 T-knots, finite-difference
+    // drho_sat,L/dT, bisect each sign change.  Cheap (one-shot at
+    // preset construction).
+    constexpr std::size_t kProbes = 64;
+    std::vector<double> T_grid(kProbes);
+    std::vector<double> rhoL(kProbes);
+    const double dT_grid = (T_max - T_min) / static_cast<double>(kProbes - 1);
+    for (std::size_t k = 0; k < kProbes; ++k) {
+        T_grid[k] = T_min + static_cast<double>(k) * dT_grid;
+        try {
+            heos.update(::CoolProp::QT_INPUTS, 0.0, T_grid[k]);
+            rhoL[k] = heos.rhomass();
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            rhoL[k] = std::nan("");
+        }
+    }
+    // Slope sign at each interior knot (central FD).  Skip non-finite
+    // entries (rare — only at very-near-critical T) by treating them
+    // as "no information".
+    auto slope_sign = [&](std::size_t i) -> int {
+        if (i == 0 || i + 1 >= kProbes) return 0;
+        const double rl = rhoL[i - 1];
+        const double rr = rhoL[i + 1];
+        if (!std::isfinite(rl) || !std::isfinite(rr)) return 0;
+        const double dr = rr - rl;
+        return (dr > 0.0) ? 1 : (dr < 0.0 ? -1 : 0);
+    };
+    std::vector<double> hits;
+    for (std::size_t i = 1; i + 1 < kProbes; ++i) {
+        const int s_lo = slope_sign(i);
+        const int s_hi = slope_sign(i + 1);
+        if (s_lo == 0 || s_hi == 0 || s_lo == s_hi) continue;
+        // Sign change between knot i and i+1; bisect on the slope sign.
+        try {
+            auto residual = [&](double T) -> double {
+                // Central FD of rho_sat,L(T) at T; reuse the kProbes
+                // grid spacing as the step (well above the noise floor
+                // of QT_INPUTS).
+                const double h = 0.5 * dT_grid;
+                heos.update(::CoolProp::QT_INPUTS, 0.0, T - h);
+                const double rl = heos.rhomass();
+                heos.update(::CoolProp::QT_INPUTS, 0.0, T + h);
+                const double rr = heos.rhomass();
+                return rr - rl;
+            };
+            boost::math::tools::eps_tolerance<double> tol(48);
+            std::uintmax_t max_iter = 64;
+            auto root = boost::math::tools::toms748_solve(residual, T_grid[i], T_grid[i + 1], tol, max_iter);
+            hits.push_back(0.5 * (root.first + root.second));
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            // Bisection failed (rare; could indicate the bracketed
+            // sign change is numerical noise rather than a real
+            // extremum).  Skip.
+        }
+    }
+    std::sort(hits.begin(), hits.end());
+    // Fallback bracketing can return near-duplicate roots under FD
+    // noise; collapse them so downstream LIQUID splitting never gets a
+    // zero-width sub-region.
+    hits.erase(std::unique(hits.begin(), hits.end(),
+                           [](double x, double y) {
+                               const double tol = 1e-8 * std::max({1.0, std::abs(x), std::abs(y)});
+                               return std::abs(x - y) <= tol;
+                           }),
+               hits.end());
+    return hits;
 }
 
 }  // namespace sbtl

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -817,6 +817,312 @@ SurfaceSpec pt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
     return spec;
 }
 
+namespace {
+// Shared property list for DmassT_INPUTS: (D, T) inputs, so outputs
+// are p, h, s, u, w (speed of sound).  Pressure rides EXP since it
+// can span ~10 orders of magnitude across the (D, T) envelope (from
+// rarified vapor at low T to compressed liquid at high p_max_eos).
+std::vector<PropertySpec> dt_properties(::CoolProp::AbstractState& src) {
+    std::vector<PropertySpec> ps = {
+      {::CoolProp::iP, svd::OutputTransform::EXP},
+      {::CoolProp::iHmass, svd::OutputTransform::IDENTITY},
+      {::CoolProp::iSmass, svd::OutputTransform::IDENTITY},
+      {::CoolProp::iUmass, svd::OutputTransform::IDENTITY},
+      {::CoolProp::ispeed_sound, svd::OutputTransform::IDENTITY},
+    };
+    if (source_supports_transport_(src, ::CoolProp::iviscosity)) {
+        ps.push_back({::CoolProp::iviscosity, svd::OutputTransform::EXP});
+    }
+    if (source_supports_transport_(src, ::CoolProp::iconductivity)) {
+        ps.push_back({::CoolProp::iconductivity, svd::OutputTransform::EXP});
+    }
+    return ps;
+}
+
+// Per-knot D upper-bound: at each T knot, find the max pressure ≤
+// p_target that HEOS accepts (binary-search down if p_target itself
+// is rejected by the melting line at this T) and return D at that
+// (T, p).  Result is a CubicSplineCurve representing the "compressed-
+// liquid / supercritical-dense ceiling".
+//
+// Why per-knot rather than fixed isobar: the melting curve cuts into
+// the high-p part of the (T, p) envelope for steep-melting fluids
+// (CO2 T_melt(0.8 GPa) ≈ 327 K > Tc = 304 K), so a single
+// p_max_eos isobar isn't defined at the cold end of LIQUID or SUPER.
+// Per-knot walk-down gives the actual reachable D extent — narrower
+// at cold T (where melting limits p), wider at hot T.  The resulting
+// curve is monotonically non-decreasing in T-region-of-interest and
+// always above ρ_sat,L (since p_target > p_sat for liquid-side
+// queries).
+//
+// p_target is the EOS-validity ceiling (≤ 0.99 * pmax); p_floor is
+// the minimum acceptable pressure (typically ≥ pc / 2 or sat pressure
+// at T to ensure the curve stays above the dome).
+// Per-knot floor source: 'sat_L' anchors the walk-down at saturation
+// pressure (Q=0 PQ flash), used for LIQUID-side envelopes that must
+// stay above the sat dome.  'critical' uses p_critical, used for
+// SUPER-side envelopes that should stay supercritical.
+enum class WalkFloor : std::uint8_t
+{
+    SAT_L,
+    CRITICAL,
+};
+
+std::unique_ptr<region::CubicSplineCurve> build_rho_max_envelope(::CoolProp::AbstractState& heos, double T_min, double T_max, double p_target,
+                                                                 WalkFloor floor_source, std::size_t n_knots = 64) {
+    if (!(T_min > 0.0) || !(T_max > T_min) || n_knots < 2) {
+        throw std::invalid_argument("build_rho_max_envelope: invalid T range or n_knots");
+    }
+    std::vector<double> T_knots(n_knots);
+    std::vector<double> y(n_knots);
+    const double dT = (T_max - T_min) / static_cast<double>(n_knots - 1);
+    const double p_crit = heos.p_critical();
+    constexpr int kMaxHalvings = 50;
+    for (std::size_t k = 0; k < n_knots; ++k) {
+        T_knots[k] = T_min + static_cast<double>(k) * dT;
+        // Per-knot floor: just above sat pressure for LIQUID-side
+        // (don't cross the dome into vapor) or just above pc for
+        // SUPER-side (stay supercritical).
+        double p_floor = 0.0;
+        if (floor_source == WalkFloor::SAT_L) {
+            try {
+                heos.update(::CoolProp::QT_INPUTS, 0.0, T_knots[k]);
+                p_floor = heos.p() * 1.001;
+            } catch (const ::CoolProp::CoolPropBaseError&) {  // NOLINT(bugprone-empty-catch)
+                p_floor = 1.0;                                // fluid without QT support at this T; defer to walk-down
+            }
+        } else {
+            p_floor = 1.001 * p_crit;
+        }
+        // Find the HIGHEST admissible pressure ≤ p_target at this T (the
+        // melting line caps it for steep-melting fluids like CO2).  Walk
+        // down from p_target to bracket a reachable pressure, then bisect
+        // upward: stopping at the first successful halving would freeze
+        // the envelope at ≤ 0.5·p_target and clip valid dense single-
+        // phase DT states near the real HEOS limit.
+        double p_try = std::max(p_target, p_floor);
+        double rho_found = std::nan("");
+        double p_ok = std::nan("");   // highest known-reachable p
+        double p_bad = std::nan("");  // lowest known-unreachable p (> p_ok)
+        for (int i = 0; i < kMaxHalvings; ++i) {
+            bool ok = false;
+            try {
+                heos.update(::CoolProp::PT_INPUTS, p_try, T_knots[k]);
+                const double rho = heos.rhomass();
+                if (std::isfinite(rho)) {
+                    rho_found = rho;
+                    p_ok = p_try;
+                    ok = true;
+                }
+            } catch (const ::CoolProp::CoolPropBaseError&) {  // NOLINT(bugprone-empty-catch)
+                // Below the melting line at this (T, p); drop p.
+            }
+            if (ok) break;
+            p_bad = p_try;  // this p is unreachable
+            if (p_try <= p_floor) break;
+            p_try = std::max(0.5 * p_try, p_floor);
+        }
+        // If p_target itself was unreachable and we backed off to a lower
+        // p_ok, bisect (p_ok, p_bad) to recover the pressure ceiling we
+        // skipped past, maximizing rho_found.
+        if (std::isfinite(p_ok) && std::isfinite(p_bad) && p_bad > p_ok) {
+            for (int i = 0; i < kMaxHalvings; ++i) {
+                if ((p_bad - p_ok) <= 1e-6 * p_bad) break;
+                const double p_mid = 0.5 * (p_ok + p_bad);
+                bool ok = false;
+                try {
+                    heos.update(::CoolProp::PT_INPUTS, p_mid, T_knots[k]);
+                    const double rho = heos.rhomass();
+                    if (std::isfinite(rho)) {
+                        rho_found = rho;
+                        p_ok = p_mid;
+                        ok = true;
+                    }
+                } catch (const ::CoolProp::CoolPropBaseError&) {  // NOLINT(bugprone-empty-catch)
+                    // (T, p_mid) below the melting line; shrink the bracket.
+                }
+                if (!ok) p_bad = p_mid;
+            }
+        }
+        if (!std::isfinite(rho_found)) {
+            throw std::runtime_error("build_rho_max_envelope: no reachable p ∈ [" + std::to_string(p_floor) + ", " + std::to_string(p_target)
+                                     + "] at T=" + std::to_string(T_knots[k]));
+        }
+        y[k] = rho_found;
+    }
+    return region::CubicSplineCurve::build(std::move(T_knots), std::move(y));
+}
+
+// Per-knot D lower-bound: D at (T, p_target) where p_target is a
+// low-pressure isobar.  No walk-down needed here — low p is always
+// reachable for the supported T range (vapor side; ideal-gas limit).
+// p_target should be ≤ p_triple for safety.
+std::unique_ptr<region::CubicSplineCurve> build_rho_min_envelope(::CoolProp::AbstractState& heos, double T_min, double T_max, double p_target,
+                                                                 std::size_t n_knots = 64) {
+    if (!(T_min > 0.0) || !(T_max > T_min) || n_knots < 2) {
+        throw std::invalid_argument("build_rho_min_envelope: invalid T range or n_knots");
+    }
+    std::vector<double> T_knots(n_knots);
+    std::vector<double> y(n_knots);
+    const double dT = (T_max - T_min) / static_cast<double>(n_knots - 1);
+    for (std::size_t k = 0; k < n_knots; ++k) {
+        T_knots[k] = T_min + static_cast<double>(k) * dT;
+        try {
+            heos.update(::CoolProp::PT_INPUTS, p_target, T_knots[k]);
+            y[k] = heos.rhomass();
+        } catch (const ::CoolProp::CoolPropBaseError& e) {
+            throw std::runtime_error("build_rho_min_envelope: HEOS rejected (T=" + std::to_string(T_knots[k]) + ", p=" + std::to_string(p_target)
+                                     + "): " + e.what());
+        }
+        if (!std::isfinite(y[k])) {
+            throw std::runtime_error("build_rho_min_envelope: non-finite rho at (T=" + std::to_string(T_knots[k]) + ", p=" + std::to_string(p_target)
+                                     + ")");
+        }
+    }
+    return region::CubicSplineCurve::build(std::move(T_knots), std::move(y));
+}
+}  // namespace
+
+SurfaceSpec dt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std::size_t NR, std::int32_t rank) {
+    // DT-indexed surface — closes CoolProp-i7j and supersedes the
+    // BICUBIC invert_single_phase_y patch attempt at #2892 / #1301.
+    //
+    // (D, T) is the Helmholtz EOS's native coordinate, so every output
+    // property (p, h, s, u, w) is a direct evaluation at table-build
+    // time.  No inversion, no critical-region stiffness, no "cells
+    // with -760 MPa" failure modes.
+    //
+    // Three primary regions: LIQUID + VAPOR (sub-critical, dome-
+    // bounded) and SUPER (T > T_critical, EOS-validity bounded).
+    // Anomaly handling: when rho_sat,L(T) has interior extrema (water
+    // ~277 K, heavy water ~284 K), LIQUID is split into N+1 sub-
+    // regions, each spanning one monotonic piece of rho_sat,L(T).
+    const double T_triple = heos.Ttriple();
+    const double T_min_eos = std::max(T_triple, heos.Tmin());
+    const double T_max_eos = heos.Tmax();
+    const double Tc = heos.T_critical();
+
+    // Sub-critical T range with margins away from triple / critical.
+    const double T_sub_lo = std::max(T_min_eos, T_triple * 1.001);
+    const double T_sub_hi = Tc * 0.999;
+    // Super-critical T range with margin above critical / below T_max.
+    const double T_sup_lo = Tc * 1.001;
+    const double T_sup_hi = T_max_eos - 0.5;
+    // KNOWN GAP (CoolProp-i7j follow-up): the [0.999, 1.001]·Tc band is
+    // intentionally uncovered.  The LIQUID/VAPOR dome boundaries
+    // (ρ_sat,L, ρ_sat,V) pinch to ρ_c there, so the dome-bounded
+    // sub-regions degenerate to zero width and the SVD η-normalisation
+    // is ill-conditioned.  Unlike PT/HmassP, DmassT is NOT yet wired
+    // into build_critical_patch_, so single-phase DmassT queries in
+    // this ±0.1%·Tc band currently return OutOfRange rather than
+    // routing to the source backend.  Coverage impact is ~0.2% of the
+    // (D, T) envelope; closing it (a DmassT critical-patch bbox) is
+    // filed as a follow-up and is best done alongside the PT/HP patch
+    // machinery.
+
+    // p envelope for the non-dome D extents.  Sub-critical fluids
+    // have well-defined p_triple from PQ flash at T_triple; use that
+    // as the low-pressure floor for the vapor / super low-D side.
+    // p_max_target = 0.99 * heos.pmax() is the EOS-validity ceiling
+    // — the build_rho_max_envelope helper handles the per-knot
+    // walk-down to clear the melting line where it cuts into high-p.
+    heos.update(::CoolProp::QT_INPUTS, 0.0, T_triple * 1.001);
+    // p_min_eos must stay >= p_triple regardless of region.  Below
+    // p_triple HEOS's PT-input path invokes the melting-curve check
+    // (the curve's domain starts at p_triple), which throws on
+    // every fluid with a polynomial-in-Θ melting curve (CO2, water,
+    // most cryogenic fluids).  The thrown error is the same whether
+    // T is sub- or super-critical, so SUPER's low-D bound is
+    // similarly constrained.  Low-D ideal-gas territory (ρ < ρ_at_
+    // (T, p_triple)) is NOT covered by this preset's atlas; queries
+    // there should be added in a follow-up that handles the ideal-
+    // gas extension (file when needed).
+    const double p_min_eos = heos.p() * 1.01;
+    const double p_max_target = 0.99 * heos.pmax();
+
+    // Detect rho_sat,L(T) extrema and build a sorted list of LIQUID
+    // sub-region breakpoints: [T_sub_lo, extrema..., T_sub_hi].
+    std::vector<double> T_breaks = {T_sub_lo};
+    for (double T_anom : find_rho_satL_extrema_T(heos, T_sub_lo, T_sub_hi)) {
+        T_breaks.push_back(T_anom);
+    }
+    T_breaks.push_back(T_sub_hi);
+
+    SurfaceSpec spec;
+    spec.fluid_name = heos.fluid_names().empty() ? std::string{} : heos.fluid_names().front();
+    spec.input_pair = ::CoolProp::DmassT_INPUTS;
+    spec.NT = NT;
+    spec.NR = NR;
+    spec.rank = rank;
+    spec.properties = dt_properties(heos);
+
+    // LIQUID sub-region(s).  Primary = T (LINEAR — T span is at most
+    // factor ~3 from triple to critical, no orders-of-magnitude
+    // variation that would motivate log scaling).  Secondary = D in
+    // [rho_sat,L(T), rho_at(T, p_max_eos)].  Each sub-region spans
+    // ONE monotonic piece of rho_sat,L(T), so the CubicSplineCurve
+    // fits cleanly without the anomaly's hairpin.
+    for (std::size_t i = 0; i + 1 < T_breaks.size(); ++i) {
+        const double T_lo = T_breaks[i];
+        const double T_hi = T_breaks[i + 1];
+        if (!(T_hi > T_lo)) continue;
+        auto axis = region::AxisTransform::make(region::AxisScale::LINEAR, T_lo, T_hi);
+        auto b_lo = build_rho_sat_L(heos, T_lo, T_hi);                                         // dome side
+        auto b_hi = build_rho_max_envelope(heos, T_lo, T_hi, p_max_target, WalkFloor::SAT_L);  // compressed-liquid ceiling
+        spec.regions.emplace_back(axis, std::move(b_lo), std::move(b_hi));
+    }
+    // VAPOR.  Secondary = D in [rho_at(T, p_min_eos), rho_sat,V(T)].
+    // No anomaly handling needed — rho_sat,V is monotone in T for
+    // every known fluid (increases from triple-vapor toward critical
+    // density as T → Tc).
+    if (T_sub_hi > T_sub_lo) {
+        auto axis = region::AxisTransform::make(region::AxisScale::LINEAR, T_sub_lo, T_sub_hi);
+        auto b_lo = build_rho_min_envelope(heos, T_sub_lo, T_sub_hi, p_min_eos);
+        auto b_hi = build_rho_sat_V(heos, T_sub_lo, T_sub_hi);
+        spec.regions.emplace_back(axis, std::move(b_lo), std::move(b_hi));
+    }
+    // SUPER (T > T_critical).  Secondary D bounded by the two HEOS-
+    // validity isobars.  No dome above Tc — single region across the
+    // full D extent.  This is the region that fixes yufang67's #1301
+    // CO2 supercritical low-density failure: HEOS at low D / high T
+    // evaluates directly (P = ρ²(∂α/∂ρ)RT), no inverter, no
+    // rectangular bands, no -760 MPa cells.
+    if (T_sup_hi > T_sup_lo) {
+        auto axis = region::AxisTransform::make(region::AxisScale::LINEAR, T_sup_lo, T_sup_hi);
+        auto b_lo = build_rho_min_envelope(heos, T_sup_lo, T_sup_hi, p_min_eos);
+        auto b_hi = build_rho_max_envelope(heos, T_sup_lo, T_sup_hi, p_max_target, WalkFloor::CRITICAL);
+        spec.regions.emplace_back(axis, std::move(b_lo), std::move(b_hi));
+    }
+
+    spec.update_state = [](::CoolProp::AbstractState& s, double T, double D) {
+        // SurfaceSpec passes (a, b) where a is primary (T) and b is
+        // secondary (D).  DmassT_INPUTS takes (D, T) in that order.
+        s.update(::CoolProp::DmassT_INPUTS, D, T);
+    };
+    spec.read_property = [](::CoolProp::AbstractState& s, ::CoolProp::parameters key) -> double {
+        switch (key) {
+            case ::CoolProp::iP:
+                return s.p();
+            case ::CoolProp::iHmass:
+                return s.hmass();
+            case ::CoolProp::iSmass:
+                return s.smass();
+            case ::CoolProp::iUmass:
+                return s.umass();
+            case ::CoolProp::ispeed_sound:
+                return s.speed_sound();
+            case ::CoolProp::iviscosity:
+                return s.viscosity();
+            case ::CoolProp::iconductivity:
+                return s.conductivity();
+            default:
+                throw std::invalid_argument("dt_subcritical: unsupported output property");
+        }
+    };
+
+    return spec;
+}
+
 }  // namespace presets
 }  // namespace sbtl
 }  // namespace CoolProp

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -23,6 +23,8 @@ using Catch::Approx;
 #    include "Configuration.h"
 #    include "CoolProp.h"
 #    include "CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h"
+#    include "CoolProp/sbtl/SatBoundaryFactory.h"
+#    include "CoolProp/sbtl/SVDSurfaceFactory.h"
 #    include "CoolProp/sbtl/SVDSurfaceSerializer.h"
 #    include "DataStructures.h"
 #    include "TestUtils.h"
@@ -924,6 +926,82 @@ TEST_CASE("SVDSBTL ALTERNATIVE_SVDTABLES_DIRECTORY end-to-end build + reload", "
     fs::remove_all(tmpdir, ec);
 }
 
+// CoolProp-i7j: a DmassT (DT-indexed) SVDSBTL surface must round-trip
+// through the on-disk cache.  The DT preset's rho_sat,L / rho_sat,V dome
+// boundaries are region::SuperancillaryTemperatureBoundaryCurve on HEOS
+// sources; before the serializer learned CurveKind::SUPERANCILLARY_T,
+// pack_curve threw "unknown BoundaryCurve subclass" on them.  save_to_file
+// swallows that throw, so the DT surface silently never cached and the
+// dense SVD rebuilt every session.  This test catches that regression:
+// pre-fix the first construction writes NO DmassT cache file (REQUIRE_FALSE
+// fails), or any cache that lands fails to load and rebuilds (mtime bumps).
+TEST_CASE("SVDSBTL DmassT surface caches + reloads from disk (CoolProp-i7j)", "[SBTL][SVDSBTL][dt][cache][slow]") {
+    namespace fs = std::filesystem;
+    const std::string saved = CoolProp::get_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY);
+    const fs::path tmpdir = fs::temp_directory_path() / ("coolprop_svdtables_dt_e2e_" + std::to_string(CoolProp::tests::test_pid()));
+    std::error_code ec;
+    fs::remove_all(tmpdir, ec);
+    CoolProp::set_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY, tmpdir.string());
+
+    // Smallest valid grid + critical_patch off, same as the PT e2e test.
+    const std::string opts = R"({"grid":{"NT":40,"NR":80,"rank":10},"critical_patch":{"mode":"off"}})";
+    const std::string spec = "SVDSBTL&HEOS";
+    const std::string spec_with_opts = std::string("Water?") + opts;
+
+    // A valid single-phase compressed-liquid (D, T): take D from HEOS at
+    // (5 MPa, 350 K) so the probe lands inside the LIQUID region.
+    double D_query = 0.0;
+    {
+        auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+        heos->update(CoolProp::PT_INPUTS, 5.0e6, 350.0);
+        D_query = heos->rhomass();
+    }
+
+    auto dt_cache_files = [&]() {
+        std::vector<fs::path> out;
+        if (!fs::is_directory(tmpdir, ec)) return out;
+        for (const auto& entry : fs::directory_iterator(tmpdir, ec)) {
+            const std::string name = entry.path().filename().string();
+            if (name.find("DmassT_INPUTS") != std::string::npos && name.find(".svd.bin.z") != std::string::npos) out.push_back(entry.path());
+        }
+        return out;
+    };
+
+    // First construction -> build + write the DmassT cache file.
+    {
+        auto first = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory(spec, spec_with_opts));
+        first->update(CoolProp::DmassT_INPUTS, D_query, 350.0);
+    }
+    auto files = dt_cache_files();
+    INFO("DmassT cache files in tmpdir: " << files.size());
+    REQUIRE_FALSE(files.empty());  // pre-fix: pack_curve threw, save swallowed -> no DT cache
+
+    auto to_ns = [](const fs::file_time_type& t) {
+        return static_cast<std::int64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(t.time_since_epoch()).count());
+    };
+    std::vector<std::int64_t> mtimes_before_ns;
+    mtimes_before_ns.reserve(files.size());
+    for (const auto& f : files)
+        mtimes_before_ns.push_back(to_ns(fs::last_write_time(f)));
+
+    // Second construction with identical options -> must reload from cache.
+    // A failed load (e.g. unknown curve kind) would fall through to rebuild
+    // and bump the mtime.
+    {
+        auto second = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory(spec, spec_with_opts));
+        second->update(CoolProp::DmassT_INPUTS, D_query, 350.0);
+    }
+    const auto files_after = dt_cache_files();
+    REQUIRE(files_after.size() == files.size());
+    for (std::size_t i = 0; i < files.size(); ++i) {
+        INFO("file: " << files[i].filename().string());
+        REQUIRE(to_ns(fs::last_write_time(files[i])) == mtimes_before_ns[i]);
+    }
+
+    CoolProp::set_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY, saved);
+    fs::remove_all(tmpdir, ec);
+}
+
 // CoolProp-4no.2: parallel docs-build invocations (joblib loky workers)
 // race on writes to the same cache file, producing torn-write artifacts.
 // ::write_bytes_atomic does write-temp + rename so readers never see a
@@ -1182,6 +1260,255 @@ TEST_CASE("SVDSBTL pc-strip routes through critical patch", "[SVDSBTL][CoolProp-
                     REQUIRE(svd->rhomass() == Approx(rho_truth_hp).epsilon(1e-12));
                 }
             }
+        }
+    }
+}
+
+// -- DT-indexed surface (CoolProp-i7j) ------------------------------------
+
+// Smoke test: DT surface for CO2 builds, single supercritical probe
+// returns finite values matching HEOS to better than 1e-3 relative.
+// Tight tolerance comes in the multi-fluid sweep below — this one just
+// proves the wiring is end-to-end.
+TEST_CASE("SVDSBTL DT-indexed surface builds and evaluates for CO2", "[SBTL][SVDSBTL][dt][smoke][slow]") {
+    auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "CarbonDioxide"));
+    auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "CarbonDioxide"));
+    // Supercritical CO2 at moderate density — the regime that broke
+    // BICUBIC #1301 with rectangular-band errors.
+    // Probes inside the atlas coverage envelope for CO2.  SUPER is the
+    // primary fix target (yufang67 #1301: low-D supercritical returned
+    // -760 MPa under BICUBIC); LIQUID + VAPOR probes pick D above /
+    // below the sat dome respectively to land in the single-phase
+    // sub-regions the preset emits.
+    struct Probe
+    {
+        double D, T;
+        const char* region;
+    };
+    for (const auto& p : std::vector<Probe>{
+           {10.0, 400.0, "SUPER mid-D"},
+           {500.0, 350.0, "SUPER high-D"},
+           {1100.0, 250.0, "LIQUID (D > rho_sat,L)"},
+           {15.0, 250.0, "VAPOR (D < rho_sat,V)"},
+         }) {
+        heos->update(CoolProp::DmassT_INPUTS, p.D, p.T);
+        svd->update(CoolProp::DmassT_INPUTS, p.D, p.T);
+        INFO(p.region << " D=" << p.D << " T=" << p.T << " svd_p=" << svd->p() << " heos_p=" << heos->p() << " svd_h=" << svd->hmass()
+                      << " heos_h=" << heos->hmass());
+        CHECK(std::isfinite(svd->p()));
+        CHECK(svd->p() > 0.0);
+        CHECK(svd->p() == Approx(heos->p()).epsilon(1e-2));
+        CHECK(svd->hmass() == Approx(heos->hmass()).epsilon(1e-2));
+        CHECK(svd->rhomass() == p.D);
+        CHECK(svd->T() == p.T);
+    }
+}
+
+// Regression gate for issue #1301 (CoolProp-i7j): a random (T, ρ)
+// sweep over yufang67's exact bounds (T ∈ [220, 500] K, ρ ∈ [0.01,
+// 1200] kg/m³) spanning subcritical liquid / vapor / two-phase dome
+// AND supercritical.  Asserts the headline contrast: SVDSBTL's
+// DT-indexed P(ρ, T) is clean across the envelope it covers, while
+// BICUBIC reproduces the documented failures (large near-saturation
+// error + negative-pressure cells).  The browsable figure is rendered
+// separately by Web/coolprop/_gen/gen_DT_validation_fig1301.py (pure
+// Python; same sweep).
+// Two-phase dome routing: a DT probe with rho_sat,V(T) < ρ < rho_sat,L(T)
+// at subcritical T lands in the dome.  Pressure must be P_sat(T) and the
+// caloric props must come from the lever rule — in particular hmass() /
+// hmolar() must NOT throw (regression: the dome block originally left
+// pt.h_mass unset and the DomeBlend switch has no enthalpy arm, so the
+// enthalpy query hit `default` and threw ValueError).
+TEST_CASE("SVDSBTL DT two-phase dome returns lever-rule props (CoolProp-i7j)", "[SBTL][SVDSBTL][dt][dome]") {
+    auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "CarbonDioxide"));
+    auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "CarbonDioxide"));
+    // T=250 K subcritical; ρ=500 sits between ρ_sat,V (~18) and
+    // ρ_sat,L (~1046), squarely two-phase.
+    const double D = 500.0;
+    const double T = 250.0;
+    heos->update(CoolProp::DmassT_INPUTS, D, T);
+    svd->update(CoolProp::DmassT_INPUTS, D, T);
+    INFO("dome probe D=" << D << " T=" << T << " svd_p=" << svd->p() << " heos_p=" << heos->p());
+    REQUIRE(svd->Q() > 0.0);
+    REQUIRE(svd->Q() < 1.0);
+    REQUIRE(svd->p() == Approx(heos->p()).epsilon(1e-3));  // P_sat(T)
+    // hmass() / hmolar() must return the lever-rule blend, not throw.
+    REQUIRE_NOTHROW(svd->hmass());
+    REQUIRE(svd->hmass() == Approx(heos->hmass()).epsilon(1e-3));
+    REQUIRE(svd->hmolar() == Approx(heos->hmolar()).epsilon(1e-3));
+    REQUIRE(svd->rhomass() == D);  // density input echoed back
+}
+
+// fast_evaluate on a DT surface requesting density back: density is the
+// INPUT, not a tabulated property, so the batched output plan must
+// short-circuit iDmass / iDmolar to the input echo.  Regression: it
+// originally routed them to a surface lookup, property_index(iDmass)
+// threw, and the whole output row was NaN'd with internal_error.
+TEST_CASE("SVDSBTL DT fast_evaluate echoes density + matches HEOS (CoolProp-i7j)", "[SBTL][SVDSBTL][dt][fast_evaluate]") {
+    auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "CarbonDioxide"));
+    auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "CarbonDioxide"));
+    // Supercritical single-phase batch.
+    const std::vector<double> Dvals = {10.0, 100.0, 500.0, 800.0};  // DmassT: val1 = D
+    const double T = 350.0;
+    std::vector<double> v2(Dvals.size(), T);  // val2 = T
+    std::vector<CoolProp::parameters> outs = {CoolProp::iP, CoolProp::iDmass, CoolProp::iHmass};
+    std::vector<double> out(Dvals.size() * outs.size(), std::nan(""));
+    std::vector<int> status(Dvals.size(), CoolProp::fast_evaluate_internal_error);
+    svd->fast_evaluate(CoolProp::DmassT_INPUTS, Dvals.data(), v2.data(), Dvals.size(), outs.data(), outs.size(), out.data(), out.size(),
+                       status.data(), status.size());
+    for (std::size_t k = 0; k < Dvals.size(); ++k) {
+        INFO("fast_evaluate k=" << k << " D=" << Dvals[k] << " status=" << static_cast<int>(status[k]));
+        REQUIRE(status[k] == CoolProp::fast_evaluate_ok);
+        const double p_fe = out[k * outs.size() + 0];
+        const double D_fe = out[k * outs.size() + 1];
+        const double h_fe = out[k * outs.size() + 2];
+        heos->update(CoolProp::DmassT_INPUTS, Dvals[k], T);
+        REQUIRE(D_fe == Dvals[k]);  // density echoed, not NaN
+        REQUIRE(p_fe == Approx(heos->p()).epsilon(1e-2));
+        REQUIRE(h_fe == Approx(heos->hmass()).epsilon(1e-2));
+    }
+}
+
+TEST_CASE("CoolProp-i7j: SVDSBTL DT clean vs BICUBIC fails on #1301 sweep", "[SBTL][SVDSBTL][dt][fig1301][slow]") {
+    auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "CarbonDioxide"));
+    auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "CarbonDioxide"));
+    auto bic = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("BICUBIC&HEOS", "CarbonDioxide"));
+
+    constexpr double T_lo = 220.0;
+    constexpr double T_hi = 500.0;
+    constexpr double rho_lo = 1.0e-2;
+    constexpr double rho_hi = 1200.0;
+    constexpr int N_SAMPLES = 20000;  // ample to characterize the contrast in CI
+    std::mt19937 rng(1301);
+    std::uniform_real_distribution<double> T_dist(T_lo, T_hi);
+    std::uniform_real_distribution<double> rho_dist(rho_lo, rho_hi);
+
+    int n_heos_valid = 0;   // cells where HEOS gives a valid positive reference p
+    int n_bicubic_bad = 0;  // BICUBIC cells with |%-err| > 1% or sign-flip, inside HEOS validity
+    int n_svd_bad = 0;      // SVDSBTL cells with |%-err| > 1% OR a finite non-positive p
+    int n_svd_covered = 0;  // cells SVDSBTL resolved to a FINITE p (positive or not)
+    auto pressure = [](CoolProp::AbstractState& s, double rho, double T) -> double {
+        try {
+            s.update(CoolProp::DmassT_INPUTS, rho, T);
+            return s.p();
+        } catch (...) {  // NOLINT(bugprone-empty-catch)
+            return std::nan("");
+        }
+    };
+    for (int k = 0; k < N_SAMPLES; ++k) {
+        const double T = T_dist(rng);
+        const double rho = rho_dist(rng);
+        const double p_heos = pressure(*heos, rho, T);
+        if (!std::isfinite(p_heos) || p_heos == 0.0) continue;
+        ++n_heos_valid;
+        const double p_svd = pressure(*svd, rho, T);
+        const double p_bic = pressure(*bic, rho, T);
+        // %-error as yufang67 defined it: |P_bk - P_EOS|/P_EOS*100.
+        if (std::isfinite(p_bic) && (std::abs(p_bic - p_heos) / std::abs(p_heos) * 100.0 > 1.0 || p_bic <= 0.0)) {
+            ++n_bicubic_bad;
+        }
+        if (std::isfinite(p_svd)) {
+            ++n_svd_covered;
+            // A finite non-positive pressure is itself a failure (the
+            // #1301 sign-flip mode), not just a >1% deviation — count
+            // both so a regression that returns negative P can't hide
+            // by being dropped from the denominator.
+            if (p_svd <= 0.0 || std::abs(p_svd - p_heos) / std::abs(p_heos) * 100.0 > 1.0) ++n_svd_bad;
+        }
+    }
+    UNSCOPED_INFO("n_heos_valid=" << n_heos_valid << " n_svd_covered=" << n_svd_covered << " n_svd_bad=" << n_svd_bad
+                                  << " n_bicubic_bad=" << n_bicubic_bad);
+    // SVDSBTL must cover most of the HEOS-valid envelope (the only
+    // uncovered band is the deep low-ρ ideal-gas corner below the
+    // p_triple sampling floor — a documented follow-up), and within
+    // what it covers the failure fraction (>1% error OR non-positive
+    // p) must be tiny.  The handful that remain are at the extreme
+    // low-ρ atlas edge where the η-normalisation sits at ξ≈0 — NOT the
+    // near-saturation region that motivated #1301.
+    CHECK(n_heos_valid > 0);
+    CHECK(static_cast<double>(n_svd_covered) > 0.90 * static_cast<double>(n_heos_valid));
+    CHECK(static_cast<double>(n_svd_bad) < 0.001 * static_cast<double>(n_svd_covered));
+    CHECK(n_bicubic_bad > 0);  // #1301 failure pattern must reproduce
+}
+
+// Anomaly detection: water has a single rho_sat,L extremum at
+// T ≈ 277 K (4 °C density anomaly).  CO2 / methane have none.
+// Verifies find_rho_satL_extrema_T does its job before the preset
+// uses it to split the LIQUID region.
+TEST_CASE("find_rho_satL_extrema_T returns water anomaly, none for other fluids", "[SBTL][SVDSBTL][dt][anomaly]") {
+    SECTION("water has anomaly near 277 K") {
+        auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+        auto extrema = CoolProp::sbtl::find_rho_satL_extrema_T(*heos, heos->Ttriple() * 1.001, heos->T_critical() * 0.999);
+        REQUIRE(extrema.size() == 1);
+        REQUIRE(extrema[0] == Approx(277.13).margin(2.0));
+    }
+    SECTION("CO2 has no anomaly") {
+        auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "CarbonDioxide"));
+        auto extrema = CoolProp::sbtl::find_rho_satL_extrema_T(*heos, heos->Ttriple() * 1.001, heos->T_critical() * 0.999);
+        REQUIRE(extrema.empty());
+    }
+    SECTION("methane has no anomaly") {
+        auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Methane"));
+        auto extrema = CoolProp::sbtl::find_rho_satL_extrema_T(*heos, heos->Ttriple() * 1.001, heos->T_critical() * 0.999);
+        REQUIRE(extrema.empty());
+    }
+}
+
+// LIQUID-split geometry: the dt_subcritical preset must emit one extra
+// LIQUID sub-region per rho_sat,L(T) extremum.  Water (one anomaly)
+// gets LIQUID_LO + LIQUID_HI + VAPOR + SUPER = 4 regions; CO2 (no
+// anomaly) gets LIQUID + VAPOR + SUPER = 3.  This is the structural
+// guard that the anomaly split actually happens — without it, a
+// single LIQUID region would straddle the density-maximum hairpin and
+// the SVD couldn't represent the resulting discontinuity.
+TEST_CASE("dt_subcritical splits LIQUID at the water density anomaly", "[SBTL][SVDSBTL][dt][anomaly]") {
+    SECTION("water emits 4 regions (LIQUID split into LO + HI)") {
+        auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+        auto spec = CoolProp::sbtl::presets::dt_subcritical(*heos);
+        REQUIRE(spec.regions.size() == 4);
+        REQUIRE(spec.input_pair == CoolProp::DmassT_INPUTS);
+    }
+    SECTION("CO2 emits 3 regions (single LIQUID)") {
+        auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "CarbonDioxide"));
+        auto spec = CoolProp::sbtl::presets::dt_subcritical(*heos);
+        REQUIRE(spec.regions.size() == 3);
+    }
+}
+
+// End-to-end: water DT lookups across the 4 °C density anomaly.  Probe
+// compressed-liquid states at D just above the saturation dome, sweeping
+// T from below the anomaly (LIQUID_LO sub-region) through the maximum to
+// above it (LIQUID_HI).  D ≈ 1000-1050 kg/m³ stays just above
+// rho_sat,L(T) (≈ 999.9 at the maximum) across the whole sweep, so every
+// probe is single-phase liquid sitting right on top of the anomaly's
+// hairpin — exactly the cells a single un-split LIQUID region would
+// botch.  All must match HEOS density-input pressure / enthalpy.
+TEST_CASE("SVDSBTL DT water across the density anomaly matches HEOS", "[SBTL][SVDSBTL][dt][anomaly][water][slow]") {
+    auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
+    auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+
+    // T sweep brackets the anomaly at ~277.13 K: two points below, the
+    // maximum, two above.  D values are compressed-liquid, comfortably
+    // above rho_sat,L (which peaks at ~999.97 kg/m³) yet inside the
+    // HEOS validity envelope.
+    for (const double T : {274.0, 276.0, 277.13, 279.0, 283.0}) {
+        for (const double D : {1000.5, 1020.0, 1050.0}) {
+            heos->update(CoolProp::DmassT_INPUTS, D, T);
+            const double p_ref = heos->p();
+            const double h_ref = heos->hmass();
+            svd->update(CoolProp::DmassT_INPUTS, D, T);
+            INFO("water anomaly probe D=" << D << " T=" << T << " svd_p=" << svd->p() << " heos_p=" << p_ref << " svd_h=" << svd->hmass()
+                                          << " heos_h=" << h_ref);
+            REQUIRE_FALSE(std::isnan(svd->p()));
+            REQUIRE(svd->p() > 0.0);
+            // 0.1% on p across the anomaly — the split keeps each
+            // sub-region's rho_sat,L(T) boundary monotone, so the
+            // η-normalisation stays well-conditioned right at the
+            // density maximum.
+            REQUIRE(svd->p() == Approx(p_ref).epsilon(1e-3));
+            REQUIRE(svd->hmass() == Approx(h_ref).epsilon(1e-3));
+            REQUIRE(svd->rhomass() == D);
+            REQUIRE(svd->T() == T);
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a `DmassT_INPUTS` / `DmolarT_INPUTS` SVD-tabulated surface to the SVDSBTL backend, closing **CoolProp-i7j** and superseding the BICUBIC `invert_single_phase_y` patch attempt (#2892 / #1301). (D, T) is the Helmholtz EOS's native coordinate, so P / H / S / U are **direct evaluations** at build time — no inversion, no critical-region stiffness, none of the rectangular-band / negative-pressure failures BICUBIC exhibits near saturation.

## What's included

- **`dt_subcritical` preset** (`src/SBTL/SurfacePresets.cpp`): LIQUID / VAPOR (dome-bounded) + SUPER (EOS-validity bounded). T-primary LINEAR axis, D-secondary. ρ_sat,L / ρ_sat,V dome boundaries + per-knot walk-down "max envelope" for the compressed-liquid ceiling (clears the melting line on steep-melting fluids like CO2).
- **Density-anomaly handling**: for fluids whose ρ_sat,L(T) is non-monotone (water ~277 K, heavy water ~284 K), LIQUID is split into one monotonic sub-region per SuperAncillary piece, detected via `find_rho_satL_extrema_T` (SA `get_x_at_extrema`, QT-walk fallback). Without the split, a single LIQUID region straddles the density-maximum hairpin and the SVD can't represent the discontinuity.
- **`SuperancillaryTemperatureBoundaryCurve`**: T-parameterized sibling of `SuperancillaryBoundaryCurve` (machine-precision ρ_sat(T), no inversion).
- **Backend wiring**: DmassT/DmolarT in `resolve_point_` (incl. a `_p` cache, since `AbstractState::p()` returns cached `_p` bypassing `calc_pressure`), two-phase **dome lever-rule routing** on atlas miss, and `fast_evaluate` support.
- Grid density tunable via existing factory options: `?{"grid":{"NT":..,"NR":..,"rank":..}}`.
- **CLAUDE.md**: build command now mandates `-DCMAKE_BUILD_TYPE=Release` (the empty default is `-O0`, making surface builds 10–50× slower).

## Validation

`Web/coolprop/fig1301_dt_validation.png` (pure-Python generator `gen_DT_validation_fig1301.py`, uses `fast_evaluate`): CO2 P(ρ,T) over yufang67's exact #1301 envelope (T∈[220,500], ρ∈[0.01,1200], %-error, jet). BICUBIC reproduces the failure (near-saturation error band + ~1450 negative-pressure cells); **SVDSBTL DT is clean** — 0 sign-flips, >1% error only at 0.04% of cells (all at the extreme low-ρ atlas edge).

## Test plan
- [x] `[dt]` tag: smoke (CO2 P/H/S round-trip + D/T input echo), anomaly detection (water/CO2/methane), 4-region LIQUID split for water, end-to-end water across the anomaly, two-phase dome lever-rule, fast_evaluate density echo, and the #1301 sweep regression gate
- [x] `./dev/ci/preflight.sh` 6/6 (clang-format, build, `[SBTL]` umbrella, cppcheck, clang-tidy, semgrep)
- [x] code-reviewer adversarial pass: 2 blocking findings (dome-enthalpy throw, fast_evaluate density NaN) fixed + regression-tested

## Follow-ups filed
- **CoolProp-eal**: lazy per-pair surface loading (defer `ensure_surface_` to first query) — worth doing before DU/HS land
- Low-ρ ideal-gas extension below the p_triple sampling floor (the uncovered corner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DT (density–temperature) input support: DT subcritical surface preset, DT two‑phase dome blending, density-based evaluation shortcuts, and improved fast-evaluate/shortcut behavior.
  * Temperature-parameterized saturation-density boundary builders with extrema detection and a new SuperAncillary-backed temperature boundary curve supporting surrogate sampling and serialization.
  * Optional cached mass-density input to speed density-based queries.

* **Documentation**
  * Updated CMake guidance to always configure Release build type.

* **Tests**
  * Added comprehensive DT surface, dome-blend, anomaly-detection, regression, and end-to-end tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2984?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
**Update**: added a second validation generator `Web/coolprop/_gen/gen_DT_water_anomaly.py` — water P(ρ,T) error vs HEOS across the 4 °C density anomaly (sat → melting), with the ρ_sat,L(T) hairpin overlaid and an `--interactive` flag for a live zoom/pan window. Confirms the LIQUID_LO/LIQUID_HI split joins cleanly with no seam at T_anom and 0 sign-flips. Worst-case error there is ~8 ppm right at the saturation boundary, decaying ~4 orders of magnitude inward — an honest consequence of liquid water's incompressibility (∂P/∂ρ ≈ 2.1e6 Pa·m³/kg amplifying the surface's ~1e-8 edge residual), not a defect.
