### PR TITLE
style(REFPROP): clang-format the LIMITXdll call in calc_melting_line [skip ci]

### DIFF
--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -1098,8 +1098,8 @@ CoolPropDbl REFPROPMixtureBackend::calc_melting_line(int param, int given, CoolP
         double t_in = static_cast<double>(calc_Ttriple()), D_in = 0.0, p_in = 0.0;
         double tmin_unused = NAN, tmax_melt = NAN, Dmax_unused = NAN, pmax_kPa = NAN;
         char htyp[] = "MLT";
-        LIMITXdll(htyp, &t_in, &D_in, &p_in, &(mole_fractions[0]), &tmin_unused, &tmax_melt, &Dmax_unused, &pmax_kPa, &ierr,
-                  herr.data(), 3, errormessagelength);
+        LIMITXdll(htyp, &t_in, &D_in, &p_in, &(mole_fractions[0]), &tmin_unused, &tmax_melt, &Dmax_unused, &pmax_kPa, &ierr, herr.data(), 3,
+                  errormessagelength);
         if (static_cast<int>(ierr) > get_config_int(REFPROP_ERROR_THRESHOLD)) {
             throw ValueError(format("%s", herr.data()).c_str());
         }


### PR DESCRIPTION
Follow-up to #3006. The `LIMITXdll(...)` call in `calc_melting_line` wraps after `&ierr` where clang-format 18.1.8 (the repo-pinned version) wants the break after the column limit (`..., 3,` / `errormessagelength)`). Pure formatting — no behavior change.

```
uvx clang-format@18.1.8 --dry-run --Werror src/Backends/REFPROP/REFPROPMixtureBackend.cpp
```
is now clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code formatting in the REFPROP module for better readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3007?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->