### PR TITLE
fix(ci): publish unique TestPyPI wheel versions (#2988)

### DIFF
--- a/.github/workflows/python_buildwheels.yml
+++ b/.github/workflows/python_buildwheels.yml
@@ -98,11 +98,23 @@ jobs:
     - name: Figure out the TestPyPi/PyPi Version
       shell: bash
       run: |
+        set -euo pipefail
         if [[ "$GITHUB_REF" == *"refs/tags"* ]]; then
-          python dev/extract_version.py --pypi --replace-version
+          COOLPROP_VERSION_OVERRIDE=$(python dev/extract_version.py --pypi)
         else
-          python dev/extract_version.py --replace-version --version "${{ needs.set-version.outputs.testpypiversion }}"
-        fi;
+          COOLPROP_VERSION_OVERRIDE=$(python dev/extract_version.py --version "${{ needs.set-version.outputs.testpypiversion }}")
+        fi
+        # Fail loudly rather than fall back to the static CMakeLists version: an
+        # empty override would silently re-publish 7.2.1.dev0 and get skipped by
+        # twine --skip-existing, which is exactly the #2988 failure mode.
+        if [[ -z "$COOLPROP_VERSION_OVERRIDE" ]]; then
+          echo "::error::extract_version.py returned an empty version"
+          exit 1
+        fi
+        echo "Resolved package version: $COOLPROP_VERSION_OVERRIDE"
+        # The sdist build resolves the version via dev/coolprop_version_provider.py,
+        # which reads this env var (see pyproject.toml).
+        echo "COOLPROP_VERSION_OVERRIDE=$COOLPROP_VERSION_OVERRIDE" >> "$GITHUB_ENV"
 
     - name: Build package, sdist
       run: |

--- a/.github/workflows/python_cibuildwheel.yml
+++ b/.github/workflows/python_cibuildwheel.yml
@@ -44,11 +44,23 @@ jobs:
     - name: Figure out the TestPyPi/PyPi Version
       shell: bash
       run: |
+        set -euo pipefail
         if [[ "$GITHUB_REF" == *"refs/tags"* ]]; then
-          python dev/extract_version.py --pypi --replace-version
+          COOLPROP_VERSION_OVERRIDE=$(python dev/extract_version.py --pypi)
         else
-          python dev/extract_version.py --replace-version --version "${{ inputs.TESTPYPI_VERSION }}"
-        fi;
+          COOLPROP_VERSION_OVERRIDE=$(python dev/extract_version.py --version "${{ inputs.TESTPYPI_VERSION }}")
+        fi
+        # Fail loudly rather than fall back to the static CMakeLists version: an
+        # empty override would silently re-publish 7.2.1.dev0 and get skipped by
+        # twine --skip-existing, which is exactly the #2988 failure mode.
+        if [[ -z "$COOLPROP_VERSION_OVERRIDE" ]]; then
+          echo "::error::extract_version.py returned an empty version"
+          exit 1
+        fi
+        echo "Resolved package version: $COOLPROP_VERSION_OVERRIDE"
+        # The build resolves the version via dev/coolprop_version_provider.py,
+        # which reads this env var (see pyproject.toml).
+        echo "COOLPROP_VERSION_OVERRIDE=$COOLPROP_VERSION_OVERRIDE" >> "$GITHUB_ENV"
 
     - name: Cache CPM packages
       uses: actions/cache@v5
@@ -81,6 +93,10 @@ jobs:
           pip install ninja &&
           git config --global --add safe.directory "*"
         CIBW_ENVIRONMENT_LINUX: COOLPROP_CMAKE=default,NATIVE CPM_SOURCE_CACHE=/root/.cache/CPM PIP_RETRIES=10 PIP_TIMEOUT=60 PIP_DEFAULT_TIMEOUT=60
+        # Linux wheels build inside the manylinux container, which does not
+        # inherit host env vars; forward the resolved version through so the
+        # version provider sees it. macOS/Windows build on the host directly.
+        CIBW_ENVIRONMENT_PASS_LINUX: COOLPROP_VERSION_OVERRIDE
         CIBW_BUILD: cp${{ inputs.python-version }}-*
         CIBW_ARCHS_MACOS: ${{ inputs.arch }} # x86_64 arm64 # universal2 is redundant
         CIBW_ARCHS_WINDOWS: ${{ inputs.arch }} # AMD64 x86 # ARM64 creates problems with msgpack-c

--- a/dev/coolprop_version_provider.py
+++ b/dev/coolprop_version_provider.py
@@ -50,7 +50,10 @@ _VERSION_RE = re.compile(
     r"set\(COOLPROP_VERSION_MAJOR\s+(?P<major>\d+)\).*?"
     r"set\(COOLPROP_VERSION_MINOR\s+(?P<minor>\d+)\).*?"
     r"set\(COOLPROP_VERSION_PATCH\s+(?P<patch>\d+)\).*?"
-    r"set\(COOLPROP_VERSION_REVISION\s+(?P<dev>\w*)\)",
+    # REVISION may be unquoted ("dev" on the development line) or a quoted
+    # string ("" on a tagged release); accept both, matching the more
+    # permissive parse in dev/extract_version.py.
+    r'set\(COOLPROP_VERSION_REVISION\s+"?(?P<dev>\w*)"?\)',
     re.DOTALL,
 )
 

--- a/dev/coolprop_version_provider.py
+++ b/dev/coolprop_version_provider.py
@@ -1,0 +1,79 @@
+"""scikit-build-core dynamic-metadata version provider for CoolProp.
+
+Why this exists
+---------------
+The Python package version is *dynamic* (``dynamic = ["version"]`` in
+``pyproject.toml``).  scikit-build-core resolves it during the PEP 517
+metadata hook (``prepare_metadata_for_build_wheel``), which runs **before
+and independently of** the CMake build — so the version that names the
+wheel and lands in the package metadata cannot be produced by CMake at
+compile time.  This provider is the supported place for the build to
+*call Python* to compute that version.
+
+Resolution order
+----------------
+1. ``$COOLPROP_VERSION_OVERRIDE`` — if set and non-empty, used verbatim.
+   CI sets this from ``dev/extract_version.py`` so every TestPyPI/PyPI
+   upload gets a unique version (the previous mechanism wrote a ``.version``
+   file that nothing read, so every build was ``7.2.1.dev0`` and TestPyPI
+   rejected all but the first with ``400 File already exists``).
+2. Otherwise the base version parsed from ``CMakeLists.txt``
+   (``{MAJOR}.{MINOR}.{PATCH}{REVISION}``).  This keeps local / offline
+   ``pip install .`` builds working with no env var and no tracked version
+   file — identical to the historical default (e.g. ``7.2.1.dev0``).
+
+CMakeLists.txt remains the single source of truth for the *base* version
+(and the C++ library version); this provider only layers on the optional
+CI-supplied unique suffix.
+
+Wired up in ``pyproject.toml``::
+
+    [tool.scikit-build.metadata.version]
+    provider = "coolprop_version_provider"
+    provider-path = "dev"
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+_ROOT = Path(__file__).resolve().parent.parent
+_CMAKELISTS = _ROOT / "CMakeLists.txt"
+
+# Mirrors the regex that pyproject.toml previously applied directly to
+# CMakeLists.txt.  REVISION is optional/empty for tagged releases (giving a
+# clean "7.2.1") and "dev" on the development line (giving "7.2.1.dev0").
+_VERSION_RE = re.compile(
+    r"set\(COOLPROP_VERSION_MAJOR\s+(?P<major>\d+)\).*?"
+    r"set\(COOLPROP_VERSION_MINOR\s+(?P<minor>\d+)\).*?"
+    r"set\(COOLPROP_VERSION_PATCH\s+(?P<patch>\d+)\).*?"
+    r"set\(COOLPROP_VERSION_REVISION\s+(?P<dev>\w*)\)",
+    re.DOTALL,
+)
+
+
+def _base_version_from_cmake() -> str:
+    text = _CMAKELISTS.read_text(encoding="utf-8")
+    match = _VERSION_RE.search(text)
+    if match is None:
+        msg = f"Could not parse COOLPROP_VERSION_* from {_CMAKELISTS}"
+        raise RuntimeError(msg)
+    return "{major}.{minor}.{patch}{dev}".format(**match.groupdict())
+
+
+def dynamic_metadata(
+    field: str,
+    settings: Optional[Mapping[str, Any]] = None,
+) -> str:
+    if field != "version":
+        msg = f"This provider only supplies 'version', not {field!r}"
+        raise RuntimeError(msg)
+
+    override = os.environ.get("COOLPROP_VERSION_OVERRIDE", "").strip()
+    if override:
+        return override
+
+    return _base_version_from_cmake()

--- a/dev/generate_headers.py
+++ b/dev/generate_headers.py
@@ -195,6 +195,14 @@ def TO_CPP(root_dir, hashes):
             print(outfile + ' is up to date')
             
 def get_version(root_dir):
+    # CI sets COOLPROP_VERSION_OVERRIDE (from dev/extract_version.py) so every
+    # uploaded wheel gets a unique version.  Honor it here too, so the version
+    # compiled into cpversion.h -- i.e. CoolProp.__version__ at runtime --
+    # matches the wheel's distribution metadata.  Same env var and resolution
+    # used by dev/coolprop_version_provider.py.
+    override = os.environ.get('COOLPROP_VERSION_OVERRIDE', '').strip()
+    if override:
+        return override
     lines = open(os.path.join(root_dir, 'CMakeLists.txt'), 'r').readlines()
     # Find the necessary lines
     MAJOR_line = [line for line in lines if ('VERSION_MAJOR' in line and 'MINOR' not in line)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,11 @@ Repository = "https://github.com/CoolProp/CoolProp"
 "Bug Tracker" = "https://github.com/CoolProp/CoolProp/issues"
 
 [tool.scikit-build]
+# Required to load the local (provider-path) dynamic-metadata version
+# plugin in dev/coolprop_version_provider.py — scikit-build-core gates
+# local plugins behind this flag.
+experimental = true
+
 # Minimum version of CMake to use
 cmake.version = ">=3.15"
 
@@ -58,8 +63,9 @@ build-dir = "build/{wheel_tag}"
 # Enable verbose output for debugging (set to true if needed)
 build.verbose = true
 
-# Include .version file in sdist
-sdist.include = [".version"]
+# Ship the dynamic-metadata version provider so sdist -> wheel builds can
+# resolve the version (see [tool.scikit-build.metadata.version] below).
+sdist.include = ["dev/coolprop_version_provider.py"]
 
 # Exclude unnecessary files from the wheel
 wheel.exclude = [
@@ -70,17 +76,15 @@ wheel.exclude = [
     "**/*.cpp",  # Exclude generated C++ from Cython
 ]
 
-# Derived from https://scikit-build-core.readthedocs.io/en/latest/configuration/dynamic.html#regex
+# Resolve the version at build time via a small Python provider (see
+# dev/coolprop_version_provider.py).  It parses the base version from
+# CMakeLists.txt — the single source of truth — and honors an optional
+# $COOLPROP_VERSION_OVERRIDE so CI can inject a unique TestPyPI/PyPI version
+# per build.  A plain regex over CMakeLists.txt cannot do that, which left
+# every dev build stuck at 7.2.1.dev0 and silently un-published (#2988).
 [tool.scikit-build.metadata.version]
-provider = "scikit_build_core.metadata.regex"
-input = "CMakeLists.txt"
-regex = '''(?sx)
-set\(COOLPROP_VERSION_MAJOR\s+(?P<major>\d+)\).*?
-set\(COOLPROP_VERSION_MINOR\s+(?P<minor>\d+)\).*?
-set\(COOLPROP_VERSION_PATCH\s+(?P<patch>\d+)\).*?
-set\(COOLPROP_VERSION_REVISION\s+(?P<dev>\w*)\).*?
-'''
-result = "{major}.{minor}.{patch}{dev}"
+provider = "coolprop_version_provider"
+provider-path = "dev"
 
 [tool.cibuildwheel]
 # Build for multiple Python versions (CPython only)


### PR DESCRIPTION
Fixes #2988.

## Problem

Every master-push wheel build resolved to a **fixed** `7.2.1.dev0`, so TestPyPI rejected each file with `400 File already exists` and twine's `--skip-existing` turned the upload into a green no-op. Only the very first `7.2.1.dev0` ever landed; every subsequent push published nothing.

Evidence from the last successful master run's `Upload to PyPi` job:
```
WARNING  Skipping coolprop-7.2.1.dev0-cp39-cp39-win_arm64.whl because it appears to already exist
WARNING  Skipping coolprop-7.2.1.dev0.tar.gz because it appears to already exist
```
TestPyPI confirms only one 7.2.1 artifact exists: `['7.2.1.dev0']`.

## Root cause

`pyproject.toml` derived the package version from a **regex over `CMakeLists.txt`** (`{major}.{minor}.{patch}{dev}` → always `7.2.1.dev0`). The unique per-build version that CI computes (`dev/extract_version.py`) was written to a `.version` file that **nothing read** — it was only listed in `sdist.include`. So the timestamp injection was a complete no-op. This broke in the scikit-build-core migration (`db49d9e0d`, #2632).

## Fix

The package version is now resolved by a small **custom scikit-build-core dynamic-metadata provider** (`dev/coolprop_version_provider.py`). This is the supported hook for the build to *call Python* to compute the version — it runs during the PEP 517 metadata step, before and independent of the CMake build (CMake runs too late to influence the wheel filename). The provider:

1. uses `$COOLPROP_VERSION_OVERRIDE` if set (CI sets it from `extract_version.py`), giving a unique version per build;
2. otherwise parses the base version from `CMakeLists.txt` — keeping local/offline `pip install .` working with no env var and no tracked version file (identical to today's `7.2.1.dev0`).

`CMakeLists.txt` stays the single source of truth for the base/C++ version; the provider only layers on the optional CI suffix.

- **pyproject.toml**: `experimental = true` + `provider-path` to load the local plugin; ship the provider in the sdist; drop the now-unused `.version` include.
- **workflows**: capture `extract_version.py` stdout into the env var under `set -euo pipefail` with a non-empty guard, so a network/resolution failure **fails loudly** instead of silently falling back to `dev0` (the original failure mode). Linux wheels forward the var into the manylinux container via `CIBW_ENVIRONMENT_PASS_LINUX`; macOS/Windows inherit the host env.

## Verification

`python -m build --sdist` locally:
- no env → `coolprop-7.2.1.dev0.tar.gz` (behavior-preserving)
- `COOLPROP_VERSION_OVERRIDE=7.2.1.post…` → `coolprop-7.2.1.post….tar.gz`
- provider module **and** `CMakeLists.txt` ship inside the sdist; `PKG-INFO` carries the injected version.

A 3-angle adversarial review surfaced the silent-failure path, which is fixed by the `set -euo pipefail` + non-empty guard above.

## Follow-up

CoolProp-7gk: centralize version resolution in the `set-version` job (eliminates ~40 redundant (Test)PyPI queries per run and a narrow split-upload window) and remove now-dead `--replace-version` code / stale `.version` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build and packaging version resolution to ensure consistent, deterministic package versions across distributions.
  * Updated metadata and build tooling to respect an explicit version override when present.

* **Bug Fixes**
  * CI workflows now fail fast on empty or ambiguous version detection to prevent accidental publication of incorrect releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->