### PR TITLE
fix(REFPROP): preserve SATTP saturation pressure in QT flash (#2671)

### DIFF
--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -1992,8 +1992,12 @@ void REFPROPMixtureBackend::update(CoolProp::input_pairs input_pair, double valu
                     rho_mol_L = (iFlsh == 1) ? rhoLmol_L : rhoVmol_L;
                 }
                 if (ierr <= 0L) {
-                    // Calculate everything else since we were able to carry out a flash call
-                    THERMdll(&_T, &rho_mol_L, &(mole_fractions[0]), &p_kPa, &emol, &hmol, &smol, &cvmol, &cpmol, &w, &hjt);
+                    // Calculate everything else since we were able to carry out a flash call.
+                    // #2671: keep the equilibrium pressure that SATTP/SATT returned; THERMdll
+                    // would otherwise recompute a slightly different p from the (SATSPLN-refined)
+                    // saturated-phase density, so send its p output to a throwaway.
+                    double p_kPa_therm = _HUGE;
+                    THERMdll(&_T, &rho_mol_L, &(mole_fractions[0]), &p_kPa_therm, &emol, &hmol, &smol, &cvmol, &cpmol, &w, &hjt);
                 }
             }
             if (static_cast<int>(ierr) > get_config_int(REFPROP_ERROR_THRESHOLD) || iFlsh == 0) {
@@ -2822,6 +2826,31 @@ TEST_CASE("Check REFPROP and CoolProp values agree", "[REFPROP]") {
             double Dcp = (cp_RP - cp_CP) / cp_RP;
             CHECK(std::abs(Dcp) < 0.05);
         }
+    }
+    SECTION("QT flash reports the equilibrium saturation pressure, not a THERMdll recompute (#2671)") {
+        // SATTP/SATT return the equilibrium saturation pressure for a (T, Q) state.
+        // Before #2671 the QT path then overwrote that pressure with THERMdll's
+        // recompute from the saturated-phase density; once the SATSPLN splines
+        // (activated by build_phase_envelope) refine that density, the recomputed
+        // pressure drifts off the saturation curve — most severely on the dew
+        // branch near the critical region.  A correct equilibrium pressure must
+        // round-trip: feeding it back through a dew-point PQ flash recovers the
+        // original temperature.  THERMdll's drifted pressure lands off the curve
+        // and the recovered temperature shifts measurably.
+        shared_ptr<CoolProp::AbstractState> S(CoolProp::AbstractState::factory("REFPROP", "Methane&Ethane"));
+        std::vector<double> z = {0.4, 0.6};
+        S->set_mole_fractions(z);
+        S->build_phase_envelope("");  // activates the SATSPLN saturation splines
+        const double T = 250;         // near-critical dew point (Tc ~ 276 K) — drift is pronounced here
+        S->update(CoolProp::QT_INPUTS, 1, T);
+        double p_dew = S->p();
+        S->update(CoolProp::PQ_INPUTS, p_dew, 1);
+        double T_back = S->T();
+        CAPTURE(p_dew);
+        CAPTURE(T_back);
+        // With the fix the round-trip is exact to ~1e-11 K; the THERMdll drift
+        // shifts it by ~3e-5 K, so 1e-7 K cleanly separates the two.
+        CHECK(std::abs(T_back - T) < 1e-7);
     }
     SECTION("Enthalpy and entropy reference state") {
         std::vector<std::string> ss = strsplit(CoolProp::get_global_param_string("FluidsList"), ',');


### PR DESCRIPTION
Fixes #2671.

## Problem

In `REFPROPMixtureBackend::update`, the `QT_INPUTS` path computes the equilibrium saturation pressure with `SATTPdll`/`SATTdll`, then calls `THERMdll` to fill in the caloric properties. `THERMdll`'s pressure output was written back into the same `p_kPa` variable, so the value reported as `_p` was `THERMdll`'s recompute from the saturated-phase *density* rather than the equilibrium pressure returned by the saturation routine.

Once `build_phase_envelope` activates the `SATSPLN` splines, the spline-refined density makes that recompute drift off the saturation curve — exactly as @kaern reported in [usnistgov/REFPROP-wrappers discussion #681](https://github.com/usnistgov/REFPROP-wrappers/discussions/681).

Measured drift (Methane(0.4)/Ethane(0.6), splines active):
- bubble / happy path: ~5e-12 relative (ULP-class)
- **dew branch near critical (T=250 K, Tc≈276 K): ~1.05e-6 relative**

## Fix

Redirect `THERMdll`'s pressure output to a throwaway local so the `SATTP`/`SATT` equilibrium pressure survives to `_p`. The caloric outputs (`emol`, `hmol`, …) are captured exactly as before. `PQ_INPUTS` already reports the input pressure, so it needs no change.

## Test

Added a `[REFPROP]` regression test: with `SATSPLN` active, feeding the QT dew pressure back through a dew-point `PQ` flash must recover the original temperature. Without the fix the round-trip is off by ~3.3e-5 K; with it, ~1e-11 K (threshold 1e-7 K gives ~330× margin). Verified red→green by reverting/restoring the fix. Full `[REFPROP]` suite passes locally (1086 assertions) with REFPROP 10 loaded.

## Follow-up (not in this PR)

Code review surfaced a deeper, same-family bug in the `DmolarQ_INPUTS` branch: `DQFL2dll` returns no caloric properties, so the subsequent `THERMdll` runs at the *overall two-phase density* — making both pressure (≈3% off at Q=0.5) and all caloric outputs non-physical for `0 < Q < 1`. That needs a proper two-phase fix (Q-weighting or a `TQFLSH` re-route), tracked separately rather than expanding this focused change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed equilibrium saturation pressure consistency in the REFPROP mixture calculations for near-critical conditions. Pressure values are now preserved through round-trip calculations, improving numerical accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3011?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->