### PR TITLE
fix(REFPROP): honor melting-line bound sentinels in calc_melting_line

### DIFF
--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -1077,7 +1077,34 @@ CoolPropDbl REFPROPMixtureBackend::calc_melting_line(int param, int given, CoolP
     int ierr = 0;
     std::array<char, 255> herr{};
 
-    if (param == iP && given == iT) {
+    // Bounding-box sentinels for the melting curve, matching the HEOS ancillary
+    // contract (Ancillaries.cpp): when param is a bound key, return the bound and
+    // ignore given/value.  Each axis bound is independent.
+    //
+    // iP_min is the triple-point pressure, for consistency with the HEOS melting
+    // ancillary.  iT_min is the melting line's lowest temperature: for most fluids
+    // that is the triple-point temperature, but for water and heavy water the
+    // melting line extends below it to the ice Ih/III junction (251.165 K for
+    // water).  REFPROP's MELTP (CORE_ANC.FOR) takes that floor as LIMITS('EOS').Tmin,
+    // so we read it from the EOS lower temperature limit.  The upper limits come from
+    // the melting-line model ("MLT") via LIMITX, distinct from the EOS limits.
+    if (param == iP_min) {
+        return calc_p_triple();
+    } else if (param == iT_min) {
+        double Tmin = NAN, Tmax = NAN, rhomolarmax = NAN, pmax = NAN;
+        limits(Tmin, Tmax, rhomolarmax, pmax);  // LIMITS('EOS'); Tmin is MELTP's temperature floor
+        return static_cast<CoolPropDbl>(Tmin);
+    } else if (param == iP_max || param == iT_max) {
+        double t_in = static_cast<double>(calc_Ttriple()), D_in = 0.0, p_in = 0.0;
+        double tmin_unused = NAN, tmax_melt = NAN, Dmax_unused = NAN, pmax_kPa = NAN;
+        char htyp[] = "MLT";
+        LIMITXdll(htyp, &t_in, &D_in, &p_in, &(mole_fractions[0]), &tmin_unused, &tmax_melt, &Dmax_unused, &pmax_kPa, &ierr,
+                  herr.data(), 3, errormessagelength);
+        if (static_cast<int>(ierr) > get_config_int(REFPROP_ERROR_THRESHOLD)) {
+            throw ValueError(format("%s", herr.data()).c_str());
+        }
+        return (param == iP_max) ? static_cast<CoolPropDbl>(pmax_kPa * 1000) : static_cast<CoolPropDbl>(tmax_melt);
+    } else if (param == iP && given == iT) {
         double _T = static_cast<double>(value), p_kPa = NAN;
         MELTTdll(&_T, &(mole_fractions[0]), &p_kPa, &ierr, herr.data(), errormessagelength);  // Error message
         if (static_cast<int>(ierr) > get_config_int(REFPROP_ERROR_THRESHOLD)) {
@@ -1092,8 +1119,10 @@ CoolPropDbl REFPROPMixtureBackend::calc_melting_line(int param, int given, CoolP
         }  //else if (ierr < 0) {set_warning(format("%s",herr.data()).c_str());}
         return _T;
     } else {
-        throw ValueError(format("calc_melting_line(%s,%s,%Lg) is an invalid set of inputs ", get_parameter_information(param, "short").c_str(),
-                                get_parameter_information(given, "short").c_str(), value));
+        // Use the raw integer keys here: param/given may be invalid keys (e.g. the
+        // -1 sentinel), and looking them up via get_parameter_information() would
+        // itself throw, masking this "invalid inputs" diagnostic.
+        throw ValueError(format("calc_melting_line(param=%d, given=%d, value=%Lg) is an invalid set of inputs", param, given, value));
     }
 }
 bool REFPROPMixtureBackend::has_melting_line() {

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -3973,6 +3973,42 @@ TEST_CASE_METHOD(SuperAncillaryOnFixture, "Phase for solid water should throw", 
     }
 }
 
+TEST_CASE("REFPROP melting_line honors iP_min/iT_min/iP_max/iT_max sentinels", "[melting][REFPROP]") {
+    Skip_if_No_REFPROP();  // Skip this test if REFPROPMixture backend is not available
+    std::shared_ptr<CoolProp::AbstractState> RP(CoolProp::AbstractState::factory("REFPROP", "Water"));
+    std::shared_ptr<CoolProp::AbstractState> HE(CoolProp::AbstractState::factory("HEOS", "Water"));
+
+    double pmin = RP->melting_line(iP_min, -1, -1);
+    double Tmin = RP->melting_line(iT_min, -1, -1);
+
+    // iP_min is the triple-point pressure, for consistency with HEOS.
+    CHECK(pmin == Catch::Approx(RP->p_triple()));
+    CHECK(pmin == Catch::Approx(HE->melting_line(iP_min, -1, -1)).epsilon(1e-3));
+
+    // iT_min is the melting line's lowest temperature.  For water that is the ice
+    // Ih/III junction (251.165 K), which lies BELOW the triple-point temperature --
+    // the one case (with heavy water) where it differs from the triple point.
+    CHECK(Tmin == Catch::Approx(251.165).epsilon(1e-5));
+    CHECK(Tmin < RP->Ttriple());
+    // ...and Tmin is a valid point on the melting line (the floor MELTT accepts).
+    CHECK_NOTHROW(RP->melting_line(iP, iT, Tmin));
+
+    // The high-pressure end must be a finite value above the minimum.
+    double pmax = RP->melting_line(iP_max, -1, -1);
+    double Tmax = RP->melting_line(iT_max, -1, -1);
+    CHECK(ValidNumber(pmax));
+    CHECK(ValidNumber(Tmax));
+    CHECK(pmax > pmin);
+    CHECK(Tmax > Tmin);
+
+    // A genuine melting lookup must still work and agree with HEOS (regression).
+    CHECK(RP->melting_line(iT, iP, 1e8) == Catch::Approx(HE->melting_line(iT, iP, 1e8)).epsilon(1e-3));
+
+    // A truly invalid input pair must throw a ValueError -- not crash building
+    // its own error message via get_parameter_information() on an invalid key.
+    CHECK_THROWS_AS(RP->melting_line(iDmolar, iHmolar, 0), CoolProp::ValueError);
+}
+
 // Tests for cubic EOS superancillaries (#2739)
 TEST_CASE("Cubic superancillary saturation_ancillary accuracy vs EOS flash", "[cubic_superanc][2739]") {
     for (const auto& backend : std::vector<std::string>{"PR", "SRK"}) {


### PR DESCRIPTION
## Problem

`REFPROPMixtureBackend::calc_melting_line` only handled the `(iP,iT)` / `(iT,iP)` input pairs. For anything else it built its "invalid inputs" error message via `get_parameter_information(given, "short")` with `given == -1` — and *that lookup itself throws* `Unable to match the key [-1]`, masking the intended diagnostic.

HEOS honors bound-sentinel queries like `melting_line(iP_min, -1, -1)` (returning the melting-curve bound, ignoring `given`/`value`; see `Ancillaries.cpp` `MeltingLineVariables::evaluate`), and `ConsistencyPlots.py` calls exactly that per pressure point. So against the REFPROP backend it threw on every call — flooding the Water REFPROP consistency CSV with hundreds of spurious "melting" rows (40 pressures × 11 single-phase axes).

## Fix

Add the melting-curve bounding-box sentinels to the REFPROP backend (each axis bound independent), matching the HEOS ancillary contract:

| Sentinel | Source | Water |
|---|---|---|
| `iP_min` | `calc_p_triple()` — triple-point pressure (HEOS-consistent) | 611.7 Pa |
| `iT_min` | `LIMITS('EOS').Tmin` — the melting line's lowest temperature, i.e. the floor `MELTP` uses (`CORE_ANC.FOR`) | **251.165 K** (ice Ih/III junction, below the triple-point T) |
| `iP_max` / `iT_max` | `LIMITX` with `htyp="MLT"` — the melting-line model limits, distinct from the EOS limits | 1e9 Pa / 2000 K |

The `iT_min`/`iP_min` split (min temperature ≠ the temperature at min pressure) only manifests for water and heavy water; for every other fluid the melting floor equals the triple-point temperature.

The `else` branch now formats the **raw int keys** (`%d`) so it can no longer self-throw on an invalid key.

Verified against the REFPROP FORTRAN source (`CORE_ANC.FOR`): `MELTP` (line 948) takes `LIMITS('EOS').Tmin` as its temperature floor, and `MLTH2O`'s `-999` flag returns 251.165 K as water's lowest fluid temperature.

## Test

New `[melting][REFPROP]` Catch2 case covering all four sentinels, a genuine `(iT,iP)` lookup (regression, vs HEOS), and the invalid-pair throw. `[melting],[2639]` all pass (REFPROP available locally, not skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced melting-line calculations for REFPROP fluids to properly recognize and return boundary limits (minimum/maximum pressure and temperature values)
  * Improved error reporting for invalid parameter queries

* **Tests**
  * Added regression tests to validate melting-line boundary condition handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3006?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->