### PR TITLE
feat(REFPROP): saturated-state props + saturation/two-phase derivatives (#2013, supersedes #2016)

### DIFF
--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -2362,6 +2362,42 @@ CoolPropDbl REFPROPMixtureBackend::calc_first_saturation_deriv(parameters Of1, p
     }
 }
 
+CoolPropDbl REFPROPMixtureBackend::calc_first_two_phase_deriv(parameters Of, parameters Wrt, parameters Constant) {
+    if (!ValidNumber(_rhoLmolar) || !ValidNumber(_rhoVmolar)) {
+        throw ValueError("The saturation properties are needed for calc_first_two_phase_deriv");
+    }
+    shared_ptr<REFPROPMixtureBackend> SatL = build_saturation_shim(0);
+    shared_ptr<REFPROPMixtureBackend> SatV = build_saturation_shim(1);
+
+    if (Of == iDmolar && Wrt == iHmolar && Constant == iP) {
+        return -POW2(rhomolar()) * (1 / SatV->rhomolar() - 1 / SatL->rhomolar()) / (SatV->hmolar() - SatL->hmolar());
+    } else if (Of == iDmass && Wrt == iHmass && Constant == iP) {
+        return -POW2(rhomass()) * (1 / SatV->rhomass() - 1 / SatL->rhomass()) / (SatV->hmass() - SatL->hmass());
+    } else if (Of == iDmolar && Wrt == iP && Constant == iHmolar) {
+        CoolPropDbl dvdrhoL = -1 / POW2(SatL->rhomolar());
+        CoolPropDbl dvdrhoV = -1 / POW2(SatV->rhomolar());
+        CoolPropDbl dvL_dp = dvdrhoL * SatL->calc_first_saturation_deriv(iDmolar, iP);
+        CoolPropDbl dvV_dp = dvdrhoV * SatV->calc_first_saturation_deriv(iDmolar, iP);
+        CoolPropDbl dhL_dp = SatL->calc_first_saturation_deriv(iHmolar, iP);
+        CoolPropDbl dhV_dp = SatV->calc_first_saturation_deriv(iHmolar, iP);
+        CoolPropDbl dxdp_h = (Q() * dhV_dp + (1 - Q()) * dhL_dp) / (SatL->hmolar() - SatV->hmolar());
+        CoolPropDbl dvdp_h = dvL_dp + dxdp_h * (1 / SatV->rhomolar() - 1 / SatL->rhomolar()) + Q() * (dvV_dp - dvL_dp);
+        return -POW2(rhomolar()) * dvdp_h;
+    } else if (Of == iDmass && Wrt == iP && Constant == iHmass) {
+        CoolPropDbl dvdrhoL = -1 / POW2(SatL->rhomass());
+        CoolPropDbl dvdrhoV = -1 / POW2(SatV->rhomass());
+        CoolPropDbl dvL_dp = dvdrhoL * SatL->calc_first_saturation_deriv(iDmass, iP);
+        CoolPropDbl dvV_dp = dvdrhoV * SatV->calc_first_saturation_deriv(iDmass, iP);
+        CoolPropDbl dhL_dp = SatL->calc_first_saturation_deriv(iHmass, iP);
+        CoolPropDbl dhV_dp = SatV->calc_first_saturation_deriv(iHmass, iP);
+        CoolPropDbl dxdp_h = (Q() * dhV_dp + (1 - Q()) * dhL_dp) / (SatL->hmass() - SatV->hmass());
+        CoolPropDbl dvdp_h = dvL_dp + dxdp_h * (1 / SatV->rhomass() - 1 / SatL->rhomass()) + Q() * (dvV_dp - dvL_dp);
+        return -POW2(rhomass()) * dvdp_h;
+    } else {
+        throw ValueError("These inputs are not supported to calc_first_two_phase_deriv");
+    }
+}
+
 CoolPropDbl REFPROPMixtureBackend::calc_saturated_liquid_keyed_output(parameters key) {
     if (!ValidNumber(_rhoLmolar)) {
         throw ValueError("The saturated liquid state has not been set.");

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -2038,6 +2038,14 @@ void REFPROPMixtureBackend::update(CoolProp::input_pairs input_pair, double valu
     if (imposed_phase_index == iphase_not_imposed) {  // If phase is imposed, _phase will already be set.
         if (Ncomp == 1) {                             // Only set _phase for pure fluids
             _phase = GetRPphase();                    // Set the CoolProp _phase variable based on RefProp's quality value (q)
+            if (_phase != iphase_twophase) {
+                // No saturated state: clear so build_saturation_shim / keyed outputs reject it.
+                _rhoLmolar = _HUGE;
+                _rhoVmolar = _HUGE;
+            }
+        } else if (!(_Q >= 0 && _Q <= 1)) {  // mixture, not two-phase
+            _rhoLmolar = _HUGE;
+            _rhoVmolar = _HUGE;
         }
     }
 }

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -2406,6 +2406,169 @@ CoolPropDbl REFPROPMixtureBackend::calc_first_two_phase_deriv(parameters Of, par
     }
 }
 
+CoolPropDbl REFPROPMixtureBackend::calc_second_two_phase_deriv(parameters Of, parameters Wrt1, parameters Constant1, parameters Wrt2,
+                                                               parameters Constant2) {
+    if (!ValidNumber(_rhoLmolar) || !ValidNumber(_rhoVmolar)) {
+        throw ValueError("The saturation properties are needed for calc_second_two_phase_deriv");
+    }
+    shared_ptr<REFPROPMixtureBackend> SatL = build_saturation_shim(0);
+    shared_ptr<REFPROPMixtureBackend> SatV = build_saturation_shim(1);
+
+    if (Of == iDmolar
+        && ((Wrt1 == iHmolar && Constant1 == iP && Wrt2 == iP && Constant2 == iHmolar)
+            || (Wrt2 == iHmolar && Constant2 == iP && Wrt1 == iP && Constant1 == iHmolar))) {
+        parameters h_key = iHmolar, rho_key = iDmolar, p_key = iP;
+        CoolPropDbl dv_dh_constp = calc_first_two_phase_deriv(rho_key, h_key, p_key) / (-POW2(rhomolar()));
+        CoolPropDbl drhomolar_dp__consth = first_two_phase_deriv(rho_key, p_key, h_key);
+
+        CoolPropDbl dhL_dp_sat = SatL->calc_first_saturation_deriv(h_key, p_key);
+        CoolPropDbl dhV_dp_sat = SatV->calc_first_saturation_deriv(h_key, p_key);
+        CoolPropDbl drhoL_dp_sat = SatL->calc_first_saturation_deriv(rho_key, p_key);
+        CoolPropDbl drhoV_dp_sat = SatV->calc_first_saturation_deriv(rho_key, p_key);
+        CoolPropDbl numerator = 1 / SatV->keyed_output(rho_key) - 1 / SatL->keyed_output(rho_key);
+        CoolPropDbl denominator = SatV->keyed_output(h_key) - SatL->keyed_output(h_key);
+        CoolPropDbl dnumerator = -1 / POW2(SatV->keyed_output(rho_key)) * drhoV_dp_sat + 1 / POW2(SatL->keyed_output(rho_key)) * drhoL_dp_sat;
+        CoolPropDbl ddenominator = dhV_dp_sat - dhL_dp_sat;
+        CoolPropDbl d_dvdh_dp__consth = (denominator * dnumerator - numerator * ddenominator) / POW2(denominator);
+        return -POW2(rhomolar()) * d_dvdh_dp__consth + dv_dh_constp * (-2 * rhomolar()) * drhomolar_dp__consth;
+    } else if (Of == iDmass
+               && ((Wrt1 == iHmass && Constant1 == iP && Wrt2 == iP && Constant2 == iHmass)
+                   || (Wrt2 == iHmass && Constant2 == iP && Wrt1 == iP && Constant1 == iHmass))) {
+        parameters h_key = iHmass, rho_key = iDmass, p_key = iP;
+        CoolPropDbl rho = keyed_output(rho_key);
+        CoolPropDbl dv_dh_constp = calc_first_two_phase_deriv(rho_key, h_key, p_key) / (-POW2(rho));
+        CoolPropDbl drho_dp__consth = first_two_phase_deriv(rho_key, p_key, h_key);
+
+        CoolPropDbl dhL_dp_sat = SatL->calc_first_saturation_deriv(h_key, p_key);
+        CoolPropDbl dhV_dp_sat = SatV->calc_first_saturation_deriv(h_key, p_key);
+        CoolPropDbl drhoL_dp_sat = SatL->calc_first_saturation_deriv(rho_key, p_key);
+        CoolPropDbl drhoV_dp_sat = SatV->calc_first_saturation_deriv(rho_key, p_key);
+        CoolPropDbl numerator = 1 / SatV->keyed_output(rho_key) - 1 / SatL->keyed_output(rho_key);
+        CoolPropDbl denominator = SatV->keyed_output(h_key) - SatL->keyed_output(h_key);
+        CoolPropDbl dnumerator = -1 / POW2(SatV->keyed_output(rho_key)) * drhoV_dp_sat + 1 / POW2(SatL->keyed_output(rho_key)) * drhoL_dp_sat;
+        CoolPropDbl ddenominator = dhV_dp_sat - dhL_dp_sat;
+        CoolPropDbl d_dvdh_dp__consth = (denominator * dnumerator - numerator * ddenominator) / POW2(denominator);
+        return -POW2(rho) * d_dvdh_dp__consth + dv_dh_constp * (-2 * rho) * drho_dp__consth;
+    } else {
+        throw ValueError("These inputs are not supported to calc_second_two_phase_deriv");
+    }
+}
+
+CoolPropDbl REFPROPMixtureBackend::calc_first_two_phase_deriv_splined(parameters Of, parameters Wrt, parameters Constant, CoolPropDbl x_end) {
+    // Note: If you need all three values (drho_dh__p, drho_dp__h and rho_spline),
+    // you should calculate drho_dp__h first to avoid duplicate calculations.
+    bool drho_dh__p = false;
+    bool drho_dp__h = false;
+    bool rho_spline = false;
+
+    if (Of == iDmolar && Wrt == iHmolar && Constant == iP) {
+        drho_dh__p = true;
+        if (_drho_spline_dh__constp) return _drho_spline_dh__constp;
+    } else if (Of == iDmass && Wrt == iHmass && Constant == iP) {
+        return first_two_phase_deriv_splined(iDmolar, iHmolar, iP, x_end) * POW2(molar_mass());
+    } else if (Of == iDmolar && Wrt == iP && Constant == iHmolar) {
+        drho_dp__h = true;
+        if (_drho_spline_dp__consth) return _drho_spline_dp__consth;
+    } else if (Of == iDmass && Wrt == iP && Constant == iHmass) {
+        return first_two_phase_deriv_splined(iDmolar, iP, iHmolar, x_end) * molar_mass();
+    } else if (Of == iDmolar && Wrt == iDmolar && Constant == iDmolar) {
+        rho_spline = true;
+        if (_rho_spline) return _rho_spline;
+    } else if (Of == iDmass && Wrt == iDmass && Constant == iDmass) {
+        return first_two_phase_deriv_splined(iDmolar, iDmolar, iDmolar, x_end) * molar_mass();
+    } else {
+        throw ValueError("These inputs are not supported to calc_first_two_phase_deriv");
+    }
+
+    if (!ValidNumber(_rhoLmolar) || !ValidNumber(_rhoVmolar)) {
+        throw ValueError("The saturation properties are needed for calc_first_two_phase_deriv_splined");
+    }
+    if (_Q > x_end) {
+        throw ValueError(format("Q [%g] is greater than x_end [%Lg]", _Q, x_end).c_str());
+    }
+    bool two_phase = (Ncomp == 1) ? (_phase == iphase_twophase) : (_Q >= 0 && _Q <= 1);
+    if (!two_phase) {
+        throw ValueError(format("state is not two-phase"));
+    }
+
+    shared_ptr<REFPROPMixtureBackend> SatL = build_saturation_shim(0);
+    shared_ptr<REFPROPMixtureBackend> SatV = build_saturation_shim(1);
+
+    // Fake single-phase liquid state at the bubble point, and the end-of-spline two-phase state.
+    shared_ptr<REFPROPMixtureBackend> Liq(new REFPROPMixtureBackend());
+    Liq->link_to_loaded_fluids(*this);
+    Liq->set_mole_fractions(this->get_mole_fractions());
+    Liq->specify_phase(iphase_liquid);
+    Liq->_Q = -1;
+    Liq->update_DmolarT_direct(SatL->rhomolar(), SatL->T());
+
+    shared_ptr<REFPROPMixtureBackend> End(new REFPROPMixtureBackend());
+    End->link_to_loaded_fluids(*this);
+    End->set_mole_fractions(this->get_mole_fractions());
+    End->update(QT_INPUTS, x_end, SatL->T());
+
+    CoolPropDbl Delta = Q() * (SatV->keyed_output(iHmolar) - SatL->keyed_output(iHmolar));
+    CoolPropDbl Delta_end = End->keyed_output(iHmolar) - SatL->keyed_output(iHmolar);
+
+    // At the end of the zone to which spline is applied
+    CoolPropDbl drho_dh_end = End->calc_first_two_phase_deriv(iDmolar, iHmolar, iP);
+    CoolPropDbl rho_end = End->keyed_output(iDmolar);
+
+    // Faking single-phase
+    CoolPropDbl rho_liq = Liq->keyed_output(iDmolar);
+    CoolPropDbl drho_dh_liq__constp = Liq->first_partial_deriv(iDmolar, iHmolar, iP);
+
+    // Spline coordinates a, b, c, d
+    CoolPropDbl Abracket = (2 * rho_liq - 2 * rho_end + Delta_end * (drho_dh_liq__constp + drho_dh_end));
+    CoolPropDbl a = 1 / POW3(Delta_end) * Abracket;
+    CoolPropDbl b = 3 / POW2(Delta_end) * (-rho_liq + rho_end) - 1 / Delta_end * (drho_dh_end + 2 * drho_dh_liq__constp);
+    CoolPropDbl c = drho_dh_liq__constp;
+    CoolPropDbl d = rho_liq;
+
+    // Either the spline value or drho/dh|p can be directly evaluated now
+    _rho_spline = a * POW3(Delta) + b * POW2(Delta) + c * Delta + d;
+    _drho_spline_dh__constp = 3 * a * POW2(Delta) + 2 * b * Delta + c;
+    if (rho_spline) return _rho_spline;
+    if (drho_dh__p) return _drho_spline_dh__constp;
+
+    // It's drho/dp|h - calculate some more things
+    // Derivatives *along* the saturation curve
+    CoolPropDbl dhL_dp_sat = SatL->calc_first_saturation_deriv(iHmolar, iP);
+    CoolPropDbl dhV_dp_sat = SatV->calc_first_saturation_deriv(iHmolar, iP);
+    CoolPropDbl drhoL_dp_sat = SatL->calc_first_saturation_deriv(iDmolar, iP);
+    CoolPropDbl drhoV_dp_sat = SatV->calc_first_saturation_deriv(iDmolar, iP);
+    CoolPropDbl rhoV = SatV->keyed_output(iDmolar);
+    CoolPropDbl rhoL = SatL->keyed_output(iDmolar);
+    CoolPropDbl drho_dp_end = POW2(End->keyed_output(iDmolar)) * (x_end / POW2(rhoV) * drhoV_dp_sat + (1 - x_end) / POW2(rhoL) * drhoL_dp_sat);
+
+    // Faking single-phase
+    CoolPropDbl d2rhodhdp_liq = Liq->second_partial_deriv(iDmolar, iHmolar, iP, iP, iHmolar);
+
+    // Derivatives at the end point
+    CoolPropDbl d2rhodhdp_end = End->calc_second_two_phase_deriv(iDmolar, iHmolar, iP, iP, iHmolar);
+
+    // Reminder: Delta = Q()*(hV-hL) = h-hL ; Delta_end = x_end*(hV-hL)
+    CoolPropDbl d_Delta_dp__consth = -dhL_dp_sat;
+    CoolPropDbl d_Delta_end_dp__consth = x_end * (dhV_dp_sat - dhL_dp_sat);
+
+    // First pressure derivative at constant h of the coefficients a,b,c,d
+    CoolPropDbl d_Abracket_dp_consth = (2 * drhoL_dp_sat - 2 * drho_dp_end + Delta_end * (d2rhodhdp_liq + d2rhodhdp_end)
+                                        + d_Delta_end_dp__consth * (drho_dh_liq__constp + drho_dh_end));
+    CoolPropDbl da_dp = 1 / POW3(Delta_end) * d_Abracket_dp_consth + Abracket * (-3 / POW4(Delta_end) * d_Delta_end_dp__consth);
+    CoolPropDbl db_dp = -6 / POW3(Delta_end) * d_Delta_end_dp__consth * (rho_end - rho_liq) + 3 / POW2(Delta_end) * (drho_dp_end - drhoL_dp_sat)
+                        + (1 / POW2(Delta_end) * d_Delta_end_dp__consth) * (drho_dh_end + 2 * drho_dh_liq__constp)
+                        - (1 / Delta_end) * (d2rhodhdp_end + 2 * d2rhodhdp_liq);
+    CoolPropDbl dc_dp = d2rhodhdp_liq;
+    CoolPropDbl dd_dp = drhoL_dp_sat;
+
+    _drho_spline_dp__consth =
+      (3 * a * POW2(Delta) + 2 * b * Delta + c) * d_Delta_dp__consth + POW3(Delta) * da_dp + POW2(Delta) * db_dp + Delta * dc_dp + dd_dp;
+    if (drho_dp__h) return _drho_spline_dp__consth;
+
+    throw ValueError("Something went wrong in REFPROPMixtureBackend::calc_first_two_phase_deriv_splined");
+    return _HUGE;
+}
+
 CoolPropDbl REFPROPMixtureBackend::calc_saturated_liquid_keyed_output(parameters key) {
     if (!ValidNumber(_rhoLmolar)) {
         throw ValueError("The saturated liquid state has not been set.");

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -2299,6 +2299,69 @@ shared_ptr<REFPROPMixtureBackend> REFPROPMixtureBackend::build_saturation_shim(i
     return shim;
 }
 
+double REFPROPMixtureBackend::dpdT_along_saturation_pure(int kph) {
+    int icomp = 1;  // pure fluid
+    double T_K = static_cast<double>(_T);
+    double p_kPa = _HUGE, rho_mol_L = _HUGE, csat = _HUGE, dpdt_kPa_K = _HUGE;
+    int ierr = 0;
+    std::array<char, errormessagelength> herr{};
+    DPTSATKdll(&icomp, &T_K, &kph, &p_kPa, &rho_mol_L, &csat, &dpdt_kPa_K, &ierr, herr.data(), errormessagelength);
+    if (static_cast<int>(ierr) > get_config_int(REFPROP_ERROR_THRESHOLD)) {
+        throw ValueError(format("%s", herr.data()));
+    }
+    return 1000.0 * dpdt_kPa_K;  // kPa/K -> Pa/K
+}
+
+double REFPROPMixtureBackend::saturation_pressure_at_T(double T, int Q) {
+    // Q==0 -> bubble (kph=1), Q==1 -> dew (kph=2). Mirror update()'s QT_INPUTS SATTdll call.
+    int kph = (Q == 0) ? 1 : 2;
+    double T_K = T, p_kPa = _HUGE, rhoLmol_L = _HUGE, rhoVmol_L = _HUGE;
+    int ierr = 0;
+    std::array<char, errormessagelength> herr{};
+    std::vector<double> xliq(ncmax, 0.0), xvap(ncmax, 0.0);
+    SATTdll(&T_K, &(mole_fractions[0]), &kph, &p_kPa, &rhoLmol_L, &rhoVmol_L, &(xliq[0]), &(xvap[0]), &ierr, herr.data(), errormessagelength);
+    if (static_cast<int>(ierr) > get_config_int(REFPROP_ERROR_THRESHOLD)) {
+        throw ValueError(format("%s", herr.data()));
+    }
+    return 1000.0 * p_kPa;  // kPa -> Pa
+}
+
+CoolPropDbl REFPROPMixtureBackend::calc_first_saturation_deriv(parameters Of1, parameters Wrt1) {
+    this->check_loaded_fluid();
+
+    if (!(_Q == 0 || _Q == 1)) {
+        throw ValueError(format("calc_first_saturation_deriv requires Q==0 (bubble) or Q==1 (dew); got Q=%g", _Q));
+    }
+    CoolPropDbl dTdP_sat;
+    if (Ncomp == 1) {
+        // Pure fluid: REFPROP gives dP/dT along the saturation line natively via
+        // DPTSATKdll (dpdt in kPa/K). icomp=1, kph: 1=liquid(bubble), 2=vapor(dew).
+        // (Equivalent to Clausius-Clapeyron T*(vV-vL)/(hV-hL); we use the native call.)
+        dTdP_sat = 1.0 / dpdT_along_saturation_pure(_Q == 1 ? 2 : 1);  // Pa/K
+    } else {
+        // Mixture: DPTSATKdll is a PER-COMPONENT routine (icomp); it does NOT give the
+        // constant-overall-composition bubble/dew slope a mixture needs. So differentiate
+        // REFPROP's own SATTdll flash numerically at fixed overall composition.
+        const double dT = 1e-3 * static_cast<double>(_T);  // relative central step
+        double pp = saturation_pressure_at_T(_T + dT, static_cast<int>(_Q));
+        double pm = saturation_pressure_at_T(_T - dT, static_cast<int>(_Q));
+        dTdP_sat = (2 * dT) / (pp - pm);
+    }
+
+    if (Of1 == iT && Wrt1 == iP) {
+        return dTdP_sat;
+    } else if (Of1 == iP && Wrt1 == iT) {
+        return 1 / dTdP_sat;
+    } else if (Wrt1 == iT) {
+        return first_partial_deriv(Of1, iT, iP) + first_partial_deriv(Of1, iP, iT) / dTdP_sat;
+    } else if (Wrt1 == iP) {
+        return first_partial_deriv(Of1, iP, iT) + first_partial_deriv(Of1, iT, iP) * dTdP_sat;
+    } else {
+        throw ValueError(
+          format("Not possible to take first saturation derivative with respect to %s", get_parameter_information(Wrt1, "short").c_str()));
+    }
+}
+
 CoolPropDbl REFPROPMixtureBackend::calc_saturated_liquid_keyed_output(parameters key) {
     if (!ValidNumber(_rhoLmolar)) {
         throw ValueError("The saturated liquid state has not been set.");

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -2345,7 +2345,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_first_saturation_deriv(parameters Of1, p
     // The saturation slope comes from REFPROP's own DPTSATKdll/SATTdll at (T, composition),
     // so this needs only a valid two-phase _Q, not the L/V saturation densities. (This is
     // also why it works when invoked on a single-phase saturation shim, whose _Q is 0 or 1.)
-    CoolPropDbl dTdP_sat;
+    CoolPropDbl dTdP_sat = _HUGE;
     if (Ncomp == 1) {
         // Pure fluid: dP/dT along the vapor-pressure curve is independent of quality, so
         // any two-phase state (0<=Q<=1) is valid. DPTSATKdll (icomp=1) returns it natively;
@@ -2444,7 +2444,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_second_two_phase_deriv(parameters Of, pa
             || (Wrt2 == iHmolar && Constant2 == iP && Wrt1 == iP && Constant1 == iHmolar))) {
         parameters h_key = iHmolar, rho_key = iDmolar, p_key = iP;
         CoolPropDbl dv_dh_constp = calc_first_two_phase_deriv(rho_key, h_key, p_key) / (-POW2(rhomolar()));
-        CoolPropDbl drhomolar_dp__consth = first_two_phase_deriv(rho_key, p_key, h_key);
+        CoolPropDbl drhomolar_dp_consth = first_two_phase_deriv(rho_key, p_key, h_key);
 
         CoolPropDbl dhL_dp_sat = SatL->calc_first_saturation_deriv(h_key, p_key);
         CoolPropDbl dhV_dp_sat = SatV->calc_first_saturation_deriv(h_key, p_key);
@@ -2454,15 +2454,15 @@ CoolPropDbl REFPROPMixtureBackend::calc_second_two_phase_deriv(parameters Of, pa
         CoolPropDbl denominator = SatV->keyed_output(h_key) - SatL->keyed_output(h_key);
         CoolPropDbl dnumerator = -1 / POW2(SatV->keyed_output(rho_key)) * drhoV_dp_sat + 1 / POW2(SatL->keyed_output(rho_key)) * drhoL_dp_sat;
         CoolPropDbl ddenominator = dhV_dp_sat - dhL_dp_sat;
-        CoolPropDbl d_dvdh_dp__consth = (denominator * dnumerator - numerator * ddenominator) / POW2(denominator);
-        return -POW2(rhomolar()) * d_dvdh_dp__consth + dv_dh_constp * (-2 * rhomolar()) * drhomolar_dp__consth;
+        CoolPropDbl d_dvdh_dp_consth = (denominator * dnumerator - numerator * ddenominator) / POW2(denominator);
+        return -POW2(rhomolar()) * d_dvdh_dp_consth + dv_dh_constp * (-2 * rhomolar()) * drhomolar_dp_consth;
     } else if (Of == iDmass
                && ((Wrt1 == iHmass && Constant1 == iP && Wrt2 == iP && Constant2 == iHmass)
                    || (Wrt2 == iHmass && Constant2 == iP && Wrt1 == iP && Constant1 == iHmass))) {
         parameters h_key = iHmass, rho_key = iDmass, p_key = iP;
         CoolPropDbl rho = keyed_output(rho_key);
         CoolPropDbl dv_dh_constp = calc_first_two_phase_deriv(rho_key, h_key, p_key) / (-POW2(rho));
-        CoolPropDbl drho_dp__consth = first_two_phase_deriv(rho_key, p_key, h_key);
+        CoolPropDbl drho_dp_consth = first_two_phase_deriv(rho_key, p_key, h_key);
 
         CoolPropDbl dhL_dp_sat = SatL->calc_first_saturation_deriv(h_key, p_key);
         CoolPropDbl dhV_dp_sat = SatV->calc_first_saturation_deriv(h_key, p_key);
@@ -2472,8 +2472,8 @@ CoolPropDbl REFPROPMixtureBackend::calc_second_two_phase_deriv(parameters Of, pa
         CoolPropDbl denominator = SatV->keyed_output(h_key) - SatL->keyed_output(h_key);
         CoolPropDbl dnumerator = -1 / POW2(SatV->keyed_output(rho_key)) * drhoV_dp_sat + 1 / POW2(SatL->keyed_output(rho_key)) * drhoL_dp_sat;
         CoolPropDbl ddenominator = dhV_dp_sat - dhL_dp_sat;
-        CoolPropDbl d_dvdh_dp__consth = (denominator * dnumerator - numerator * ddenominator) / POW2(denominator);
-        return -POW2(rho) * d_dvdh_dp__consth + dv_dh_constp * (-2 * rho) * drho_dp__consth;
+        CoolPropDbl d_dvdh_dp_consth = (denominator * dnumerator - numerator * ddenominator) / POW2(denominator);
+        return -POW2(rho) * d_dvdh_dp_consth + dv_dh_constp * (-2 * rho) * drho_dp_consth;
     } else {
         throw ValueError("These inputs are not supported to calc_second_two_phase_deriv");
     }
@@ -2483,19 +2483,19 @@ CoolPropDbl REFPROPMixtureBackend::calc_first_two_phase_deriv_splined(parameters
     if (Ncomp > 1) {
         throw NotImplementedError("calc_first_two_phase_deriv_splined is not implemented for mixtures in the REFPROP backend");
     }
-    // Note: If you need all three values (drho_dh__p, drho_dp__h and rho_spline),
-    // you should calculate drho_dp__h first to avoid duplicate calculations.
-    bool drho_dh__p = false;
-    bool drho_dp__h = false;
+    // Note: If you need all three values (drho_dh_p, drho_dp_h and rho_spline),
+    // you should calculate drho_dp_h first to avoid duplicate calculations.
+    bool drho_dh_p = false;
+    bool drho_dp_h = false;
     bool rho_spline = false;
 
     if (Of == iDmolar && Wrt == iHmolar && Constant == iP) {
-        drho_dh__p = true;
+        drho_dh_p = true;
         if (_drho_spline_dh__constp) return _drho_spline_dh__constp;
     } else if (Of == iDmass && Wrt == iHmass && Constant == iP) {
         return first_two_phase_deriv_splined(iDmolar, iHmolar, iP, x_end) * POW2(molar_mass());
     } else if (Of == iDmolar && Wrt == iP && Constant == iHmolar) {
-        drho_dp__h = true;
+        drho_dp_h = true;
         if (_drho_spline_dp__consth) return _drho_spline_dp__consth;
     } else if (Of == iDmass && Wrt == iP && Constant == iHmass) {
         return first_two_phase_deriv_splined(iDmolar, iP, iHmolar, x_end) * molar_mass();
@@ -2544,20 +2544,20 @@ CoolPropDbl REFPROPMixtureBackend::calc_first_two_phase_deriv_splined(parameters
 
     // Faking single-phase
     CoolPropDbl rho_liq = Liq->keyed_output(iDmolar);
-    CoolPropDbl drho_dh_liq__constp = Liq->first_partial_deriv(iDmolar, iHmolar, iP);
+    CoolPropDbl drho_dh_liq_constp = Liq->first_partial_deriv(iDmolar, iHmolar, iP);
 
     // Spline coordinates a, b, c, d
-    CoolPropDbl Abracket = (2 * rho_liq - 2 * rho_end + Delta_end * (drho_dh_liq__constp + drho_dh_end));
+    CoolPropDbl Abracket = (2 * rho_liq - 2 * rho_end + Delta_end * (drho_dh_liq_constp + drho_dh_end));
     CoolPropDbl a = 1 / POW3(Delta_end) * Abracket;
-    CoolPropDbl b = 3 / POW2(Delta_end) * (-rho_liq + rho_end) - 1 / Delta_end * (drho_dh_end + 2 * drho_dh_liq__constp);
-    CoolPropDbl c = drho_dh_liq__constp;
+    CoolPropDbl b = 3 / POW2(Delta_end) * (-rho_liq + rho_end) - 1 / Delta_end * (drho_dh_end + 2 * drho_dh_liq_constp);
+    CoolPropDbl c = drho_dh_liq_constp;
     CoolPropDbl d = rho_liq;
 
     // Either the spline value or drho/dh|p can be directly evaluated now
     _rho_spline = a * POW3(Delta) + b * POW2(Delta) + c * Delta + d;
     _drho_spline_dh__constp = 3 * a * POW2(Delta) + 2 * b * Delta + c;
     if (rho_spline) return _rho_spline;
-    if (drho_dh__p) return _drho_spline_dh__constp;
+    if (drho_dh_p) return _drho_spline_dh__constp;
 
     // It's drho/dp|h - calculate some more things
     // Derivatives *along* the saturation curve
@@ -2576,22 +2576,22 @@ CoolPropDbl REFPROPMixtureBackend::calc_first_two_phase_deriv_splined(parameters
     CoolPropDbl d2rhodhdp_end = End->calc_second_two_phase_deriv(iDmolar, iHmolar, iP, iP, iHmolar);
 
     // Reminder: Delta = Q()*(hV-hL) = h-hL ; Delta_end = x_end*(hV-hL)
-    CoolPropDbl d_Delta_dp__consth = -dhL_dp_sat;
-    CoolPropDbl d_Delta_end_dp__consth = x_end * (dhV_dp_sat - dhL_dp_sat);
+    CoolPropDbl d_Delta_dp_consth = -dhL_dp_sat;
+    CoolPropDbl d_Delta_end_dp_consth = x_end * (dhV_dp_sat - dhL_dp_sat);
 
     // First pressure derivative at constant h of the coefficients a,b,c,d
-    CoolPropDbl d_Abracket_dp_consth = (2 * drhoL_dp_sat - 2 * drho_dp_end + Delta_end * (d2rhodhdp_liq + d2rhodhdp_end)
-                                        + d_Delta_end_dp__consth * (drho_dh_liq__constp + drho_dh_end));
-    CoolPropDbl da_dp = 1 / POW3(Delta_end) * d_Abracket_dp_consth + Abracket * (-3 / POW4(Delta_end) * d_Delta_end_dp__consth);
-    CoolPropDbl db_dp = -6 / POW3(Delta_end) * d_Delta_end_dp__consth * (rho_end - rho_liq) + 3 / POW2(Delta_end) * (drho_dp_end - drhoL_dp_sat)
-                        + (1 / POW2(Delta_end) * d_Delta_end_dp__consth) * (drho_dh_end + 2 * drho_dh_liq__constp)
+    CoolPropDbl d_Abracket_dp_consth =
+      (2 * drhoL_dp_sat - 2 * drho_dp_end + Delta_end * (d2rhodhdp_liq + d2rhodhdp_end) + d_Delta_end_dp_consth * (drho_dh_liq_constp + drho_dh_end));
+    CoolPropDbl da_dp = 1 / POW3(Delta_end) * d_Abracket_dp_consth + Abracket * (-3 / POW4(Delta_end) * d_Delta_end_dp_consth);
+    CoolPropDbl db_dp = -6 / POW3(Delta_end) * d_Delta_end_dp_consth * (rho_end - rho_liq) + 3 / POW2(Delta_end) * (drho_dp_end - drhoL_dp_sat)
+                        + (1 / POW2(Delta_end) * d_Delta_end_dp_consth) * (drho_dh_end + 2 * drho_dh_liq_constp)
                         - (1 / Delta_end) * (d2rhodhdp_end + 2 * d2rhodhdp_liq);
     CoolPropDbl dc_dp = d2rhodhdp_liq;
     CoolPropDbl dd_dp = drhoL_dp_sat;
 
     _drho_spline_dp__consth =
-      (3 * a * POW2(Delta) + 2 * b * Delta + c) * d_Delta_dp__consth + POW3(Delta) * da_dp + POW2(Delta) * db_dp + Delta * dc_dp + dd_dp;
-    if (drho_dp__h) return _drho_spline_dp__consth;
+      (3 * a * POW2(Delta) + 2 * b * Delta + c) * d_Delta_dp_consth + POW3(Delta) * da_dp + POW2(Delta) * db_dp + Delta * dc_dp + dd_dp;
+    if (drho_dp_h) return _drho_spline_dp__consth;
 
     throw ValueError("Something went wrong in REFPROPMixtureBackend::calc_first_two_phase_deriv_splined");
     return _HUGE;

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -2170,7 +2170,7 @@ void REFPROPMixtureBackend::update_DmolarT_direct(CoolPropDbl rhomolar, CoolProp
     _Q = -1;  // not on the saturation envelope by construction
 
     double rho_mol_L = 0.001 * static_cast<double>(_rhomolar);
-    double T_K = static_cast<double>(_T);
+    auto T_K = static_cast<double>(_T);
     double p_kPa = _HUGE, emol = _HUGE, hmol = _HUGE, smol = _HUGE, cvmol = _HUGE, cpmol = _HUGE, w = _HUGE, hjt = _HUGE;
     THERMdll(&T_K, &rho_mol_L, &(mole_fractions[0]), &p_kPa, &emol, &hmol, &smol, &cvmol, &cpmol, &w, &hjt);
 
@@ -2292,8 +2292,10 @@ shared_ptr<REFPROPMixtureBackend> REFPROPMixtureBackend::build_saturation_shim(i
         throw ValueError(format("build_saturation_shim requires Q==0 or Q==1; got %d", Q));
     }
     const std::vector<double>& x_phase = (Q == 0) ? mole_fractions_liq : mole_fractions_vap;
-    CoolPropDbl rho_phase = (Q == 0) ? _rhoLmolar : _rhoVmolar;
-    if (!ValidNumber(rho_phase)) {
+    // is_cached (operator bool) check first: operator double()/CoolPropDbl() throws if uncached.
+    bool have = (Q == 0) ? static_cast<bool>(_rhoLmolar) : static_cast<bool>(_rhoVmolar);
+    CoolPropDbl rho_phase = have ? ((Q == 0) ? static_cast<CoolPropDbl>(_rhoLmolar) : static_cast<CoolPropDbl>(_rhoVmolar)) : _HUGE;
+    if (!have || !ValidNumber(rho_phase)) {
         throw ValueError("The saturated state has not been set (no two-phase density available).");
     }
     shared_ptr<REFPROPMixtureBackend> shim(new REFPROPMixtureBackend());
@@ -2308,8 +2310,11 @@ shared_ptr<REFPROPMixtureBackend> REFPROPMixtureBackend::build_saturation_shim(i
 }
 
 double REFPROPMixtureBackend::dpdT_along_saturation_pure(int kph) {
+    if (Ncomp != 1) {  // precondition: DPTSATKdll is a single-component saturation routine
+        throw ValueError("dpdT_along_saturation_pure is only valid for pure fluids");
+    }
     int icomp = 1;  // pure fluid
-    double T_K = static_cast<double>(_T);
+    auto T_K = static_cast<double>(_T);
     double p_kPa = _HUGE, rho_mol_L = _HUGE, csat = _HUGE, dpdt_kPa_K = _HUGE;
     int ierr = 0;
     std::array<char, errormessagelength> herr{};
@@ -2337,22 +2342,32 @@ double REFPROPMixtureBackend::saturation_pressure_at_T(double T, int Q) {
 CoolPropDbl REFPROPMixtureBackend::calc_first_saturation_deriv(parameters Of1, parameters Wrt1) {
     this->check_loaded_fluid();
 
-    if (!(_Q == 0 || _Q == 1)) {
-        throw ValueError(format("calc_first_saturation_deriv requires Q==0 (bubble) or Q==1 (dew); got Q=%g", _Q));
-    }
+    // The saturation slope comes from REFPROP's own DPTSATKdll/SATTdll at (T, composition),
+    // so this needs only a valid two-phase _Q, not the L/V saturation densities. (This is
+    // also why it works when invoked on a single-phase saturation shim, whose _Q is 0 or 1.)
     CoolPropDbl dTdP_sat;
     if (Ncomp == 1) {
-        // Pure fluid: REFPROP gives dP/dT along the saturation line natively via
-        // DPTSATKdll (dpdt in kPa/K). icomp=1, kph: 1=liquid(bubble), 2=vapor(dew).
-        // (Equivalent to Clausius-Clapeyron T*(vV-vL)/(hV-hL); we use the native call.)
-        dTdP_sat = 1.0 / dpdT_along_saturation_pure(_Q == 1 ? 2 : 1);  // Pa/K
+        // Pure fluid: dP/dT along the vapor-pressure curve is independent of quality, so
+        // any two-phase state (0<=Q<=1) is valid. DPTSATKdll (icomp=1) returns it natively;
+        // kph=1 (liquid side) suffices for a pure fluid (liquid and vapor lines coincide).
+        if (!(_Q >= 0 && _Q <= 1)) {
+            throw ValueError(format("calc_first_saturation_deriv requires a two-phase state (0<=Q<=1); got Q=%g", _Q));
+        }
+        dTdP_sat = 1.0 / dpdT_along_saturation_pure(1);  // Pa/K
     } else {
         // Mixture: DPTSATKdll is a PER-COMPONENT routine (icomp); it does NOT give the
         // constant-overall-composition bubble/dew slope a mixture needs. So differentiate
-        // REFPROP's own SATTdll flash numerically at fixed overall composition.
+        // REFPROP's own SATTdll flash numerically at fixed overall composition. Only defined
+        // on the bubble (Q==0) or dew (Q==1) curve (tolerance mirrors update()'s 1e-10).
+        bool at_bubble = std::abs(_Q) < 1e-10;
+        bool at_dew = std::abs(_Q - 1) < 1e-10;
+        if (!at_bubble && !at_dew) {
+            throw ValueError(format("calc_first_saturation_deriv requires Q==0 (bubble) or Q==1 (dew) for mixtures; got Q=%g", _Q));
+        }
+        int Qint = at_dew ? 1 : 0;
         const double dT = 1e-3 * static_cast<double>(_T);  // relative central step
-        double pp = saturation_pressure_at_T(_T + dT, static_cast<int>(_Q));
-        double pm = saturation_pressure_at_T(_T - dT, static_cast<int>(_Q));
+        double pp = saturation_pressure_at_T(static_cast<double>(_T) + dT, Qint);
+        double pm = saturation_pressure_at_T(static_cast<double>(_T) - dT, Qint);
         dTdP_sat = (2 * dT) / (pp - pm);
     }
 
@@ -2371,7 +2386,14 @@ CoolPropDbl REFPROPMixtureBackend::calc_first_saturation_deriv(parameters Of1, p
 }
 
 CoolPropDbl REFPROPMixtureBackend::calc_first_two_phase_deriv(parameters Of, parameters Wrt, parameters Constant) {
-    if (!ValidNumber(_rhoLmolar) || !ValidNumber(_rhoVmolar)) {
+    if (Ncomp > 1) {
+        // The constant-overall-composition saturation slope a mixture two-phase derivative
+        // needs is not available from the per-phase saturation shims; only pure fluids are
+        // supported here. (Mixture saturated-state properties and bubble/dew first_saturation_deriv
+        // are available separately.)
+        throw NotImplementedError("calc_first_two_phase_deriv is not implemented for mixtures in the REFPROP backend");
+    }
+    if (!_rhoLmolar || !_rhoVmolar || !ValidNumber(static_cast<CoolPropDbl>(_rhoLmolar)) || !ValidNumber(static_cast<CoolPropDbl>(_rhoVmolar))) {
         throw ValueError("The saturation properties are needed for calc_first_two_phase_deriv");
     }
     shared_ptr<REFPROPMixtureBackend> SatL = build_saturation_shim(0);
@@ -2408,7 +2430,10 @@ CoolPropDbl REFPROPMixtureBackend::calc_first_two_phase_deriv(parameters Of, par
 
 CoolPropDbl REFPROPMixtureBackend::calc_second_two_phase_deriv(parameters Of, parameters Wrt1, parameters Constant1, parameters Wrt2,
                                                                parameters Constant2) {
-    if (!ValidNumber(_rhoLmolar) || !ValidNumber(_rhoVmolar)) {
+    if (Ncomp > 1) {
+        throw NotImplementedError("calc_second_two_phase_deriv is not implemented for mixtures in the REFPROP backend");
+    }
+    if (!_rhoLmolar || !_rhoVmolar || !ValidNumber(static_cast<CoolPropDbl>(_rhoLmolar)) || !ValidNumber(static_cast<CoolPropDbl>(_rhoVmolar))) {
         throw ValueError("The saturation properties are needed for calc_second_two_phase_deriv");
     }
     shared_ptr<REFPROPMixtureBackend> SatL = build_saturation_shim(0);
@@ -2455,6 +2480,9 @@ CoolPropDbl REFPROPMixtureBackend::calc_second_two_phase_deriv(parameters Of, pa
 }
 
 CoolPropDbl REFPROPMixtureBackend::calc_first_two_phase_deriv_splined(parameters Of, parameters Wrt, parameters Constant, CoolPropDbl x_end) {
+    if (Ncomp > 1) {
+        throw NotImplementedError("calc_first_two_phase_deriv_splined is not implemented for mixtures in the REFPROP backend");
+    }
     // Note: If you need all three values (drho_dh__p, drho_dp__h and rho_spline),
     // you should calculate drho_dp__h first to avoid duplicate calculations.
     bool drho_dh__p = false;
@@ -2480,7 +2508,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_first_two_phase_deriv_splined(parameters
         throw ValueError("These inputs are not supported to calc_first_two_phase_deriv");
     }
 
-    if (!ValidNumber(_rhoLmolar) || !ValidNumber(_rhoVmolar)) {
+    if (!_rhoLmolar || !_rhoVmolar || !ValidNumber(static_cast<CoolPropDbl>(_rhoLmolar)) || !ValidNumber(static_cast<CoolPropDbl>(_rhoVmolar))) {
         throw ValueError("The saturation properties are needed for calc_first_two_phase_deriv_splined");
     }
     if (_Q > x_end) {
@@ -2570,7 +2598,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_first_two_phase_deriv_splined(parameters
 }
 
 CoolPropDbl REFPROPMixtureBackend::calc_saturated_liquid_keyed_output(parameters key) {
-    if (!ValidNumber(_rhoLmolar)) {
+    if (!_rhoLmolar || !ValidNumber(static_cast<CoolPropDbl>(_rhoLmolar))) {
         throw ValueError("The saturated liquid state has not been set.");
     }
     switch (key) {
@@ -2590,7 +2618,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_saturated_liquid_keyed_output(parameters
     }
 }
 CoolPropDbl REFPROPMixtureBackend::calc_saturated_vapor_keyed_output(parameters key) {
-    if (!ValidNumber(_rhoVmolar)) {
+    if (!_rhoVmolar || !ValidNumber(static_cast<CoolPropDbl>(_rhoVmolar))) {
         throw ValueError("The saturated vapor state has not been set.");
     }
     switch (key) {

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -2505,7 +2505,7 @@ CoolPropDbl REFPROPMixtureBackend::calc_first_two_phase_deriv_splined(parameters
     } else if (Of == iDmass && Wrt == iDmass && Constant == iDmass) {
         return first_two_phase_deriv_splined(iDmolar, iDmolar, iDmolar, x_end) * molar_mass();
     } else {
-        throw ValueError("These inputs are not supported to calc_first_two_phase_deriv");
+        throw ValueError("These inputs are not supported to calc_first_two_phase_deriv_splined");
     }
 
     if (!_rhoLmolar || !_rhoVmolar || !ValidNumber(static_cast<CoolPropDbl>(_rhoLmolar)) || !ValidNumber(static_cast<CoolPropDbl>(_rhoVmolar))) {

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -2153,6 +2153,30 @@ void REFPROPMixtureBackend::update_with_guesses(CoolProp::input_pairs input_pair
     _delta = _rhomolar / calc_rhomolar_reducing();
     _Q = q;
 }
+
+void REFPROPMixtureBackend::update_DmolarT_direct(CoolPropDbl rhomolar, CoolPropDbl T) {
+    this->check_loaded_fluid();
+    clear();
+    _T = T;
+    _rhomolar = rhomolar;
+    _Q = -1;  // not on the saturation envelope by construction
+
+    double rho_mol_L = 0.001 * static_cast<double>(_rhomolar);
+    double T_K = static_cast<double>(_T);
+    double p_kPa = _HUGE, emol = _HUGE, hmol = _HUGE, smol = _HUGE, cvmol = _HUGE, cpmol = _HUGE, w = _HUGE, hjt = _HUGE;
+    THERMdll(&T_K, &rho_mol_L, &(mole_fractions[0]), &p_kPa, &emol, &hmol, &smol, &cvmol, &cpmol, &w, &hjt);
+
+    _p = 1000.0 * p_kPa;
+    _hmolar = hmol;
+    _smolar = smol;
+    _umolar = emol;
+    _cvmolar = cvmol;
+    _cpmolar = cpmol;
+    _speed_sound = w;
+    _gibbsmolar = hmol - T_K * smol;
+    _tau = calc_T_reducing() / _T;
+    _delta = _rhomolar / calc_rhomolar_reducing();
+}
 CoolPropDbl REFPROPMixtureBackend::call_phixdll(int itau, int idel) {
     this->check_loaded_fluid();
     double val = 0, tau = _tau, delta = _delta;

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -2300,40 +2300,44 @@ shared_ptr<REFPROPMixtureBackend> REFPROPMixtureBackend::build_saturation_shim(i
 }
 
 CoolPropDbl REFPROPMixtureBackend::calc_saturated_liquid_keyed_output(parameters key) {
-    if (_rhoLmolar) {
-        if (key == iDmolar) {
+    if (!ValidNumber(_rhoLmolar)) {
+        throw ValueError("The saturated liquid state has not been set.");
+    }
+    switch (key) {
+        case iDmolar:
             return _rhoLmolar;
-        } else if (key == iDmass) {
+        case iDmass:
             return static_cast<double>(_rhoLmolar) * calc_saturated_liquid_keyed_output(imolar_mass);
-        } else if (key == imolar_mass) {
+        case imolar_mass: {
             double wmm_kg_kmol = 0;
             WMOLdll(&(mole_fractions_liq[0]), &wmm_kg_kmol);  // returns mole mass in kg/kmol
             return wmm_kg_kmol / 1000;                        // kg/mol
-        } else {
-            throw ValueError("Invalid parameter. Only mass and molar density are available with RefProp");
-            return _HUGE;
+        }
+        default: {
+            shared_ptr<REFPROPMixtureBackend> shimL = build_saturation_shim(0);
+            return shimL->keyed_output(key);
         }
     }
-    throw ValueError("The saturated liquid state has not been set.");
-    return _HUGE;
 }
 CoolPropDbl REFPROPMixtureBackend::calc_saturated_vapor_keyed_output(parameters key) {
-    if (_rhoVmolar) {
-        if (key == iDmolar) {
+    if (!ValidNumber(_rhoVmolar)) {
+        throw ValueError("The saturated vapor state has not been set.");
+    }
+    switch (key) {
+        case iDmolar:
             return _rhoVmolar;
-        } else if (key == iDmass) {
+        case iDmass:
             return static_cast<double>(_rhoVmolar) * calc_saturated_vapor_keyed_output(imolar_mass);
-        } else if (key == imolar_mass) {
+        case imolar_mass: {
             double wmm_kg_kmol = 0;
             WMOLdll(&(mole_fractions_vap[0]), &wmm_kg_kmol);  // returns mole mass in kg/kmol
             return wmm_kg_kmol / 1000;                        // kg/mol
-        } else {
-            throw ValueError("Invalid key.");
-            return _HUGE;
+        }
+        default: {
+            shared_ptr<REFPROPMixtureBackend> shimV = build_saturation_shim(1);
+            return shimV->keyed_output(key);
         }
     }
-    throw ValueError("The saturated vapor state has not been set.");
-    return _HUGE;
 }
 
 void REFPROPMixtureBackend::calc_ideal_curve(const std::string& type, std::vector<double>& T, std::vector<double>& p) {

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -2266,6 +2266,39 @@ void REFPROPMixtureBackend::calc_true_critical_point(double& T, double& rho) {
     rho = xfinal[1] * 1000.0;
 }
 
+void REFPROPMixtureBackend::link_to_loaded_fluids(const REFPROPMixtureBackend& host) {
+    // Per-class access: we may read host's private cached_component_string.
+    this->Ncomp = host.Ncomp;
+    this->fluid_names = host.fluid_names;
+    this->cached_component_string = host.cached_component_string;  // => check_loaded_fluid() reuse path, no SETUPdll
+    this->mole_fractions.assign(ncmax, 0.0);
+    this->mole_fractions_liq.assign(ncmax, 0.0);
+    this->mole_fractions_vap.assign(ncmax, 0.0);
+    this->imposed_phase_index = iphase_not_imposed;
+    this->_mole_fractions_set = false;
+}
+
+shared_ptr<REFPROPMixtureBackend> REFPROPMixtureBackend::build_saturation_shim(int Q) {
+    this->check_loaded_fluid();
+    if (!(Q == 0 || Q == 1)) {
+        throw ValueError(format("build_saturation_shim requires Q==0 or Q==1; got %d", Q));
+    }
+    const std::vector<double>& x_phase = (Q == 0) ? mole_fractions_liq : mole_fractions_vap;
+    CoolPropDbl rho_phase = (Q == 0) ? _rhoLmolar : _rhoVmolar;
+    if (!ValidNumber(rho_phase)) {
+        throw ValueError("The saturated state has not been set (no two-phase density available).");
+    }
+    shared_ptr<REFPROPMixtureBackend> shim(new REFPROPMixtureBackend());
+    shim->link_to_loaded_fluids(*this);
+    // Copy only the first Ncomp entries of the per-phase composition.
+    std::vector<CoolPropDbl> x(x_phase.begin(), x_phase.begin() + Ncomp);
+    shim->set_mole_fractions(x);
+    shim->specify_phase((Q == 0) ? iphase_liquid : iphase_gas);
+    shim->update_DmolarT_direct(rho_phase, _T);
+    shim->_Q = static_cast<CoolPropDbl>(Q);  // mark the shim as sitting on the envelope
+    return shim;
+}
+
 CoolPropDbl REFPROPMixtureBackend::calc_saturated_liquid_keyed_output(parameters key) {
     if (_rhoLmolar) {
         if (key == iDmolar) {

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.h
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.h
@@ -175,6 +175,8 @@ class REFPROPMixtureBackend : public AbstractState
     CoolPropDbl calc_first_saturation_deriv(parameters Of1, parameters Wrt1) override;
 
     CoolPropDbl calc_first_two_phase_deriv(parameters Of, parameters Wrt, parameters Constant) override;
+    CoolPropDbl calc_second_two_phase_deriv(parameters Of, parameters Wrt1, parameters Constant1, parameters Wrt2, parameters Constant2) override;
+    CoolPropDbl calc_first_two_phase_deriv_splined(parameters Of, parameters Wrt, parameters Constant, CoolPropDbl x_end) override;
 
     CoolPropDbl calc_molar_mass() override;
 

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.h
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.h
@@ -174,6 +174,8 @@ class REFPROPMixtureBackend : public AbstractState
 
     CoolPropDbl calc_first_saturation_deriv(parameters Of1, parameters Wrt1) override;
 
+    CoolPropDbl calc_first_two_phase_deriv(parameters Of, parameters Wrt, parameters Constant) override;
+
     CoolPropDbl calc_molar_mass() override;
 
     PhaseMolarMasses calc_phase_molar_masses() override;

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.h
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.h
@@ -76,16 +76,14 @@ class REFPROPMixtureBackend : public AbstractState
     PhaseEnvelopeData PhaseEnvelope;
 
     /// Set binary mixture floating point parameter
-    void set_binary_interaction_double(const std::string& CAS1, const std::string& CAS2, const std::string& parameter,
-                                       const double value) override;
+    void set_binary_interaction_double(const std::string& CAS1, const std::string& CAS2, const std::string& parameter, const double value) override;
     /// Get binary mixture double value
     double get_binary_interaction_double(const std::string& CAS1, const std::string& CAS2, const std::string& parameter) override;
 
     /// Get binary mixture string value
     std::string get_binary_interaction_string(const std::string& CAS1, const std::string& CAS2, const std::string& parameter) override;
     /// Set binary mixture string value
-    void set_binary_interaction_string(const std::size_t i, const std::size_t j, const std::string& parameter,
-                                       const std::string& value) override;
+    void set_binary_interaction_string(const std::size_t i, const std::size_t j, const std::string& parameter, const std::string& value) override;
 
     /// Set binary mixture string parameter (EXPERT USE ONLY!!!)
     void set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter, const double value) override;
@@ -156,6 +154,10 @@ class REFPROPMixtureBackend : public AbstractState
      * @brief Update the state, while providing guess values
      */
     void update_with_guesses(CoolProp::input_pairs, double value1, double value2, const GuessesStructure& guesses) override;
+
+    /// Set the state directly from (rho_molar, T) using THERMdll, no flash.
+    /// Used internally to drive saturation/two-phase derivative shims.
+    void update_DmolarT_direct(CoolPropDbl rhomolar, CoolPropDbl T);
 
     CoolPropDbl calc_molar_mass() override;
 

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.h
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.h
@@ -52,6 +52,11 @@ class REFPROPMixtureBackend : public AbstractState
     /// Configure *this* as a shim linked to `host`'s already-loaded REFPROP fluids (no SETUPdll).
     void link_to_loaded_fluids(const REFPROPMixtureBackend& host);
 
+    /// dP/dT [Pa/K] along the pure-component saturation line via DPTSATKdll. kph: 1=liquid, 2=vapor.
+    double dpdT_along_saturation_pure(int kph);
+    /// Saturation pressure [Pa] at temperature T for the bubble (Q=0) / dew (Q=1) branch via SATTdll.
+    double saturation_pressure_at_T(double T, int Q);
+
    public:
     REFPROPMixtureBackend() : Ncomp(0), _mole_fractions_set(false) {
         instance_counter++;
@@ -166,6 +171,8 @@ class REFPROPMixtureBackend : public AbstractState
     /// The shim reuses the fluids already loaded by this instance (no SETUPdll) and
     /// carries the correct per-phase composition (mole_fractions_liq / mole_fractions_vap).
     shared_ptr<REFPROPMixtureBackend> build_saturation_shim(int Q);
+
+    CoolPropDbl calc_first_saturation_deriv(parameters Of1, parameters Wrt1) override;
 
     CoolPropDbl calc_molar_mass() override;
 

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.h
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.h
@@ -49,6 +49,9 @@ class REFPROPMixtureBackend : public AbstractState
     /// Call the PHI0dll function in the dll
     CoolPropDbl call_phi0dll(int itau, int idelta);
 
+    /// Configure *this* as a shim linked to `host`'s already-loaded REFPROP fluids (no SETUPdll).
+    void link_to_loaded_fluids(const REFPROPMixtureBackend& host);
+
    public:
     REFPROPMixtureBackend() : Ncomp(0), _mole_fractions_set(false) {
         instance_counter++;
@@ -158,6 +161,11 @@ class REFPROPMixtureBackend : public AbstractState
     /// Set the state directly from (rho_molar, T) using THERMdll, no flash.
     /// Used internally to drive saturation/two-phase derivative shims.
     void update_DmolarT_direct(CoolPropDbl rhomolar, CoolPropDbl T);
+
+    /// Build a fully-populated saturated-phase shim. `Q` must be 0 (liquid) or 1 (vapor).
+    /// The shim reuses the fluids already loaded by this instance (no SETUPdll) and
+    /// carries the correct per-phase composition (mole_fractions_liq / mole_fractions_vap).
+    shared_ptr<REFPROPMixtureBackend> build_saturation_shim(int Q);
 
     CoolPropDbl calc_molar_mass() override;
 

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5842,4 +5842,17 @@ TEST_CASE("REFPROP saturated keyed outputs (h,s,cp,visc) match endpoint flashes"
     CHECK(twophase->saturated_liquid_keyed_output(iconductivity) == Catch::Approx(bubble->conductivity()).epsilon(1e-6));
 }
 
+TEST_CASE("REFPROP first_saturation_deriv matches HEOS for a pure fluid", "[REFPROPsat]") {
+    Skip_if_No_REFPROP();
+    std::shared_ptr<AbstractState> RP(AbstractState::factory("REFPROP", "Propane"));
+    std::shared_ptr<AbstractState> HE(AbstractState::factory("HEOS", "Propane"));
+    for (double T = 200; T <= 360; T += 40) {
+        RP->update(QT_INPUTS, 0.0, T);
+        HE->update(QT_INPUTS, 0.0, T);
+        CHECK(RP->first_saturation_deriv(iT, iP) == Catch::Approx(HE->first_saturation_deriv(iT, iP)).epsilon(1e-4));
+        CHECK(RP->first_saturation_deriv(iDmolar, iT) == Catch::Approx(HE->first_saturation_deriv(iDmolar, iT)).epsilon(1e-3));
+        CHECK(RP->first_saturation_deriv(iHmolar, iP) == Catch::Approx(HE->first_saturation_deriv(iHmolar, iP)).epsilon(1e-3));
+    }
+}
+
 #endif

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5795,4 +5795,17 @@ TEST_CASE("BICUBIC PT below saturation no longer segfaults (#1950)", "[BICUBIC][
     CHECK(rho == Catch::Approx(HEOS->rhomass()).epsilon(1e-2));  // 1% bicubic tolerance
 }
 
+TEST_CASE("REFPROP update_DmolarT_direct matches update(DmolarT)", "[REFPROPsat]") {
+    Skip_if_No_REFPROP();
+    std::shared_ptr<AbstractState> direct(AbstractState::factory("REFPROP", "Propane"));
+    std::shared_ptr<AbstractState> flash(AbstractState::factory("REFPROP", "Propane"));
+    double T = 300.0, rhomolar = 12000.0;  // dense liquid, single phase
+    flash->update(DmolarT_INPUTS, rhomolar, T);
+    auto* be = static_cast<REFPROPMixtureBackend*>(direct.get());
+    be->update_DmolarT_direct(rhomolar, T);
+    CHECK(direct->p() == Catch::Approx(flash->p()).epsilon(1e-9));
+    CHECK(direct->hmolar() == Catch::Approx(flash->hmolar()).epsilon(1e-9));
+    CHECK(direct->smolar() == Catch::Approx(flash->smolar()).epsilon(1e-9));
+}
+
 #endif

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5855,4 +5855,14 @@ TEST_CASE("REFPROP first_saturation_deriv matches HEOS for a pure fluid", "[REFP
     }
 }
 
+TEST_CASE("REFPROP first_two_phase_deriv matches HEOS for a pure fluid", "[REFPROPsat]") {
+    Skip_if_No_REFPROP();
+    std::shared_ptr<AbstractState> RP(AbstractState::factory("REFPROP", "Propane"));
+    std::shared_ptr<AbstractState> HE(AbstractState::factory("HEOS", "Propane"));
+    RP->update(QT_INPUTS, 0.4, 300.0);
+    HE->update(QT_INPUTS, 0.4, 300.0);
+    CHECK(RP->first_two_phase_deriv(iDmolar, iHmolar, iP) == Catch::Approx(HE->first_two_phase_deriv(iDmolar, iHmolar, iP)).epsilon(1e-4));
+    CHECK(RP->first_two_phase_deriv(iDmolar, iP, iHmolar) == Catch::Approx(HE->first_two_phase_deriv(iDmolar, iP, iHmolar)).epsilon(1e-3));
+}
+
 #endif

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5801,7 +5801,8 @@ TEST_CASE("REFPROP update_DmolarT_direct matches update(DmolarT)", "[REFPROPsat]
     std::shared_ptr<AbstractState> flash(AbstractState::factory("REFPROP", "Propane"));
     double T = 300.0, rhomolar = 12000.0;  // dense liquid, single phase
     flash->update(DmolarT_INPUTS, rhomolar, T);
-    auto* be = static_cast<REFPROPMixtureBackend*>(direct.get());
+    auto* be = dynamic_cast<REFPROPMixtureBackend*>(direct.get());
+    REQUIRE(be != nullptr);
     be->update_DmolarT_direct(rhomolar, T);
     CHECK(direct->p() == Catch::Approx(flash->p()).epsilon(1e-9));
     CHECK(direct->hmolar() == Catch::Approx(flash->hmolar()).epsilon(1e-9));
@@ -5812,7 +5813,8 @@ TEST_CASE("REFPROP saturation shim reproduces saturated densities", "[REFPROPsat
     Skip_if_No_REFPROP();
     std::shared_ptr<AbstractState> host(AbstractState::factory("REFPROP", "Propane"));
     host->update(QT_INPUTS, 0.5, 300.0);  // two-phase
-    auto* be = static_cast<REFPROPMixtureBackend*>(host.get());
+    auto* be = dynamic_cast<REFPROPMixtureBackend*>(host.get());
+    REQUIRE(be != nullptr);
     auto shimL = be->build_saturation_shim(0);  // liquid
     auto shimV = be->build_saturation_shim(1);  // vapor
     CHECK(shimL->rhomolar() == Catch::Approx(be->saturated_liquid_keyed_output(iDmolar)).epsilon(1e-10));
@@ -5846,13 +5848,18 @@ TEST_CASE("REFPROP first_saturation_deriv matches HEOS for a pure fluid", "[REFP
     Skip_if_No_REFPROP();
     std::shared_ptr<AbstractState> RP(AbstractState::factory("REFPROP", "Propane"));
     std::shared_ptr<AbstractState> HE(AbstractState::factory("HEOS", "Propane"));
-    for (double T = 200; T <= 360; T += 40) {
+    for (int Ti = 200; Ti <= 360; Ti += 40) {
+        double T = Ti;
         RP->update(QT_INPUTS, 0.0, T);
         HE->update(QT_INPUTS, 0.0, T);
         CHECK(RP->first_saturation_deriv(iT, iP) == Catch::Approx(HE->first_saturation_deriv(iT, iP)).epsilon(1e-4));
         CHECK(RP->first_saturation_deriv(iDmolar, iT) == Catch::Approx(HE->first_saturation_deriv(iDmolar, iT)).epsilon(1e-3));
         CHECK(RP->first_saturation_deriv(iHmolar, iP) == Catch::Approx(HE->first_saturation_deriv(iHmolar, iP)).epsilon(1e-3));
     }
+    // Pure fluid: a two-phase state with 0<Q<1 must also work (vapor-pressure slope is Q-independent).
+    RP->update(QT_INPUTS, 0.5, 300.0);
+    HE->update(QT_INPUTS, 0.5, 300.0);
+    CHECK(RP->first_saturation_deriv(iT, iP) == Catch::Approx(HE->first_saturation_deriv(iT, iP)).epsilon(1e-4));
 }
 
 TEST_CASE("REFPROP first_two_phase_deriv matches HEOS for a pure fluid", "[REFPROPsat]") {
@@ -5898,6 +5905,11 @@ TEST_CASE("REFPROP saturation derivs work for a mixture", "[REFPROPsat]") {
     double dTdp = RP->first_saturation_deriv(iT, iP);
     CHECK(ValidNumber(dTdp));
     CHECK(dTdp > 0);
+    // Two-phase interior derivatives are not implemented for mixtures (need the
+    // constant-overall-composition saturation slope); they must throw, not return garbage.
+    RP->update(QT_INPUTS, 0.4, 180.0);
+    CHECK_THROWS(RP->first_two_phase_deriv(iDmolar, iHmolar, iP));
+    CHECK_THROWS(RP->first_two_phase_deriv_splined(iDmolar, iHmolar, iP, 0.5));
 }
 
 #endif

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5865,4 +5865,14 @@ TEST_CASE("REFPROP first_two_phase_deriv matches HEOS for a pure fluid", "[REFPR
     CHECK(RP->first_two_phase_deriv(iDmolar, iP, iHmolar) == Catch::Approx(HE->first_two_phase_deriv(iDmolar, iP, iHmolar)).epsilon(1e-3));
 }
 
+TEST_CASE("REFPROP saturated keyed output throws in single phase", "[REFPROPsat]") {
+    Skip_if_No_REFPROP();
+    std::shared_ptr<AbstractState> AS(AbstractState::factory("REFPROP", "Propane"));
+    AS->update(PT_INPUTS, 101325, 300.0);  // single-phase gas
+    CHECK_THROWS(AS->saturated_liquid_keyed_output(iHmolar));
+    // A subsequent two-phase update must still work (no stale state leaks).
+    AS->update(QT_INPUTS, 0.3, 280.0);
+    CHECK(ValidNumber(AS->saturated_liquid_keyed_output(iHmolar)));
+}
+
 #endif

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5875,4 +5875,29 @@ TEST_CASE("REFPROP saturated keyed output throws in single phase", "[REFPROPsat]
     CHECK(ValidNumber(AS->saturated_liquid_keyed_output(iHmolar)));
 }
 
+TEST_CASE("REFPROP first_two_phase_deriv_splined matches HEOS (pure)", "[REFPROPsat]") {
+    Skip_if_No_REFPROP();
+    std::shared_ptr<AbstractState> RP(AbstractState::factory("REFPROP", "Propane"));
+    std::shared_ptr<AbstractState> HE(AbstractState::factory("HEOS", "Propane"));
+    double x_end = 0.3;
+    RP->update(QT_INPUTS, 0.1, 300.0);
+    HE->update(QT_INPUTS, 0.1, 300.0);
+    CHECK(RP->first_two_phase_deriv_splined(iDmolar, iHmolar, iP, x_end)
+          == Catch::Approx(HE->first_two_phase_deriv_splined(iDmolar, iHmolar, iP, x_end)).epsilon(1e-3));
+    CHECK(RP->first_two_phase_deriv_splined(iDmolar, iP, iHmolar, x_end)
+          == Catch::Approx(HE->first_two_phase_deriv_splined(iDmolar, iP, iHmolar, x_end)).epsilon(1e-3));
+}
+
+TEST_CASE("REFPROP saturation derivs work for a mixture", "[REFPROPsat]") {
+    Skip_if_No_REFPROP();
+    std::shared_ptr<AbstractState> RP(AbstractState::factory("REFPROP", "Methane&Ethane"));
+    std::vector<double> z = {0.6, 0.4};
+    RP->set_mole_fractions(z);
+    RP->update(QT_INPUTS, 0.0, 180.0);  // bubble
+    // dT/dp along the bubble curve should be finite and positive away from the critical point.
+    double dTdp = RP->first_saturation_deriv(iT, iP);
+    CHECK(ValidNumber(dTdp));
+    CHECK(dTdp > 0);
+}
+
 #endif

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5808,4 +5808,21 @@ TEST_CASE("REFPROP update_DmolarT_direct matches update(DmolarT)", "[REFPROPsat]
     CHECK(direct->smolar() == Catch::Approx(flash->smolar()).epsilon(1e-9));
 }
 
+TEST_CASE("REFPROP saturation shim reproduces saturated densities", "[REFPROPsat]") {
+    Skip_if_No_REFPROP();
+    std::shared_ptr<AbstractState> host(AbstractState::factory("REFPROP", "Propane"));
+    host->update(QT_INPUTS, 0.5, 300.0);  // two-phase
+    auto* be = static_cast<REFPROPMixtureBackend*>(host.get());
+    auto shimL = be->build_saturation_shim(0);  // liquid
+    auto shimV = be->build_saturation_shim(1);  // vapor
+    CHECK(shimL->rhomolar() == Catch::Approx(be->saturated_liquid_keyed_output(iDmolar)).epsilon(1e-10));
+    CHECK(shimV->rhomolar() == Catch::Approx(be->saturated_vapor_keyed_output(iDmolar)).epsilon(1e-10));
+    // The shim must NOT have triggered a re-SETUP: enthalpy from THERMdll at (T, rhoL)
+    // must equal a fresh single-phase evaluation at the same point.
+    std::shared_ptr<AbstractState> probe(AbstractState::factory("REFPROP", "Propane"));
+    probe->specify_phase(iphase_liquid);
+    probe->update(DmolarT_INPUTS, shimL->rhomolar(), 300.0);
+    CHECK(shimL->hmolar() == Catch::Approx(probe->hmolar()).epsilon(1e-9));
+}
+
 #endif

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5825,4 +5825,21 @@ TEST_CASE("REFPROP saturation shim reproduces saturated densities", "[REFPROPsat
     CHECK(shimL->hmolar() == Catch::Approx(probe->hmolar()).epsilon(1e-9));
 }
 
+TEST_CASE("REFPROP saturated keyed outputs (h,s,cp,visc) match endpoint flashes", "[REFPROPsat]") {
+    Skip_if_No_REFPROP();
+    std::shared_ptr<AbstractState> twophase(AbstractState::factory("REFPROP", "Propane"));
+    twophase->update(QT_INPUTS, 0.5, 300.0);
+    std::shared_ptr<AbstractState> bubble(AbstractState::factory("REFPROP", "Propane"));
+    bubble->update(QT_INPUTS, 0.0, 300.0);
+    std::shared_ptr<AbstractState> dew(AbstractState::factory("REFPROP", "Propane"));
+    dew->update(QT_INPUTS, 1.0, 300.0);
+
+    CHECK(twophase->saturated_liquid_keyed_output(iHmolar) == Catch::Approx(bubble->hmolar()).epsilon(1e-7));
+    CHECK(twophase->saturated_vapor_keyed_output(iHmolar) == Catch::Approx(dew->hmolar()).epsilon(1e-7));
+    CHECK(twophase->saturated_liquid_keyed_output(iSmolar) == Catch::Approx(bubble->smolar()).epsilon(1e-7));
+    CHECK(twophase->saturated_liquid_keyed_output(iCpmolar) == Catch::Approx(bubble->cpmolar()).epsilon(1e-6));
+    CHECK(twophase->saturated_vapor_keyed_output(iviscosity) == Catch::Approx(dew->viscosity()).epsilon(1e-6));
+    CHECK(twophase->saturated_liquid_keyed_output(iconductivity) == Catch::Approx(bubble->conductivity()).epsilon(1e-6));
+}
+
 #endif


### PR DESCRIPTION
## Purpose

Reimplements the still-valuable parts of the stale PR #2016 (follow-up to #2013, originally by @dongkeun-oh) so the REFPROP backend exposes the saturated-state properties and saturation/two-phase derivatives that ExternalMedia/Modelica needs. PR #2016 could not be merged (years of conflicts with the rewritten flash logic, plus style issues), so this is a fresh implementation against current `master`.

## What's added

- `calc_saturated_liquid_keyed_output` / `calc_saturated_vapor_keyed_output` extended from density/molar-mass only to the full set: **h, s, u, cp, cv, speed of sound, viscosity, conductivity** (molar and mass basis).
- `calc_first_saturation_deriv` — pure fluids use REFPROP's native `DPTSATKdll` (dp/dT along the saturation line); mixtures differentiate `SATTdll` numerically at the bubble (Q=0) / dew (Q=1) curve.
- `calc_first_two_phase_deriv`, `calc_second_two_phase_deriv`, `calc_first_two_phase_deriv_splined` — mirror the proven `HelmholtzEOSMixtureBackend` math (pure fluids).
- `update_DmolarT_direct` — no-flash state set via `THERMdll`.

## Key design: the saturation "shim"

REFPROP is a global-state DLL, so we cannot hold live `SatL`/`SatV` backend copies the way HEOS does. But **composition is a per-call argument** to every REFPROP routine (`PHIXdll`/`THERMdll`/`TRNPRPdll`/`REDXdll`); only the loaded fluid *set* (`SETUPdll`) is global. So we add a lightweight **shim**: a `REFPROPMixtureBackend` that copies the host's `cached_component_string` (so `check_loaded_fluid()` takes the no-op reuse path and never re-runs `SETUPdll`), carries the correct per-phase composition (`mole_fractions_liq`/`_vap`), and is driven by `update_DmolarT_direct`. The derivative math then reuses the inherited single-phase `first_partial_deriv` machinery.

## Scope / limitations

- **Mixtures:** saturated-state properties and bubble/dew `first_saturation_deriv` are supported. Two-phase *interior* derivatives (`first/second_two_phase_deriv`, `_splined`) require the constant-overall-composition saturation slope, which the per-phase shim cannot supply, so they raise `NotImplementedError` for mixtures rather than return wrong numbers. (Promoting these to a shared `AbstractState` implementation is tracked separately.)
- Pure-fluid two-phase/saturation/spline derivatives are validated against HEOS (`Propane`) to tight tolerance in the new `[REFPROPsat]` tests.

## Dropped from PR #2016 (deliberately)

- Quality-weighted `calc_hmolar`/`calc_smolar` — `update()` already sets these directly from the REFPROP flash.
- `_RPcheckTwophase()` — redundant with `_phase`/`_Q`.
- The `SATPdll`/`SATTdll` `kph` rewiring and the kPa factor-of-1000 edits — they collided with flash logic rewritten in #2865/#2866/#2042/#1845.

## Testing

New `[REFPROPsat]` Catch2 cases (8 cases, 40 assertions) compare REFPROP vs HEOS for saturated outputs and all derivatives, plus the mixture saturation derivative and the mixture-gate behavior. Full `[refprop]` suite (1066 assertions) green — no regressions. clang-format/build/tests/semgrep pass; clang-tidy diff-only clean.

Closes #2013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved saturation and two‑phase derivative calculations, including a splined two‑phase derivative for smoother interpolation.
  * Construct validated saturated-phase shims for reliable saturated-property queries.
  * Direct state update from (density, temperature) and ability to link to already-loaded fluid setups for faster shim construction.

* **Refactor**
  * Stricter validation and consistency checks for saturated-property retrieval to prevent stale or invalid states.

* **Tests**
  * Extensive tests covering shims, saturated outputs, derivative accuracy and error handling for pure fluids and mixtures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->