### PR TITLE
ci: cancel a merged PR's in-flight CI runs

### DIFF
--- a/.github/workflows/cancel_merged_pr_runs.yml
+++ b/.github/workflows/cancel_merged_pr_runs.yml
@@ -1,0 +1,71 @@
+name: Cancel CI for merged PRs
+
+# Concurrency groups (PR #2989) cancel superseded runs on the same ref
+# while a PR is open, but they never fire once a PR is merged — nothing
+# pushes to refs/pull/<N>/merge again, so any still-running matrix jobs
+# run to completion even though their result is now worthless.  This
+# workflow closes that gap: when a PR is merged, cancel its in-flight CI
+# runs.  (deleteBranchOnMerge is off, so a `delete`-event trigger would
+# be unreliable — pull_request:closed is the canonical merge signal.)
+
+on:
+  pull_request:
+    types: [closed]
+
+# Only need permission to cancel workflow runs.
+permissions:
+  actions: write
+
+# Don't let two cancellers for the same PR stack up.
+concurrency:
+  group: cancel-merged-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  cancel:
+    # Merged only — a PR closed without merging is left alone.
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel in-flight runs for the merged PR's head commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # Scope by --branch (the PR head ref) so mainline runs from the
+          # merge-commit push — listed under headBranch=master — are never
+          # returned.  This branch filter is what protects master: for a
+          # rebase/fast-forward merge the landed commit can share the PR
+          # head SHA, so the headSha guard alone wouldn't.  Match headSha
+          # too so we don't touch an unrelated branch that shares a name
+          # (e.g. a fork's branch).  Exclude this canceller's own run — it
+          # shares the PR head branch+SHA, so an unguarded match would
+          # cancel ourselves mid-step.
+          #
+          # On a merged fork PR the token is downscoped to read-only and
+          # `gh run cancel` 403s; that's swallowed by the `|| true` below
+          # (a harmless no-op — those runs have usually finished anyway).
+          mapfile -t ids < <(
+            gh run list --repo "$REPO" --branch "$HEAD_BRANCH" --limit 200 \
+              --json databaseId,headSha,status \
+              --jq '.[]
+                    | select(.headSha == env.HEAD_SHA)
+                    | select((.databaseId | tostring) != env.RUN_ID)
+                    | select(.status | IN("queued","in_progress","requested","waiting","pending"))
+                    | .databaseId'
+          )
+          if [ "${#ids[@]}" -eq 0 ]; then
+            echo "No in-flight runs for $HEAD_BRANCH@$HEAD_SHA."
+            exit 0
+          fi
+          for id in "${ids[@]}"; do
+            echo "Cancelling run $id"
+            # gh run cancel is a no-op on already-finished runs; `|| true`
+            # only guards the race where a run completes between list and
+            # cancel.
+            gh run cancel "$id" --repo "$REPO" || true
+          done


### PR DESCRIPTION
## What

Adds `.github/workflows/cancel_merged_pr_runs.yml`: when a PR is **merged**, cancel its still-in-flight CI runs.

## Why

The concurrency groups from #2989 cancel *superseded* runs on the same ref while a PR is open (repeated pushes), but they never fire once a PR is **merged** — nothing pushes to `refs/pull/<N>/merge` again, so any still-running matrix jobs run to completion even though their result is now worthless. This was the last gap in cutting CI backlog.

## How

Fires on `pull_request: closed`, gated to `merged == true`. Lists the merged PR's still-active runs (matched by head ref + head SHA, excluding its own run) and cancels them with `gh run cancel`.

### Design notes
- **Merged-only** by request — a PR closed without merging is left alone.
- **No injection:** uses `pull_request` (not `pull_request_target`); attacker-influenceable values (`head.ref`/`head.sha`) are read via `env:`, never inline `${{ }}` in the shell body.
- **Least privilege:** top-level `permissions:` restricts `GITHUB_TOKEN` to `actions: write` only (all `gh run cancel` needs); everything else defaults to none.
- **Mainline-safe:** `--branch` scoping means merge-commit master runs (listed under `headBranch=master`) are never returned. This branch filter — not the SHA filter — is what protects master for rebase/fast-forward merges, where the landed commit can share the PR head SHA.
- **Self-safe:** the canceller's own run shares the PR head branch+SHA, so it's excluded by `github.run_id`.
- **Forks:** the token is downscoped read-only on forked PRs, so `gh run cancel` 403s — swallowed by `|| true` (harmless no-op; those runs have usually finished by merge time).
- `deleteBranchOnMerge` is off, so a `delete`-event trigger would be unreliable; `pull_request: closed` is the canonical merge signal.

## Validation

- `actionlint` clean (includes shellcheck on the run step)
- jq filter unit-tested against representative run lists (selects in-flight siblings; excludes self, completed, and different-SHA runs)
- YAML-only; no C/C++ compile impact

Tracked by bead CoolProp-wxt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD efficiency by automating cancellation of redundant workflow runs on merged pull requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->