### PR TITLE
fix(HEOS): melting-line PT guards honor DONT_CHECK_PROPERTY_LIMITS (#1936)

### DIFF
--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -1677,8 +1677,9 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
         _Q = 1e9;
         switch (other) {
             case iT: {
-                // Check for the presence of the melting line
-                if (has_melting_line()) {
+                // Check for the presence of the melting line (skipped when the caller has
+                // opted out of property-limit checks, mirroring the subcritical path below)
+                if (has_melting_line() && !get_config_bool(DONT_CHECK_PROPERTY_LIMITS)) {
                     double Tm = melting_line(iT, iP, _p);
                     if (_T < Tm - 0.001) {
                         throw ValueError(format("For now, we don't support T [%g K] below Tmelt(p) [%g K]", _T, Tm));
@@ -2139,8 +2140,9 @@ void HelmholtzEOSMixtureBackend::T_phase_determination_pure_or_pseudopure(int ot
     auto hmolar_critical = [this, &T_crit_, &rhomolar_crit_]() { return this->calc_hmolar_nocache(T_crit_, rhomolar_crit_); };
     auto umolar_critical = [this, &T_crit_, &rhomolar_crit_]() { return this->calc_umolar_nocache(T_crit_, rhomolar_crit_); };
 
-    // Check for the presence of the melting line
-    if (other == iP && has_melting_line()) {
+    // Check for the presence of the melting line (skipped when the caller has opted out
+    // of property-limit checks, mirroring p_phase_determination_pure_or_pseudopure)
+    if (other == iP && has_melting_line() && !get_config_bool(DONT_CHECK_PROPERTY_LIMITS)) {
         double Tm = melting_line(iT, iP, value);
         if (_T < Tm - 0.001) {
             throw ValueError(format("For now, we don't support T [%g K] below Tmelt(p) [%g K]", _T, Tm));

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4019,7 +4019,7 @@ TEST_CASE_METHOD(PropertyLimitsFixture, "Below-melting PT guard honors DONT_CHEC
     //   - p_sup  at Ttriple  -> p_phase_determination, supercritical-pressure branch (p > psat_max)
     //   - p_hiT  at T > triple-routing threshold -> T_phase_determination, other==iP branch
     const double p_sub = 0.5 * (AS->p_triple() + pc);  // between ptriple and pcrit
-    const double p_sup = 5 * pc;                        // well above pcrit
+    const double p_sup = 5 * pc;                       // well above pcrit
     struct Case
     {
         double p_Pa, T;
@@ -4039,6 +4039,9 @@ TEST_CASE_METHOD(PropertyLimitsFixture, "Below-melting PT guard honors DONT_CHEC
         {
             CoolProp::set_config_bool(DONT_CHECK_PROPERTY_LIMITS, true);
             CHECK_NOTHROW(AS->update(PT_INPUTS, c.p_Pa, c.T));
+            // Guard against a silent no-op update leaving the prior case's state behind
+            CHECK(AS->T() == Catch::Approx(c.T).epsilon(1e-12));
+            CHECK(AS->p() == Catch::Approx(c.p_Pa).epsilon(1e-12));
             CHECK(ValidNumber(AS->rhomolar()));
             CHECK(AS->rhomolar() > 0);
         }

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -3378,6 +3378,21 @@ class SuperAncillaryOffFixture
     }
 };
 
+/// A fixture class that saves and restores DONT_CHECK_PROPERTY_LIMITS so a test may
+/// toggle it freely without leaking the global config state to later tests
+class PropertyLimitsFixture
+{
+   private:
+    const configuration_keys m_key = DONT_CHECK_PROPERTY_LIMITS;
+    const bool initial_value;
+
+   public:
+    PropertyLimitsFixture() : initial_value(CoolProp::get_config_bool(m_key)) {}
+    ~PropertyLimitsFixture() {
+        CoolProp::set_config_bool(m_key, initial_value);
+    }
+};
+
 TEST_CASE_METHOD(SuperAncillaryOnFixture, "Check superancillary for water", "[superanc]") {
 
     auto json = nlohmann::json::parse(get_fluid_param_string("WATER", "JSON"))[0].at("EOS")[0].at("SUPERANCILLARY");
@@ -3985,6 +4000,48 @@ TEST_CASE_METHOD(SuperAncillaryOnFixture, "Phase for solid water should throw", 
         auto Tm = AS->melting_line(iT, iP, p_Pa);
         CAPTURE(Tm);
         CHECK_THROWS(AS->update(PT_INPUTS, p_Pa, -5 + Tm));
+    }
+}
+
+// The melting-line guards added in #2648 must honor DONT_CHECK_PROPERTY_LIMITS so the
+// metastable/below-melting escape hatch behaves the same below and above the critical
+// pressure.  Before the fix, the supercritical-pressure branch (p > psat_max) and the
+// other==iP branch in T_phase_determination_pure_or_pseudopure ignored the override and
+// threw regardless.  See GitHub #1936.
+TEST_CASE_METHOD(PropertyLimitsFixture, "Below-melting PT guard honors DONT_CHECK_PROPERTY_LIMITS", "[1936]") {
+    std::shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "CO2"));
+    const double Tt = AS->Ttriple();
+    const double pc = AS->p_critical();
+    // CO2's melting line has positive slope, so each of these (T, p) pairs sits just below
+    // the melting line.  The three pressures exercise the three distinct internal paths
+    // that carry a melting-line guard:
+    //   - p_sub  at Ttriple  -> p_phase_determination, subcritical superancillary branch
+    //   - p_sup  at Ttriple  -> p_phase_determination, supercritical-pressure branch (p > psat_max)
+    //   - p_hiT  at T > triple-routing threshold -> T_phase_determination, other==iP branch
+    const double p_sub = 0.5 * (AS->p_triple() + pc);  // between ptriple and pcrit
+    const double p_sup = 5 * pc;                        // well above pcrit
+    struct Case
+    {
+        double p_Pa, T;
+    };
+    for (const Case& c : {Case{p_sub, Tt}, Case{p_sup, Tt}, Case{1e8, 230.0}}) {
+        CAPTURE(c.p_Pa);
+        CAPTURE(c.T);
+        const double Tm = AS->melting_line(iT, iP, c.p_Pa);
+        CAPTURE(Tm);
+        REQUIRE(c.T < Tm - 0.001);  // sanity: the state really is below the melting line
+        // Default: below the melting line throws
+        {
+            CoolProp::set_config_bool(DONT_CHECK_PROPERTY_LIMITS, false);
+            CHECK_THROWS(AS->update(PT_INPUTS, c.p_Pa, c.T));
+        }
+        // With the override, the same state must resolve to a finite (metastable) density
+        {
+            CoolProp::set_config_bool(DONT_CHECK_PROPERTY_LIMITS, true);
+            CHECK_NOTHROW(AS->update(PT_INPUTS, c.p_Pa, c.T));
+            CHECK(ValidNumber(AS->rhomolar()));
+            CHECK(AS->rhomolar() > 0);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Closes the investigation of #1936 (`PT_INPUTS` `ValueError` at `T_triple`).

**Root cause of #1936.** At `T = Ttriple`, any pressure above `ptriple` is below the melting line for fluids with a positive-slope melting curve (CO2, Water, …), so those states are formally in the **solid region** and the melting-line guards added in #2648 correctly throw. Fluids with no melting line (NH3 — the issue's headline fluid) already work. The default solid-region-throws behavior is intended and is preserved (the #2648/#2639 contract).

**Residual bug fixed here.** #2648 added the melting-line check in three places, but only the subcritical superancillary branch honored the documented `DONT_CHECK_PROPERTY_LIMITS` escape hatch. The other two ignored it:

- `p_phase_determination_pure_or_pseudopure`, supercritical-pressure branch (`_p > psat_max`, `case iT`)
- `T_phase_determination_pure_or_pseudopure`, `other == iP` branch

So the metastable/below-melting escape hatch worked **below** `pcrit` but threw **above** it — inconsistent behavior split purely on `p ≷ pcrit`. This gates both throws behind `!get_config_bool(DONT_CHECK_PROPERTY_LIMITS)`, matching the subcritical path, for consistent behavior across the whole p–T plane.

Before (CO2, `DONT_CHECK_PROPERTY_LIMITS=true`, at `Ttriple`):
```
subcrit p=6.64e6 : OK   rho=27056   ← honors override
supcrit p=1.48e7 : THROW            ← ignores override (bug)
```

## Test

New `[1936]` regression test exercises all three guarded paths for CO2 (subcritical superancillary branch, supercritical-pressure branch, and the `T_phase_determination` `other==iP` branch): asserts each below-melting state throws by default and resolves to a finite positive density under the override.

## Verification

- `./build_catch/CatchTestRunner [1936]` — 15 assertions pass
- `[2639]`/`[2608]` (existing melting-line behavior) — unchanged, pass
- `./dev/ci/preflight.sh` gating set (clang-format, build, `[Helmholtz]`/`[REFPROP]` tests, semgrep) — pass. The informational-only cppcheck/clang-tidy steps report pre-existing baseline findings on lines unrelated to this 2-line diff; both are non-gating in CI per `dev_checks.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Melting-line property-limit checks now honor the DONT_CHECK_PROPERTY_LIMITS configuration, preventing erroneous errors when property-limit validation is disabled and allowing pressure–temperature based calculations to proceed.

* **Tests**
  * Added tests that verify the melting-line guard respects the DONT_CHECK_PROPERTY_LIMITS setting, including cases that confirm updates succeed and return valid thermodynamic results when checks are disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3031?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->