### PR TITLE
fix(HEOS): two-phase awareness for chemical_potential and fugacity_coefficient (#2345 follow-up)

### DIFF
--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -3360,7 +3360,16 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_helmholtzmolar() {
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_fugacity_coefficient(std::size_t i) {
     x_N_dependency_flag xN_flag = XN_DEPENDENT;
-    return exp(MixtureDerivatives::ln_fugacity_coefficient(*this, i, xN_flag));
+    if (isTwoPhase()) {
+        // phi_i = f_i / (x_i * p).  At VLE f_i^L == f_i^V but x_i^L != x_i^V, so
+        // phi_i^L != phi_i^V and no convex combination is physically meaningful for
+        // the overall two-phase state.  Force callers to evaluate on SatL or SatV.
+        throw ValueError(format("fugacity_coefficient is not well-defined in the two-phase region; evaluate on SatL or SatV instead"));
+    } else if (isHomogeneousPhase()) {
+        return exp(MixtureDerivatives::ln_fugacity_coefficient(*this, i, xN_flag));
+    } else {
+        throw ValueError(format("phase is invalid in calc_fugacity_coefficient"));
+    }
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_fugacity(std::size_t i) {
     x_N_dependency_flag xN_flag = XN_DEPENDENT;
@@ -3383,12 +3392,28 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_fugacity(std::size_t i) {
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_chemical_potential(std::size_t i) {
     x_N_dependency_flag xN_flag = XN_DEPENDENT;
-    double Tci = get_fluid_constant(i, iT_critical);
-    double rhoci = get_fluid_constant(i, irhomolar_critical);
-    double dnar_dni__const_T_V_nj = MixtureDerivatives::dnalphar_dni__constT_V_nj(*this, i, xN_flag);
-    double dna0_dni__const_T_V_nj =
-      components[i].EOS().alpha0.base(tau() * (Tci / T_reducing()), delta() / (rhoci / rhomolar_reducing())) + 1 + log(mole_fractions[i]);
-    return gas_constant() * T() * (dna0_dni__const_T_V_nj + dnar_dni__const_T_V_nj);
+    if (isTwoPhase()) {
+        // mu_i^L == mu_i^V at VLE (equality of chemical potentials is the equilibrium
+        // condition), so the Q-weighted form collapses to either sat-state value up to
+        // flash tolerance.  Mirrors the calc_fugacity pattern from PR #2345.
+        if (!this->SatL || !this->SatV) throw ValueError(format("The saturation properties are needed for the two-phase properties"));
+        if (std::abs(_Q) < DBL_EPSILON) {
+            return SatL->chemical_potential(i);
+        } else if (std::abs(_Q - 1) < DBL_EPSILON) {
+            return SatV->chemical_potential(i);
+        } else {
+            return _Q * SatV->chemical_potential(i) + (1 - _Q) * SatL->chemical_potential(i);
+        }
+    } else if (isHomogeneousPhase()) {
+        double Tci = get_fluid_constant(i, iT_critical);
+        double rhoci = get_fluid_constant(i, irhomolar_critical);
+        double dnar_dni__const_T_V_nj = MixtureDerivatives::dnalphar_dni__constT_V_nj(*this, i, xN_flag);
+        double dna0_dni__const_T_V_nj =
+          components[i].EOS().alpha0.base(tau() * (Tci / T_reducing()), delta() / (rhoci / rhomolar_reducing())) + 1 + log(mole_fractions[i]);
+        return gas_constant() * T() * (dna0_dni__const_T_V_nj + dnar_dni__const_T_V_nj);
+    } else {
+        throw ValueError(format("phase is invalid in calc_chemical_potential"));
+    }
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_phase_identification_parameter() {
     return 2

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -1891,11 +1891,17 @@ void StabilityRoutines::StabilityEvaluationClass::check_stability() {
     CoolPropDbl rho_bulk = HEOS.solver_rho_Tp_global(the_T, the_p, 0.9 / HEOS.SRK_covolume());
     HEOS.update_DmolarT_direct(rho_bulk, the_T);
 
-    // Calculate the fugacity coefficient at initial composition of the bulk phase
+    // Calculate the fugacity coefficient at initial composition of the bulk phase.
+    // The bulk HEOS state is a hypothetical homogeneous root forced via
+    // update_DmolarT_direct above, but _phase isn't reset by that call (it can
+    // be iphase_twophase from a prior PQ flash).  Call MixtureDerivatives
+    // directly to bypass the phase-dispatch in calc_fugacity / calc_fugacity_coefficient
+    // and get the actual bulk-composition values — same pattern used in the
+    // tpd_L / tpd_H accumulation just below.
     std::vector<double> fugacity_coefficient0(z.size()), fugacity0(z.size());
     for (std::size_t i = 0; i < z.size(); ++i) {
-        fugacity_coefficient0[i] = HEOS.fugacity_coefficient(i);
-        fugacity0[i] = HEOS.fugacity(i);
+        fugacity_coefficient0[i] = exp(MixtureDerivatives::ln_fugacity_coefficient(HEOS, i, XN_DEPENDENT));
+        fugacity0[i] = MixtureDerivatives::fugacity_i(HEOS, i, XN_DEPENDENT);
     }
 
     // Generate light and heavy test compositions (Gernert, 2014, Eq. 23)

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5055,6 +5055,45 @@ TEST_CASE("first_saturation_deriv mixture: throws at intermediate Q", "[first_sa
     CHECK_THROWS(AS->first_saturation_deriv(CoolProp::iT, CoolProp::iP));
 }
 
+TEST_CASE("Two-phase chemical_potential mirrors sat-state values; fugacity_coefficient throws", "[mixtures][2345-followup]") {
+    // Follow-up to PR #2345: calc_chemical_potential and calc_fugacity_coefficient
+    // were calling MixtureDerivatives::* directly on the overall homogeneous state,
+    // which is meaningless inside the two-phase dome.
+    //   - mu_i^L == mu_i^V at VLE (the equilibrium condition), so the new code
+    //     returns the Q-weighted sat-state value, which collapses to either
+    //     endpoint up to flash tolerance.
+    //   - phi_i^L != phi_i^V because the phase compositions differ; the new
+    //     code throws to force callers to evaluate on SatL/SatV explicitly.
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Methane&Ethane&Propane"));
+    AS->set_mole_fractions({0.25, 0.25, 0.5});
+    AS->update(CoolProp::PQ_INPUTS, 500e3, 0.5);
+    REQUIRE(AS->phase() == CoolProp::iphase_twophase);
+
+    auto* heos_ptr = dynamic_cast<CoolProp::HelmholtzEOSMixtureBackend*>(AS.get());
+    REQUIRE(heos_ptr != nullptr);
+    auto& satL = heos_ptr->get_SatL();
+    auto& satV = heos_ptr->get_SatV();
+
+    for (std::size_t i = 0; i < 3; ++i) {
+        CAPTURE(i);
+        // chemical_potential: mu_i^L == mu_i^V at VLE
+        const double mu = AS->chemical_potential(i);
+        const double muL = satL.chemical_potential(i);
+        const double muV = satV.chemical_potential(i);
+        CHECK(std::isfinite(mu));
+        // sat-state pair equal up to flash tolerance
+        CHECK(std::abs(muL - muV) < 1e-4 * std::abs(muL));
+        // overall == Q-weighted combination of sat states (Q=0.5)
+        CHECK(std::abs(mu - 0.5 * (muL + muV)) < 1e-9 * std::abs(0.5 * (muL + muV)));
+
+        // fugacity_coefficient throws in two-phase
+        CHECK_THROWS(AS->fugacity_coefficient(i));
+        // but works on the sat states
+        CHECK(std::isfinite(satL.fugacity_coefficient(i)));
+        CHECK(std::isfinite(satV.fugacity_coefficient(i)));
+    }
+}
+
 TEST_CASE("HAPropsSI Twb at high T (T > Tsat) returns the physical root (#2255)", "[HAPropsSI][2255]") {
     // Issue #2255: HAPropsSI('Twb','T',200+273.15,'W',0.2,'P',1000E3)
     // returned 180.7241 C (essentially Tsat at 1 MPa) instead of the
@@ -6056,6 +6095,55 @@ TEST_CASE("REFPROP saturation derivs work for a mixture", "[REFPROPsat]") {
     RP->update(QT_INPUTS, 0.4, 180.0);
     CHECK_THROWS(RP->first_two_phase_deriv(iDmolar, iHmolar, iP));
     CHECK_THROWS(RP->first_two_phase_deriv_splined(iDmolar, iHmolar, iP, 0.5));
+}
+
+TEST_CASE("REFPROP cross-check: sat-state fugacity_coefficient agrees with HEOS for Methane/Ethane/Propane", "[REFPROPsat][2345-followup]") {
+    Skip_if_No_REFPROP();
+    const std::vector<double> z = {0.25, 0.25, 0.5};
+
+    std::shared_ptr<AbstractState> HEOS(AbstractState::factory("HEOS", "Methane&Ethane&Propane"));
+    HEOS->set_mole_fractions(z);
+    HEOS->update(PQ_INPUTS, 500e3, 0.5);
+
+    std::shared_ptr<AbstractState> RP(AbstractState::factory("REFPROP", "Methane&Ethane&Propane"));
+    RP->set_mole_fractions(z);
+    RP->update(PQ_INPUTS, 500e3, 0.5);
+
+    // Bubble/dew T should agree across the two libraries to a few mK; that's the
+    // anchor for the fugacity-coefficient comparison below.
+    CHECK(std::abs(HEOS->T() - RP->T()) < 0.05);
+
+    auto* heos_mix_ptr = dynamic_cast<HelmholtzEOSMixtureBackend*>(HEOS.get());
+    REQUIRE(heos_mix_ptr != nullptr);
+    auto& satL_heos = heos_mix_ptr->get_SatL();
+    auto& satV_heos = heos_mix_ptr->get_SatV();
+
+    // The REFPROP sat states are re-flashed at the bubble/dew T of the
+    // liquid/vapor composition respectively — those T's differ slightly from
+    // the original two-phase T at Q=0.5, so this is a near-apples comparison
+    // rather than exact.  The 1 % tolerance below absorbs the mismatch.
+    std::shared_ptr<AbstractState> satL_rp(AbstractState::factory("REFPROP", "Methane&Ethane&Propane"));
+    satL_rp->set_mole_fractions(RP->mole_fractions_liquid());
+    satL_rp->update(PQ_INPUTS, RP->p(), 0.0);
+    std::shared_ptr<AbstractState> satV_rp(AbstractState::factory("REFPROP", "Methane&Ethane&Propane"));
+    satV_rp->set_mole_fractions(RP->mole_fractions_vapor());
+    satV_rp->update(PQ_INPUTS, RP->p(), 1.0);
+
+    for (std::size_t i = 0; i < 3; ++i) {
+        CAPTURE(i);
+        const double phiL_heos = satL_heos.fugacity_coefficient(i);
+        const double phiL_rp = satL_rp->fugacity_coefficient(i);
+        const double phiV_heos = satV_heos.fugacity_coefficient(i);
+        const double phiV_rp = satV_rp->fugacity_coefficient(i);
+        CAPTURE(phiL_heos);
+        CAPTURE(phiL_rp);
+        CAPTURE(phiV_heos);
+        CAPTURE(phiV_rp);
+        // Both libraries use Helmholtz-based mixture models; for this well-studied
+        // alkane system the fugacity coefficients should agree to ~1%.
+        CHECK(std::abs(phiL_heos - phiL_rp) / std::abs(phiL_rp) < 1e-2);
+        CHECK(std::abs(phiV_heos - phiV_rp) / std::abs(phiV_rp) < 1e-2);
+    }
 }
 
 #endif


### PR DESCRIPTION
## Summary

Follow-up to #2345.  The sibling functions `calc_chemical_potential` and `calc_fugacity_coefficient` had the same defect as `calc_fugacity` — silently evaluating `MixtureDerivatives::*` on the overall homogeneous state inside the two-phase dome — but were left untouched by that PR.

- **`calc_chemical_potential`**: mirror #2345's pattern (Q-weighted `SatL`/`SatV` endpoints).  At VLE μᵢᴸ = μᵢⱽ is the equilibrium condition, so the weighting collapses to either sat-state value up to flash tolerance.

- **`calc_fugacity_coefficient`**: **throw** in the two-phase region.  Unlike fugacity/chemical potential, φᵢᴸ ≠ φᵢⱽ at VLE — fᵢᴸ = fᵢⱽ but xᵢᴸ ≠ xᵢⱽ, so no convex combination is physically meaningful for the overall two-phase state.  Callers must evaluate on `SatL` or `SatV` explicitly.

## Latent bug surfaced in `StabilityRoutines::check_stability`

The bulk HEOS state there is a hypothetical homogeneous root forced via `update_DmolarT_direct`, but `_phase` isn't reset by that call and can remain `iphase_twophase` from a prior PQ flash.  #2345's strict `calc_fugacity` was silently returning the Q-weighted sat-state value in that path instead of the bulk-composition value (CHECK_NOTHROW didn't catch it); the new `fugacity_coefficient` throw turned the same root cause into a hard fail.

Replaced both calls in `VLERoutines.cpp:1894-1903` with direct `MixtureDerivatives::*` invocations — same pattern used a few lines below in the `tpd_L`/`tpd_H` accumulation loop.

## Test plan

- [x] `[2345-followup]` (HEOS): Methane&Ethane&Propane PQ=500 kPa Q=0.5 — verifies `chemical_potential` matches Q-weighted SatL/SatV (1e-9 rel tol) and `fugacity_coefficient` throws
- [x] `[2345-followup]`+`[REFPROPsat]`: REFPROP cross-check — sat-state φᵢ values agree with HEOS to within 1 % (REFPROP re-flashes at the bubble/dew T of the sat composition, slightly different from the two-phase T, which the 1 % tolerance absorbs)
- [x] `[stability]` — the regression caught the latent #2345 bug; passes after the VLERoutines fix
- [x] Full `~[slow]` suite: 131 760 assertions, 302 cases, all pass (REFPROP locally available)

Bd issue: CoolProp-58i

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fugacity coefficient now throws an error for two-phase states, directing users to evaluate at saturated liquid or saturated vapor states instead.
  * Chemical potential calculation for two-phase states now returns quality-weighted saturated-phase values.
  * Improved phase state handling in stability checks to ensure accurate calculations.

* **Tests**
  * Added verification tests for two-phase state thermodynamic properties.
  * Added cross-validation tests against REFPROP for saturated state calculations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3022?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->