### PR TITLE
fix(superancillary): guard balance_matrix against non-finite norms (devdocs Propyne hang)

### DIFF
--- a/include/superancillary/superancillary.h
+++ b/include/superancillary/superancillary.h
@@ -34,6 +34,7 @@ Subsequent edits by Ian Bell
 #pragma once
 
 #include <atomic>
+#include <cmath>
 #include <cstdio>
 #include <mutex>
 #include <utility>
@@ -62,12 +63,22 @@ inline void balance_matrix(const Matrix& A, Matrix& Aprime, Matrix& D) {
         for (Eigen::Index i = 0; i < A.rows(); ++i) {
             double c = Aprime.col(i).template lpNorm<p>();
             double r = Aprime.row(i).template lpNorm<p>();
+            // A row/column norm that is zero or non-finite cannot be balanced by
+            // diagonal scaling, and worse, it spins the scaling loops below
+            // forever: e.g. r == inf makes (c < r/beta) perpetually true while
+            // c *= beta never catches up (inf/beta == inf), and the symmetric
+            // (c >= r*beta) loop traps once c overflows to inf. The companion
+            // matrix picks up an inf entry from a near-zero leading Chebyshev
+            // coefficient (last column is -coeffs.head(N)/(2*coeffs(N))); whether
+            // that division overflows is FP-rounding-dependent, so the hang is
+            // platform-specific. Leave such a row/column at unit scaling: the
+            // eigenvalue solve still runs and the caller falls through on the
+            // (degenerate) result instead of looping forever.
+            if (!std::isfinite(c) || !std::isfinite(r) || c == 0.0 || r == 0.0) {
+                continue;
+            }
             double s = pow(c, p) + pow(r, p);
             double f = 1;
-            //if (!ValidNumber(c)){
-            //    std::cout << A << std::endl;
-            //    throw std::range_error("c is not a valid number in balance_matrix"); }
-            //if (!ValidNumber(r)) { throw std::range_error("r is not a valid number in balance_matrix"); }
             while (c < r / beta) {
                 c *= beta;
                 r /= beta;

--- a/src/Tests/CoolProp-Tests-HSU_D.cpp
+++ b/src/Tests/CoolProp-Tests-HSU_D.cpp
@@ -38,12 +38,14 @@
 #include "DataStructures.h"
 #include "Configuration.h"
 #include "../Backends/Helmholtz/HelmholtzEOSMixtureBackend.h"
+#include "superancillary/superancillary.h"
 
 #if defined(ENABLE_CATCH)
 #    include <catch2/catch_all.hpp>
 
 #    include <cmath>
 #    include <cstdlib>
+#    include <limits>
 #    include <memory>
 #    include <string>
 #    include <vector>
@@ -584,6 +586,39 @@ TEST_CASE("HSU_D: dense PT sweep over all superancillary fluids", "[HSU_D_ptswee
             }
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Regression: the matrix-balancing helper used by the superancillary
+// Chebyshev root finder (CoolProp::superancillary::detail::balance_matrix) must
+// always terminate, even when a companion-matrix row/column norm is non-finite.
+//
+// A near-zero leading Chebyshev coefficient makes the companion matrix's last
+// column (-coeffs.head(N)/(2*coeffs(N))) overflow to +/-inf. With an inf row
+// norm r, the scaling loop condition (c < r/beta) is perpetually true and
+// c *= beta never catches up, so balance_matrix spun forever -- the root cause
+// of the devdocs consistency-plot hang (Propyne D+H flash on x86 Linux, exposed
+// when #2995 routed D+{H,S,U} through get_all_intersections -> get_x_for_y ->
+// balance_matrix). The hang was FP-rounding dependent, hence x86-only.
+//
+// This drives balance_matrix directly with an inf entry so the guard is
+// exercised hermetically on every platform. Without the fix the test hangs.
+// ---------------------------------------------------------------------------
+TEST_CASE("balance_matrix terminates on a non-finite companion entry", "[HSU_D][balance_matrix]") {
+    Eigen::MatrixXd A(3, 3), Aprime, D;
+    A.setZero();
+    A(1, 0) = 1.0;
+    A(2, 1) = 1.0;
+    // Last column as produced by a near-zero leading coefficient: overflows to inf.
+    A(0, 2) = -1.0 / (2.0 * std::numeric_limits<double>::min() * std::numeric_limits<double>::min());
+    REQUIRE(std::isinf(A(0, 2)));
+
+    // Must return (terminate) rather than spin in the scaling loops.
+    CoolProp::superancillary::detail::balance_matrix(A, Aprime, D);
+
+    // The inf row/column is left at unit scaling; finite rows stay finite.
+    CHECK(std::isfinite(D(1, 1)));
+    CHECK(D(1, 1) == 1.0);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Symptom

Since 2026-05-27, every devdocs build (https://github.com/CoolProp/devdocs) hangs ~6h then gets cancelled at GitHub's hard 6-hour job cap, so no documentation has published. Last passing run: 2026-05-26 19:04 UTC. The hang sits silently in the docs `Build homepage and create graphs` step → consistency-plot loop → fluid **Propyne**, panel `DmolarHmolar`: last per-panel print at 19:51:53, dead air until `context canceled` at 01:05:30.

## Root cause

`detail::balance_matrix` (`include/superancillary/superancillary.h:51-92`) has unbounded inner scaling loops:

```cpp
while (c < r / beta) { c *= beta; r /= beta; f *= beta; }
while (c >= r * beta) { c /= beta; r *= beta; f /= beta; }
```

When a row/column norm is non-finite or zero these spin forever — e.g. `r==inf` makes `c < r/beta` perpetually true and `c *= beta` cannot catch up (`inf/beta == inf`); once `c` itself overflows the symmetric loop traps on `inf >= inf`. The outer `iter>50` cap never fires because we never exit the inner `while`. The commented-out lines 67-70 show the original author already suspected this risk but disabled the guard.

**How #2995 exposed it:** the new HSU_D superancillary "happy path" routes D+{H,S,U} through

```
get_all_intersections('D', rho, …) → get_x_for_y → determine_extrema
    → companion_matrix_transposed   // last column = -coeffs.head(N)/(2*coeffs(N))
    → balance_matrix
```

`companion_matrix_transposed`'s last column divides by `coeffs(N)` (the trimmed leading Chebyshev coefficient). The right-trim only strips *exact* zeros, so a tiny-but-nonzero leading coeff slips through and the division overflows to ±`inf`. Whether that division overflows vs. produces a huge-but-finite number is **FP-rounding-sensitive**, which is exactly why the hang manifests on x86-64 Linux (the docs container) but does **not** reproduce on ARM macOS for the same Propyne grid point.

## Fix

Skip balancing any row/column whose norm is non-finite or zero — leave it at unit scaling and let the eigenvalue solve run on the (degenerate) matrix. The downstream filter at `superancillary.h:529-530` (`std::abs(im) < thresh_im` AND `re_n11 in [-1,1]`) drops the resulting NaN/inf eigenvalues, so the caller falls through cleanly on the degenerate result instead of spinning forever.

```cpp
if (!std::isfinite(c) || !std::isfinite(r) || c == 0.0 || r == 0.0) {
    continue;
}
```

(+ `#include <cmath>` for `std::isfinite`; replaces the dead commented-out lines.)

## Verification (this build, ARM macOS)

| Check | Result |
|---|---|
| New `[balance_matrix]` regression test (drives `balance_matrix` directly with an `inf` entry; `REQUIRE(isinf)` self-check guards against any platform that defies IEEE underflow) | **Pass (3/3 assertions)** — pre-fix it hangs; post-fix it terminates with the inf row left at unit scaling |
| `[HSU_D]` suite | 12/14 pass, 2 REFPROP-skipped, **56 935 / 56 935 assertions** |
| `[HSU_D_ptsweep]` (1.86M-assertion sweep over all SA fluids) | 37 failures, **identical fluid set and count to pre-fix** (all OrthoHydrogen `D<DLtriple`, tracked in `CoolProp-j3n.2`). Zero new failures. |
| `./dev/ci/preflight.sh` (clang-format, build, `[!slow][!benchmark]` tests, cppcheck, clang-tidy diff, semgrep) | **6 passed / 0 failed** |
| Pre-PR adversarial review (`superpowers:code-reviewer` subagent) | **No blocking findings** — every failure mode of the inner whiles (`r==inf`, `c==inf`, both-inf, `c=r=0`, `c=0,r>0`, `c>0,r=0`, NaN) enumerated and the guard confirmed necessary and sufficient; downstream NaN/inf filter cross-checked; no other callers of `balance_matrix` depend on the old behavior. |

## What this PR cannot verify locally

The hang itself is FP-rounding-platform-sensitive (x86-only) and did not reproduce on ARM via either the happy or legacy path on the exact 200×200 docs grid. The fix is correct by direct unit test of the precise degenerate input (`balance_matrix` no longer infinite-loops on `inf`) and the chain from #2995 → `get_all_intersections('D')` → `balance_matrix` is confirmed by inspection. **End-to-end docs unblock will be confirmed by the next CoolProp-master push triggering a fresh devdocs build** (current hung runs: https://github.com/CoolProp/devdocs/actions).

## Related

- Introduced by #2995 (HSU_D superancillary happy path) — that PR's design intent is preserved; this just makes the underlying matrix-balancer robust against the degenerate companion-matrix input that the new code path can produce on x86.
- Sibling defect in the same `HSU_D` happy path: `CoolProp-j3n.2` (OrthoHydrogen `D<DLtriple` failures) — pre-existing, unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an infinite loop issue in matrix balancing operations when encountering non-finite or zero values.

* **Tests**
  * Added regression test to ensure matrix balancing correctly handles edge cases with non-finite matrix entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3021?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->