### PR TITLE
WIP: P+X test infrastructure + standalone preconditioner (CoolProp-cdj prep)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2121,6 +2121,8 @@ if(COOLPROP_CATCH_MODULE)
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-HSU_D.cpp")
   list(APPEND APP_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-PXcdj.cpp")
+  list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-PXFlash.cpp")
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-FPUGuard.cpp")

--- a/docs/superpowers/specs/2026-05-28-pxcdj-testinfra-and-preconditioner-design.md
+++ b/docs/superpowers/specs/2026-05-28-pxcdj-testinfra-and-preconditioner-design.md
@@ -1,0 +1,150 @@
+# P+X test infrastructure + preconditioner (preparation for CoolProp-cdj)
+
+- **Date:** 2026-05-28
+- **Issue:** the bd issue filed against this branch (see `bd list --status=open`)
+- **Parent effort:** CoolProp-cdj (direct-EOS inner Newton + basin-safety refactor)
+- **Status:** Design — autonomous overnight execution
+
+## Scope (what this delivers)
+
+1. A **test bed** for P+X flash refactoring work: broad sweep over ~120 CoolProp pure
+   fluids × dense (log-p, T) grid × PH/PS/PU, with watermap instrumentation, named
+   regression points, structural tests, and a baseline-fingerprint fixture.
+2. A **standalone preconditioner** — per-fluid melt-curve table (p-indexed) plus a
+   regime-classified seed function — used to augment the *existing* cached path's
+   warm-start ρ. Does NOT change the inner Newton.
+
+The actual direct-EOS inner-Newton refactor (CoolProp-cdj) is the next phase, **out
+of scope here.** This branch's role is to make that refactor fast and low-risk.
+
+## Out of scope
+
+- The direct-EOS inner Newton replacing `solver_rho_Tp` (CoolProp-cdj).
+- Tolerance / per-fluid perf trade-offs (Ian's calls; surface as open questions).
+- Mixture / pseudo-pure paths (the preconditioner is for `is_pure()` only;
+  pseudo-pure passes through to the existing cached path unchanged).
+
+## Gates (G1–G5)
+
+| Gate | What it asserts | Tolerance | Applies to |
+|---|---|---|---|
+| **G1: Correctness (round-trip)** | Every PT-established single-phase state recovers (T, ρ) through P+Y | \|ΔT\|/T ≤ 1e-6 | both paths |
+| **G2: Basin equivalence** | Direct path lands on the same root as cached path | \|Δρ\|/ρ ≤ 1e-9, relax to 1e-8 at the TOMS748 floor with rationale | CoolProp-cdj only — *not* required for the preconditioner |
+| **G3: Zero-failure vs master** | Every point master succeeds, the path under test must succeed | exact | both paths |
+| **G4: Convergence bound** | Inner Newton iters ≤ 5 with preconditioner seed | hard cap | CoolProp-cdj only |
+| **G5: Performance regression guard** | Per-fluid mean µs/call ≤ master | bench-asserted | both paths |
+
+This branch enforces **G1, G3, G5** for the preconditioner. G2, G4 are the CoolProp-cdj
+phase's gates.
+
+## Test infrastructure
+
+### CI-default tests (`[PXcdj]`)
+- The two original Nitrogen/PS supercritical-cold points (86.35 K/4.754 MPa, 90.20 K/7.768 MPa) — must still round-trip after #3020 lands.
+- The prototype's known-hard cases: Nitrogen-PS at (121 K, 3.7 MPa), R134a-PH at (250 K, 300 kPa), Water near (277 K, 0.1–200 MPa) for the density anomaly band.
+- A representative fluid sample (Water, CO₂, R134a, Propane, Nitrogen, MM) × gas+liquid+supercritical states × PH/PS/PU.
+- Structural tests: lazy-init runs once, pseudo-pure passthrough, no-melt-curve fallback path activated, thread-safety of lazy init.
+
+### Opt-in heavy sweeps (`[.]`-tagged)
+- **`[PXcdj_sweep][.]`**: all CoolProp pure fluids (`get_global_param_string("fluids_list")`) × dense (log-p, T) single-phase grid (default 40×40, env-tunable). For each (T, p, pair): establish via PT, round-trip via P+Y, record success + (T_solved, ρ_solved, microseconds). Write per-fluid CSV.
+- **`[PXcdj_watermap][.]`**: instrumented variant of the above that also records `inner_iter_count`, `basin_rejections`, `fallback_count`, `seed_method` (which preconditioner branch was used), per point.
+- **`[PXcdj_bench][.]`**: per-fluid timing distribution comparing preconditioner-on vs preconditioner-off, mean/median/p95 µs/call. Flags any fluid where preconditioner is slower.
+
+### Visualization
+- `wrappers/Python/CoolProp/Plots/PXcdjTimingMap.py` (sibling of `TwoPropFlashTimingMap.py`, `HSFlashTimingMap.py`) — renders the watermap CSV as p–T and p–s/p–h heatmaps with overlays (saturation dome, melt curve, critical isobar, supercritical isothermal). Matplotlib output; static PNG/PDF.
+
+### Baseline fixture
+- A small CSV committed under `dev/fixtures/pxcdj_master_baseline.csv.gz` (or similar) containing the per-fluid success/failure tally + (T_solved, ρ_solved) statistics at a reference grid, generated against the current master. The CI-default `[PXcdj]` test asserts the current build still matches this fingerprint within tolerance — a regression guard against subtle behavior drift.
+
+## Preconditioner
+
+### Per-fluid melt-curve table (p-indexed, lazy)
+
+```
+struct MeltCurveTable {
+    std::vector<double> p;          // monotone increasing, log-spaced
+    std::vector<double> T_melt;     // T at each p_i
+    std::vector<double> rho_melt;   // liquid-side density at each (T_melt, p)
+    bool has_data;                  // false if fluid has no melting line
+};
+```
+
+- Indexed by **pressure** because some fluids (notably water) have melt curves that
+  are multi-valued in T but single-valued in p.
+- Lazy-initialized once per backend on first `regime_classified_rho_seed` call.
+- Generation: sample N ≈ 30 pressures from `p_triple` to `p_max_useful` log-spaced;
+  for each, `T_melt_i = calc_melting_line(iT, iP, p_i)`, then
+  `ρ_melt_i = update(PT_INPUTS, p_i, T_melt_i).rhomolar()`.
+- Lookup: binary search on `p`, linear interpolation between adjacent triples.
+- Fluids with `has_melting_line() == false`: `has_data = false`; the seed function
+  uses the compressibility-extrapolation fallback.
+
+### Regime-classified seed function
+
+```
+double regime_classified_rho_seed(HelmholtzEOSMixtureBackend& H, double T, double p) {
+    if (T > Tc) {
+        if (T > 0.8*Tmax || p < 0.01*pc) return p/(R*T);          // ideal-gas
+        return blend(rho_c, p/(R*T));                             // crit-isochore ↔ ideal
+    }
+    double Tsat = superanc.get_T_from_p(p);
+    if (T < Tsat) {                                                // liquid
+        double rhoL = superanc.eval_sat(T, 'D', 0);
+        if (H.melt_table.has_data) {
+            double rhoM = H.melt_table.rho_at(p);
+            double psi = (log(p) - log(p_sat(T))) / (log(p_max_table) - log(p_sat(T)));
+            psi = clamp(psi, 0.0, 1.0);
+            return rhoL + psi * (rhoM - rhoL);
+        }
+        return rhoL * (1 + (p - p_sat(T)) / kappa_sat_L);          // compressibility extrapolation
+    }
+    // vapor
+    double rhoV = superanc.eval_sat(T, 'D', 1);
+    if (T > 0.5*Tmax || p < 0.1*p_sat(T)) return p/(R*T);          // ideal-gas at high-T / low-p
+    return blend(rhoV, p/(R*T));                                   // sat-vapor ↔ ideal on p/p_sat
+}
+```
+
+Total cost ≈ 50–100 ns per call (superanc reads, log/exp, blend). Always
+basin-classified.
+
+### Integration
+
+Wire the preconditioner into `HSU_P_flash_singlephase_Brent`:
+- Before the TOMS748 / Halley dispatch, compute `rho_seed = regime_classified_rho_seed(HEOS, T_mid, p)` where `T_mid` is a representative T (e.g. midpoint of the bracket).
+- Plumb `rho_seed` into the existing `solver_resid` so the warm path (`update_TP_guessrho`) starts with the preconditioner's seed when iter ≥ 2 (or earlier if confidence is high).
+- This is **additive**: if the seed is bad, `update_TP_guessrho` falls back via the existing safety net (which itself falls back to cold `update(PT_INPUTS)`); no new failure modes introduced.
+
+### Toggle
+
+`PXCDJ_PRECONDITIONER` env var (static-const read once); default OFF this branch
+so master behavior is preserved. The validation work decides whether to flip the
+default ON before merge.
+
+## Validation pass
+
+Final pass before push:
+1. Build Release, run `[PXcdj]` — must pass.
+2. Run `[PXcdj_sweep]` with `PXCDJ_PRECONDITIONER=0` (master baseline) → generate baseline CSV.
+3. Run `[PXcdj_sweep]` with `PXCDJ_PRECONDITIONER=1` (preconditioner on) → comparison CSV.
+4. Diff: G1 (round-trip ≤ 1e-6) on both; G3 (no new failures); G5 (per-fluid timing ≤ baseline).
+5. Render the watermap plots for spot-check.
+6. `./dev/ci/preflight.sh`; clang-format clean; adversarial code review on the diff.
+7. Push to a **draft** PR (`--draft`). Update bd issue with the wake-up status block.
+
+## Wake-up status
+
+The draft PR's description will include explicit sections:
+
+- **What works** — gates G1/G3/G5 satisfied, with per-fluid summary stats.
+- **What's open** — anything I flagged for Ian's call (e.g., a fluid where preconditioner regresses slightly, a tolerance question, an unexpected master-side bug surfaced by the sweep).
+- **What's deferred** — the direct-EOS inner Newton (CoolProp-cdj), any G2/G4 work, any per-fluid opt-outs that need investigation.
+
+## Definition of done
+
+- Branch `ihb/pxcdj-testinfra-precond` pushed as a **draft** PR.
+- `[PXcdj]` (CI default) passes; `[PXcdj_sweep]` heavy-but-passes locally.
+- Preconditioner is env-gated (`PXCDJ_PRECONDITIONER`), default OFF.
+- Baseline fixture committed; watermap plotter committed.
+- bd issue updated with PR link + status.
+- No master-behavior change when the toggle is OFF.

--- a/docs/superpowers/specs/2026-05-28-pxcdj-testinfra-and-preconditioner-design.md
+++ b/docs/superpowers/specs/2026-05-28-pxcdj-testinfra-and-preconditioner-design.md
@@ -148,3 +148,51 @@ The draft PR's description will include explicit sections:
 - Baseline fixture committed; watermap plotter committed.
 - bd issue updated with PR link + status.
 - No master-behavior change when the toggle is OFF.
+
+## Phase 3b findings (integration attempted, not shipped)
+
+Two integration attempts were made; both failed the G3 hard gate. The
+preconditioner unit + test bed are shipped; the integration is deferred to
+CoolProp-cdj proper (with the inner-Newton replacement).
+
+### Attempt 1 — seed at `T_mid`
+- Strategy: compute `regime_classified_rho_seed(H, T_mid, p)` once at function entry; reuse on every Brent probe.
+- Result: **10,762 new failures vs baseline.**
+- Root cause: Brent probes `Tmin` and `Tmax` first (often very far from `T_mid`); a seed classified for `T_mid` lands the inner Newton in the wrong basin for the bracket-endpoint probes → wrong-root convergence → Brent bisects around a fake solution.
+
+### Attempt 2 — per-call seed re-classification
+- Strategy: compute `regime_classified_rho_seed(H, T_probe, p)` on every `solver_resid::call(T)`. Cost: ~50–200 ns × ~9 calls ≈ ~1–2 µs overhead.
+- Result: **234 new failures vs baseline** (down from 10,762 — big improvement), but still violates G3 = 0.
+- Net effect: **+2,204 newly-successful points** (preconditioner is a clear win overall), but the spec mandates *zero new* failures, not a net gain.
+- Failure clustering: 234 failures across just 4 fluids in 2 regimes:
+  - **Deep supercritical compressed** (p > ~3·p_c): R12 at p=2×10⁸ Pa, R123 at 2.4–7.6×10⁷, Methane at 4.6–10×10⁸. Classifier picks ideal-gas/critical blend; actual is compressed-liquid density at ~30,000 mol/m³.
+  - **Near-T_c handoff** (|T − T_c|/T_c < 0.005): R152A at T ≈ T_c. The sub/supercritical branch switch at exactly T = T_c is discontinuous.
+
+### Attempt 3 — engagement gate (exclude failure regimes)
+- Strategy: same as Attempt 2 plus an engagement gate excluding the two failure regimes (`p > 3·p_c`, `|T − T_c|/T_c < 0.005`); fall back to baseline (cold update) otherwise.
+- Result: **444 new failures vs baseline** — *worse* than Attempt 2.
+- Aggregate ON/OFF timing ratio: **1.257** (~26% slower when engaged).
+- Failure clustering: **95% of new failures are pseudo-pure mixtures** (R407C 107, R410A 97, R507A 101, R404A 91, SES36 28) in well-behaved subcritical and moderately-supercritical regimes — the engagement gate's "safe zone" was wrong because `is_pure() == true` returns true for pseudo-pure mixtures whose superancillaries behave differently than true pure-fluid superancillaries.
+
+### Lessons learned
+
+1. **`is_pure()` is not the right gate for the preconditioner.** Pseudo-pure mixtures pass `is_pure()` but their superancillary-derived ρ_sat,L/V values don't seed the cold-path inner Newton correctly. The classifier needs `is_pure() && !is_pseudopure()` or an explicit check that the superancillary behaves as expected.
+2. **Brent's bracket-endpoint probes need basin-correct seeds at the actual probe T**, not at any single representative T. Per-call re-classification fixes this for most regimes but exposes (1).
+3. **Per-call seed-compute overhead (~200 ns × ~9 outer iters) is not paid back** by faster convergence on most fluids — the cached path's SRK guess + Householder4 + retry is already well-tuned for the bulk regime, and replacing it with the preconditioner's seed adds work without reducing inner-iter count enough to win.
+4. **The preconditioner architecture is not enough on its own.** The big speedup hypothesis (preconditioner → fewer inner iters AND cheaper per iter) requires *also* replacing the cached `solver_rho_Tp` + Householder4 path with the direct-EOS inner Newton (CoolProp-cdj proper). The preconditioner alone changes only the seed; the inner-Newton machinery is unchanged and dominates the time.
+5. **Net G3-positive but G3-not-zero** is a real outcome of opt-in preconditioning. The spec's hard G3 = 0 is the right gate for a *default-on* change, but if the toggle stays OFF in production, a net-positive ON path is shippable IF the test infrastructure can prove the net gain on representative grids.
+
+### Status
+
+- **Phase 2a** (test bed + named regressions + baseline fixture): ✅ shipped, commit `1b4bc2272`.
+- **Phase 3a** (standalone preconditioner unit + unit tests): ✅ shipped, commit `1306d4e24`.
+- **Phase 3b** (production integration): ❌ deferred — three attempts failed G3; the architecture needs to be reconsidered in conjunction with the CoolProp-cdj inner-Newton replacement.
+- **Plotter** (Python visualization): deferred (lower priority; sweep CSV is directly parseable).
+- **Structural tests** (lazy-init, pseudo-pure passthrough, thread-safety): partially covered by the Phase 3a preconditioner tests; full structural suite deferred to integration phase.
+
+### Recommendations for CoolProp-cdj (the next phase)
+
+1. **Re-design the gate**: `is_pure() && !is_pseudopure()` AND the per-fluid melt table actually has data AND the superancillary is consistent (run a startup sanity check).
+2. **Co-design the seed with the inner Newton**: the preconditioner's value is in giving a *basin-classified* seed for a *direct-EOS, cache-bypassing* inner Newton. The cached `solver_rho_Tp` doesn't benefit enough from the seed because its iteration cost is already dominated by `CachedElement` and virtual-dispatch overhead.
+3. **Consider a stricter ship gate**: instead of G3 = 0, allow "G3 net-positive AND no fluid regresses by more than X%" for an opt-in toggle. This admits net-improvement scenarios that the hard gate rejects.
+4. **Address the pseudo-pure mixture handling explicitly** — these are a real and common class (HFCs blends like R407C/R410A/R404A) that need either a separate seed strategy or explicit opt-out.

--- a/include/CoolProp/px_preconditioner.h
+++ b/include/CoolProp/px_preconditioner.h
@@ -1,0 +1,73 @@
+// P+X flash preconditioner — standalone unit (CoolProp-cdj prep, Phase 3a)
+//
+// Two facilities:
+//   1. ensure_melt_curve_table(H) / get_melt_curve_table(H) — lazily builds a
+//      per-fluid melt-curve table indexed by pressure (single-valued in p even
+//      for water, whose melt curve is multi-valued in T).  Cached per-backend
+//      via a static map + mutex inside the .cpp, so the public header for
+//      HelmholtzEOSMixtureBackend does not need to change.
+//   2. regime_classified_rho_seed(H, T, p) — returns a positive finite rho_seed
+//      (mol/m^3) chosen by region (supercritical / subcritical liquid /
+//      subcritical vapor).  Builds the melt curve table on first call (lazy).
+//      Cost target: <= ~200 ns per call in Release builds.  Always finite + > 0.
+//
+// This unit is NOT yet wired into the production flash path; Phase 3b will
+// integrate it into HSU_P_flash_singlephase_Brent.  This phase ships the
+// preconditioner as a separable, unit-tested module.
+
+#ifndef COOLPROP_PX_PRECONDITIONER_H
+#define COOLPROP_PX_PRECONDITIONER_H
+
+#include <vector>
+
+namespace CoolProp {
+
+class HelmholtzEOSMixtureBackend;
+
+namespace pxprecond {
+
+/// Per-fluid melt-curve density table, p-indexed (single-valued in p for all
+/// fluids, including water whose melt curve is multi-valued in T).  Built
+/// lazily on first use.
+struct MeltCurveTable
+{
+    std::vector<double> p;         ///< log-spaced from p_triple to a useful upper bound; monotone increasing
+    std::vector<double> T_melt;    ///< melting temperature at each p_i
+    std::vector<double> rho_melt;  ///< liquid-side molar density at each (T_melt(p_i), p_i)
+    bool has_data = false;         ///< false if the fluid has no melting line / build failed
+    bool initialized = false;      ///< guard against repeated init
+
+    /// Linear-interpolate rho_melt at the query pressure.  Clamps p to the
+    /// table's p range; returns NaN if !has_data.  Cost: O(log N) binary search
+    /// + O(1) interp.
+    double rho_at(double p_query) const;
+};
+
+/// Lazily build (or no-op if already built) the per-fluid melt-curve table for
+/// H.  The table is stored in a static map keyed by H's address, protected by a
+/// mutex.  If H.has_melting_line() is false, sets has_data=false and returns —
+/// no entries.
+void ensure_melt_curve_table(HelmholtzEOSMixtureBackend& H);
+
+/// Accessor: returns a const reference to the melt-curve table on H (calling
+/// ensure_melt_curve_table first if needed).
+const MeltCurveTable& get_melt_curve_table(HelmholtzEOSMixtureBackend& H);
+
+/// Regime-classified seed for the inner density Newton at (T, p), single-phase.
+/// Returns a positive rho_seed (mol/m^3) chosen by region:
+///   - supercritical (T > Tc): ideal-gas density p/(RT) for high T or low p,
+///     blended toward rho_c near the critical point.
+///   - subcritical liquid (T < T_sat(p)): log-p interpolation between
+///     rho_sat,L(T) and rho_melt(p) when the melt table has data, else
+///     compressibility extrapolation.
+///   - subcritical vapor (T > T_sat(p)): rho_sat,V(T) blended toward p/(RT) on
+///     p/p_sat.
+/// Cost target: <= 200 ns per call (Release).  Always finite + positive — if
+/// any internal computation yields NaN/Inf/<=0, falls back to p/(RT).  Builds
+/// the melt curve table on first call (lazy).
+double regime_classified_rho_seed(HelmholtzEOSMixtureBackend& H, double T, double p);
+
+}  // namespace pxprecond
+}  // namespace CoolProp
+
+#endif  // COOLPROP_PX_PRECONDITIONER_H

--- a/src/Backends/Helmholtz/PXPreconditioner.cpp
+++ b/src/Backends/Helmholtz/PXPreconditioner.cpp
@@ -1,0 +1,460 @@
+// P+X flash preconditioner — standalone unit (CoolProp-cdj prep, Phase 3a).
+// Header: include/CoolProp/px_preconditioner.h.  See header for API + intent.
+//
+// Storage model: per-fluid MeltCurveTable is held in a static map keyed by the
+// fluid's canonical name, guarded by a mutex.  This keeps the change local —
+// HelmholtzEOSMixtureBackend's header does not need to grow a new member —
+// and is robust to heap-slot reuse (consecutive AbstractState allocations
+// can land at the same address, which would otherwise serve stale entries
+// when keying by backend pointer).
+// Lifetime: entries stay in the map until process exit.  The map is sized in
+// proportion to the number of distinct fluid names that get queried, which
+// is at most ~120 (CoolProp's pure-fluid list) for typical use.
+//
+// Thread safety: lazy-init takes a write lock around the build (cheap, only
+// runs once per backend); the seed function takes a read lock to fetch the
+// (already-built) table and otherwise operates on locals.
+
+#include "CoolProp/px_preconditioner.h"
+
+#include "AbstractState.h"
+#include "Backends/Helmholtz/HelmholtzEOSMixtureBackend.h"
+#include "CoolProp.h"
+#include "CoolPropFluid.h"
+#include "DataStructures.h"
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace CoolProp {
+namespace pxprecond {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Per-fluid table storage.  Keyed by canonical fluid name (the first entry of
+// HelmholtzEOSMixtureBackend::fluid_names() for the pure-fluid case we care
+// about).  Guarded by a mutex.  The table is small (a handful of vectors);
+// we never erase entries — the map grows monotonically with distinct fluids.
+//
+// Why fluid-name keyed (not pointer-keyed): consecutive AbstractState
+// allocations can land at the same heap address, which would cause a
+// pointer-keyed map to return stale entries for what is logically a different
+// backend.  Fluid names are stable across backend recreation.
+// ---------------------------------------------------------------------------
+using table_key_t = std::string;
+
+std::unordered_map<table_key_t, MeltCurveTable>& table_map() {
+    static std::unordered_map<table_key_t, MeltCurveTable> m;
+    return m;
+}
+std::mutex& table_mutex() {
+    static std::mutex m;
+    return m;
+}
+
+// Build the key (= first fluid name) for H.  Empty string on failure.
+table_key_t make_key(HelmholtzEOSMixtureBackend& H) {
+    try {
+        const auto names = H.fluid_names();
+        if (!names.empty()) return names[0];
+    } catch (...) {
+    }
+    return {};
+}
+
+constexpr std::size_t kMeltSamples = 30;       ///< target number of (p_i, T_i, rho_i) sample triples
+constexpr std::size_t kMeltMinSamples = 5;     ///< minimum successful samples required to mark has_data=true
+constexpr double kSupercritIdealCutoff = 0.8;  ///< T > kSupercritIdealCutoff * Tmax  -> ideal-gas seed
+constexpr double kSupercritLowPCutoff = 0.01;  ///< p < kSupercritLowPCutoff * pc    -> ideal-gas seed
+constexpr double kVaporIdealCutoff = 0.5;      ///< T > kVaporIdealCutoff * Tmax     -> ideal-gas vapor seed
+constexpr double kVaporLowPCutoff = 0.1;       ///< p < kVaporLowPCutoff * p_sat(T)  -> ideal-gas vapor seed
+constexpr double kCompExtrapFactor = 10.0;     ///< stiff-liquid compressibility-extrap conservative factor
+
+// Safe finite-positive check
+inline bool finite_pos(double x) {
+    return std::isfinite(x) && x > 0.0;
+}
+
+// Build the melt-curve table for H.  Assumes caller holds the table_mutex.
+// On failure (no melt line, build error, etc.) leaves has_data=false but sets
+// initialized=true so we don't retry forever.
+void build_table_locked(HelmholtzEOSMixtureBackend& H, MeltCurveTable& tbl) {
+    tbl.has_data = false;
+    tbl.initialized = true;
+    tbl.p.clear();
+    tbl.T_melt.clear();
+    tbl.rho_melt.clear();
+
+    if (!H.has_melting_line()) {
+        return;
+    }
+
+    // Determine melt-line p range.  The ancillary exposes pmin/pmax via the
+    // iP_min / iP_max OF codes; the given arg is unused for these queries.
+    double p_lo = 0, p_hi = 0;
+    try {
+        p_lo = H.calc_melting_line(iP_min, iT, 0.0);
+        p_hi = H.calc_melting_line(iP_max, iT, 0.0);
+    } catch (...) {
+        return;
+    }
+    if (!finite_pos(p_lo) || !finite_pos(p_hi) || !(p_hi > p_lo)) {
+        return;
+    }
+
+    // Defensive caps: keep the upper bound below pmax and below
+    // 100 * p_critical (avoids absurd extrapolations).  Keep the lower bound
+    // at p_triple if available (small numerical guard above triple_p).
+    double pc = 0, pmax_eos = 0, p_triple_eos = 0;
+    try {
+        pc = H.p_critical();
+    } catch (...) {
+        pc = 0;
+    }
+    try {
+        pmax_eos = H.pmax();
+    } catch (...) {
+        pmax_eos = 0;
+    }
+    try {
+        p_triple_eos = H.p_triple();
+    } catch (...) {
+        p_triple_eos = 0;
+    }
+    if (finite_pos(p_triple_eos)) {
+        p_lo = std::max(p_lo, p_triple_eos);
+    }
+    if (finite_pos(pmax_eos)) {
+        p_hi = std::min(p_hi, pmax_eos);
+    }
+    if (finite_pos(pc)) {
+        p_hi = std::min(p_hi, 100.0 * pc);
+    }
+    if (!(p_hi > p_lo)) {
+        return;
+    }
+
+    // Build a fresh working state so we don't mutate H.  Use the "HEOS"
+    // factory key — H is the Helmholtz mixture backend; this is a pure fluid
+    // (has_melting_line() requires is_pure_or_pseudopure), so fluid_names()[0]
+    // is well-defined.
+    std::vector<std::string> fnames;
+    try {
+        fnames = H.fluid_names();
+    } catch (...) {
+        return;
+    }
+    if (fnames.empty()) {
+        return;
+    }
+    std::shared_ptr<AbstractState> work;
+    try {
+        work.reset(AbstractState::factory("HEOS", fnames[0]));
+    } catch (...) {
+        return;
+    }
+    if (!work) {
+        return;
+    }
+
+    // Sample log-spaced pressures.  For each, compute T_melt(p_i) from the
+    // melting-line ancillary, then update(PT_INPUTS, p_i, T_melt_i) to read
+    // rho.  Skip points that throw — some fluids' melting curves aren't fully
+    // consistent with their EOS near the bounds.
+    tbl.p.reserve(kMeltSamples);
+    tbl.T_melt.reserve(kMeltSamples);
+    tbl.rho_melt.reserve(kMeltSamples);
+    const double log_lo = std::log(p_lo);
+    const double log_hi = std::log(p_hi);
+    for (std::size_t i = 0; i < kMeltSamples; ++i) {
+        const double frac = (kMeltSamples == 1) ? 0.0 : static_cast<double>(i) / static_cast<double>(kMeltSamples - 1);
+        const double p_i = std::exp(log_lo + frac * (log_hi - log_lo));
+        double T_i = NAN, rho_i = NAN;
+        try {
+            T_i = H.calc_melting_line(iT, iP, p_i);
+        } catch (...) {
+            continue;
+        }
+        if (!finite_pos(T_i)) continue;
+        try {
+            work->update(PT_INPUTS, p_i, T_i);
+            rho_i = work->rhomolar();
+        } catch (...) {
+            continue;
+        }
+        if (!finite_pos(rho_i)) continue;
+        tbl.p.push_back(p_i);
+        tbl.T_melt.push_back(T_i);
+        tbl.rho_melt.push_back(rho_i);
+    }
+
+    if (tbl.p.size() >= kMeltMinSamples) {
+        // Defend monotonicity: if any later p_i happens to be <= the previous
+        // (shouldn't, but be paranoid given log-spacing+float), drop the
+        // offending point.  Iterate forward; pop offenders.
+        std::vector<double> p2, T2, r2;
+        p2.reserve(tbl.p.size());
+        T2.reserve(tbl.p.size());
+        r2.reserve(tbl.p.size());
+        for (std::size_t i = 0; i < tbl.p.size(); ++i) {
+            if (i == 0 || tbl.p[i] > p2.back()) {
+                p2.push_back(tbl.p[i]);
+                T2.push_back(tbl.T_melt[i]);
+                r2.push_back(tbl.rho_melt[i]);
+            }
+        }
+        if (p2.size() >= kMeltMinSamples) {
+            tbl.p = std::move(p2);
+            tbl.T_melt = std::move(T2);
+            tbl.rho_melt = std::move(r2);
+            tbl.has_data = true;
+        }
+    }
+}
+
+// Snapshot of the seed-relevant invariants we need for one regime-classified
+// query.  Reads them off H once so the hot path is local arithmetic.
+struct SeedContext
+{
+    double Tc = 0, pc = 0, rho_c = 0;
+    double Tmax = 0, R = 0;
+    bool pure_with_superanc = false;
+    std::shared_ptr<EquationOfState::SuperAncillary_t> sa;
+};
+
+SeedContext load_seed_context(HelmholtzEOSMixtureBackend& H) {
+    SeedContext c;
+    try {
+        c.Tc = H.T_critical();
+    } catch (...) {
+    }
+    try {
+        c.pc = H.p_critical();
+    } catch (...) {
+    }
+    try {
+        c.rho_c = H.rhomolar_critical();
+    } catch (...) {
+    }
+    try {
+        c.Tmax = H.Tmax();
+    } catch (...) {
+    }
+    try {
+        c.R = H.gas_constant();
+    } catch (...) {
+    }
+    if (H.is_pure()) {
+        try {
+            c.sa = H.get_superanc();
+        } catch (...) {
+            c.sa.reset();
+        }
+        c.pure_with_superanc = static_cast<bool>(c.sa);
+    }
+    return c;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// MeltCurveTable::rho_at
+// ---------------------------------------------------------------------------
+double MeltCurveTable::rho_at(double p_query) const {
+    if (!has_data || p.size() < 2 || !std::isfinite(p_query)) {
+        return std::nan("");
+    }
+    // Clamp to table range.
+    if (p_query <= p.front()) return rho_melt.front();
+    if (p_query >= p.back()) return rho_melt.back();
+    // Binary search for the upper bound — first p[i] > p_query.
+    auto it = std::lower_bound(p.begin(), p.end(), p_query);
+    if (it == p.begin()) return rho_melt.front();
+    if (it == p.end()) return rho_melt.back();
+    const std::size_t hi = static_cast<std::size_t>(it - p.begin());
+    const std::size_t lo = hi - 1;
+    const double t = (p_query - p[lo]) / (p[hi] - p[lo]);
+    return rho_melt[lo] + t * (rho_melt[hi] - rho_melt[lo]);
+}
+
+// ---------------------------------------------------------------------------
+// ensure_melt_curve_table / get_melt_curve_table
+// ---------------------------------------------------------------------------
+void ensure_melt_curve_table(HelmholtzEOSMixtureBackend& H) {
+    const table_key_t key = make_key(H);
+    if (key.empty()) {
+        // Can't key it; nothing to do.  Subsequent get_melt_curve_table on
+        // the same H will also key-empty and return a default (no-data) table.
+        return;
+    }
+    std::lock_guard<std::mutex> lk(table_mutex());
+    auto& m = table_map();
+    auto it = m.find(key);
+    if (it != m.end() && it->second.initialized) {
+        return;
+    }
+    MeltCurveTable& tbl = m[key];
+    if (tbl.initialized) return;  // raced; somebody else built it
+    build_table_locked(H, tbl);
+}
+
+const MeltCurveTable& get_melt_curve_table(HelmholtzEOSMixtureBackend& H) {
+    ensure_melt_curve_table(H);
+    std::lock_guard<std::mutex> lk(table_mutex());
+    auto& m = table_map();
+    const table_key_t key = make_key(H);
+    auto it = (!key.empty()) ? m.find(key) : m.end();
+    if (it == m.end()) {
+        // Return a sentinel "empty" table.  Stored in a function-local static
+        // so the const reference remains valid.
+        static const MeltCurveTable kEmpty{};
+        return kEmpty;
+    }
+    return it->second;
+}
+
+// ---------------------------------------------------------------------------
+// regime_classified_rho_seed
+// ---------------------------------------------------------------------------
+double regime_classified_rho_seed(HelmholtzEOSMixtureBackend& H, double T, double p) {
+    // Ensure the melt table is built (lazy, idempotent).  We then snapshot it
+    // inside the lock so the rest of the hot path can run unlocked.
+    ensure_melt_curve_table(H);
+
+    SeedContext ctx = load_seed_context(H);
+
+    // Reasonable defaults if any constant came back bad — fall through to ideal-gas.
+    auto ideal_gas = [&](double T_q, double p_q) -> double {
+        if (ctx.R > 0 && T_q > 0 && std::isfinite(p_q) && p_q > 0) {
+            return p_q / (ctx.R * T_q);
+        }
+        return std::nan("");
+    };
+
+    auto clamp01 = [](double x) {
+        if (!(x >= 0.0)) return 0.0;
+        if (!(x <= 1.0)) return 1.0;
+        return x;
+    };
+
+    double seed = std::nan("");
+
+    if (!finite_pos(ctx.Tc) || !finite_pos(ctx.pc) || !finite_pos(ctx.R) || !finite_pos(ctx.Tmax)) {
+        // Degenerate: no critical info.  Best we can do is ideal-gas.
+        seed = ideal_gas(T, p);
+    } else if (T > ctx.Tc) {
+        // Supercritical.
+        if (T > kSupercritIdealCutoff * ctx.Tmax || p < kSupercritLowPCutoff * ctx.pc) {
+            seed = ideal_gas(T, p);
+        } else {
+            const double alpha = clamp01((T - ctx.Tc) / ctx.Tc);
+            const double rg = ideal_gas(T, p);
+            const double rc = finite_pos(ctx.rho_c) ? ctx.rho_c : rg;
+            if (finite_pos(rg) && finite_pos(rc)) {
+                seed = (1.0 - alpha) * rc + alpha * rg;
+            } else {
+                seed = rg;
+            }
+        }
+    } else {
+        // Subcritical: need T_sat(p) and rho_sat,L/V(T) — requires superanc.
+        if (!ctx.pure_with_superanc || !ctx.sa) {
+            seed = ideal_gas(T, p);
+        } else {
+            EquationOfState::SuperAncillary_t& sa = *ctx.sa;
+            double p_sat = NAN;
+            try {
+                p_sat = sa.eval_sat(T, 'P', 1);
+            } catch (...) {
+                p_sat = NAN;
+            }
+            if (!finite_pos(p_sat)) {
+                seed = ideal_gas(T, p);
+            } else if (p >= p_sat) {
+                // Liquid branch.
+                double rhoL = NAN;
+                try {
+                    rhoL = sa.eval_sat(T, 'D', 0);
+                } catch (...) {
+                    rhoL = NAN;
+                }
+                if (!finite_pos(rhoL)) {
+                    seed = ideal_gas(T, p);
+                } else {
+                    // Snapshot the melt table (under lock) for the log-p interp.
+                    MeltCurveTable tbl_copy;
+                    {
+                        std::lock_guard<std::mutex> lk(table_mutex());
+                        auto& m = table_map();
+                        const table_key_t key = make_key(H);
+                        if (!key.empty()) {
+                            auto it = m.find(key);
+                            if (it != m.end()) tbl_copy = it->second;
+                        }
+                    }
+                    if (tbl_copy.has_data && tbl_copy.p.size() >= 2) {
+                        const double p_max_table = tbl_copy.p.back();
+                        const double rhoM = tbl_copy.rho_at(p);
+                        if (finite_pos(rhoM) && p_max_table > p_sat) {
+                            const double num = std::log(std::max(p, p_sat)) - std::log(p_sat);
+                            const double den = std::log(p_max_table) - std::log(p_sat);
+                            const double psi = (den > 0) ? clamp01(num / den) : 0.0;
+                            seed = rhoL + psi * (rhoM - rhoL);
+                        } else {
+                            // Melt table available but inconsistent at this query — fall through.
+                            const double bulk_mod_scale = rhoL * ctx.R * T * kCompExtrapFactor;
+                            seed = (bulk_mod_scale > 0) ? rhoL * (1.0 + (p - p_sat) / bulk_mod_scale) : rhoL;
+                        }
+                    } else {
+                        // No melt table data — crude compressibility extrapolation.
+                        // Conservative bulk-modulus-equivalent term (kCompExtrapFactor in
+                        // the denominator damps the response for stiff liquids).
+                        const double bulk_mod_scale = rhoL * ctx.R * T * kCompExtrapFactor;
+                        seed = (bulk_mod_scale > 0) ? rhoL * (1.0 + (p - p_sat) / bulk_mod_scale) : rhoL;
+                    }
+                }
+            } else {
+                // Vapor branch (p < p_sat).
+                double rhoV = NAN;
+                try {
+                    rhoV = sa.eval_sat(T, 'D', 1);
+                } catch (...) {
+                    rhoV = NAN;
+                }
+                if (!finite_pos(rhoV)) {
+                    seed = ideal_gas(T, p);
+                } else if (T > kVaporIdealCutoff * ctx.Tmax || p < kVaporLowPCutoff * p_sat) {
+                    seed = ideal_gas(T, p);
+                } else {
+                    const double beta = clamp01((p_sat - p) / p_sat);
+                    const double rg = ideal_gas(T, p);
+                    if (finite_pos(rg)) {
+                        seed = (1.0 - beta) * rhoV + beta * rg;
+                    } else {
+                        seed = rhoV;
+                    }
+                }
+            }
+        }
+    }
+
+    // Final safety net: NEVER return non-finite or non-positive.  Fall back
+    // to ideal-gas; if that's also bad, return a tiny positive (1e-3 mol/m^3
+    // — vacuum-ish but guaranteed positive).
+    if (!finite_pos(seed)) {
+        seed = ideal_gas(T, p);
+    }
+    if (!finite_pos(seed)) {
+        seed = 1.0e-3;
+    }
+    return seed;
+}
+
+}  // namespace pxprecond
+}  // namespace CoolProp

--- a/src/Tests/CoolProp-Tests-PXcdj.cpp
+++ b/src/Tests/CoolProp-Tests-PXcdj.cpp
@@ -1,0 +1,386 @@
+// Characterization tests for P + {H, S, U} flash inputs.
+//
+// The legacy P+X solver is HSU_P_flash_singlephase_Brent in
+// src/Backends/Helmholtz/FlashRoutines.cpp; PH/PS/PU all dispatch through
+// FlashRoutines::HSU_P_flash.  This file is the acceptance harness for the
+// rewrite tracked in bd CoolProp-cdj — it characterises both the named
+// regressions we expect to keep passing (CI default) and a broad single-phase
+// (T, p) sweep that maps the full surface for the production code path
+// (opt-in heavy test, writes a CSV fixture).
+//
+// Two test cases:
+//   [PXcdj]              named regressions, must pass on current master
+//   [PXcdj_sweep][.]     opt-in dense grid across CoolProp's pure-fluid list
+//                        — writes a CSV with timing + round-trip results, used
+//                        to produce dev/fixtures/pxcdj_master_baseline.csv.gz
+//
+// Input pair argument orders (verified against include/DataStructures.h):
+//   HmolarP_INPUTS : (value1=h, value2=p)
+//   PSmolar_INPUTS : (value1=p, value2=s)
+//   PUmolar_INPUTS : (value1=p, value2=u)
+//
+// Built into CatchTestRunner when COOLPROP_CATCH_MODULE=ON.  Run via
+//   ./build_catch_rel/CatchTestRunner "[PXcdj]"        # CI default
+//   ./build_catch_rel/CatchTestRunner "[PXcdj_sweep]"  # opt-in heavy
+
+#include "AbstractState.h"
+#include "CoolProp.h"
+#include "CPstrings.h"
+#include "DataStructures.h"
+
+#if defined(ENABLE_CATCH)
+#    include <catch2/catch_all.hpp>
+
+#    include <chrono>
+#    include <cmath>
+#    include <cstdio>
+#    include <cstdlib>
+#    include <fstream>
+#    include <memory>
+#    include <string>
+#    include <vector>
+
+namespace {
+
+// Read an env var as a size_t, returning def if absent or malformed.
+std::size_t env_or(const char* name, std::size_t def) {
+    const char* v = std::getenv(name);
+    if (v == nullptr) return def;
+    try {
+        const long n = std::stol(v);
+        if (n > 1) return static_cast<std::size_t>(n);
+    } catch (...) {
+        return def;
+    }
+    return def;
+}
+
+std::vector<double> linspace(double a, double b, std::size_t n) {
+    std::vector<double> v(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        v[i] = (n == 1) ? a : a + (b - a) * static_cast<double>(i) / static_cast<double>(n - 1);
+    }
+    return v;
+}
+
+std::vector<double> logspace(double a, double b, std::size_t n) {
+    std::vector<double> v(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        v[i] = (n == 1) ? a : a * std::pow(b / a, static_cast<double>(i) / static_cast<double>(n - 1));
+    }
+    return v;
+}
+
+const char* pair_label(CoolProp::input_pairs pr) {
+    switch (pr) {
+        case CoolProp::HmolarP_INPUTS:
+            return "PH";
+        case CoolProp::PSmolar_INPUTS:
+            return "PS";
+        case CoolProp::PUmolar_INPUTS:
+            return "PU";
+        default:
+            return "??";
+    }
+}
+
+double caloric_molar(CoolProp::AbstractState& AS, CoolProp::input_pairs pr) {
+    switch (pr) {
+        case CoolProp::HmolarP_INPUTS:
+            return AS.hmolar();
+        case CoolProp::PSmolar_INPUTS:
+            return AS.smolar();
+        case CoolProp::PUmolar_INPUTS:
+            return AS.umolar();
+        default:
+            return _HUGE;
+    }
+}
+
+// Re-flash via the chosen P+X pair and check (T, rho) recover within 1e-5
+// relative.  Uses CHECK (not FAIL_CHECK on the recover assertions) so callers
+// see WHICH coordinate missed.  Wraps the flash in try/catch and FAIL_CHECKs
+// on throw — every named-regression point must complete on current master.
+void check_PX_roundtrip(CoolProp::AbstractState& wrk, CoolProp::input_pairs pr, double p, double value, double T_expect, double rho_expect) {
+    INFO("pair=" << pair_label(pr) << " p=" << p << " value=" << value << " T_expect=" << T_expect << " rho_expect=" << rho_expect);
+    try {
+        if (pr == CoolProp::HmolarP_INPUTS) {
+            wrk.update(pr, value, p);  // (h, p)
+        } else {
+            wrk.update(pr, p, value);  // (p, s) or (p, u)
+        }
+    } catch (const std::exception& e) {
+        FAIL_CHECK("update threw: " << e.what());
+        return;
+    } catch (...) {
+        FAIL_CHECK("update threw non-std exception");
+        return;
+    }
+    const double T_out = wrk.T(), rho_out = wrk.rhomolar();
+    CHECK(std::isfinite(T_out));
+    CHECK(std::isfinite(rho_out));
+    CHECK(T_out == Catch::Approx(T_expect).epsilon(1e-5));
+    CHECK(rho_out == Catch::Approx(rho_expect).epsilon(1e-5));
+}
+
+// One named-regression record.
+struct NamedCase
+{
+    const char* fluid;
+    double T_K;
+    double p_Pa;
+    const char* note;
+};
+
+// Round-trip a single (fluid, T, p) point across all three P+X pairs.  The
+// reference state is set via PT_INPUTS; rho, h, s, u are read off; then
+// PH/PS/PU each get a fresh state and must recover (T, rho).
+void run_named_case(const NamedCase& c) {
+    CAPTURE(c.fluid, c.note, c.T_K, c.p_Pa);
+    auto ref = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", c.fluid));
+    auto wrk = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", c.fluid));
+    try {
+        ref->update(CoolProp::PT_INPUTS, c.p_Pa, c.T_K);
+    } catch (const std::exception& e) {
+        FAIL_CHECK("PT reference update threw for " << c.fluid << ": " << e.what());
+        return;
+    }
+    const double T_ref = ref->T(), rho_ref = ref->rhomolar();
+    const double h = ref->hmolar(), s = ref->smolar(), u = ref->umolar();
+    if (!std::isfinite(rho_ref) || !std::isfinite(h) || !std::isfinite(s) || !std::isfinite(u)) {
+        FAIL_CHECK("non-finite reference state for " << c.fluid);
+        return;
+    }
+    {
+        INFO("PH");
+        check_PX_roundtrip(*wrk, CoolProp::HmolarP_INPUTS, c.p_Pa, h, T_ref, rho_ref);
+    }
+    {
+        INFO("PS");
+        check_PX_roundtrip(*wrk, CoolProp::PSmolar_INPUTS, c.p_Pa, s, T_ref, rho_ref);
+    }
+    {
+        INFO("PU");
+        check_PX_roundtrip(*wrk, CoolProp::PUmolar_INPUTS, c.p_Pa, u, T_ref, rho_ref);
+    }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// CI default: focused PH/PS/PU round-trips that should PASS on current master.
+// Every point is established via PT_INPUTS first, then re-flashed through each
+// of HmolarP/PSmolar/PUmolar — the recovered (T, rho) must agree to 1e-5
+// relative.  Covers:
+//   * gas / liquid / supercritical points across a representative fluid set
+//     (Water, CO2, R134a, Propane, Nitrogen, MM)
+//   * three prototype-era known-hard points that current master DOES handle:
+//       - Nitrogen PS at the supercritical-cold wrong-basin trap
+//       - R134a PH at the spinodal step
+//       - Water near the density anomaly
+//
+// NOTE: The two Nitrogen PS supercritical-cold failures on master at
+// (T=86.35K, p=4.754MPa) and (T=90.20K, p=7.768MPa) are deliberately omitted
+// here — they are fixed in PR #3020.  They show up in the [PXcdj_sweep] CSV.
+// ---------------------------------------------------------------------------
+TEST_CASE("PXcdj named regressions", "[PXcdj]") {
+    static const NamedCase kCases[] = {
+        // Water: gas, liquid, supercritical
+        {"Water", 600.0, 1.0e5, "gas"},
+        {"Water", 320.0, 5.0e6, "liquid"},
+        {"Water", 700.0, 30.0e6, "supercrit"},
+        // CO2: gas, supercritical, liquid
+        {"CarbonDioxide", 350.0, 1.0e6, "gas"},
+        {"CarbonDioxide", 320.0, 10.0e6, "supercrit"},
+        {"CarbonDioxide", 250.0, 5.0e6, "liquid"},
+        // R134a: liquid, gas
+        {"R134a", 250.0, 3.0e5, "liquid"},
+        {"R134a", 350.0, 2.0e5, "gas"},
+        // Propane: gas, liquid
+        {"n-Propane", 350.0, 1.0e6, "gas"},
+        {"n-Propane", 250.0, 5.0e6, "liquid"},
+        // Nitrogen: gas, supercritical (NOT the 86.35K / 90.20K failing points)
+        {"Nitrogen", 300.0, 1.0e5, "gas"},
+        {"Nitrogen", 200.0, 10.0e6, "supercrit"},
+        // MM (hexamethyldisiloxane): gas, liquid
+        {"MM", 450.0, 1.0e5, "gas"},
+        {"MM", 350.0, 5.0e6, "liquid"},
+        // Prototype-era known-hard points that master handles correctly.
+        {"Nitrogen", 121.0, 3.7e6, "supercritical-cold wrong-basin trap"},
+        {"R134a", 250.0, 3.0e5, "spinodal step"},
+        {"Water", 277.0, 5.0e6, "density anomaly"},
+    };
+    for (const auto& c : kCases) {
+        DYNAMIC_SECTION(c.fluid << " " << c.note << " T=" << c.T_K << "K p=" << c.p_Pa << "Pa") {
+            run_named_case(c);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Opt-in heavy sweep: iterate CoolProp's pure-fluid list, build a dense
+// (log-p, linear-T) grid, establish a reference via PT_INPUTS, then re-flash
+// each P+X pair through the production code and check (T, rho) recovery.
+// Writes a single CSV with timing + per-point success — the moderate (30x30)
+// run is committed as dev/fixtures/pxcdj_master_baseline.csv.gz to serve as
+// a regression fingerprint.
+//
+// Env knobs:
+//   PXCDJ_NT      grid size in T (default 40)
+//   PXCDJ_NP      grid size in p (default 40)
+//   PXCDJ_CSV     output CSV path (default "pxcdj_sweep.csv" in cwd)
+//   PXCDJ_REPS    timing reps per point (default 3); best of reps is kept
+// ---------------------------------------------------------------------------
+TEST_CASE("PXcdj broad sweep", "[PXcdj_sweep][.]") {
+    const std::size_t NT = env_or("PXCDJ_NT", 40);
+    const std::size_t NP = env_or("PXCDJ_NP", 40);
+    const std::size_t reps = env_or("PXCDJ_REPS", 3);
+    const char* csv_env = std::getenv("PXCDJ_CSV");
+    const std::string csv_path = (csv_env != nullptr) ? csv_env : "pxcdj_sweep.csv";
+
+    std::ofstream out(csv_path);
+    if (!out.is_open()) {
+        FAIL("Failed to open PXcdj sweep CSV: " << csv_path);
+    }
+    out << "fluid,pair,T_K,p_Pa,rho_molm3,value,T_solved,rho_solved,success,microseconds\n";
+
+    const std::string fluids_csv = CoolProp::get_global_param_string("FluidsList");
+    const std::vector<std::string> fluids = strsplit(fluids_csv, ',');
+
+    static const CoolProp::input_pairs kPairs[] = {CoolProp::HmolarP_INPUTS, CoolProp::PSmolar_INPUTS, CoolProp::PUmolar_INPUTS};
+
+    std::size_t fluids_attempted = 0, fluids_completed = 0;
+    std::size_t grand_total = 0, grand_ok = 0;
+
+    for (const auto& fluid : fluids) {
+        if (fluid.empty()) continue;
+        ++fluids_attempted;
+
+        std::shared_ptr<CoolProp::AbstractState> ref, wrk;
+        try {
+            ref.reset(CoolProp::AbstractState::factory("HEOS", fluid));
+            wrk.reset(CoolProp::AbstractState::factory("HEOS", fluid));
+        } catch (const std::exception& e) {
+            std::printf("[PXcdj_sweep] %s: factory threw — skipped (%s)\n", fluid.c_str(), e.what());
+            continue;
+        } catch (...) {
+            std::printf("[PXcdj_sweep] %s: factory threw non-std — skipped\n", fluid.c_str());
+            continue;
+        }
+
+        double Tmin = 0, Tmax = 0, pmax = 0, ptriple = 0;
+        try {
+            Tmin = ref->Tmin();
+            Tmax = ref->Tmax();
+            pmax = ref->pmax();
+        } catch (const std::exception& e) {
+            std::printf("[PXcdj_sweep] %s: limits query threw — skipped (%s)\n", fluid.c_str(), e.what());
+            continue;
+        }
+        try {
+            ptriple = ref->p_triple();
+        } catch (...) {
+            ptriple = 0;
+        }
+        const double plo = std::max(std::max(ptriple, pmax * 1e-8), 1.0);
+        if (!(Tmax > Tmin) || !(pmax > plo)) {
+            std::printf("[PXcdj_sweep] %s: degenerate (T,p) bounds — skipped\n", fluid.c_str());
+            continue;
+        }
+
+        const auto T_vec = linspace(Tmin + 0.1, Tmax, NT);
+        const auto p_vec = logspace(plo, pmax, NP);
+
+        // Per-pair counters: total points, successful round-trips.
+        std::size_t pair_total[3] = {0, 0, 0};
+        std::size_t pair_ok[3] = {0, 0, 0};
+        std::size_t fluid_total = 0, fluid_ok = 0;
+
+        for (double T : T_vec) {
+            for (double p : p_vec) {
+                // Establish reference state; skip out-of-domain or two-phase.
+                try {
+                    ref->update(CoolProp::PT_INPUTS, p, T);
+                } catch (...) {
+                    continue;
+                }
+                if (ref->phase() == CoolProp::iphase_twophase) continue;
+                const double rho_ref = ref->rhomolar();
+                if (!std::isfinite(rho_ref) || rho_ref <= 0) continue;
+
+                for (std::size_t pi = 0; pi < 3; ++pi) {
+                    const CoolProp::input_pairs pr = kPairs[pi];
+                    double value = _HUGE;
+                    try {
+                        value = caloric_molar(*ref, pr);
+                    } catch (...) {
+                        continue;
+                    }
+                    if (!std::isfinite(value)) continue;
+
+                    ++pair_total[pi];
+                    ++fluid_total;
+                    ++grand_total;
+
+                    double best_us = 1e300;
+                    bool threw = false;
+                    double T_out = std::nan(""), rho_out = std::nan("");
+                    for (std::size_t r = 0; r < reps; ++r) {
+                        const auto t0 = std::chrono::steady_clock::now();
+                        try {
+                            if (pr == CoolProp::HmolarP_INPUTS) {
+                                wrk->update(pr, value, p);  // (h, p)
+                            } else {
+                                wrk->update(pr, p, value);  // (p, s/u)
+                            }
+                        } catch (...) {
+                            threw = true;
+                        }
+                        const double us = std::chrono::duration<double, std::micro>(std::chrono::steady_clock::now() - t0).count();
+                        if (us < best_us) best_us = us;
+                        if (threw) break;  // no point timing repeats once it threw
+                    }
+
+                    bool point_ok = false;
+                    if (!threw) {
+                        try {
+                            T_out = wrk->T();
+                            rho_out = wrk->rhomolar();
+                        } catch (...) {
+                            T_out = std::nan("");
+                            rho_out = std::nan("");
+                        }
+                        if (std::isfinite(T_out) && std::isfinite(rho_out) && std::abs(T_out - T) / T < 1e-5
+                            && std::abs(rho_out - rho_ref) / rho_ref < 1e-5) {
+                            point_ok = true;
+                        }
+                    }
+                    if (point_ok) {
+                        ++pair_ok[pi];
+                        ++fluid_ok;
+                        ++grand_ok;
+                    }
+
+                    // Always write a row, even on failure / throw.  T_solved /
+                    // rho_solved are nan on throw; success is 0/1.
+                    out << fluid << ',' << pair_label(pr) << ',' << T << ',' << p << ',' << rho_ref << ',' << value << ',' << T_out << ','
+                        << rho_out << ',' << (point_ok ? 1 : 0) << ',' << best_us << '\n';
+                }
+            }
+        }
+
+        ++fluids_completed;
+        std::printf("[PXcdj_sweep] %s: %zu/%zu round-trips (PH:%zu/%zu PS:%zu/%zu PU:%zu/%zu)\n", fluid.c_str(), fluid_ok, fluid_total,
+                    pair_ok[0], pair_total[0], pair_ok[1], pair_total[1], pair_ok[2], pair_total[2]);
+    }
+
+    out.close();
+    std::printf("[PXcdj_sweep] wrote %zu rows to %s\n", grand_total, csv_path.c_str());
+    std::printf("[PXcdj_sweep] fluids: %zu attempted, %zu completed; round-trips: %zu/%zu (%.2f%%)\n", fluids_attempted, fluids_completed,
+                grand_ok, grand_total, (grand_total > 0) ? 100.0 * grand_ok / grand_total : 0.0);
+    // The sweep is a characterisation map, not a pass/fail: don't fail the
+    // test when some points fail (e.g. the Nitrogen/PS supercritical-cold
+    // points fixed by PR #3020).  The CSV is the artifact of interest.
+}
+
+#endif  // ENABLE_CATCH

--- a/src/Tests/CoolProp-Tests-PXcdj.cpp
+++ b/src/Tests/CoolProp-Tests-PXcdj.cpp
@@ -27,10 +27,13 @@
 #include "CoolProp.h"
 #include "CPstrings.h"
 #include "DataStructures.h"
+#include "CoolProp/px_preconditioner.h"
+#include "Backends/Helmholtz/HelmholtzEOSMixtureBackend.h"
 
 #if defined(ENABLE_CATCH)
 #    include <catch2/catch_all.hpp>
 
+#    include <atomic>
 #    include <chrono>
 #    include <cmath>
 #    include <cstdio>
@@ -38,6 +41,7 @@
 #    include <fstream>
 #    include <memory>
 #    include <string>
+#    include <thread>
 #    include <vector>
 
 namespace {
@@ -185,30 +189,30 @@ void run_named_case(const NamedCase& c) {
 // ---------------------------------------------------------------------------
 TEST_CASE("PXcdj named regressions", "[PXcdj]") {
     static const NamedCase kCases[] = {
-        // Water: gas, liquid, supercritical
-        {"Water", 600.0, 1.0e5, "gas"},
-        {"Water", 320.0, 5.0e6, "liquid"},
-        {"Water", 700.0, 30.0e6, "supercrit"},
-        // CO2: gas, supercritical, liquid
-        {"CarbonDioxide", 350.0, 1.0e6, "gas"},
-        {"CarbonDioxide", 320.0, 10.0e6, "supercrit"},
-        {"CarbonDioxide", 250.0, 5.0e6, "liquid"},
-        // R134a: liquid, gas
-        {"R134a", 250.0, 3.0e5, "liquid"},
-        {"R134a", 350.0, 2.0e5, "gas"},
-        // Propane: gas, liquid
-        {"n-Propane", 350.0, 1.0e6, "gas"},
-        {"n-Propane", 250.0, 5.0e6, "liquid"},
-        // Nitrogen: gas, supercritical (NOT the 86.35K / 90.20K failing points)
-        {"Nitrogen", 300.0, 1.0e5, "gas"},
-        {"Nitrogen", 200.0, 10.0e6, "supercrit"},
-        // MM (hexamethyldisiloxane): gas, liquid
-        {"MM", 450.0, 1.0e5, "gas"},
-        {"MM", 350.0, 5.0e6, "liquid"},
-        // Prototype-era known-hard points that master handles correctly.
-        {"Nitrogen", 121.0, 3.7e6, "supercritical-cold wrong-basin trap"},
-        {"R134a", 250.0, 3.0e5, "spinodal step"},
-        {"Water", 277.0, 5.0e6, "density anomaly"},
+      // Water: gas, liquid, supercritical
+      {"Water", 600.0, 1.0e5, "gas"},
+      {"Water", 320.0, 5.0e6, "liquid"},
+      {"Water", 700.0, 30.0e6, "supercrit"},
+      // CO2: gas, supercritical, liquid
+      {"CarbonDioxide", 350.0, 1.0e6, "gas"},
+      {"CarbonDioxide", 320.0, 10.0e6, "supercrit"},
+      {"CarbonDioxide", 250.0, 5.0e6, "liquid"},
+      // R134a: liquid, gas
+      {"R134a", 250.0, 3.0e5, "liquid"},
+      {"R134a", 350.0, 2.0e5, "gas"},
+      // Propane: gas, liquid
+      {"n-Propane", 350.0, 1.0e6, "gas"},
+      {"n-Propane", 250.0, 5.0e6, "liquid"},
+      // Nitrogen: gas, supercritical (NOT the 86.35K / 90.20K failing points)
+      {"Nitrogen", 300.0, 1.0e5, "gas"},
+      {"Nitrogen", 200.0, 10.0e6, "supercrit"},
+      // MM (hexamethyldisiloxane): gas, liquid
+      {"MM", 450.0, 1.0e5, "gas"},
+      {"MM", 350.0, 5.0e6, "liquid"},
+      // Prototype-era known-hard points that master handles correctly.
+      {"Nitrogen", 121.0, 3.7e6, "supercritical-cold wrong-basin trap"},
+      {"R134a", 250.0, 3.0e5, "spinodal step"},
+      {"Water", 277.0, 5.0e6, "density anomaly"},
     };
     for (const auto& c : kCases) {
         DYNAMIC_SECTION(c.fluid << " " << c.note << " T=" << c.T_K << "K p=" << c.p_Pa << "Pa") {
@@ -363,24 +367,375 @@ TEST_CASE("PXcdj broad sweep", "[PXcdj_sweep][.]") {
 
                     // Always write a row, even on failure / throw.  T_solved /
                     // rho_solved are nan on throw; success is 0/1.
-                    out << fluid << ',' << pair_label(pr) << ',' << T << ',' << p << ',' << rho_ref << ',' << value << ',' << T_out << ','
-                        << rho_out << ',' << (point_ok ? 1 : 0) << ',' << best_us << '\n';
+                    out << fluid << ',' << pair_label(pr) << ',' << T << ',' << p << ',' << rho_ref << ',' << value << ',' << T_out << ',' << rho_out
+                        << ',' << (point_ok ? 1 : 0) << ',' << best_us << '\n';
                 }
             }
         }
 
         ++fluids_completed;
-        std::printf("[PXcdj_sweep] %s: %zu/%zu round-trips (PH:%zu/%zu PS:%zu/%zu PU:%zu/%zu)\n", fluid.c_str(), fluid_ok, fluid_total,
-                    pair_ok[0], pair_total[0], pair_ok[1], pair_total[1], pair_ok[2], pair_total[2]);
+        std::printf("[PXcdj_sweep] %s: %zu/%zu round-trips (PH:%zu/%zu PS:%zu/%zu PU:%zu/%zu)\n", fluid.c_str(), fluid_ok, fluid_total, pair_ok[0],
+                    pair_total[0], pair_ok[1], pair_total[1], pair_ok[2], pair_total[2]);
     }
 
     out.close();
     std::printf("[PXcdj_sweep] wrote %zu rows to %s\n", grand_total, csv_path.c_str());
-    std::printf("[PXcdj_sweep] fluids: %zu attempted, %zu completed; round-trips: %zu/%zu (%.2f%%)\n", fluids_attempted, fluids_completed,
-                grand_ok, grand_total, (grand_total > 0) ? 100.0 * grand_ok / grand_total : 0.0);
+    std::printf("[PXcdj_sweep] fluids: %zu attempted, %zu completed; round-trips: %zu/%zu (%.2f%%)\n", fluids_attempted, fluids_completed, grand_ok,
+                grand_total, (grand_total > 0) ? 100.0 * grand_ok / grand_total : 0.0);
     // The sweep is a characterisation map, not a pass/fail: don't fail the
     // test when some points fail (e.g. the Nitrogen/PS supercritical-cold
     // points fixed by PR #3020).  The CSV is the artifact of interest.
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3a — preconditioner unit tests.
+//
+// The preconditioner is a standalone unit (include/CoolProp/px_preconditioner.h,
+// src/Backends/Helmholtz/PXPreconditioner.cpp).  Phase 3b will wire it into
+// HSU_P_flash_singlephase_Brent; this phase just unit-tests the standalone
+// pieces:
+//   1. ensure_melt_curve_table / MeltCurveTable::rho_at
+//   2. regime_classified_rho_seed (supercritical / liquid / vapor / edges)
+//   3. lazy-init idempotence + (light) thread safety
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Cast helper: get the HelmholtzEOSMixtureBackend from an AbstractState built
+// via the "HEOS" factory.  Returns nullptr if the cast fails (shouldn't on the
+// pure fluids we test below, but be defensive).
+CoolProp::HelmholtzEOSMixtureBackend* as_heos(CoolProp::AbstractState& AS) {
+    return dynamic_cast<CoolProp::HelmholtzEOSMixtureBackend*>(&AS);
+}
+
+}  // namespace
+
+TEST_CASE("PXcdj preconditioner: melt-curve table", "[PXcdj][PXcdj_precond]") {
+    // Fluids known to ship a melting line in CoolProp (dev/fluids/*.json with a
+    // "melting_line" block).  R134a / R32 / R1234yf etc. do NOT have one; the
+    // no-melt branch is exercised in the dedicated section below.
+    static const char* kMeltFluids[] = {"Water", "CarbonDioxide", "n-Propane", "Methane"};
+    for (const char* fluid : kMeltFluids) {
+        DYNAMIC_SECTION("melt table: " << fluid) {
+            std::shared_ptr<CoolProp::AbstractState> AS;
+            try {
+                AS.reset(CoolProp::AbstractState::factory("HEOS", fluid));
+            } catch (const std::exception& e) {
+                FAIL("factory threw for " << fluid << ": " << e.what());
+            }
+            auto* H = as_heos(*AS);
+            REQUIRE(H != nullptr);
+            REQUIRE(H->has_melting_line());
+
+            CoolProp::pxprecond::ensure_melt_curve_table(*H);
+            const auto& tbl = CoolProp::pxprecond::get_melt_curve_table(*H);
+            CAPTURE(tbl.p.size());
+            REQUIRE(tbl.has_data);
+            REQUIRE(tbl.p.size() >= 5);
+            REQUIRE(tbl.p.size() == tbl.T_melt.size());
+            REQUIRE(tbl.p.size() == tbl.rho_melt.size());
+
+            // Monotone-increasing in p.
+            for (std::size_t i = 1; i < tbl.p.size(); ++i) {
+                REQUIRE(tbl.p[i] > tbl.p[i - 1]);
+            }
+
+            // Spot-check Water at p=1MPa: melt-side liquid density ~ 55000 mol/m^3
+            // (standard water is ~ 55556 mol/m^3 at NTP; near the melting point it
+            // is similar to within ~50%).
+            if (std::string(fluid) == "Water") {
+                const double rhoM = tbl.rho_at(1.0e6);
+                CAPTURE(rhoM);
+                REQUIRE(std::isfinite(rhoM));
+                REQUIRE(rhoM > 0.5 * 55000.0);
+                REQUIRE(rhoM < 1.5 * 55000.0);
+                // Diagnostic printout — useful for the wake-up report.
+                std::printf("[PXcdj_precond] Water melt table (%zu pts):\n", tbl.p.size());
+                std::printf("  p_lo=%.4e  T_melt=%.4f K  rho_melt=%.4f mol/m^3\n", tbl.p.front(), tbl.T_melt.front(), tbl.rho_melt.front());
+                std::printf("  p_hi=%.4e  T_melt=%.4f K  rho_melt=%.4f mol/m^3\n", tbl.p.back(), tbl.T_melt.back(), tbl.rho_melt.back());
+                for (double pq : {1.0e6, 1.0e7, 1.0e8, 5.0e8}) {
+                    std::printf("  rho_at(%.2e Pa) = %.4f mol/m^3\n", pq, tbl.rho_at(pq));
+                }
+            }
+
+            // rho_at across the table range returns finite positive values.
+            for (std::size_t i = 0; i < tbl.p.size(); ++i) {
+                const double rho = tbl.rho_at(tbl.p[i]);
+                REQUIRE(std::isfinite(rho));
+                REQUIRE(rho > 0.0);
+            }
+            // Mid-points too.
+            for (std::size_t i = 1; i < tbl.p.size(); ++i) {
+                const double pm = 0.5 * (tbl.p[i - 1] + tbl.p[i]);
+                const double rho = tbl.rho_at(pm);
+                REQUIRE(std::isfinite(rho));
+                REQUIRE(rho > 0.0);
+            }
+
+            // Clamp on either side — must not throw, must return finite positive.
+            const double rho_lo = tbl.rho_at(tbl.p.front() * 0.001);
+            const double rho_hi = tbl.rho_at(tbl.p.back() * 1000.0);
+            CHECK(std::isfinite(rho_lo));
+            CHECK(rho_lo > 0.0);
+            CHECK(std::isfinite(rho_hi));
+            CHECK(rho_hi > 0.0);
+            // Clamped value at p_lo*1e-3 == rho_melt.front(); at p_hi*1e3 == rho_melt.back().
+            CHECK(rho_lo == tbl.rho_melt.front());
+            CHECK(rho_hi == tbl.rho_melt.back());
+        }
+    }
+
+    SECTION("fluid without a melting line") {
+        // Find the first fluid (from a small candidate list) that has no melting
+        // line.  Document which we picked.  R134a / R1234yf / R32 / R125 do not
+        // ship a melting line.  Helium, IsoButane, n-Butane DO have one (per
+        // dev/fluids/*.json) — keep them out of this candidate list.
+        static const char* kNoMeltCandidates[] = {"R134a", "R1234yf", "R32", "R125", "MM", "MDM"};
+        const char* picked = nullptr;
+        std::shared_ptr<CoolProp::AbstractState> AS;
+        for (const char* f : kNoMeltCandidates) {
+            try {
+                AS.reset(CoolProp::AbstractState::factory("HEOS", f));
+            } catch (...) {
+                continue;
+            }
+            if (!AS->has_melting_line()) {
+                picked = f;
+                break;
+            }
+        }
+        CAPTURE(picked);
+        REQUIRE(picked != nullptr);
+        auto* H = as_heos(*AS);
+        REQUIRE(H != nullptr);
+        CoolProp::pxprecond::ensure_melt_curve_table(*H);
+        const auto& tbl = CoolProp::pxprecond::get_melt_curve_table(*H);
+        REQUIRE_FALSE(tbl.has_data);
+        REQUIRE(tbl.p.empty());
+        // rho_at on a no-data table returns NaN.
+        const double r = tbl.rho_at(1.0e6);
+        CHECK(std::isnan(r));
+    }
+}
+
+TEST_CASE("PXcdj preconditioner: regime-classified seed", "[PXcdj][PXcdj_precond]") {
+    using CoolProp::pxprecond::regime_classified_rho_seed;
+
+    struct Point
+    {
+        const char* fluid;
+        double T;
+        double p;
+        const char* regime;  // "super", "liquid", "vapor", "edge"
+        const char* note;
+    };
+    // Representative points.  Pick points clearly inside each regime
+    // (don't sit near T_sat or near Tc — there the seed can legitimately be
+    // far from rho_sat,L or rho_sat,V).  Tc's used to pick: Water 647.1K,
+    // CO2 304.1K, n-Propane 369.8K, R134a 374.2K.
+    //
+    // Regime labels:
+    //   "super-ideal"  T > 0.8*Tmax or p < 0.01*pc -> seed == p/(RT) exactly
+    //   "super-blend"  supercritical blend; seed lies between rho_c and p/(RT)
+    //   "liquid"       T < T_sat(p), p > p_sat(T); seed within factor 2 of rho_sat,L
+    //   "vapor"        T < Tc, p < p_sat(T); seed within factor 2 of rho_sat,V or p/(RT)
+    static const Point kPts[] = {
+      // Supercritical-ideal: hit the cutoffs.
+      // Water: Tmax=2000K so 0.8*Tmax=1600K; pc=22.064 MPa so 0.01*pc=220.64 kPa.
+      // 200 kPa is below the low-p cutoff.
+      {"Water", 700.0, 2.0e5, "super-ideal", "low-p super (< 0.01*pc) -> ideal-gas"},
+      // CO2: pc=7.37 MPa, 0.01*pc=73.7 kPa; 50 kPa is below.
+      {"CarbonDioxide", 400.0, 5.0e4, "super-ideal", "low-p super -> ideal-gas"},
+      // Supercritical-blend: moderate p, moderate T above Tc.
+      {"Water", 700.0, 30.0e6, "super-blend", "blended"},
+      {"CarbonDioxide", 400.0, 1.0e6, "super-blend", "blended"},
+      {"n-Propane", 450.0, 5.0e5, "super-blend", "blended"},
+      // Subcritical liquid: T well below T_sat(p).  All Ts < Tc, p above p_sat(T).
+      {"Water", 320.0, 5.0e6, "liquid", "moderate p"},
+      {"CarbonDioxide", 250.0, 5.0e6, "liquid", "moderate p"},
+      {"n-Propane", 280.0, 2.0e6, "liquid", "moderate p"},
+      {"R134a", 280.0, 5.0e5, "liquid", "moderate p"},
+      // Subcritical vapor (T < Tc and p < p_sat(T)).  Choose T well below Tc.
+      {"Water", 500.0, 1.0e5, "vapor", "T<Tc(647), p<p_sat(500)"},
+      {"CarbonDioxide", 280.0, 1.0e5, "vapor", "T<Tc(304), p<p_sat(280)"},
+      {"n-Propane", 320.0, 1.0e5, "vapor", "T<Tc(370), p<p_sat(320)"},
+      {"R134a", 350.0, 1.0e5, "vapor", "T<Tc(374), p<p_sat(350)"},
+    };
+
+    for (const auto& pt : kPts) {
+        DYNAMIC_SECTION(pt.fluid << " " << pt.regime << " T=" << pt.T << "K p=" << pt.p << "Pa (" << pt.note << ")") {
+            std::shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", pt.fluid));
+            auto* H = as_heos(*AS);
+            REQUIRE(H != nullptr);
+
+            const double seed = regime_classified_rho_seed(*H, pt.T, pt.p);
+            CAPTURE(seed);
+            REQUIRE(std::isfinite(seed));
+            REQUIRE(seed > 0.0);
+
+            const double R = H->gas_constant();
+            const double ig = pt.p / (R * pt.T);
+            REQUIRE(std::isfinite(ig));
+            REQUIRE(ig > 0.0);
+
+            if (std::string(pt.regime) == "super-ideal") {
+                // The ideal-gas branches (high T or low p) should give exactly p/(RT).
+                CHECK(seed == Catch::Approx(ig).epsilon(1e-12));
+            } else if (std::string(pt.regime) == "super-blend") {
+                // Blended (1-alpha)*rho_c + alpha*p/(RT).  Seed lies between
+                // ideal-gas and rho_c (whichever is larger/smaller); just
+                // sanity-check it is bounded by min/max of those two.
+                const double rho_c = H->rhomolar_critical();
+                REQUIRE(std::isfinite(rho_c));
+                REQUIRE(rho_c > 0.0);
+                const double lo = std::min(ig, rho_c);
+                const double hi = std::max(ig, rho_c);
+                CAPTURE(rho_c, lo, hi);
+                CHECK(seed >= lo - 1e-9 * hi);
+                CHECK(seed <= hi + 1e-9 * hi);
+            } else if (std::string(pt.regime) == "liquid") {
+                // Compare to rho_sat,L(T) via the same superanc the seed used.
+                auto sa = H->get_superanc();
+                REQUIRE(sa);
+                double rhoL = 0.0;
+                REQUIRE_NOTHROW(rhoL = sa->eval_sat(pt.T, 'D', 0));
+                REQUIRE(rhoL > 0.0);
+                CAPTURE(rhoL);
+                // Seed must be within a factor of 2 of rho_sat,L for moderate p.
+                CHECK(seed > 0.5 * rhoL);
+                CHECK(seed < 2.0 * rhoL);
+            } else if (std::string(pt.regime) == "vapor") {
+                auto sa = H->get_superanc();
+                REQUIRE(sa);
+                double rhoV = 0.0;
+                REQUIRE_NOTHROW(rhoV = sa->eval_sat(pt.T, 'D', 1));
+                REQUIRE(rhoV > 0.0);
+                CAPTURE(rhoV);
+                // Seed must be within a factor of 2 of rho_sat,V for moderate p.
+                // The seed may also legitimately equal p/(RT) for low p — accept that too.
+                const bool near_rhoV = (seed > 0.5 * rhoV && seed < 2.0 * rhoV);
+                const bool near_ig = (seed > 0.5 * ig && seed < 2.0 * ig);
+                CAPTURE(near_rhoV, near_ig, rhoV, ig);
+                CHECK((near_rhoV || near_ig));
+            }
+        }
+    }
+
+    SECTION("edge cases") {
+        // For each of a few fluids, hit edges and check seed is finite positive.
+        for (const char* f : {"Water", "CarbonDioxide", "n-Propane", "R134a"}) {
+            DYNAMIC_SECTION(f) {
+                std::shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", f));
+                auto* H = as_heos(*AS);
+                REQUIRE(H != nullptr);
+                const double Tc = H->T_critical();
+                const double pc = H->p_critical();
+                const double Tmax = H->Tmax();
+                double p_triple = 1.0;
+                try {
+                    p_triple = H->p_triple();
+                } catch (...) {
+                    p_triple = 1.0;
+                }
+                struct EdgePt
+                {
+                    double T;
+                    double p;
+                    const char* note;
+                };
+                const EdgePt edges[] = {
+                  {Tc, pc, "T=Tc, p=pc"},
+                  {Tc, std::max(p_triple, pc * 0.5), "T=Tc"},
+                  {std::min(Tmax, 1.2 * Tc), 0.5 * pc, "near Tmax-ish"},
+                  {0.5 * Tc, std::max(p_triple, 100.0), "low T low p (~p_triple)"},
+                  {0.7 * Tc, pc, "subcrit at pc"},
+                };
+                for (const auto& e : edges) {
+                    CAPTURE(e.note, e.T, e.p);
+                    const double seed = CoolProp::pxprecond::regime_classified_rho_seed(*H, e.T, e.p);
+                    CAPTURE(seed);
+                    CHECK(std::isfinite(seed));
+                    CHECK(seed > 0.0);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("PXcdj preconditioner: idempotent lazy-init", "[PXcdj][PXcdj_precond]") {
+    using clock_t = std::chrono::steady_clock;
+    SECTION("Argon: second ensure_melt_curve_table call is essentially free") {
+        // Pick a melt-line fluid that is unlikely to have been queried in earlier
+        // test_cases (the table_map is process-wide; Water/CO2/Propane/Methane
+        // are all queried by the melt-table test_case above, so reusing them
+        // here would measure "cached" both times).  Argon has a melting line.
+        std::shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "Argon"));
+        auto* H = as_heos(*AS);
+        REQUIRE(H != nullptr);
+        REQUIRE(H->has_melting_line());
+
+        const auto t0 = clock_t::now();
+        CoolProp::pxprecond::ensure_melt_curve_table(*H);
+        const auto t1 = clock_t::now();
+        CoolProp::pxprecond::ensure_melt_curve_table(*H);
+        const auto t2 = clock_t::now();
+
+        const double first_us = std::chrono::duration<double, std::micro>(t1 - t0).count();
+        const double second_us = std::chrono::duration<double, std::micro>(t2 - t1).count();
+        std::printf("[PXcdj_precond] Argon lazy-init: first=%.1f us, second=%.3f us\n", first_us, second_us);
+
+        // First call should genuinely build (PT_INPUTS updates etc.); on this
+        // machine that's O(ms) IF the fluid has not already been seeded
+        // elsewhere in the test process.  Second call must be a small
+        // constant — the map lookup + initialized check.  Documenting actual
+        // numbers via the printf above; the assertion is a loose ceiling.
+        CHECK(first_us >= 0.0);     // sanity (steady_clock guarantees non-decreasing)
+        CHECK(second_us < 1000.0);  // < 1 ms — loose, would pass even under heavy load
+
+        // Table contents unchanged across the two calls.
+        const auto& tbl = CoolProp::pxprecond::get_melt_curve_table(*H);
+        REQUIRE(tbl.has_data);
+        const auto p_size = tbl.p.size();
+        CoolProp::pxprecond::ensure_melt_curve_table(*H);
+        const auto& tbl2 = CoolProp::pxprecond::get_melt_curve_table(*H);
+        REQUIRE(tbl2.p.size() == p_size);
+        for (std::size_t i = 0; i < p_size; ++i) {
+            CHECK(tbl.p[i] == tbl2.p[i]);
+            CHECK(tbl.rho_melt[i] == tbl2.rho_melt[i]);
+        }
+    }
+
+    SECTION("concurrent ensure + seed (4 threads, Water)") {
+        std::shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "Water"));
+        auto* H = as_heos(*AS);
+        REQUIRE(H != nullptr);
+
+        std::atomic<bool> ok{true};
+        std::atomic<int> nonpos{0};
+        auto worker = [&]() {
+            for (int i = 0; i < 200; ++i) {
+                try {
+                    CoolProp::pxprecond::ensure_melt_curve_table(*H);
+                    const double T = 320.0 + 0.1 * i;
+                    const double p = 1.0e5 + 1.0e4 * i;
+                    const double seed = CoolProp::pxprecond::regime_classified_rho_seed(*H, T, p);
+                    if (!(std::isfinite(seed) && seed > 0.0)) {
+                        ++nonpos;
+                        ok = false;
+                    }
+                } catch (...) {
+                    ok = false;
+                }
+            }
+        };
+        std::vector<std::thread> threads;
+        for (int t = 0; t < 4; ++t)
+            threads.emplace_back(worker);
+        for (auto& t : threads)
+            t.join();
+        CAPTURE(nonpos.load());
+        CHECK(ok.load());
+    }
 }
 
 #endif  // ENABLE_CATCH


### PR DESCRIPTION
**Draft / WIP — overnight prep work for the CoolProp-cdj refactor.**

## TL;DR — what's here

This PR delivers the *test bed* and *standalone preconditioner unit* that the CoolProp-cdj direct-EOS inner-Newton refactor will need. **No production behavior change** (no integration of the preconditioner with \`HSU_P_flash_singlephase_Brent\` was shipped — three attempts failed the G3 hard gate; findings documented for next session).

## What's shipped (3 commits)

| # | Commit | Content | LOC |
|---|---|---|---|
| 1 | \`d12c87cfa\` | Design spec at \`docs/superpowers/specs/2026-05-28-pxcdj-testinfra-and-preconditioner-design.md\` — G1–G5 gates, preconditioner design, validation plan | docs |
| 2 | \`1b4bc2272\` | Test bed: \`[PXcdj]\` (CI default named regressions) + \`[PXcdj_sweep][.]\` (heavy 136-fluid broad sweep) + baseline fixture \`dev/fixtures/pxcdj_master_baseline.csv.gz\` (4.7 MB compressed, 364,680 rows) | +388 |
| 3 | \`1306d4e24\` | Standalone preconditioner unit: \`include/CoolProp/px_preconditioner.h\` + \`src/Backends/Helmholtz/PXPreconditioner.cpp\` + unit tests. Per-fluid melt-curve table (p-indexed for water-anomaly compatibility) + regime-classified seed function. | +918 |
| 4 | \`219def85c\` | Spec append: full findings from the 3 failed integration attempts | +48 |

## What works (gates met)

- ✅ \`[PXcdj]\` CI-default test: **1073 assertions / 4 cases, all pass on master** (commit \`2a3f1995e\`).
- ✅ \`[PXcdj_sweep][.]\` heavy test: **364,680 round-trips across 136 fluids in 30s** wall time at NT=NP=30. **99.27% baseline success.**
- ✅ Baseline fixture committed at 4.7 MB compressed (24 MB uncompressed).
- ✅ Preconditioner unit tests: **869 assertions / 3 cases, all pass.**
- ✅ Lazy-init verified (~700 µs first call, ~0.13 µs cached — 5000× speedup).
- ✅ Water \`rho_melt\` values sanity-check correctly (55–69 kmol/m³ across the table).

## What's deferred — and why

**Production integration attempted 3 times; all failed G3 (zero new failures vs baseline).**

| Attempt | Strategy | G3 result |
|---|---|---:|
| 1 | Seed at \`T_mid = 0.5*(Tmin+Tmax)\`, reuse on every probe | **10,762 new failures** (Brent's Tmin/Tmax probes hit wrong basin) |
| 2 | Per-call seed re-classification at actual probe T | **234 new failures** (deep supercritical + near-T_c regimes) |
| 3 | Attempt 2 + engagement gate (\`p > 3·p_c\`, \`\|T-T_c\|/T_c < 0.005\`) excluded | **444 new failures** (95% pseudo-pure mixtures — \`is_pure()\` gate is wrong) |

Net effect of Attempt 2: **+2,204 newly-successful points** (clear net win), but the spec mandates *zero new* failures.

## Key lessons (for the next session)

1. **\`is_pure()\` is not the right gate** for the preconditioner. Pseudo-pure mixtures (R407C, R410A, R507A, R404A, SES36) pass it but their superancillaries behave differently than true pure-fluid superancillaries — they account for **95% of Attempt 3's failures.**
2. **Per-call seed re-classification is necessary** (Attempt 1 → 2 cut failures 46×). The seed must match the probe T's basin, not a representative T.
3. **The preconditioner alone is not enough.** ~25% timing slowdown when engaged because the cached \`solver_rho_Tp\` + Householder4 path is the dominant cost, not the seed. The preconditioner's value is realized in conjunction with the **direct-EOS inner Newton** (CoolProp-cdj proper) that bypasses the cache and virtual-dispatch machinery.
4. **Hard G3 = 0 may be too strict** for opt-in preconditioning. A net-positive ON path is shippable if the test bed can prove the net gain — the gate should perhaps be "G3 net-positive AND no fluid regresses by more than X%."

Full findings in the spec doc (\`docs/superpowers/specs/2026-05-28-pxcdj-testinfra-and-preconditioner-design.md\`).

## What CoolProp-cdj's next session should do

1. **Re-design the gate**: \`is_pure() && !is_pseudopure()\` AND the per-fluid melt table actually has data AND superancillary consistency check at startup.
2. **Co-design the seed with the inner Newton**: the preconditioner's value is the basin-classified seed for a *direct-EOS, cache-bypassing* inner Newton.
3. **Reconsider the ship gate**: net-positive G3 with per-fluid regression cap is more useful than absolute G3 = 0 for opt-in.
4. **Handle pseudo-pure mixtures explicitly** — common class, currently broken.

## CI status

- \`[PXcdj]\` (CI default) passes on master and on this branch.
- \`[HS]\` unchanged baseline (16|15|1, pre-existing prototype fail).
- No production code change; HSU_P_flash_singlephase_Brent is byte-identical to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)