### PR TITLE
chore(blame): add #2980 + #3019 to .git-blame-ignore-revs [skip ci]

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -16,3 +16,13 @@ ee879788a10365c13f812993c4db6e69cb2d51a7
 # clang-tidy --fix for cppcoreguidelines-init-variables across src/
 # (CoolProp-2uw.13 part 2, PR #2808)
 7adb0aa1a216a0495b075fb84ad402b331bf9655
+
+# clang-tidy perf sweep + virtual-in-ctor + float-loops
+# (CoolProp-kig, #2926, PR #2980)
+2e61d46eeaa083895d14b64b461c973f4c52b2dd
+
+# clang-tidy Tier-2 mechanical fix-it sweep (modernize/perf:
+# unnecessary-value-param, prefer-member-initializer, use-auto,
+# loop-convert, use-equals-default, use-using, etc.)
+# (CoolProp-0xu, #2926 layer 2, PR #3019)
+fe950bbfa4c2cf53a79fb5a3d848b7c945dd1ddf


### PR DESCRIPTION
## Summary

- Add merge commit of #3019 (Tier-2 mechanical clang-tidy sweep, `fe950bbfa`) to `.git-blame-ignore-revs` so subsequent `git blame` walks through it, matching the precedent set by #2803 / #2805 / #2808 already in the file.
- Also adds #2980 (`2e61d46ee`, Tier-1 clang-tidy perf sweep + virtual-in-ctor + float-loops) — same mechanical-sweep category; was cited as a precedent in #3019's PR description but never landed in this file at its own merge time.

## Why `[skip ci]`

Tooling-only file. No build/source touched. The `.git-blame-ignore-revs` format is read by `git blame --ignore-revs-file=...` and by GitHub's blame view; CI doesn't consume it. Skipping CI is consistent with the prior blame-ignore additions in #2805 / #2808.

## Test plan

- [ ] `git blame -- include/Ancillaries.h` walks past `fe950bbfa` with `git config blame.ignoreRevsFile .git-blame-ignore-revs` set
- [ ] GitHub blame view on a file touched by #3019 (e.g. `src/Backends/Cubics/GeneralizedCubic.h`) attributes lines to the pre-#3019 author rather than the sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal developer tooling configuration for source control workflow optimization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3027?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->