### PR TITLE
test(incompressible): regression guard for enthalpy at T==Tbase (#1578)

### DIFF
--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5004,7 +5004,11 @@ TEST_CASE("Incompressible enthalpy is finite and continuous at T == Tbase (#1578
     // against the throw returning.
     const double p = 101325.0;
     // (fluid name, Tbase [K]) pairs taken straight from the issue report.
-    struct Case { std::string name; double Tbase; };
+    struct Case
+    {
+        std::string name;
+        double Tbase;
+    };
     const std::vector<Case> cases = {
       {"INCOMP::AS30", 273.15},    // single-point case from the issue
       {"INCOMP::TD12", 345.65},    // single-point case from the issue

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4993,6 +4993,46 @@ TEST_CASE("INCOMP psat throws below TminPsat instead of returning 0 silently (#2
     CHECK(ValidNumber(v2));
     CHECK(v2 > 0);
 }
+TEST_CASE("Incompressible enthalpy is finite and continuous at T == Tbase (#1578)", "[INCOMP][1578]") {
+    // Issue #1578: PropsSI for incompressible fluids used to throw "A fraction
+    // cannot be evaluated with zero as denominator" whenever the requested
+    // temperature equalled the fluid's Tbase (so x_in - x_base == 0). For most
+    // fluids that is a single unlucky point, but Antifrogen N/L (AN/AL) have
+    // Tbase == 293.15 K, which is also their reference temperature, so
+    // enthalpy/entropy failed for *every* state. The singularity is now handled
+    // by L'Hopital-style interpolation in Polynomial2DFrac::evaluate; this guards
+    // against the throw returning.
+    const double p = 101325.0;
+    // (fluid name, Tbase [K]) pairs taken straight from the issue report.
+    struct Case { std::string name; double Tbase; };
+    const std::vector<Case> cases = {
+      {"INCOMP::AS30", 273.15},    // single-point case from the issue
+      {"INCOMP::TD12", 345.65},    // single-point case from the issue
+      {"INCOMP::AN-30%", 293.15},  // Antifrogen N: Tbase == Tref, failed for all T
+      {"INCOMP::AL-30%", 293.15},  // Antifrogen L: Tbase == Tref, failed for all T
+    };
+    for (const Case& c : cases) {
+        const double dT = 0.1;
+        double h_lo = 0, h_mid = 0, h_hi = 0;
+        CHECK_NOTHROW(h_lo = CoolProp::PropsSI("Hmass", "T", c.Tbase - dT, "P", p, c.name));
+        CHECK_NOTHROW(h_mid = CoolProp::PropsSI("Hmass", "T", c.Tbase, "P", p, c.name));
+        CHECK_NOTHROW(h_hi = CoolProp::PropsSI("Hmass", "T", c.Tbase + dT, "P", p, c.name));
+        CAPTURE(c.name);
+        CAPTURE(c.Tbase);
+        CAPTURE(h_lo);
+        CAPTURE(h_mid);
+        CAPTURE(h_hi);
+        CAPTURE(CoolProp::get_global_param_string("errstring"));
+        REQUIRE(ValidNumber(h_mid));
+        // Enthalpy is ~linear in T over a 0.2 K window (cp is locally constant),
+        // so the value at Tbase must equal the midpoint of its neighbours: this
+        // catches a spike/dropout if the singular point is mishandled. The bound
+        // is on the linearity residual (curvature ~ d(cp)/dT * dT^2), not the
+        // slope (~cp*dT ~ 400 J/kg); 1.0 J/kg leaves a wide margin.
+        const double midpoint = 0.5 * (h_lo + h_hi);
+        CHECK(std::abs(h_mid - midpoint) < 1.0);  // [J/kg]
+    }
+}
 TEST_CASE("PropsSImulti with empty input vectors returns empty result instead of segfaulting", "[PropsSImulti][2417]") {
     // Issue #2417: PropsSI('T','P',[],'Q',[],'Ammonia') segfaulted because
     // _PropsSI_outputs forced N1 = max(1, in1.size()) and then dereferenced


### PR DESCRIPTION
## Summary

Closes #1578 by adding regression coverage. 

Issue #1578: `PropsSI` for incompressible fluids threw *"A fraction cannot be evaluated with zero as denominator"* whenever the requested temperature equalled the fluid's `Tbase` (so `x_in - x_base == 0` in `Polynomial2DFrac`). For most fluids that's a single unlucky point, but **Antifrogen N/L** (`AN`/`AL`) have `Tbase == 293.15 K`, which is also their reference temperature — so enthalpy/entropy failed for **every** state.

## Status: underlying bug already fixed, but uncovered

The defect was fixed back in **v6.6.0** (PR #2324), which replaced the throw in `Polynomial2DFrac::evaluate` with L'Hôpital-style interpolation around the singular point. The issue was never closed and had **no regression test**, so this PR adds one.

I verified empirically that all of the issue's failing scenarios now work on `master`:

```
PropsSI("Hmass","T",273.15,"P",101325,"INCOMP::AS30")   -> -62026 J/kg  (was: throw)
PropsSI("Hmass","T",345.65,"P",101325,"INCOMP::TD12")   -> 115306 J/kg  (was: throw)
PropsSI("Hmass","T",293.15,"P",101325,"INCOMP::AN-30%") -> 0 J/kg       (was: throw; 0 = ref T)
```

## The test

`[INCOMP][1578]` exercises the exact fluids from the issue (`AS30`, `TD12` at their `Tbase`; `AN-30%`, `AL-30%` whose `Tbase == Tref`) and asserts enthalpy at `Tbase` is finite, doesn't throw, and is continuous through `Tbase` (equals the midpoint of its ±0.1 K neighbours — catches a spike/dropout if the singularity is mishandled).

**Validated as a real guard:** re-enabling the old throw in `PolyMath.cpp` makes the test go RED (`AS30 -> h_mid = inf`, exact issue error in `errstring`); it's GREEN on `master`.

## Notes for reviewers

- Test-only change; no production code touched.
- `./dev/ci/preflight.sh`: clang-format ✓, build ✓, tests ✓, semgrep ✓. cppcheck/clang-tidy were skipped — they report **pre-existing** whole-file findings in `CoolProp-Tests.cpp` (none in the added lines), and both are informational/non-gating in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a validation test ensuring incompressible-fluid enthalpy is finite and continuous at baseline temperatures. The test samples just below, at, and just above each baseline, requires the midpoint value to be valid, and verifies the midpoint matches the linear interpolation of neighbors within a tight tolerance for several fluids.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3030?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->