### PR TITLE
ci(codeql): analyse C++ buildless so vendored sources are excluded (#3010)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,15 +3,23 @@ name: "CoolProp CodeQL config"
 # Keep the default security-and-quality query suite (added by the workflow
 # via `queries: +security-and-quality`).
 
-# Exclude vendored / fetched third-party sources we cannot patch.
-# - build/_deps/**     : CPM/FetchContent downloads (Eigen, fmt, msgpack, …)
-# - externals/miniz-*  : vendored miniz copy
-# - externals/fmt*     : any in-tree fmt copy (defensive; fetched copy lives under build/_deps)
-# - .claude/worktrees  : local Claude Code worktrees, never analysed
+# Exclude vendored / fetched third-party sources and auto-generated files we
+# cannot (and should not) patch. The vendored / generated set mirrors the
+# canonical exclusion list in CMakeLists.txt (clang-format `format` target,
+# regex /include/(.*_JSON.*|gitrevision|miniz)\.h$) and the dev_checks
+# clang-tidy negative pathspecs.
+# - build/**, _deps/**      : CPM/FetchContent downloads (Eigen, fmt, msgpack, rapidjson, …)
+# - externals/**            : all vendored third-party libs (miniz, nlohmann-json, incbin, …)
+# - include/miniz.h         : vendored upstream miniz amalgamation header
+# - include/gitrevision.h   : auto-generated at configure time
+# - include/*_JSON*.h       : auto-generated from dev/fluids JSON (huge raw-string blobs)
+# - .claude/**              : local Claude Code worktrees, never analysed
 paths-ignore:
   - build/**
   - build_*/**
   - "**/_deps/**"
-  - externals/miniz-*/**
-  - externals/fmt*/**
+  - externals/**
+  - include/miniz.h
+  - include/gitrevision.h
+  - "include/*_JSON*.h"
   - .claude/**

--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -239,29 +239,26 @@ jobs:
         with:
           python-version: '3.x'
 
+      # cpp uses build-mode: none (buildless extractor). Two reasons:
+      #   1. paths-ignore in codeql-config.yml is honoured for C/C++ ONLY when
+      #      analysing without building; a build-based run silently ignores it,
+      #      so vendored sources (Eigen, nlohmann-json, miniz, …) kept flooding
+      #      the alert list. See GitHub #3010.
+      #   2. No build means no build/_deps tree, so the fetched header-only deps
+      #      (Eigen/boost/msgpack/fmt/rapidjson/if97/refprop) are never extracted
+      #      in the first place.
+      # python keeps its default extraction (build-mode left unset → autobuild).
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.language == 'cpp' && 'none' || '' }}
           queries: +security-and-quality
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild Python
         if: ${{ matrix.language == 'python' }}
         uses: github/codeql-action/autobuild@v4
-
-      - name: Configure CPP
-        if: ${{ matrix.language == 'cpp' }}
-        run: cmake
-               -DCOOLPROP_MY_MAIN=dev/ci/main.cpp
-               -B ${{github.workspace}}/build
-               -S .
-
-      - name: Build CPP
-        if: ${{ matrix.language == 'cpp' }}
-        run: cmake
-               --build ${{github.workspace}}/build
-               --config Release
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
Closes #3010.

## Root cause

CodeQL's `paths-ignore` config keyword is honoured for **interpreted** languages but is **silently ignored for compiled languages when the analysis builds the code** ([GitHub docs](https://docs.github.com/en/code-security/code-scanning): paths/paths-ignore apply to compiled languages only "when you analyze a compiled language without building the code").

Our `dev_checks.yml:codeql` job built the C++ (autobuild + `cmake --build`), so every `paths-ignore` entry was a no-op for `cpp`. Proof from the live alert set on `master`:

| Language | Vendored alerts open in `_deps` / `externals` |
|---|---|
| python (interpreted) | **0** — paths-ignore works |
| cpp (compiled, built) | **475+** — 217 Eigen, 135 nlohmann-json, 32 boost, 27 miniz, 20 msgpack, 15 rapidjson, 14 fmt, 13 if97, 4 refprop |

That's why the `externals/miniz-*` and `**/_deps/**` entries (added in #2845, ~4 weeks ago) never suppressed a single Eigen or miniz alert.

## Fix

**1. `dev_checks.yml` — analyse the cpp leg with `build-mode: none`.**
- No build → no `build/_deps` tree → the fetched header-only deps (Eigen/boost/msgpack/fmt/rapidjson/if97/refprop) are never extracted (**315 `_deps` alerts gone at the source**).
- `paths-ignore` now applies to C/C++ → in-tree vendored copies are excluded.
- Drops the now-unused Configure/Build CPP steps. Python extraction is unchanged (`build-mode` left unset → autobuild). `build-mode` is `required: false`, so the empty value on the python matrix leg = unset; `none` is documented as available for the cpp extractor.

**2. `codeql-config.yml` — broaden `paths-ignore` to the full vendored/generated set** (now that it actually bites for cpp):

| Pattern | Why |
|---|---|
| `externals/**` | all vendored third-party (miniz, nlohmann-json, incbin, …) — replaces narrow `externals/miniz-*` / `externals/fmt*` |
| `include/miniz.h` | vendored upstream miniz amalgamation |
| `include/gitrevision.h` | auto-generated |
| `include/*_JSON*.h` | auto-generated from `dev/fluids` JSON |

Mirrors the canonical exclusion list in `CMakeLists.txt` (`format` target regex `/include/(.*_JSON.*|gitrevision|miniz)\.h$`) and the `dev_checks` clang-tidy negative pathspecs.

## Trade-off

`build-mode: none` uses CodeQL's buildless C/C++ extractor, which can have somewhat lower recall on heavily-templated code than a full compiled extraction. Accepted in exchange for eliminating the vendored-header noise that `paths-ignore` provably could not.

## Verification

- Both YAML files parse; matrix conditional resolves to `none` for cpp / unset for python.
- `paths-ignore` globs match no tracked first-party headers (`rapidjson_include.h`, `CoolPropTools.h` stay in scope); `externals/` is third-party only.
- Final confirmation comes from the alert count on this PR's CodeQL run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated static analysis configuration to refine exclusion patterns for vendored and generated files, reducing irrelevant alerts.
  * Adjusted analysis workflow behavior so native/C++ scanning runs without a build step to avoid vendored-source noise and unintended dependency extraction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3013?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->