### PR TITLE
ci: cancel superseded runs to cut CI backlog (concurrency groups)

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -26,6 +26,14 @@ on:
     - cron: '15 8 * * 0,4'  # twice weekly Sun+Thu — codeql fallback
   workflow_dispatch:
 
+concurrency:
+  # Cancel superseded runs on the same ref to cut CI backlog on heavy
+  # dev days (repeated pushes to an open PR).  Protected: master / main
+  # / develop and tags never cancel, so mainline + release runs always
+  # complete.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   asan:
     name: address sanitizer

--- a/.github/workflows/dev_msvc.yml
+++ b/.github/workflows/dev_msvc.yml
@@ -27,6 +27,14 @@ env:
   build: '${{ github.workspace }}/build'
   config: 'Release'
 
+concurrency:
+  # Cancel superseded runs on the same ref to cut CI backlog on heavy
+  # dev days (repeated pushes to an open PR).  Protected: master / main
+  # / develop and tags never cancel, so mainline + release runs always
+  # complete.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   analyze:
     permissions:

--- a/.github/workflows/docs_docker-build.yml
+++ b/.github/workflows/docs_docker-build.yml
@@ -22,6 +22,14 @@ env:
   IMAGE_SUFFIX: docs_01_base
   IMAGE_NAME: ${{ github.repository }}
 
+concurrency:
+  # Cancel superseded runs on the same ref to cut CI backlog on heavy
+  # dev days (repeated pushes to an open PR).  Protected: master / main
+  # / develop and tags never cancel, so mainline + release runs always
+  # complete.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   build:
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/docs_docker-run.yml
+++ b/.github/workflows/docs_docker-run.yml
@@ -16,6 +16,14 @@ on:
   pull_request:
     branches: [ 'master', 'main', 'develop' ]
 
+concurrency:
+  # Cancel superseded runs on the same ref to cut CI backlog on heavy
+  # dev days (repeated pushes to an open PR).  Protected: master / main
+  # / develop and tags never cancel, so mainline + release runs always
+  # complete.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/gui_builder.yml
+++ b/.github/workflows/gui_builder.yml
@@ -27,6 +27,14 @@ on:
       - '.github/workflows/gui_builder.yml'
   workflow_dispatch:
 
+concurrency:
+  # Cancel superseded runs on the same ref to cut CI backlog on heavy
+  # dev days (repeated pushes to an open PR).  Protected: master / main
+  # / develop and tags never cancel, so mainline + release runs always
+  # complete.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   build:
     name: ${{ matrix.os }}

--- a/.github/workflows/javascript_builder.yml
+++ b/.github/workflows/javascript_builder.yml
@@ -11,6 +11,14 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
+concurrency:
+  # Cancel superseded runs on the same ref to cut CI backlog on heavy
+  # dev days (repeated pushes to an open PR).  Protected: master / main
+  # / develop and tags never cancel, so mainline + release runs always
+  # complete.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   build:
 

--- a/.github/workflows/library_shared.yml
+++ b/.github/workflows/library_shared.yml
@@ -11,6 +11,14 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
+concurrency:
+  # Cancel superseded runs on the same ref to cut CI backlog on heavy
+  # dev days (repeated pushes to an open PR).  Protected: master / main
+  # / develop and tags never cancel, so mainline + release runs always
+  # complete.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   build:
 

--- a/.github/workflows/libreoffice_builder.yml
+++ b/.github/workflows/libreoffice_builder.yml
@@ -7,6 +7,14 @@ on:
   pull_request:
     branches: [ 'master', 'main', 'develop' ]
 
+concurrency:
+  # Cancel superseded runs on the same ref to cut CI backlog on heavy
+  # dev days (repeated pushes to an open PR).  Protected: master / main
+  # / develop and tags never cancel, so mainline + release runs always
+  # complete.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/mathcad_builder.yml
+++ b/.github/workflows/mathcad_builder.yml
@@ -10,6 +10,14 @@ on:
   # ========= Run on call from other workflows
   workflow_call:
 
+concurrency:
+  # Cancel superseded runs on the same ref to cut CI backlog on heavy
+  # dev days (repeated pushes to an open PR).  Protected: master / main
+  # / develop and tags never cancel, so mainline + release runs always
+  # complete.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   build:
 

--- a/.github/workflows/python_buildwheels.yml
+++ b/.github/workflows/python_buildwheels.yml
@@ -19,6 +19,14 @@ on:
     branches: [ 'master', 'main', 'develop' ]
     types: [opened, synchronize, reopened, labeled]
 
+concurrency:
+  # Cancel superseded runs on the same ref to cut CI backlog on heavy
+  # dev days (repeated pushes to an open PR).  Protected: master / main
+  # / develop and tags never cancel, so mainline + release runs always
+  # complete.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   set-version:
     # Skip this whole workflow on label events unless the label is `full-wheels`,

--- a/.github/workflows/test_catch2.yml
+++ b/.github/workflows/test_catch2.yml
@@ -13,6 +13,14 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
+concurrency:
+  # Cancel superseded runs on the same ref to cut CI backlog on heavy
+  # dev days (repeated pushes to an open PR).  Protected: master / main
+  # / develop and tags never cancel, so mainline + release runs always
+  # complete.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   build:
 

--- a/.github/workflows/windows_installer.yml
+++ b/.github/workflows/windows_installer.yml
@@ -11,6 +11,14 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
+concurrency:
+  # Cancel superseded runs on the same ref to cut CI backlog on heavy
+  # dev days (repeated pushes to an open PR).  Protected: master / main
+  # / develop and tags never cancel, so mainline + release runs always
+  # complete.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   build:
 


### PR DESCRIPTION
## Summary

No workflow had a `concurrency:` block, so every push to an open PR spawned a full multi-OS run and **none of the superseded runs were cancelled** — they all completed, piling up tens of hours of queue on heavy dev days.

This adds a **guarded** top-level concurrency group to the push / pull_request validation + build workflows:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/tags/') }}
```

So repeated pushes to a PR cancel the stale in-flight run, but **mainline (master/main/develop) and release/tag runs are never cancelled** and always complete.

## Scope

**Applied** (12): `dev_checks`, `dev_msvc`, `docs_docker-build`, `docs_docker-run`, `gui_builder`, `javascript_builder`, `library_shared`, `libreoffice_builder`, `mathcad_builder`, `python_buildwheels`, `test_catch2`, `windows_installer`.

**Intentionally not applied:**
- `release_all_files` / `release_get_artifact` — must never cancel
- `delete_workflow_runs` — scheduled cleanup
- `dev_tmate` — interactive debug session
- `python_cibuildwheel` — `workflow_call`; governed by the caller's concurrency group

## Notes
- YAML-only; no compile impact. All 12 files validated to parse with a top-level `concurrency` key.
- This is the cheapest, highest-leverage backlog lever. Follow-on options (separate): gate the wheel matrix off every push (cf. `ihb/ci-consolidate-dev-and-gate-wheels`), and shift ASan left into `preflight.sh` + demote CI ASan to nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to implement concurrency controls that group runs by workflow and git reference.
  * Configured automatic cancellation of superseded workflow runs on non-protected branches and non-tag references.
  * Applied consistent concurrency policies across 12 GitHub Actions workflows to optimize pipeline execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2989?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->