### PR TITLE
docs(IF97Profile): order backends HEOS, IF97, then tabular [skip ci]

### DIFF
--- a/Web/scripts/fluid_properties.IF97Profile.py
+++ b/Web/scripts/fluid_properties.IF97Profile.py
@@ -58,9 +58,12 @@ P_RANGE = (1.0e4, 5.0e7)    # Pa — 0.01 to 50 MPa
 # runs.  Cheap to bump if the noise looks high.
 N_RUNS = 200
 
+# Order left-to-right: HEOS (the slow iterative baseline) first, then
+# IF97 (closed-form backward equations), then the tabular backends — so
+# the figure reads as a descending cost ladder.
 BACKENDS = [
-    ('IF97',         'Water', 'IF97'),
     ('HEOS',         'Water', 'HEOS'),
+    ('IF97',         'Water', 'IF97'),
     ('SVDSBTL&HEOS', 'Water', 'SVDSBTL+HEOS'),
     ('SVDSBTL&IF97', 'Water', 'SVDSBTL+IF97'),
 ]


### PR DESCRIPTION
## What

Reorders the `BACKENDS` list in `Web/scripts/fluid_properties.IF97Profile.py` so the `HmassP_INPUTS` timing figure reads left-to-right as a **descending cost ladder**:

`HEOS → IF97 → SVDSBTL+HEOS → SVDSBTL+IF97`

Previously IF97 was the first column; HEOS (the slow iterative baseline) now leads.

## Why

The figure's point is to show the cost ladder from the iterative two-input inversion of IAPWS-95 (HEOS) down through IF97's closed-form backward equations to the tabular lookups. Leading with HEOS makes that narrative read naturally.

## Notes

- **Plot-script-only change.** The plotting loop and all downstream arrays (`labels`/`medians`/`samples`) consume `BACKENDS`/`results` in iteration order — nothing indexes positions or hardcodes IF97 as row 0 — so the reorder propagates automatically with no label/data mismatch.
- The committed `IF97_profile.png` regenerates at doc-build time on CI; this PR does not rebuild it.
- `[skip ci]` — nothing buildable or testable is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reordered performance benchmark output sequence for improved result visualization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3028?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->