### PR TITLE
ci(asan): drop detect_stack_use_after_return + add 90-min timeout (CoolProp-xuu)

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -39,6 +39,14 @@ jobs:
     name: address sanitizer
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ${{ matrix.os }}
+    # Guardrail (CoolProp-xuu).  Without this the job inherits GitHub's 6-hour
+    # default cap; when a test runs away the job is silently reported as
+    # `cancelled` rather than a real failure (that is exactly how the
+    # detect_stack_use_after_return BDCSVD blow-up hid for so long).  The full
+    # ASan suite + REFPROP completes in ~12 min locally (~40-50 min expected on
+    # the slower 2-vCPU runner); 90 min is a ~2x headroom that still surfaces a
+    # genuine runaway fast and visibly instead of burning six hours.
+    timeout-minutes: 90
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -64,7 +72,18 @@ jobs:
       - name: build all Catch tests
         run: cmake --build build --config Asan
       - name: run all the compiled Catch tests with address sanitizer
-        run: cd build && ASAN_OPTIONS=detect_stack_use_after_return=1:verbosity=1 ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-18 ./CatchTestRunner --benchmark-samples 1
+        # detect_stack_use_after_return is deliberately NOT enabled here
+        # (CoolProp-xuu).  With REFPROP present — which CI builds — the 5
+        # SVDSBTL&REFPROP [source] tests build large BDCSVD surfaces, and
+        # under detect_stack_use_after_return=1 the per-coefficient
+        # __asan_stack_malloc inside Eigen's O(n^2-n^3) singular-value inner
+        # loop becomes unbounded (a single such test went from 87s to a
+        # >38-minute hang locally).  That is what drove the whole job into
+        # GitHub's 6-hour cap, where it was silently reported as `cancelled`
+        # rather than producing a real pass/fail.  ASan's heap/global/UAF
+        # checks all still run; only the fake-stack (use-after-return)
+        # instrumentation is dropped.
+        run: cd build && ASAN_OPTIONS=verbosity=1 ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-18 ./CatchTestRunner --benchmark-samples 1
 
   clang-format:
     name: clang-format (PR diff)


### PR DESCRIPTION
## Problem

The **address sanitizer** job in `dev_checks.yml` has been consistently reported as `cancelled` in CI, never producing a real pass/fail. Profiling (locally, mirroring the CI config) found two compounding causes:

1. **No `timeout-minutes`** → the job inherits GitHub's 6-hour default job cap. When a test runs away, GitHub force-terminates the job with a `cancelled` conclusion (not `failure`), so the failure mode is silent.
2. **`ASAN_OPTIONS=detect_stack_use_after_return=1` × large BDCSVD builds.** CI builds REFPROP, so the 5 `SVDSBTL&REFPROP …[source]` tests run and build large Eigen `BDCSVD` SVD surfaces. Under `detect_stack_use_after_return=1`, the per-coefficient `__asan_stack_malloc` (fake-stack frames) fires inside BDCSVD's O(n²–n³) singular-value inner loop and the cost becomes unbounded.

A live stack sample of the hung process showed ~100% of time in `__asan_stack_malloc_1` under `Eigen::BDCSVD::computeSingVals → secularEq → …::coeff()`. Locally, **one** such test went from **87 s** (flag off) to a **>38-minute hang** (flag on, killed). Without REFPROP these tests skip the surface build, which is why the problem only bites in CI.

## Fix

- **Drop `detect_stack_use_after_return=1`** (keep `verbosity=1` + the symbolizer path). ASan's heap / global / use-after-free detection is unaffected; only stack-**use-after-return** instrumentation is given up.
- **Add `timeout-minutes: 90`** at the job level as a guardrail, so a genuine future runaway fails *fast and visibly* at 90 min instead of silently riding to the 6-hour cap.

## Evidence (local, Apple-Silicon, ASan build = CI config)

| Configuration | Result |
|---|---|
| Full suite + REFPROP, `detect_stack_use_after_return=0` | **12 min**, 314 cases / 79,899 assertions, 0 failures |
| Single `[source]` test, flag **=0** | 87 s, passes |
| Single `[source]` test, flag **=1** (CI's setting) | **>38 min**, never finished |

Expected on the 2-vCPU `ubuntu-latest` runner: ~40–50 min (single-threaded test exec + ~10 min compile), comfortably inside the 90-min guardrail. Fork PRs skip the REFPROP build entirely, so they finish faster still.

Tracked as `CoolProp-xuu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ASan job timeout configuration in CI/CD workflows
  * Adjusted ASan testing parameters to optimize test execution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/2998?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->