### PR TITLE
refactor(clang-tidy): Tier-2 mechanical fix-it sweep (#2926 layer 2)

### DIFF
--- a/include/AbstractState.h
+++ b/include/AbstractState.h
@@ -728,7 +728,7 @@ class AbstractState
         // and silence clang-analyzer-optin.cplusplus.VirtualCall.
         AbstractState::clear();
     }
-    virtual ~AbstractState() {};
+    virtual ~AbstractState() = default;
 
     /// A factory function to return a pointer to a new-allocated instance of one of the backends.
     /**
@@ -852,7 +852,7 @@ class AbstractState
     /// Get the mole fractions of the equilibrium liquid phase (but as a double for use in SWIG wrapper)
     std::vector<double> mole_fractions_liquid_double() {
         std::vector<CoolPropDbl> x = calc_mole_fractions_liquid();
-        return std::vector<double>(x.begin(), x.end());
+        return {x.begin(), x.end()};
     };
 
     /// Get the mole fractions of the equilibrium vapor phase
@@ -862,7 +862,7 @@ class AbstractState
     /// Get the mole fractions of the equilibrium vapor phase (but as a double for use in SWIG wrapper)
     std::vector<double> mole_fractions_vapor_double() {
         std::vector<CoolPropDbl> y = calc_mole_fractions_vapor();
-        return std::vector<double>(y.begin(), y.end());
+        return {y.begin(), y.end()};
     };
 
     /// Get the mole fractions of the fluid
@@ -1701,13 +1701,13 @@ class AbstractStateGenerator
     /// own JSON parse and schema validation.
     virtual AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names, const std::string& options_json);
 
-    virtual ~AbstractStateGenerator() {};
+    virtual ~AbstractStateGenerator() = default;
 };
 
 /** Register a backend in the backend library (statically defined in AbstractState.cpp and not
  *  publicly accessible)
  */
-void register_backend(const backend_families& bf, shared_ptr<AbstractStateGenerator> gen);
+void register_backend(const backend_families& bf, const shared_ptr<AbstractStateGenerator>& gen);
 
 template <class T>
 class GeneratorInitializer

--- a/include/Ancillaries.h
+++ b/include/Ancillaries.h
@@ -39,8 +39,12 @@ class SurfaceTensionCorrelation
         Tc = cpjson::get_double(json_code, "Tc");
         BibTeX = cpjson::get_string(json_code, "BibTeX");
 
-        this->N = n.size();
-        s = n;
+        // NB: N and s derive from n, which is populated above in the body, so
+        // they must NOT be hoisted into a member-initializer list (clang-tidy
+        // cppcoreguidelines-prefer-member-initializer) — at init-list time n is
+        // still empty, which would silently make every surface tension 0.
+        this->N = n.size();  // NOLINT(cppcoreguidelines-prefer-member-initializer)
+        s = n;               // NOLINT(cppcoreguidelines-prefer-member-initializer)
     };
     /// Actually evaluate the surface tension equation
     CoolPropDbl evaluate(CoolPropDbl T) {
@@ -109,11 +113,10 @@ class SaturationAncillaryFunction
     };
     ancillaryfunctiontypes type;  ///< The type of ancillary curve being used
    public:
-    SaturationAncillaryFunction() {
-        type = TYPE_NOT_SET;
-        Tmin = _HUGE;
-        Tmax = _HUGE;
-    };
+    SaturationAncillaryFunction()
+      : type(TYPE_NOT_SET), Tmin(_HUGE), Tmax(_HUGE) {
+
+        };
     SaturationAncillaryFunction(rapidjson::Value& json_code);
 
     /// Return true if the ancillary is enabled (type is not TYPE_NOT_SET)

--- a/include/CPfilepaths.h
+++ b/include/CPfilepaths.h
@@ -19,7 +19,7 @@ bool path_exists(const std::string& path);
 std::string join_path(const std::string& one, const std::string& two);
 
 /// Make directory and all required intermediate directories
-void make_dirs(std::string file_path);
+void make_dirs(const std::string& file_path);
 
 /// Get the size of a directory in bytes.
 /// Uses std::filesystem on modern platforms (Windows, Linux, macOS).

--- a/include/CPnumerics.h
+++ b/include/CPnumerics.h
@@ -62,7 +62,7 @@ class Spline
 {
    public:
     /** An empty, invalid spline */
-    Spline() {}
+    Spline() = default;
 
     /** A spline with x and y values */
     Spline(const std::vector<X>& x, const std::vector<Y>& y) {
@@ -76,7 +76,7 @@ class Spline
             return;
         }
 
-        typedef typename std::vector<X>::difference_type size_type;
+        using size_type = typename std::vector<X>::difference_type;
 
         size_type n = y.size() - 1;
 
@@ -109,7 +109,7 @@ class Spline
             mElements.push_back(Element(x[i], y[i], b[i], c[i], d[i]));
         }
     }
-    virtual ~Spline() {}
+    virtual ~Spline() = default;
 
     Y operator[](const X& x) const {
         return interpolate(x);
@@ -170,7 +170,7 @@ class Spline
         Y a, b, c, d;
     };
 
-    typedef Element element_type;
+    using element_type = Element;
     std::vector<element_type> mElements;
 };
 
@@ -483,7 +483,7 @@ double interp1d(const std::vector<double>* x, const std::vector<double>* y, doub
 double powInt(double x, int y);
 
 template <class T>
-T POW2(T x) {
+T POW2(const T& x) {
     return x * x;
 }
 template <class T>

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -167,35 +167,30 @@ class ConfigurationItem
         return v_integer;
     };
     // Initializer for bool
-    ConfigurationItem(configuration_keys key, bool val) {
-        this->key = key;
-        type = CONFIGURATION_BOOL_TYPE;
+    ConfigurationItem(configuration_keys key, bool val) : key(key), type(CONFIGURATION_BOOL_TYPE) {
+
         v_bool = val;
     };
     // Initializer for integer
-    ConfigurationItem(configuration_keys key, int val) {
-        this->key = key;
-        type = CONFIGURATION_INTEGER_TYPE;
+    ConfigurationItem(configuration_keys key, int val) : key(key), type(CONFIGURATION_INTEGER_TYPE) {
+
         v_integer = val;
     };
     // Initializer for double
-    ConfigurationItem(configuration_keys key, double val) {
-        this->key = key;
-        type = CONFIGURATION_DOUBLE_TYPE;
+    ConfigurationItem(configuration_keys key, double val) : key(key), type(CONFIGURATION_DOUBLE_TYPE) {
+
         v_double = val;
     };
     // Initializer for const char *
-    ConfigurationItem(configuration_keys key, const char* val) {
-        this->key = key;
-        type = CONFIGURATION_STRING_TYPE;
-        v_string = val;
-    };
+    ConfigurationItem(configuration_keys key, const char* val)
+      : key(key), type(CONFIGURATION_STRING_TYPE), v_string(val) {
+
+        };
     // Initializer for string
-    ConfigurationItem(configuration_keys key, const std::string& val) {
-        this->key = key;
-        type = CONFIGURATION_STRING_TYPE;
-        v_string = val;
-    };
+    ConfigurationItem(configuration_keys key, const std::string& val)
+      : key(key), type(CONFIGURATION_STRING_TYPE), v_string(val) {
+
+        };
     void set_bool(bool val) {
         check_data_type(CONFIGURATION_BOOL_TYPE);
         v_bool = val;
@@ -311,12 +306,12 @@ class Configuration
     Configuration() {
         set_defaults();
     };
-    ~Configuration() {};
+    ~Configuration() = default;
 
     /// Get an item from the configuration
     ConfigurationItem& get_item(configuration_keys key) {
         // Try to find it
-        std::unordered_map<configuration_keys, ConfigurationItem>::iterator it = items.find(key);
+        auto it = items.find(key);
         // If equal to end, not found
         if (it != items.end()) {
             // Found, return it
@@ -326,7 +321,7 @@ class Configuration
         }
     }
     /// Add an item to the configuration
-    void add_item(ConfigurationItem item) {
+    void add_item(const ConfigurationItem& item) {
         std::pair<configuration_keys, ConfigurationItem> pair(item.get_key(), item);
         items.insert(pair);
     };
@@ -341,7 +336,7 @@ class Configuration
         std::string envkey = "COOLPROP_" + config_key_to_string(key);
         const char* envval = std::getenv(envkey.c_str());
         if (envval) {
-            auto tobool = [](const std::string x) {
+            auto tobool = [](const std::string& x) {
                 if (x == "True" || x == "true") {
                     return true;
                 }

--- a/include/CoolPropFluid.h
+++ b/include/CoolPropFluid.h
@@ -531,10 +531,11 @@ class CoolPropFluid
     std::string ECSReferenceFluid;  ///< A string that gives the name of the fluids that should be used for the ECS method for transport properties
     double ECS_qd;                  ///< The critical qd parameter for the Olchowy-Sengers cross-over term
    public:
-    CoolPropFluid() : ECS_qd(-_HUGE) {
-        this->ChemSpider_id = -1;
-    };
-    ~CoolPropFluid() {};
+    CoolPropFluid()
+      : ECS_qd(-_HUGE), ChemSpider_id(-1) {
+
+        };
+    ~CoolPropFluid() = default;
     const EquationOfState& EOS() const {
         return EOSVector[0];
     }  ///< Get a reference to the equation of state

--- a/include/CoolPropTools.h
+++ b/include/CoolPropTools.h
@@ -44,7 +44,7 @@
 
 #define COOLPROPDBL_MAPS_TO_DOUBLE
 #ifdef COOLPROPDBL_MAPS_TO_DOUBLE
-typedef double CoolPropDbl;
+using CoolPropDbl = double;
 #else
 typedef long double CoolPropDbl;
 #endif
@@ -54,17 +54,17 @@ typedef long double CoolPropDbl;
 class Dictionary
 {
    private:
-    typedef std::map<std::string, double> numbers_map;
+    using numbers_map = std::map<std::string, double>;
     numbers_map numbers;
-    typedef std::map<std::string, std::string> strings_map;
+    using strings_map = std::map<std::string, std::string>;
     strings_map strings;
-    typedef std::map<std::string, std::vector<double>> double_vectors_map;
+    using double_vectors_map = std::map<std::string, std::vector<double>>;
     double_vectors_map double_vectors;
-    typedef std::map<std::string, std::vector<std::string>> string_vectors_map;
+    using string_vectors_map = std::map<std::string, std::vector<std::string>>;
     string_vectors_map string_vectors;
 
    public:
-    Dictionary() {};
+    Dictionary() = default;
     bool is_empty() const {
         return numbers.empty() && strings.empty() && double_vectors.empty() && string_vectors.empty();
     }
@@ -85,7 +85,7 @@ class Dictionary
         string_vectors.insert(std::pair<std::string, std::vector<std::string>>(s1, d));
     }
     std::string get_string(const std::string& s) const {
-        strings_map::const_iterator i = strings.find(s);
+        auto i = strings.find(s);
         if (i != strings.end()) {
             return i->second;
         } else {
@@ -93,7 +93,7 @@ class Dictionary
         }
     };
     double get_double(const std::string& s) const {
-        numbers_map::const_iterator i = numbers.find(s);
+        auto i = numbers.find(s);
         if (i != numbers.end()) {
             return i->second;
         } else {
@@ -102,7 +102,7 @@ class Dictionary
     };
     /// Get a double, or return the default value if not found
     double get_double(const std::string& s, const double default_value) const {
-        numbers_map::const_iterator i = numbers.find(s);
+        auto i = numbers.find(s);
         if (i != numbers.end()) {
             return i->second;
         } else {
@@ -113,7 +113,7 @@ class Dictionary
         return get_double(s);
     };
     const std::vector<double>& get_double_vector(const std::string& s) const {
-        double_vectors_map::const_iterator i = double_vectors.find(s);
+        auto i = double_vectors.find(s);
         if (i != double_vectors.end()) {
             return i->second;
         } else {
@@ -121,7 +121,7 @@ class Dictionary
         }
     };
     const std::vector<std::string>& get_string_vector(const std::string& s) const {
-        string_vectors_map::const_iterator i = string_vectors.find(s);
+        auto i = string_vectors.find(s);
         if (i != string_vectors.end()) {
             return i->second;
         } else {

--- a/include/DataStructures.h
+++ b/include/DataStructures.h
@@ -378,7 +378,8 @@ inline bool is_Qmass_pair(input_pairs p) {
  * @return pair, or INPUT_PAIR_INVALID if not valid
  */
 template <class T>
-[[nodiscard]] CoolProp::input_pairs generate_update_pair(parameters key1, T value1, parameters key2, T value2, T& out1, T& out2) noexcept {
+[[nodiscard]] CoolProp::input_pairs generate_update_pair(parameters key1, const T& value1, parameters key2, const T& value2, T& out1,
+                                                         T& out2) noexcept {
     CoolProp::input_pairs pair;
     bool swap;
 
@@ -525,7 +526,7 @@ enum backends : int
 };
 
 /// Convert a string into the enum values
-void extract_backend_families(std::string backend_string, backend_families& f1, backend_families& f2);
+void extract_backend_families(const std::string& backend_string, backend_families& f1, backend_families& f2);
 void extract_backend_families_string(std::string backend_string, backend_families& f1, std::string& f2);
 std::string get_backend_string(backends backend);
 

--- a/include/Exceptions.h
+++ b/include/Exceptions.h
@@ -29,7 +29,7 @@ class CoolPropBaseError : public std::exception
         eMultipleSolutions
     };
     CoolPropBaseError(const std::string& err, ErrCode code) throw() : m_code(code), m_err(err) {}
-    ~CoolPropBaseError() throw() {};
+    ~CoolPropBaseError() throw() = default;
     const char* what() const throw() override {
         return m_err.c_str();
     }
@@ -49,15 +49,15 @@ class CoolPropError : public CoolPropBaseError
     CoolPropError(const std::string& err = "", ErrCode ecode = errcode) throw() : CoolPropBaseError(err, ecode) {}
 };
 
-typedef CoolPropError<CoolPropBaseError::eNotImplemented> NotImplementedError;
-typedef CoolPropError<CoolPropBaseError::eSolution> SolutionError;
-typedef CoolPropError<CoolPropBaseError::eAttribute> AttributeError;
-typedef CoolPropError<CoolPropBaseError::eOutOfRange> OutOfRangeError;
-typedef CoolPropError<CoolPropBaseError::eValue> ValueError;
-typedef CoolPropError<CoolPropBaseError::eKey> KeyError;
-typedef CoolPropError<CoolPropBaseError::eHandle> HandleError;
-typedef CoolPropError<CoolPropBaseError::eUnableToLoad> UnableToLoadError;
-typedef CoolPropError<CoolPropBaseError::eDirectorySize> DirectorySizeError;
+using NotImplementedError = CoolPropError<CoolPropBaseError::eNotImplemented>;
+using SolutionError = CoolPropError<CoolPropBaseError::eSolution>;
+using AttributeError = CoolPropError<CoolPropBaseError::eAttribute>;
+using OutOfRangeError = CoolPropError<CoolPropBaseError::eOutOfRange>;
+using ValueError = CoolPropError<CoolPropBaseError::eValue>;
+using KeyError = CoolPropError<CoolPropBaseError::eKey>;
+using HandleError = CoolPropError<CoolPropBaseError::eHandle>;
+using UnableToLoadError = CoolPropError<CoolPropBaseError::eUnableToLoad>;
+using DirectorySizeError = CoolPropError<CoolPropBaseError::eDirectorySize>;
 
 // ValueError specializations
 template <CoolPropBaseError::ErrCode errcode>
@@ -67,15 +67,15 @@ class ValueErrorSpec : public ValueError
     ValueErrorSpec(const std::string& err = "", ErrCode ecode = errcode) throw() : ValueError(err, ecode) {}
 };
 
-typedef ValueErrorSpec<CoolPropBaseError::eWrongFluid> WrongFluidError;
-typedef ValueErrorSpec<CoolPropBaseError::eComposition> CompositionError;
-typedef ValueErrorSpec<CoolPropBaseError::eInput> InputError;
-typedef ValueErrorSpec<CoolPropBaseError::eNotAvailable> NotAvailableError;
+using WrongFluidError = ValueErrorSpec<CoolPropBaseError::eWrongFluid>;
+using CompositionError = ValueErrorSpec<CoolPropBaseError::eComposition>;
+using InputError = ValueErrorSpec<CoolPropBaseError::eInput>;
+using NotAvailableError = ValueErrorSpec<CoolPropBaseError::eNotAvailable>;
 /// Thrown when a saturation flash input maps to more than one temperature on
 /// the saturation curve (e.g. water saturated-vapor enthalpy at a given h has
 /// two T-roots). The caller should use update_with_guesses with a guess.T to
 /// pick a branch. See GitHub #2773.
-typedef ValueErrorSpec<CoolPropBaseError::eMultipleSolutions> MultipleSolutionsError;
+using MultipleSolutionsError = ValueErrorSpec<CoolPropBaseError::eMultipleSolutions>;
 
 }; /* namespace CoolProp */
 #endif

--- a/include/Helmholtz.h
+++ b/include/Helmholtz.h
@@ -173,8 +173,8 @@ struct HelmholtzDerivatives
 class BaseHelmholtzTerm
 {
    public:
-    BaseHelmholtzTerm() {};
-    virtual ~BaseHelmholtzTerm() {};
+    BaseHelmholtzTerm() = default;
+    virtual ~BaseHelmholtzTerm() = default;
 
     /// Returns the base, non-dimensional, Helmholtz energy term (no derivatives) [-]
     /** @param tau Reciprocal reduced temperature where \f$\tau=T_c / T\f$
@@ -316,27 +316,28 @@ struct ResidualHelmholtzGeneralizedExponentialElement
     /// If l is an integer, store a boolean flag so we can evaluate the correct pow() function
     bool l_is_int, m_is_int;
 
-    ResidualHelmholtzGeneralizedExponentialElement() {
-        n = 0;
-        d = 0;
-        t = 0;
-        c = 0;
-        l_double = 0;
-        omega = 0;
-        m_double = 0;
-        eta1 = 0;
-        epsilon1 = 0;
-        eta2 = 0;
-        epsilon2 = 0;
-        beta1 = 0;
-        gamma1 = 0;
-        beta2 = 0;
-        gamma2 = 0;
-        l_int = 0;
-        m_int = 0;
-        l_is_int = false;
-        m_is_int = true;
-    };
+    ResidualHelmholtzGeneralizedExponentialElement()
+      : n(0),
+        d(0),
+        t(0),
+        c(0),
+        l_double(0),
+        omega(0),
+        m_double(0),
+        eta1(0),
+        epsilon1(0),
+        eta2(0),
+        epsilon2(0),
+        beta1(0),
+        gamma1(0),
+        beta2(0),
+        gamma2(0),
+        l_int(0),
+        m_int(0),
+        l_is_int(false),
+        m_is_int(true) {
+
+        };
 };
 /** \brief A generalized residual helmholtz energy container that can deal with a wide range of terms which can be converted to this general form
  *
@@ -564,16 +565,18 @@ class ResidualHelmholtzNonAnalytic : public BaseHelmholtzTerm
     std::vector<CoolPropDbl> s;
     std::vector<ResidualHelmholtzNonAnalyticElement> elements;
     /// Default Constructor
-    ResidualHelmholtzNonAnalytic() {
-        N = 0;
-    };
+    ResidualHelmholtzNonAnalytic()
+      : N(0) {
+
+        };
     /// Destructor. No implementation
-    ~ResidualHelmholtzNonAnalytic() {};
+    ~ResidualHelmholtzNonAnalytic() = default;
     /// Constructor
     ResidualHelmholtzNonAnalytic(const std::vector<CoolPropDbl>& n, const std::vector<CoolPropDbl>& a, const std::vector<CoolPropDbl>& b,
                                  const std::vector<CoolPropDbl>& beta, const std::vector<CoolPropDbl>& A, const std::vector<CoolPropDbl>& B,
-                                 const std::vector<CoolPropDbl>& C, const std::vector<CoolPropDbl>& D) {
-        N = n.size();
+                                 const std::vector<CoolPropDbl>& C, const std::vector<CoolPropDbl>& D)
+      : N(n.size()) {
+
         s.resize(N);
         for (std::size_t i = 0; i < n.size(); ++i) {
             ResidualHelmholtzNonAnalyticElement el;
@@ -604,12 +607,13 @@ class ResidualHelmholtzGeneralizedCubic : public BaseHelmholtzTerm
     bool enabled;
 
     /// Default Constructor
-    ResidualHelmholtzGeneralizedCubic() {
-        enabled = false;
-    };
+    ResidualHelmholtzGeneralizedCubic()
+      : enabled(false) {
+
+        };
     /// Constructor given an abstract cubic instance
-    ResidualHelmholtzGeneralizedCubic(shared_ptr<AbstractCubic>& ac) : m_abstractcubic(ac) {
-        enabled = true;
+    ResidualHelmholtzGeneralizedCubic(shared_ptr<AbstractCubic>& ac) : m_abstractcubic(ac), enabled(true) {
+
         z = std::vector<double>(1, 1);  // Init the vector to [1.0]
     };
 
@@ -626,17 +630,18 @@ class ResidualHelmholtzGaoB : public BaseHelmholtzTerm
     bool enabled;
 
     /// Default Constructor
-    ResidualHelmholtzGaoB() {
-        enabled = false;
-    };
+    ResidualHelmholtzGaoB()
+      : enabled(false) {
+
+        };
 
     /// Constructor given coefficients
     ResidualHelmholtzGaoB(const std::vector<CoolPropDbl>& n, const std::vector<CoolPropDbl>& t, const std::vector<CoolPropDbl>& d,
                           const std::vector<CoolPropDbl>& eta, const std::vector<CoolPropDbl>& beta, const std::vector<CoolPropDbl>& gamma,
                           const std::vector<CoolPropDbl>& epsilon, const std::vector<CoolPropDbl>& b)
-      : n(n), t(t), d(d), eta(eta), beta(beta), gamma(gamma), epsilon(epsilon), b(b) {
-        enabled = true;
-    };
+      : n(n), t(t), d(d), eta(eta), beta(beta), gamma(gamma), epsilon(epsilon), b(b), enabled(true) {
+
+        };
 
     void to_json(rapidjson::Value& el, rapidjson::Document& doc);
     void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) override;
@@ -655,9 +660,10 @@ class ResidualHelmholtzXiangDeiters : public BaseHelmholtzTerm
     ResidualHelmholtzGeneralizedExponential phi0, phi1, phi2;
     CoolPropDbl Tc, pc, rhomolarc, acentric, R, theta;
     /// Default Constructor
-    ResidualHelmholtzXiangDeiters() : Tc(_HUGE), pc(_HUGE), rhomolarc(_HUGE), acentric(_HUGE), R(_HUGE), theta(_HUGE) {
-        enabled = false;
-    };
+    ResidualHelmholtzXiangDeiters()
+      : enabled(false), Tc(_HUGE), pc(_HUGE), rhomolarc(_HUGE), acentric(_HUGE), R(_HUGE), theta(_HUGE) {
+
+        };
     /// Constructor
     ResidualHelmholtzXiangDeiters(const CoolPropDbl Tc, const CoolPropDbl pc, const CoolPropDbl rhomolarc, const CoolPropDbl acentric,
                                   const CoolPropDbl R);
@@ -706,20 +712,21 @@ class ResidualHelmholtzSAFTAssociating : public BaseHelmholtzTerm
 
    public:
     /// Default constructor
-    ResidualHelmholtzSAFTAssociating() : a(_HUGE), m(_HUGE), epsilonbar(_HUGE), vbarn(_HUGE), kappabar(_HUGE) {
-        disabled = true;
-    };
+    ResidualHelmholtzSAFTAssociating()
+      : a(_HUGE), m(_HUGE), epsilonbar(_HUGE), vbarn(_HUGE), kappabar(_HUGE), disabled(true) {
+
+        };
 
     // Constructor
     ResidualHelmholtzSAFTAssociating(double a, double m, double epsilonbar, double vbarn, double kappabar)
-      : a(a), m(m), epsilonbar(epsilonbar), vbarn(vbarn), kappabar(kappabar) {
-        disabled = false;
-    };
+      : a(a), m(m), epsilonbar(epsilonbar), vbarn(vbarn), kappabar(kappabar), disabled(false) {
+
+        };
 
     bool disabled;
 
     //Destructor. No Implementation
-    ~ResidualHelmholtzSAFTAssociating() {};
+    ~ResidualHelmholtzSAFTAssociating() = default;
 
     void to_json(rapidjson::Value& el, rapidjson::Document& doc);
 
@@ -1140,18 +1147,19 @@ class IdealHelmholtzCP0Constant : public BaseHelmholtzTerm
 
    public:
     /// Default constructor
-    IdealHelmholtzCP0Constant() : cp_over_R(_HUGE), Tc(_HUGE), T0(_HUGE), tau0(_HUGE) {
-        enabled = false;
-    };
+    IdealHelmholtzCP0Constant()
+      : cp_over_R(_HUGE), Tc(_HUGE), T0(_HUGE), tau0(_HUGE), enabled(false) {
+
+        };
 
     /// Constructor with just a single double value
-    IdealHelmholtzCP0Constant(CoolPropDbl cp_over_R, CoolPropDbl Tc, CoolPropDbl T0) : cp_over_R(cp_over_R), Tc(Tc), T0(T0) {
-        enabled = true;
-        tau0 = Tc / T0;
-    };
+    IdealHelmholtzCP0Constant(CoolPropDbl cp_over_R, CoolPropDbl Tc, CoolPropDbl T0)
+      : cp_over_R(cp_over_R), Tc(Tc), T0(T0), enabled(true), tau0(Tc / T0) {
+
+        };
 
     /// Destructor
-    ~IdealHelmholtzCP0Constant() {};
+    ~IdealHelmholtzCP0Constant() = default;
 
     bool is_enabled() const {
         return enabled;

--- a/include/IncompressibleFluid.h
+++ b/include/IncompressibleFluid.h
@@ -14,6 +14,7 @@
 
 #include <numeric>
 #include <string>
+#include <utility>
 #include <vector>
 #include <map>
 #include <cassert>
@@ -39,9 +40,10 @@ struct IncompressibleData
     IncompressibleTypeEnum type;
     Eigen::MatrixXd coeffs;  //TODO: Can we store the Eigen::Matrix objects more efficiently?
     //std::vector<std::vector<double> > coeffs;
-    IncompressibleData() {
-        type = INCOMPRESSIBLE_NOT_SET;
-    };
+    IncompressibleData()
+      : type(INCOMPRESSIBLE_NOT_SET) {
+
+        };
 };
 
 #if !defined(NO_FMTLIB) && FMT_VERSION >= 90000
@@ -137,11 +139,11 @@ class IncompressibleFluid
     //double u_h(double T, double p, double x);
 
    public:
-    IncompressibleFluid() : Tmin(_HUGE), Tmax(_HUGE), xmin(_HUGE), xmax(_HUGE), TminPsat(_HUGE), xbase(_HUGE), Tbase(_HUGE) {
-        strict = true;
-        xid = IFRAC_UNDEFINED;
-    };
-    virtual ~IncompressibleFluid() {};
+    IncompressibleFluid()
+      : strict(true), Tmin(_HUGE), Tmax(_HUGE), xmin(_HUGE), xmax(_HUGE), xid(IFRAC_UNDEFINED), TminPsat(_HUGE), xbase(_HUGE), Tbase(_HUGE) {
+
+        };
+    virtual ~IncompressibleFluid() = default;
 
     std::string getName() const {
         return name;
@@ -217,33 +219,33 @@ class IncompressibleFluid
 
     /// Setters for the coefficients
     void setDensity(IncompressibleData density) {
-        this->density = density;
+        this->density = std::move(density);
     }
     void setSpecificHeat(IncompressibleData specific_heat) {
-        this->specific_heat = specific_heat;
+        this->specific_heat = std::move(specific_heat);
     }
     void setViscosity(IncompressibleData viscosity) {
-        this->viscosity = viscosity;
+        this->viscosity = std::move(viscosity);
     }
     void setConductivity(IncompressibleData conductivity) {
-        this->conductivity = conductivity;
+        this->conductivity = std::move(conductivity);
     }
     void setPsat(IncompressibleData p_sat) {
-        this->p_sat = p_sat;
+        this->p_sat = std::move(p_sat);
     }
     void setTfreeze(IncompressibleData T_freeze) {
-        this->T_freeze = T_freeze;
+        this->T_freeze = std::move(T_freeze);
     }
 
     /// Setters for the concentration conversion coefficients
     void setMass2input(IncompressibleData mass2input) {
-        this->mass2input = mass2input;
+        this->mass2input = std::move(mass2input);
     }
     void setVolume2input(IncompressibleData volume2input) {
-        this->volume2input = volume2input;
+        this->volume2input = std::move(volume2input);
     }
     void setMole2input(IncompressibleData mole2input) {
-        this->mole2input = mole2input;
+        this->mole2input = std::move(mole2input);
     }
 
     /// A function to check coefficients and equation types.
@@ -253,8 +255,8 @@ class IncompressibleFluid
 
    protected:
     /// Base functions that handle the custom function types
-    double baseExponential(IncompressibleData data, double y, double ybase);
-    double baseLogexponential(IncompressibleData data, double y, double ybase);
+    double baseExponential(const IncompressibleData& data, double y, double ybase);
+    double baseLogexponential(const IncompressibleData& data, double y, double ybase);
     double baseExponentialOffset(IncompressibleData data, double y);
     double basePolyOffset(IncompressibleData data, double y, double z = 0.0);
 

--- a/include/MatrixMath.h
+++ b/include/MatrixMath.h
@@ -22,12 +22,12 @@
 template <size_t dimcount, typename T>
 struct VectorNd
 {
-    typedef std::vector<typename VectorNd<dimcount - 1, T>::type> type;
+    using type = std::vector<typename VectorNd<dimcount - 1, T>::type>;
 };
 template <typename T>
 struct VectorNd<0, T>
 {
-    typedef T type;
+    using type = T;
 };
 
 namespace CoolProp {
@@ -317,7 +317,7 @@ static const char* stdFmt = "%8.3f";
 ///Templates for turning vectors (1D-matrices) into strings
 template <class T>
 std::string vec_to_string(const std::vector<T>& a, const char* fmt) {
-    if (a.size() < 1) return std::string("");
+    if (a.size() < 1) return {""};
     std::stringstream out;
     out << "[ " << format(fmt, a[0]);
     for (size_t j = 1; j < a.size(); j++) {
@@ -332,7 +332,7 @@ std::string vec_to_string(const std::vector<T>& a) {
 };
 ///Templates for turning vectors (1D-matrices) into strings
 inline std::string stringvec_to_string(const std::vector<std::string>& a) {
-    if (a.size() < 1) return std::string("");
+    if (a.size() < 1) return {""};
     std::stringstream out;
     out << "[ " << format("%s", a[0].c_str());
     for (size_t j = 1; j < a.size(); j++) {
@@ -357,7 +357,7 @@ std::string vec_to_string(const T& a) {
 ///Templates for turning 2D-matrices into strings
 template <class T>
 std::string vec_to_string(const std::vector<std::vector<T>>& A, const char* fmt) {
-    if (A.size() < 1) return std::string("");
+    if (A.size() < 1) return {""};
     std::stringstream out;
     out << "[ " << vec_to_string(A[0], fmt);
     for (size_t j = 1; j < A.size(); j++) {
@@ -377,7 +377,7 @@ std::string mat_to_string(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>
     //std::string mat_to_string(const Eigen::MatrixXd &A, const char *fmt) {
     std::size_t r = A.rows();
     std::size_t c = A.cols();
-    if ((r < 1) || (c < 1)) return std::string("");
+    if ((r < 1) || (c < 1)) return {""};
     std::stringstream out;
     out << "[ ";
     if (r == 1) {
@@ -877,7 +877,7 @@ std::vector<std::vector<T>> invert(std::vector<std::vector<T>> const& in) {
 
 inline void removeRow(Eigen::MatrixXd& matrix, unsigned int rowToRemove) {
     unsigned int numRows = static_cast<unsigned int>(matrix.rows()) - 1;
-    unsigned int numCols = static_cast<unsigned int>(matrix.cols());
+    auto numCols = static_cast<unsigned int>(matrix.cols());
 
     if (rowToRemove <= numRows)
         matrix.block(rowToRemove, 0, numRows - rowToRemove, numCols) = matrix.block(rowToRemove + 1, 0, numRows - rowToRemove, numCols);
@@ -888,7 +888,7 @@ inline void removeRow(Eigen::MatrixXd& matrix, unsigned int rowToRemove) {
 };
 
 inline void removeColumn(Eigen::MatrixXd& matrix, unsigned int colToRemove) {
-    unsigned int numRows = static_cast<unsigned int>(matrix.rows());
+    auto numRows = static_cast<unsigned int>(matrix.rows());
     unsigned int numCols = static_cast<unsigned int>(matrix.cols()) - 1;
 
     if (colToRemove <= numCols)

--- a/include/PCSAFTFluid.h
+++ b/include/PCSAFTFluid.h
@@ -32,9 +32,9 @@ class PCSAFTFluid
     PCSAFTValues params;
 
    public:
-    PCSAFTFluid() {};
+    PCSAFTFluid() = default;
     PCSAFTFluid(rapidjson::Value::ValueIterator itr);
-    ~PCSAFTFluid() {};
+    ~PCSAFTFluid() = default;
 
     std::string getName() const {
         return name;

--- a/include/PolyMath.h
+++ b/include/PolyMath.h
@@ -29,10 +29,10 @@ class Polynomial2D
 
    public:
     /// Constructors
-    Polynomial2D() {};
+    Polynomial2D() = default;
 
     /// Destructor.  No implementation
-    virtual ~Polynomial2D() {};
+    virtual ~Polynomial2D() = default;
 
    public:
     /// Convert the coefficient vector.
@@ -204,7 +204,7 @@ class Poly2DResidual : public FuncWrapper1DWithDeriv
     /// @param z_in double value that represents the current output in the 3rd dimension
     /// @param axis unsigned integer value that represents the axis to solve for (0=x, 1=y)
     Poly2DResidual(Polynomial2D& poly, const Eigen::MatrixXd& coefficients, const double& in, const double& z_in, const int& axis);
-    virtual ~Poly2DResidual() {};
+    virtual ~Poly2DResidual() = default;
 
     double call(double target) override;
     double deriv(double target) override;
@@ -222,10 +222,10 @@ class Polynomial2DFrac : public Polynomial2D
 
    public:
     /// Constructors
-    Polynomial2DFrac() {};
+    Polynomial2DFrac() = default;
 
     /// Destructor.  No implementation
-    virtual ~Polynomial2DFrac() {};
+    virtual ~Polynomial2DFrac() = default;
 
    public:
     //    /// Integration functions
@@ -424,7 +424,7 @@ class Poly2DFracResidual : public Poly2DResidual
     /// @param y_base base value for y (y = y_in - y_base)
     Poly2DFracResidual(Polynomial2DFrac& poly, const Eigen::MatrixXd& coefficients, const double& in, const double& z_in, const int& axis,
                        const int& x_exp, const int& y_exp, const double& x_base, const double& y_base);
-    virtual ~Poly2DFracResidual() {};
+    virtual ~Poly2DFracResidual() = default;
     double call(double target) override;
     double deriv(double target) override;
 };
@@ -450,7 +450,7 @@ class Poly2DFracIntResidual : public Poly2DFracResidual
     /// @param int_axis axis for the integration (0=x, 1=y)
     Poly2DFracIntResidual(Polynomial2DFrac& poly, const Eigen::MatrixXd& coefficients, const double& in, const double& z_in, const int& axis,
                           const int& x_exp, const int& y_exp, const double& x_base, const double& y_base, const int& int_axis);
-    virtual ~Poly2DFracIntResidual() {};
+    virtual ~Poly2DFracIntResidual() = default;
     double call(double target) override;
     double deriv(double target) override;
 };

--- a/include/Solvers.h
+++ b/include/Solvers.h
@@ -23,7 +23,7 @@ class FuncWrapper1D
     int iter;
     int verbosity = 0;
     FuncWrapper1D() : errcode(0), errstring(""), iter(0) {};
-    virtual ~FuncWrapper1D() {};
+    virtual ~FuncWrapper1D() = default;
     virtual double call(double) = 0;
     /**
      * /brief A function for checking whether the input is in range;
@@ -59,7 +59,7 @@ class FuncWrapperND
     int errcode;
     std::string errstring;
     FuncWrapperND() : errcode(0), errstring("") {};
-    virtual ~FuncWrapperND() {};
+    virtual ~FuncWrapperND() = default;
     virtual std::vector<double> call(const std::vector<double>&) = 0;  // must be provided
     virtual std::vector<std::vector<double>> Jacobian(const std::vector<double>&);
 };

--- a/include/rapidjson_include.h
+++ b/include/rapidjson_include.h
@@ -60,7 +60,7 @@ inline std::string json2string(const rapidjson::Value& v) {
     return buffer.GetString();
 }
 /// A convenience function to get a double from a JSON value, including error checking
-inline int get_integer(const rapidjson::Value& v, std::string m) {
+inline int get_integer(const rapidjson::Value& v, const std::string& m) {
     if (!v.HasMember(m.c_str())) {
         throw CoolProp::ValueError(format("Does not have member [%s]", m.c_str()));
     }
@@ -72,7 +72,7 @@ inline int get_integer(const rapidjson::Value& v, std::string m) {
     }
 };
 /// A convenience function to get a double from a JSON value, including error checking
-inline double get_double(const rapidjson::Value& v, std::string m) {
+inline double get_double(const rapidjson::Value& v, const std::string& m) {
     if (!v.HasMember(m.c_str())) {
         throw CoolProp::ValueError(format("Does not have member [%s]", m.c_str()));
     }
@@ -84,7 +84,7 @@ inline double get_double(const rapidjson::Value& v, std::string m) {
     }
 };
 /// A convenience function to get a bool from a JSON value, including error checking
-inline bool get_bool(const rapidjson::Value& v, std::string m) {
+inline bool get_bool(const rapidjson::Value& v, const std::string& m) {
     if (!v.HasMember(m.c_str())) {
         throw CoolProp::ValueError(format("Does not have member [%s]", m.c_str()));
     }
@@ -96,7 +96,7 @@ inline bool get_bool(const rapidjson::Value& v, std::string m) {
     }
 };
 /// A convenience function to get a string from a JSON value, including error checking
-inline std::string get_string(const rapidjson::Value& v, std::string m) {
+inline std::string get_string(const rapidjson::Value& v, const std::string& m) {
     if (!v.HasMember(m.c_str())) {
         throw CoolProp::ValueError(format("Does not have member [%s]", m.c_str()));
     }
@@ -124,7 +124,7 @@ inline std::vector<double> get_double_array(const rapidjson::Value& v) {
 };
 
 /// A convenience function to get a double array compactly
-inline std::vector<double> get_double_array(const rapidjson::Value& v, std::string m) {
+inline std::vector<double> get_double_array(const rapidjson::Value& v, const std::string& m) {
     if (!v.HasMember(m.c_str())) {
         throw CoolProp::ValueError(format("Does not have member [%s]", m.c_str()));
     } else {
@@ -196,7 +196,7 @@ inline std::vector<std::vector<CoolPropDbl>> get_long_double_array2D(const rapid
 };
 
 /// A convenience function to get a long double array compactly
-inline std::vector<CoolPropDbl> get_long_double_array(const rapidjson::Value& v, std::string name) {
+inline std::vector<CoolPropDbl> get_long_double_array(const rapidjson::Value& v, const std::string& name) {
     std::vector<CoolPropDbl> out;
     if (!v.HasMember(name.c_str())) {
         throw CoolProp::ValueError(format("Does not have member [%s]", name.c_str()));
@@ -226,7 +226,7 @@ inline std::vector<std::string> get_string_array(const rapidjson::Value& v) {
 };
 
 /// A convenience function to get a string array compactly
-inline std::vector<std::string> get_string_array(const rapidjson::Value& v, std::string m) {
+inline std::vector<std::string> get_string_array(const rapidjson::Value& v, const std::string& m) {
     if (!v.HasMember(m.c_str())) {
         throw CoolProp::ValueError(format("Does not have member [%s]", m.c_str()));
     } else {
@@ -246,11 +246,11 @@ inline std::string to_string(const T& v) {
 /// A convenience function to set a 2D array of double compactly
 inline void set_double_array2D(const char* key, const std::vector<std::vector<double>>& vec, rapidjson::Value& value, rapidjson::Document& doc) {
     rapidjson::Value _i(rapidjson::kArrayType);
-    for (unsigned int i = 0; i < vec.size(); ++i) {
+    for (const auto& i : vec) {
         rapidjson::Value _j(rapidjson::kArrayType);
-        for (unsigned int j = 0; j < vec[i].size(); ++j) {
+        for (double j : i) {
             rapidjson::Value v(rapidjson::kNumberType);
-            v.SetDouble(vec[i][j]);
+            v.SetDouble(j);
             _j.PushBack(v, doc.GetAllocator());
         }
         _i.PushBack(_j, doc.GetAllocator());
@@ -267,8 +267,8 @@ inline void set_string(const std::string& key, const std::string& s, rapidjson::
 /// A convenience function to set a string array compactly
 inline void set_string_array(const char* key, const std::vector<std::string>& vec, rapidjson::Value& value, rapidjson::Document& doc) {
     rapidjson::Value _v(rapidjson::kArrayType);
-    for (unsigned int i = 0; i < vec.size(); ++i) {
-        _v.PushBack(rapidjson::Value(vec[i].c_str(), doc.GetAllocator()).Move(), doc.GetAllocator());
+    for (const auto& i : vec) {
+        _v.PushBack(rapidjson::Value(i.c_str(), doc.GetAllocator()).Move(), doc.GetAllocator());
     }
     value.AddMember(rapidjson::Value(key, doc.GetAllocator()).Move(), _v, doc.GetAllocator());
 };
@@ -276,8 +276,8 @@ inline void set_string_array(const char* key, const std::vector<std::string>& ve
 /// A convenience function to set an integer array compactly
 inline void set_int_array(const char* key, const std::vector<int>& vec, rapidjson::Value& value, rapidjson::Document& doc) {
     rapidjson::Value _v(rapidjson::kArrayType);
-    for (unsigned int i = 0; i < vec.size(); ++i) {
-        _v.PushBack(vec[i], doc.GetAllocator());
+    for (int i : vec) {
+        _v.PushBack(i, doc.GetAllocator());
     }
     value.AddMember(rapidjson::Value(key, doc.GetAllocator()).Move(), _v, doc.GetAllocator());
 };
@@ -285,8 +285,8 @@ inline void set_int_array(const char* key, const std::vector<int>& vec, rapidjso
 /// A convenience function to set a double array compactly
 inline void set_double_array(const char* key, const std::vector<double>& vec, rapidjson::Value& value, rapidjson::Document& doc) {
     rapidjson::Value _v(rapidjson::kArrayType);
-    for (unsigned int i = 0; i < vec.size(); ++i) {
-        _v.PushBack(vec[i], doc.GetAllocator());
+    for (double i : vec) {
+        _v.PushBack(i, doc.GetAllocator());
     }
     value.AddMember(rapidjson::Value(key, doc.GetAllocator()).Move(), _v, doc.GetAllocator());
 };
@@ -294,8 +294,8 @@ inline void set_double_array(const char* key, const std::vector<double>& vec, ra
 /// A convenience function to set a double array compactly
 inline void set_long_double_array(const char* const key, const std::vector<CoolPropDbl>& vec, rapidjson::Value& value, rapidjson::Document& doc) {
     rapidjson::Value _v(rapidjson::kArrayType);
-    for (unsigned int i = 0; i < vec.size(); ++i) {
-        _v.PushBack(static_cast<double>(vec[i]), doc.GetAllocator());
+    for (double i : vec) {
+        _v.PushBack(static_cast<double>(i), doc.GetAllocator());
     }
     value.AddMember(rapidjson::Value(key, doc.GetAllocator()).Move(), _v, doc.GetAllocator());
 };

--- a/include/superancillary/superancillary.h
+++ b/include/superancillary/superancillary.h
@@ -259,7 +259,7 @@ class ChebyshevExpansion
       m_xmax;           ///< The maximum value of the independent variable
     ArrayType m_coeff;  ///< The coefficients of the expansion
    public:
-    ChebyshevExpansion() {};
+    ChebyshevExpansion() = default;
 
     /// Constructor with bounds and coefficients
     ChebyshevExpansion(double xmin, double xmax, const ArrayType& coeff) : m_xmin(xmin), m_xmax(xmax), m_coeff(coeff) {};
@@ -368,7 +368,7 @@ class ChebyshevExpansion
         if (std::abs(fb) < boundsytol) {
             return std::make_tuple(b, std::size_t{2});
         }
-        boost::math::uintmax_t max_iter_ = static_cast<boost::math::uintmax_t>(max_iter);
+        auto max_iter_ = static_cast<boost::math::uintmax_t>(max_iter);
         auto [l, r] = toms748_solve(f, a, b, fa, fb, eps_tolerance<double>(bits), max_iter_);
         return std::make_tuple((r + l) / 2.0, counter);
     }
@@ -485,7 +485,7 @@ struct ChebyshevApproximation1D
         return c.head(N);
     }
     std::vector<double> head(const std::vector<double>& c, Eigen::Index N) const {
-        return std::vector<double>(c.begin(), c.begin() + N);
+        return {c.begin(), c.begin() + N};
     }
 
     /** Determine the values of x for the extrema where y'(x)=0 according to the expansions
@@ -1389,7 +1389,7 @@ class SuperAncillary
         }
         // Neither bound meets the convergence criterion, we need to iterate on temperature
         try {
-            boost::math::uintmax_t max_iter_ = static_cast<boost::math::uintmax_t>(max_iter);
+            auto max_iter_ = static_cast<boost::math::uintmax_t>(max_iter);
             auto [l, r] = toms748_solve(f, Tmin, Tmax, fTmin, fTmax, eps_tolerance<double>(bits), max_iter_);
             T = (r + l) / 2.0;
             return returner();

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -57,7 +57,7 @@ inline BackendLibrary& get_backend_library() {
     return the_library;
 }
 
-void register_backend(const backend_families& bf, shared_ptr<AbstractStateGenerator> gen) {
+void register_backend(const backend_families& bf, const shared_ptr<AbstractStateGenerator>& gen) {
     get_backend_library().add_backend(bf, gen);
 };
 
@@ -85,8 +85,8 @@ class IF97BackendGenerator : public AbstractStateGenerator
 {
    public:
     AbstractState* get_AbstractState(const std::vector<std::string>& fluid_names) override {
-        if (fluid_names.size() == 1) {               // Check that fluid_names[0] has only one component
-            const std::string str = fluid_names[0];  // Check that the fluid name is an alias for "Water"
+        if (fluid_names.size() == 1) {                // Check that fluid_names[0] has only one component
+            const std::string& str = fluid_names[0];  // Check that the fluid name is an alias for "Water"
             if ((upper(str) == "WATER") || (upper(str) == "H2O")) {
                 return new IF97Backend();
             } else {
@@ -255,7 +255,7 @@ AbstractState* AbstractState::factory(const std::string& backend, const std::vec
         // SVDSBTLBackend.h for rationale.  factory("SVDSBTL", ...)
         // without the '&' lands here with f2 empty and throws.
         if (f2.empty()) {
-            throw ValueError(format("SVDSBTL requires an explicit source backend, e.g. factory(\"SVDSBTL&HEOS\", \"%s\")",
+            throw ValueError(format(R"(SVDSBTL requires an explicit source backend, e.g. factory("SVDSBTL&HEOS", "%s"))",
                                     clean_fluid_names.empty() ? "<fluid>" : clean_fluid_names[0].c_str()));
         }
         if (clean_fluid_names.size() != 1) {

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -129,8 +129,8 @@ std::string CoolProp::AbstractCubicBackend::fluid_param_string(const std::string
 std::vector<std::string> CoolProp::AbstractCubicBackend::calc_fluid_names() {
     std::vector<std::string> out;
     out.reserve(components.size());
-    for (std::size_t i = 0; i < components.size(); ++i) {
-        out.push_back(components[i].name);
+    for (auto& component : components) {
+        out.push_back(component.name);
     }
     return out;
 }
@@ -411,7 +411,7 @@ class SaturationResidual : public CoolProp::FuncWrapper1D
     double imposed_variable;
     double deltaL, deltaV;
 
-    SaturationResidual() {};
+    SaturationResidual() = default;
     SaturationResidual(CoolProp::AbstractCubicBackend* ACB, CoolProp::input_pairs inputs, double imposed_variable)
       : ACB(ACB), inputs(inputs), imposed_variable(imposed_variable) {};
 
@@ -671,7 +671,7 @@ double CoolProp::AbstractCubicBackend::get_binary_interaction_double(const std::
 void CoolProp::AbstractCubicBackend::copy_all_alpha_functions(AbstractCubicBackend* donor) {
     get_cubic()->set_all_alpha_functions(donor->get_cubic()->get_all_alpha_functions());
     for (auto& state : linked_states) {
-        AbstractCubicBackend* ACB = static_cast<AbstractCubicBackend*>(state.get());
+        auto* ACB = static_cast<AbstractCubicBackend*>(state.get());
         ACB->copy_all_alpha_functions(this);
     }
 }
@@ -679,7 +679,7 @@ void CoolProp::AbstractCubicBackend::copy_all_alpha_functions(AbstractCubicBacke
 void CoolProp::AbstractCubicBackend::copy_k(AbstractCubicBackend* donor) {
     get_cubic()->set_kmat(donor->get_cubic()->get_kmat());
     for (auto& state : linked_states) {
-        AbstractCubicBackend* ACB = static_cast<AbstractCubicBackend*>(state.get());
+        auto* ACB = static_cast<AbstractCubicBackend*>(state.get());
         ACB->copy_k(this);
     }
 }
@@ -691,7 +691,7 @@ void CoolProp::AbstractCubicBackend::copy_internals(AbstractCubicBackend& donor)
     this->set_alpha_from_components();
     this->set_alpha0_from_components();
     for (auto& state : linked_states) {
-        AbstractCubicBackend* ACB = static_cast<AbstractCubicBackend*>(state.get());
+        auto* ACB = static_cast<AbstractCubicBackend*>(state.get());
         ACB->components = donor.components;
         ACB->set_alpha_from_components();
         ACB->set_alpha0_from_components();
@@ -712,7 +712,7 @@ void CoolProp::AbstractCubicBackend::set_cubic_alpha_C(const size_t i, const std
         throw ValueError(format("I don't know what to do with parameter [%s]", parameter.c_str()));
     }
     for (auto& state : linked_states) {
-        AbstractCubicBackend* ACB = static_cast<AbstractCubicBackend*>(state.get());
+        auto* ACB = static_cast<AbstractCubicBackend*>(state.get());
         ACB->set_cubic_alpha_C(i, parameter, c1, c2, c3);
     }
 }
@@ -726,13 +726,13 @@ void CoolProp::AbstractCubicBackend::set_fluid_parameter_double(const size_t i, 
     if (parameter == "c" || parameter == "cm" || parameter == "c_m") {
         get_cubic()->set_cm(value);
         for (auto& state : linked_states) {
-            AbstractCubicBackend* ACB = static_cast<AbstractCubicBackend*>(state.get());
+            auto* ACB = static_cast<AbstractCubicBackend*>(state.get());
             ACB->set_fluid_parameter_double(i, parameter, value);
         }
     } else if (parameter == "Q" || parameter == "Qk" || parameter == "Q_k") {
         get_cubic()->set_Q_k(i, value);
         for (auto& state : linked_states) {
-            AbstractCubicBackend* ACB = static_cast<AbstractCubicBackend*>(state.get());
+            auto* ACB = static_cast<AbstractCubicBackend*>(state.get());
             ACB->set_fluid_parameter_double(i, parameter, value);
         }
     } else {

--- a/src/Backends/Cubics/CubicBackend.h
+++ b/src/Backends/Cubics/CubicBackend.h
@@ -279,7 +279,7 @@ class SRKBackend : public AbstractCubicBackend
         cubic = std::make_shared<SRK>(Tc, pc, acentric, R_u);
         setup(generate_SatL_and_SatV);
     }
-    SRKBackend(const std::vector<std::string> fluid_identifiers, const double R_u = get_config_double(R_U_CODATA),
+    SRKBackend(const std::vector<std::string>& fluid_identifiers, const double R_u = get_config_double(R_U_CODATA),
                bool generate_SatL_and_SatV = true) {
         std::vector<double> Tc, pc, acentric;
         N = fluid_identifiers.size();
@@ -310,7 +310,7 @@ class PengRobinsonBackend : public AbstractCubicBackend
 {
 
    public:
-    PengRobinsonBackend() {};  // Default constructor (make sure you know what you are doing)
+    PengRobinsonBackend() = default;  // Default constructor (make sure you know what you are doing)
     PengRobinsonBackend(const std::vector<double>& Tc, const std::vector<double>& pc, const std::vector<double>& acentric, double R_u,
                         bool generate_SatL_and_SatV = true) {
         cubic = std::make_shared<PengRobinson>(Tc, pc, acentric, R_u);
@@ -320,7 +320,7 @@ class PengRobinsonBackend : public AbstractCubicBackend
         cubic = std::make_shared<PengRobinson>(Tc, pc, acentric, R_u);
         setup(generate_SatL_and_SatV);
     };
-    PengRobinsonBackend(const std::vector<std::string> fluid_identifiers, const double R_u = get_config_double(R_U_CODATA),
+    PengRobinsonBackend(const std::vector<std::string>& fluid_identifiers, const double R_u = get_config_double(R_U_CODATA),
                         bool generate_SatL_and_SatV = true) {
         std::vector<double> Tc, pc, acentric;
         N = fluid_identifiers.size();
@@ -359,9 +359,10 @@ class CubicResidualHelmholtz : public ResidualHelmholtz
     AbstractCubicBackend* ACB;
 
    public:
-    CubicResidualHelmholtz() {
-        ACB = nullptr;
-    };
+    CubicResidualHelmholtz()
+      : ACB(nullptr) {
+
+        };
     CubicResidualHelmholtz(AbstractCubicBackend* ACB) : ACB(ACB) {};
 
     // copy assignment

--- a/src/Backends/Cubics/CubicsLibrary.cpp
+++ b/src/Backends/Cubics/CubicsLibrary.cpp
@@ -62,7 +62,7 @@ class CubicsLibraryClass
                 assert(ret.second == true);
             }
 
-            for (std::vector<std::string>::const_iterator it = val.aliases.begin(); it != val.aliases.end(); ++it) {
+            for (auto it = val.aliases.begin(); it != val.aliases.end(); ++it) {
                 if (aliases_map.find(*it) == aliases_map.end()) {
                     // It's not already in aliases map
                     aliases_map.emplace(*it, upper(val.name));
@@ -91,10 +91,10 @@ class CubicsLibraryClass
     std::string get_JSONstring(const std::string& key) {
         std::string uppercase_identifier = upper(key);
         // Try to find it
-        std::map<std::string, std::string>::iterator it = JSONstring_map.find(uppercase_identifier);
+        auto it = JSONstring_map.find(uppercase_identifier);
         // If it is found
         if (it == JSONstring_map.end()) {
-            std::map<std::string, std::string>::iterator italias = aliases_map.find(uppercase_identifier);
+            auto italias = aliases_map.find(uppercase_identifier);
             if (italias != aliases_map.end()) {
                 // Alias was found, use it to get the fluid name, and then the cubic values
                 it = JSONstring_map.find(italias->second);
@@ -114,12 +114,12 @@ class CubicsLibraryClass
     CubicsValues get(const std::string& identifier) {
         std::string uppercase_identifier = upper(identifier);
         // Try to find it
-        std::map<std::string, CubicsValues>::iterator it = fluid_map.find(uppercase_identifier);
+        auto it = fluid_map.find(uppercase_identifier);
         // If it is found
         if (it != fluid_map.end()) {
             return it->second;
         } else {
-            std::map<std::string, std::string>::iterator italias = aliases_map.find(uppercase_identifier);
+            auto italias = aliases_map.find(uppercase_identifier);
             if (italias != aliases_map.end()) {
                 // Alias was found, use it to get the fluid name, and then the cubic values
                 return fluid_map.find(italias->second)->second;
@@ -130,7 +130,7 @@ class CubicsLibraryClass
     };
     std::string get_fluids_list() {
         std::vector<std::string> out;
-        for (std::map<std::string, CubicsValues>::const_iterator it = fluid_map.begin(); it != fluid_map.end(); ++it) {
+        for (auto it = fluid_map.begin(); it != fluid_map.end(); ++it) {
             out.push_back(it->first);
         }
         return strjoin(out, ",");

--- a/src/Backends/Cubics/GeneralizedCubic.cpp
+++ b/src/Backends/Cubics/GeneralizedCubic.cpp
@@ -1,6 +1,7 @@
 #include "GeneralizedCubic.h"
 #include "CPnumerics.h"
 #include <cmath>
+#include <utility>
 
 double BasicMathiasCopemanAlphaFunction::term(double tau, std::size_t itau) {
 
@@ -117,15 +118,22 @@ double TwuAlphaFunction::term(double tau, std::size_t itau) {
     }
 }
 
-AbstractCubic::AbstractCubic(std::vector<double> Tc, std::vector<double> pc, std::vector<double> acentric, double R_u, double Delta_1, double Delta_2,
-                             std::vector<double> C1, std::vector<double> C2, std::vector<double> C3)
-  : Tc(Tc), pc(pc), acentric(acentric), R_u(R_u), Delta_1(Delta_1), Delta_2(Delta_2) {
-    N = static_cast<int>(Tc.size());
+AbstractCubic::AbstractCubic(const std::vector<double>& Tc, std::vector<double> pc, std::vector<double> acentric, double R_u, double Delta_1,
+                             double Delta_2, const std::vector<double>& C1, const std::vector<double>& C2, const std::vector<double>& C3)
+  : T_r(1.0),
+    rho_r(1.0),
+    Tc(Tc),
+    pc(std::move(pc)),
+    acentric(std::move(acentric)),
+    R_u(R_u),
+    Delta_1(Delta_1),
+    Delta_2(Delta_2),
+    N(static_cast<int>(Tc.size())),
+    cm(0.) {
+
     k.resize(N, std::vector<double>(N, 0));
-    cm = 0.;
+
     alpha.resize(N);
-    T_r = 1.0;
-    rho_r = 1.0;
 };
 
 void AbstractCubic::set_alpha(const std::vector<double>& C1, const std::vector<double>& C2, const std::vector<double>& C3) {

--- a/src/Backends/Cubics/GeneralizedCubic.h
+++ b/src/Backends/Cubics/GeneralizedCubic.h
@@ -618,7 +618,7 @@ class PengRobinson : public AbstractCubic
     PengRobinson(const std::vector<double>& Tc, std::vector<double> pc, std::vector<double> acentric, double R_u,
                  const std::vector<double>& C1 = std::vector<double>(), const std::vector<double>& C2 = std::vector<double>(),
                  const std::vector<double>& C3 = std::vector<double>())
-      : AbstractCubic(std::move(Tc), std::move(pc), std::move(acentric), R_u, 1 + sqrt(2.0), 1 - sqrt(2.0), C1, C2, C3) {
+      : AbstractCubic(Tc, std::move(pc), std::move(acentric), R_u, 1 + sqrt(2.0), 1 - sqrt(2.0), C1, C2, C3) {
         set_alpha(C1, C2, C3);
     };
 
@@ -638,7 +638,7 @@ class SRK : public AbstractCubic
     SRK(const std::vector<double>& Tc, std::vector<double> pc, std::vector<double> acentric, double R_u,
         const std::vector<double>& C1 = std::vector<double>(), const std::vector<double>& C2 = std::vector<double>(),
         const std::vector<double>& C3 = std::vector<double>())
-      : AbstractCubic(std::move(Tc), std::move(pc), std::move(acentric), R_u, 1, 0, C1, C2, C3) {
+      : AbstractCubic(Tc, std::move(pc), std::move(acentric), R_u, 1, 0, C1, C2, C3) {
         set_alpha(C1, C2, C3);
     };
     SRK(double Tc, double pc, double acentric, double R_u)

--- a/src/Backends/Cubics/GeneralizedCubic.h
+++ b/src/Backends/Cubics/GeneralizedCubic.h
@@ -11,6 +11,7 @@
 #ifndef CUBIC_H
 #define CUBIC_H
 
+#include <utility>
 #include <vector>
 #include <cmath>
 #include <memory>
@@ -26,7 +27,7 @@ class AbstractCubicAlphaFunction
       sqrt_Tr_Tci;          ///< The sqrt of the (constant) reducing temperature divided by the critical temperature of the pure component
     std::vector<double> c;  ///< The vector of constants
    public:
-    virtual ~AbstractCubicAlphaFunction() {};
+    virtual ~AbstractCubicAlphaFunction() = default;
     virtual double term(double tau, std::size_t itau) = 0;
     void set_Tr_over_Tci(double Tr_over_Tci) {
         this->Tr_over_Tci = Tr_over_Tci;
@@ -40,9 +41,10 @@ class BasicMathiasCopemanAlphaFunction : public AbstractCubicAlphaFunction
 {
     double m;  ///< The term coming from the function of omega
    public:
-    BasicMathiasCopemanAlphaFunction(double a0, double m_ii, double Tr_over_Tci) : AbstractCubicAlphaFunction(a0, Tr_over_Tci) {
-        this->m = m_ii;
-    };
+    BasicMathiasCopemanAlphaFunction(double a0, double m_ii, double Tr_over_Tci)
+      : AbstractCubicAlphaFunction(a0, Tr_over_Tci), m(m_ii) {
+
+        };
     double term(double tau, std::size_t itau) override;
 };
 
@@ -98,10 +100,10 @@ class AbstractCubic
      so long as it has the formulation given in this work.
 
      */
-    AbstractCubic(std::vector<double> Tc, std::vector<double> pc, std::vector<double> acentric, double R_u, double Delta_1, double Delta_2,
-                  std::vector<double> C1 = std::vector<double>(), std::vector<double> C2 = std::vector<double>(),
-                  std::vector<double> C3 = std::vector<double>());
-    virtual ~AbstractCubic() {};
+    AbstractCubic(const std::vector<double>& Tc, std::vector<double> pc, std::vector<double> acentric, double R_u, double Delta_1, double Delta_2,
+                  const std::vector<double>& C1 = std::vector<double>(), const std::vector<double>& C2 = std::vector<double>(),
+                  const std::vector<double>& C3 = std::vector<double>());
+    virtual ~AbstractCubic() = default;
     /// Set the constants for the Mathias-Copeman alpha function, or if C1,C2,C3 are all empty, set the default alpha model
     void set_alpha(const std::vector<double>& C1, const std::vector<double>& C2, const std::vector<double>& C3);
     /// Set the alpha function for the i-th component
@@ -613,10 +615,10 @@ class AbstractCubic
 class PengRobinson : public AbstractCubic
 {
    public:
-    PengRobinson(std::vector<double> Tc, std::vector<double> pc, std::vector<double> acentric, double R_u,
-                 std::vector<double> C1 = std::vector<double>(), std::vector<double> C2 = std::vector<double>(),
-                 std::vector<double> C3 = std::vector<double>())
-      : AbstractCubic(Tc, pc, acentric, R_u, 1 + sqrt(2.0), 1 - sqrt(2.0), C1, C2, C3) {
+    PengRobinson(const std::vector<double>& Tc, std::vector<double> pc, std::vector<double> acentric, double R_u,
+                 const std::vector<double>& C1 = std::vector<double>(), const std::vector<double>& C2 = std::vector<double>(),
+                 const std::vector<double>& C3 = std::vector<double>())
+      : AbstractCubic(std::move(Tc), std::move(pc), std::move(acentric), R_u, 1 + sqrt(2.0), 1 - sqrt(2.0), C1, C2, C3) {
         set_alpha(C1, C2, C3);
     };
 
@@ -633,9 +635,10 @@ class PengRobinson : public AbstractCubic
 class SRK : public AbstractCubic
 {
    public:
-    SRK(std::vector<double> Tc, std::vector<double> pc, std::vector<double> acentric, double R_u, std::vector<double> C1 = std::vector<double>(),
-        std::vector<double> C2 = std::vector<double>(), std::vector<double> C3 = std::vector<double>())
-      : AbstractCubic(Tc, pc, acentric, R_u, 1, 0, C1, C2, C3) {
+    SRK(const std::vector<double>& Tc, std::vector<double> pc, std::vector<double> acentric, double R_u,
+        const std::vector<double>& C1 = std::vector<double>(), const std::vector<double>& C2 = std::vector<double>(),
+        const std::vector<double>& C3 = std::vector<double>())
+      : AbstractCubic(std::move(Tc), std::move(pc), std::move(acentric), R_u, 1, 0, C1, C2, C3) {
         set_alpha(C1, C2, C3);
     };
     SRK(double Tc, double pc, double acentric, double R_u)

--- a/src/Backends/Cubics/UNIFAC.cpp
+++ b/src/Backends/Cubics/UNIFAC.cpp
@@ -35,8 +35,7 @@ void UNIFAC::UNIFACMixture::set_interaction_parameter(const std::size_t mgi1, co
     }
 }
 double UNIFAC::UNIFACMixture::get_interaction_parameter(const std::size_t mgi1, const std::size_t mgi2, const std::string& parameter) {
-    std::map<std::pair<int, int>, UNIFACLibrary::InteractionParameters>::iterator it =
-      this->interaction.find(std::pair<int, int>(static_cast<int>(mgi1), static_cast<int>(mgi2)));
+    auto it = this->interaction.find(std::pair<int, int>(static_cast<int>(mgi1), static_cast<int>(mgi2)));
     if (it == this->interaction.end()) {
         throw CoolProp::ValueError(format("Unable to match mgi-mgi pair: [%d,%d]", static_cast<int>(mgi1), static_cast<int>(mgi1)));
     } else {
@@ -109,8 +108,7 @@ double UNIFAC::UNIFACMixture::Psi(std::size_t sgi1, std::size_t sgi2) const {
     if (mgi1 == mgi2) {
         return 1;
     } else {
-        std::map<std::pair<int, int>, UNIFACLibrary::InteractionParameters>::const_iterator it =
-          this->interaction.find(std::pair<int, int>(static_cast<int>(mgi1), static_cast<int>(mgi2)));
+        auto it = this->interaction.find(std::pair<int, int>(static_cast<int>(mgi1), static_cast<int>(mgi2)));
         if (it != this->interaction.end()) {
             return exp(-(it->second.a_ij / this->m_T + it->second.b_ij + it->second.c_ij * this->m_T));
         } else {
@@ -159,8 +157,8 @@ void UNIFAC::UNIFACMixture::set_temperature(const double T) {
             double Q = c.groups[k].group.Q_k;
             int sgik = c.groups[k].group.sgi;
             double sum1 = 0;
-            for (std::size_t m = 0; m < c.groups.size(); ++m) {
-                int sgim = c.groups[m].group.sgi;
+            for (const auto& group : c.groups) {
+                int sgim = group.group.sgi;
                 sum1 += theta_pure(i, sgim) * Psi_.find(std::pair<std::size_t, std::size_t>(sgim, sgik))->second;
             }
             // sum1 > 0: c.groups is the set of groups present in component i, theta_pure
@@ -171,8 +169,8 @@ void UNIFAC::UNIFACMixture::set_temperature(const double T) {
             for (std::size_t m = 0; m < c.groups.size(); ++m) {
                 int sgim = c.groups[m].group.sgi;
                 double sum2 = 0;
-                for (std::size_t n = 0; n < c.groups.size(); ++n) {
-                    int sgin = c.groups[n].group.sgi;
+                for (const auto& group : c.groups) {
+                    int sgin = group.group.sgi;
                     sum2 += theta_pure(i, sgin) * Psi_.find(std::pair<std::size_t, std::size_t>(sgin, sgim))->second;
                 }
                 s -= theta_pure(i, sgim) * Psi_.find(std::pair<std::size_t, std::size_t>(sgik, sgim))->second / sum2;
@@ -229,8 +227,7 @@ void UNIFAC::UNIFACMixture::activity_coefficients(double tau, const std::vector<
     for (std::size_t i = 0; i < N; ++i) {
         double summerr = 0, summerq = 0;
         const UNIFACLibrary::Component& c = components[i];
-        for (std::size_t j = 0; j < c.groups.size(); ++j) {
-            const UNIFACLibrary::ComponentGroup& cg = c.groups[j];
+        for (const auto& cg : c.groups) {
             summerr += cg.count * cg.group.R_k;
             summerq += cg.count * cg.group.Q_k;
         }
@@ -259,7 +256,7 @@ void UNIFAC::UNIFACMixture::add_component(const UNIFACLibrary::Component& comp) 
     }
 }
 
-void UNIFAC::UNIFACMixture::set_components(const std::string& identifier_type, std::vector<std::string> identifiers) {
+void UNIFAC::UNIFACMixture::set_components(const std::string& identifier_type, const std::vector<std::string>& identifiers) {
     components.clear();
     N = identifiers.size();
     if (identifier_type == "name") {
@@ -286,10 +283,9 @@ void UNIFAC::UNIFACMixture::set_pure_data() {
         ComponentData cd;
         double summerxq = 0;
         cd.group_count = 0;
-        for (std::size_t j = 0; j < c.groups.size(); ++j) {
-            const UNIFACLibrary::ComponentGroup& cg = c.groups[j];
-            double x = static_cast<double>(cg.count);
-            double theta = static_cast<double>(cg.count * cg.group.Q_k);
+        for (const auto& cg : c.groups) {
+            auto x = static_cast<double>(cg.count);
+            auto theta = static_cast<double>(cg.count * cg.group.Q_k);
             cd.X.emplace(cg.group.sgi, x);
             cd.theta.emplace(cg.group.sgi, theta);
             cd.group_count += cg.count;
@@ -314,9 +310,9 @@ void UNIFAC::UNIFACMixture::set_pure_data() {
 /// Modify the surface parameter Q_k of the sub group sgi
 void UNIFAC::UNIFACMixture::set_Q_k(const size_t sgi, const double value) {
     for (std::size_t i = 0; i < N; ++i) {
-        for (std::size_t j = 0; j < components[i].groups.size(); ++j) {
-            if (components[i].groups[j].group.sgi == sgi) {
-                components[i].groups[j].group.Q_k = value;
+        for (auto& group : components[i].groups) {
+            if (group.group.sgi == sgi) {
+                group.group.Q_k = value;
             }
         }
     }
@@ -328,9 +324,9 @@ void UNIFAC::UNIFACMixture::set_Q_k(const size_t sgi, const double value) {
 /// Modify the surface parameter Q_k of the sub group sgi
 double UNIFAC::UNIFACMixture::get_Q_k(const size_t sgi) const {
     for (std::size_t i = 0; i < N; ++i) {
-        for (std::size_t j = 0; j < components[i].groups.size(); ++j) {
-            if (components[i].groups[j].group.sgi == sgi) {
-                return components[i].groups[j].group.Q_k;
+        for (const auto& group : components[i].groups) {
+            if (group.group.sgi == sgi) {
+                return group.group.Q_k;
             }
         }
     }

--- a/src/Backends/Cubics/UNIFAC.h
+++ b/src/Backends/Cubics/UNIFAC.h
@@ -88,7 +88,7 @@ class UNIFACMixture
     /// Add a component with the defined groups defined by (count, sgi) pairs
     void add_component(const UNIFACLibrary::Component& comp);
 
-    void set_components(const std::string& identifier_type, std::vector<std::string> identifiers);
+    void set_components(const std::string& identifier_type, const std::vector<std::string>& identifiers);
 
     const std::vector<UNIFACLibrary::Component>& get_components() {
         return components;

--- a/src/Backends/Cubics/UNIFACLibrary.cpp
+++ b/src/Backends/Cubics/UNIFACLibrary.cpp
@@ -86,16 +86,16 @@ void UNIFACParameterLibrary::populate(std::string& group_data, std::string& inte
     m_populated = true;
 }
 Group UNIFACParameterLibrary::get_group(int sgi) const {
-    for (std::vector<Group>::const_iterator it = groups.begin(); it != groups.end(); ++it) {
-        if (it->sgi == sgi) {
-            return *it;
+    for (const auto& group : groups) {
+        if (group.sgi == sgi) {
+            return group;
         }
     }
     throw CoolProp::ValueError("Could not find group");
 }
 bool UNIFACParameterLibrary::has_group(int sgi) const {
-    for (std::vector<Group>::const_iterator it = groups.begin(); it != groups.end(); ++it) {
-        if (it->sgi == sgi) {
+    for (const auto& group : groups) {
+        if (group.sgi == sgi) {
             return true;
         }
     }
@@ -112,14 +112,14 @@ InteractionParameters UNIFACParameterLibrary::get_interaction_parameters(int mgi
         ip.zero_out();
         return ip;
     }
-    for (std::vector<InteractionParameters>::const_iterator it = interaction_parameters.begin(); it != interaction_parameters.end(); ++it) {
-        if (it->mgi1 == mgi1 && it->mgi2 == mgi2) {
+    for (const auto& interaction_parameter : interaction_parameters) {
+        if (interaction_parameter.mgi1 == mgi1 && interaction_parameter.mgi2 == mgi2) {
             // Correct order, return it
-            return *it;
+            return interaction_parameter;
         }
-        if (it->mgi2 == mgi1 && it->mgi1 == mgi2) {
+        if (interaction_parameter.mgi2 == mgi1 && interaction_parameter.mgi1 == mgi2) {
             // Backwards, swap the parameters
-            InteractionParameters ip = *it;
+            InteractionParameters ip = interaction_parameter;
             ip.swap();
             return ip;
         }
@@ -129,9 +129,9 @@ InteractionParameters UNIFACParameterLibrary::get_interaction_parameters(int mgi
 
 Component UNIFACParameterLibrary::get_component(const std::string& identifier, const std::string& value) const {
     if (identifier == "name") {
-        for (std::vector<Component>::const_iterator it = components.begin(); it != components.end(); ++it) {
-            if (it->name == value) {
-                return *it;
+        for (const auto& component : components) {
+            if (component.name == value) {
+                return component;
             }
         }
     }
@@ -154,16 +154,15 @@ TEST_CASE("Check Poling example for UNIFAC", "[UNIFAC]") {
     std::string groups = "[{\"Q_k\": 0.848, \"R_k\": 0.9011, \"maingroup_name\": \"CH2\", \"mgi\": 1, \"sgi\": 1, \"subgroup_name\": \"CH3\"},"
                          "{\"Q_k\": 0.540, \"R_k\": 0.6744, \"maingroup_name\": \"CH2\", \"mgi\": 1, \"sgi\": 2, \"subgroup_name\": \"CH2\"},"
                          "{\"Q_k\": 1.488, \"R_k\": 1.6724, \"maingroup_name\": \"CH2CO\", \"mgi\": 9, \"sgi\": 18, \"subgroup_name\": \"CH3CO\"}]";
-    std::string interactions =
-      "[{\"a_ij\": 476.4, \"a_ji\": 26.76, \"b_ij\": 0.0, \"b_ji\": 0.0,  \"c_ij\": 0.0, \"c_ji\": 0.0, \"mgi1\": 1, \"mgi2\": 9}]";
+    std::string interactions = R"([{"a_ij": 476.4, "a_ji": 26.76, "b_ij": 0.0, "b_ji": 0.0,  "c_ij": 0.0, "c_ji": 0.0, "mgi1": 1, "mgi2": 9}])";
 
     SECTION("Validate AC for acetone + n-pentane") {
         UNIFACLibrary::UNIFACParameterLibrary lib;
         CHECK_NOTHROW(lib.populate(groups, interactions, acetone_pentane_groups));
         UNIFAC::UNIFACMixture mix(lib, 1.0);
         std::vector<std::string> names;
-        names.push_back("Acetone");
-        names.push_back("n-Pentane");
+        names.emplace_back("Acetone");
+        names.emplace_back("n-Pentane");
         mix.set_components("name", names);
         mix.set_interaction_parameters();
 

--- a/src/Backends/Cubics/VTPRBackend.cpp
+++ b/src/Backends/Cubics/VTPRBackend.cpp
@@ -26,7 +26,7 @@ void CoolProp::VTPRBackend::setup(const std::vector<std::string>& names, bool ge
     // Now set the reducing function for the mixture
     Reducing = std::make_shared<ConstantReducingFunction>(cubic->get_Tr(), cubic->get_rhor());
 
-    VTPRCubic* _cubic = static_cast<VTPRCubic*>(cubic.get());
+    auto* _cubic = static_cast<VTPRCubic*>(cubic.get());
     _cubic->get_unifaq().set_components("name", names);
     _cubic->get_unifaq().set_interaction_parameters();
 
@@ -64,7 +64,7 @@ void CoolProp::VTPRBackend::setup(const std::vector<std::string>& names, bool ge
 
 void CoolProp::VTPRBackend::set_alpha_from_components() {
 
-    VTPRCubic* _cubic = static_cast<VTPRCubic*>(cubic.get());
+    auto* _cubic = static_cast<VTPRCubic*>(cubic.get());
     const std::vector<UNIFACLibrary::Component>& components = _cubic->get_unifaq().get_components();
 
     /// If components is not present, you are using a vanilla cubic, so don't do anything
@@ -111,8 +111,8 @@ void CoolProp::VTPRBackend::set_binary_interaction_double(const std::size_t i, c
         throw ValueError(format("Index j [%d] is out of bounds. Must be between 0 and %d.", j, N - 1));
     }
     cubic->set_interaction_parameter(i, j, parameter, value);
-    for (std::vector<shared_ptr<HelmholtzEOSMixtureBackend>>::iterator it = linked_states.begin(); it != linked_states.end(); ++it) {
-        (*it)->set_binary_interaction_double(i, j, parameter, value);
+    for (auto& linked_state : linked_states) {
+        linked_state->set_binary_interaction_double(i, j, parameter, value);
     }
 };
 
@@ -156,7 +156,7 @@ const UNIFACLibrary::UNIFACParameterLibrary& CoolProp::VTPRBackend::LoadLibrary(
 
 CoolPropDbl CoolProp::VTPRBackend::calc_fugacity_coefficient(std::size_t i) {
     //double slower = log(HelmholtzEOSMixtureBackend::calc_fugacity_coefficient(i));
-    VTPRCubic* _cubic = static_cast<VTPRCubic*>(cubic.get());
+    auto* _cubic = static_cast<VTPRCubic*>(cubic.get());
     std::vector<double> here = _cubic->ln_fugacity_coefficient(mole_fractions, rhomolar(), p(), T());
     return exp(here[i]);
 }

--- a/src/Backends/Cubics/VTPRBackend.h
+++ b/src/Backends/Cubics/VTPRBackend.h
@@ -33,21 +33,21 @@ class VTPRBackend : public PengRobinsonBackend
     std::vector<std::string> m_fluid_names;
 
    public:
-    VTPRBackend(const std::vector<std::string> fluid_identifiers, const std::vector<double>& Tc, const std::vector<double>& pc,
+    VTPRBackend(const std::vector<std::string>& fluid_identifiers, const std::vector<double>& Tc, const std::vector<double>& pc,
                 const std::vector<double>& acentric, double R_u, bool generate_SatL_and_SatV = true) {
         const UNIFACLibrary::UNIFACParameterLibrary& lib = LoadLibrary();
         cubic = std::make_shared<VTPRCubic>(Tc, pc, acentric, R_u, lib);
         setup(fluid_identifiers, generate_SatL_and_SatV);
     };
-    VTPRBackend(const std::vector<std::string> fluid_identifiers, const double R_u = get_config_double(R_U_CODATA),
+    VTPRBackend(const std::vector<std::string>& fluid_identifiers, const double R_u = get_config_double(R_U_CODATA),
                 bool generate_SatL_and_SatV = true) {
         std::vector<double> Tc, pc, acentric;
         N = fluid_identifiers.size();
         components.resize(N);
         // Extract data from the UNIFAC parameter library
         const UNIFACLibrary::UNIFACParameterLibrary& lib = LoadLibrary();
-        for (std::size_t i = 0; i < fluid_identifiers.size(); ++i) {
-            UNIFACLibrary::Component comp = lib.get_component("name", fluid_identifiers[i]);
+        for (const auto& fluid_identifier : fluid_identifiers) {
+            UNIFACLibrary::Component comp = lib.get_component("name", fluid_identifier);
             Tc.push_back(comp.Tc);              // [K]
             pc.push_back(comp.pc);              // [Pa]
             acentric.push_back(comp.acentric);  // [-]
@@ -84,7 +84,7 @@ class VTPRBackend : public PengRobinsonBackend
 
     void set_mole_fractions(const std::vector<double>& z) override {
         mole_fractions = z;
-        VTPRCubic* _cubic = static_cast<VTPRCubic*>(cubic.get());
+        auto* _cubic = static_cast<VTPRCubic*>(cubic.get());
         _cubic->get_unifaq().set_mole_fractions(z);
     };
 

--- a/src/Backends/Cubics/VTPRCubic.h
+++ b/src/Backends/Cubics/VTPRCubic.h
@@ -6,6 +6,8 @@
 //
 //
 
+#include <utility>
+
 #include "GeneralizedCubic.h"
 #include "Exceptions.h"
 
@@ -18,9 +20,9 @@ class VTPRCubic : public PengRobinson
     UNIFAC::UNIFACMixture unifaq;
 
    public:
-    VTPRCubic(std::vector<double> Tc, std::vector<double> pc, std::vector<double> acentric, double R_u,
+    VTPRCubic(const std::vector<double>& Tc, std::vector<double> pc, std::vector<double> acentric, double R_u,
               const UNIFACLibrary::UNIFACParameterLibrary& lib)
-      : PengRobinson(Tc, pc, acentric, R_u), unifaq(lib, T_r) {};
+      : PengRobinson(std::move(Tc), std::move(pc), std::move(acentric), R_u), unifaq(lib, T_r) {};
 
     VTPRCubic(double Tc, double pc, double acentric, double R_u, const UNIFACLibrary::UNIFACParameterLibrary& lib)
       : PengRobinson(std::vector<double>(1, Tc), std::vector<double>(1, pc), std::vector<double>(1, acentric), R_u), unifaq(lib, T_r) {};

--- a/src/Backends/Cubics/VTPRCubic.h
+++ b/src/Backends/Cubics/VTPRCubic.h
@@ -22,7 +22,7 @@ class VTPRCubic : public PengRobinson
    public:
     VTPRCubic(const std::vector<double>& Tc, std::vector<double> pc, std::vector<double> acentric, double R_u,
               const UNIFACLibrary::UNIFACParameterLibrary& lib)
-      : PengRobinson(std::move(Tc), std::move(pc), std::move(acentric), R_u), unifaq(lib, T_r) {};
+      : PengRobinson(Tc, std::move(pc), std::move(acentric), R_u), unifaq(lib, T_r) {};
 
     VTPRCubic(double Tc, double pc, double acentric, double R_u, const UNIFACLibrary::UNIFACParameterLibrary& lib)
       : PengRobinson(std::vector<double>(1, Tc), std::vector<double>(1, pc), std::vector<double>(1, acentric), R_u), unifaq(lib, T_r) {};

--- a/src/Backends/Helmholtz/ExcessHEFunction.h
+++ b/src/Backends/Helmholtz/ExcessHEFunction.h
@@ -10,7 +10,7 @@ using std::shared_ptr;
 
 namespace CoolProp {
 
-typedef std::vector<std::vector<CoolPropDbl>> STLMatrix;
+using STLMatrix = std::vector<std::vector<CoolPropDbl>>;
 
 /** \brief The abstract base class for departure functions used in the excess part of the Helmholtz energy
  *
@@ -20,9 +20,9 @@ typedef std::vector<std::vector<CoolPropDbl>> STLMatrix;
 class DepartureFunction
 {
    public:
-    DepartureFunction() {};
+    DepartureFunction() = default;
     DepartureFunction(const ResidualHelmholtzGeneralizedExponential& _phi) : phi(_phi) {};
-    virtual ~DepartureFunction() {};
+    virtual ~DepartureFunction() = default;
     ResidualHelmholtzGeneralizedExponential phi;
     HelmholtzDerivatives derivs;
 
@@ -104,7 +104,7 @@ class DepartureFunction
 class GERG2008DepartureFunction : public DepartureFunction
 {
    public:
-    GERG2008DepartureFunction() {};
+    GERG2008DepartureFunction() = default;
     GERG2008DepartureFunction(const std::vector<double>& n, const std::vector<double>& d, const std::vector<double>& t,
                               const std::vector<double>& eta, const std::vector<double>& epsilon, const std::vector<double>& beta,
                               const std::vector<double>& gamma, std::size_t Npower) {
@@ -128,7 +128,7 @@ class GERG2008DepartureFunction : public DepartureFunction
             phi.add_GERG2008Gaussian(_n, _d, _t, _eta, _epsilon, _beta, _gamma);
         }
     };
-    ~GERG2008DepartureFunction() {};
+    ~GERG2008DepartureFunction() = default;
 };
 
 /** \brief A hybrid gaussian with temperature and density dependence along with
@@ -142,7 +142,7 @@ class GERG2008DepartureFunction : public DepartureFunction
 class GaussianExponentialDepartureFunction : public DepartureFunction
 {
    public:
-    GaussianExponentialDepartureFunction() {};
+    GaussianExponentialDepartureFunction() = default;
     GaussianExponentialDepartureFunction(const std::vector<double>& n, const std::vector<double>& d, const std::vector<double>& t,
                                          const std::vector<double>& l, const std::vector<double>& eta, const std::vector<double>& epsilon,
                                          const std::vector<double>& beta, const std::vector<double>& gamma, std::size_t Npower) {
@@ -167,7 +167,7 @@ class GaussianExponentialDepartureFunction : public DepartureFunction
         }
         phi.finish();
     };
-    ~GaussianExponentialDepartureFunction() {};
+    ~GaussianExponentialDepartureFunction() = default;
 };
 
 /** \brief A polynomial/exponential departure function
@@ -181,7 +181,7 @@ class GaussianExponentialDepartureFunction : public DepartureFunction
 class ExponentialDepartureFunction : public DepartureFunction
 {
    public:
-    ExponentialDepartureFunction() {};
+    ExponentialDepartureFunction() = default;
     ExponentialDepartureFunction(const std::vector<double>& n, const std::vector<double>& d, const std::vector<double>& t,
                                  const std::vector<double>& l) {
         std::vector<CoolPropDbl> _n(n.begin(), n.begin() + n.size());
@@ -190,10 +190,10 @@ class ExponentialDepartureFunction : public DepartureFunction
         std::vector<CoolPropDbl> _l(l.begin(), l.begin() + l.size());
         phi.add_Power(_n, _d, _t, _l);
     };
-    ~ExponentialDepartureFunction() {};
+    ~ExponentialDepartureFunction() = default;
 };
 
-typedef shared_ptr<DepartureFunction> DepartureFunctionPointer;
+using DepartureFunctionPointer = shared_ptr<DepartureFunction>;
 
 class ExcessTerm
 {

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -1198,9 +1198,10 @@ void FlashRoutines::PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend& HEOS, parame
         // *********************************************************
         // Find the correct solution
         std::vector<std::size_t> solutions;
-        for (std::vector<std::pair<std::size_t, std::size_t>>::const_iterator it = intersections.begin(); it != intersections.end(); ++it) {
-            if (std::abs(env.Q[it->first] - HEOS._Q) < 10 * DBL_EPSILON && std::abs(env.Q[it->second] - HEOS._Q) < 10 * DBL_EPSILON) {
-                solutions.push_back(it->first);
+        for (const auto& intersection : intersections) {
+            if (std::abs(env.Q[intersection.first] - HEOS._Q) < 10 * DBL_EPSILON
+                && std::abs(env.Q[intersection.second] - HEOS._Q) < 10 * DBL_EPSILON) {
+                solutions.push_back(intersection.first);
             }
         }
 
@@ -1276,12 +1277,12 @@ void FlashRoutines::PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend& HEOS, parame
 
         // Find the correct solution
         std::vector<std::size_t> liquid_solutions, vapor_solutions;
-        for (std::vector<std::pair<std::size_t, std::size_t>>::const_iterator it = intersections.begin(); it != intersections.end(); ++it) {
-            if (std::abs(env.Q[it->first] - 0) < 10 * DBL_EPSILON && std::abs(env.Q[it->second] - 0) < 10 * DBL_EPSILON) {
-                liquid_solutions.push_back(it->first);
+        for (const auto& intersection : intersections) {
+            if (std::abs(env.Q[intersection.first] - 0) < 10 * DBL_EPSILON && std::abs(env.Q[intersection.second] - 0) < 10 * DBL_EPSILON) {
+                liquid_solutions.push_back(intersection.first);
             }
-            if (std::abs(env.Q[it->first] - 1) < 10 * DBL_EPSILON && std::abs(env.Q[it->second] - 1) < 10 * DBL_EPSILON) {
-                vapor_solutions.push_back(it->first);
+            if (std::abs(env.Q[intersection.first] - 1) < 10 * DBL_EPSILON && std::abs(env.Q[intersection.second] - 1) < 10 * DBL_EPSILON) {
+                vapor_solutions.push_back(intersection.first);
             }
         }
 
@@ -1368,9 +1369,9 @@ void FlashRoutines::HSU_D_flash_twophase(HelmholtzEOSMixtureBackend& HEOS, CoolP
         CoolPropDbl value;          // value for S,H,U
         CoolPropDbl Qd;             // Quality from density
         Residual(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl rhomolar_spec, parameters other, CoolPropDbl value)
-          : HEOS(HEOS), rhomolar_spec(rhomolar_spec), other(other), value(value) {
-            Qd = _HUGE;
-        };
+          : HEOS(HEOS), rhomolar_spec(rhomolar_spec), other(other), value(value), Qd(_HUGE) {
+
+            };
         double call(double T) override {
             HEOS.update(QT_INPUTS, 0, T);
             HelmholtzEOSMixtureBackend &SatL = HEOS.get_SatL(), &SatV = HEOS.get_SatV();
@@ -3621,8 +3622,7 @@ TEST_CASE("Test critical points for nitrogen + ethane with HEOS", "[critical_poi
     shared_ptr<HelmholtzEOSMixtureBackend> HEOS = std::make_shared<HelmholtzEOSMixtureBackend>(strsplit("Nitrogen&Ethane", '&'));
     std::vector<double> zz = linspace(0.001, 0.999, 21);
     int failure_count = 0;
-    for (int i = 0; i < static_cast<std::size_t>(zz.size()); ++i) {
-        double z0 = zz[i];
+    for (double z0 : zz) {
         std::vector<double> z(2);
         z[0] = z0;
         z[1] = 1 - z0;
@@ -3644,8 +3644,7 @@ TEST_CASE("Test critical points for nitrogen + ethane with PR", "[critical_point
     shared_ptr<PengRobinsonBackend> HEOS = std::make_shared<PengRobinsonBackend>(strsplit("Nitrogen&Ethane", '&'));
     HEOS->set_binary_interaction_double(0, 1, "kij", 0.0407);  // Ramırez-Jimenez et al.
     std::vector<double> zz = linspace(0.001, 0.999, 21);
-    for (int i = 0; i < static_cast<std::size_t>(zz.size()); ++i) {
-        double z0 = zz[i];
+    for (double z0 : zz) {
         std::vector<double> z(2);
         z[0] = z0;
         z[1] = 1 - z0;

--- a/src/Backends/Helmholtz/FlashRoutines.h
+++ b/src/Backends/Helmholtz/FlashRoutines.h
@@ -229,9 +229,7 @@ class FlashRoutines
     struct HS_flash_singlephaseOptions
     {
         double omega;
-        HS_flash_singlephaseOptions() {
-            omega = 1.0;
-        }
+        HS_flash_singlephaseOptions() : omega(1.0) {}
     };
     static void HS_flash_singlephase(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl hmolar_spec, CoolPropDbl smolar_spec,
                                      HS_flash_singlephaseOptions& options);
@@ -239,9 +237,7 @@ class FlashRoutines
     struct HS_flash_twophaseOptions
     {
         double omega;
-        HS_flash_twophaseOptions() {
-            omega = 1.0;
-        }
+        HS_flash_twophaseOptions() : omega(1.0) {}
     };
     static void HS_flash_twophase(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl hmolar_spec, CoolPropDbl smolar_spec,
                                   HS_flash_twophaseOptions& options);

--- a/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
+++ b/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
@@ -124,8 +124,7 @@ void MeltingLineVariables::set_limits() {
     if (type == MELTING_LINE_SIMON_TYPE) {
 
         // Fill in the min and max pressures for each part
-        for (std::size_t i = 0; i < simon.parts.size(); ++i) {
-            MeltingLinePiecewiseSimonSegment& part = simon.parts[i];
+        for (auto& part : simon.parts) {
             part.p_min = part.p_0 + part.a * (pow(part.T_min / part.T_0, part.c) - 1);
             part.p_max = part.p_0 + part.a * (pow(part.T_max / part.T_0, part.c) - 1);
         }
@@ -135,8 +134,7 @@ void MeltingLineVariables::set_limits() {
         Tmax = simon.parts.back().T_max;
     } else if (type == MELTING_LINE_POLYNOMIAL_IN_TR_TYPE) {
         // Fill in the min and max pressures for each part
-        for (std::size_t i = 0; i < polynomial_in_Tr.parts.size(); ++i) {
-            MeltingLinePiecewisePolynomialInTrSegment& part = polynomial_in_Tr.parts[i];
+        for (auto& part : polynomial_in_Tr.parts) {
             part.p_min = part.evaluate(part.T_min);
             part.p_max = part.evaluate(part.T_max);
         }
@@ -146,8 +144,7 @@ void MeltingLineVariables::set_limits() {
         pmax = polynomial_in_Tr.parts.back().p_max;
     } else if (type == MELTING_LINE_POLYNOMIAL_IN_THETA_TYPE) {
         // Fill in the min and max pressures for each part
-        for (std::size_t i = 0; i < polynomial_in_Theta.parts.size(); ++i) {
-            MeltingLinePiecewisePolynomialInThetaSegment& part = polynomial_in_Theta.parts[i];
+        for (auto& part : polynomial_in_Theta.parts) {
             part.p_min = part.evaluate(part.T_min);
             part.p_max = part.evaluate(part.T_max);
         }
@@ -176,8 +173,7 @@ CoolPropDbl MeltingLineVariables::evaluate(int OF, int GIVEN, CoolPropDbl value)
         CoolPropDbl T = value;
         if (type == MELTING_LINE_SIMON_TYPE) {
             // Need to find the right segment
-            for (std::size_t i = 0; i < simon.parts.size(); ++i) {
-                MeltingLinePiecewiseSimonSegment& part = simon.parts[i];
+            for (auto& part : simon.parts) {
                 if (is_in_closed_range(part.T_min, part.T_max, T)) {
                     return part.p_0 + part.a * (pow(T / part.T_0, part.c) - 1);
                 }
@@ -185,8 +181,7 @@ CoolPropDbl MeltingLineVariables::evaluate(int OF, int GIVEN, CoolPropDbl value)
             throw ValueError("unable to calculate melting line (p,T) for Simon curve");
         } else if (type == MELTING_LINE_POLYNOMIAL_IN_TR_TYPE) {
             // Need to find the right segment
-            for (std::size_t i = 0; i < polynomial_in_Tr.parts.size(); ++i) {
-                MeltingLinePiecewisePolynomialInTrSegment& part = polynomial_in_Tr.parts[i];
+            for (auto& part : polynomial_in_Tr.parts) {
                 if (is_in_closed_range(part.T_min, part.T_max, T)) {
                     return part.evaluate(T);
                 }
@@ -194,8 +189,7 @@ CoolPropDbl MeltingLineVariables::evaluate(int OF, int GIVEN, CoolPropDbl value)
             throw ValueError("unable to calculate melting line (p,T) for polynomial_in_Tr curve");
         } else if (type == MELTING_LINE_POLYNOMIAL_IN_THETA_TYPE) {
             // Need to find the right segment
-            for (std::size_t i = 0; i < polynomial_in_Theta.parts.size(); ++i) {
-                MeltingLinePiecewisePolynomialInThetaSegment& part = polynomial_in_Theta.parts[i];
+            for (auto& part : polynomial_in_Theta.parts) {
                 if (is_in_closed_range(part.T_min, part.T_max, T)) {
                     return part.evaluate(T);
                 }
@@ -207,8 +201,7 @@ CoolPropDbl MeltingLineVariables::evaluate(int OF, int GIVEN, CoolPropDbl value)
     } else {
         if (type == MELTING_LINE_SIMON_TYPE) {
             // Need to find the right segment
-            for (std::size_t i = 0; i < simon.parts.size(); ++i) {
-                MeltingLinePiecewiseSimonSegment& part = simon.parts[i];
+            for (auto& part : simon.parts) {
                 //  p = part.p_0 + part.a*(pow(T/part.T_0,part.c)-1);
                 CoolPropDbl T = pow((value - part.p_0) / part.a + 1, 1 / part.c) * part.T_0;
                 if (get_config_bool(DONT_CHECK_PROPERTY_LIMITS) || (T >= part.T_0 && T <= part.T_max)) {
@@ -233,8 +226,7 @@ CoolPropDbl MeltingLineVariables::evaluate(int OF, int GIVEN, CoolPropDbl value)
             };
 
             // Need to find the right segment
-            for (std::size_t i = 0; i < polynomial_in_Tr.parts.size(); ++i) {
-                MeltingLinePiecewisePolynomialInTrSegment& part = polynomial_in_Tr.parts[i];
+            for (auto& part : polynomial_in_Tr.parts) {
                 if (is_in_closed_range(part.p_min, part.p_max, value)) {
                     solver_resid resid(&part, value);
                     double T = Brent(resid, part.T_min, part.T_max, DBL_EPSILON, 1e-12, 100);
@@ -261,8 +253,7 @@ CoolPropDbl MeltingLineVariables::evaluate(int OF, int GIVEN, CoolPropDbl value)
             };
 
             // Need to find the right segment
-            for (std::size_t i = 0; i < polynomial_in_Theta.parts.size(); ++i) {
-                MeltingLinePiecewisePolynomialInThetaSegment& part = polynomial_in_Theta.parts[i];
+            for (auto& part : polynomial_in_Theta.parts) {
                 if (is_in_closed_range(part.p_min, part.p_max, value)) {
                     solver_resid resid(&part, value);
                     double T = Brent(resid, part.T_min, part.T_max, DBL_EPSILON, 1e-12, 100);
@@ -317,11 +308,11 @@ TEST_CASE("Water melting line", "[melting]") {
 TEST_CASE("Tests for values from melting lines", "[melting]") {
     int iT = CoolProp::iT, iP = CoolProp::iP;
     std::vector<std::string> fluids = strsplit(CoolProp::get_global_param_string("fluids_list"), ',');
-    for (std::size_t i = 0; i < fluids.size(); ++i) {
-        shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", fluids[i]));
+    for (const auto& fluid : fluids) {
+        shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", fluid));
 
         // Water has its own better tests; skip fluids without melting line
-        if (!AS->has_melting_line() || !fluids[i].compare("Water")) {
+        if (!AS->has_melting_line() || !fluid.compare("Water")) {
             continue;
         }
 
@@ -332,7 +323,7 @@ TEST_CASE("Tests for values from melting lines", "[melting]") {
 
         // See https://groups.google.com/forum/?fromgroups#!topic/catch-forum/mRBKqtTrITU
         std::ostringstream ss0;
-        ss0 << "Check melting line limits for fluid " << fluids[i];
+        ss0 << "Check melting line limits for fluid " << fluid;
         SECTION(ss0.str(), "") {
             CAPTURE(Tmin);
             CAPTURE(Tmax);
@@ -351,7 +342,7 @@ TEST_CASE("Tests for values from melting lines", "[melting]") {
             const double p = pmin + (0.1 + 0.2 * p_i) * p_range;
             // See https://groups.google.com/forum/?fromgroups#!topic/catch-forum/mRBKqtTrITU
             std::ostringstream ss1;
-            ss1 << "Melting line for " << fluids[i] << " at p=" << p;
+            ss1 << "Melting line for " << fluid << " at p=" << p;
             SECTION(ss1.str(), "") {
                 double actual_T = AS->melting_line(iT, iP, p);
                 CAPTURE(Tmin);
@@ -363,7 +354,7 @@ TEST_CASE("Tests for values from melting lines", "[melting]") {
         }
         // See https://groups.google.com/forum/?fromgroups#!topic/catch-forum/mRBKqtTrITU
         std::ostringstream ss2;
-        ss2 << "Ensure melting line valid for " << fluids[i] << " @ EOS pmax";
+        ss2 << "Ensure melting line valid for " << fluid << " @ EOS pmax";
         SECTION(ss2.str(), "") {
             double actual_T = -_HUGE;
             double EOS_pmax = AS->pmax();
@@ -388,14 +379,14 @@ TEST_CASE("Tests for values from melting lines", "[melting]") {
 
 TEST_CASE("Test that hs_anchor enthalpy/entropy agrees with EOS", "[ancillaries]") {
     std::vector<std::string> fluids = strsplit(CoolProp::get_global_param_string("fluids_list"), ',');
-    for (std::size_t i = 0; i < fluids.size(); ++i) {
-        shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", fluids[i]));
+    for (const auto& fluid : fluids) {
+        shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", fluid));
 
         CoolProp::SimpleState hs_anchor = AS->get_state("hs_anchor");
 
         // See https://groups.google.com/forum/?fromgroups#!topic/catch-forum/mRBKqtTrITU
         std::ostringstream ss1;
-        ss1 << "Check hs_anchor for " << fluids[i];
+        ss1 << "Check hs_anchor for " << fluid;
         SECTION(ss1.str(), "") {
             INFO("The enthalpy and entropy are hardcoded in the fluid JSON files.  They MUST agree with the values calculated by the EOS");
             AS->update(CoolProp::DmolarT_INPUTS, hs_anchor.rhomolar, hs_anchor.T);

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
@@ -45,7 +45,7 @@ static void ensure_library_loaded() {
 
 void load() {
     std::vector<unsigned char> outbuffer(gall_fluids_JSON_zSize * 7);
-    uLong outlen = static_cast<uLong>(outbuffer.size());
+    auto outlen = static_cast<uLong>(outbuffer.size());
     auto code = uncompress(&outbuffer[0], &outlen, gall_fluids_JSON_zData, gall_fluids_JSON_zSize);
     std::string buf(outbuffer.begin(), outbuffer.begin() + outlen);
     if (code != 0) {
@@ -74,9 +74,9 @@ void load() {
 
 void JSONFluidLibrary::set_fluid_enthalpy_entropy_offset(const std::string& fluid, double delta_a1, double delta_a2, const std::string& ref) {
     // Try to find it
-    std::map<std::string, std::size_t>::const_iterator it = string_to_index_map.find(fluid);
+    auto it = string_to_index_map.find(fluid);
     if (it != string_to_index_map.end()) {
-        std::map<std::size_t, CoolPropFluid>::iterator it2 = fluid_map.find(it->second);
+        auto it2 = fluid_map.find(it->second);
         // If it is found
         if (it2 != fluid_map.end()) {
             if (!ValidNumber(delta_a1) || !ValidNumber(delta_a2)) {
@@ -304,13 +304,13 @@ void JSONFluidLibrary::add_one(rapidjson::Value& fluid_json) {
             index = string_to_index_map.find(upper(fluid.name))->second;  // if uppercase name found, grab index
         } else {
             // Check the aliases
-            for (std::size_t i = 0; i < fluid.aliases.size(); ++i) {
-                if (string_to_index_map.find(fluid.aliases[i]) != string_to_index_map.end()) {
-                    index = string_to_index_map.find(fluid.aliases[i])->second;  // if alias found, grab index
+            for (const auto& aliase : fluid.aliases) {
+                if (string_to_index_map.find(aliase) != string_to_index_map.end()) {
+                    index = string_to_index_map.find(aliase)->second;  // if alias found, grab index
                     break;
                 }
-                if (string_to_index_map.find(upper(fluid.aliases[i])) != string_to_index_map.end()) {  // if ALIAS found, grab index
-                    index = string_to_index_map.find(upper(fluid.aliases[i]))->second;
+                if (string_to_index_map.find(upper(aliase)) != string_to_index_map.end()) {  // if ALIAS found, grab index
+                    index = string_to_index_map.find(upper(aliase))->second;
                     break;
                 }
             }
@@ -363,11 +363,11 @@ void JSONFluidLibrary::add_one(rapidjson::Value& fluid_json) {
         // Add/Replace the aliases->index mapping
         // This map quickly finds the index of a fluid in the fluid_map given an alias string
         // Again, the map [] operator replaces if the alias is found, adds the new (alias,index) pair if not
-        for (std::size_t i = 0; i < fluid.aliases.size(); ++i) {
-            string_to_index_map[fluid.aliases[i]] = index;
+        for (const auto& aliase : fluid.aliases) {
+            string_to_index_map[aliase] = index;
 
             // Add uppercase alias for EES compatibility
-            string_to_index_map[upper(fluid.aliases[i])] = index;
+            string_to_index_map[upper(aliase)] = index;
         }
 
         //If Debug level set >5 print fluid name and total size of fluid_map

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
@@ -363,11 +363,11 @@ void JSONFluidLibrary::add_one(rapidjson::Value& fluid_json) {
         // Add/Replace the aliases->index mapping
         // This map quickly finds the index of a fluid in the fluid_map given an alias string
         // Again, the map [] operator replaces if the alias is found, adds the new (alias,index) pair if not
-        for (const auto& aliase : fluid.aliases) {
-            string_to_index_map[aliase] = index;
+        for (const auto& alias : fluid.aliases) {
+            string_to_index_map[alias] = index;
 
             // Add uppercase alias for EES compatibility
-            string_to_index_map[upper(aliase)] = index;
+            string_to_index_map[upper(alias)] = index;
         }
 
         //If Debug level set >5 print fluid name and total size of fluid_map

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
@@ -304,13 +304,13 @@ void JSONFluidLibrary::add_one(rapidjson::Value& fluid_json) {
             index = string_to_index_map.find(upper(fluid.name))->second;  // if uppercase name found, grab index
         } else {
             // Check the aliases
-            for (const auto& aliase : fluid.aliases) {
-                if (string_to_index_map.find(aliase) != string_to_index_map.end()) {
-                    index = string_to_index_map.find(aliase)->second;  // if alias found, grab index
+            for (const auto& alias : fluid.aliases) {
+                if (string_to_index_map.find(alias) != string_to_index_map.end()) {
+                    index = string_to_index_map.find(alias)->second;  // if alias found, grab index
                     break;
                 }
-                if (string_to_index_map.find(upper(aliase)) != string_to_index_map.end()) {  // if ALIAS found, grab index
-                    index = string_to_index_map.find(upper(aliase))->second;
+                if (string_to_index_map.find(upper(alias)) != string_to_index_map.end()) {  // if ALIAS found, grab index
+                    index = string_to_index_map.find(upper(alias))->second;
                     break;
                 }
             }

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.h
@@ -225,8 +225,8 @@ class JSONFluidLibrary
                 std::vector<CoolPropDbl> n = cpjson::get_long_double_array(contribution["n"]);
                 std::vector<CoolPropDbl> t = cpjson::get_long_double_array(contribution["t"]);
                 // Flip the sign of theta
-                for (std::size_t i = 0; i < t.size(); ++i) {
-                    t[i] *= -1;
+                for (double& i : t) {
+                    i *= -1;
                 }
                 std::vector<CoolPropDbl> c(n.size(), 1);
                 std::vector<CoolPropDbl> d(c.size(), -1);
@@ -1078,7 +1078,7 @@ class JSONFluidLibrary
     /// Parse the critical state for the given EOS
     void parse_states(rapidjson::Value& states, CoolPropFluid& fluid) {
         if (!states.HasMember("critical")) {
-            throw ValueError(format("fluid[\"STATES\"] [%s] does not have \"critical\" member", fluid.name.c_str()));
+            throw ValueError(format(R"(fluid["STATES"] [%s] does not have "critical" member)", fluid.name.c_str()));
         }
         rapidjson::Value& crit = states["critical"];
         fluid.crit.T = cpjson::get_double(crit, "T");
@@ -1088,7 +1088,7 @@ class JSONFluidLibrary
         fluid.crit.smolar = cpjson::get_double(crit, "smolar");
 
         if (!states.HasMember("triple_liquid")) {
-            throw ValueError(format("fluid[\"STATES\"] [%s] does not have \"triple_liquid\" member", fluid.name.c_str()));
+            throw ValueError(format(R"(fluid["STATES"] [%s] does not have "triple_liquid" member)", fluid.name.c_str()));
         }
         rapidjson::Value& triple_liquid = states["triple_liquid"];
         if (triple_liquid.ObjectEmpty()) {
@@ -1107,7 +1107,7 @@ class JSONFluidLibrary
         }
 
         if (!states.HasMember("triple_vapor")) {
-            throw ValueError(format("fluid[\"STATES\"] [%s] does not have \"triple_vapor\" member", fluid.name.c_str()));
+            throw ValueError(format(R"(fluid["STATES"] [%s] does not have "triple_vapor" member)", fluid.name.c_str()));
         }
         rapidjson::Value& triple_vapor = states["triple_vapor"];
         if (triple_vapor.ObjectEmpty()) {
@@ -1195,9 +1195,10 @@ class JSONFluidLibrary
 
    public:
     // Default constructor;
-    JSONFluidLibrary() {
-        _is_empty = true;
-    };
+    JSONFluidLibrary()
+      : _is_empty(true) {
+
+        };
     bool is_empty() {
         return _is_empty;
     };
@@ -1212,10 +1213,10 @@ class JSONFluidLibrary
 
     std::string get_JSONstring(const std::string& key) {
         // Try to find it
-        std::map<std::string, std::size_t>::const_iterator it = string_to_index_map.find(key);
+        auto it = string_to_index_map.find(key);
         if (it != string_to_index_map.end()) {
 
-            std::map<std::size_t, std::string>::const_iterator it2 = JSONstring_map.find(it->second);
+            auto it2 = JSONstring_map.find(it->second);
             if (it2 != JSONstring_map.end()) {
                 // Then, load the fluids we would like to add
                 rapidjson::Document doc;
@@ -1238,7 +1239,7 @@ class JSONFluidLibrary
     */
     CoolPropFluid get(const std::string& key) {
         // Try to find it
-        std::map<std::string, std::size_t>::const_iterator it = string_to_index_map.find(key);
+        auto it = string_to_index_map.find(key);
         // If it is found
         if (it != string_to_index_map.end()) {
             return get(it->second);
@@ -1247,9 +1248,9 @@ class JSONFluidLibrary
             std::vector<std::string> endings;
             endings.emplace_back("-SRK");
             endings.emplace_back("-PengRobinson");
-            for (std::vector<std::string>::const_iterator end = endings.begin(); end != endings.end(); ++end) {
-                if (endswith(key, *end)) {
-                    std::string used_name = key.substr(0, key.size() - (*end).size());
+            for (const auto& ending : endings) {
+                if (endswith(key, ending)) {
+                    std::string used_name = key.substr(0, key.size() - ending.size());
                     it = string_to_index_map.find(used_name);
                     if (it != string_to_index_map.end()) {
                         // We found the name of the fluid within the library of multiparameter
@@ -1267,12 +1268,12 @@ class JSONFluidLibrary
                         CoolPropDbl R = 8.3144598;  // fluid.EOSVector[0].R_u;
                         // Set the cubic contribution to the residual Helmholtz energy
                         shared_ptr<AbstractCubic> ac;
-                        if (*end == "-SRK") {
+                        if (ending == "-SRK") {
                             ac = std::make_shared<SRK>(Tc, pc, acentric, R);
-                        } else if (*end == "-PengRobinson") {
+                        } else if (ending == "-PengRobinson") {
                             ac = std::make_shared<PengRobinson>(Tc, pc, acentric, R);
                         } else {
-                            throw CoolProp::ValueError(format("Unable to match this ending [%s]", (*end).c_str()));
+                            throw CoolProp::ValueError(format("Unable to match this ending [%s]", ending.c_str()));
                         }
                         ac->set_Tr(Tc);
                         ac->set_rhor(rhomolarc);
@@ -1283,12 +1284,12 @@ class JSONFluidLibrary
                         CubicLibrary::CubicsValues vals = CubicLibrary::get_cubic_values(used_name);
                         // Set the cubic contribution to the residual Helmholtz energy
                         shared_ptr<AbstractCubic> ac;
-                        if (*end == "-SRK") {
+                        if (ending == "-SRK") {
                             ac = std::make_shared<SRK>(vals.Tc, vals.pc, vals.acentric, get_config_double(R_U_CODATA));
-                        } else if (*end == "-PengRobinson") {
+                        } else if (ending == "-PengRobinson") {
                             ac = std::make_shared<PengRobinson>(vals.Tc, vals.pc, vals.acentric, get_config_double(R_U_CODATA));
                         } else {
-                            throw CoolProp::ValueError(format("Unable to match this ending [%s]", (*end).c_str()));
+                            throw CoolProp::ValueError(format("Unable to match this ending [%s]", ending.c_str()));
                         }
                         ac->set_Tr(vals.Tc);
                         if (vals.rhomolarc > 0) {
@@ -1332,7 +1333,7 @@ class JSONFluidLibrary
     */
     CoolPropFluid get(std::size_t key) {
         // Try to find it
-        std::map<std::size_t, CoolPropFluid>::iterator it = fluid_map.find(key);
+        auto it = fluid_map.find(key);
         // If it is found
         if (it != fluid_map.end()) {
             return it->second;

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.h
@@ -225,7 +225,7 @@ class JSONFluidLibrary
                 std::vector<CoolPropDbl> n = cpjson::get_long_double_array(contribution["n"]);
                 std::vector<CoolPropDbl> t = cpjson::get_long_double_array(contribution["t"]);
                 // Flip the sign of theta
-                for (double& i : t) {
+                for (auto& i : t) {
                     i *= -1;
                 }
                 std::vector<CoolPropDbl> c(n.size(), 1);

--- a/src/Backends/Helmholtz/HelmholtzEOSBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSBackend.h
@@ -30,8 +30,8 @@ inline std::string vecstring_to_string(const std::vector<std::string>& a) {
 class HelmholtzEOSBackend : public HelmholtzEOSMixtureBackend
 {
    public:
-    HelmholtzEOSBackend() {};
-    HelmholtzEOSBackend(CoolPropFluid Fluid) {
+    HelmholtzEOSBackend() = default;
+    HelmholtzEOSBackend(const CoolPropFluid& Fluid) {
         set_components(std::vector<CoolPropFluid>(1, Fluid));
     };
     HelmholtzEOSBackend(const std::string& name) : HelmholtzEOSMixtureBackend() {
@@ -46,8 +46,8 @@ class HelmholtzEOSBackend : public HelmholtzEOSMixtureBackend
                 std::cout << "Got the fluids" << vecstring_to_string(fluids) << '\n';
                 std::cout << "Got the fractions" << vec_to_string(mole_fractions, "%g") << '\n';
             }
-            for (unsigned int i = 0; i < fluids.size(); ++i) {
-                components.push_back(library.get(fluids[i]));
+            for (const auto& fluid : fluids) {
+                components.push_back(library.get(fluid));
             }
         } else {
             components.push_back(library.get(name));  // Until now it's empty
@@ -61,7 +61,7 @@ class HelmholtzEOSBackend : public HelmholtzEOSMixtureBackend
             std::cout << "successfully set up state" << '\n';
         }
     };
-    virtual ~HelmholtzEOSBackend() {};
+    virtual ~HelmholtzEOSBackend() = default;
     std::string backend_name() override {
         return get_backend_string(HEOS_BACKEND_PURE);
     }

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -65,10 +65,9 @@ class HEOSGenerator : public AbstractStateGenerator
 // NOLINTNEXTLINE(cert-err58-cpp)
 static CoolProp::GeneratorInitializer<HEOSGenerator> heos_gen(CoolProp::HEOS_BACKEND_FAMILY);
 
-HelmholtzEOSMixtureBackend::HelmholtzEOSMixtureBackend() {
+HelmholtzEOSMixtureBackend::HelmholtzEOSMixtureBackend() : is_pure_or_pseudopure(false), N(0) {
     imposed_phase_index = iphase_not_imposed;
-    is_pure_or_pseudopure = false;
-    N = 0;
+
     _phase = iphase_unknown;
     // Reset the residual Helmholtz energy class
     residual_helmholtz = std::make_shared<ResidualHelmholtz>();
@@ -164,7 +163,7 @@ void HelmholtzEOSMixtureBackend::sync_linked_states(const HelmholtzEOSMixtureBac
 }
 HelmholtzEOSMixtureBackend* HelmholtzEOSMixtureBackend::get_copy(bool generate_SatL_and_SatV) {
     // Set up the class with these components
-    HelmholtzEOSMixtureBackend* ptr = new HelmholtzEOSMixtureBackend(components, generate_SatL_and_SatV);
+    auto* ptr = new HelmholtzEOSMixtureBackend(components, generate_SatL_and_SatV);
     // Recursively walk into linked states, setting the departure and reducing terms
     // to be equal to the parent (this instance)
     ptr->sync_linked_states(this);
@@ -240,7 +239,7 @@ std::string HelmholtzEOSMixtureBackend::fluid_param_string(const std::string& Pa
         if (parts.size() != 2) {
             throw ValueError(format("Unable to parse BibTeX string %s", ParamName.c_str()));
         }
-        std::string key = parts[1];
+        const std::string& key = parts[1];
         if (!key.compare("EOS")) {
             return cpfluid.EOS().BibTeX_EOS;
         } else if (!key.compare("CP0")) {
@@ -1111,8 +1110,8 @@ void HelmholtzEOSMixtureBackend::calc_ideal_curve(const std::string& type, std::
 std::vector<std::string> HelmholtzEOSMixtureBackend::calc_fluid_names() {
     std::vector<std::string> out;
     out.reserve(components.size());
-    for (std::size_t i = 0; i < components.size(); ++i) {
-        out.push_back(components[i].name);
+    for (auto& component : components) {
+        out.push_back(component.name);
     }
     return out;
 }
@@ -2882,7 +2881,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::solver_rho_Tp(CoolPropDbl T, CoolPropDbl
             double rhomolar = NAN;
             if (is_pure_or_pseudopure) {
                 // It's liquid at subcritical pressure, we can use ancillaries as guess value
-                CoolPropDbl _rhoLancval = static_cast<CoolPropDbl>(components[0].ancillaries.rhoL.evaluate(T));
+                auto _rhoLancval = static_cast<CoolPropDbl>(components[0].ancillaries.rhoL.evaluate(T));
                 try {
                     // First we try with Halley's method starting at saturated liquid
                     rhomolar = Halley(resid, _rhoLancval, 1e-8, 100);
@@ -2903,8 +2902,8 @@ CoolPropDbl HelmholtzEOSMixtureBackend::solver_rho_Tp(CoolPropDbl T, CoolPropDbl
             }
             return rhomolar;
         } else if (phase == iphase_supercritical_liquid) {
-            CoolPropDbl rhoLancval = static_cast<CoolPropDbl>(components[0].ancillaries.rhoL.evaluate(T));
-            CoolPropDbl rhoLtripleancval = static_cast<CoolPropDbl>(components[0].ancillaries.rhoL.evaluate(Ttriple()));
+            auto rhoLancval = static_cast<CoolPropDbl>(components[0].ancillaries.rhoL.evaluate(T));
+            auto rhoLtripleancval = static_cast<CoolPropDbl>(components[0].ancillaries.rhoL.evaluate(Ttriple()));
 
             // Next we try with a Brent method bounded solver since the function should be 1-1 in most cases
             // But some EOS have a maximum in pressure so if rhoc*4 is after the maximum in pressure, this method will fail
@@ -4139,10 +4138,17 @@ class L0CurveTracer : public FuncWrapper1DWithDeriv
     bool
       find_critical_points;  ///< If true, actually calculate the critical points, otherwise, skip evaluation of critical points but still trace the spinodal
     L0CurveTracer(HelmholtzEOSMixtureBackend& HEOS, double tau0, double delta0)
-      : HEOS(HEOS), delta(delta0), tau(tau0), M1_last(_HUGE), N_critical_points(0), find_critical_points(true) {
-        R_delta_tracer = 0.1;
+      : HEOS(HEOS),
+        delta(delta0),
+        tau(tau0),
+        M1_last(_HUGE),
+        R_delta_tracer(0.1),
+        R_tau_tracer(0.1),
+        N_critical_points(0),
+        find_critical_points(true) {
+
         R_delta = R_delta_tracer;
-        R_tau_tracer = 0.1;
+
         R_tau = R_tau_tracer;
     };
     /***
@@ -4354,8 +4360,8 @@ void HelmholtzEOSMixtureBackend::calc_build_spinodal() {
 }
 
 void HelmholtzEOSMixtureBackend::set_reference_stateS(const std::string& reference_state) {
-    for (std::size_t i = 0; i < components.size(); ++i) {
-        CoolProp::HelmholtzEOSMixtureBackend HEOS(std::vector<CoolPropFluid>(1, components[i]));
+    for (auto& component : components) {
+        CoolProp::HelmholtzEOSMixtureBackend HEOS(std::vector<CoolPropFluid>(1, component));
         if (!reference_state.compare("IIR")) {
             if (HEOS.Ttriple() > 273.15) {
                 throw ValueError(format("Cannot use IIR reference state; Ttriple [%Lg] is greater than 273.15 K", HEOS.Ttriple()));
@@ -4368,7 +4374,7 @@ void HelmholtzEOSMixtureBackend::set_reference_stateS(const std::string& referen
             double delta_a1 = deltas / (HEOS.gas_constant() / HEOS.molar_mass());
             double delta_a2 = -deltah / (HEOS.gas_constant() / HEOS.molar_mass() * HEOS.get_reducing_state().T);
             // Change the value in the library for the given fluid
-            set_fluid_enthalpy_entropy_offset(components[i], delta_a1, delta_a2, "IIR");
+            set_fluid_enthalpy_entropy_offset(component, delta_a1, delta_a2, "IIR");
             if (get_debug_level() > 0) {
                 std::cout << format("set offsets to %0.15g and %0.15g\n", delta_a1, delta_a2);
             }
@@ -4384,7 +4390,7 @@ void HelmholtzEOSMixtureBackend::set_reference_stateS(const std::string& referen
             double delta_a1 = deltas / (HEOS.gas_constant() / HEOS.molar_mass());
             double delta_a2 = -deltah / (HEOS.gas_constant() / HEOS.molar_mass() * HEOS.get_reducing_state().T);
             // Change the value in the library for the given fluid
-            set_fluid_enthalpy_entropy_offset(components[i], delta_a1, delta_a2, "ASHRAE");
+            set_fluid_enthalpy_entropy_offset(component, delta_a1, delta_a2, "ASHRAE");
             if (get_debug_level() > 0) {
                 std::cout << format("set offsets to %0.15g and %0.15g\n", delta_a1, delta_a2);
             }
@@ -4400,14 +4406,14 @@ void HelmholtzEOSMixtureBackend::set_reference_stateS(const std::string& referen
             double delta_a1 = deltas / (HEOS.gas_constant() / HEOS.molar_mass());
             double delta_a2 = -deltah / (HEOS.gas_constant() / HEOS.molar_mass() * HEOS.get_reducing_state().T);
             // Change the value in the library for the given fluid
-            set_fluid_enthalpy_entropy_offset(components[i], delta_a1, delta_a2, "NBP");
+            set_fluid_enthalpy_entropy_offset(component, delta_a1, delta_a2, "NBP");
             if (get_debug_level() > 0) {
                 std::cout << format("set offsets to %0.15g and %0.15g\n", delta_a1, delta_a2);
             }
         } else if (!reference_state.compare("DEF")) {
-            set_fluid_enthalpy_entropy_offset(components[i], 0, 0, "DEF");
+            set_fluid_enthalpy_entropy_offset(component, 0, 0, "DEF");
         } else if (!reference_state.compare("RESET")) {
-            set_fluid_enthalpy_entropy_offset(components[i], 0, 0, "RESET");
+            set_fluid_enthalpy_entropy_offset(component, 0, 0, "RESET");
         } else {
             throw ValueError(format("reference state string is invalid: [%s]", reference_state.c_str()));
         }
@@ -4420,8 +4426,8 @@ void HelmholtzEOSMixtureBackend::set_reference_stateS(const std::string& referen
 /// @param hmolar0 Molar enthalpy at reference state [J/mol]
 /// @param smolar0 Molar entropy at reference state [J/mol/K]
 void HelmholtzEOSMixtureBackend::set_reference_stateD(double T, double rhomolar, double hmolar0, double smolar0) {
-    for (std::size_t i = 0; i < components.size(); ++i) {
-        CoolProp::HelmholtzEOSMixtureBackend HEOS(std::vector<CoolPropFluid>(1, components[i]));
+    for (auto& component : components) {
+        CoolProp::HelmholtzEOSMixtureBackend HEOS(std::vector<CoolPropFluid>(1, component));
 
         // Skip the cache and phase calculation because we are given a temperature and density directly;
         // just evaluate the EOS
@@ -4433,7 +4439,7 @@ void HelmholtzEOSMixtureBackend::set_reference_stateD(double T, double rhomolar,
         double deltas = smolar - smolar0;  // offset from specified entropy in J/mol/K
         double delta_a1 = deltas / (HEOS.gas_constant());
         double delta_a2 = -deltah / (HEOS.gas_constant() * HEOS.get_reducing_state().T);
-        set_fluid_enthalpy_entropy_offset(components[i], delta_a1, delta_a2, "custom");
+        set_fluid_enthalpy_entropy_offset(component, delta_a1, delta_a2, "custom");
     }
 }
 

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
@@ -133,7 +133,7 @@ class HelmholtzEOSMixtureBackend : public AbstractState
     // Copy over the reducing and departure terms to all linked states (recursively)
     void sync_linked_states(const HelmholtzEOSMixtureBackend* const);
 
-    virtual ~HelmholtzEOSMixtureBackend() {};
+    virtual ~HelmholtzEOSMixtureBackend() = default;
     std::string backend_name() override {
         return get_backend_string(HEOS_BACKEND_MIX);
     }
@@ -147,9 +147,9 @@ class HelmholtzEOSMixtureBackend : public AbstractState
     bool clear() override {
         // Clear the locally cached values for the derivatives of the Helmholtz energy
         // in each component
-        for (std::vector<CoolPropFluid>::iterator it = components.begin(); it != components.end(); ++it) {
-            (*it).EOS().alphar.clear();
-            (*it).EOS().alpha0.clear();
+        for (auto& component : components) {
+            component.EOS().alphar.clear();
+            component.EOS().alpha0.clear();
         }
         return AbstractState::clear();
     };
@@ -831,7 +831,7 @@ class ResidualHelmholtz
     ExcessTerm Excess;
     CorrespondingStatesTerm CS;
 
-    ResidualHelmholtz() {};
+    ResidualHelmholtz() = default;
     ResidualHelmholtz(const ExcessTerm& E, const CorrespondingStatesTerm& C) : Excess(E), CS(C) {};
     virtual ~ResidualHelmholtz() = default;
 

--- a/src/Backends/Helmholtz/MixtureDerivatives.cpp
+++ b/src/Backends/Helmholtz/MixtureDerivatives.cpp
@@ -1035,13 +1035,13 @@ CoolPropDbl MixtureDerivatives::dpsir_dxi(HelmholtzEOSMixtureBackend& HEOS, std:
 }
 
 CoolPropDbl MixtureDerivatives::d_rhorTr_dxi(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) {
-    GERG2008ReducingFunction* GERG = static_cast<GERG2008ReducingFunction*>(HEOS.Reducing.get());
+    auto* GERG = static_cast<GERG2008ReducingFunction*>(HEOS.Reducing.get());
     return HEOS.rhomolar_reducing() * GERG->dTrdxi__constxj(HEOS.mole_fractions, i, xN_flag)
            + HEOS.T_reducing() * GERG->drhormolardxi__constxj(HEOS.mole_fractions, i, xN_flag);
 }
 
 CoolPropDbl MixtureDerivatives::d2_rhorTr_dxidxj(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j, x_N_dependency_flag xN_flag) {
-    GERG2008ReducingFunction* GERG = static_cast<GERG2008ReducingFunction*>(HEOS.Reducing.get());
+    auto* GERG = static_cast<GERG2008ReducingFunction*>(HEOS.Reducing.get());
     return (HEOS.rhomolar_reducing() * GERG->d2Trdxidxj(HEOS.mole_fractions, i, j, xN_flag)
             + GERG->drhormolardxi__constxj(HEOS.mole_fractions, j, xN_flag) * GERG->dTrdxi__constxj(HEOS.mole_fractions, i, xN_flag)
             + HEOS.T_reducing() * GERG->d2rhormolardxidxj(HEOS.mole_fractions, i, j, xN_flag)
@@ -1118,7 +1118,7 @@ double mix_deriv_err_func(double numeric, double analytic) {
     }
 }
 
-typedef CoolProp::MixtureDerivatives MD;
+using MD = CoolProp::MixtureDerivatives;
 
 enum derivative
 {
@@ -1136,12 +1136,12 @@ enum derivative
     CONST_TRHO
 };
 
-typedef double (*zero_mole_fraction_pointer)(CoolProp::HelmholtzEOSMixtureBackend& HEOS, CoolProp::x_N_dependency_flag xN_flag);
-typedef double (*one_mole_fraction_pointer)(CoolProp::HelmholtzEOSMixtureBackend& HEOS, std::size_t i, CoolProp::x_N_dependency_flag xN_flag);
-typedef double (*two_mole_fraction_pointer)(CoolProp::HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j,
-                                            CoolProp::x_N_dependency_flag xN_flag);
-typedef double (*three_mole_fraction_pointer)(CoolProp::HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j, std::size_t k,
-                                              CoolProp::x_N_dependency_flag xN_flag);
+using zero_mole_fraction_pointer = double (*)(CoolProp::HelmholtzEOSMixtureBackend& HEOS, CoolProp::x_N_dependency_flag xN_flag);
+using one_mole_fraction_pointer = double (*)(CoolProp::HelmholtzEOSMixtureBackend& HEOS, std::size_t i, CoolProp::x_N_dependency_flag xN_flag);
+using two_mole_fraction_pointer = double (*)(CoolProp::HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j,
+                                             CoolProp::x_N_dependency_flag xN_flag);
+using three_mole_fraction_pointer = double (*)(CoolProp::HelmholtzEOSMixtureBackend& HEOS, std::size_t i, std::size_t j, std::size_t k,
+                                               CoolProp::x_N_dependency_flag xN_flag);
 
 template <class backend>
 class DerivativeFixture
@@ -1154,20 +1154,13 @@ class DerivativeFixture
       HEOS_plus_n, HEOS_minus_n, HEOS_plus_2z, HEOS_minus_2z, HEOS_plus_2z__constTrho, HEOS_minus_2z__constTrho;
     CoolProp::x_N_dependency_flag xN;
     double dtau, ddelta, dz, dn, tol, dT, drho, dp;
-    DerivativeFixture() : xN(XN_INDEPENDENT) {
-        dtau = 1e-6;
-        ddelta = 1e-6;
-        dz = 1e-6;
-        dn = 1e-6;
-        dT = 1e-3;
-        drho = 1e-3;
-        dp = 1;
-        tol = 5e-6;
+    DerivativeFixture() : xN(XN_INDEPENDENT), dtau(1e-6), ddelta(1e-6), dz(1e-6), dn(1e-6), dT(1e-3), drho(1e-3), dp(1), tol(5e-6) {
+
         std::vector<std::string> names;
-        names.push_back("n-Pentane");
-        names.push_back("Ethane");
-        names.push_back("n-Propane");
-        names.push_back("n-Butane");
+        names.emplace_back("n-Pentane");
+        names.emplace_back("Ethane");
+        names.emplace_back("n-Propane");
+        names.emplace_back("n-Butane");
         std::vector<CoolPropDbl> mole_fractions;
         mole_fractions.push_back(0.1);
         mole_fractions.push_back(0.12);
@@ -1467,7 +1460,7 @@ class DerivativeFixture
             }
         }
     }
-    Eigen::MatrixXd get_matrix(CoolProp::HelmholtzEOSMixtureBackend& HEOS, const std::string name) {
+    Eigen::MatrixXd get_matrix(CoolProp::HelmholtzEOSMixtureBackend& HEOS, const std::string& name) {
         Eigen::MatrixXd Lstar = MixtureDerivatives::Lstar(HEOS, xN);
         if (name == "Lstar") {
             return Lstar;
@@ -1477,7 +1470,7 @@ class DerivativeFixture
             throw ValueError("Must be one of Lstar or Mstar");
         }
     }
-    void matrix_derivative(const std::string name, const std::string& wrt) {
+    void matrix_derivative(const std::string& name, const std::string& wrt) {
         CAPTURE(name);
         CAPTURE(wrt);
         double err = 10000;

--- a/src/Backends/Helmholtz/MixtureParameters.cpp
+++ b/src/Backends/Helmholtz/MixtureParameters.cpp
@@ -64,7 +64,7 @@ std::string get_csv_predefined_mixtures() {
 }
 
 bool is_predefined_mixture(const std::string& name, Dictionary& dict) {
-    std::map<std::string, Dictionary>::const_iterator iter = predefined_mixtures_library.predefined_mixture_map.find(name);
+    auto iter = predefined_mixtures_library.predefined_mixture_map.find(name);
     if (iter != predefined_mixtures_library.predefined_mixture_map.end()) {
         dict = iter->second;
         return true;
@@ -180,7 +180,7 @@ class MixtureBinaryPairLibrary
                 continue;
             }
 
-            std::map<std::vector<std::string>, std::vector<Dictionary>>::iterator it = m_binary_pair_map.find(CAS);
+            auto it = m_binary_pair_map.find(CAS);
             if (it == m_binary_pair_map.end()) {
                 // Add to binary pair map by creating one-element vector
                 m_binary_pair_map.emplace(CAS, std::vector<Dictionary>(1, dict));
@@ -268,7 +268,7 @@ class MixtureBinaryPairLibrary
             throw ValueError(format("Your simple mixing rule [%s] was not understood", rule.c_str()));
         }
 
-        std::map<std::vector<std::string>, std::vector<Dictionary>>::iterator it = m_binary_pair_map.find(CAS);
+        auto it = m_binary_pair_map.find(CAS);
         if (it == m_binary_pair_map.end()) {
             // Add to binary pair map by creating one-element vector
             m_binary_pair_map.emplace(CAS, std::vector<Dictionary>(1, dict));
@@ -488,7 +488,7 @@ class MixtureDepartureFunctionsLibrary
     void add_one(const std::string& name, Dictionary& dict) {
 
         // Check if this name is already in use
-        std::map<std::string, Dictionary>::iterator it = m_departure_function_map.find(name);
+        auto it = m_departure_function_map.find(name);
         if (it == m_departure_function_map.end()) {
             // Not in map, add new entry to map with dictionary as value and Name as key
             m_departure_function_map.insert(std::pair<std::string, Dictionary>(name, dict));

--- a/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
+++ b/src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp
@@ -599,9 +599,8 @@ void PhaseEnvelopeRoutines::finalize(HelmholtzEOSMixtureBackend& HEOS) {
                 HelmholtzEOSMixtureBackend* HEOS;
                 SaturationSolvers::newton_raphson_saturation NR;
                 SaturationSolvers::newton_raphson_saturation_options IO;
-                solver_resid(HelmholtzEOSMixtureBackend& HEOS, std::size_t imax, maxima_points maxima) {
+                solver_resid(HelmholtzEOSMixtureBackend& HEOS, std::size_t imax, maxima_points maxima) : maxima(maxima) {
                     this->HEOS = &HEOS, this->imax = imax;
-                    this->maxima = maxima;
                 };
                 double call(double rhomolar_vap) override {
                     PhaseEnvelopeData& env = HEOS->PhaseEnvelope;

--- a/src/Backends/Helmholtz/ReducingFunctions.h
+++ b/src/Backends/Helmholtz/ReducingFunctions.h
@@ -14,7 +14,7 @@ using std::shared_ptr;
 
 namespace CoolProp {
 
-typedef std::vector<std::vector<CoolPropDbl>> STLMatrix;
+using STLMatrix = std::vector<std::vector<CoolPropDbl>>;
 
 enum x_N_dependency_flag
 {
@@ -36,7 +36,7 @@ class ReducingFunction
 
    public:
     ReducingFunction() : N(0) {};
-    virtual ~ReducingFunction() {};
+    virtual ~ReducingFunction() = default;
 
     virtual ReducingFunction* copy() = 0;
 
@@ -158,12 +158,9 @@ class GERG2008ReducingFunction : public ReducingFunction
 
    public:
     GERG2008ReducingFunction(const std::vector<CoolPropFluid>& pFluids, const STLMatrix& beta_v, const STLMatrix& gamma_v, const STLMatrix& beta_T,
-                             const STLMatrix& gamma_T) {
-        this->pFluids = pFluids;
-        this->beta_v = beta_v;
-        this->gamma_v = gamma_v;
-        this->beta_T = beta_T;
-        this->gamma_T = gamma_T;
+                             const STLMatrix& gamma_T)
+      : pFluids(pFluids), beta_v(beta_v), gamma_v(gamma_v), beta_T(beta_T), gamma_T(gamma_T) {
+
         this->N = pFluids.size();
         T_c.resize(N, std::vector<CoolPropDbl>(N, 0));
         v_c.resize(N, std::vector<CoolPropDbl>(N, 0));
@@ -184,7 +181,7 @@ class GERG2008ReducingFunction : public ReducingFunction
     };
 
     /// Default destructor
-    ~GERG2008ReducingFunction() {};
+    ~GERG2008ReducingFunction() = default;
 
     /// Set all beta and gamma values in one shot
     void set_binary_interaction_double(const std::size_t i, const std::size_t j, double betaT, double gammaT, double betaV, double gammaV) {

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -208,10 +208,7 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend& HEOS, C
                public:
                 CoolPropFluid* component;
                 double h;
-                Residual(CoolPropFluid& component, double h) {
-                    this->component = &component;
-                    this->h = h;
-                }
+                Residual(CoolPropFluid& component, double h) : component(&component), h(h) {}
                 double call(double T) override {
                     CoolPropDbl h_liq = component->ancillaries.hL.evaluate(T) + component->EOS().hs_anchor.hmolar;
                     return h_liq + component->ancillaries.hLV.evaluate(T) - h;
@@ -272,10 +269,7 @@ void SaturationSolvers::saturation_PHSU_pure(HelmholtzEOSMixtureBackend& HEOS, C
                public:
                 CoolPropFluid* component;
                 double s;
-                Residual(CoolPropFluid& component, double s) {
-                    this->component = &component;
-                    this->s = s;
-                }
+                Residual(CoolPropFluid& component, double s) : component(&component), s(s) {}
                 double call(double T) override {
                     CoolPropDbl s_liq = component->ancillaries.sL.evaluate(T) + component->EOS().hs_anchor.smolar;
                     CoolPropDbl resid = s_liq + component->ancillaries.sLV.evaluate(T) - s;

--- a/src/Backends/Helmholtz/VLERoutines.h
+++ b/src/Backends/Helmholtz/VLERoutines.h
@@ -32,10 +32,16 @@ struct saturation_D_pure_options
     CoolPropDbl omega, rhoL, rhoV, pL, pV;
     int imposed_rho;
     int max_iterations;
-    saturation_D_pure_options() : use_guesses(false), rhoL(_HUGE), rhoV(_HUGE), pL(_HUGE), pV(_HUGE), imposed_rho(0), max_iterations(200) {
-        use_logdelta = true;
-        omega = 1.0;
-    }  // Defaults
+    saturation_D_pure_options()
+      : use_guesses(false),
+        use_logdelta(true),
+        omega(1.0),
+        rhoL(_HUGE),
+        rhoV(_HUGE),
+        pL(_HUGE),
+        pV(_HUGE),
+        imposed_rho(0),
+        max_iterations(200) {}  // Defaults
 };
 
 enum sstype_enum
@@ -90,11 +96,17 @@ struct saturation_PHSU_pure_options
       use_logdelta;    ///< True to use partials with respect to log(delta) rather than delta
     specified_variable_options specified_variable;
     CoolPropDbl omega, rhoL, rhoV, pL, pV, T, p;
-    saturation_PHSU_pure_options() : use_logdelta(true), rhoL(_HUGE), rhoV(_HUGE), pL(_HUGE), pV(_HUGE), T(_HUGE), p(_HUGE) {
-        specified_variable = IMPOSED_INVALID_INPUT;
-        use_guesses = true;
-        omega = 1.0;
-    }
+    saturation_PHSU_pure_options()
+      : use_guesses(true),
+        use_logdelta(true),
+        specified_variable(IMPOSED_INVALID_INPUT),
+        omega(1.0),
+        rhoL(_HUGE),
+        rhoV(_HUGE),
+        pL(_HUGE),
+        pV(_HUGE),
+        T(_HUGE),
+        p(_HUGE) {}
 };
 
 #if !defined(NO_FMTLIB) && FMT_VERSION >= 90000
@@ -428,7 +440,9 @@ struct newton_raphson_saturation_options
     imposed_variable_options imposed_variable;
     std::vector<CoolPropDbl> x, y;
     newton_raphson_saturation_options()
-      : bubble_point(false),
+      : Nstep_max(30),
+        bubble_point(false),
+        Nsteps(0),
         omega(_HUGE),
         rhomolar_liq(_HUGE),
         rhomolar_vap(_HUGE),
@@ -440,10 +454,7 @@ struct newton_raphson_saturation_options
         hmolar_vap(_HUGE),
         smolar_liq(_HUGE),
         smolar_vap(_HUGE),
-        imposed_variable(NO_VARIABLE_IMPOSED) {
-        Nstep_max = 30;
-        Nsteps = 0;
-    }  // Defaults
+        imposed_variable(NO_VARIABLE_IMPOSED) {}  // Defaults
 };
 
 /** \brief A class to do newton raphson solver mixture bubble point and dew point calculations
@@ -489,7 +500,7 @@ class newton_raphson_saturation
     Eigen::VectorXd r, err_rel;
     std::vector<SuccessiveSubstitutionStep> step_logger;
 
-    newton_raphson_saturation() {};
+    newton_raphson_saturation() = default;
 
     void resize(std::size_t N);
 
@@ -538,9 +549,10 @@ struct PTflash_twophase_options
     std::vector<CoolPropDbl> x,  ///< Liquid mole fractions
       y,                         ///< Vapor mole fractions
       z;                         ///< Bulk mole fractions
-    PTflash_twophase_options() : omega(_HUGE), rhomolar_liq(_HUGE), rhomolar_vap(_HUGE), pL(_HUGE), pV(_HUGE), p(_HUGE), T(_HUGE) {
-        Nstep_max = 30;
-        Nsteps = 0;  // Defaults
+    PTflash_twophase_options()
+      : Nstep_max(30), Nsteps(0), omega(_HUGE), rhomolar_liq(_HUGE), rhomolar_vap(_HUGE), pL(_HUGE), pV(_HUGE), p(_HUGE), T(_HUGE) {
+
+        // Defaults
     }
 };
 

--- a/src/Backends/Incompressible/IncompressibleBackend.cpp
+++ b/src/Backends/Incompressible/IncompressibleBackend.cpp
@@ -27,8 +27,8 @@ IncompressibleBackend::IncompressibleBackend() {
     //this->fluid = NULL;
 }
 
-IncompressibleBackend::IncompressibleBackend(IncompressibleFluid* fluid) {
-    this->fluid = fluid;
+IncompressibleBackend::IncompressibleBackend(IncompressibleFluid* fluid) : fluid(fluid) {
+
     this->set_reference_state();
     if (this->fluid->is_pure()) {
         this->set_fractions(std::vector<CoolPropDbl>(1, 1.0));
@@ -42,8 +42,8 @@ IncompressibleBackend::IncompressibleBackend(IncompressibleFluid* fluid) {
     //}
 }
 
-IncompressibleBackend::IncompressibleBackend(const std::string& fluid_name) {
-    this->fluid = &get_incompressible_fluid(fluid_name);
+IncompressibleBackend::IncompressibleBackend(const std::string& fluid_name) : fluid(&get_incompressible_fluid(fluid_name)) {
+
     this->set_reference_state();
     if (this->fluid->is_pure()) {
         this->set_fractions(std::vector<CoolPropDbl>(1, 1.0));
@@ -229,8 +229,8 @@ void IncompressibleBackend::set_mole_fractions(const std::vector<CoolPropDbl>& m
     } else {
         std::vector<CoolPropDbl> tmp_fractions;
         tmp_fractions.reserve(mole_fractions.size());
-        for (std::size_t i = 0; i < mole_fractions.size(); i++) {
-            tmp_fractions.push_back((CoolPropDbl)fluid->inputFromMole(0.0, mole_fractions[i]));
+        for (double mole_fraction : mole_fractions) {
+            tmp_fractions.push_back((CoolPropDbl)fluid->inputFromMole(0.0, mole_fraction));
         }
         this->set_fractions(tmp_fractions);
     }
@@ -256,8 +256,8 @@ void IncompressibleBackend::set_mass_fractions(const std::vector<CoolPropDbl>& m
     } else {
         std::vector<CoolPropDbl> tmp_fractions;
         tmp_fractions.reserve(mass_fractions.size());
-        for (std::size_t i = 0; i < mass_fractions.size(); i++) {
-            tmp_fractions.push_back((CoolPropDbl)fluid->inputFromMass(0.0, mass_fractions[i]));
+        for (double mass_fraction : mass_fractions) {
+            tmp_fractions.push_back((CoolPropDbl)fluid->inputFromMass(0.0, mass_fraction));
         }
         this->set_fractions(tmp_fractions);
     }
@@ -284,8 +284,8 @@ void IncompressibleBackend::set_volu_fractions(const std::vector<CoolPropDbl>& v
     } else {
         std::vector<CoolPropDbl> tmp_fractions;
         tmp_fractions.reserve(volu_fractions.size());
-        for (std::size_t i = 0; i < volu_fractions.size(); i++) {
-            tmp_fractions.push_back((CoolPropDbl)fluid->inputFromVolume(0.0, volu_fractions[i]));
+        for (double volu_fraction : volu_fractions) {
+            tmp_fractions.push_back((CoolPropDbl)fluid->inputFromVolume(0.0, volu_fraction));
         }
         this->set_fractions(tmp_fractions);
     }

--- a/src/Backends/Incompressible/IncompressibleBackend.cpp
+++ b/src/Backends/Incompressible/IncompressibleBackend.cpp
@@ -229,7 +229,7 @@ void IncompressibleBackend::set_mole_fractions(const std::vector<CoolPropDbl>& m
     } else {
         std::vector<CoolPropDbl> tmp_fractions;
         tmp_fractions.reserve(mole_fractions.size());
-        for (double mole_fraction : mole_fractions) {
+        for (auto mole_fraction : mole_fractions) {
             tmp_fractions.push_back((CoolPropDbl)fluid->inputFromMole(0.0, mole_fraction));
         }
         this->set_fractions(tmp_fractions);
@@ -256,7 +256,7 @@ void IncompressibleBackend::set_mass_fractions(const std::vector<CoolPropDbl>& m
     } else {
         std::vector<CoolPropDbl> tmp_fractions;
         tmp_fractions.reserve(mass_fractions.size());
-        for (double mass_fraction : mass_fractions) {
+        for (auto mass_fraction : mass_fractions) {
             tmp_fractions.push_back((CoolPropDbl)fluid->inputFromMass(0.0, mass_fraction));
         }
         this->set_fractions(tmp_fractions);
@@ -284,7 +284,7 @@ void IncompressibleBackend::set_volu_fractions(const std::vector<CoolPropDbl>& v
     } else {
         std::vector<CoolPropDbl> tmp_fractions;
         tmp_fractions.reserve(volu_fractions.size());
-        for (double volu_fraction : volu_fractions) {
+        for (auto volu_fraction : volu_fractions) {
             tmp_fractions.push_back((CoolPropDbl)fluid->inputFromVolume(0.0, volu_fraction));
         }
         this->set_fractions(tmp_fractions);

--- a/src/Backends/Incompressible/IncompressibleBackend.h
+++ b/src/Backends/Incompressible/IncompressibleBackend.h
@@ -37,7 +37,7 @@ class IncompressibleBackend : public AbstractState
 
    public:
     IncompressibleBackend();
-    virtual ~IncompressibleBackend() {};
+    virtual ~IncompressibleBackend() = default;
     std::string backend_name() override {
         return get_backend_string(INCOMP_BACKEND);
     }

--- a/src/Backends/Incompressible/IncompressibleFluid.cpp
+++ b/src/Backends/Incompressible/IncompressibleFluid.cpp
@@ -35,7 +35,7 @@ bool IncompressibleFluid::is_pure() {
 }
 
 /// Base exponential function
-double IncompressibleFluid::baseExponential(IncompressibleData data, double y, double ybase) {
+double IncompressibleFluid::baseExponential(const IncompressibleData& data, double y, double ybase) {
     Eigen::VectorXd coeffs = makeVector(data.coeffs);
     size_t r = coeffs.rows(), c = coeffs.cols();
     if (strict && (r != 3 || c != 1)) {
@@ -61,7 +61,7 @@ double IncompressibleFluid::baseExponential(IncompressibleData data, double y, d
 }
 
 /// Base exponential function with logarithmic term
-double IncompressibleFluid::baseLogexponential(IncompressibleData data, double y, double ybase) {
+double IncompressibleFluid::baseLogexponential(const IncompressibleData& data, double y, double ybase) {
     Eigen::VectorXd coeffs = makeVector(data.coeffs);
     size_t r = coeffs.rows(), c = coeffs.cols();
     if (strict && (r != 3 || c != 1)) {

--- a/src/Backends/Incompressible/IncompressibleLibrary.cpp
+++ b/src/Backends/Incompressible/IncompressibleLibrary.cpp
@@ -326,14 +326,15 @@ namespace CoolProp {
 //}
 
 /// Default constructor
-JSONIncompressibleLibrary::JSONIncompressibleLibrary() {
-    _is_empty = true;
-    //    fluid_map.clear();
-    //    name_vector.clear();
-    //    string_to_index_map.clear();
-    //
-    //    //shared_ptr<double> array (new double [256], ArrayDeleter<double> ());
-};
+JSONIncompressibleLibrary::JSONIncompressibleLibrary()
+  : _is_empty(true) {
+
+        //    fluid_map.clear();
+        //    name_vector.clear();
+        //    string_to_index_map.clear();
+        //
+        //    //shared_ptr<double> array (new double [256], ArrayDeleter<double> ());
+    };
 
 /// Default destructor
 JSONIncompressibleLibrary::~JSONIncompressibleLibrary() {
@@ -514,7 +515,7 @@ void JSONIncompressibleLibrary::add_obj(const IncompressibleFluid& fluid_obj) {
 // Get an IncompressibleFluid instance stored in this library
 IncompressibleFluid& JSONIncompressibleLibrary::get(const std::string& key) {
     // Try to find it
-    std::map<std::string, std::size_t>::const_iterator it = string_to_index_map.find(key);
+    auto it = string_to_index_map.find(key);
     // If it is found
     if (it != string_to_index_map.end()) {
         return get(it->second);
@@ -529,7 +530,7 @@ IncompressibleFluid& JSONIncompressibleLibrary::get(const std::string& key) {
  */
 IncompressibleFluid& JSONIncompressibleLibrary::get(std::size_t key) {
     // Try to find it
-    std::map<std::size_t, IncompressibleFluid>::iterator it = fluid_map.find(key);
+    auto it = fluid_map.find(key);
     // If it is found
     if (it != fluid_map.end()) {
         return it->second;

--- a/src/Backends/PCSAFT/PCSAFTBackend.cpp
+++ b/src/Backends/PCSAFT/PCSAFTBackend.cpp
@@ -212,7 +212,7 @@ void PCSAFTBackend::set_mass_fractions(const std::vector<CoolPropDbl>& mass_frac
         sum_moles += tmp;
     }
     std::vector<CoolPropDbl> mole_fractions;
-    for (double& mole : moles) {
+    for (const auto& mole : moles) {
         mole_fractions.push_back(mole / sum_moles);
     }
     this->set_mole_fractions(mole_fractions);

--- a/src/Backends/PCSAFT/PCSAFTBackend.cpp
+++ b/src/Backends/PCSAFT/PCSAFTBackend.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <utility>
 #include <vector>
 #include <string>
 #include <Eigen/Dense>
@@ -53,14 +54,11 @@ revised,” Chem. Eng. Res. Des., vol. 92, no. 12, pp. 2884–2897, Dec. 2014.
 
 namespace CoolProp {
 
-PCSAFTBackend::PCSAFTBackend(const std::vector<std::string>& component_names, bool generate_SatL_and_SatV) {
-    N = component_names.size();
+PCSAFTBackend::PCSAFTBackend(const std::vector<std::string>& component_names, bool generate_SatL_and_SatV)
+  : N(component_names.size()), ion_term(false), polar_term(false), assoc_term(false), water_present(false), water_idx(0) {
+
     components.resize(N);
-    ion_term = false;
-    polar_term = false;
-    assoc_term = false;
-    water_present = false;
-    water_idx = 0;
+
     for (unsigned int i = 0; i < N; ++i) {
         components[i] = PCSAFTLibrary::get_library().get(component_names[i]);
         // Determining which PC-SAFT terms should be used
@@ -124,15 +122,11 @@ PCSAFTBackend::PCSAFTBackend(const std::vector<std::string>& component_names, bo
     _phase = iphase_unknown;
 }
 
-PCSAFTBackend::PCSAFTBackend(const std::vector<PCSAFTFluid>& components_in, bool generate_SatL_and_SatV) {
-    components = components_in;
-    N = components.size();
+PCSAFTBackend::PCSAFTBackend(const std::vector<PCSAFTFluid>& components_in, bool generate_SatL_and_SatV)
+  : components(components_in), N(components.size()), ion_term(false), polar_term(false), assoc_term(false), water_present(false), water_idx(0) {
+
     // Determining which PC-SAFT terms should be used
-    ion_term = false;
-    polar_term = false;
-    assoc_term = false;
-    water_present = false;
-    water_idx = 0;
+
     for (unsigned int i = 0; i < N; ++i) {
         if (components[i].getZ() != 0) {
             ion_term = true;
@@ -218,15 +212,15 @@ void PCSAFTBackend::set_mass_fractions(const std::vector<CoolPropDbl>& mass_frac
         sum_moles += tmp;
     }
     std::vector<CoolPropDbl> mole_fractions;
-    for (std::vector<CoolPropDbl>::iterator it = moles.begin(); it != moles.end(); ++it) {
-        mole_fractions.push_back(*it / sum_moles);
+    for (double& mole : moles) {
+        mole_fractions.push_back(mole / sum_moles);
     }
     this->set_mole_fractions(mole_fractions);
 };
 
 PCSAFTBackend* PCSAFTBackend::get_copy(bool generate_SatL_and_SatV) {
     // Set up the class with these components
-    PCSAFTBackend* ptr = new PCSAFTBackend(components, generate_SatL_and_SatV);
+    auto* ptr = new PCSAFTBackend(components, generate_SatL_and_SatV);
     return ptr;
 };
 
@@ -431,7 +425,7 @@ CoolPropDbl PCSAFTBackend::calc_alphar() {
     if (assoc_term) {
         int num_sites = 0;
         vector<int> iA;  //indices of associating compounds
-        for (std::vector<int>::iterator it = assoc_num.begin(); it != assoc_num.end(); ++it) {
+        for (auto it = assoc_num.begin(); it != assoc_num.end(); ++it) {
             num_sites += *it;
             for (int i = 0; i < *it; i++) {
                 iA.push_back(static_cast<int>(it - assoc_num.begin()));
@@ -748,7 +742,7 @@ CoolPropDbl PCSAFTBackend::calc_dadt() {
     if (assoc_term) {
         int num_sites = 0;
         vector<int> iA;  //indices of associating compounds
-        for (std::vector<int>::iterator it = assoc_num.begin(); it != assoc_num.end(); ++it) {
+        for (auto it = assoc_num.begin(); it != assoc_num.end(); ++it) {
             num_sites += *it;
             for (int i = 0; i < *it; i++) {
                 iA.push_back(static_cast<int>(it - assoc_num.begin()));
@@ -1215,7 +1209,7 @@ vector<CoolPropDbl> PCSAFTBackend::calc_fugacity_coefficients() {
     if (assoc_term) {
         int num_sites = 0;
         vector<int> iA;  //indices of associating compounds
-        for (std::vector<int>::iterator it = assoc_num.begin(); it != assoc_num.end(); ++it) {
+        for (auto it = assoc_num.begin(); it != assoc_num.end(); ++it) {
             num_sites += *it;
             for (int i = 0; i < *it; i++) {
                 iA.push_back(static_cast<int>(it - assoc_num.begin()));
@@ -1581,7 +1575,7 @@ CoolPropDbl PCSAFTBackend::calc_compressibility_factor() {
     if (assoc_term) {
         int num_sites = 0;
         vector<int> iA;  //indices of associating compounds
-        for (std::vector<int>::iterator it = assoc_num.begin(); it != assoc_num.end(); ++it) {
+        for (auto it = assoc_num.begin(); it != assoc_num.end(); ++it) {
             num_sites += *it;
             for (int i = 0; i < *it; i++) {
                 iA.push_back(static_cast<int>(it - assoc_num.begin()));
@@ -2101,7 +2095,7 @@ double PCSAFTBackend::outerPQ(double t_guess, PCSAFTBackend& PCSAFT) {
         CoolPropDbl kb0;
         vector<CoolPropDbl> u;
 
-        SolverInnerResid(PCSAFTBackend& PCSAFT, CoolPropDbl kb0, vector<CoolPropDbl> u) : PCSAFT(PCSAFT), kb0(kb0), u(u) {}
+        SolverInnerResid(PCSAFTBackend& PCSAFT, CoolPropDbl kb0, vector<CoolPropDbl> u) : PCSAFT(PCSAFT), kb0(kb0), u(std::move(u)) {}
         CoolPropDbl call(CoolPropDbl R) override {
             auto ncomp = PCSAFT.components.size();
             double error = 0;
@@ -2362,7 +2356,7 @@ double PCSAFTBackend::outerTQ(double p_guess, PCSAFTBackend& PCSAFT) {
         CoolPropDbl kb0;
         vector<CoolPropDbl> u;
 
-        SolverInnerResid(PCSAFTBackend& PCSAFT, CoolPropDbl kb0, vector<CoolPropDbl> u) : PCSAFT(PCSAFT), kb0(kb0), u(u) {}
+        SolverInnerResid(PCSAFTBackend& PCSAFT, CoolPropDbl kb0, vector<CoolPropDbl> u) : PCSAFT(PCSAFT), kb0(kb0), u(std::move(u)) {}
         CoolPropDbl call(CoolPropDbl R) override {
             auto ncomp = PCSAFT.components.size();
             double error = 0;
@@ -3051,13 +3045,13 @@ void PCSAFTBackend::set_assoc_matrix() {
         assoc_num.push_back(num_sites);
     }
 
-    for (std::vector<int>::iterator i1 = charge.begin(); i1 != charge.end(); i1++) {
-        for (std::vector<int>::iterator i2 = charge.begin(); i2 != charge.end(); i2++) {
-            if (*i1 == 0 || *i2 == 0) {
+    for (auto i1 = charge.begin(); i1 != charge.end(); i1++) {
+        for (int& i2 : charge) {
+            if (*i1 == 0 || i2 == 0) {
                 assoc_matrix.push_back(1);
-            } else if (*i1 == 1 && *i2 == -1) {
+            } else if (*i1 == 1 && i2 == -1) {
                 assoc_matrix.push_back(1);
-            } else if (*i1 == -1 && *i2 == 1) {
+            } else if (*i1 == -1 && i2 == 1) {
                 assoc_matrix.push_back(1);
             } else {
                 assoc_matrix.push_back(0);

--- a/src/Backends/PCSAFT/PCSAFTLibrary.cpp
+++ b/src/Backends/PCSAFT/PCSAFTLibrary.cpp
@@ -74,7 +74,7 @@ PCSAFTLibraryClass::PCSAFTLibraryClass() : empty(true) {
 // Get a PCSAFTFluid instance stored in this library
 PCSAFTFluid& PCSAFTLibraryClass::get(const std::string& key) {
     // Try to find it
-    std::map<std::string, std::size_t>::iterator it = string_to_index_map.find(key);
+    auto it = string_to_index_map.find(key);
     // If it is found
     if (it != string_to_index_map.end()) {
         return get(it->second);
@@ -89,7 +89,7 @@ PCSAFTFluid& PCSAFTLibraryClass::get(const std::string& key) {
  */
 PCSAFTFluid& PCSAFTLibraryClass::get(std::size_t key) {
     // Try to find it
-    std::map<std::size_t, PCSAFTFluid>::iterator it = fluid_map.find(key);
+    auto it = fluid_map.find(key);
     // If it is found
     if (it != fluid_map.end()) {
         return it->second;
@@ -366,7 +366,7 @@ void PCSAFTLibraryClass::load_from_JSON(rapidjson::Document& doc) {
             dict.add_number("kijT", cpjson::get_double(*itr, "kijT"));
         }
 
-        std::map<std::vector<std::string>, std::vector<Dictionary>>::iterator it = m_binary_pair_map.find(CAS);
+        auto it = m_binary_pair_map.find(CAS);
         if (it == m_binary_pair_map.end()) {
             // Add to binary pair map by creating one-element vector
             m_binary_pair_map.insert(std::pair<std::vector<std::string>, std::vector<Dictionary>>(CAS, std::vector<Dictionary>(1, dict)));

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -103,7 +103,7 @@ std::string get_casesensitive_fluids(const std::string& root) {
         if (path_exists(ucase_joined)) {
             return ucase_joined;
         } else {
-            throw CoolProp::ValueError(format("fluid directories \"FLUIDS\" or \"fluids\" could not be found in the directory [%s]", root));
+            throw CoolProp::ValueError(format(R"(fluid directories "FLUIDS" or "fluids" could not be found in the directory [%s])", root));
         }
     }
 }
@@ -305,8 +305,8 @@ std::string REFPROPMixtureBackend::version() {
         return "n/a";
     };
     // Pad the version string with NULL characters
-    for (int i = 0; i < 255; ++i) {
-        herr[i] = '\0';
+    for (char& i : herr) {
+        i = '\0';
     }
     SETUPdll(&N, fluids, hmx, default_reference_state, &ierr, herr,
              10000,              // Length of component_string (see PASS_FTN.for from REFPROP)
@@ -2769,16 +2769,16 @@ TEST_CASE("Check REFPROP and CoolProp values agree", "[REFPROP]") {
     SECTION("Saturation densities agree within 0.5% at T/Tc = 0.9") {
         std::vector<std::string> ss = strsplit(CoolProp::get_global_param_string("FluidsList"), ',');
 
-        for (std::vector<std::string>::iterator it = ss.begin(); it != ss.end(); ++it) {
-            std::string Name = (*it);
-            std::string RPName = CoolProp::get_fluid_param_string((*it), "REFPROP_name");
+        for (auto& s : ss) {
+            const std::string& Name = s;
+            std::string RPName = CoolProp::get_fluid_param_string(s, "REFPROP_name");
 
             // Skip fluids not in REFPROP
             if (RPName.find("N/A") == 0) {
                 continue;
             }
 
-            shared_ptr<CoolProp::AbstractState> S1(CoolProp::AbstractState::factory("HEOS", (*it)));
+            shared_ptr<CoolProp::AbstractState> S1(CoolProp::AbstractState::factory("HEOS", s));
             double Tr = S1->T_critical();
             CHECK_NOTHROW(S1->update(CoolProp::QT_INPUTS, 0, Tr * 0.9));
             double rho_CP = S1->rhomolar();
@@ -2799,16 +2799,16 @@ TEST_CASE("Check REFPROP and CoolProp values agree", "[REFPROP]") {
     SECTION("Saturation specific heats agree within 0.5% at T/Tc = 0.9") {
         std::vector<std::string> ss = strsplit(CoolProp::get_global_param_string("FluidsList"), ',');
 
-        for (std::vector<std::string>::iterator it = ss.begin(); it != ss.end(); ++it) {
-            std::string Name = (*it);
-            std::string RPName = CoolProp::get_fluid_param_string((*it), "REFPROP_name");
+        for (auto& s : ss) {
+            const std::string& Name = s;
+            std::string RPName = CoolProp::get_fluid_param_string(s, "REFPROP_name");
 
             // Skip fluids not in REFPROP
             if (RPName.find("N/A") == 0) {
                 continue;
             }
 
-            shared_ptr<CoolProp::AbstractState> S1(CoolProp::AbstractState::factory("HEOS", (*it)));
+            shared_ptr<CoolProp::AbstractState> S1(CoolProp::AbstractState::factory("HEOS", s));
             double Tr = S1->T_critical();
             S1->update(CoolProp::QT_INPUTS, 0, Tr * 0.9);
             double cp_CP = S1->cpmolar();
@@ -2855,16 +2855,16 @@ TEST_CASE("Check REFPROP and CoolProp values agree", "[REFPROP]") {
     SECTION("Enthalpy and entropy reference state") {
         std::vector<std::string> ss = strsplit(CoolProp::get_global_param_string("FluidsList"), ',');
 
-        for (std::vector<std::string>::iterator it = ss.begin(); it != ss.end(); ++it) {
-            std::string Name = (*it);
-            std::string RPName = CoolProp::get_fluid_param_string((*it), "REFPROP_name");
+        for (auto& it : ss) {
+            const std::string& Name = it;
+            std::string RPName = CoolProp::get_fluid_param_string(it, "REFPROP_name");
 
             // Skip fluids not in REFPROP
             if (RPName.find("N/A") == 0) {
                 continue;
             }
 
-            shared_ptr<CoolProp::AbstractState> S1(CoolProp::AbstractState::factory("HEOS", (*it)));
+            shared_ptr<CoolProp::AbstractState> S1(CoolProp::AbstractState::factory("HEOS", it));
             double Tr = S1->T_critical();
             double RCP = S1->gas_constant();
             CHECK_NOTHROW(S1->update(CoolProp::QT_INPUTS, 0, 0.9 * Tr));
@@ -2910,12 +2910,12 @@ TEST_CASE("Check trivial inputs for REFPROP work", "[REFPROP_trivial]") {
 
     const int num_inputs = 6;
     std::string inputs[num_inputs] = {"T_triple", "T_critical", "p_critical", "molar_mass", "rhomolar_critical", "rhomass_critical"};
-    for (int i = 0; i < num_inputs; ++i) {
+    for (const auto& input : inputs) {
         std::ostringstream ss;
-        ss << "Check " << inputs[i];
+        ss << "Check " << input;
         SECTION(ss.str(), "") {
-            double cp_val = CoolProp::PropsSI(inputs[i], "P", 0, "T", 0, "HEOS::Water");
-            double rp_val = CoolProp::PropsSI(inputs[i], "P", 0, "T", 0, "REFPROP::Water");
+            double cp_val = CoolProp::PropsSI(input, "P", 0, "T", 0, "HEOS::Water");
+            double rp_val = CoolProp::PropsSI(input, "P", 0, "T", 0, "REFPROP::Water");
 
             std::string errstr = CoolProp::get_global_param_string("errstring");
             CAPTURE(errstr);
@@ -2930,12 +2930,12 @@ TEST_CASE("Check PHI0 derivatives", "[REFPROP_PHI0]") {
 
     const int num_inputs = 3;
     std::string inputs[num_inputs] = {"DALPHA0_DDELTA_CONSTTAU", "D2ALPHA0_DDELTA2_CONSTTAU", "D3ALPHA0_DDELTA3_CONSTTAU"};
-    for (int i = 0; i < num_inputs; ++i) {
+    for (const auto& input : inputs) {
         std::ostringstream ss;
-        ss << "Check " << inputs[i];
+        ss << "Check " << input;
         SECTION(ss.str(), "") {
-            double cp_val = CoolProp::PropsSI(inputs[i], "P", 101325, "T", 298, "HEOS::Water");
-            double rp_val = CoolProp::PropsSI(inputs[i], "P", 101325, "T", 298, "REFPROP::Water");
+            double cp_val = CoolProp::PropsSI(input, "P", 101325, "T", 298, "HEOS::Water");
+            double rp_val = CoolProp::PropsSI(input, "P", 101325, "T", 298, "REFPROP::Water");
 
             std::string errstr = CoolProp::get_global_param_string("errstring");
             CAPTURE(errstr);

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.h
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.h
@@ -230,10 +230,10 @@ class REFPROPMixtureBackend : public AbstractState
     };
 
     std::vector<CoolPropDbl> calc_mole_fractions_liquid() override {
-        return std::vector<CoolPropDbl>(mole_fractions_liq.begin(), mole_fractions_liq.begin() + this->Ncomp);
+        return {mole_fractions_liq.begin(), mole_fractions_liq.begin() + this->Ncomp};
     }
     std::vector<CoolPropDbl> calc_mole_fractions_vapor() override {
-        return std::vector<CoolPropDbl>(mole_fractions_vap.begin(), mole_fractions_vap.begin() + this->Ncomp);
+        return {mole_fractions_vap.begin(), mole_fractions_vap.begin() + this->Ncomp};
     }
 
     /// Check if the mole fractions have been set, etc.

--- a/src/Backends/Tabular/BicubicBackend.h
+++ b/src/Backends/Tabular/BicubicBackend.h
@@ -1,6 +1,8 @@
 #ifndef BICUBICBACKEND_H
 #define BICUBICBACKEND_H
 
+#include <utility>
+
 #include "TabularBackends.h"
 #include "Exceptions.h"
 #include "DataStructures.h"
@@ -57,12 +59,12 @@ A^{-1} =  \left[ \begin{array}{*{16}c} 1 & 0 & 0 & 0 & 0 & 0 & 0 & 0 & 0 & 0 & 0
  \f]
  \
 */
-typedef std::vector<std::vector<double>> mat;
+using mat = std::vector<std::vector<double>>;
 class BicubicBackend : public TabularBackend
 {
    public:
     /// Instantiator; base class loads or makes tables
-    BicubicBackend(shared_ptr<CoolProp::AbstractState> AS) : TabularBackend(AS) {
+    BicubicBackend(shared_ptr<CoolProp::AbstractState> AS) : TabularBackend(std::move(AS)) {
         imposed_phase_index = iphase_not_imposed;
         // If a pure fluid or a predefined mixture, don't need to set fractions, go ahead and build
         if (!this->AS->get_mole_fractions().empty()) {

--- a/src/Backends/Tabular/TTSEBackend.h
+++ b/src/Backends/Tabular/TTSEBackend.h
@@ -1,6 +1,8 @@
 #ifndef TTSEBACKEND_H
 #define TTSEBACKEND_H
 
+#include <utility>
+
 #include "TabularBackends.h"
 #include "DataStructures.h"
 
@@ -13,7 +15,7 @@ class TTSEBackend : public TabularBackend
         return get_backend_string(TTSE_BACKEND);
     }
     /// Instantiator; base class loads or makes tables
-    TTSEBackend(shared_ptr<CoolProp::AbstractState> AS) : TabularBackend(AS) {
+    TTSEBackend(shared_ptr<CoolProp::AbstractState> AS) : TabularBackend(std::move(AS)) {
         imposed_phase_index = iphase_not_imposed;
         // If a pure fluid or a predefined mixture, don't need to set fractions, go ahead and build
         if (!this->AS->get_mole_fractions().empty()) {

--- a/src/Backends/Tabular/TabularBackends.cpp
+++ b/src/Backends/Tabular/TabularBackends.cpp
@@ -50,8 +50,8 @@ void load_table(T& table, const std::string& path_to_tables, const std::string& 
         throw UnableToLoadError(err);
     }
     std::vector<unsigned char> newBuffer(raw.size() * 5);
-    uLong newBufferSize = static_cast<uLong>(newBuffer.size());
-    mz_ulong rawBufferSize = static_cast<mz_ulong>(raw.size());
+    auto newBufferSize = static_cast<uLong>(newBuffer.size());
+    auto rawBufferSize = static_cast<mz_ulong>(raw.size());
     int code = 0;
     do {
         code = uncompress((unsigned char*)(&(newBuffer[0])), &newBufferSize, (unsigned char*)(&(raw[0])), rawBufferSize);
@@ -95,7 +95,7 @@ void write_table(const T& table, const std::string& path_to_tables, const std::s
     std::string tabPath = std::string(path_to_tables + "/" + name + ".bin");
     std::string zPath = tabPath + ".z";
     std::vector<char> buffer(sbuf.size());
-    uLong outSize = static_cast<uLong>(buffer.size());
+    auto outSize = static_cast<uLong>(buffer.size());
     compress((unsigned char*)(&(buffer[0])), &outSize, (unsigned char*)(sbuf.data()), static_cast<mz_ulong>(sbuf.size()));
     std::ofstream ofs2(zPath.c_str(), std::ofstream::binary);
     ofs2.write(&buffer[0], outSize);
@@ -1532,7 +1532,7 @@ std::pair<CoolProp::TabularDataSet*, bool> CoolProp::TabularDataLibrary::get_set
     const int cfg_Nx = get_config_int(TABULAR_NX);
     const int cfg_Ny = get_config_int(TABULAR_NY);
     // Try to find tabular set if it is already loaded
-    std::map<std::string, TabularDataSet>::iterator it = data.find(path);
+    auto it = data.find(path);
     if (it != data.end()) {
         // Verify the cached dataset's grid matches the current TABULAR_NX/TABULAR_NY
         // config; if not, evict so we rebuild at the requested resolution rather than
@@ -1582,8 +1582,7 @@ void CoolProp::TabularDataSet::build_coeffs(SinglePhaseGriddedTableData& table, 
     coeffs.resize(table.Nx - 1, std::vector<CellCoeffs>(table.Ny - 1));
 
     int valid_cell_count = 0;
-    for (std::size_t k = 0; k < param_count; ++k) {
-        parameters param = param_list[k];
+    for (auto param : param_list) {
         if (param == table.xkey || param == table.ykey) {
             continue;
         }  // Skip tables that match either of the input variables
@@ -1721,7 +1720,7 @@ static shared_ptr<CoolProp::AbstractState> ASHEOS, ASTTSE, ASBICUBIC;
 class TabularFixture
 {
    public:
-    TabularFixture() {}
+    TabularFixture() = default;
     void setup() {
         if (ASHEOS.get() == nullptr) {
             ASHEOS.reset(CoolProp::AbstractState::factory("HEOS", "Water"));

--- a/src/Backends/Tabular/TabularBackends.h
+++ b/src/Backends/Tabular/TabularBackends.h
@@ -8,6 +8,7 @@ using std::shared_ptr;
 #include "Exceptions.h"
 #include "CoolProp.h"
 #include <optional>
+#include <utility>
 #include "Configuration.h"
 #include "Backends/Helmholtz/PhaseEnvelopeRoutines.h"
 
@@ -127,14 +128,14 @@ class PackablePhaseEnvelopeData : public PhaseEnvelopeData
 #undef X
     };
     std::map<std::string, std::vector<double>>::iterator get_vector_iterator(const std::string& name) {
-        std::map<std::string, std::vector<double>>::iterator it = vectors.find(name);
+        auto it = vectors.find(name);
         if (it == vectors.end()) {
             throw UnableToLoadError(format("could not find vector %s", name.c_str()));
         }
         return it;
     }
     std::map<std::string, std::vector<std::vector<double>>>::iterator get_matrix_iterator(const std::string& name) {
-        std::map<std::string, std::vector<std::vector<double>>>::iterator it = matrices.find(name);
+        auto it = matrices.find(name);
         if (it == matrices.end()) {
             throw UnableToLoadError(format("could not find matrix %s", name.c_str()));
         }
@@ -227,10 +228,7 @@ class PureFluidSaturationTableData
     std::size_t N;
     shared_ptr<CoolProp::AbstractState> AS;
 
-    PureFluidSaturationTableData() {
-        N = 1000;
-        revision = 1;
-    }
+    PureFluidSaturationTableData() : N(1000), revision(1) {}
 
     /// Build this table
     void build(shared_ptr<CoolProp::AbstractState>& AS);
@@ -380,7 +378,7 @@ class PureFluidSaturationTableData
 #undef X
     };
     std::map<std::string, std::vector<double>>::iterator get_vector_iterator(const std::string& name) {
-        std::map<std::string, std::vector<double>>::iterator it = vectors.find(name);
+        auto it = vectors.find(name);
         if (it == vectors.end()) {
             throw UnableToLoadError(format("could not find vector %s", name.c_str()));
         }
@@ -600,20 +598,12 @@ class SinglePhaseGriddedTableData
 
     virtual void set_limits() = 0;
 
-    SinglePhaseGriddedTableData() {
+    SinglePhaseGriddedTableData()
+      : revision(0), xkey(INVALID_PARAMETER), ykey(INVALID_PARAMETER), logx(false), logy(false), xmin(_HUGE), xmax(_HUGE), ymin(_HUGE), ymax(_HUGE) {
         const int nx_cfg = get_config_int(TABULAR_NX);
         const int ny_cfg = get_config_int(TABULAR_NY);
         Nx = (nx_cfg > 1) ? static_cast<std::size_t>(nx_cfg) : 200;
         Ny = (ny_cfg > 1) ? static_cast<std::size_t>(ny_cfg) : 200;
-        revision = 0;
-        xkey = INVALID_PARAMETER;
-        ykey = INVALID_PARAMETER;
-        logx = false;
-        logy = false;
-        xmin = _HUGE;
-        xmax = _HUGE;
-        ymin = _HUGE;
-        ymax = _HUGE;
     }
 
 /* Use X macros to auto-generate the variables; each will look something like: std::vector< std::vector<double> > T; */
@@ -681,7 +671,7 @@ class SinglePhaseGriddedTableData
 #undef X
     };
     std::map<std::string, std::vector<std::vector<double>>>::iterator get_matrices_iterator(const std::string& name) {
-        std::map<std::string, std::vector<std::vector<double>>>::iterator it = matrices.find(name);
+        auto it = matrices.find(name);
         if (it == matrices.end()) {
             throw UnableToLoadError(format("could not find matrix %s", name.c_str()));
         }
@@ -914,14 +904,7 @@ class CellCoeffs
 
    public:
     double dx_dxhat, dy_dyhat;
-    CellCoeffs() {
-        _valid = false;
-        _has_valid_neighbor = false;
-        dx_dxhat = _HUGE;
-        dy_dyhat = _HUGE;
-        alt_i = 9999999;
-        alt_j = 9999999;
-    }
+    CellCoeffs() : _valid(false), _has_valid_neighbor(false), dx_dxhat(_HUGE), dy_dyhat(_HUGE), alt_i(9999999), alt_j(9999999) {}
     std::vector<double> T, rhomolar, hmolar, p, smolar, umolar;
     /// Return a const reference to the desired matrix
     const std::vector<double>& get(const parameters params) const {
@@ -1005,9 +988,7 @@ class TabularDataSet
     PackablePhaseEnvelopeData phase_envelope;
     std::vector<std::vector<CellCoeffs>> coeffs_ph, coeffs_pT;
 
-    TabularDataSet() {
-        tables_loaded = false;
-    }
+    TabularDataSet() : tables_loaded(false) {}
     /// Write the tables to files on the computer
     void write_tables(const std::string& path_to_tables);
     /// Load the tables from file
@@ -1024,7 +1005,7 @@ class TabularDataLibrary
     std::map<std::string, TabularDataSet> data;
 
    public:
-    TabularDataLibrary() {};
+    TabularDataLibrary() = default;
     std::string path_to_tables(shared_ptr<CoolProp::AbstractState>& AS) {
         std::vector<std::string> fluids = AS->fluid_names();
         std::vector<CoolPropDbl> fractions = AS->get_mole_fractions();
@@ -1074,22 +1055,28 @@ class TabularBackend : public AbstractState
 
    public:
     shared_ptr<CoolProp::AbstractState> AS;
-    TabularBackend(shared_ptr<CoolProp::AbstractState> AS) : tables_loaded(false), using_single_phase_table(false), is_mixture(false), AS(AS) {
-        selected_table = SELECTED_NO_TABLE;
-        // Flush the cached indices (set to large number)
-        cached_single_phase_i = std::numeric_limits<std::size_t>::max();
-        cached_single_phase_j = std::numeric_limits<std::size_t>::max();
-        cached_saturation_iL = std::numeric_limits<std::size_t>::max();
-        cached_saturation_iV = std::numeric_limits<std::size_t>::max();
-        z = nullptr;
-        dzdx = nullptr;
-        dzdy = nullptr;
-        d2zdx2 = nullptr;
-        d2zdxdy = nullptr;
-        d2zdy2 = nullptr;
-        dataset = nullptr;
-        imposed_phase_index = iphase_not_imposed;
-    };
+    TabularBackend(shared_ptr<CoolProp::AbstractState> AS)
+      : imposed_phase_index(iphase_not_imposed),
+        tables_loaded(false),
+        using_single_phase_table(false),
+        is_mixture(false),
+        selected_table(SELECTED_NO_TABLE),
+        cached_single_phase_i(std::numeric_limits<std::size_t>::max()),
+        cached_single_phase_j(std::numeric_limits<std::size_t>::max()),
+        cached_saturation_iL(std::numeric_limits<std::size_t>::max()),
+        cached_saturation_iV(std::numeric_limits<std::size_t>::max()),
+        z(nullptr),
+        dzdx(nullptr),
+        dzdy(nullptr),
+        d2zdx2(nullptr),
+        d2zdxdy(nullptr),
+        d2zdy2(nullptr),
+        AS(std::move(AS)),
+        dataset(nullptr) {
+
+            // Flush the cached indices (set to large number)
+
+        };
 
     // None of the tabular methods are available from the high-level interface
     bool available_in_high_level() override {

--- a/src/Backends/Tabular/TabularBackends.h
+++ b/src/Backends/Tabular/TabularBackends.h
@@ -1072,11 +1072,7 @@ class TabularBackend : public AbstractState
         d2zdxdy(nullptr),
         d2zdy2(nullptr),
         AS(std::move(AS)),
-        dataset(nullptr) {
-
-            // Flush the cached indices (set to large number)
-
-        };
+        dataset(nullptr) {};
 
     // None of the tabular methods are available from the high-level interface
     bool available_in_high_level() override {

--- a/src/CPfilepaths.cpp
+++ b/src/CPfilepaths.cpp
@@ -164,7 +164,7 @@ void write_bytes_atomic(const std::filesystem::path& target, const void* bytes, 
 
 // ---- make_dirs --------------------------------------------------------------
 
-void make_dirs(std::string file_path) {
+void make_dirs(const std::string& file_path) {
     std::error_code ec;
     fs::create_directories(fs::path(file_path), ec);
     // Ignore errors (same behaviour as legacy code which silently skipped failures)
@@ -204,7 +204,7 @@ void make_dirs(std::string file_path) {
 // ---- get_separator ----------------------------------------------------------
 
 std::string get_separator() {
-    return std::string(1, fs::path::preferred_separator);
+    return {1, fs::path::preferred_separator};
 }
 
 // Legacy implementation kept for reference (powerpc / pre-NDK-r23 Android):
@@ -239,7 +239,7 @@ std::string get_home_dir() {
     if (home == nullptr) {
         throw CoolProp::NotImplementedError("Could not detect home directory.");
     }
-    return std::string(home);
+    return {home};
 #elif defined(__ISWINDOWS__)
 #    if defined(_MSC_VER)
 #        pragma warning(push)

--- a/src/CPnumerics.cpp
+++ b/src/CPnumerics.cpp
@@ -5,8 +5,8 @@
 
 double root_sum_square(const std::vector<double>& x) {
     double sum = 0;
-    for (unsigned int i = 0; i < x.size(); i++) {
-        sum += pow(x[i], 2);
+    for (double i : x) {
+        sum += pow(i, 2);
     }
     return sqrt(sum);
 }

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -105,7 +105,7 @@ std::string get_config_string(configuration_keys key) {
 void get_config_as_json(rapidjson::Document& doc) {
     // Get the items
     std::unordered_map<configuration_keys, ConfigurationItem> items = _get_config()->get_items();
-    for (std::unordered_map<configuration_keys, ConfigurationItem>::const_iterator it = items.begin(); it != items.end(); ++it) {
+    for (auto it = items.begin(); it != items.end(); ++it) {
         it->second.add_to_json(doc, doc);
     }
 }

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -191,7 +191,7 @@ std::string extract_fractions(const std::string& fluid_string, std::vector<doubl
         // Check it worked
         if (fluid_parts.size() != 2) {
             throw ValueError(
-              format("Format of incompressible solution string [%s] is invalid, should be like \"EG-20%\" or \"EG-0.2\" ", fluid_string.c_str()));
+              format(R"(Format of incompressible solution string [%s] is invalid, should be like "EG-20%" or "EG-0.2" )", fluid_string.c_str()));
         }
 
         // Convert the concentration into a string
@@ -289,24 +289,24 @@ struct output_parameter
     /// Covers both normal and derivative outputs
     static std::vector<output_parameter> get_output_parameters(const std::vector<std::string>& Outputs) {
         std::vector<output_parameter> outputs;
-        for (std::vector<std::string>::const_iterator str = Outputs.begin(); str != Outputs.end(); ++str) {
+        for (const auto& Output : Outputs) {
             output_parameter out;
             CoolProp::parameters iOutput;
-            if (is_valid_parameter(*str, iOutput)) {
+            if (is_valid_parameter(Output, iOutput)) {
                 out.Of1 = iOutput;
                 if (is_trivial_parameter(iOutput)) {
                     out.type = OUTPUT_TYPE_TRIVIAL;
                 } else {
                     out.type = OUTPUT_TYPE_NORMAL;
                 }
-            } else if (is_valid_first_saturation_derivative(*str, out.Of1, out.Wrt1)) {
+            } else if (is_valid_first_saturation_derivative(Output, out.Of1, out.Wrt1)) {
                 out.type = OUTPUT_TYPE_FIRST_SATURATION_DERIVATIVE;
-            } else if (is_valid_first_derivative(*str, out.Of1, out.Wrt1, out.Constant1)) {
+            } else if (is_valid_first_derivative(Output, out.Of1, out.Wrt1, out.Constant1)) {
                 out.type = OUTPUT_TYPE_FIRST_DERIVATIVE;
-            } else if (is_valid_second_derivative(*str, out.Of1, out.Wrt1, out.Constant1, out.Wrt2, out.Constant2)) {
+            } else if (is_valid_second_derivative(Output, out.Of1, out.Wrt1, out.Constant1, out.Wrt2, out.Constant2)) {
                 out.type = OUTPUT_TYPE_SECOND_DERIVATIVE;
             } else {
-                throw ValueError(format("Output string is invalid [%s]", str->c_str()));
+                throw ValueError(format("Output string is invalid [%s]", Output.c_str()));
             }
             outputs.push_back(out);
         }
@@ -333,8 +333,8 @@ void _PropsSI_outputs(shared_ptr<AbstractState>& State, const std::vector<output
     const bool one_input_one_output = (in1.size() == 1 && in2.size() == 1 && output_parameters.size() == 1);
     // If all trivial outputs, never do a state update
     bool all_trivial_outputs = true;
-    for (std::size_t j = 0; j < output_parameters.size(); ++j) {
-        if (output_parameters[j].type != output_parameter::OUTPUT_TYPE_TRIVIAL) {
+    for (const auto& j : output_parameters) {
+        if (j.type != output_parameter::OUTPUT_TYPE_TRIVIAL) {
             all_trivial_outputs = false;
         }
     }
@@ -345,12 +345,12 @@ void _PropsSI_outputs(shared_ptr<AbstractState>& State, const std::vector<output
         // Split the input pair into parameters
         split_input_pair(input_pair, p1, p2);
         // See if each parameter is in the output vector and is a normal type input
-        for (std::size_t j = 0; j < output_parameters.size(); ++j) {
-            if (output_parameters[j].type != output_parameter::OUTPUT_TYPE_NORMAL) {
+        for (const auto& j : output_parameters) {
+            if (j.type != output_parameter::OUTPUT_TYPE_NORMAL) {
                 all_outputs_in_inputs = false;
                 break;
             }
-            if (!(output_parameters[j].Of1 == p1 || output_parameters[j].Of1 == p2)) {
+            if (!(j.Of1 == p1 || j.Of1 == p2)) {
                 all_outputs_in_inputs = false;
                 break;
             }
@@ -405,8 +405,8 @@ void _PropsSI_outputs(shared_ptr<AbstractState>& State, const std::vector<output
                 throw;
             }  // Re-raise the exception since we want to bubble the error
             // All the outputs are filled with _HUGE; go to next input
-            for (std::size_t j = 0; j < IO[i].size(); ++j) {
-                IO[i][j] = _HUGE;
+            for (double& j : IO[i]) {
+                j = _HUGE;
             }
             continue;
         }
@@ -561,7 +561,7 @@ void _PropsSImulti(const std::vector<std::string>& Outputs, const std::string& N
         _PropsSI_initialize(backend, fluids, fractions, State);
     } catch (std::exception& e) {
         // Initialization failed.  Stop.
-        throw ValueError(format("Initialize failed for backend: \"%s\", fluid: \"%s\" fractions \"%s\"; error: %s", backend.c_str(),
+        throw ValueError(format(R"(Initialize failed for backend: "%s", fluid: "%s" fractions "%s"; error: %s)", backend.c_str(),
                                 strjoin(fluids, "&").c_str(), vec_to_string(fractions, "%0.10f").c_str(), e.what()));
     }
 
@@ -578,7 +578,7 @@ void _PropsSImulti(const std::vector<std::string>& Outputs, const std::string& N
         if (is_valid_parameter(N1, key1) && is_valid_parameter(N2, key2)) input_pair = generate_update_pair(key1, Prop1, key2, Prop2, v1, v2);
     } catch (std::exception& e) {
         // Input parameter parsing failed.  Stop
-        throw ValueError(format("Input pair parsing failed for Name1: \"%s\", Name2: \"%s\"; err: %s", Name1.c_str(), Name2.c_str(), e.what()));
+        throw ValueError(format(R"(Input pair parsing failed for Name1: "%s", Name2: "%s"; err: %s)", Name1.c_str(), Name2.c_str(), e.what()));
     }
 
     try {
@@ -623,7 +623,7 @@ std::vector<std::vector<double>> PropsSImulti(const std::vector<std::string>& Ou
         // swallowed and surfaced via the empty return below.
     }
 #endif
-    return std::vector<std::vector<double>>();
+    return {};
 }
 double PropsSI(const std::string& Output, const std::string& Name1, double Prop1, const std::string& Name2, double Prop2,
                const std::string& FluidName) {
@@ -659,7 +659,7 @@ double PropsSI(const std::string& Output, const std::string& Name1, double Prop1
 #if !defined(NO_ERROR_CATCHING)
     } catch (const std::exception& e) {
         set_error_string(e.what()
-                         + format(" : PropsSI(\"%s\",\"%s\",%0.10g,\"%s\",%0.10g,\"%s\")", Output.c_str(), Name1.c_str(), Prop1, Name2.c_str(), Prop2,
+                         + format(R"( : PropsSI("%s","%s",%0.10g,"%s",%0.10g,"%s"))", Output.c_str(), Name1.c_str(), Prop1, Name2.c_str(), Prop2,
                                   FluidName.c_str()));
 #    if defined(PROPSSI_ERROR_STDOUT)
         std::cout << e.what() << std::endl;
@@ -739,7 +739,7 @@ TEST_CASE("Check inputs to PropsSI", "[PropsSI]") {
     SECTION("Predefined mixture") {
         std::vector<double> p(1, 101325), Q(1, 1.0), z;
         std::vector<std::string> outputs(1, "T");
-        outputs.push_back("Dmolar");
+        outputs.emplace_back("Dmolar");
         std::vector<std::vector<double>> IO;
         std::vector<std::string> fluids(1, "R410A.mix");
         CHECK_NOTHROW(IO = CoolProp::PropsSImulti(outputs, "P", p, "Q", Q, "HEOS", fluids, z));
@@ -747,7 +747,7 @@ TEST_CASE("Check inputs to PropsSI", "[PropsSI]") {
     SECTION("Single state, two outputs") {
         std::vector<double> p(1, 101325), Q(1, 1.0), z(1, 1.0);
         std::vector<std::string> outputs(1, "T");
-        outputs.push_back("Dmolar");
+        outputs.emplace_back("Dmolar");
         std::vector<std::string> fluids(1, "Water");
         CHECK_NOTHROW(CoolProp::PropsSImulti(outputs, "P", p, "Q", Q, "HEOS", fluids, z));
     };
@@ -755,7 +755,7 @@ TEST_CASE("Check inputs to PropsSI", "[PropsSI]") {
         std::vector<double> p(1, 101325), Q(1, 1.0), z(1, 1.0);
         std::vector<std::vector<double>> IO;
         std::vector<std::string> outputs(1, "???????");
-        outputs.push_back("?????????");
+        outputs.emplace_back("?????????");
         std::vector<std::string> fluids(1, "Water");
         CHECK_NOTHROW(IO = CoolProp::PropsSImulti(outputs, "P", p, "Q", Q, "HEOS", fluids, z));
         CHECK(IO.size() == 0);
@@ -769,7 +769,7 @@ TEST_CASE("Check inputs to PropsSI", "[PropsSI]") {
     SECTION("Two states, two outputs") {
         std::vector<double> p(2, 101325), Q(2, 1.0), z(1, 1.0);
         std::vector<std::string> outputs(1, "T");
-        outputs.push_back("Dmolar");
+        outputs.emplace_back("Dmolar");
         std::vector<std::string> fluids(1, "Water");
         CHECK_NOTHROW(CoolProp::PropsSImulti(outputs, "P", p, "Q", Q, "HEOS", fluids, z));
     };
@@ -777,7 +777,7 @@ TEST_CASE("Check inputs to PropsSI", "[PropsSI]") {
         std::vector<double> p(1, 101325), Q(1, 1.0), z(1, 1.0);
         std::vector<std::vector<double>> IO;
         std::vector<std::string> outputs(1, "Cpmolar");
-        outputs.push_back("d(Hmolar)/d(T)|P");
+        outputs.emplace_back("d(Hmolar)/d(T)|P");
         std::vector<std::string> fluids(1, "Water");
         CHECK_NOTHROW(IO = CoolProp::PropsSImulti(outputs, "P", p, "Q", Q, "HEOS", fluids, z));
         std::string errstring = get_global_param_string("errstring");
@@ -791,7 +791,7 @@ TEST_CASE("Check inputs to PropsSI", "[PropsSI]") {
         std::vector<double> p(1, 101325), Q(1, 1.0), z(1, 1.0);
         std::vector<std::vector<double>> IO;
         std::vector<std::string> outputs(1, "Cpmolar");
-        outputs.push_back("d(Hmolar)/d(T)|P");
+        outputs.emplace_back("d(Hmolar)/d(T)|P");
         std::vector<std::string> fluids(1, "????????");
         CHECK_NOTHROW(IO = CoolProp::PropsSImulti(outputs, "P", p, "Q", Q, "HEOS", fluids, z));
         std::string errstring = get_global_param_string("errstring");
@@ -812,7 +812,7 @@ TEST_CASE("Check inputs to PropsSI", "[PropsSI]") {
         std::vector<double> p(1, 101325), Q(2, 1.0), z(100, 1.0);
         std::vector<std::vector<double>> IO;
         std::vector<std::string> outputs(1, "Cpmolar");
-        outputs.push_back("d(Hmolar)/d(T)|P");
+        outputs.emplace_back("d(Hmolar)/d(T)|P");
         std::vector<std::string> fluids(1, "Water");
         CHECK_NOTHROW(IO = CoolProp::PropsSImulti(outputs, "P", p, "Q", Q, "HEOS", fluids, z));
         std::string errstring = get_global_param_string("errstring");
@@ -823,7 +823,7 @@ TEST_CASE("Check inputs to PropsSI", "[PropsSI]") {
         std::vector<double> Q(2, 1.0), z(1, 1.0);
         std::vector<std::vector<double>> IO;
         std::vector<std::string> outputs(1, "Cpmolar");
-        outputs.push_back("d(Hmolar)/d(T)|P");
+        outputs.emplace_back("d(Hmolar)/d(T)|P");
         std::vector<std::string> fluids(1, "Water");
         CHECK_NOTHROW(IO = CoolProp::PropsSImulti(outputs, "Q", Q, "Q", Q, "HEOS", fluids, z));
         std::string errstring = get_global_param_string("errstring");
@@ -1059,10 +1059,10 @@ TEST_CASE("Check inputs to get_global_param_string", "[get_global_param_string]"
       "version",        "gitrevision",        "fluids_list", "incompressible_list_pure", "incompressible_list_solution", "mixture_binary_pairs_list",
       "parameter_list", "predefined_mixtures"};
     std::ostringstream ss3c;
-    for (int i = 0; i < num_good_inputs; ++i) {
-        ss3c << "Test for" << good_inputs[i];
+    for (const auto& good_input : good_inputs) {
+        ss3c << "Test for" << good_input;
         SECTION(ss3c.str(), "") {
-            CHECK_NOTHROW(CoolProp::get_global_param_string(good_inputs[i]));
+            CHECK_NOTHROW(CoolProp::get_global_param_string(good_input));
         };
     }
     CHECK_THROWS(CoolProp::get_global_param_string(""));
@@ -1088,10 +1088,10 @@ TEST_CASE("Check inputs to get_fluid_param_string", "[get_fluid_param_string]") 
                                                 "BibTeX-MELTING_LINE",
                                                 "BibTeX-VISCOSITY"};
     std::ostringstream ss3c;
-    for (int i = 0; i < num_good_inputs; ++i) {
-        ss3c << "Test for" << good_inputs[i];
+    for (const auto& good_input : good_inputs) {
+        ss3c << "Test for" << good_input;
         SECTION(ss3c.str(), "") {
-            CHECK_NOTHROW(CoolProp::get_fluid_param_string("Water", good_inputs[i]));
+            CHECK_NOTHROW(CoolProp::get_fluid_param_string("Water", good_input));
         };
     }
     CHECK_THROWS(CoolProp::get_fluid_param_string("", "aliases"));
@@ -1135,8 +1135,8 @@ std::string PhaseSI(const std::string& Name1, double Prop1, const std::string& N
         }
         return strPhase;  //     return the "unknown" phase string
     }  // else
-    std::size_t Phase_int = static_cast<std::size_t>(Phase_double);  //     convert returned phase to int
-    return phase_lookup_string(static_cast<phases>(Phase_int));      //     return phase as a string
+    auto Phase_int = static_cast<std::size_t>(Phase_double);     //     convert returned phase to int
+    return phase_lookup_string(static_cast<phases>(Phase_int));  //     return phase as a string
 }
 
 /*

--- a/src/CoolPropPlot.cpp
+++ b/src/CoolPropPlot.cpp
@@ -330,10 +330,10 @@ Isolines PropertyPlot::calc_isolines(CoolProp::parameters key, const std::vector
 std::vector<CoolProp::parameters> PropertyPlot::supported_isoline_keys() const {
     // taken from PropertyPlot::calc_isolines when called with iso_type='all'
     std::vector<CoolProp::parameters> keys;
-    for (auto it = Detail::xy_switch.begin(); it != Detail::xy_switch.end(); ++it) {
-        const std::map<int, Detail::IsolineSupported>& supported = it->second;
+    for (const auto& it : Detail::xy_switch) {
+        const std::map<int, Detail::IsolineSupported>& supported = it.second;
         auto supported_xy = supported.find(ykey_ * 10 + xkey_);
-        if (supported_xy != supported.end() && supported_xy->second != Detail::IsolineSupported::No) keys.push_back(it->first);
+        if (supported_xy != supported.end() && supported_xy->second != Detail::IsolineSupported::No) keys.push_back(it.first);
     }
     return keys;
 }

--- a/src/DataStructures.cpp
+++ b/src/DataStructures.cpp
@@ -213,7 +213,7 @@ std::string get_csv_parameter_list() {
 bool is_valid_parameter(const std::string& param_name, parameters& iOutput) {
     auto& parameter_information = get_parameter_information();
     // Try to find it
-    std::map<std::string, int>::const_iterator it = parameter_information.index_map.find(param_name);
+    auto it = parameter_information.index_map.find(param_name);
     // If equal to end, not found
     if (it != parameter_information.index_map.end()) {
         // Found, return it
@@ -409,7 +409,7 @@ const std::string& get_phase_short_desc(phases phase) {
 bool is_valid_phase(const std::string& phase_name, phases& iOutput) {
     auto& phase_information = get_phase_information();
     // Try to find it
-    std::map<std::string, phases>::const_iterator it = phase_information.index_map.find(phase_name);
+    auto it = phase_information.index_map.find(phase_name);
     // If equal to end, not found
     if (it != phase_information.index_map.end()) {
         // Found, return it
@@ -852,7 +852,7 @@ const BackendInformation& get_backend_information() {
 }
 
 /// Convert a string into the enum values
-void extract_backend_families(std::string backend_string, backend_families& f1, backend_families& f2) {
+void extract_backend_families(const std::string& backend_string, backend_families& f1, backend_families& f2) {
     auto& backend_information = get_backend_information();
     f1 = INVALID_BACKEND_FAMILY;
     f2 = INVALID_BACKEND_FAMILY;
@@ -872,7 +872,7 @@ void extract_backend_families(std::string backend_string, backend_families& f1, 
 void extract_backend_families_string(std::string backend_string, backend_families& f1, std::string& f2) {
     auto& backend_information = get_backend_information();
     backend_families f2_enum;
-    extract_backend_families(backend_string, f1, f2_enum);
+    extract_backend_families(std::move(backend_string), f1, f2_enum);
     std::map<backend_families, std::string>::const_iterator it;
     it = backend_information.family_name_map.find(f2_enum);
     if (it != backend_information.family_name_map.end())
@@ -888,7 +888,7 @@ std::string get_backend_string(backends backend) {
     if (it != backend_information.backend_name_map.end())
         return it->second;
     else
-        return std::string("");
+        return {""};
 }
 
 } /* namespace CoolProp */
@@ -896,6 +896,7 @@ std::string get_backend_string(backends backend) {
 #ifdef ENABLE_CATCH
 #    include <catch2/catch_all.hpp>
 #    include <sstream>
+#    include <utility>
 
 TEST_CASE("Check that csv list of parameters is possible", "[parameter_list]") {
     CHECK_NOTHROW(CoolProp::get_csv_parameter_list());

--- a/src/Helmholtz.cpp
+++ b/src/Helmholtz.cpp
@@ -1819,8 +1819,8 @@ class HelmholtzConsistencyFixture
 std::string terms[] = {"Lead",         "LogTau",       "IGPower", "PlanckEinstein", "CP0Constant", "CP0PolyT", "Gaussian",
                        "Lemmon2005",   "Power",        "SAFT",    "NonAnalytic",    "Exponential", "GERG2008", "SRK",
                        "PengRobinson", "XiangDeiters", "GaoB",    "GERG2004Cosh",   "GERG2004Sinh"};
-std::string derivs[] = {"dTau",         "dTau2",        "dTau3", "dDelta",       "dDelta2",       "dDelta3",      "dDelta_dTau",
-                        "dDelta_dTau2", "dDelta2_dTau", "dTau4", "dDelta_dTau3", "dDelta2_dTau2", "dDelta3_dTau", "dDelta4"};
+const std::vector<std::string> derivs = {"dTau",         "dTau2",        "dTau3", "dDelta",       "dDelta2",       "dDelta3",      "dDelta_dTau",
+                                         "dDelta_dTau2", "dDelta2_dTau", "dTau4", "dDelta_dTau3", "dDelta2_dTau2", "dDelta3_dTau", "dDelta4"};
 std::map<std::string, std::tuple<int, int>> counts = {
   {"dTau", {1, 0}},         {"dTau2", {2, 0}},        {"dTau3", {3, 0}},         {"dTau4", {4, 0}},        {"dDelta", {0, 1}},
   {"dDelta2", {0, 2}},      {"dDelta3", {0, 3}},      {"dDelta4", {0, 4}},       {"dDelta_dTau", {1, 1}},  {"dDelta_dTau2", {2, 1}},

--- a/src/Helmholtz.cpp
+++ b/src/Helmholtz.cpp
@@ -767,7 +767,7 @@ mcx::MultiComplex<double> ResidualHelmholtzGaoB::one_mcx(const mcx::MultiComplex
 
 ResidualHelmholtzXiangDeiters::ResidualHelmholtzXiangDeiters(const CoolPropDbl Tc, const CoolPropDbl pc, const CoolPropDbl rhomolarc,
                                                              const CoolPropDbl acentric, const CoolPropDbl R)
-  : Tc(Tc), pc(pc), rhomolarc(rhomolarc), acentric(acentric), R(R) {
+  : enabled(true), Tc(Tc), pc(pc), rhomolarc(rhomolarc), acentric(acentric), R(R) {
     double Zc = pc / (R * Tc * rhomolarc);
     theta = POW2(Zc - 0.29);
 
@@ -793,8 +793,6 @@ ResidualHelmholtzXiangDeiters::ResidualHelmholtzXiangDeiters(const CoolPropDbl T
     phi0.add_Exponential(a0, d, t, g, l);
     phi1.add_Exponential(a1, d, t, g, l);
     phi2.add_Exponential(a2, d, t, g, l);
-
-    enabled = true;
 };
 
 void ResidualHelmholtzXiangDeiters::all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) {
@@ -1638,7 +1636,7 @@ class HelmholtzConsistencyFixture
               std::vector<CoolPropDbl>(gamma, gamma + sizeof(gamma) / sizeof(gamma[0])));
         }
     }
-    void call(std::string d, shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
+    void call(const std::string& d, const shared_ptr<CoolProp::BaseHelmholtzTerm>& term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
         if (!d.compare("dTau")) {
             return dTau(term, tau, delta, ddelta);
         } else if (!d.compare("dTau2")) {
@@ -1671,7 +1669,7 @@ class HelmholtzConsistencyFixture
             throw CoolProp::ValueError("don't understand deriv type");
         }
     }
-    shared_ptr<CoolProp::BaseHelmholtzTerm> get(std::string t) {
+    shared_ptr<CoolProp::BaseHelmholtzTerm> get(const std::string& t) {
         if (!t.compare("Lead")) {
             return Lead;
         } else if (!t.compare("LogTau")) {
@@ -1716,85 +1714,85 @@ class HelmholtzConsistencyFixture
             throw CoolProp::ValueError(format("don't understand helmholtz type: %s", t.c_str()));
         }
     }
-    void dTau(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl dtau) {
+    void dTau(const shared_ptr<CoolProp::BaseHelmholtzTerm>& term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl dtau) {
         CoolPropDbl term_plus = term->base(tau + dtau, delta);
         CoolPropDbl term_minus = term->base(tau - dtau, delta);
         numerical = (term_plus - term_minus) / (2 * dtau);
         analytic = term->dTau(tau, delta);
     };
-    void dTau2(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl dtau) {
+    void dTau2(const shared_ptr<CoolProp::BaseHelmholtzTerm>& term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl dtau) {
         CoolPropDbl term_plus = term->dTau(tau + dtau, delta);
         CoolPropDbl term_minus = term->dTau(tau - dtau, delta);
         numerical = (term_plus - term_minus) / (2 * dtau);
         analytic = term->dTau2(tau, delta);
     };
-    void dTau3(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl dtau) {
+    void dTau3(const shared_ptr<CoolProp::BaseHelmholtzTerm>& term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl dtau) {
         CoolPropDbl term_plus = term->dTau2(tau + dtau, delta);
         CoolPropDbl term_minus = term->dTau2(tau - dtau, delta);
         numerical = (term_plus - term_minus) / (2 * dtau);
         analytic = term->dTau3(tau, delta);
     };
-    void dTau4(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl dtau) {
+    void dTau4(const shared_ptr<CoolProp::BaseHelmholtzTerm>& term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl dtau) {
         CoolPropDbl term_plus = term->dTau3(tau + dtau, delta);
         CoolPropDbl term_minus = term->dTau3(tau - dtau, delta);
         numerical = (term_plus - term_minus) / (2 * dtau);
         analytic = term->dTau4(tau, delta);
     };
-    void dDelta(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
+    void dDelta(const shared_ptr<CoolProp::BaseHelmholtzTerm>& term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
         CoolPropDbl term_plus = term->base(tau, delta + ddelta);
         CoolPropDbl term_minus = term->base(tau, delta - ddelta);
         numerical = (term_plus - term_minus) / (2 * ddelta);
         analytic = term->dDelta(tau, delta);
     };
-    void dDelta2(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
+    void dDelta2(const shared_ptr<CoolProp::BaseHelmholtzTerm>& term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
         CoolPropDbl term_plus = term->dDelta(tau, delta + ddelta);
         CoolPropDbl term_minus = term->dDelta(tau, delta - ddelta);
         numerical = (term_plus - term_minus) / (2 * ddelta);
         analytic = term->dDelta2(tau, delta);
     };
-    void dDelta3(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
+    void dDelta3(const shared_ptr<CoolProp::BaseHelmholtzTerm>& term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
         CoolPropDbl term_plus = term->dDelta2(tau, delta + ddelta);
         CoolPropDbl term_minus = term->dDelta2(tau, delta - ddelta);
         numerical = (term_plus - term_minus) / (2 * ddelta);
         analytic = term->dDelta3(tau, delta);
     };
-    void dDelta4(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
+    void dDelta4(const shared_ptr<CoolProp::BaseHelmholtzTerm>& term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
         CoolPropDbl term_plus = term->dDelta3(tau, delta + ddelta);
         CoolPropDbl term_minus = term->dDelta3(tau, delta - ddelta);
         numerical = (term_plus - term_minus) / (2 * ddelta);
         analytic = term->dDelta4(tau, delta);
     };
-    void dDelta_dTau(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
+    void dDelta_dTau(const shared_ptr<CoolProp::BaseHelmholtzTerm>& term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
         CoolPropDbl term_plus = term->dTau(tau, delta + ddelta);
         CoolPropDbl term_minus = term->dTau(tau, delta - ddelta);
         numerical = (term_plus - term_minus) / (2 * ddelta);
         analytic = term->dDelta_dTau(tau, delta);
     };
-    void dDelta_dTau2(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
+    void dDelta_dTau2(const shared_ptr<CoolProp::BaseHelmholtzTerm>& term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
         CoolPropDbl term_plus = term->dTau2(tau, delta + ddelta);
         CoolPropDbl term_minus = term->dTau2(tau, delta - ddelta);
         numerical = (term_plus - term_minus) / (2 * ddelta);
         analytic = term->dDelta_dTau2(tau, delta);
     };
-    void dDelta2_dTau(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
+    void dDelta2_dTau(const shared_ptr<CoolProp::BaseHelmholtzTerm>& term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
         CoolPropDbl term_plus = term->dDelta_dTau(tau, delta + ddelta);
         CoolPropDbl term_minus = term->dDelta_dTau(tau, delta - ddelta);
         numerical = (term_plus - term_minus) / (2 * ddelta);
         analytic = term->dDelta2_dTau(tau, delta);
     };
-    void dDelta3_dTau(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
+    void dDelta3_dTau(const shared_ptr<CoolProp::BaseHelmholtzTerm>& term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
         CoolPropDbl term_plus = term->dDelta2_dTau(tau, delta + ddelta);
         CoolPropDbl term_minus = term->dDelta2_dTau(tau, delta - ddelta);
         numerical = (term_plus - term_minus) / (2 * ddelta);
         analytic = term->dDelta3_dTau(tau, delta);
     };
-    void dDelta2_dTau2(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
+    void dDelta2_dTau2(const shared_ptr<CoolProp::BaseHelmholtzTerm>& term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
         CoolPropDbl term_plus = term->dDelta_dTau2(tau, delta + ddelta);
         CoolPropDbl term_minus = term->dDelta_dTau2(tau, delta - ddelta);
         numerical = (term_plus - term_minus) / (2 * ddelta);
         analytic = term->dDelta2_dTau2(tau, delta);
     };
-    void dDelta_dTau3(shared_ptr<CoolProp::BaseHelmholtzTerm> term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
+    void dDelta_dTau3(const shared_ptr<CoolProp::BaseHelmholtzTerm>& term, CoolPropDbl tau, CoolPropDbl delta, CoolPropDbl ddelta) {
         CoolPropDbl term_plus = term->dTau3(tau, delta + ddelta);
         CoolPropDbl term_minus = term->dTau3(tau, delta - ddelta);
         numerical = (term_plus - term_minus) / (2 * ddelta);
@@ -1834,18 +1832,17 @@ TEST_CASE_METHOD(HelmholtzConsistencyFixture, "Helmholtz energy derivatives", "[
     std::size_t n = sizeof(terms) / sizeof(terms[0]);
     for (std::size_t i = 0; i < n; ++i) {
         term = get(terms[i]);
-        for (std::size_t j = 0; j < sizeof(derivs) / sizeof(derivs[0]); ++j) {
+        for (const auto& deriv : derivs) {
             if (terms[i] == "SAFT"
-                && (derivs[j] == "dTau4" || derivs[j] == "dDelta_dTau3" || derivs[j] == "dDelta2_dTau2" || derivs[j] == "dDelta3_dTau"
-                    || derivs[j] == "dDelta4")) {
+                && (deriv == "dTau4" || deriv == "dDelta_dTau3" || deriv == "dDelta2_dTau2" || deriv == "dDelta3_dTau" || deriv == "dDelta4")) {
                 continue;
             }
             double tau = 1.3, delta = 0.9;
-            call(derivs[j], term, tau, delta, 1e-5);
+            call(deriv, term, tau, delta, 1e-5);
             double alphar = term->base(tau, delta);
 
             // Do calculations with multicomplex, if the one_mcx function has been implemented
-            auto [ntau, ndelta] = counts.at(derivs[j]);
+            auto [ntau, ndelta] = counts.at(deriv);
             double numerical_mcx = _HUGE;
             double alphar_mcx = _HUGE;
             try {
@@ -1860,7 +1857,7 @@ TEST_CASE_METHOD(HelmholtzConsistencyFixture, "Helmholtz energy derivatives", "[
             CAPTURE(alphar_mcx);
             CAPTURE(numerical_mcx);
 
-            CAPTURE(derivs[j]);
+            CAPTURE(deriv);
             CAPTURE(alphar);
             double numerical_finitediff = numerical;
             CAPTURE(numerical_finitediff);

--- a/src/HumidAirProp.cpp
+++ b/src/HumidAirProp.cpp
@@ -528,10 +528,11 @@ static double Secant_Tdb_at_saturated_W(double psi_w, double p, double T_guess) 
         double pp_water, psi_w, p;
 
        public:
-        BrentSolverResids(double psi_w, double p) : psi_w(psi_w), p(p) {
-            pp_water = psi_w * p;
-        };
-        ~BrentSolverResids() {};
+        BrentSolverResids(double psi_w, double p)
+          : pp_water(psi_w * p), psi_w(psi_w), p(p) {
+
+            };
+        ~BrentSolverResids() = default;
 
         double call(double T) override {
             double p_ws = NAN;
@@ -2494,16 +2495,10 @@ struct hel
    public:
     std::string in1, in2, in3, out;
     double v1, v2, v3, expected;
-    hel(std::string in1, double v1, std::string in2, double v2, std::string in3, double v3, std::string out, double expected) {
-        this->in1 = in1;
-        this->in2 = in2;
-        this->in3 = in3;
-        this->v1 = v1;
-        this->v2 = v2;
-        this->v3 = v3;
-        this->expected = expected;
-        this->out = out;
-    };
+    hel(std::string in1, double v1, std::string in2, double v2, std::string in3, double v3, std::string out, double expected)
+      : in1(in1), in2(in2), in3(in3), v1(v1), v2(v2), v3(v3), expected(expected), out(out) {
+
+        };
 };
 std::vector<hel> table_A11 = {hel("T", 473.15, "W", 0.00, "P", 101325, "B", 45.07 + 273.15), hel("T", 473.15, "W", 0.00, "P", 101325, "V", 1.341),
                               hel("T", 473.15, "W", 0.00, "P", 101325, "H", 202520),         hel("T", 473.15, "W", 0.00, "P", 101325, "S", 555.8),
@@ -2551,15 +2546,15 @@ class HAPropsConsistencyFixture
 TEST_CASE_METHOD(HAPropsConsistencyFixture, "ASHRAE RP1485 Tables", "[RP1485]") {
     SECTION("Table A.15") {
         inputs = table_A15;
-        for (std::size_t i = 0; i < inputs.size(); ++i) {
-            set_values(inputs[i]);
+        for (auto& input : inputs) {
+            set_values(input);
             call();
-            CAPTURE(inputs[i].in1);
-            CAPTURE(inputs[i].v1);
-            CAPTURE(inputs[i].in2);
-            CAPTURE(inputs[i].v2);
-            CAPTURE(inputs[i].in3);
-            CAPTURE(inputs[i].v3);
+            CAPTURE(input.in1);
+            CAPTURE(input.v1);
+            CAPTURE(input.in2);
+            CAPTURE(input.v2);
+            CAPTURE(input.in3);
+            CAPTURE(input.v3);
             CAPTURE(out);
             CAPTURE(actual);
             CAPTURE(expected);
@@ -2570,15 +2565,15 @@ TEST_CASE_METHOD(HAPropsConsistencyFixture, "ASHRAE RP1485 Tables", "[RP1485]") 
     }
     SECTION("Table A.11") {
         inputs = table_A11;
-        for (std::size_t i = 0; i < inputs.size(); ++i) {
-            set_values(inputs[i]);
+        for (auto& input : inputs) {
+            set_values(input);
             call();
-            CAPTURE(inputs[i].in1);
-            CAPTURE(inputs[i].v1);
-            CAPTURE(inputs[i].in2);
-            CAPTURE(inputs[i].v2);
-            CAPTURE(inputs[i].in3);
-            CAPTURE(inputs[i].v3);
+            CAPTURE(input.in1);
+            CAPTURE(input.v1);
+            CAPTURE(input.in2);
+            CAPTURE(input.v2);
+            CAPTURE(input.in3);
+            CAPTURE(input.v3);
             CAPTURE(out);
             CAPTURE(actual);
             CAPTURE(expected);
@@ -2589,15 +2584,15 @@ TEST_CASE_METHOD(HAPropsConsistencyFixture, "ASHRAE RP1485 Tables", "[RP1485]") 
     }
     SECTION("Table A.12") {
         inputs = table_A12;
-        for (std::size_t i = 0; i < inputs.size(); ++i) {
-            set_values(inputs[i]);
+        for (auto& input : inputs) {
+            set_values(input);
             call();
-            CAPTURE(inputs[i].in1);
-            CAPTURE(inputs[i].v1);
-            CAPTURE(inputs[i].in2);
-            CAPTURE(inputs[i].v2);
-            CAPTURE(inputs[i].in3);
-            CAPTURE(inputs[i].v3);
+            CAPTURE(input.in1);
+            CAPTURE(input.v1);
+            CAPTURE(input.in2);
+            CAPTURE(input.v2);
+            CAPTURE(input.in3);
+            CAPTURE(input.v3);
             CAPTURE(out);
             CAPTURE(actual);
             CAPTURE(expected);
@@ -2706,9 +2701,10 @@ class ConsistencyTestData
     bool is_built;
     std::vector<Dictionary> data;
     std::list<std::set<std::size_t>> inputs_list;
-    ConsistencyTestData() {
-        is_built = false;
-    };
+    ConsistencyTestData()
+      : is_built(false) {
+
+        };
     void build() {
         if (is_built) {
             return;
@@ -2740,9 +2736,9 @@ class ConsistencyTestData
                 const double W = W_lo + dW * iw;
                 Dictionary vals;
                 // Calculate all the values using T, W
-                for (int i = 0; i < number_of_inputs; ++i) {
-                    double v = HumidAir::HAPropsSI(inputs[i], "T", T, "P", p, "W", W);
-                    vals.add_number(inputs[i], v);
+                for (const auto& input : inputs) {
+                    double v = HumidAir::HAPropsSI(input, "T", T, "P", p, "W", W);
+                    vals.add_number(input, v);
                 }
                 data.push_back(vals);
                 std::cout << format("T %g W %g\n", T, W);

--- a/src/PolyMath.cpp
+++ b/src/PolyMath.cpp
@@ -792,12 +792,7 @@ double Polynomial2DFrac::fracIntCentral(const Eigen::MatrixXd& coefficients, con
 
 Poly2DFracResidual::Poly2DFracResidual(Polynomial2DFrac& poly, const Eigen::MatrixXd& coefficients, const double& in, const double& z_in,
                                        const int& axis, const int& x_exp, const int& y_exp, const double& x_base, const double& y_base)
-  : Poly2DResidual(poly, coefficients, in, z_in, axis) {
-    this->x_exp = x_exp;
-    this->y_exp = y_exp;
-    this->x_base = x_base;
-    this->y_base = y_base;
-}
+  : Poly2DResidual(poly, coefficients, in, z_in, axis), x_exp(x_exp), y_exp(y_exp), x_base(x_base), y_base(y_base) {}
 
 double Poly2DFracResidual::call(double target) {
     if (axis == iX) return poly.evaluate(coefficients, target, in, x_exp, y_exp, x_base, y_base) - z_in;
@@ -814,9 +809,7 @@ double Poly2DFracResidual::deriv(double target) {
 Poly2DFracIntResidual::Poly2DFracIntResidual(Polynomial2DFrac& poly, const Eigen::MatrixXd& coefficients, const double& in, const double& z_in,
                                              const int& axis, const int& x_exp, const int& y_exp, const double& x_base, const double& y_base,
                                              const int& int_axis)
-  : Poly2DFracResidual(poly, coefficients, in, z_in, axis, x_exp, y_exp, x_base, y_base) {
-    this->int_axis = int_axis;
-}
+  : Poly2DFracResidual(poly, coefficients, in, z_in, axis, x_exp, y_exp, x_base, y_base), int_axis(int_axis) {}
 
 double Poly2DFracIntResidual::call(double target) {
     if (axis == iX) return poly.integral(coefficients, target, in, int_axis, x_exp, y_exp, x_base, y_base) - z_in;
@@ -964,7 +957,7 @@ TEST_CASE("Internal consistency checks and example use cases for PolyMath.cpp", 
 
         CoolProp::Polynomial2D poly;
 
-        Eigen::MatrixXd matrix(matrix2D);
+        const Eigen::MatrixXd& matrix(matrix2D);
         Eigen::MatrixXd matrixInt = poly.integrateCoeffs(matrix, 1);
         Eigen::MatrixXd matrixDer = poly.deriveCoeffs(matrix, 1);
         Eigen::MatrixXd matrixInt2 = poly.integrateCoeffs(matrix, 1, 2);
@@ -985,7 +978,7 @@ TEST_CASE("Internal consistency checks and example use cases for PolyMath.cpp", 
         // (cert-flp30-c).  N_T = ceil((Tmax-Tmin)/Tinc) matches the
         // count the original `for (T = Tmin; T < Tmax; T += Tinc)` loop
         // produces for the current Tmin/Tmax/Tinc (223.15/523.15/200 -> 2).
-        const std::size_t N_T = static_cast<std::size_t>(std::ceil((Tmax - Tmin) / Tinc));
+        const auto N_T = static_cast<std::size_t>(std::ceil((Tmax - Tmin) / Tinc));
 
         for (std::size_t i = 0; i < N_T; ++i) {
             const double T = Tmin + i * Tinc;
@@ -1187,7 +1180,7 @@ TEST_CASE("Internal consistency checks and example use cases for PolyMath.cpp", 
         // Integer-indexed grid (cert-flp30-c) — same N_T derivation as
         // the loops in the previous SECTION; T is the outer-scope test
         // variable, reuse it.
-        const std::size_t N_T_frac = static_cast<std::size_t>(std::ceil((Tmax - Tmin) / Tinc));
+        const auto N_T_frac = static_cast<std::size_t>(std::ceil((Tmax - Tmin) / Tinc));
         for (std::size_t i = 0; i < N_T_frac; ++i) {
             T = Tmin + i * Tinc;
             a = poly.evaluate(matrix, T - deltaT, y);

--- a/src/SBTL/SVDSurfaceSerializer.cpp
+++ b/src/SBTL/SVDSurfaceSerializer.cpp
@@ -281,7 +281,7 @@ region::Region unpack_region(const msgpack::object& o, const std::shared_ptr<reg
     // trip diagnostics only.
     auto b_lo = unpack_curve(o.via.array.ptr[6], sa);
     auto b_hi = unpack_curve(o.via.array.ptr[7], sa);
-    return region::Region(axis, std::move(b_lo), std::move(b_hi));
+    return {axis, std::move(b_lo), std::move(b_hi)};
 }
 
 svd::SVDDecomposition unpack_decomp(const msgpack::object& o, std::size_t* out_region_idx, ::CoolProp::parameters* out_prop) {
@@ -379,7 +379,7 @@ std::vector<char> zlib_compress(const msgpack::sbuffer& sbuf) {
     // raw size and let zlib write into that buffer.  miniz returns
     // Z_OK when it fits.
     std::vector<char> out(sbuf.size() + (sbuf.size() / 1000) + 128);
-    mz_ulong out_size = static_cast<mz_ulong>(out.size());
+    auto out_size = static_cast<mz_ulong>(out.size());
     const int code = compress((unsigned char*)out.data(), &out_size, (const unsigned char*)sbuf.data(), static_cast<mz_ulong>(sbuf.size()));
     if (code != Z_OK) {
         throw std::runtime_error(std::string("SVDSurfaceSerializer: zlib compress failed (code ") + std::to_string(code) + ")");
@@ -392,8 +392,8 @@ std::vector<char> zlib_uncompress(const std::vector<char>& compressed) {
     // Mirrors TabularBackends.cpp:52-69: start at 5x the compressed
     // size, double on Z_BUF_ERROR until it fits or we exhaust patience.
     std::vector<char> out(compressed.size() * 5);
-    mz_ulong out_size = static_cast<mz_ulong>(out.size());
-    mz_ulong in_size = static_cast<mz_ulong>(compressed.size());
+    auto out_size = static_cast<mz_ulong>(out.size());
+    auto in_size = static_cast<mz_ulong>(compressed.size());
     int code = 0;
     int retries = 0;
     do {

--- a/src/SchemaValidation.cpp
+++ b/src/SchemaValidation.cpp
@@ -52,7 +52,7 @@ void copy_sorted(const rapidjson::Value& src, rapidjson::Value& dst, rapidjson::
 std::string pointer_to_string(const rapidjson::GenericPointer<rapidjson::Value>& p) {
     rapidjson::StringBuffer sb;
     p.StringifyUriFragment(sb);
-    return std::string(sb.GetString(), sb.GetSize());
+    return {sb.GetString(), sb.GetSize()};
 }
 
 rapidjson::Document parse_json(const std::string& s, const char* what) {
@@ -102,7 +102,7 @@ std::string to_canonical_json(const rapidjson::Value& value) {
     rapidjson::StringBuffer sb;
     rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
     sorted.Accept(writer);
-    return std::string(sb.GetString(), sb.GetSize());
+    return {sb.GetString(), sb.GetSize()};
 }
 
 std::string to_canonical_json(const std::string& json_str) {

--- a/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
+++ b/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
@@ -286,7 +286,7 @@ TEST_CASE("SVDSurfaceSerializer rejects corrupt input", "[SBTL][serializer]") {
     {
         const char hello[] = "hello world";
         bogus_payload.resize(64);
-        mz_ulong out_size = static_cast<mz_ulong>(bogus_payload.size());
+        auto out_size = static_cast<mz_ulong>(bogus_payload.size());
         const int rc = compress((unsigned char*)bogus_payload.data(), &out_size, (const unsigned char*)hello, sizeof(hello) - 1);
         // miniz returns MZ_OK == Z_OK == 0.  Failing here means the
         // test setup itself is broken (not what we're trying to

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -1468,23 +1468,23 @@ TEST_CASE("Test consistency between Gernert models in CoolProp and Gernert model
     Skip_if_No_REFPROP();  // Skip this test if REFPROPMixture backend is not available
 
     std::string mixes[] = {"CO2[0.7]&Argon[0.3]", "CO2[0.7]&Water[0.3]", "CO2[0.7]&Nitrogen[0.3]"};
-    for (const auto& mixe : mixes) {
-        const char* ykey = mixe.c_str();
+    for (const auto& mix : mixes) {
+        const char* ykey = mix.c_str();
         std::ostringstream ss1;
-        ss1 << mixe;
+        ss1 << mix;
         SECTION(ss1.str(), "") {
             double Tnbp_CP, Tnbp_RP, R_RP, R_CP, pchk_CP, pchk_RP;
-            CHECK_NOTHROW(R_CP = PropsSI("gas_constant", "P", 101325, "Q", 1, "HEOS::" + mixe));
+            CHECK_NOTHROW(R_CP = PropsSI("gas_constant", "P", 101325, "Q", 1, "HEOS::" + mix));
             CAPTURE(R_CP);
-            CHECK_NOTHROW(R_RP = PropsSI("gas_constant", "P", 101325, "Q", 1, "REFPROP::" + mixe));
+            CHECK_NOTHROW(R_RP = PropsSI("gas_constant", "P", 101325, "Q", 1, "REFPROP::" + mix));
             CAPTURE(R_RP);
-            CHECK_NOTHROW(Tnbp_CP = PropsSI("T", "P", 101325, "Q", 1, "HEOS::" + mixe));
+            CHECK_NOTHROW(Tnbp_CP = PropsSI("T", "P", 101325, "Q", 1, "HEOS::" + mix));
             CAPTURE(Tnbp_CP);
-            CHECK_NOTHROW(pchk_CP = PropsSI("P", "T", Tnbp_CP, "Q", 1, "HEOS::" + mixe));
+            CHECK_NOTHROW(pchk_CP = PropsSI("P", "T", Tnbp_CP, "Q", 1, "HEOS::" + mix));
             CAPTURE(pchk_CP);
-            CHECK_NOTHROW(Tnbp_RP = PropsSI("T", "P", 101325, "Q", 1, "REFPROP::" + mixe));
+            CHECK_NOTHROW(Tnbp_RP = PropsSI("T", "P", 101325, "Q", 1, "REFPROP::" + mix));
             CAPTURE(Tnbp_RP);
-            CHECK_NOTHROW(pchk_RP = PropsSI("P", "T", Tnbp_RP, "Q", 1, "REFPROP::" + mixe));
+            CHECK_NOTHROW(pchk_RP = PropsSI("P", "T", Tnbp_RP, "Q", 1, "REFPROP::" + mix));
             CAPTURE(pchk_RP);
             double diff = std::abs(Tnbp_CP / Tnbp_RP - 1);
             CHECK(diff < 1e-2);
@@ -1557,7 +1557,7 @@ TEST_CASE("P,T flash at the critical point returns rhomolar_critical", "[flash],
 TEST_CASE("Tests for solvers in P,Y flash using Water", "[flash],[PH],[PS],[PU]") {
     double Ts, y, T2;
     // See https://groups.google.com/forum/?fromgroups#!topic/catch-forum/mRBKqtTrITU
-    std::string Ykeys[] = {"H", "S", "U", "Hmass", "Smass", "Umass", "Hmolar", "Smolar", "Umolar"};
+    const std::vector<std::string> Ykeys = {"H", "S", "U", "Hmass", "Smass", "Umass", "Hmolar", "Smolar", "Umolar"};
     for (const auto& Ykey : Ykeys) {
         const char* ykey = Ykey.c_str();
         std::ostringstream ss1;
@@ -2273,19 +2273,19 @@ TEST_CASE("Test that reference states yield proper values using high-level inter
     std::string fluids[] = {"n-Propane", "R134a", "R124"};
     ref_entry entries[3] = {{"IIR", 200000, 1000, "T", 273.15, "Q", 0}, {"ASHRAE", 0, 0, "T", 233.15, "Q", 0}, {"NBP", 0, 0, "P", 101325, "Q", 0}};
     for (const auto& fluid : fluids) {
-        for (auto& entrie : entries) {
+        for (auto& entry : entries) {
             std::ostringstream ss1;
-            ss1 << "Check state for " << fluid << " for " + entrie.name + " reference state ";
+            ss1 << "Check state for " << fluid << " for " + entry.name + " reference state ";
             SECTION(ss1.str(), "") {
                 // First reset the reference state
                 set_reference_stateS(fluid, "DEF");
                 // Then set to desired reference state
-                set_reference_stateS(fluid, entrie.name);
+                set_reference_stateS(fluid, entry.name);
                 // Calculate the values
-                double hmass = PropsSI("Hmass", entrie.in1, entrie.val1, entrie.in2, entrie.val2, fluid);
-                double smass = PropsSI("Smass", entrie.in1, entrie.val1, entrie.in2, entrie.val2, fluid);
-                CHECK(std::abs(hmass - entrie.hmass) < 1e-8);
-                CHECK(std::abs(smass - entrie.smass) < 1e-8);
+                double hmass = PropsSI("Hmass", entry.in1, entry.val1, entry.in2, entry.val2, fluid);
+                double smass = PropsSI("Smass", entry.in1, entry.val1, entry.in2, entry.val2, fluid);
+                CHECK(std::abs(hmass - entry.hmass) < 1e-8);
+                CHECK(std::abs(smass - entry.smass) < 1e-8);
                 // Then reset the reference state
                 set_reference_stateS(fluid, "DEF");
             }
@@ -2305,12 +2305,12 @@ TEST_CASE("Test that reference states yield proper values using low-level interf
     std::string fluids[] = {"n-Propane", "R134a", "R124"};
     ref_entry entries[3] = {{"IIR", 200000, 1000, iT, 273.15, iQ, 0}, {"ASHRAE", 0, 0, iT, 233.15, iQ, 0}, {"NBP", 0, 0, iP, 101325, iQ, 0}};
     for (const auto& fluid : fluids) {
-        for (auto& entrie : entries) {
+        for (auto& entry : entries) {
             std::ostringstream ss1;
-            ss1 << "Check state for " << fluid << " for " + entrie.name + " reference state ";
+            ss1 << "Check state for " << fluid << " for " + entry.name + " reference state ";
             SECTION(ss1.str(), "") {
                 double val1, val2;
-                input_pairs pair = generate_update_pair(entrie.in1, entrie.val1, entrie.in2, entrie.val2, val1, val2);
+                input_pairs pair = generate_update_pair(entry.in1, entry.val1, entry.in2, entry.val2, val1, val2);
                 // Generate a state instance
                 shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", fluid));
                 AS->update(pair, val1, val2);
@@ -2325,7 +2325,7 @@ TEST_CASE("Test that reference states yield proper values using low-level interf
                 CHECK(std::abs(smass00 - smass0) < 1e-10);
 
                 // Then set to desired reference state
-                set_reference_stateS(fluid, entrie.name);
+                set_reference_stateS(fluid, entry.name);
 
                 // Should not change existing instance
                 AS->clear();
@@ -2340,8 +2340,8 @@ TEST_CASE("Test that reference states yield proper values using low-level interf
                 AS2->update(pair, val1, val2);
                 double hmass2 = AS2->hmass();
                 double smass2 = AS2->smass();
-                CHECK(std::abs(hmass2 - entrie.hmass) < 1e-8);
-                CHECK(std::abs(smass2 - entrie.smass) < 1e-8);
+                CHECK(std::abs(hmass2 - entry.hmass) < 1e-8);
+                CHECK(std::abs(smass2 - entry.smass) < 1e-8);
 
                 // Then reset the reference state
                 set_reference_stateS(fluid, "DEF");

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -35,15 +35,10 @@ struct vel
    public:
     std::string in1, in2, out, fluid;
     double v1, v2, tol, expected;
-    vel(std::string fluid, std::string in1, double v1, std::string in2, double v2, std::string out, double expected, double tol) {
-        this->in1 = in1;
-        this->in2 = in2;
-        this->fluid = fluid;
-        this->v1 = v1;
-        this->v2 = v2;
-        this->expected = expected;
-        this->tol = tol;
-    };
+    vel(std::string fluid, std::string in1, double v1, std::string in2, double v2, const std::string& out, double expected, double tol)
+      : in1(in1), in2(in2), fluid(fluid), v1(v1), v2(v2), expected(expected), tol(tol) {
+
+        };
 };
 
 vel viscosity_validation_data[] = {
@@ -313,9 +308,9 @@ class TransportValidationFixture
     CoolProp::input_pairs pair;
 
    public:
-    TransportValidationFixture() {}
-    ~TransportValidationFixture() {}
-    void set_backend(std::string backend, std::string fluid_name) {
+    TransportValidationFixture() = default;
+    ~TransportValidationFixture() = default;
+    void set_backend(const std::string& backend, const std::string& fluid_name) {
         pState.reset(CoolProp::AbstractState::factory(backend, fluid_name));
     }
     void set_pair(std::string& in1, double v1, std::string& in2, double v2) {
@@ -635,9 +630,9 @@ class ConsistencyFixture
     CoolProp::input_pairs pair;
 
    public:
-    ConsistencyFixture() {}
-    ~ConsistencyFixture() {}
-    void set_backend(std::string backend, std::string fluid_name) {
+    ConsistencyFixture() = default;
+    ~ConsistencyFixture() = default;
+    void set_backend(const std::string& backend, const std::string& fluid_name) {
         pState.reset(CoolProp::AbstractState::factory(backend, fluid_name));
     }
     void set_pair(CoolProp::input_pairs pair) {
@@ -803,9 +798,9 @@ TEST_CASE("Test saturation properties for a few fluids", "[saturation],[slow]") 
         std::vector<double> pv = linspace(Props1SI("CO2", "ptriple"), Props1SI("CO2", "pcrit") - 1e-6, 5);
 
         SECTION("All pressures are ok")
-        for (std::size_t i = 0; i < pv.size(); ++i) {
-            CAPTURE(pv[i]);
-            double T = CoolProp::PropsSI("T", "P", pv[i], "Q", 0, "CO2");
+        for (double i : pv) {
+            CAPTURE(i);
+            double T = CoolProp::PropsSI("T", "P", i, "Q", 0, "CO2");
         }
     }
 }
@@ -992,8 +987,7 @@ TEST_CASE("Humid-air h and s are consistent with individual EOS alpha0", "[humid
         // Tests that the alpha0-derived enthalpy is internally consistent.
         // Note: H+S alone cannot determine T (humidity ratio is unknown), so
         // we keep W=0 fixed and invert H(T, W=0, P) → T.
-        for (int i = 0; i < NT; ++i) {
-            const double T = Tvals[i];
+        for (double T : Tvals) {
             CAPTURE(T);
             double H = HumidAir::HAPropsSI("H", "T", T, "W", 0.0, "P", P);
             REQUIRE(ValidNumber(H));
@@ -1474,23 +1468,23 @@ TEST_CASE("Test consistency between Gernert models in CoolProp and Gernert model
     Skip_if_No_REFPROP();  // Skip this test if REFPROPMixture backend is not available
 
     std::string mixes[] = {"CO2[0.7]&Argon[0.3]", "CO2[0.7]&Water[0.3]", "CO2[0.7]&Nitrogen[0.3]"};
-    for (int i = 0; i < 3; ++i) {
-        const char* ykey = mixes[i].c_str();
+    for (const auto& mixe : mixes) {
+        const char* ykey = mixe.c_str();
         std::ostringstream ss1;
-        ss1 << mixes[i];
+        ss1 << mixe;
         SECTION(ss1.str(), "") {
             double Tnbp_CP, Tnbp_RP, R_RP, R_CP, pchk_CP, pchk_RP;
-            CHECK_NOTHROW(R_CP = PropsSI("gas_constant", "P", 101325, "Q", 1, "HEOS::" + mixes[i]));
+            CHECK_NOTHROW(R_CP = PropsSI("gas_constant", "P", 101325, "Q", 1, "HEOS::" + mixe));
             CAPTURE(R_CP);
-            CHECK_NOTHROW(R_RP = PropsSI("gas_constant", "P", 101325, "Q", 1, "REFPROP::" + mixes[i]));
+            CHECK_NOTHROW(R_RP = PropsSI("gas_constant", "P", 101325, "Q", 1, "REFPROP::" + mixe));
             CAPTURE(R_RP);
-            CHECK_NOTHROW(Tnbp_CP = PropsSI("T", "P", 101325, "Q", 1, "HEOS::" + mixes[i]));
+            CHECK_NOTHROW(Tnbp_CP = PropsSI("T", "P", 101325, "Q", 1, "HEOS::" + mixe));
             CAPTURE(Tnbp_CP);
-            CHECK_NOTHROW(pchk_CP = PropsSI("P", "T", Tnbp_CP, "Q", 1, "HEOS::" + mixes[i]));
+            CHECK_NOTHROW(pchk_CP = PropsSI("P", "T", Tnbp_CP, "Q", 1, "HEOS::" + mixe));
             CAPTURE(pchk_CP);
-            CHECK_NOTHROW(Tnbp_RP = PropsSI("T", "P", 101325, "Q", 1, "REFPROP::" + mixes[i]));
+            CHECK_NOTHROW(Tnbp_RP = PropsSI("T", "P", 101325, "Q", 1, "REFPROP::" + mixe));
             CAPTURE(Tnbp_RP);
-            CHECK_NOTHROW(pchk_RP = PropsSI("P", "T", Tnbp_RP, "Q", 1, "REFPROP::" + mixes[i]));
+            CHECK_NOTHROW(pchk_RP = PropsSI("P", "T", Tnbp_RP, "Q", 1, "REFPROP::" + mixe));
             CAPTURE(pchk_RP);
             double diff = std::abs(Tnbp_CP / Tnbp_RP - 1);
             CHECK(diff < 1e-2);
@@ -1564,8 +1558,8 @@ TEST_CASE("Tests for solvers in P,Y flash using Water", "[flash],[PH],[PS],[PU]"
     double Ts, y, T2;
     // See https://groups.google.com/forum/?fromgroups#!topic/catch-forum/mRBKqtTrITU
     std::string Ykeys[] = {"H", "S", "U", "Hmass", "Smass", "Umass", "Hmolar", "Smolar", "Umolar"};
-    for (int i = 0; i < 9; ++i) {
-        const char* ykey = Ykeys[i].c_str();
+    for (const auto& Ykey : Ykeys) {
+        const char* ykey = Ykey.c_str();
         std::ostringstream ss1;
         ss1 << "Subcritical superheated P," << ykey;
         SECTION(ss1.str(), "") {
@@ -1979,11 +1973,11 @@ TEST_CASE("REFPROP names for coolprop fluids", "[REFPROPName]") {
     Skip_if_No_REFPROP();  // Skip this test if REFPROPMixture backend is not available
 
     std::vector<std::string> fluids = strsplit(CoolProp::get_global_param_string("fluids_list"), ',');
-    for (std::size_t i = 0; i < fluids.size(); ++i) {
+    for (const auto& fluid : fluids) {
         std::ostringstream ss1;
-        ss1 << "Check that REFPROP fluid name for fluid " << fluids[i] << " is valid";
+        ss1 << "Check that REFPROP fluid name for fluid " << fluid << " is valid";
         SECTION(ss1.str(), "") {
-            std::string RPName = get_fluid_param_string(fluids[i], "REFPROPName");
+            std::string RPName = get_fluid_param_string(fluid, "REFPROPName");
             CHECK(!RPName.empty());
             CAPTURE(RPName);
             if (!RPName.compare("N/A")) {
@@ -2019,8 +2013,8 @@ class AncillaryFixture
     std::string name;
     void run_checks() {
         std::vector<std::string> fluids = strsplit(CoolProp::get_global_param_string("fluids_list"), ',');
-        for (std::size_t i = 0; i < fluids.size(); ++i) {
-            shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", fluids[i]));
+        for (const auto& fluid : fluids) {
+            shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", fluid));
             auto* rHEOS = dynamic_cast<HelmholtzEOSMixtureBackend*>(AS.get());
             if (!rHEOS->is_pure()) {
                 continue;
@@ -2101,8 +2095,8 @@ class AncillaryFixture
 
 TEST_CASE("Triple point checks", "[triple_point]") {
     std::vector<std::string> fluids = strsplit(CoolProp::get_global_param_string("fluids_list"), ',');
-    for (std::size_t i = 0; i < fluids.size(); ++i) {
-        std::vector<std::string> names(1, fluids[i]);
+    for (const auto& fluid : fluids) {
+        std::vector<std::string> names(1, fluid);
         shared_ptr<CoolProp::HelmholtzEOSMixtureBackend> HEOS = std::make_shared<CoolProp::HelmholtzEOSMixtureBackend>(names);
         // Skip pseudo-pure
         if (!HEOS->is_pure()) {
@@ -2110,7 +2104,7 @@ TEST_CASE("Triple point checks", "[triple_point]") {
         }
 
         std::ostringstream ss1;
-        ss1 << "Minimum saturation temperature state matches for liquid " << fluids[i];
+        ss1 << "Minimum saturation temperature state matches for liquid " << fluid;
         SECTION(ss1.str(), "") {
             REQUIRE_NOTHROW(HEOS->update(CoolProp::QT_INPUTS, 0, HEOS->Ttriple()));
             double p_EOS = HEOS->p();
@@ -2125,7 +2119,7 @@ TEST_CASE("Triple point checks", "[triple_point]") {
             CHECK(err_sat_min_liquid < 1e-3);
         }
         std::ostringstream ss2;
-        ss2 << "Minimum saturation temperature state matches for vapor " << fluids[i];
+        ss2 << "Minimum saturation temperature state matches for vapor " << fluid;
         SECTION(ss2.str(), "") {
             REQUIRE_NOTHROW(HEOS->update(CoolProp::QT_INPUTS, 1, HEOS->Ttriple()));
 
@@ -2141,7 +2135,7 @@ TEST_CASE("Triple point checks", "[triple_point]") {
             CHECK(err_sat_min_vapor < 1e-3);
         }
         std::ostringstream ss3;
-        ss3 << "Minimum saturation temperature state matches for vapor " << fluids[i];
+        ss3 << "Minimum saturation temperature state matches for vapor " << fluid;
         SECTION(ss3.str(), "") {
             if (HEOS->p_triple() < 10) {
                 continue;
@@ -2157,7 +2151,7 @@ TEST_CASE("Triple point checks", "[triple_point]") {
             CHECK(err_sat_min_vapor < 1e-3);
         }
         std::ostringstream ss4;
-        ss4 << "Minimum saturation temperature state matches for liquid " << fluids[i];
+        ss4 << "Minimum saturation temperature state matches for liquid " << fluid;
         SECTION(ss4.str(), "") {
             if (HEOS->p_triple() < 10) {
                 continue;
@@ -2205,8 +2199,8 @@ class SatTFixture
     double Tc;
     void run_checks() {
         std::vector<std::string> fluids = strsplit(CoolProp::get_global_param_string("fluids_list"), ',');
-        for (std::size_t i = 0; i < fluids.size(); ++i) {
-            shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", fluids[i]));
+        for (const auto& fluid : fluids) {
+            shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", fluid));
             auto* rHEOS = dynamic_cast<HelmholtzEOSMixtureBackend*>(AS.get());
             if (!rHEOS->is_pure()) {
                 continue;
@@ -2278,22 +2272,22 @@ TEST_CASE("Test that reference states yield proper values using high-level inter
     };
     std::string fluids[] = {"n-Propane", "R134a", "R124"};
     ref_entry entries[3] = {{"IIR", 200000, 1000, "T", 273.15, "Q", 0}, {"ASHRAE", 0, 0, "T", 233.15, "Q", 0}, {"NBP", 0, 0, "P", 101325, "Q", 0}};
-    for (std::size_t i = 0; i < 3; ++i) {
-        for (std::size_t j = 0; j < 3; ++j) {
+    for (const auto& fluid : fluids) {
+        for (auto& entrie : entries) {
             std::ostringstream ss1;
-            ss1 << "Check state for " << fluids[i] << " for " + entries[j].name + " reference state ";
+            ss1 << "Check state for " << fluid << " for " + entrie.name + " reference state ";
             SECTION(ss1.str(), "") {
                 // First reset the reference state
-                set_reference_stateS(fluids[i], "DEF");
+                set_reference_stateS(fluid, "DEF");
                 // Then set to desired reference state
-                set_reference_stateS(fluids[i], entries[j].name);
+                set_reference_stateS(fluid, entrie.name);
                 // Calculate the values
-                double hmass = PropsSI("Hmass", entries[j].in1, entries[j].val1, entries[j].in2, entries[j].val2, fluids[i]);
-                double smass = PropsSI("Smass", entries[j].in1, entries[j].val1, entries[j].in2, entries[j].val2, fluids[i]);
-                CHECK(std::abs(hmass - entries[j].hmass) < 1e-8);
-                CHECK(std::abs(smass - entries[j].smass) < 1e-8);
+                double hmass = PropsSI("Hmass", entrie.in1, entrie.val1, entrie.in2, entrie.val2, fluid);
+                double smass = PropsSI("Smass", entrie.in1, entrie.val1, entrie.in2, entrie.val2, fluid);
+                CHECK(std::abs(hmass - entrie.hmass) < 1e-8);
+                CHECK(std::abs(smass - entrie.smass) < 1e-8);
                 // Then reset the reference state
-                set_reference_stateS(fluids[i], "DEF");
+                set_reference_stateS(fluid, "DEF");
             }
         }
     }
@@ -2310,20 +2304,20 @@ TEST_CASE("Test that reference states yield proper values using low-level interf
     };
     std::string fluids[] = {"n-Propane", "R134a", "R124"};
     ref_entry entries[3] = {{"IIR", 200000, 1000, iT, 273.15, iQ, 0}, {"ASHRAE", 0, 0, iT, 233.15, iQ, 0}, {"NBP", 0, 0, iP, 101325, iQ, 0}};
-    for (std::size_t i = 0; i < 3; ++i) {
-        for (std::size_t j = 0; j < 3; ++j) {
+    for (const auto& fluid : fluids) {
+        for (auto& entrie : entries) {
             std::ostringstream ss1;
-            ss1 << "Check state for " << fluids[i] << " for " + entries[j].name + " reference state ";
+            ss1 << "Check state for " << fluid << " for " + entrie.name + " reference state ";
             SECTION(ss1.str(), "") {
                 double val1, val2;
-                input_pairs pair = generate_update_pair(entries[j].in1, entries[j].val1, entries[j].in2, entries[j].val2, val1, val2);
+                input_pairs pair = generate_update_pair(entrie.in1, entrie.val1, entrie.in2, entrie.val2, val1, val2);
                 // Generate a state instance
-                shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", fluids[i]));
+                shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", fluid));
                 AS->update(pair, val1, val2);
                 double hmass0 = AS->hmass();
                 double smass0 = AS->smass();
                 // First reset the reference state
-                set_reference_stateS(fluids[i], "DEF");
+                set_reference_stateS(fluid, "DEF");
                 AS->update(pair, val1, val2);
                 double hmass00 = AS->hmass();
                 double smass00 = AS->smass();
@@ -2331,7 +2325,7 @@ TEST_CASE("Test that reference states yield proper values using low-level interf
                 CHECK(std::abs(smass00 - smass0) < 1e-10);
 
                 // Then set to desired reference state
-                set_reference_stateS(fluids[i], entries[j].name);
+                set_reference_stateS(fluid, entrie.name);
 
                 // Should not change existing instance
                 AS->clear();
@@ -2342,15 +2336,15 @@ TEST_CASE("Test that reference states yield proper values using low-level interf
                 CHECK(std::abs(smass1 - smass0) < 1e-10);
 
                 // New instance - should get updated reference state
-                shared_ptr<CoolProp::AbstractState> AS2(CoolProp::AbstractState::factory("HEOS", fluids[i]));
+                shared_ptr<CoolProp::AbstractState> AS2(CoolProp::AbstractState::factory("HEOS", fluid));
                 AS2->update(pair, val1, val2);
                 double hmass2 = AS2->hmass();
                 double smass2 = AS2->smass();
-                CHECK(std::abs(hmass2 - entries[j].hmass) < 1e-8);
-                CHECK(std::abs(smass2 - entries[j].smass) < 1e-8);
+                CHECK(std::abs(hmass2 - entrie.hmass) < 1e-8);
+                CHECK(std::abs(smass2 - entrie.smass) < 1e-8);
 
                 // Then reset the reference state
-                set_reference_stateS(fluids[i], "DEF");
+                set_reference_stateS(fluid, "DEF");
             }
         }
     }
@@ -2429,12 +2423,12 @@ class FixedStateFixture
     void run_checks() {
 
         std::vector<std::string> fluids = strsplit(CoolProp::get_global_param_string("fluids_list"), ',');
-        for (std::size_t i = 0; i < fluids.size(); ++i) {
+        for (const auto& fluid : fluids) {
             std::string ref_state[4] = {"DEF", "IIR", "ASHRAE", "NBP"};
-            for (std::size_t j = 0; j < 4; ++j) {
+            for (const auto& j : ref_state) {
                 std::string states[] = {"hs_anchor", "reducing", "critical", "max_sat_T", "max_sat_p", "triple_liquid", "triple_vapor"};
-                for (std::size_t k = 0; k < 7; ++k) {
-                    run_fluid(fluids[i], states[k], ref_state[j]);
+                for (const auto& state : states) {
+                    run_fluid(fluid, state, j);
                 }
             }
         }
@@ -2453,28 +2447,28 @@ TEST_CASE("Check the first partial derivatives", "[first_saturation_partial_deri
     pair pairs[number_of_pairs] = {{iP, iT}, {iDmolar, iT}, {iHmolar, iT}, {iSmolar, iT}, {iUmolar, iT},
                                    {iT, iP}, {iDmolar, iP}, {iHmolar, iP}, {iSmolar, iP}, {iUmolar, iP}};
     shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "n-Propane"));
-    for (std::size_t i = 0; i < number_of_pairs; ++i) {
+    for (auto& pair : pairs) {
         // See https://groups.google.com/forum/?fromgroups#!topic/catch-forum/mRBKqtTrITU
         std::ostringstream ss1;
-        ss1 << "Check first partial derivative for d(" << get_parameter_information(pairs[i].p1, "short") << ")/d("
-            << get_parameter_information(pairs[i].p2, "short") << ")|sat";
+        ss1 << "Check first partial derivative for d(" << get_parameter_information(pair.p1, "short") << ")/d("
+            << get_parameter_information(pair.p2, "short") << ")|sat";
         SECTION(ss1.str(), "") {
             AS->update(QT_INPUTS, 1, 300);
             CoolPropDbl p = AS->p();
-            CoolPropDbl analytical = AS->first_saturation_deriv(pairs[i].p1, pairs[i].p2);
+            CoolPropDbl analytical = AS->first_saturation_deriv(pair.p1, pair.p2);
             CAPTURE(analytical);
             CoolPropDbl numerical;
-            if (pairs[i].p2 == iT) {
+            if (pair.p2 == iT) {
                 AS->update(QT_INPUTS, 1, 300 + 1e-5);
-                CoolPropDbl v1 = AS->keyed_output(pairs[i].p1);
+                CoolPropDbl v1 = AS->keyed_output(pair.p1);
                 AS->update(QT_INPUTS, 1, 300 - 1e-5);
-                CoolPropDbl v2 = AS->keyed_output(pairs[i].p1);
+                CoolPropDbl v2 = AS->keyed_output(pair.p1);
                 numerical = (v1 - v2) / (2e-5);
-            } else if (pairs[i].p2 == iP) {
+            } else if (pair.p2 == iP) {
                 AS->update(PQ_INPUTS, p + 1e-2, 1);
-                CoolPropDbl v1 = AS->keyed_output(pairs[i].p1);
+                CoolPropDbl v1 = AS->keyed_output(pair.p1);
                 AS->update(PQ_INPUTS, p - 1e-2, 1);
-                CoolPropDbl v2 = AS->keyed_output(pairs[i].p1);
+                CoolPropDbl v2 = AS->keyed_output(pair.p1);
                 numerical = (v1 - v2) / (2e-2);
             } else {
                 throw ValueError();
@@ -2493,24 +2487,24 @@ TEST_CASE("Check the second saturation derivatives", "[second_saturation_partial
     };
     pair pairs[number_of_pairs] = {{iT, iP, iP}, {iDmolar, iP, iP}, {iHmolar, iP, iP}, {iSmolar, iP, iP}, {iUmolar, iP, iP}};
     shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "n-Propane"));
-    for (std::size_t i = 0; i < number_of_pairs; ++i) {
+    for (auto& pair : pairs) {
         // See https://groups.google.com/forum/?fromgroups#!topic/catch-forum/mRBKqtTrITU
         std::ostringstream ss1;
-        ss1 << "Check second saturation derivative for d2(" << get_parameter_information(pairs[i].p1, "short") << ")/d("
-            << get_parameter_information(pairs[i].p2, "short") << ")2|sat";
+        ss1 << "Check second saturation derivative for d2(" << get_parameter_information(pair.p1, "short") << ")/d("
+            << get_parameter_information(pair.p2, "short") << ")2|sat";
         SECTION(ss1.str(), "") {
             AS->update(QT_INPUTS, 1, 300);
             CoolPropDbl p = AS->p();
-            CoolPropDbl analytical = AS->second_saturation_deriv(pairs[i].p1, pairs[i].p2, pairs[i].p3);
+            CoolPropDbl analytical = AS->second_saturation_deriv(pair.p1, pair.p2, pair.p3);
             CAPTURE(analytical);
             CoolPropDbl numerical;
-            if (pairs[i].p2 == iT) {
+            if (pair.p2 == iT) {
                 throw NotImplementedError();
-            } else if (pairs[i].p2 == iP) {
+            } else if (pair.p2 == iP) {
                 AS->update(PQ_INPUTS, p + 1e-2, 1);
-                CoolPropDbl v1 = AS->first_saturation_deriv(pairs[i].p1, pairs[i].p2);
+                CoolPropDbl v1 = AS->first_saturation_deriv(pair.p1, pair.p2);
                 AS->update(PQ_INPUTS, p - 1e-2, 1);
-                CoolPropDbl v2 = AS->first_saturation_deriv(pairs[i].p1, pairs[i].p2);
+                CoolPropDbl v2 = AS->first_saturation_deriv(pair.p1, pair.p2);
                 numerical = (v1 - v2) / (2e-2);
             } else {
                 throw ValueError();
@@ -2529,29 +2523,29 @@ TEST_CASE("Check the first two-phase derivative", "[first_two_phase_deriv]") {
     };
     pair pairs[number_of_pairs] = {{iDmass, iP, iHmass}, {iDmolar, iP, iHmolar}, {iDmolar, iHmolar, iP}, {iDmass, iHmass, iP}};
     shared_ptr<CoolProp::HelmholtzEOSBackend> AS = std::make_shared<CoolProp::HelmholtzEOSBackend>("n-Propane");
-    for (std::size_t i = 0; i < number_of_pairs; ++i) {
+    for (auto& pair : pairs) {
         // See https://groups.google.com/forum/?fromgroups#!topic/catch-forum/mRBKqtTrITU
         std::ostringstream ss1;
-        ss1 << "for (" << get_parameter_information(pairs[i].p1, "short") << ", " << get_parameter_information(pairs[i].p2, "short") << ", "
-            << get_parameter_information(pairs[i].p3, "short") << ")";
+        ss1 << "for (" << get_parameter_information(pair.p1, "short") << ", " << get_parameter_information(pair.p2, "short") << ", "
+            << get_parameter_information(pair.p3, "short") << ")";
         SECTION(ss1.str(), "") {
             AS->update(QT_INPUTS, 0.3, 300);
             CoolPropDbl numerical;
-            CoolPropDbl analytical = AS->first_two_phase_deriv(pairs[i].p1, pairs[i].p2, pairs[i].p3);
+            CoolPropDbl analytical = AS->first_two_phase_deriv(pair.p1, pair.p2, pair.p3);
             CAPTURE(analytical);
 
             CoolPropDbl out1, out2;
             CoolPropDbl v2base, v3base;
-            v2base = AS->keyed_output(pairs[i].p2);
-            v3base = AS->keyed_output(pairs[i].p3);
+            v2base = AS->keyed_output(pair.p2);
+            v3base = AS->keyed_output(pair.p3);
             CoolPropDbl v2plus = v2base * 1.001;
             CoolPropDbl v2minus = v2base * 0.999;
-            CoolProp::input_pairs input_pair1 = generate_update_pair(pairs[i].p2, v2plus, pairs[i].p3, v3base, out1, out2);
+            CoolProp::input_pairs input_pair1 = generate_update_pair(pair.p2, v2plus, pair.p3, v3base, out1, out2);
             AS->update(input_pair1, out1, out2);
-            CoolPropDbl v1 = AS->keyed_output(pairs[i].p1);
-            CoolProp::input_pairs input_pair2 = generate_update_pair(pairs[i].p2, v2minus, pairs[i].p3, v3base, out1, out2);
+            CoolPropDbl v1 = AS->keyed_output(pair.p1);
+            CoolProp::input_pairs input_pair2 = generate_update_pair(pair.p2, v2minus, pair.p3, v3base, out1, out2);
             AS->update(input_pair2, out1, out2);
-            CoolPropDbl v2 = AS->keyed_output(pairs[i].p1);
+            CoolPropDbl v2 = AS->keyed_output(pair.p1);
 
             numerical = (v1 - v2) / (v2plus - v2minus);
             CAPTURE(numerical);
@@ -3670,7 +3664,7 @@ TEST_CASE("Superancillary source_eos_hash matches current EOS at bit level", "[a
         std::string hex() const {
             char buf[17];
             std::snprintf(buf, sizeof(buf), "%016llx", static_cast<unsigned long long>(h));
-            return std::string(buf);
+            return {buf};
         }
     };
 
@@ -3701,7 +3695,7 @@ TEST_CASE("Superancillary source_eos_hash matches current EOS at bit level", "[a
     // Decompress the raw all_fluids JSON bytes — the same blob FluidLibrary
     // loads, but without the subsequent rapidjson round-trip.
     std::vector<unsigned char> buf(gall_fluids_JSON_zSize * 7);
-    mz_ulong out_len = static_cast<mz_ulong>(buf.size());
+    auto out_len = static_cast<mz_ulong>(buf.size());
     REQUIRE(mz_uncompress(buf.data(), &out_len, gall_fluids_JSON_zData, gall_fluids_JSON_zSize) == MZ_OK);
     auto all_fluids = nlohmann::json::parse(buf.begin(), buf.begin() + out_len);
 
@@ -3883,13 +3877,13 @@ TEST_CASE_METHOD(SuperAncillaryOnFixture, "Benchmarking caching options", "[cach
     std::array<bool, 100> bool100;
     bool100.fill(false);
     std::vector<CachedElement> cache100(100);
-    for (auto i = 0; i < cache100.size(); ++i) {
-        cache100[i] = _HUGE;
+    for (auto& i : cache100) {
+        i = _HUGE;
     }
 
     std::vector<std::optional<double>> opt100(100);
-    for (auto i = 0; i < opt100.size(); ++i) {
-        opt100[i] = _HUGE;
+    for (auto& i : opt100) {
+        i = _HUGE;
     }
 
     BENCHMARK("memset array15 w/ 0") {
@@ -3925,14 +3919,14 @@ TEST_CASE_METHOD(SuperAncillaryOnFixture, "Benchmarking caching options", "[cach
         return buf100;
     };
     BENCHMARK("fill cache100") {
-        for (auto i = 0; i < cache100.size(); ++i) {
-            cache100[i] = _HUGE;
+        for (auto& i : cache100) {
+            i = _HUGE;
         }
         return cache100;
     };
     BENCHMARK("fill opt100") {
-        for (auto i = 0; i < opt100.size(); ++i) {
-            opt100[i] = _HUGE;
+        for (auto& i : opt100) {
+            i = _HUGE;
         }
         return opt100;
     };
@@ -6144,6 +6138,28 @@ TEST_CASE("REFPROP cross-check: sat-state fugacity_coefficient agrees with HEOS 
         CHECK(std::abs(phiL_heos - phiL_rp) / std::abs(phiL_rp) < 1e-2);
         CHECK(std::abs(phiV_heos - phiV_rp) / std::abs(phiV_rp) < 1e-2);
     }
+}
+
+// Regression guard for the SurfaceTensionCorrelation ctor: a clang-tidy
+// prefer-member-initializer "fix" once hoisted N=n.size() and s=n into the
+// member-init list, where n is still empty (it's populated in the body), so
+// every surface tension silently evaluated to 0.0.  These checks fail loudly
+// if that ever recurs.  IAPWS reference values, ~1% tolerance.
+TEST_CASE("Surface tension of water is nonzero and matches IAPWS", "[surface_tension]") {
+    const double st_300 = CoolProp::PropsSI("I", "T", 300, "Q", 0, "Water");
+    const double st_350 = CoolProp::PropsSI("I", "T", 350, "Q", 0, "Water");
+    CAPTURE(st_300);
+    CAPTURE(st_350);
+    // Load-bearing: the regression made these exactly 0.
+    CHECK(st_300 > 0.0);
+    CHECK(st_350 > 0.0);
+    // IAPWS: sigma(300 K) ~ 0.07170 N/m, sigma(350 K) ~ 0.06301 N/m.
+    CHECK(st_300 == Catch::Approx(0.07170).epsilon(0.01));
+    CHECK(st_350 == Catch::Approx(0.06301).epsilon(0.01));
+    // Surface tension decreases monotonically toward the critical point.
+    CHECK(st_350 < st_300);
+    // A second fluid, looser bound, just to exercise another correlation.
+    CHECK(CoolProp::PropsSI("I", "T", 300, "Q", 0, "R134a") > 0.0);
 }
 
 #endif

--- a/src/Tests/Tests.cpp
+++ b/src/Tests/Tests.cpp
@@ -19,7 +19,7 @@ int run_fast_tests() {
 #ifdef ENABLE_CATCH
     Catch::ConfigData& config = session.configData();
     config.testsOrTags.clear();
-    config.testsOrTags.push_back("[fast]");
+    config.testsOrTags.emplace_back("[fast]");
     session.useConfigData(config);
     return session.run();
 #else
@@ -31,7 +31,7 @@ int run_not_slow_tests() {
 #ifdef ENABLE_CATCH
     Catch::ConfigData& config = session.configData();
     config.testsOrTags.clear();
-    config.testsOrTags.push_back("~[slow]");
+    config.testsOrTags.emplace_back("~[slow]");
     session.useConfigData(config);
 
     time_t t1, t2;
@@ -50,8 +50,8 @@ int run_user_defined_tests(const std::vector<std::string>& tests_or_tags) {
 #ifdef ENABLE_CATCH
     Catch::ConfigData& config = session.configData();
     config.testsOrTags.clear();
-    for (unsigned int i = 0; i < tests_or_tags.size(); i++) {
-        config.testsOrTags.push_back(tests_or_tags[i]);
+    for (const auto& tests_or_tag : tests_or_tags) {
+        config.testsOrTags.push_back(tests_or_tag);
     }
     session.useConfigData(config);
 


### PR DESCRIPTION
## What

Mechanical clang-tidy fix-it sweep — the leftover modernize/perf batch from the **layer-2 triage** (CoolProp-1pr) that #2980 did not run. Pairs with #3018 (Tier-1). 70 files, behavior-preserving.

## Checks applied

Override the `.clang-tidy` whitelist for this run:

| Check | Effect |
|---|---|
| `performance-unnecessary-value-param` | pass containers/strings by `const&` |
| `cppcoreguidelines-prefer-member-initializer` | ctor-body assign → init list |
| `modernize-use-auto` | `auto` for `new` / iterators |
| `modernize-loop-convert` | range-based `for` |
| `modernize-use-equals-default` | `{}` → `= default` |
| `modernize-use-using` | `typedef` → `using` |
| `modernize-return-braced-init-list`, `-raw-string-literal`, `-use-emplace`, `performance-unnecessary-copy-initialization` | small mechanical |

## How it was run (safely)

The naïve `run-clang-tidy -fix` approach has two footguns that I hit and worked around:
- **Anchored header-filter** `^<repo>/(include|src)/` — an unanchored `(include|src)` matches `build_catch/_deps/eigen-src/Eigen/src/` and `_deps/rapidjson-src/include/`, corrupting third-party trees.
- **Per-file sequential `clang-tidy -fix`** (not `run-clang-tidy`'s export+apply) — the YAML-merge path double-applies the same shared-header constructor fix from multiple TUs (`: a(a) : a(a) {`). Sequential application fixes each header once.

Formatted with the pinned clang-format 18.1.8.

## Caught-and-reverted regression (⚠️ adversarial review value)

The `prefer-member-initializer` fix wrongly hoisted `N = n.size(); s = n;` into the `SurfaceTensionCorrelation(rapidjson::Value&)` member-init list (`include/Ancillaries.h`). `n` is populated in the constructor **body**, so at init-list time it's empty → `N=0`, `s={}` → `evaluate()` silently returns **0.0 for every fluid's surface tension**. The full test suite missed it because **no surface-tension test existed**.

Fix: that one constructor assigns `N`/`s` in the body (NOLINT + explanatory comment), and a new `[surface_tension]` regression test checks water σ against IAPWS at 300/350 K (and would fail loudly on the `0.0` regression).

## Verification

- Full `~[slow]~[benchmark]` suite: **298 cases, 117,586 assertions, 0 failures**.
- Per-check confirmation: swept files drop to ~0 remaining Tier-2 findings.
- Adversarial review (two passes): the one regression found and fixed; all other hoisted init-lists confirmed to read only params/constants, not later-assigned siblings.
- Whole-file clang-tidy/cppcheck in preflight skipped (pre-existing other-category findings in these legacy files; this PR is itself the clang-tidy cleanup); clang-format + semgrep + tests pass.

## Follow-up

- Recommend adding the squashed commit to `.git-blame-ignore-revs` (mechanical sweep), matching #2803/#2805/#2808/#2980.
- Vendored `include/superancillary/superancillary.h` carries trivial `=default`/`auto` fixes; the same should go upstream to avoid a re-vendor clobber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Broad modernization across the codebase: cleaner initialization, defaulted special members, safer parameter passing, fewer unnecessary copies, and updated iteration/alias styles to improve stability and maintainability.
* **Tests**
  * Test suite cleaned up for reliability and readability; new regression validating nonzero surface tension behavior for water added.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3019?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->