### PR TITLE
CodeQL first-party C++ triage: suppress commented-out-code + safe fixes (#3010)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -15,3 +15,13 @@ paths-ignore:
   - externals/miniz-*/**
   - externals/fmt*/**
   - .claude/**
+
+# Suppress individual queries that are pure noise on this codebase.
+# Unlike paths-ignore (inert for built C/C++), query-filters are applied at
+# result-interpretation time and DO take effect for compiled languages.
+# - cpp/commented-out-code: 250 first-party hits, all low-signal style; the
+#   commented-out blocks are deliberate (alternative formulations, disabled
+#   debug, doc snippets) and reviewing them yields no security/correctness value.
+query-filters:
+  - exclude:
+      id: cpp/commented-out-code

--- a/include/CPnumerics.h
+++ b/include/CPnumerics.h
@@ -558,7 +558,7 @@ T2 CubicInterp(const std::vector<T1>& x, const std::vector<T1>& y, std::size_t i
 };
 
 template <class T>
-T is_in_closed_range(T x1, T x2, T x) {
+bool is_in_closed_range(T x1, T x2, T x) {
     return (x >= std::min(x1, x2) && x <= std::max(x1, x2));
 };
 

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -632,13 +632,13 @@ CoolPropDbl CoolProp::AbstractCubicBackend::calc_molar_mass() {
 void CoolProp::AbstractCubicBackend::set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter,
                                                                    const double value) {
     // bound-check indices
-    if (i < 0 || i >= N) {
-        if (j < 0 || j >= N) {
+    if (i >= N) {
+        if (j >= N) {
             throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N - 1));
         } else {
             throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N - 1));
         }
-    } else if (j < 0 || j >= N) {
+    } else if (j >= N) {
         throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N - 1));
     }
     if (parameter == "kij" || parameter == "k_ij") {
@@ -652,13 +652,13 @@ void CoolProp::AbstractCubicBackend::set_binary_interaction_double(const std::si
 };
 double CoolProp::AbstractCubicBackend::get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter) {
     // bound-check indices
-    if (i < 0 || i >= N) {
-        if (j < 0 || j >= N) {
+    if (i >= N) {
+        if (j >= N) {
             throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N - 1));
         } else {
             throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N - 1));
         }
-    } else if (j < 0 || j >= N) {
+    } else if (j >= N) {
         throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N - 1));
     }
     if (parameter == "kij" || parameter == "k_ij") {
@@ -701,7 +701,7 @@ void CoolProp::AbstractCubicBackend::copy_internals(AbstractCubicBackend& donor)
 void CoolProp::AbstractCubicBackend::set_cubic_alpha_C(const size_t i, const std::string& parameter, const double c1, const double c2,
                                                        const double c3) {
     // bound-check indices
-    if (i < 0 || i >= N) {
+    if (i >= N) {
         throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N - 1));
     }
     if (parameter == "MC" || parameter == "mc" || parameter == "Mathias-Copeman") {
@@ -719,7 +719,7 @@ void CoolProp::AbstractCubicBackend::set_cubic_alpha_C(const size_t i, const std
 
 void CoolProp::AbstractCubicBackend::set_fluid_parameter_double(const size_t i, const std::string& parameter, const double value) {
     // bound-check indices
-    if (i < 0 || i >= N) {
+    if (i >= N) {
         throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N - 1));
     }
     // Set the volume translation parrameter, currently applied to the whole fluid, not to components.
@@ -741,7 +741,7 @@ void CoolProp::AbstractCubicBackend::set_fluid_parameter_double(const size_t i, 
 }
 double CoolProp::AbstractCubicBackend::get_fluid_parameter_double(const size_t i, const std::string& parameter) {
     // bound-check indices
-    if (i < 0 || i >= N) {
+    if (i >= N) {
         throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N - 1));
     }
     // Get the volume translation parrameter, currently applied to the whole fluid, not to components.

--- a/src/Backends/Cubics/VTPRBackend.cpp
+++ b/src/Backends/Cubics/VTPRBackend.cpp
@@ -101,13 +101,13 @@ CoolPropDbl CoolProp::VTPRBackend::calc_molar_mass() {
 void CoolProp::VTPRBackend::set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter,
                                                           const double value) {
     // bound-check indices
-    if (i < 0 || i >= N) {
-        if (j < 0 || j >= N) {
+    if (i >= N) {
+        if (j >= N) {
             throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N - 1));
         } else {
             throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N - 1));
         }
-    } else if (j < 0 || j >= N) {
+    } else if (j >= N) {
         throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N - 1));
     }
     cubic->set_interaction_parameter(i, j, parameter, value);
@@ -122,13 +122,13 @@ void CoolProp::VTPRBackend::set_Q_k(const size_t sgi, const double value) {
 
 double CoolProp::VTPRBackend::get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter) {
     // bound-check indices
-    if (i < 0 || i >= N) {
-        if (j < 0 || j >= N) {
+    if (i >= N) {
+        if (j >= N) {
             throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N - 1));
         } else {
             throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N - 1));
         }
-    } else if (j < 0 || j >= N) {
+    } else if (j >= N) {
         throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N - 1));
     }
     return cubic->get_interaction_parameter(i, j, parameter);

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -1856,7 +1856,7 @@ void FlashRoutines::HSU_D_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
                         Sat = HEOS.SatV;
                     }
                     break;  // good solve
-                } catch (CoolPropBaseError) {
+                } catch (const CoolPropBaseError&) {
                     optionsD.omega /= 2;
                     optionsD.max_iterations *= 2;
                     if (i_try >= 6) {

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -356,13 +356,13 @@ double HelmholtzEOSMixtureBackend::get_fluid_parameter_double(const size_t i, co
 
 void HelmholtzEOSMixtureBackend::apply_simple_mixing_rule(std::size_t i, std::size_t j, const std::string& model) {
     // bound-check indices
-    if (i < 0 || i >= N) {
-        if (j < 0 || j >= N) {
+    if (i >= N) {
+        if (j >= N) {
             throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N - 1));
         } else {
             throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N - 1));
         }
-    } else if (j < 0 || j >= N) {
+    } else if (j >= N) {
         throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N - 1));
     }
     if (model == "linear") {
@@ -387,13 +387,13 @@ void HelmholtzEOSMixtureBackend::apply_simple_mixing_rule(std::size_t i, std::si
 void HelmholtzEOSMixtureBackend::set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter,
                                                                const double value) {
     // bound-check indices
-    if (i < 0 || i >= N) {
-        if (j < 0 || j >= N) {
+    if (i >= N) {
+        if (j >= N) {
             throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N - 1));
         } else {
             throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N - 1));
         }
-    } else if (j < 0 || j >= N) {
+    } else if (j >= N) {
         throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N - 1));
     }
     if (parameter == "Fij") {
@@ -410,13 +410,13 @@ void HelmholtzEOSMixtureBackend::set_binary_interaction_double(const std::size_t
 /// Get binary mixture floating point parameter for this instance
 double HelmholtzEOSMixtureBackend::get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter) {
     // bound-check indices
-    if (i < 0 || i >= N) {
-        if (j < 0 || j >= N) {
+    if (i >= N) {
+        if (j >= N) {
             throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N - 1));
         } else {
             throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N - 1));
         }
-    } else if (j < 0 || j >= N) {
+    } else if (j >= N) {
         throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N - 1));
     }
     if (parameter == "Fij") {
@@ -433,13 +433,13 @@ double HelmholtzEOSMixtureBackend::get_binary_interaction_double(const std::size
 void HelmholtzEOSMixtureBackend::set_binary_interaction_string(const std::size_t i, const std::size_t j, const std::string& parameter,
                                                                const std::string& value) {
     // bound-check indices
-    if (i < 0 || i >= N) {
-        if (j < 0 || j >= N) {
+    if (i >= N) {
+        if (j >= N) {
             throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N - 1));
         } else {
             throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N - 1));
         }
-    } else if (j < 0 || j >= N) {
+    } else if (j >= N) {
         throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N - 1));
     }
     if (parameter == "function") {

--- a/src/Backends/Helmholtz/ReducingFunctions.h
+++ b/src/Backends/Helmholtz/ReducingFunctions.h
@@ -189,13 +189,13 @@ class GERG2008ReducingFunction : public ReducingFunction
     /// Set all beta and gamma values in one shot
     void set_binary_interaction_double(const std::size_t i, const std::size_t j, double betaT, double gammaT, double betaV, double gammaV) {
         // bound-check indices
-        if (i < 0 || i >= N) {
-            if (j < 0 || j >= N) {
+        if (i >= N) {
+            if (j >= N) {
                 throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N - 1));
             } else {
                 throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N - 1));
             }
-        } else if (j < 0 || j >= N) {
+        } else if (j >= N) {
             throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N - 1));
         }
         beta_T[i][j] = betaT;
@@ -211,13 +211,13 @@ class GERG2008ReducingFunction : public ReducingFunction
     /// Set a parameter
     void set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter, double value) override {
         // bound-check indices
-        if (i < 0 || i >= N) {
-            if (j < 0 || j >= N) {
+        if (i >= N) {
+            if (j >= N) {
                 throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, N - 1));
             } else {
                 throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N - 1));
             }
-        } else if (j < 0 || j >= N) {
+        } else if (j >= N) {
             throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N - 1));
         }
         if (parameter == "betaT") {

--- a/src/Backends/PCSAFT/PCSAFTLibrary.cpp
+++ b/src/Backends/PCSAFT/PCSAFTLibrary.cpp
@@ -234,7 +234,7 @@ std::string PCSAFTLibraryClass::get_binary_interaction_pcsaft(const std::string&
             } else if (key == "kijT") {
                 try {
                     return format("%0.16g", v[0].get_double("kijT"));
-                } catch (ValueError) {
+                } catch (const ValueError&) {
                     return format("%0.16g", 0.0);
                 }
             } else {
@@ -259,7 +259,7 @@ std::string PCSAFTLibraryClass::get_binary_interaction_pcsaft(const std::string&
             } else if (key == "kijT") {
                 try {
                     return format("%0.16g", v[0].get_double("kijT"));
-                } catch (ValueError) {
+                } catch (const ValueError&) {
                     return format("%0.16g", 0.0);
                 }
             } else {

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -605,13 +605,13 @@ std::string REFPROPMixtureBackend::get_binary_interaction_string(const std::stri
 void REFPROPMixtureBackend::set_binary_interaction_string(const std::size_t i, const std::size_t j, const std::string& parameter,
                                                           const std::string& value) {
     // bound-check indices
-    if (i < 0 || i >= Ncomp) {
-        if (j < 0 || j >= Ncomp) {
+    if (i >= Ncomp) {
+        if (j >= Ncomp) {
             throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, Ncomp - 1));
         } else {
             throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, Ncomp - 1));
         }
-    } else if (j < 0 || j >= Ncomp) {
+    } else if (j >= Ncomp) {
         throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, Ncomp - 1));
     }
     int icomp = static_cast<int>(i) + 1, jcomp = static_cast<int>(j) + 1, ierr = 0L;
@@ -644,13 +644,13 @@ void REFPROPMixtureBackend::set_binary_interaction_string(const std::size_t i, c
 void REFPROPMixtureBackend::set_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter,
                                                           const double value) {
     // bound-check indices
-    if (i < 0 || i >= Ncomp) {
-        if (j < 0 || j >= Ncomp) {
+    if (i >= Ncomp) {
+        if (j >= Ncomp) {
             throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, Ncomp - 1));
         } else {
             throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, Ncomp - 1));
         }
-    } else if (j < 0 || j >= Ncomp) {
+    } else if (j >= Ncomp) {
         throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, Ncomp - 1));
     }
     int icomp = static_cast<int>(i) + 1, jcomp = static_cast<int>(j) + 1, ierr = 0L;
@@ -692,13 +692,13 @@ void REFPROPMixtureBackend::set_binary_interaction_double(const std::size_t i, c
 /// Get binary mixture double value (EXPERT USE ONLY!!!)
 double REFPROPMixtureBackend::get_binary_interaction_double(const std::size_t i, const std::size_t j, const std::string& parameter) {
     // bound-check indices
-    if (i < 0 || i >= Ncomp) {
-        if (j < 0 || j >= Ncomp) {
+    if (i >= Ncomp) {
+        if (j >= Ncomp) {
             throw ValueError(format("Both indices i [%d] and j [%d] are out of bounds. Must be between 0 and %d.", i, j, Ncomp - 1));
         } else {
             throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, Ncomp - 1));
         }
-    } else if (j < 0 || j >= Ncomp) {
+    } else if (j >= Ncomp) {
         throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, Ncomp - 1));
     }
     int icomp = static_cast<int>(i) + 1, jcomp = static_cast<int>(j) + 1;


### PR DESCRIPTION
Follow-up to the #3010 triage. The 431 first-party C++ CodeQL alerts are heavily skewed: 250 are pure `cpp/commented-out-code` style noise, only 6 are security-classified, and the rest are quality/correctness warnings. This PR clears the actionable, **behaviour-preserving** subset and silences the dominant noise source.

## 1. Suppress `cpp/commented-out-code` (config)

`.github/codeql/codeql-config.yml` — add a `query-filters` exclude. Unlike `paths-ignore` (which is inert for built C/C++, see the closed #3013 investigation), `query-filters` are applied at result-interpretation time and **do** take effect for compiled languages. The 250 hits are deliberate commented blocks (alternative formulations, disabled debug, doc snippets) with no security/correctness value.

## 2. Safe correctness fixes (source)

All behaviour-preserving:

- **`is_in_closed_range` return type `T` → `bool`** (`CPnumerics.h`). It was declared `template<class T> T` but returns a boolean expression, so every call did an implicit `double→bool` cast (`cpp/lossy-function-result-cast`, ~most of 32). Values were only ever `0.0`/`1.0`, so no behaviour change. All 34 call sites are boolean contexts (verified).
- **Catch by `const&` instead of by value** (`cpp/catch-by-value` ×3): `PCSAFTLibrary.cpp` ×2, `FlashRoutines.cpp` ×1. None use the caught object — purely avoids slicing.
- **Drop dead `i < 0`/`j < 0` checks** on `std::size_t` indices in the `set/get_binary_interaction_*` bound-checks (`cpp/constant-comparison` ×42 across Cubics, VTPR, Helmholtz, ReducingFunctions, REFPROP). Unsigned can't be negative; the `>= N`/`>= Ncomp` upper-bound checks still hold, so out-of-range inputs (including negatives that wrap to huge values) are rejected identically.

Net: clears ~80 of the actionable alerts and 250 noise alerts.

## Verification
- Build clean; **272 non-slow Catch2 cases pass** (117,580 assertions). 25 REFPROP cases skipped (not linked in this build config; the REFPROP edit compiles).
- clang-format and semgrep clean.
- cppcheck/clang-tidy preflight findings are all pre-existing issues on lines this diff does not touch (no overlap with changed lines); both are informational/never-gate in CI.

## Not in scope (deferred)
The 6 `cpp/path-injection` (high-severity, env-var-derived paths — modest practical risk) and the float-equality / loop-variable warnings, which need judgement rather than mechanical fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bounds-checking logic in equation of state backends to properly validate array indices.

* **Refactor**
  * Updated `is_in_closed_range` function to return boolean type.
  * Improved exception handling with const references for better code efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3017?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->