### PR TITLE
ci(devdocs): add workflow_dispatch escape hatch

### DIFF
--- a/.github/workflows/docs_devdocs-run.yml
+++ b/.github/workflows/docs_devdocs-run.yml
@@ -1,6 +1,7 @@
 name: Run devdocs deployment
 
 on:
+  workflow_dispatch:
   push:
     branches: [ 'master', 'main']
     tags: [ 'v*' ]


### PR DESCRIPTION
## What

Adds a `workflow_dispatch` trigger to `.github/workflows/docs_devdocs-run.yml` so the devdocs deployment can be run manually.

## Why

The workflow only fires on `push` to `master`/`main`. But many of our merge commits carry `[skip ci]`, and GitHub honors that token **globally** — it skips *every* workflow triggered by that push, including this devdocs dispatch. As a result, docs-only / chore merges (which are exactly the ones tagged `[skip ci]`) never refresh devdocs.

`workflow_dispatch` is independent of commit-message skip tokens, giving a reliable manual escape hatch:

- **Actions UI:** "Run devdocs deployment" → **Run workflow**
- **CLI:** `gh workflow run docs_devdocs-run.yml --ref master`

## Note

`workflow_dispatch` only becomes available once this file is on the default branch, so the button/CLI trigger appears after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documentation workflow now supports manual triggering in addition to automatic triggers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->