### PR TITLE
refactor(clang-tidy): Tier-1 bug-finder batch (#2926 layer 2)

### DIFF
--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -1489,7 +1489,14 @@ void FlashRoutines::HSU_D_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
         // guesses and converge to metastable roots in the compressed-
         // liquid region (e.g. CO2 LIQUID).  See solver_rho_Tp; #2738.
         ~solver_resid() {
-            HEOS->unspecify_phase();
+            // This RAII cleanup runs from a destructor (implicitly noexcept):
+            // a throw escaping here would call std::terminate.  unspecify_phase()
+            // only resets a flag and shouldn't throw, but guard it so a future
+            // change can't silently turn this into a crash.
+            try {
+                HEOS->unspecify_phase();
+            } catch (...) {  // NOLINT(bugprone-empty-catch) — a dtor must not let an exception escape
+            }
         }
         double call(double T) override {
             HEOS->update_DmolarT_direct(rhomolar, T);

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -621,6 +621,8 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_saturation_ancillary(parameters par
                     return components[0].ancillaries.pL.evaluate(value);
                 case 1:
                     return components[0].ancillaries.pV.evaluate(value);
+                default:
+                    break;  // falls through to the "Q invalid" throw below
             }
         } else if (param == iT && given == iP) {
             // T = f(p), inverse evaluation
@@ -629,6 +631,8 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_saturation_ancillary(parameters par
                     return components[0].ancillaries.pL.invert(value);
                 case 1:
                     return components[0].ancillaries.pV.invert(value);
+                default:
+                    break;  // falls through to the "Q invalid" throw below
             }
         } else if (param == iDmolar && given == iT) {
             // rho = f(T), inverse evaluation
@@ -637,6 +641,8 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_saturation_ancillary(parameters par
                     return components[0].ancillaries.rhoL.evaluate(value);
                 case 1:
                     return components[0].ancillaries.rhoV.evaluate(value);
+                default:
+                    break;  // falls through to the "Q invalid" throw below
             }
         } else if (param == iT && given == iDmolar) {
             // T = f(rho), inverse evaluation
@@ -645,6 +651,8 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_saturation_ancillary(parameters par
                     return components[0].ancillaries.rhoL.invert(value);
                 case 1:
                     return components[0].ancillaries.rhoV.invert(value);
+                default:
+                    break;  // falls through to the "Q invalid" throw below
             }
         } else if (param == isurface_tension && given == iT) {
             return components[0].ancillaries.surface_tension.evaluate(value);
@@ -1959,6 +1967,8 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
                     }
                     break;
                 }
+                default:
+                    break;  // non-density inputs fall through to the full VLE path below
             }
         }
 

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -41,8 +41,8 @@ std::string config_key_description(const std::string& key) {
     * See http://stackoverflow.com/questions/147267/easy-way-to-use-variables-of-enum-types-as-string-in-c#202511
     */
 #define X(Enum, String, Default, Desc) \
-    if (key == String) {               \
-        return Desc;                   \
+    if (key == (String)) {             \
+        return (Desc);                 \
     }
     CONFIGURATION_KEYS_ENUM
 #undef X
@@ -55,7 +55,7 @@ configuration_keys config_string_to_key(const std::string& s) {
      * See http://stackoverflow.com/questions/147267/easy-way-to-use-variables-of-enum-types-as-string-in-c#202511
      */
 #define X(Enum, String, Default, Desc) \
-    if (s == String) {                 \
+    if (s == (String)) {               \
         return Enum;                   \
     }
     CONFIGURATION_KEYS_ENUM

--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -1795,16 +1795,18 @@ void _HAPropsSI_inputs(double p, const std::vector<givens>& input_keys, const st
         if (CoolProp::get_debug_level() > 0) {
             std::cout << format("The main input is not T\n", T);
         }
-        // Need to iterate to find dry bulb temperature since temperature is not provided
-        if ((key = get_input_key(input_keys, GIVEN_HUMRAT)) >= 0) {
-        }  // Humidity ratio is given
-        // Prefer T_dp over R as main key when both are present: T_dp determines psi_w directly
-        // without requiring dry-bulb T, so it gives better iteration bounds.
-        else if ((key = get_input_key(input_keys, GIVEN_TDP)) >= 0) {
-        }  // Dewpoint temperature is given
-        else if ((key = get_input_key(input_keys, GIVEN_RH)) >= 0) {
-        }  // Relative humidity is given
-        else {
+        // Need to iterate to find dry bulb temperature since temperature is not provided.
+        // Pick the first available key in priority order: humidity ratio, then dewpoint,
+        // then relative humidity.  Prefer T_dp over R when both are present: T_dp determines
+        // psi_w directly without requiring dry-bulb T, so it gives better iteration bounds.
+        key = get_input_key(input_keys, GIVEN_HUMRAT);  // Humidity ratio is given
+        if (key < 0) {
+            key = get_input_key(input_keys, GIVEN_TDP);  // Dewpoint temperature is given
+        }
+        if (key < 0) {
+            key = get_input_key(input_keys, GIVEN_RH);  // Relative humidity is given
+        }
+        if (key < 0) {
             throw CoolProp::ValueError(
               "Sorry, but currently at least one of the variables as an input to HAPropsSI() must be temperature, relative humidity, humidity ratio, "
               "or dewpoint\n  Eventually will add a 2-D NR solver to find T and psi_w simultaneously, but not included now");


### PR DESCRIPTION
## What

Hand-written, high-signal clang-tidy fixes from the **layer-2 sweep** (CoolProp-1pr) — the follow-up to the #2926 triage now that the first fix wave landed (#2978/#2980/#2983/#2985). These are the Tier-1 "real bug / hardening" findings; the mechanical modernize/perf batch follows in a separate PR.

## Changes

- **`bugprone-exception-escape`** (`FlashRoutines.cpp`, `~solver_resid`): wrap the RAII cleanup `HEOS->unspecify_phase()` in `try/catch`. The destructor is implicitly `noexcept`, so a throw escaping it calls `std::terminate`. `unspecify_phase()` resolves to a single flag assignment and can't throw today, but the guard makes the no-crash guarantee explicit and future-proof. (`NOLINT(bugprone-empty-catch)` — a dtor must swallow.)
- **`bugprone-switch-missing-default-case` ×5** (`HelmholtzEOSMixtureBackend.cpp`): add `default: break;` to the four `calc_saturation_ancillary` Q-switches (which fall through to the existing `"Q [%d] is invalid"` throw) and to the `iDmolar` phase-guess switch (falls through to the full VLE path). Control-flow-neutral; documents the unhandled arms.
- **`bugprone-assignment-in-if-condition` ×3** (`HumidAirProp.cpp`): replace the `if((key=get_input_key(...))>=0){} else if … else throw` chain (empty bodies, side-effecting conditions) with sequential first-match assignment. Same priority order (HUMRAT > TDP > RH), same throw-on-none, same resulting `key`.
- **`bugprone-macro-parentheses` ×2** (`Configuration.cpp`): parenthesize the `String` arg in the `CONFIGURATION_KEYS_ENUM` X-macro.

## Verification

- Compiles clean (Release).
- `[HAProps]`/`[HAPropsSI]`/`[humid_air*]`/`[ancillary]`/`[saturation]`/`[flash]` + the preflight `[Helmholtz],[REFPROP],[!benchmark]` suite pass (5027 assertions).
- Changed lines verified clean diff-only with clang-tidy (`-line-filter`). The whole-file clang-tidy/cppcheck findings in these legacy files are pre-existing and out of scope (catalogued in CoolProp-1pr); preflight clang-tidy/cppcheck skipped with that justification, consistent with CoolProp-2qt.
- Adversarial review: no blocking findings (confirmed `get_input_key` ∈ {0,1,-1} and all fall-through paths unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced exception handling in cleanup routines to prevent potential crashes
  * Added validation for edge cases in saturation property calculations
  * Improved robustness in input validation for humid air calculations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3018?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->