### PR TITLE
fix(HEOS): round-trip D+{H,S,U} for sub-triple compressed liquid (CoolProp-lgk)

### DIFF
--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -1647,7 +1647,100 @@ void FlashRoutines::HSU_D_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
                 HEOS._phase = iphase_liquid;
                 HEOS._Q = 10000;
             } else {
-                throw ValueError(format("D < DLtriple %g %g", value, y));
+                // value <= y means the requested state sits below the triple-point
+                // isochore (T < Ttriple).  Compressed liquid still exists there
+                // above the melting curve (e.g. water down to ~251 K near the
+                // 209 MPa melting minimum; IAPWS-95 stays valid), so extend the
+                // single-phase solve below the triple point to the coldest point
+                // on the melting line rather than rejecting outright.  Only fluids
+                // with a melting line have a defined sub-triple liquid region
+                // (CoolProp-lgk).
+                if (!HEOS.has_melting_line()) {
+                    throw ValueError(format("D < DLtriple %g %g", value, y));
+                }
+                // Coldest liquid temperature = the global minimum of the melting
+                // curve.  The curve can be non-monotonic in p (water dips to
+                // ~251 K near 209 MPa) and its minimum can sit at a non-smooth
+                // segment corner, so neither the endpoint-based
+                // MeltingLineVariables::Tmin nor a single coarse scan pinpoints
+                // it: sweep coarsely in log(p), then refine linearly around the
+                // best point.  For normal fluids whose melting temperature rises
+                // monotonically with pressure this stays at ~Ttriple, so the sign
+                // check below still rejects (correctly -- they have no sub-triple
+                // liquid region).
+                MeltingLineVariables& ml = component.ancillaries.melting_line;
+                auto Tmelt_at = [&](CoolPropDbl p) -> CoolPropDbl {
+                    try {
+                        return HEOS.melting_line(iT, iP, p);
+                    } catch (...) {
+                        return _HUGE;  // p outside this curve's valid range; ignore this sample
+                    }
+                };
+                CoolPropDbl T_lo = ml.Tmin;
+                if (ml.pmin > 0 && ml.pmax > ml.pmin) {
+                    const int Ncoarse = 100;
+                    CoolPropDbl p_best = ml.pmin;
+                    for (int i = 0; i <= Ncoarse; ++i) {
+                        const CoolPropDbl p_scan = ml.pmin * std::pow(ml.pmax / ml.pmin, static_cast<CoolPropDbl>(i) / Ncoarse);
+                        const CoolPropDbl Tm = Tmelt_at(p_scan);
+                        if (Tm < T_lo) {
+                            T_lo = Tm;
+                            p_best = p_scan;
+                        }
+                    }
+                    // Refine within +/- one coarse log-step of the best pressure.
+                    const CoolPropDbl step = std::pow(ml.pmax / ml.pmin, 1.0 / Ncoarse);
+                    const CoolPropDbl p_a = (std::max)(ml.pmin, p_best / step);
+                    const CoolPropDbl p_b = (std::min)(ml.pmax, p_best * step);
+                    const int Nfine = 200;
+                    for (int i = 0; i <= Nfine; ++i) {
+                        const CoolPropDbl p_scan = p_a + (p_b - p_a) * static_cast<CoolPropDbl>(i) / Nfine;
+                        const CoolPropDbl Tm = Tmelt_at(p_scan);
+                        if (Tm < T_lo) {
+                            T_lo = Tm;
+                        }
+                    }
+                }
+                // y_lo is the caloric value on the requested isochore at the
+                // coldest liquid temperature.  Using the curve's global minimum
+                // (rather than the melting point at this exact density) makes the
+                // floor conservative on rejection: states below it are genuinely
+                // solid, while a thin metastable sliver just below the per-density
+                // melting point may still be accepted -- it round-trips correctly.
+                CoolPropDbl y_lo = NAN;
+                switch (other) {
+                    case iSmolar:
+                        y_lo = HEOS.calc_smolar_nocache(T_lo, HEOS._rhomolar);
+                        break;
+                    case iHmolar:
+                        y_lo = HEOS.calc_hmolar_nocache(T_lo, HEOS._rhomolar);
+                        break;
+                    case iUmolar:
+                        y_lo = HEOS.calc_umolar_nocache(T_lo, HEOS._rhomolar);
+                        break;
+                    default:  // iP
+                        y_lo = HEOS.calc_pressure_nocache(T_lo, HEOS._rhomolar);
+                        break;
+                }
+                if (!ValidNumber(y_lo) || value < y_lo) {
+                    // Colder than the coldest liquid attainable at this density:
+                    // genuinely below the melting line (solid / out of range).
+                    throw ValueError(format("D+X below melting line [other=%d]: %g < %g at Tmelt_min %g K", other, value, y_lo, T_lo));
+                }
+                solver_resid resid(&HEOS, HEOS._rhomolar, value, other, T_lo, TLtriple);
+                HEOS._phase = iphase_liquid;
+                CoolPropDbl T_converged;
+                try {
+                    T_converged = Halley(resid, 0.5 * (T_lo + TLtriple), DBL_EPSILON, 100);
+                } catch (...) {
+                    T_converged = Brent(resid, T_lo, TLtriple, DBL_EPSILON, 1e-12, 100);
+                }
+                // Re-evaluate at converged (rho, T) so alphar cache is
+                // consistent with the final state (#1907).
+                HEOS.unspecify_phase();
+                HEOS.update_DmolarT_direct(HEOS._rhomolar, T_converged);
+                HEOS._phase = iphase_liquid;
+                HEOS._Q = 10000;
             }
         }
         // Update the state for conditions where the state was guessed

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5317,6 +5317,72 @@ TEST_CASE("DmassSmass round-trip on the dew curve preserves enthalpy (#1907)", "
     }
 }
 
+TEST_CASE("D+{H,S,U} round-trip for sub-triple compressed-liquid water (CoolProp-lgk)", "[water_flash][HSU_D_subtriple][lgk]") {
+    // Dense liquid water exists below the triple-point temperature (273.16 K)
+    // wherever the state is above the melting curve Tmelt(p): ~266 K at 100 MPa,
+    // down toward ~251 K near the 209 MPa melting minimum.  IAPWS-95 is valid
+    // there, so a density+caloric flash must round-trip these compressed-liquid
+    // states.  Previously PHSU_D_flash bracketed the single-phase T-search at
+    // [Ttriple, Tmax*1.5] and threw "D < DLtriple" for any state colder than the
+    // triple-point isochore (i.e. all T < Ttriple), even above the melting line.
+    auto ref = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+    auto rt = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+    const double Tt = Props1SI("Water", "Ttriple");
+
+    const CoolProp::input_pairs pair = GENERATE(CoolProp::DmassHmass_INPUTS, CoolProp::DmassSmass_INPUTS, CoolProp::DmassUmass_INPUTS);
+    CAPTURE(static_cast<int>(pair));
+
+    for (double p : {100e6, 150e6, 200e6}) {
+        const double Tmelt = ref->melting_line(CoolProp::iT, CoolProp::iP, p);
+        CAPTURE(p, Tmelt, Tt);
+        // The sampled band is [Tmelt+1, Tt-0.5]; require it non-inverted so the
+        // sweep genuinely lands below the triple point (not a vacuous pass).
+        REQUIRE(Tmelt + 1.0 < Tt - 0.5);
+        // Strictly above the melting curve, strictly below the triple point.
+        for (double T : linspace(Tmelt + 1.0, Tt - 0.5, 6)) {
+            CAPTURE(T);
+            ref->update(CoolProp::PT_INPUTS, p, T);
+            const double d = ref->rhomass();
+            double other = 0;
+            switch (pair) {
+                case CoolProp::DmassHmass_INPUTS:
+                    other = ref->hmass();
+                    break;
+                case CoolProp::DmassSmass_INPUTS:
+                    other = ref->smass();
+                    break;
+                default:
+                    other = ref->umass();
+                    break;
+            }
+            CAPTURE(d, other);
+            REQUIRE_NOTHROW(rt->update(pair, d, other));
+            CHECK(rt->rhomass() == Catch::Approx(d).epsilon(1e-5));
+            CHECK(rt->T() == Catch::Approx(T).epsilon(1e-4));
+        }
+    }
+
+    // Deep point near the melting-curve minimum (~251.2 K at ~208.5 MPa, the
+    // coldest liquid water attainable).  A coarse-scan-only floor lands ~1 K
+    // high (~252.3 K) and would wrongly reject this valid liquid state; the
+    // refined two-stage melting-minimum search must round-trip it.
+    {
+        const double p = 208.5e6;
+        const double Tmelt = ref->melting_line(CoolProp::iT, CoolProp::iP, p);
+        const double T = Tmelt + 0.5;  // valid liquid just above the melting line, well below Ttriple
+        REQUIRE(T < Tt);
+        ref->update(CoolProp::PT_INPUTS, p, T);
+        const double d = ref->rhomass();
+        const double other = (pair == CoolProp::DmassHmass_INPUTS)   ? ref->hmass()
+                             : (pair == CoolProp::DmassSmass_INPUTS) ? ref->smass()
+                                                                     : ref->umass();
+        CAPTURE(p, Tmelt, T, d, other);
+        REQUIRE_NOTHROW(rt->update(pair, d, other));
+        CHECK(rt->rhomass() == Catch::Approx(d).epsilon(1e-5));
+        CHECK(rt->T() == Catch::Approx(T).epsilon(1e-4));
+    }
+}
+
 TEST_CASE("REFPROP DmolarSmolar honours imposed phase (#2042)", "[REFPROP][2042]") {
     CoolProp::Skip_if_No_REFPROP();
     // Issue #2042: a multi-component natural-gas mixture with phase


### PR DESCRIPTION
## Summary

`FlashRoutines::PHSU_D_flash` (the density + {H,S,U,P} flash) brackets its single-phase liquid temperature search at `[Ttriple, Tmax·1.5]` and throws `"D < DLtriple"` for any density-input state whose caloric value falls **below the triple-point isochore** — i.e. *every* compressed-liquid state colder than `Ttriple`, even where it sits above the melting curve and the EOS is valid. For water that wrongly rejects the whole liquid region down to ~251 K near the 209 MPa melting minimum (IAPWS-95 stays valid there).

```
PropsSI("T","Dmass",1046.7,"Hmass",-30967,"Water")   # 265 K @ 100 MPa, valid liquid
  -> throws "D < DLtriple"            (before)
  -> 265.0 K                          (after)
```

## Fix

When the requested state is below the triple-point isochore (`value <= y`), extend the solve below `Ttriple` instead of rejecting:

- **Floor = global minimum of the melting curve.** The curve can be non-monotonic in `p` and its minimum can sit at a non-smooth segment corner (water dips to ~251.2 K at ~208.5 MPa), so the endpoint-based `MeltingLineVariables::Tmin` (≈ `Ttriple`) is wrong. Find it with a coarse `log(p)` sweep + a fine linear refinement around the best point.
- **Self-correcting for normal fluids:** where the melting temperature rises monotonically with pressure the floor stays ≈ `Ttriple`, so the sign check still rejects — those fluids have no sub-triple liquid region.
- Bracket the (monotonic, single-phase) residual on `[T_lo, Ttriple]` and solve; throw only if the input is colder than the coldest liquid attainable at that density (genuinely below the melting line / solid).
- Gated on `has_melting_line()`; fluids without one keep the prior throw.

Strictly an improvement: the modified branch previously *always* threw, so no working path changes — confirmed identical behavior with `COOLPROP_DISABLE_SUPERANC_HSU_D` and across `[flash]`/`[pureflash]`/`[consistency]`/`[water_flash]` (25k+ assertions green).

## Tests

`[HSU_D_subtriple]` round-trips D+{H,S,U} for water across the `Tmelt(p)..Ttriple` band at 100–200 MPa, plus a deep point ~0.5 K above the melting minimum (~208.5 MPa) that a coarse-only floor would reject (locks in the two-stage scan).

## Notes

- Found while reviewing the HSU_D test coverage for #2995 (its tests stopped at 274 K, ~0.84 K above the triple point).
- The reject floor uses the curve's global minimum rather than the melting point at the exact input density, so a thin metastable sliver just below the per-density melting point may be accepted — it still round-trips correctly. Documented inline.
- Tracked in `bd CoolProp-lgk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced compressed liquid state handling below the triple point; previously unattainable states now compute successfully when a melting line is defined, instead of returning an error.

* **Tests**
  * Added regression tests for compressed liquid water states below the triple point to verify round-trip accuracy across density and thermodynamic property inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3000?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->