### PR TITLE
fix(HumidAir): drop spurious 1e6 factor in vbar_ws ice branch (#2657)

### DIFF
--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -2332,8 +2332,10 @@ double HAProps_Aux(const char* Name, double T, double p, double W, char* units) 
                 Water->update(CoolProp::QT_INPUTS, 0, T);
                 return 1.0 / Water->keyed_output(CoolProp::iDmolar);
             } else {
-                // It is ice
-                return dg_dp_Ice(T, p) * MM_Water() / 1000 / 1000;  //[m^3/mol]
+                // It is ice. dg_dp_Ice is the specific volume [m^3/kg] (rho_Ice = 1/dg_dp_Ice)
+                // and MM_Water is [kg/mol], so the product is already [m^3/mol]; no further
+                // unit conversion is needed. This mirrors the f_factor() computation. (GH #2657)
+                return dg_dp_Ice(T, p) * MM_Water();  //[m^3/mol]
             }
         } else if (!strcmp(Name, "f")) {
             strcpy(units, "-");

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -1415,7 +1415,12 @@ TEST_CASE("Humid air auxiliary functions: physical validity and monotonicity", "
         }
     }
 
-    SECTION("Saturated molar volume vbar_ws is positive") {
+    SECTION("Saturated molar volume vbar_ws is physically sane") {
+        // Molar volume of condensed water (liquid or ice) is ~1.8e-5 to ~2.0e-5
+        // m^3/mol. Both branches must land in this range; in particular the ice
+        // branch must not be off by the 1e6 factor of GH #2657. See also the
+        // f_factor() computation in HumidAirProp.cpp which uses the correct
+        // expression. Bound generously to allow for compression/expansion.
         const double Tvals[] = {213.15, 253.15, 273.15, 293.15, 333.15, 373.15};
         const double Pvals[] = {101325.0, 500000.0, 1000000.0};
         for (double T : Tvals) {
@@ -1424,9 +1429,25 @@ TEST_CASE("Humid air auxiliary functions: physical validity and monotonicity", "
                 CAPTURE(T);
                 CAPTURE(p);
                 CHECK(ValidNumber(v));
-                CHECK(v > 0.0);
+                CHECK(v > 1.5e-5);
+                CHECK(v < 2.5e-5);
             }
         }
+    }
+
+    SECTION("vbar_ws is continuous across the ice/liquid boundary (GH #2657)") {
+        // Just below (ice) and just above (liquid) the triple-point temperature
+        // 273.16 K the molar volume must be nearly equal — ice is only ~9%
+        // larger than liquid water, not 1e6x smaller as in GH #2657.
+        const double p = 101325.0;
+        double v_ice = HumidAir::HAProps_Aux("vbar_ws", 273.15, p, 0.0, units);
+        double v_liq = HumidAir::HAProps_Aux("vbar_ws", 273.17, p, 0.0, units);
+        CAPTURE(v_ice);
+        CAPTURE(v_liq);
+        CHECK(ValidNumber(v_ice));
+        CHECK(ValidNumber(v_liq));
+        CHECK(v_ice > 0.9 * v_liq);
+        CHECK(v_ice < 1.2 * v_liq);
     }
 
     SECTION("Virial coefficients Baa and Bww have expected signs") {


### PR DESCRIPTION
## Summary

Fixes #2657. `HAProps_Aux("vbar_ws")` returned the molar volume of saturated **ice** ~1e6 too small (~1.96e-11 instead of ~1.96e-5 m³/mol), producing the six-orders-of-magnitude discontinuity at the triple point that GentleVincent reported.

## Root cause

The ice branch (`T <= 273.16 K`) multiplied `dg_dp_Ice(T,p) * MM_Water()` by a spurious `/1000/1000`:

```cpp
return dg_dp_Ice(T, p) * MM_Water() / 1000 / 1000;  // wrong: extra 1e-6
```

`dg_dp_Ice` is the specific volume in **m³/kg** (confirmed by `rho_Ice = 1/dg_dp_Ice`, `src/Ice.cpp:130`), and `MM_Water()` is **kg/mol**, so the product is already **m³/mol** — no further conversion is needed. The correct expression is already used in `f_factor()` (`src/HumidAirProp.cpp:843`), which is why **`HAPropsSI` results were never affected** — only the diagnostic accessor was wrong.

## Fix

- Drop the `/1000/1000` so the accessor matches `f_factor()`.
- Strengthen the `vbar_ws` test from positivity-only to assert physical magnitude (1.5e-5..2.5e-5 m³/mol) and continuity across the ice/liquid boundary, so the regression cannot recur.

## Verification

- New/updated tests fail before the fix (ice value 1.965e-11) and pass after.
- Full `[humid_air],[humid_air_validation]` suite: 2618 assertions pass.
- Adversarial review independently confirmed the unit reasoning and that all 18 tested (T,p) points land within bounds (ice 1.948e-5..1.965e-5; liquid 1.802e-5..1.880e-5 m³/mol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected molar volume calculations for humid air under icy conditions to eliminate unit conversion errors and ensure consistency across computational methods.

* **Tests**
  * Expanded test suite with stricter physical bounds validation and regression checks ensuring molar volume remains continuous across the ice-liquid phase boundary at triple point.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3009?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->