### PR TITLE
fix(interface): mask FP exceptions at C-interface entry points (#3012)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2120,6 +2120,8 @@ if(COOLPROP_CATCH_MODULE)
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-HS-prototypes.cpp")
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-HSU_D.cpp")
+  list(APPEND APP_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-FPUGuard.cpp")
 
   # CATCH TEST, compile everything with catch and set test entry point
   add_executable(CatchTestRunner ${APP_SOURCES})

--- a/include/CoolProp/FPUGuard.h
+++ b/include/CoolProp/FPUGuard.h
@@ -1,0 +1,91 @@
+#ifndef COOLPROP_FPUGUARD_H
+#define COOLPROP_FPUGUARD_H
+
+// RAII guard that masks IEEE-754 floating-point exceptions on construction and
+// restores the caller's FP environment on destruction.
+//
+// CoolProp uses NaN and _HUGE (HUGE_VAL) as in-band sentinels.  Arithmetic and
+// comparisons on those values set the FP exception *status* flags (FE_INVALID,
+// FE_OVERFLOW, FE_DIVBYZERO).  Host environments react two ways:
+//   * Polling hosts (Excel/VBA) read the status word after a call returns and
+//     report a spurious FP error.
+//   * Trapping hosts (Delphi, some TRNSYS/Fortran builds) run with FP
+//     exceptions *unmasked*, so the CPU raises a hardware trap / SIGFPE at the
+//     offending instruction -- mid-calculation, before any cleanup can run.
+//
+// Clearing the status flags on exit (the historical fpu_reset_guard behavior)
+// only helps polling hosts.  This guard additionally *masks* the exceptions on
+// entry so trapping hosts do not fault, then restores the caller's environment
+// on exit (which also wipes any flags we raised, covering the polling case).
+//
+// Windows is the platform that hurts most here: Delphi's RTL *unmasks* FP
+// exceptions by default, and Excel/VBA poll the status word.  So the Windows
+// masking path is keyed on _WIN32 (any compiler), not just _MSC_VER, so that
+// MinGW-built DLLs are protected too -- _controlfp_s lives in <float.h> for
+// both MSVC and MinGW-w64.
+//
+// See GitHub issue #3012 and bd CoolProp-i3o.
+
+#if defined(_WIN32)
+#    include <float.h>  // _controlfp_s, _clearfp, _MCW_EM (MS CRT extension)
+#    define COOLPROP_FPUGUARD_WIN
+#elif defined(__GLIBC__)
+#    include <cfenv>  // fegetexcept/fedisableexcept/feenableexcept are glibc-only
+#    if defined(FE_ALL_EXCEPT)
+#        define COOLPROP_FPUGUARD_GLIBC
+#    endif
+#else
+#    include <cfenv>  // standard feclearexcept only (no portable masking API)
+#endif
+
+namespace CoolProp {
+
+class fpu_guard
+{
+   public:
+    fpu_guard() {
+#if defined(COOLPROP_FPUGUARD_WIN)
+        // Read the current control word, then set every exception-mask bit
+        // (_MCW_EM): a set bit *disables* (masks) that exception's trap.
+        unsigned int dummy = 0;
+        _controlfp_s(&saved_cw, 0, 0);           // snapshot current control word
+        _controlfp_s(&dummy, _MCW_EM, _MCW_EM);  // mask all FP exceptions
+#elif defined(COOLPROP_FPUGUARD_GLIBC)
+        // fegetexcept() returns the set of currently *enabled* (trapping)
+        // exceptions; remember it so we can restore the caller's choice.
+        saved_excepts = fegetexcept();
+        fedisableexcept(FE_ALL_EXCEPT);  // mask all
+#endif
+        // Platforms without a portable masking API (macOS/BSD, PowerPC) fall
+        // through with no masking; they do not enable FP traps by default, so
+        // clearing status flags on exit (see ~fpu_guard) is the sufficient,
+        // historical mitigation there.
+    }
+    fpu_guard(const fpu_guard&) = delete;
+    fpu_guard(fpu_guard&&) = delete;
+    fpu_guard& operator=(const fpu_guard&) = delete;
+    fpu_guard& operator=(fpu_guard&&) = delete;
+    ~fpu_guard() {
+#if defined(COOLPROP_FPUGUARD_WIN)
+        _clearfp();  // clear flags we raised
+        unsigned int dummy = 0;
+        _controlfp_s(&dummy, saved_cw, _MCW_EM);  // restore caller's masking
+#elif defined(COOLPROP_FPUGUARD_GLIBC)
+        feclearexcept(FE_ALL_EXCEPT);   // clear flags we raised
+        feenableexcept(saved_excepts);  // restore caller's trapping set
+#elif defined(FE_ALL_EXCEPT)
+        feclearexcept(FE_ALL_EXCEPT);  // fallback: clear status flags only
+#endif
+    }
+
+   private:
+#if defined(COOLPROP_FPUGUARD_WIN)
+    unsigned int saved_cw{0};
+#elif defined(COOLPROP_FPUGUARD_GLIBC)
+    int saved_excepts{0};
+#endif
+};
+
+}  // namespace CoolProp
+
+#endif  // COOLPROP_FPUGUARD_H

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -7,6 +7,7 @@
 #endif
 
 #include "CoolPropLib.h"
+#include "CoolProp/FPUGuard.h"
 #include "CoolProp.h"
 #include "HumidAirProp.h"
 #include "DataStructures.h"
@@ -53,25 +54,14 @@ void HandleException(long* errcode, char* message_buffer, const long buffer_leng
     }
 }
 
-// In Microsoft Excel, they seem to check the FPU exception bits and error out because of it.
-// By calling the _clearfp(), we can reset these bits, and not get the error
-// See also http://stackoverflow.com/questions/11685441/floating-point-error-when-calling-dll-function-from-vba/27336496#27336496
-// See also http://stackoverflow.com/questions/16849009/in-linux-do-there-exist-functions-similar-to-clearfp-and-statusfp for linux and OSX
-struct fpu_reset_guard
-{
-    fpu_reset_guard() = default;
-    fpu_reset_guard(const fpu_reset_guard&) = delete;
-    fpu_reset_guard(fpu_reset_guard&&) = delete;
-    fpu_reset_guard& operator=(const fpu_reset_guard&) = delete;
-    fpu_reset_guard& operator=(fpu_reset_guard&&) = delete;
-    ~fpu_reset_guard() {
-#if defined(_MSC_VER)
-        _clearfp();  // For MSVC, clear the floating point error flags
-#elif defined(FE_ALL_EXCEPT)
-        feclearexcept(FE_ALL_EXCEPT);
-#endif
-    }
-};
+// FP-exception handling at the C-interface boundary lives in CoolProp/FPUGuard.h
+// (CoolProp::fpu_guard).  It masks FP exceptions on entry so trapping hosts
+// (Delphi, some TRNSYS/Fortran builds) do not fault on CoolProp's NaN/_HUGE
+// sentinels, and restores the caller's environment -- clearing the status flags
+// Excel/VBA polls -- on exit.  See GitHub #3012 / bd CoolProp-i3o.
+//
+// fpu_reset_guard is retained as an alias so existing call sites are unchanged.
+using fpu_reset_guard = CoolProp::fpu_guard;
 double convert_from_kSI_to_SI(long iInput, double value) {
     if (get_debug_level() > 8) {
         std::cout << format("%s:%d: convert_from_kSI_to_SI(i=%d,value=%g)\n", __FILE__, __LINE__, iInput, value).c_str();
@@ -449,6 +439,7 @@ EXPORT_CODE void CONVENTION set_config_bool(const char* key, const bool val) {
 }
 EXPORT_CODE void CONVENTION set_departure_functions(const char* string_data, long* errcode, char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         CoolProp::set_departure_functions(string_data);
     } catch (...) {
@@ -521,6 +512,7 @@ static AbstractStateLibrary handle_manager;
 EXPORT_CODE long CONVENTION AbstractState_factory(const char* backend, const char* fluids, long* errcode, char* message_buffer,
                                                   const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory(backend, fluids));
         return handle_manager.add(AS);
@@ -532,6 +524,7 @@ EXPORT_CODE long CONVENTION AbstractState_factory(const char* backend, const cha
 EXPORT_CODE void CONVENTION AbstractState_fluid_names(const long handle, char* fluids, long* errcode, char* message_buffer,
                                                       const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
 
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
@@ -550,6 +543,7 @@ EXPORT_CODE void CONVENTION AbstractState_fluid_names(const long handle, char* f
 }
 EXPORT_CODE void CONVENTION AbstractState_free(const long handle, long* errcode, char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         handle_manager.remove(handle);
     } catch (...) {
@@ -559,6 +553,7 @@ EXPORT_CODE void CONVENTION AbstractState_free(const long handle, long* errcode,
 EXPORT_CODE void CONVENTION AbstractState_set_fractions(const long handle, const double* fractions, const long N, long* errcode, char* message_buffer,
                                                         const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     std::vector<double> _fractions(fractions, fractions + N);
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
@@ -576,6 +571,7 @@ EXPORT_CODE void CONVENTION AbstractState_set_fractions(const long handle, const
 EXPORT_CODE void CONVENTION AbstractState_get_mole_fractions(const long handle, double* fractions, const long maxN, long* N, long* errcode,
                                                              char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
 
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
@@ -595,6 +591,7 @@ EXPORT_CODE void CONVENTION AbstractState_get_mole_fractions_satState(const long
                                                                       const long maxN, long* N, long* errcode, char* message_buffer,
                                                                       const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
 
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
@@ -630,6 +627,7 @@ EXPORT_CODE void CONVENTION AbstractState_get_mole_fractions_satState(const long
 EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, const long i, long* errcode, char* message_buffer,
                                                          const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         return AS->fugacity(i);
@@ -641,6 +639,7 @@ EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, cons
 EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long handle, const long i, long* errcode, char* message_buffer,
                                                                      const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         return AS->fugacity_coefficient(i);
@@ -652,6 +651,7 @@ EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long 
 EXPORT_CODE void CONVENTION AbstractState_update(const long handle, const long input_pair, const double value1, const double value2, long* errcode,
                                                  char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         AS->update(static_cast<CoolProp::input_pairs>(input_pair), value1, value2);
@@ -662,6 +662,7 @@ EXPORT_CODE void CONVENTION AbstractState_update(const long handle, const long i
 EXPORT_CODE void CONVENTION AbstractState_specify_phase(const long handle, const char* phase, long* errcode, char* message_buffer,
                                                         const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         return AS->specify_phase(CoolProp::get_phase_index(std::string(phase)));
@@ -671,6 +672,7 @@ EXPORT_CODE void CONVENTION AbstractState_specify_phase(const long handle, const
 }
 EXPORT_CODE void CONVENTION AbstractState_unspecify_phase(const long handle, long* errcode, char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         return AS->unspecify_phase();
@@ -681,6 +683,7 @@ EXPORT_CODE void CONVENTION AbstractState_unspecify_phase(const long handle, lon
 EXPORT_CODE double CONVENTION AbstractState_keyed_output(const long handle, const long param, long* errcode, char* message_buffer,
                                                          const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         return AS->keyed_output(static_cast<CoolProp::parameters>(param));
@@ -693,6 +696,7 @@ EXPORT_CODE double CONVENTION AbstractState_keyed_output(const long handle, cons
 EXPORT_CODE double CONVENTION AbstractState_first_saturation_deriv(const long handle, const long Of, const long Wrt, long* errcode,
                                                                    char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         return AS->first_saturation_deriv(static_cast<CoolProp::parameters>(Of), static_cast<CoolProp::parameters>(Wrt));
@@ -705,6 +709,7 @@ EXPORT_CODE double CONVENTION AbstractState_first_saturation_deriv(const long ha
 EXPORT_CODE double CONVENTION AbstractState_first_partial_deriv(const long handle, const long Of, const long Wrt, const long Constant, long* errcode,
                                                                 char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         return AS->first_partial_deriv(static_cast<CoolProp::parameters>(Of), static_cast<CoolProp::parameters>(Wrt),
@@ -719,6 +724,7 @@ EXPORT_CODE double CONVENTION AbstractState_second_partial_deriv(const long hand
                                                                  const long Wrt2, const long Constant2, long* errcode, char* message_buffer,
                                                                  const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         return AS->second_partial_deriv(static_cast<CoolProp::parameters>(Of1), static_cast<CoolProp::parameters>(Wrt1),
@@ -734,6 +740,7 @@ EXPORT_CODE double CONVENTION AbstractState_second_two_phase_deriv(const long ha
                                                                    const long Wrt2, const long Constant2, long* errcode, char* message_buffer,
                                                                    const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         return AS->second_two_phase_deriv(static_cast<CoolProp::parameters>(Of1), static_cast<CoolProp::parameters>(Wrt1),
@@ -748,6 +755,7 @@ EXPORT_CODE double CONVENTION AbstractState_second_two_phase_deriv(const long ha
 EXPORT_CODE double CONVENTION AbstractState_first_two_phase_deriv(const long handle, const long Of, const long Wrt, const long Constant,
                                                                   long* errcode, char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         return AS->first_two_phase_deriv(static_cast<CoolProp::parameters>(Of), static_cast<CoolProp::parameters>(Wrt),
@@ -762,6 +770,7 @@ EXPORT_CODE double CONVENTION AbstractState_first_two_phase_deriv_splined(const 
                                                                           const double x_end, long* errcode, char* message_buffer,
                                                                           const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         return AS->first_two_phase_deriv_splined(static_cast<CoolProp::parameters>(Of), static_cast<CoolProp::parameters>(Wrt),
@@ -776,6 +785,7 @@ EXPORT_CODE void CONVENTION AbstractState_update_and_common_out(const long handl
                                                                 const long length, double* T, double* p, double* rhomolar, double* hmolar,
                                                                 double* smolar, long* errcode, char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
 
@@ -803,6 +813,7 @@ EXPORT_CODE void CONVENTION AbstractState_update_and_1_out(const long handle, co
                                                            const long length, const long output, double* out, long* errcode, char* message_buffer,
                                                            const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
 
@@ -826,6 +837,7 @@ EXPORT_CODE void CONVENTION AbstractState_update_and_5_out(const long handle, co
                                                            const long length, long* outputs, double* out1, double* out2, double* out3, double* out4,
                                                            double* out5, long* errcode, char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
 
@@ -853,6 +865,7 @@ EXPORT_CODE void CONVENTION AbstractState_set_binary_interaction_double(const lo
                                                                         const double value, long* errcode, char* message_buffer,
                                                                         const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         AS->set_binary_interaction_double(static_cast<std::size_t>(i), static_cast<std::size_t>(j), parameter, value);
@@ -864,6 +877,7 @@ EXPORT_CODE void CONVENTION AbstractState_set_binary_interaction_double(const lo
 EXPORT_CODE void CONVENTION AbstractState_set_cubic_alpha_C(const long handle, const long i, const char* parameter, const double c1, const double c2,
                                                             const double c3, long* errcode, char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         AS->set_cubic_alpha_C(static_cast<std::size_t>(i), parameter, c1, c2, c3);
@@ -875,6 +889,7 @@ EXPORT_CODE void CONVENTION AbstractState_set_cubic_alpha_C(const long handle, c
 EXPORT_CODE void CONVENTION AbstractState_set_fluid_parameter_double(const long handle, const long i, const char* parameter, const double value,
                                                                      long* errcode, char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         AS->set_fluid_parameter_double(static_cast<std::size_t>(i), parameter, value);
@@ -886,6 +901,7 @@ EXPORT_CODE void CONVENTION AbstractState_set_fluid_parameter_double(const long 
 EXPORT_CODE void CONVENTION AbstractState_build_phase_envelope(const long handle, const char* level, long* errcode, char* message_buffer,
                                                                const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         AS->build_phase_envelope(level);
@@ -898,6 +914,7 @@ EXPORT_CODE void CONVENTION AbstractState_get_phase_envelope_data(const long han
                                                                   double* rhomolar_liq, double* x, double* y, long* errcode, char* message_buffer,
                                                                   const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         CoolProp::PhaseEnvelopeData pe = AS->get_phase_envelope_data();
@@ -926,6 +943,7 @@ EXPORT_CODE void CONVENTION AbstractState_get_phase_envelope_data_checkedMemory(
                                                                                 double* x, double* y, long* actual_length, long* actual_components,
                                                                                 long* errcode, char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         CoolProp::PhaseEnvelopeData pe = AS->get_phase_envelope_data();
@@ -956,6 +974,7 @@ EXPORT_CODE void CONVENTION AbstractState_get_phase_envelope_data_checkedMemory(
 
 EXPORT_CODE void CONVENTION AbstractState_build_spinodal(const long handle, long* errcode, char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         AS->build_spinodal();
@@ -967,6 +986,7 @@ EXPORT_CODE void CONVENTION AbstractState_build_spinodal(const long handle, long
 EXPORT_CODE void CONVENTION AbstractState_get_spinodal_data(const long handle, const long length, double* tau, double* delta, double* M1,
                                                             long* errcode, char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         CoolProp::SpinodalData spin = AS->get_spinodal_data();
@@ -987,6 +1007,7 @@ EXPORT_CODE void CONVENTION AbstractState_get_spinodal_data(const long handle, c
 EXPORT_CODE void CONVENTION AbstractState_all_critical_points(const long handle, long length, double* T, double* p, double* rhomolar, long* stable,
                                                               long* errcode, char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         std::vector<CoolProp::CriticalState> pts = AS->all_critical_points();
@@ -1008,6 +1029,7 @@ EXPORT_CODE void CONVENTION AbstractState_all_critical_points(const long handle,
 EXPORT_CODE double CONVENTION AbstractState_keyed_output_satState(const long handle, const char* saturated_state, const long param, long* errcode,
                                                                   char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
 
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
@@ -1036,6 +1058,7 @@ EXPORT_CODE double CONVENTION AbstractState_keyed_output_satState(const long han
 EXPORT_CODE void CONVENTION AbstractState_backend_name(const long handle, char* backend, long* errcode, char* message_buffer,
                                                        const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
 
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
@@ -1053,6 +1076,7 @@ EXPORT_CODE void CONVENTION AbstractState_backend_name(const long handle, char* 
 
 EXPORT_CODE int CONVENTION AbstractState_phase(const long handle, long* errcode, char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         return AS->phase();
@@ -1066,6 +1090,7 @@ EXPORT_CODE void CONVENTION AbstractState_fluid_param_string(const long handle, 
                                                              const long return_buffer_length, long* errcode, char* message_buffer,
                                                              const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         std::string temp = AS->fluid_param_string(param);
@@ -1082,6 +1107,7 @@ EXPORT_CODE void CONVENTION AbstractState_fluid_param_string(const long handle, 
 EXPORT_CODE double CONVENTION AbstractState_saturated_liquid_keyed_output(const long handle, const long param, long* errcode, char* message_buffer,
                                                                           const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         return AS->saturated_liquid_keyed_output(static_cast<CoolProp::parameters>(param));
@@ -1094,6 +1120,7 @@ EXPORT_CODE double CONVENTION AbstractState_saturated_liquid_keyed_output(const 
 EXPORT_CODE double CONVENTION AbstractState_saturated_vapor_keyed_output(const long handle, const long param, long* errcode, char* message_buffer,
                                                                          const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
         return AS->saturated_vapor_keyed_output(static_cast<CoolProp::parameters>(param));
@@ -1106,6 +1133,7 @@ EXPORT_CODE double CONVENTION AbstractState_saturated_vapor_keyed_output(const l
 EXPORT_CODE void CONVENTION add_fluids_as_JSON(const char* backend, const char* fluidstring, long* errcode, char* message_buffer,
                                                const long buffer_length) {
     *errcode = 0;
+    fpu_reset_guard guard;
 
     try {
         CoolProp::add_fluids_as_JSON(backend, fluidstring);

--- a/src/Tests/CoolProp-Tests-FPUGuard.cpp
+++ b/src/Tests/CoolProp-Tests-FPUGuard.cpp
@@ -1,0 +1,75 @@
+// Regression tests for CoolProp::fpu_guard (GitHub #3012 / bd CoolProp-i3o).
+//
+// CoolProp uses NaN and _HUGE as in-band sentinels.  Host environments that run
+// with FP exceptions *unmasked* (Delphi, some TRNSYS/Fortran builds) take a
+// hardware trap / SIGFPE the instant CoolProp touches one of those values,
+// crashing mid-calculation.  fpu_guard masks FP exceptions on construction and
+// restores the caller's environment on destruction.
+//
+// These tests assert the guard's contract directly (it is a header-only type,
+// so it is reachable from the Catch2 runner even though CoolPropLib.cpp -- the
+// C-interface that wires the guard into every entry point -- is excluded from
+// that binary by CMakeLists.txt).  The decisive check is the divide-and-invalid
+// inside the guarded scope: with FE_INVALID *enabled* and no masking, the
+// volatile 0.0/0.0 below would raise SIGFPE and abort the process.
+
+#if defined(ENABLE_CATCH)
+
+#    include <catch2/catch_all.hpp>
+#    include "CoolProp/FPUGuard.h"
+#    include <cmath>  // std::isnan
+
+// fegetexcept/feenableexcept/fedisableexcept are GNU glibc extensions; the
+// "trapping host" half of the contract can only be exercised where they exist.
+#    if defined(__GLIBC__) && defined(FE_ALL_EXCEPT)
+#        include <cfenv>
+
+TEST_CASE("fpu_guard masks FP traps inside its scope and survives a NaN op", "[fpu_guard][fpu][3012]") {
+    std::feclearexcept(FE_ALL_EXCEPT);
+    feenableexcept(FE_INVALID);  // emulate a trapping host (Delphi/TRNSYS)
+
+    {
+        CoolProp::fpu_guard guard;
+        // Inside the guard FE_INVALID must be masked, so this 0.0/0.0 (which a
+        // trapping host would fault on) produces a quiet NaN instead of SIGFPE.
+        CHECK((fegetexcept() & FE_INVALID) == 0);
+        volatile double zero = 0.0;
+        volatile double nan = zero / zero;
+        CHECK(std::isnan(nan));
+    }
+
+    // After the guard the caller's trapping configuration is restored ...
+    CHECK((fegetexcept() & FE_INVALID) != 0);
+    // ... and the status flags the guard raised are cleared, so a polling host
+    // (Excel/VBA) sees a clean status word.
+    CHECK(std::fetestexcept(FE_INVALID) == 0);
+
+    fedisableexcept(FE_ALL_EXCEPT);
+    std::feclearexcept(FE_ALL_EXCEPT);
+}
+
+TEST_CASE("fpu_guard leaves an already-masked environment unchanged", "[fpu_guard][fpu][3012]") {
+    fedisableexcept(FE_ALL_EXCEPT);  // nothing trapping (the common host default)
+    std::feclearexcept(FE_ALL_EXCEPT);
+
+    {
+        CoolProp::fpu_guard guard;
+        CHECK((fegetexcept() & FE_ALL_EXCEPT) == 0);
+    }
+
+    // Restoring an empty trapping set must not enable anything spuriously.
+    CHECK((fegetexcept() & FE_ALL_EXCEPT) == 0);
+    std::feclearexcept(FE_ALL_EXCEPT);
+}
+#    endif  // __GLIBC__ && FE_ALL_EXCEPT
+
+TEST_CASE("fpu_guard is constructible and clears status flags on every platform", "[fpu_guard][fpu][3012]") {
+    // Platform-independent smoke test: the guard must compile and run a NaN op
+    // without aborting even where the GNU trapping API is unavailable.
+    CoolProp::fpu_guard guard;
+    volatile double zero = 0.0;
+    volatile double nan = zero / zero;
+    CHECK(std::isnan(nan));
+}
+
+#endif  // ENABLE_CATCH

--- a/src/Tests/CoolProp-Tests-FPUGuard.cpp
+++ b/src/Tests/CoolProp-Tests-FPUGuard.cpp
@@ -18,11 +18,11 @@
 #    include <catch2/catch_all.hpp>
 #    include "CoolProp/FPUGuard.h"
 #    include <cmath>  // std::isnan
+#    include <cfenv>  // std::fetestexcept / std::feclearexcept
 
 // fegetexcept/feenableexcept/fedisableexcept are GNU glibc extensions; the
 // "trapping host" half of the contract can only be exercised where they exist.
 #    if defined(__GLIBC__) && defined(FE_ALL_EXCEPT)
-#        include <cfenv>
 
 TEST_CASE("fpu_guard masks FP traps inside its scope and survives a NaN op", "[fpu_guard][fpu][3012]") {
     std::feclearexcept(FE_ALL_EXCEPT);
@@ -64,12 +64,19 @@ TEST_CASE("fpu_guard leaves an already-masked environment unchanged", "[fpu_guar
 #    endif  // __GLIBC__ && FE_ALL_EXCEPT
 
 TEST_CASE("fpu_guard is constructible and clears status flags on every platform", "[fpu_guard][fpu][3012]") {
-    // Platform-independent smoke test: the guard must compile and run a NaN op
-    // without aborting even where the GNU trapping API is unavailable.
-    CoolProp::fpu_guard guard;
-    volatile double zero = 0.0;
-    volatile double nan = zero / zero;
-    CHECK(std::isnan(nan));
+    // Platform-independent smoke test: the guard must compile, run a NaN op
+    // without aborting even where the GNU trapping API is unavailable, and -- on
+    // every platform path (glibc/MSVC/macOS) -- leave a clean status word once
+    // destroyed, since each ~fpu_guard clears the flags it raised.
+    std::feclearexcept(FE_ALL_EXCEPT);
+    {
+        CoolProp::fpu_guard guard;
+        volatile double zero = 0.0;
+        volatile double nan = zero / zero;  // raises FE_INVALID inside the guard
+        CHECK(std::isnan(nan));
+    }
+    // The guard is now destroyed; the flag it raised must have been cleared.
+    CHECK(std::fetestexcept(FE_INVALID) == 0);
 }
 
 #endif  // ENABLE_CATCH


### PR DESCRIPTION
## Summary

Fixes #3012. CoolProp uses `NaN` and `_HUGE` as in-band sentinels; floating-point operations on those values set the IEEE-754 status flags (`FE_INVALID`/`FE_OVERFLOW`/`FE_DIVBYZERO`). Host environments react two ways:

- **Polling hosts** (Excel/VBA) read the status word after a call returns and report a spurious FP error.
- **Trapping hosts** (Delphi's RTL *unmasks* FP exceptions by default; some TRNSYS/Fortran builds) take a hardware trap / `SIGFPE` at the offending instruction — **mid-calculation**, which is the "errors out in the middle of a calculation" symptom in the issue.

The previous `fpu_reset_guard` only **cleared** the status flags on scope exit. That helps polling hosts but cannot help trapping hosts (the trap has already fired). It also covered only **13 of 72** export functions — the entire `AbstractState_*` low-level API had **no** protection.

## What changed

- **New `include/CoolProp/FPUGuard.h`** — RAII `CoolProp::fpu_guard`:
  - **ctor**: snapshot the caller's FP environment, then *mask* all FP exceptions.
  - **dtor**: clear the flags we raised, then *restore* the caller's masking (so we leave the host environment exactly as we found it).
  - Windows masking is keyed on `_WIN32` (any compiler, incl. MinGW-w64) via `_controlfp_s` — Windows/Delphi is the worst-hit platform. Linux uses the glibc `fe{get,disable,enable}except` extensions. macOS/BSD/PowerPC keep the historical clear-only behavior (no FP traps enabled there by default).
- **`src/CoolPropLib.cpp`** — `fpu_reset_guard` is now an alias for `CoolProp::fpu_guard`, and the guard is applied to all 38 `errcode`-based `AbstractState_*` entry points. Guard sites: **13 → 51**, closing the coverage gap.
- **`src/Tests/CoolProp-Tests-FPUGuard.cpp`** (`[fpu_guard]`) — under glibc, enable `FE_INVALID` then assert no `SIGFPE` inside the guard and that the trapping set is restored afterward; plus a cross-platform construction/NaN smoke test. Wired into the CMake CATCH module.

## Testing / review

- `./dev/ci/preflight.sh`: **6 passed / 0 failed** (clang-format 18.1.8, build, Catch2 `[!slow][!benchmark]`, cppcheck, clang-tidy 0 signal findings, semgrep).
- `[fpu_guard]` passes locally (smoke test on macOS; the glibc trapping cases run in Linux CI).
- Multi-angle adversarial review run on the diff: no blocking findings. Verified glibc nesting/restore, MSVC field-masked restore, and clear-then-enable dtor ordering are correct.

> [!NOTE]
> The Windows masking and Delphi-style trapping paths can't be exercised on the macOS dev machine; they rely on Linux CI plus manual Windows verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved floating-point exception handling across core API entry points for more stable numerical behavior.

* **Tests**
  * Added regression tests to validate the floating-point guard's behavior and portability.

* **Chores**
  * Updated build configuration to include the new test sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3016?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->