### PR TITLE
docs(CLAUDE.md): pin Release build type in the configure line [skip ci]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,11 @@ bd close <id>         # Complete work
 ## Build & Test
 
 ```bash
-# Configure (one-time)
-cmake -B build_catch -S . -DCOOLPROP_CATCH_MODULE=ON -DBUILD_TESTING=ON
+# Configure (one-time).  Always set -DCMAKE_BUILD_TYPE=Release: the
+# default is an UNOPTIMIZED build, which makes the [slow] SVDSBTL surface
+# builds (a dense SVD at production resolution, NT=200/NR=800/rank=20)
+# crawl for minutes per fresh fluid.  Release turns that into seconds.
+cmake -B build_catch -S . -DCOOLPROP_CATCH_MODULE=ON -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
 
 # Build the Catch2 runner
 cmake --build build_catch --target CatchTestRunner -j8


### PR DESCRIPTION
## What

The documented `Build & Test` configure command omitted `-DCMAKE_BUILD_TYPE`, leaving it empty — i.e. an **unoptimized** build.

## Why

The `[slow]` SVDSBTL tests build a dense SVD surface at production resolution (NT=200 / NR=800 / rank=20). Without optimization that decomposition crawls for minutes per fresh fluid; in Release it's seconds. Following the docs verbatim repeatedly produced a painfully slow build.

## Change

Adds `-DCMAKE_BUILD_TYPE=Release` to the configure line plus a short comment explaining why. Docs-only, `[skip ci]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build and test instructions to include an optimized Release configuration option, enabling faster build times compared to default settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->