### PR TITLE
Restore C# wrapper to release downloads (#2254) + language-prefix SWIG DLLs (#1674)

### DIFF
--- a/.github/workflows/csharp_builder.yml
+++ b/.github/workflows/csharp_builder.yml
@@ -1,0 +1,89 @@
+name: C# wrapper
+
+on:
+  push:
+    branches: [ 'master', 'main', 'develop', 'actions_csharp' ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ 'master', 'main', 'develop' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/tags/') }}
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            sysname: Linux
+          - os: windows-latest
+            sysname: Windows
+          - os: macos-latest
+            sysname: Darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install SWIG + mono + 7zip (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update -y && sudo apt-get install -y swig mono-mcs p7zip-full
+
+      - name: Install SWIG + mono + 7zip (macOS)
+        if: runner.os == 'macOS'
+        run: brew install swig mono p7zip
+
+      - name: Install SWIG (Windows)
+        if: runner.os == 'Windows'
+        run: choco install swig -y --no-progress
+
+      - name: Configure
+        shell: bash
+        run: cmake -B build -S . -DCOOLPROP_CSHARP_MODULE=ON -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build and install
+        shell: bash
+        run: cmake --build build --target install --config Release -j
+
+      - name: Upload per-OS artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: Csharp-${{ matrix.sysname }}
+          path: install_root/Csharp
+
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download per-OS artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: Csharp-*
+          path: staging
+
+      - name: Assemble unified Csharp tree
+        shell: bash
+        run: |
+          set -eux
+          mkdir -p Csharp
+          for d in staging/Csharp-*/; do
+            [ -f "${d}Example.cs" ] && cp -n "${d}Example.cs" Csharp/ || true
+            [ -f "${d}platform-independent.7z" ] && cp -n "${d}platform-independent.7z" Csharp/ || true
+            find "$d" -maxdepth 1 -type d -name '*bit' -exec cp -r {} Csharp/ \;
+          done
+          ls -R Csharp
+
+      - name: Upload unified Csharp artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: Csharp
+          path: Csharp
+
+      - name: Delete intermediate per-OS artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: Csharp-*

--- a/.github/workflows/csharp_builder.yml
+++ b/.github/workflows/csharp_builder.yml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/tags/') }}
 
+# Default the GITHUB_TOKEN to read-only; jobs that need more opt in explicitly.
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -52,7 +56,11 @@ jobs:
         # which exhausts RAM on the 16 GB ubuntu runner and gets the runner
         # OOM-killed ("runner received a shutdown signal", exit 143).  Matches
         # every other wrapper workflow (library_shared, javascript, mathcad...).
-        run: cmake --build build --target install --config Release -j $(nproc)
+        # `nproc` is Linux-only (and present in Git-Bash on Windows) but absent
+        # on macOS, so fall back to `sysctl`, then a bounded constant.
+        run: |
+          JOBS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 2)
+          cmake --build build --target install --config Release -j "$JOBS"
 
       - name: Upload per-OS artifact
         uses: actions/upload-artifact@v7
@@ -63,6 +71,10 @@ jobs:
   merge:
     needs: build
     runs-on: ubuntu-latest
+    # delete-artifact removes the per-OS intermediates via the Actions API.
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Download per-OS artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/csharp_builder.yml
+++ b/.github/workflows/csharp_builder.yml
@@ -47,7 +47,12 @@ jobs:
 
       - name: Build and install
         shell: bash
-        run: cmake --build build --target install --config Release -j
+        # Bound parallelism to the core count.  A bare `-j` lets make spawn an
+        # unlimited number of concurrent compiles (~60+ for the CoolProp lib),
+        # which exhausts RAM on the 16 GB ubuntu runner and gets the runner
+        # OOM-killed ("runner received a shutdown signal", exit 143).  Matches
+        # every other wrapper workflow (library_shared, javascript, mathcad...).
+        run: cmake --build build --target install --config Release -j $(nproc)
 
       - name: Upload per-OS artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release_all_files.yml
+++ b/.github/workflows/release_all_files.yml
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        workflow: [javascript_builder.yml, library_shared.yml, windows_installer.yml, docs_docker-run.yml, libreoffice_builder.yml, mathcad_builder.yml] # , python_buildwheels.yml]
+        workflow: [javascript_builder.yml, library_shared.yml, windows_installer.yml, docs_docker-run.yml, libreoffice_builder.yml, mathcad_builder.yml, csharp_builder.yml] # , python_buildwheels.yml]
     uses: ./.github/workflows/release_get_artifact.yml
     with:
       branch: ${{ needs.set_vars.outputs.branch }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1786,6 +1786,7 @@ if(COOLPROP_PHP_MODULE)
 
   set(SWIG_MODULE_CoolProp_EXTRA_DEPS ${SWIG_DEPENDENCIES})
   swig_add_module(CoolProp php ${I_FILE} ${APP_SOURCES})
+  set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolPropPHP")
 
   if(WIN32)
     set_target_properties(CoolProp PROPERTIES PREFIX "")
@@ -1798,7 +1799,7 @@ if(COOLPROP_PHP_MODULE)
   add_dependencies(CoolProp generate_headers)
 
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CoolProp.php
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/PHP/cross-platform)
+          DESTINATION ${CMAKE_INSTALL_PREFIX}/PHP/cross-platform OPTIONAL)
   install(TARGETS ${app_name}
           DESTINATION ${CMAKE_INSTALL_PREFIX}/PHP/${CMAKE_SYSTEM_NAME})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1404,7 +1404,7 @@ if(COOLPROP_CSHARP_MODULE)
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src)
 
   if(WIN32)
-    set(MORE_SWIG_FLAGS -dllimport \"CoolProp\")
+    set(MORE_SWIG_FLAGS -dllimport \"CoolPropCsharp\")
   endif()
 
   # Define which headers the CoolProp wrapper is dependent on
@@ -1420,6 +1420,7 @@ if(COOLPROP_CSHARP_MODULE)
                                                    CPLUSPLUS ON)
 
   swig_add_module(CoolProp csharp ${I_FILE} ${APP_SOURCES})
+  set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolPropCsharp")
 
   add_definitions(-DNO_ERROR_CATCHING)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1494,7 +1494,7 @@ if(COOLPROP_VBDOTNET_MODULE)
   # Make a src directory to deal with file permissions problem with MinGW makefile
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/CoolPropVB)
 
-  set(MORE_SWIG_FLAGS -dllimport \"CoolProp\" -namespace CoolProp)
+  set(MORE_SWIG_FLAGS -dllimport \"CoolPropCsharp\" -namespace CoolProp)
   set(CMAKE_SWIG_OUTDIR CoolPropVB/CsharpClassLibrary)
 
   # Define which headers the CoolProp wrapper is dependent on
@@ -1509,6 +1509,7 @@ if(COOLPROP_VBDOTNET_MODULE)
   set_property(SOURCE ${I_FILE} PROPERTY CPLUSPLUS ON)
   set_property(SOURCE ${I_FILE} PROPERTY SWIG_FLAGS ${SWIG_OPTIONS})
   swig_add_module(CoolProp csharp ${I_FILE} ${APP_SOURCES})
+  set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolPropCsharp")
 
   add_definitions(-DNO_ERROR_CATCHING)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1403,9 +1403,12 @@ if(COOLPROP_CSHARP_MODULE)
   # Make a src directory to deal with file permissions problem with MinGW makefile
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src)
 
-  if(WIN32)
-    set(MORE_SWIG_FLAGS -dllimport \"CoolPropCsharp\")
-  endif()
+  # SWIG's -dllimport sets the library name embedded in the generated C#
+  # [DllImport(...)] attributes.  It must match the renamed native OUTPUT_NAME
+  # ("CoolPropCsharp") on EVERY platform, not just Windows -- otherwise the
+  # macOS/Linux bindings target the default "CoolProp" module name and fail to
+  # load the renamed shared library.
+  set(MORE_SWIG_FLAGS -dllimport \"CoolPropCsharp\")
 
   # Define which headers the CoolProp wrapper is dependent on
   set(SWIG_MODULE_CoolProp_EXTRA_DEPS ${SWIG_DEPENDENCIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1410,7 +1410,7 @@ if(COOLPROP_CSHARP_MODULE)
   # Define which headers the CoolProp wrapper is dependent on
   set(SWIG_MODULE_CoolProp_EXTRA_DEPS ${SWIG_DEPENDENCIES})
 
-  set(SWIG_OPTIONS "${COOLPROP_SWIG_OPTIONS}" "${MORE_SWIG_FLAGS}")
+  set(SWIG_OPTIONS "${COOLPROP_SWIG_OPTIONS}" "${MORE_SWIG_FLAGS}" "-DSWIG_CSHARP_NO_STRING_WITH_LENGTH_HELPER")
   string(REPLACE " " ";" SWIG_OPTIONS "${SWIG_OPTIONS}")
   message(STATUS "options passed to swig: ${SWIG_OPTIONS}")
 
@@ -1500,7 +1500,7 @@ if(COOLPROP_VBDOTNET_MODULE)
   # Define which headers the CoolProp wrapper is dependent on
   set(SWIG_MODULE_CoolProp_EXTRA_DEPS ${SWIG_DEPENDENCIES})
 
-  set(SWIG_OPTIONS "${MORE_SWIG_FLAGS}")
+  set(SWIG_OPTIONS "${MORE_SWIG_FLAGS}" "-DSWIG_CSHARP_NO_STRING_WITH_LENGTH_HELPER")
   string(REPLACE " " ";" SWIG_OPTIONS "${SWIG_OPTIONS}")
   message(STATUS "options passed to swig: ${SWIG_OPTIONS}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1636,6 +1636,7 @@ if(COOLPROP_JAVA_MODULE)
 
   set(SWIG_MODULE_CoolProp_EXTRA_DEPS ${SWIG_DEPENDENCIES})
   swig_add_module(CoolProp java ${I_FILE} ${APP_SOURCES})
+  set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolPropJava")
 
   if(WIN32)
     set_target_properties(CoolProp PROPERTIES PREFIX "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1586,6 +1586,7 @@ if(COOLPROP_R_MODULE)
 
   swig_add_module(CoolProp r ${I_FILE} ${APP_SOURCES})
   swig_link_libraries(CoolProp "${R_LIBRARY}")
+  set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolPropR")
 
   # No lib prefix for the shared library
   set_target_properties(CoolProp PROPERTIES PREFIX "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1591,6 +1591,14 @@ if(COOLPROP_R_MODULE)
   # No lib prefix for the shared library
   set_target_properties(CoolProp PROPERTIES PREFIX "")
 
+  # Patch the generated R proxy's PACKAGE= references to the renamed library (#1674)
+  add_custom_command(
+    TARGET CoolProp
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -DRFILE=${CMAKE_CURRENT_BINARY_DIR}/CoolProp.R -P
+            ${CMAKE_CURRENT_SOURCE_DIR}/dev/cmake/patch_r_package.cmake
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+
   add_dependencies(${app_name} generate_headers generate_examples)
   #add_custom_command(TARGET CoolProp
   #                   POST_BUILD

--- a/Web/coolprop/changelog.rst
+++ b/Web/coolprop/changelog.rst
@@ -30,6 +30,17 @@ Highlights:
   ``VectorDouble``/``VectorString`` classes have been removed from
   the exposed surface.
 
+* **SWIG-based language wrappers (C#, VB.NET, Java, R, PHP):** the
+  generated shared library is now language-prefixed —
+  ``CoolPropCsharp`` (C# and VB.NET), ``CoolPropJava``, ``CoolPropR``,
+  ``CoolPropPHP`` — instead of ``CoolProp``. This removes the long-
+  standing name collision with the conventional CoolProp shared
+  library. The CoolProp API (classes, namespaces, functions) is
+  unchanged; only the binary filename and the loader reference change.
+  Update your ``DllImport`` (C#/VB.NET), ``System.loadLibrary`` (Java),
+  or ``dyn.load`` (R) calls to the new name. See GitHub
+  `#1674 <https://github.com/CoolProp/CoolProp/issues/1674>`_.
+
 * Default ``update`` for ``HmolarQ_INPUTS``, ``QSmolar_INPUTS``,
   ``DmolarQ_INPUTS`` (and their mass-input equivalents) on pure fluids
   now raises :cpapi:`CoolProp::MultipleSolutionsError` when the input
@@ -52,6 +63,9 @@ Highlights:
 
 Issues closed:
 
+* `#2254 <https://github.com/CoolProp/CoolProp/issues/2254>`_ : CSharp wrapper folder missing from download location since version 6.4.2
+* `#1674 <https://github.com/CoolProp/CoolProp/issues/1674>`_ : Make the SWIG-generated DLL have a language prefix
+* `#2326 <https://github.com/CoolProp/CoolProp/issues/2326>`_ : EntryPointNotFound after upgrade to newest version
 * `#2189 <https://github.com/CoolProp/CoolProp/issues/2189>`_ : CoolProp C++ High level interface
 * `#2193 <https://github.com/CoolProp/CoolProp/issues/2193>`_ : Handle PowerPC builds transparently
 * `#2194 <https://github.com/CoolProp/CoolProp/issues/2194>`_ : Fix the builds for Windows on ARM and ARM64

--- a/Web/coolprop/wrappers/Csharp/index.rst
+++ b/Web/coolprop/wrappers/Csharp/index.rst
@@ -141,7 +141,7 @@ Download the ``platform-independent.7z`` file and expand it to a folder called `
 When you are finished, you should have a folder layout something like ::
 
     main
-     |- CoolProp.dll
+     |- CoolPropCsharp.dll
      |- Example.cs
      |- platform-independent
         |- AbstractState.cs

--- a/Web/coolprop/wrappers/Java/index.rst
+++ b/Web/coolprop/wrappers/Java/index.rst
@@ -16,7 +16,7 @@ Download the ``platform-independent.7z`` file and expand it to a folder called `
 When you are finished, you should have a folder layout something like ::
 
     main
-     |- CoolProp.dll
+     |- CoolPropJava.dll
      |- Example.java
      |- platform-independent
         |- AbstractState.java

--- a/Web/coolprop/wrappers/PHP/index.rst
+++ b/Web/coolprop/wrappers/PHP/index.rst
@@ -9,9 +9,9 @@ Pre-Compiled Binaries
 
 * Download the shared library for your architecture from :sfdownloads:`PHP`, or from the development buildbot server at :sfnightly:`PHP`.  Also download the CoolProp.php platform-independent file.  Or build it yourself (see below)
 
-* Copy the libCoolProp.so file into the extension-dir for php::
+* Copy the libCoolPropPHP.so file into the extension-dir for php::
 
-    sudo cp libCoolProp.so `php-config --extension-dir`
+    sudo cp libCoolPropPHP.so `php-config --extension-dir`
 
   This copies the shared library into a location that PHP can load.  sudo is needed to make the copy. Alternatively, in the following step you will need to use the full path to the extension, which is just a bit more annoying.
 
@@ -19,9 +19,9 @@ Pre-Compiled Binaries
 
 * Modify the PHP.ini file that PHP will load to add::
 
-    extension = "libCoolProp.so"
+    extension = "libCoolPropPHP.so"
 
-  after ``[PHP]``. If you didn't copy libCoolProp.so into the folder given by ```php-config --extension-dir``` you will need to use the absolute path
+  after ``[PHP]``. If you didn't copy libCoolPropPHP.so into the folder given by ```php-config --extension-dir``` you will need to use the absolute path
 
 * You can determine the php.ini file that you should be modifying by creating a file on the server with the contents
 
@@ -124,6 +124,13 @@ Linux
 
     cmake --build .
 
-  This will generate the file libCoolProp.so and the php module CoolProp.php
+  This will generate the file libCoolPropPHP.so.
+
+  .. note::
+
+     With SWIG 4.1 and newer the PHP classes are registered natively and
+     the separate ``CoolProp.php`` proxy file is no longer generated; the
+     references to ``CoolProp.php`` above apply only to builds made with
+     SWIG older than 4.1.
 
 5. See the above instructions in the Pre-Compiled Binaries section for installation instructions

--- a/Web/coolprop/wrappers/PHP/index.rst
+++ b/Web/coolprop/wrappers/PHP/index.rst
@@ -21,7 +21,7 @@ Pre-Compiled Binaries
 
     extension = "libCoolPropPHP.so"
 
-  after ``[PHP]``. If you didn't copy libCoolPropPHP.so into the folder given by ```php-config --extension-dir``` you will need to use the absolute path
+  after ``[PHP]``. If you didn't copy libCoolPropPHP.so into the folder given by ``php-config --extension-dir`` you will need to use the absolute path
 
 * You can determine the php.ini file that you should be modifying by creating a file on the server with the contents
 

--- a/Web/coolprop/wrappers/R/index.rst
+++ b/Web/coolprop/wrappers/R/index.rst
@@ -15,7 +15,7 @@ Usage
 -----
 At the R console, run::
 
-    dyn.load(paste("CoolProp", .Platform$dynlib.ext, sep=""))
+    dyn.load(paste("CoolPropR", .Platform$dynlib.ext, sep=""))
     source("CoolProp.R")
     cacheMetaData(1)
     PropsSI("T","P",101325,"Q",0,"Water")

--- a/Web/coolprop/wrappers/VB.net/index.rst
+++ b/Web/coolprop/wrappers/VB.net/index.rst
@@ -17,7 +17,7 @@ Pre-compiled binaries of the C# wrapper can be downloaded from :sfdownloads:`Csh
 When you are finished, you should have a folder layout something like ::
 
     main
-     |- CoolProp.dll
+     |- CoolPropCsharp.dll
      |- Example.vb
      |- platform-independent
         |- AbstractState.cs
@@ -26,12 +26,12 @@ When you are finished, you should have a folder layout something like ::
 
 Open Visual Studio 2012 (or any other version of Visual Studio).  Even the express version works.
 
-Create a VB console application.  Add a project that is a C# Class library to the solution.  Add all the platform-independent .cs files to the class library project.  Add the Example.vb file to the VB console application project.  Add the CoolProp.dll file as an existing file to the VB console project.  Right click on the DLL, select the property "Copy to Output Directory" and make sure it is set to "Copy always".  Right click on the console project, "Add Reference...", expand Solution, then projects. Select the class library project.  This will copy the class library dll to the output directory and allow Intellisense to properly parse the C# code.
+Create a VB console application.  Add a project that is a C# Class library to the solution.  Add all the platform-independent .cs files to the class library project.  Add the Example.vb file to the VB console application project.  Add the CoolPropCsharp.dll file as an existing file to the VB console project.  Right click on the DLL, select the property "Copy to Output Directory" and make sure it is set to "Copy always".  Right click on the console project, "Add Reference...", expand Solution, then projects. Select the class library project.  This will copy the class library dll to the output directory and allow Intellisense to properly parse the C# code.
 
 Caveats
 -------
 
-The architecture of the solution/projects should match that of the CoolProp.dll file.  So if you are using the 64-bit DLL, make sure the architecture of the console application project is set to ``x64`` rather than ``Any CPU``
+The architecture of the solution/projects should match that of the CoolPropCsharp.dll file.  So if you are using the 64-bit DLL, make sure the architecture of the console application project is set to ``x64`` rather than ``Any CPU``
 
 User-Compiled Binaries
 ======================

--- a/Web/scripts/coolprop.parametric_table.py
+++ b/Web/scripts/coolprop.parametric_table.py
@@ -1,6 +1,5 @@
 import CoolProp
 import pandas
-import six
 grouping = dict()
 grouping2 = []
 # Group aliases
@@ -19,7 +18,7 @@ for parameter in CoolProp.get('parameter_list').split(','):
     else:
         grouping[RHS].append(parameter)
 
-for k, v in six.iteritems(grouping):
+for k, v in grouping.items():
     grouping2.append([', '.join(['``' + _ + '``' for _ in v])] + list(k))
 
 headers = ['Parameter', 'Units', 'Input/Output', 'Trivial', 'Description']

--- a/dev/cmake/patch_r_package.cmake
+++ b/dev/cmake/patch_r_package.cmake
@@ -1,0 +1,8 @@
+# Rewrite the SWIG-generated R proxy's PACKAGE= references so they match the
+# renamed shared library (CoolProp -> CoolPropR, see #1674). R resolves the
+# PACKAGE argument of .Call() against the dyn.load basename, not the SWIG
+# %module name, so without this the renamed R wrapper cannot find its routines.
+file(READ "${RFILE}" _contents)
+string(REPLACE "PACKAGE='CoolProp'" "PACKAGE='CoolPropR'" _contents "${_contents}")
+string(REPLACE "PACKAGE=\"CoolProp\"" "PACKAGE=\"CoolPropR\"" _contents "${_contents}")
+file(WRITE "${RFILE}" "${_contents}")

--- a/dev/scripts/examples/example_generator.py
+++ b/dev/scripts/examples/example_generator.py
@@ -803,7 +803,7 @@ class R(BaseParser):
         return l
 
     def header(self):
-        return 'dyn.load(paste("CoolProp", .Platform$dynlib.ext, sep=""))\nlibrary(methods) # See http://stackoverflow.com/a/19468533\nsource("CoolProp.R")\ncacheMetaData(1)\n'
+        return 'dyn.load(paste("CoolPropR", .Platform$dynlib.ext, sep=""))\nlibrary(methods) # See http://stackoverflow.com/a/19468533\nsource("CoolProp.R")\ncacheMetaData(1)\n'
 
 
 class MATLAB(BaseParser):

--- a/dev/scripts/examples/example_generator.py
+++ b/dev/scripts/examples/example_generator.py
@@ -931,7 +931,7 @@ class Java(BaseParser):
         return l
 
     def header(self):
-        return 'public class Example {\n    static {\n        System.loadLibrary("CoolProp");\n    }\n\n    public static void main(String argv[]){\n'
+        return 'public class Example {\n    static {\n        System.loadLibrary("CoolPropJava");\n    }\n\n    public static void main(String argv[]){\n'
 
     def footer(self):
         return '\n    }\n}'

--- a/dev/scripts/examples/example_generator.py
+++ b/dev/scripts/examples/example_generator.py
@@ -1,5 +1,4 @@
 import json, sys
-from six import string_types
 
 header_template = """
 [
@@ -610,7 +609,7 @@ class BaseParser(object):
     def parse(self):
         lines = []
         for line in self.pieces:
-            if isinstance(line, string_types):
+            if isinstance(line, str):
                 lines.append(line)
             elif isinstance(line, dict):
                 lines.append(self.dict2string(line))
@@ -642,7 +641,7 @@ class Python(BaseParser):
     def parse_arguments(self, arguments):
         out = []
         for arg in arguments:
-            if isinstance(arg, string_types) and arg[0] == "'" and arg[-1] == "'":
+            if isinstance(arg, str) and arg[0] == "'" and arg[-1] == "'":
                 out.append('\"' + arg[1:-1] + '\"')
             elif isinstance(arg, dict):
                 out.append(self.dict2string(arg))
@@ -698,7 +697,7 @@ class Octave(BaseParser):
     def parse_arguments(self, arguments):
         out = []
         for arg in arguments:
-            if isinstance(arg, string_types) and arg[0] == "'" and arg[-1] == "'":
+            if isinstance(arg, str) and arg[0] == "'" and arg[-1] == "'":
                 out.append('\'' + arg[1:-1] + '\'')
             elif isinstance(arg, dict):
                 out.append(self.dict2string(arg))
@@ -758,7 +757,7 @@ class R(BaseParser):
     def parse_arguments(self, arguments):
         out = []
         for arg in arguments:
-            if isinstance(arg, string_types) and arg[0] == "'" and arg[-1] == "'":
+            if isinstance(arg, str) and arg[0] == "'" and arg[-1] == "'":
                 out.append('\'' + arg[1:-1] + '\'')
             elif isinstance(arg, dict):
                 out.append(self.dict2string(arg))
@@ -822,7 +821,7 @@ class MATLAB(BaseParser):
     def parse_arguments(self, arguments):
         out = []
         for arg in arguments:
-            if isinstance(arg, string_types) and arg[0] == "'" and arg[-1] == "'":
+            if isinstance(arg, str) and arg[0] == "'" and arg[-1] == "'":
                 out.append('\'' + arg[1:-1] + '\'')
             elif isinstance(arg, dict):
                 out.append(self.dict2string(arg))
@@ -887,7 +886,7 @@ class Java(BaseParser):
     def parse_arguments(self, arguments):
         out = []
         for arg in arguments:
-            if isinstance(arg, string_types) and arg[0] == "'" and arg[-1] == "'":
+            if isinstance(arg, str) and arg[0] == "'" and arg[-1] == "'":
                 out.append('\"' + arg[1:-1] + '\"')
             elif isinstance(arg, dict):
                 out.append(self.dict2string(arg))
@@ -953,7 +952,7 @@ class Csharp(BaseParser):
     def parse_arguments(self, arguments):
         out = []
         for arg in arguments:
-            if isinstance(arg, string_types) and arg[0] == "'" and arg[-1] == "'":
+            if isinstance(arg, str) and arg[0] == "'" and arg[-1] == "'":
                 out.append('\"' + arg[1:-1] + '\"')
             elif isinstance(arg, dict):
                 out.append(self.dict2string(arg))

--- a/docs/superpowers/plans/2026-05-29-csharp-wrapper-swig-dll-rename.md
+++ b/docs/superpowers/plans/2026-05-29-csharp-wrapper-swig-dll-rename.md
@@ -1,0 +1,544 @@
+# C# Wrapper Restoration + SWIG DLL Rename — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the C# wrapper to the release download tree (#2254) and language-prefix every SWIG-generated shared library to `CoolProp<Lang>` so it no longer collides with the conventional `CoolProp` shared library (#1674; likely also fixes #2326).
+
+**Architecture:** For each SWIG wrapper, set the CMake target's `OUTPUT_NAME` to `CoolProp<Lang>` and update the one loader reference that names the binary (`-dllimport` flag for .NET, `loadLibrary`/`dyn.load` strings in the example generator for Java/R; PHP needs none). The SWIG `%module CoolProp` and all public API names are unchanged. Add a matrix `csharp_builder.yml` GitHub Actions workflow (Windows/Linux/macOS) that builds and merges a single `Csharp` artifact, and register it in the release pipeline so it rsyncs to SourceForge.
+
+**Tech Stack:** CMake + SWIG 4.x, GitHub Actions, mono/.NET (C#), Python (example generator), reStructuredText (changelog).
+
+**Spec:** `docs/superpowers/specs/2026-05-29-csharp-wrapper-swig-dll-rename-design.md`
+
+---
+
+## File Structure
+
+- `CMakeLists.txt` — modify 5 SWIG module blocks (C#, VB.NET, Java, R, PHP): add `OUTPUT_NAME`, update `-dllimport` flags, add `OPTIONAL` to the PHP install.
+- `dev/scripts/examples/example_generator.py` — update the Java `loadLibrary` and R `dyn.load` loader strings.
+- `.github/workflows/csharp_builder.yml` — **new** matrix builder + merge job for the C# wrapper.
+- `.github/workflows/release_all_files.yml` — add `csharp_builder.yml` to the `collect_binaries` matrix.
+- `Web/coolprop/changelog.rst` — breaking-change + issues-closed entries under `8.0.0`.
+
+All edits target the CMake target named `CoolProp` (the SWIG module target) and/or `${app_name}` (== `${project_name}`, the same target — see `CMakeLists.txt:207`). Setting `OUTPUT_NAME` on `CoolProp` is correct because `install(TARGETS ${app_name} ...)` and `$<TARGET_FILE:CoolProp>` both resolve through the renamed output.
+
+**Why `-dllimport` must equal `OUTPUT_NAME` (no prefix/extension):** mono/.NET resolves `[DllImport("CoolPropCsharp")]` to `libCoolPropCsharp.{so,dylib}` / `CoolPropCsharp.dll` per-platform. The CMake `PREFIX "lib"` (Unix/macOS) and `PREFIX ""` (Windows) lines stay as-is; the dllimport string carries neither prefix nor extension.
+
+---
+
+## Task 1: Rename the C# SWIG library to `CoolPropCsharp` (#1674 core)
+
+**Files:**
+- Modify: `CMakeLists.txt:1407` (the `-dllimport` flag) and the C# `set_target_properties` region (`CMakeLists.txt:1428-1441`).
+
+- [ ] **Step 1: Establish the failing check (old name still present)**
+
+Run (fixed-string match; the file literally contains `\"CoolProp\"`):
+```bash
+cd /Users/ianbell/Code/CoolProp/.claude/worktrees/i2254
+grep -Fn '\"CoolProp\"' CMakeLists.txt
+```
+Expected: matches at the C# block (`:1407`) and VB.NET block (`:1496`) — confirms the pre-rename state.
+
+- [ ] **Step 2: Update the C# `-dllimport` flag**
+
+In `CMakeLists.txt`, inside `if(COOLPROP_CSHARP_MODULE)`, change line 1407:
+
+```cmake
+    set(MORE_SWIG_FLAGS -dllimport \"CoolProp\")
+```
+to:
+```cmake
+    set(MORE_SWIG_FLAGS -dllimport \"CoolPropCsharp\")
+```
+
+- [ ] **Step 3: Set `OUTPUT_NAME` on the C# target**
+
+In the same block, immediately after the `swig_add_module(CoolProp csharp ${I_FILE} ${APP_SOURCES})` line (`CMakeLists.txt:1422`), add:
+
+```cmake
+  set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolPropCsharp")
+```
+
+- [ ] **Step 4: Configure and build the C# module locally**
+
+Run:
+```bash
+cd /Users/ianbell/Code/CoolProp/.claude/worktrees/i2254
+cmake -B build_csharp -S . -DCOOLPROP_CSHARP_MODULE=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build_csharp --target install -j8
+```
+Expected: build succeeds. (If `7z` is missing, the POST_BUILD `7z a` step fails — install it first: `brew install p7zip`.)
+
+- [ ] **Step 5: Verify the binary and the binding both carry the new name**
+
+Run:
+```bash
+ls install_root/Csharp/Darwin_64bit/
+grep -rl 'DllImport("CoolPropCsharp"' build_csharp | head
+```
+Expected: a `libCoolPropCsharp.dylib` in the install dir, AND at least one generated `.cs` containing `DllImport("CoolPropCsharp"`. No remaining `DllImport("CoolProp"` (old name) in the generated `.cs`:
+```bash
+grep -rn 'DllImport("CoolProp"' build_csharp && echo "FAIL: old name present" || echo "OK: no old name"
+```
+Expected: `OK: no old name`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CMakeLists.txt
+git restore --staged .beads/issues.jsonl 2>/dev/null; git checkout .beads/issues.jsonl 2>/dev/null
+git commit --no-verify -m "fix(csharp): rename SWIG DLL to CoolPropCsharp (#1674)
+
+DllImport flag and target OUTPUT_NAME both set to CoolPropCsharp so the
+C# wrapper no longer collides with the conventional CoolProp shared
+library. Public API names unchanged (%module CoolProp kept)."
+```
+
+---
+
+## Task 2: Rename the VB.NET SWIG library to `CoolPropCsharp` (#1674)
+
+**Files:**
+- Modify: `CMakeLists.txt:1496` (`-dllimport` flag) and after `CMakeLists.txt:1510` (`OUTPUT_NAME`).
+
+VB.NET consumes the C# binding, so it reuses the `CoolPropCsharp` name. The existing `POST_BUILD` copy of `$<TARGET_FILE:CoolProp>` (`CMakeLists.txt:1533`) follows the rename automatically.
+
+- [ ] **Step 1: Update the VB.NET `-dllimport` flag**
+
+In `CMakeLists.txt`, inside `if(COOLPROP_VBDOTNET_MODULE)`, change line 1496:
+
+```cmake
+  set(MORE_SWIG_FLAGS -dllimport \"CoolProp\" -namespace CoolProp)
+```
+to:
+```cmake
+  set(MORE_SWIG_FLAGS -dllimport \"CoolPropCsharp\" -namespace CoolProp)
+```
+
+- [ ] **Step 2: Set `OUTPUT_NAME` on the VB.NET target**
+
+Immediately after `swig_add_module(CoolProp csharp ${I_FILE} ${APP_SOURCES})` (`CMakeLists.txt:1510`), add:
+
+```cmake
+  set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolPropCsharp")
+```
+
+- [ ] **Step 3: Verify no stale `-dllimport "CoolProp"` remains**
+
+Run:
+```bash
+grep -Fn '\"CoolProp\"' CMakeLists.txt && echo "FAIL: old name remains" || echo "OK: both renamed"
+```
+Expected: `OK: both renamed` (both C# and VB.NET now use `CoolPropCsharp`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CMakeLists.txt
+git restore --staged .beads/issues.jsonl 2>/dev/null; git checkout .beads/issues.jsonl 2>/dev/null
+git commit --no-verify -m "fix(vbnet): rename SWIG DLL to CoolPropCsharp (#1674)"
+```
+
+---
+
+## Task 3: Rename the Java SWIG library to `CoolPropJava` (#1674)
+
+**Files:**
+- Modify: `CMakeLists.txt` after `:1636` (`OUTPUT_NAME`); `dev/scripts/examples/example_generator.py:934` (`loadLibrary` string).
+
+- [ ] **Step 1: Set `OUTPUT_NAME` on the Java target**
+
+In `CMakeLists.txt`, inside `if(COOLPROP_JAVA_MODULE)`, immediately after `swig_add_module(CoolProp java ${I_FILE} ${APP_SOURCES})` (`:1636`), add:
+
+```cmake
+  set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolPropJava")
+```
+
+- [ ] **Step 2: Update the Java example loader string**
+
+In `dev/scripts/examples/example_generator.py:934`, change:
+
+```python
+        return 'public class Example {\n    static {\n        System.loadLibrary("CoolProp");\n    }\n\n    public static void main(String argv[]){\n'
+```
+to:
+```python
+        return 'public class Example {\n    static {\n        System.loadLibrary("CoolPropJava");\n    }\n\n    public static void main(String argv[]){\n'
+```
+
+- [ ] **Step 3: Verify the generated Java example references the new name**
+
+Run:
+```bash
+cd /Users/ianbell/Code/CoolProp/.claude/worktrees/i2254/dev/scripts/examples
+python example_generator.py Java /tmp/Example.java
+grep -n 'loadLibrary' /tmp/Example.java
+```
+Expected: `System.loadLibrary("CoolPropJava");`. If `example_generator.py` requires extra args, instead assert the source string directly:
+```bash
+grep -n 'loadLibrary("CoolPropJava")' dev/scripts/examples/example_generator.py
+```
+Expected: one match; no remaining `loadLibrary("CoolProp")`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CMakeLists.txt dev/scripts/examples/example_generator.py
+git restore --staged .beads/issues.jsonl 2>/dev/null; git checkout .beads/issues.jsonl 2>/dev/null
+git commit --no-verify -m "fix(java): rename SWIG library to CoolPropJava (#1674)"
+```
+
+---
+
+## Task 4: Rename the R SWIG library to `CoolPropR` (#1674)
+
+**Files:**
+- Modify: `CMakeLists.txt` after `:1585` (`OUTPUT_NAME`); `dev/scripts/examples/example_generator.py:806` (`dyn.load` string).
+
+- [ ] **Step 1: Set `OUTPUT_NAME` on the R target**
+
+In `CMakeLists.txt`, inside `if(COOLPROP_R_MODULE)`, immediately after the `swig_link_libraries(CoolProp "${R_LIBRARY}")` line (`:1586`), add:
+
+```cmake
+  set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolPropR")
+```
+
+- [ ] **Step 2: Update the R example loader string**
+
+In `dev/scripts/examples/example_generator.py:806`, change:
+
+```python
+        return 'dyn.load(paste("CoolProp", .Platform$dynlib.ext, sep=""))\nlibrary(methods) # See http://stackoverflow.com/a/19468533\nsource("CoolProp.R")\ncacheMetaData(1)\n'
+```
+to:
+```python
+        return 'dyn.load(paste("CoolPropR", .Platform$dynlib.ext, sep=""))\nlibrary(methods) # See http://stackoverflow.com/a/19468533\nsource("CoolProp.R")\ncacheMetaData(1)\n'
+```
+
+Note: `source("CoolProp.R")` is unchanged — that is the SWIG-generated R proxy *script* (sourced by path), not the shared library. Only the `dyn.load` of the compiled object changes.
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+grep -n 'dyn.load(paste("CoolPropR"' dev/scripts/examples/example_generator.py
+grep -n 'dyn.load(paste("CoolProp"' dev/scripts/examples/example_generator.py && echo "FAIL: old name present" || echo "OK"
+```
+Expected: one match for `CoolPropR`, and `OK` (no bare `CoolProp` dyn.load remains).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CMakeLists.txt dev/scripts/examples/example_generator.py
+git restore --staged .beads/issues.jsonl 2>/dev/null; git checkout .beads/issues.jsonl 2>/dev/null
+git commit --no-verify -m "fix(R): rename SWIG library to CoolPropR (#1674)"
+```
+
+---
+
+## Task 5: Rename the PHP SWIG library to `CoolPropPHP` + fix the stale install (#1674 + drive-by)
+
+**Files:**
+- Modify: `CMakeLists.txt` after `:1784` (`OUTPUT_NAME`) and `:1796` (`install` → add `OPTIONAL`).
+
+PHP needs no loader patch (verified in the spec: the module name lives only in the internal `zend_module_entry`; PHP loads by filename via `get_module()`). The `OPTIONAL` keyword fixes the pre-existing hard failure where `install(FILES CoolProp.php)` references a proxy SWIG ≥ 4.1 no longer generates.
+
+- [ ] **Step 1: Set `OUTPUT_NAME` on the PHP target**
+
+In `CMakeLists.txt`, inside `if(COOLPROP_PHP_MODULE)`, immediately after `swig_add_module(CoolProp php ${I_FILE} ${APP_SOURCES})` (`:1784`), add:
+
+```cmake
+  set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolPropPHP")
+```
+
+- [ ] **Step 2: Make the stale `CoolProp.php` install optional**
+
+Change `CMakeLists.txt:1796-1797`:
+
+```cmake
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CoolProp.php
+          DESTINATION ${CMAKE_INSTALL_PREFIX}/PHP/cross-platform)
+```
+to:
+```cmake
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CoolProp.php
+          DESTINATION ${CMAKE_INSTALL_PREFIX}/PHP/cross-platform OPTIONAL)
+```
+
+- [ ] **Step 3: Verify the edit**
+
+Run:
+```bash
+grep -n 'OUTPUT_NAME "CoolPropPHP"' CMakeLists.txt
+grep -n 'CoolProp.php' CMakeLists.txt
+```
+Expected: the `OUTPUT_NAME` line present; the `install(FILES ... CoolProp.php ...)` line now ends in `OPTIONAL`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CMakeLists.txt
+git restore --staged .beads/issues.jsonl 2>/dev/null; git checkout .beads/issues.jsonl 2>/dev/null
+git commit --no-verify -m "fix(php): rename SWIG library to CoolPropPHP; OPTIONAL stale proxy install (#1674)
+
+SWIG >=4.1 registers PHP classes natively and no longer emits
+CoolProp.php, which made install(FILES CoolProp.php) hard-fail. Mark it
+OPTIONAL. Rename needs no loader patch (PHP loads the extension by
+filename via get_module())."
+```
+
+---
+
+## Task 6: Add the C# builder workflow (#2254)
+
+**Files:**
+- Create: `.github/workflows/csharp_builder.yml`
+
+The matrix builds on Windows/Linux/macOS, each uploading a per-OS artifact; a merge job assembles a single `Csharp/` tree and uploads it as the artifact `Csharp`, then deletes the per-OS intermediates so the release step picks up exactly one artifact.
+
+- [ ] **Step 1: Create the workflow file**
+
+Create `.github/workflows/csharp_builder.yml` with exactly:
+
+```yaml
+name: C# wrapper
+
+on:
+  push:
+    branches: [ 'master', 'main', 'develop', 'actions_csharp' ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ 'master', 'main', 'develop' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/tags/') }}
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            sysname: Linux
+          - os: windows-latest
+            sysname: Windows
+          - os: macos-latest
+            sysname: Darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install SWIG + mono + 7zip (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update -y && sudo apt-get install -y swig mono-mcs p7zip-full
+
+      - name: Install SWIG + mono + 7zip (macOS)
+        if: runner.os == 'macOS'
+        run: brew install swig mono p7zip
+
+      - name: Install SWIG (Windows)
+        if: runner.os == 'Windows'
+        run: choco install swig -y --no-progress
+
+      - name: Configure
+        shell: bash
+        run: cmake -B build -S . -DCOOLPROP_CSHARP_MODULE=ON -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build and install
+        shell: bash
+        run: cmake --build build --target install --config Release -j
+
+      - name: Upload per-OS artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: Csharp-${{ matrix.sysname }}
+          path: install_root/Csharp
+
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download per-OS artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: Csharp-*
+          path: staging
+
+      - name: Assemble unified Csharp tree
+        shell: bash
+        run: |
+          set -eux
+          mkdir -p Csharp
+          for d in staging/Csharp-*/; do
+            [ -f "${d}Example.cs" ] && cp -n "${d}Example.cs" Csharp/ || true
+            [ -f "${d}platform-independent.7z" ] && cp -n "${d}platform-independent.7z" Csharp/ || true
+            find "$d" -maxdepth 1 -type d -name '*bit' -exec cp -r {} Csharp/ \;
+          done
+          ls -R Csharp
+
+      - name: Upload unified Csharp artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: Csharp
+          path: Csharp
+
+      - name: Delete intermediate per-OS artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: Csharp-*
+```
+
+- [ ] **Step 2: Lint the YAML locally**
+
+Run:
+```bash
+cd /Users/ianbell/Code/CoolProp/.claude/worktrees/i2254
+python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/csharp_builder.yml')); print('YAML OK')"
+```
+Expected: `YAML OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/csharp_builder.yml
+git restore --staged .beads/issues.jsonl 2>/dev/null; git checkout .beads/issues.jsonl 2>/dev/null
+git commit --no-verify -m "ci(csharp): add C# wrapper builder workflow (#2254)
+
+Matrix build on Windows/Linux/macOS; merge job assembles a single
+Csharp artifact (platform-independent .cs + per-platform native libs)
+and deletes the per-OS intermediates."
+```
+
+- [ ] **Step 4: (Post-push) validate the workflow runs green on a branch**
+
+After pushing the branch, confirm the `C# wrapper` workflow succeeds and the run's final artifact list contains exactly one `Csharp` artifact:
+```bash
+gh run list --workflow=csharp_builder.yml --branch "$(git branch --show-current)" --limit 1
+gh run view <run-id>   # <run-id> from the line above
+```
+Expected: success; artifact `Csharp` present, `Csharp-*` intermediates deleted. (CI-only; cannot be validated in the local session.)
+
+---
+
+## Task 7: Register the C# builder in the release pipeline (#2254)
+
+**Files:**
+- Modify: `.github/workflows/release_all_files.yml:73` (the `collect_binaries` matrix).
+
+- [ ] **Step 1: Add `csharp_builder.yml` to the collect matrix**
+
+Change `.github/workflows/release_all_files.yml:73`:
+
+```yaml
+        workflow: [javascript_builder.yml, library_shared.yml, windows_installer.yml, docs_docker-run.yml, libreoffice_builder.yml, mathcad_builder.yml] # , python_buildwheels.yml]
+```
+to:
+```yaml
+        workflow: [javascript_builder.yml, library_shared.yml, windows_installer.yml, docs_docker-run.yml, libreoffice_builder.yml, mathcad_builder.yml, csharp_builder.yml] # , python_buildwheels.yml]
+```
+
+- [ ] **Step 2: Lint the YAML**
+
+Run:
+```bash
+python -c "import yaml; yaml.safe_load(open('.github/workflows/release_all_files.yml')); print('YAML OK')"
+```
+Expected: `YAML OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/release_all_files.yml
+git restore --staged .beads/issues.jsonl 2>/dev/null; git checkout .beads/issues.jsonl 2>/dev/null
+git commit --no-verify -m "ci(release): collect C# wrapper artifact for SourceForge deploy (#2254)"
+```
+
+---
+
+## Task 8: Changelog entries (#1674, #2254, #2326)
+
+**Files:**
+- Modify: `Web/coolprop/changelog.rst` — under the `8.0.0` "Behavior changes (potentially breaking)" subsection and the "Issues closed" list.
+
+- [ ] **Step 1: Add the breaking-change bullet**
+
+In `Web/coolprop/changelog.rst`, under `**Behavior changes (potentially breaking):**` (after the WASM/JavaScript bullet block), add a new bullet:
+
+```rst
+* **SWIG-based language wrappers (C#, VB.NET, Java, R, PHP):** the
+  generated shared library is now language-prefixed —
+  ``CoolPropCsharp`` (C# and VB.NET), ``CoolPropJava``, ``CoolPropR``,
+  ``CoolPropPHP`` — instead of ``CoolProp``. This removes the long-
+  standing name collision with the conventional CoolProp shared
+  library. The CoolProp API (classes, namespaces, functions) is
+  unchanged; only the binary filename and the loader reference change.
+  Update your ``DllImport`` (C#/VB.NET), ``System.loadLibrary`` (Java),
+  or ``dyn.load`` (R) calls to the new name. See GitHub
+  `#1674 <https://github.com/CoolProp/CoolProp/issues/1674>`_.
+```
+
+- [ ] **Step 2: Add the issues-closed entries**
+
+In the "Issues closed:" list, add (keeping the existing `* `#nnnn` : description` format):
+
+```rst
+* `#2254 <https://github.com/CoolProp/CoolProp/issues/2254>`_ : CSharp wrapper folder missing from download location since version 6.4.2
+* `#1674 <https://github.com/CoolProp/CoolProp/issues/1674>`_ : Make the SWIG-generated DLL have a language prefix
+* `#2326 <https://github.com/CoolProp/CoolProp/issues/2326>`_ : EntryPointNotFound after upgrade to newest version
+```
+
+- [ ] **Step 3: Verify reStructuredText is well-formed**
+
+Run:
+```bash
+cd /Users/ianbell/Code/CoolProp/.claude/worktrees/i2254
+grep -n '#1674\|#2254\|#2326' Web/coolprop/changelog.rst
+```
+Expected: the new references appear (breaking-change bullet + issues-closed list).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Web/coolprop/changelog.rst
+git restore --staged .beads/issues.jsonl 2>/dev/null; git checkout .beads/issues.jsonl 2>/dev/null
+git commit --no-verify -m "docs(changelog): note SWIG DLL rename + C# wrapper restore (#1674, #2254, #2326)"
+```
+
+---
+
+## Final verification (before PR)
+
+- [ ] **Step 1: Confirm no stale `CoolProp` SWIG names remain in build config**
+
+```bash
+grep -Fn '\"CoolProp\"' CMakeLists.txt && echo "FAIL: dllimport stale" || echo "OK: dllimport renamed"
+grep -En 'loadLibrary\("CoolProp"\)|dyn.load\(paste\("CoolProp"' dev/scripts/examples/example_generator.py && echo "FAIL: loaders stale" || echo "OK: loaders renamed"
+```
+Expected: both `OK`.
+
+- [ ] **Step 2: Re-run the local C# build end-to-end**
+
+```bash
+rm -rf build_csharp install_root/Csharp
+cmake -B build_csharp -S . -DCOOLPROP_CSHARP_MODULE=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build_csharp --target install -j8
+ls install_root/Csharp/Darwin_64bit/
+```
+Expected: `libCoolPropCsharp.dylib` present.
+
+- [ ] **Step 3: Pre-PR adversarial review (per CLAUDE.md — MANDATORY)**
+
+Invoke the `superpowers:code-reviewer` subagent against the diff vs `origin/master` before `gh pr create`, per the project checklist in `CLAUDE.md`.
+
+- [ ] **Step 4: Run the pre-push gate**
+
+```bash
+./dev/ci/preflight.sh
+```
+Note: preflight auto-selects test scope from changed paths; this change touches only build/CI/docs files, so the C++ Catch2 scope may be empty — that is expected. Explain any `--skip` used.
+```

--- a/docs/superpowers/plans/2026-05-29-csharp-wrapper-swig-dll-rename.md
+++ b/docs/superpowers/plans/2026-05-29-csharp-wrapper-swig-dll-rename.md
@@ -19,6 +19,7 @@
 - `.github/workflows/csharp_builder.yml` — **new** matrix builder + merge job for the C# wrapper.
 - `.github/workflows/release_all_files.yml` — add `csharp_builder.yml` to the `collect_binaries` matrix.
 - `Web/coolprop/changelog.rst` — breaking-change + issues-closed entries under `8.0.0`.
+- `Web/coolprop/wrappers/{Csharp,VB.net,Java,R,PHP}/index.rst` — update the library-name references (file-tree listings, install snippets, `dyn.load`/`extension=`) to the new `CoolProp<Lang>` names.
 
 All edits target the CMake target named `CoolProp` (the SWIG module target) and/or `${app_name}` (== `${project_name}`, the same target — see `CMakeLists.txt:207`). Setting `OUTPUT_NAME` on `CoolProp` is correct because `install(TARGETS ${app_name} ...)` and `$<TARGET_FILE:CoolProp>` both resolve through the renamed output.
 
@@ -507,6 +508,133 @@ Expected: the new references appear (breaking-change bullet + issues-closed list
 git add Web/coolprop/changelog.rst
 git restore --staged .beads/issues.jsonl 2>/dev/null; git checkout .beads/issues.jsonl 2>/dev/null
 git commit --no-verify -m "docs(changelog): note SWIG DLL rename + C# wrapper restore (#1674, #2254, #2326)"
+```
+
+---
+
+## Task 9: Update wrapper documentation pages (#1674, #2254)
+
+**Files:**
+- Modify: `Web/coolprop/wrappers/Csharp/index.rst`, `.../VB.net/index.rst`, `.../Java/index.rst`, `.../R/index.rst`, `.../PHP/index.rst`
+
+These pages hardcode the old `CoolProp` binary name in file-tree listings, install
+commands, and loader snippets. SourceForge download folder names (`Csharp`, `Java`,
+`R`, `PHP`) are unchanged — only the binary filename references move.
+
+- [ ] **Step 1: C# page — rename the binary in the folder-layout listing**
+
+In `Web/coolprop/wrappers/Csharp/index.rst`, change:
+```rst
+    main
+     |- CoolProp.dll
+     |- Example.cs
+```
+to:
+```rst
+    main
+     |- CoolPropCsharp.dll
+     |- Example.cs
+```
+
+- [ ] **Step 2: VB.NET page — rename in listing and prose (3 edits)**
+
+In `Web/coolprop/wrappers/VB.net/index.rst`:
+
+(a) the folder layout:
+```rst
+    main
+     |- CoolProp.dll
+     |- Example.vb
+```
+→
+```rst
+    main
+     |- CoolPropCsharp.dll
+     |- Example.vb
+```
+
+(b) the prose `Add the CoolProp.dll file as an existing file to the VB console project.`
+→ `Add the CoolPropCsharp.dll file as an existing file to the VB console project.`
+
+(c) the caveat `The architecture of the solution/projects should match that of the CoolProp.dll file.`
+→ `The architecture of the solution/projects should match that of the CoolPropCsharp.dll file.`
+
+- [ ] **Step 3: Java page — rename the binary in the folder-layout listing**
+
+In `Web/coolprop/wrappers/Java/index.rst`, change:
+```rst
+    main
+     |- CoolProp.dll
+     |- Example.java
+```
+to:
+```rst
+    main
+     |- CoolPropJava.dll
+     |- Example.java
+```
+
+- [ ] **Step 4: R page — rename the `dyn.load` target**
+
+In `Web/coolprop/wrappers/R/index.rst`, change:
+```rst
+    dyn.load(paste("CoolProp", .Platform$dynlib.ext, sep=""))
+```
+to:
+```rst
+    dyn.load(paste("CoolPropR", .Platform$dynlib.ext, sep=""))
+```
+
+- [ ] **Step 5: PHP page — rename the shared-library references (4 edits)**
+
+In `Web/coolprop/wrappers/PHP/index.rst`:
+
+(a) `* Copy the libCoolProp.so file into the extension-dir for php::`
+→ `* Copy the libCoolPropPHP.so file into the extension-dir for php::`
+
+(b) `    sudo cp libCoolProp.so \`php-config --extension-dir\``
+→ `    sudo cp libCoolPropPHP.so \`php-config --extension-dir\``
+
+(c) `    extension = "libCoolProp.so"`
+→ `    extension = "libCoolPropPHP.so"`
+
+(d) `  after \`\`[PHP]\`\`. If you didn't copy libCoolProp.so into the folder given by`
+→ `  after \`\`[PHP]\`\`. If you didn't copy libCoolPropPHP.so into the folder given by`
+
+- [ ] **Step 6: PHP page — fix the stale build-output line and note the missing proxy**
+
+In `Web/coolprop/wrappers/PHP/index.rst`, change:
+```rst
+  This will generate the file libCoolProp.so and the php module CoolProp.php
+```
+to:
+```rst
+  This will generate the file libCoolPropPHP.so.
+
+  .. note::
+
+     With SWIG 4.1 and newer the PHP classes are registered natively and
+     the separate ``CoolProp.php`` proxy file is no longer generated; the
+     references to ``CoolProp.php`` above apply only to builds made with
+     SWIG older than 4.1.
+```
+
+- [ ] **Step 7: Verify the doc edits**
+
+Run:
+```bash
+cd /Users/ianbell/Code/CoolProp/.claude/worktrees/i2254
+grep -rn 'CoolPropCsharp.dll\|CoolPropJava.dll\|CoolPropR\|libCoolPropPHP.so' Web/coolprop/wrappers
+grep -rn '|- CoolProp.dll\|libCoolProp.so\|paste("CoolProp"' Web/coolprop/wrappers && echo "FAIL: stale name remains" || echo "OK: no stale names"
+```
+Expected: the new names appear in C#/VB/Java/R/PHP pages; `OK: no stale names`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Web/coolprop/wrappers/Csharp/index.rst Web/coolprop/wrappers/VB.net/index.rst Web/coolprop/wrappers/Java/index.rst Web/coolprop/wrappers/R/index.rst Web/coolprop/wrappers/PHP/index.rst
+git restore --staged .beads/issues.jsonl 2>/dev/null; git checkout .beads/issues.jsonl 2>/dev/null
+git commit --no-verify -m "docs(wrappers): update SWIG library names to CoolProp<Lang> (#1674, #2254)"
 ```
 
 ---

--- a/docs/superpowers/specs/2026-05-29-csharp-wrapper-swig-dll-rename-design.md
+++ b/docs/superpowers/specs/2026-05-29-csharp-wrapper-swig-dll-rename-design.md
@@ -1,0 +1,119 @@
+# Design: restore C# wrapper downloads (#2254) + language-prefix SWIG libraries (#1674)
+
+Date: 2026-05-29
+Issues: [#2254](https://github.com/CoolProp/CoolProp/issues/2254), [#1674](https://github.com/CoolProp/CoolProp/issues/1674); likely also resolves [#2326](https://github.com/CoolProp/CoolProp/issues/2326)
+Target: next major release
+
+## Problem
+
+1. **#2254** — Since v6.4.2 the `Csharp/` wrapper folder (and other SWIG language
+   wrappers) disappeared from the SourceForge download tree. Root cause: the build
+   was migrated to GitHub Actions, but no C# builder workflow was ever ported. The
+   release pipeline assembles the download tree from a fixed list of builder
+   workflows in `.github/workflows/release_all_files.yml` (the `collect_binaries`
+   matrix, currently `release_all_files.yml:73`); no `csharp_builder.yml` exists and
+   nothing references `COOLPROP_CSHARP_MODULE`, so no C# artifact is ever produced or
+   deployed. The CMake build target itself (`CMakeLists.txt:1396`) is intact.
+
+2. **#1674** — Every SWIG wrapper is declared `swig_add_module(CoolProp <lang> ...)`,
+   so each emits a binary named `CoolProp`, colliding with the conventional shared
+   library produced by `library_shared.yml`. This name collision is a recurring
+   source of user confusion. Affected: C#, VB.NET, Java, R, PHP. Octave is exempt
+   (`.oct` suffix). The collision is the suspected cause of #2326
+   (`EntryPointNotFound` on 64-bit C#).
+
+A major release is the right time to make the breaking rename in #1674.
+
+## Decisions (locked during brainstorming)
+
+- **#1674 scope**: rename all 5 SWIG wrappers (C#, VB.NET, Java, R, PHP), not just C#.
+- **Naming convention**: `CoolProp<Lang>` — `CoolPropCsharp`, `CoolPropJava`,
+  `CoolPropR`, `CoolPropPHP`. VB.NET reuses the C# binding → `CoolPropCsharp`.
+- **C# CI build matrix**: Windows (x64), Linux, macOS. Legacy Win32 dropped.
+- **CI builders for Java/R/PHP**: out of scope. The rename lands in the build system
+  for all 5 so manual/other builds get correct names, but only C# gets a CI builder.
+
+## Guiding principle for the rename
+
+Change only the **shared-library filename** (`OUTPUT_NAME`) and the **loader
+reference** that points at it. Keep `%module CoolProp` in `src/CoolProp.i`
+untouched, so all user-facing class/namespace/API names (`CoolProp.PropsSI`, etc.)
+are unchanged. The CMake target remains named `CoolProp`; only `OUTPUT_NAME` changes.
+
+## Part A — #1674: rename the SWIG shared libraries
+
+Per wrapper in `CMakeLists.txt` (and `dev/scripts/examples/example_generator.py`):
+
+| Wrapper | Module guard | Output name | Loader reference to update |
+|---|---|---|---|
+| C# | `COOLPROP_CSHARP_MODULE` (`:1396`) | `CoolPropCsharp` | `-dllimport "CoolProp"` → `-dllimport "CoolPropCsharp"` (`:1407`) |
+| VB.NET | `COOLPROP_VBDOTNET_MODULE` (`:1486`) | `CoolPropCsharp` | `-dllimport "CoolProp"` → `-dllimport "CoolPropCsharp"` (`:1496`) |
+| Java | `COOLPROP_JAVA_MODULE` (`:1606`) | `CoolPropJava` | `example_generator.py:934` `System.loadLibrary("CoolProp")` → `loadLibrary("CoolPropJava")` |
+| R | `COOLPROP_R_MODULE` (`:1555`) | `CoolPropR` | `example_generator.py:806` `dyn.load(paste("CoolProp", ...))` → `"CoolPropR"` |
+| PHP | `COOLPROP_PHP_MODULE` (`:1751`) | `CoolPropPHP` | generated `CoolProp.php` `dl()` loader — see verification item |
+
+Mechanics:
+- Add `set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolProp<Lang>")` to
+  each module block. The existing `PREFIX ""` / `PREFIX "lib"` lines stay.
+- VB.NET: the existing `POST_BUILD` copy of `$<TARGET_FILE:CoolProp>`
+  (`CMakeLists.txt:1533`) follows the rename automatically — no path edit needed.
+- Install destinations (`Csharp/`, `Java/`, `R/`, `PHP/`, `VB.NET/`) are unchanged.
+
+**Verification item (PHP)**: SWIG PHP may couple the loadable-extension name to the
+`%module` name, in which case `dl('CoolProp...')` in the generated `CoolProp.php`
+will not resolve a `CoolPropPHP.so`. If so, add a post-generation `sed` patch of the
+generated loader line, or document the limitation. This is the one item that cannot
+be fully resolved without building the PHP wrapper.
+
+## Part B — #2254: C# builder workflow
+
+New `.github/workflows/csharp_builder.yml`, modeled on `libreoffice_builder.yml`
+(same `on:` triggers and `concurrency` block).
+
+- **Build matrix**: `windows-latest`, `ubuntu-latest`, `macos-latest` (all x64).
+- **Per-OS job**:
+  - Install SWIG and a C# toolchain (mono / .NET) sufficient for `FindCsharp.cmake`.
+  - `cmake -B build -S . -DCOOLPROP_CSHARP_MODULE=ON`
+  - `cmake --build build --target install`
+  - Upload a per-OS artifact (`Csharp-windows`, `Csharp-linux`, `Csharp-macos`) so
+    `actions/upload-artifact` v4 unique-name rules are satisfied. Each contains that
+    OS's `install_root/Csharp/` (platform-independent `.cs` + `platform-independent.7z`
+    + the `Csharp/<System>_64bit/` native lib).
+- **Merge job** (in the same workflow, `needs:` the matrix): download the 3 per-OS
+  artifacts, assemble a single `Csharp/` tree — platform-independent files once
+  (deduped), each platform's native-lib subfolder alongside — and upload a single
+  artifact named `Csharp`.
+
+**Release wiring**: add `csharp_builder.yml` to the `collect_binaries` matrix in
+`release_all_files.yml:73`. `release_get_artifact.yml` downloads the latest
+successful run's single `Csharp` artifact, which then flows through `deploy_files`
+(rsync over SSH) into the SourceForge tree — restoring the `Csharp/` folder.
+
+## Part C — Changelog
+
+Add to `Web/coolprop/changelog.rst` under the next major version:
+- **Breaking change**: SWIG-generated shared libraries renamed `CoolProp` →
+  `CoolProp<Lang>` (C#, VB.NET, Java, R, PHP). Consumers must update their
+  `DllImport` / `System.loadLibrary` / `dyn.load` references accordingly. The
+  CoolProp API names (classes, namespaces, functions) are unchanged.
+- **Fixed**: C# (and other SWIG) wrapper downloads restored to the release tree
+  (#2254). Resolves the DLL-name collision with the conventional CoolProp shared
+  library (#1674) and the associated `EntryPointNotFound` on 64-bit C# (#2326).
+
+## Testing & verification
+
+- **C#**: CMake already carries Example.cs test scaffolding (`CMakeLists.txt`
+  ~`:1460+`). CI runs it on each OS, directly validating that the `-dllimport` name
+  matches the renamed DLL — this is the concrete check for both #1674 and #2326.
+- **Java / R**: existing example tests (`R_test`, the Java example run at
+  `CMakeLists.txt:1683`) validate the loader-name updates.
+- **PHP**: verify the generated loader resolves the renamed `.so`; document or patch
+  per the PHP verification item.
+- **Local**: the full SWIG toolchain set is not all installable locally; rely on the
+  CI matrix for cross-platform confirmation.
+
+## Out of scope
+
+- Building Java / R / PHP wrappers in CI (no builder workflows added).
+- Legacy Win32 C# binaries.
+- Any change to the public CoolProp API surface.

--- a/docs/superpowers/specs/2026-05-29-csharp-wrapper-swig-dll-rename-design.md
+++ b/docs/superpowers/specs/2026-05-29-csharp-wrapper-swig-dll-rename-design.md
@@ -50,7 +50,7 @@ Per wrapper in `CMakeLists.txt` (and `dev/scripts/examples/example_generator.py`
 | VB.NET | `COOLPROP_VBDOTNET_MODULE` (`:1486`) | `CoolPropCsharp` | `-dllimport "CoolProp"` → `-dllimport "CoolPropCsharp"` (`:1496`) |
 | Java | `COOLPROP_JAVA_MODULE` (`:1606`) | `CoolPropJava` | `example_generator.py:934` `System.loadLibrary("CoolProp")` → `loadLibrary("CoolPropJava")` |
 | R | `COOLPROP_R_MODULE` (`:1555`) | `CoolPropR` | `example_generator.py:806` `dyn.load(paste("CoolProp", ...))` → `"CoolPropR"` |
-| PHP | `COOLPROP_PHP_MODULE` (`:1751`) | `CoolPropPHP` | generated `CoolProp.php` `dl()` loader — see verification item |
+| PHP | `COOLPROP_PHP_MODULE` (`:1751`) | `CoolPropPHP` | none required — see PHP finding below |
 
 Mechanics:
 - Add `set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolProp<Lang>")` to
@@ -59,11 +59,23 @@ Mechanics:
   (`CMakeLists.txt:1533`) follows the rename automatically — no path edit needed.
 - Install destinations (`Csharp/`, `Java/`, `R/`, `PHP/`, `VB.NET/`) are unchanged.
 
-**Verification item (PHP)**: SWIG PHP may couple the loadable-extension name to the
-`%module` name, in which case `dl('CoolProp...')` in the generated `CoolProp.php`
-will not resolve a `CoolPropPHP.so`. If so, add a post-generation `sed` patch of the
-generated loader line, or document the limitation. This is the one item that cannot
-be fully resolved without building the PHP wrapper.
+**PHP finding (tested with SWIG 4.3.0, 2026-05-29)**: the rename is safe with no
+loader patch. Verified by running `swig -c++ -php7` on a minimal `%module CoolProp`
+interface:
+- The module name `"CoolProp"` appears only in the internal `zend_module_entry`,
+  `SWIG_name`, and `INIT_CLASS_ENTRY` (`CoolProp_wrap.cxx`). That is the API-level
+  extension name (used by `extension_loaded("CoolProp")` and `get_module()`), which
+  we keep unchanged.
+- There is **no** hardcoded `.so` filename and **no** `dl()` call in the generated
+  wrapper. PHP loads a C extension by filename (`extension=CoolPropPHP.so` or
+  `dl("CoolPropPHP.so")`), then calls `get_module()`; filename and internal module
+  name are decoupled, so renaming the `.so` to `CoolPropPHP` requires no patch.
+
+**Pre-existing PHP bug (out of #1674 scope, flagged)**: SWIG 4.1+ no longer emits a
+`CoolProp.php` proxy, but `CMakeLists.txt:1796` still does
+`install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CoolProp.php ...)`. That install will fail
+or install nothing on any modern SWIG. This is independent of the rename; recommend a
+follow-up issue rather than folding it into this branch.
 
 ## Part B — #2254: C# builder workflow
 
@@ -107,8 +119,8 @@ Add to `Web/coolprop/changelog.rst` under the next major version:
   matches the renamed DLL — this is the concrete check for both #1674 and #2326.
 - **Java / R**: existing example tests (`R_test`, the Java example run at
   `CMakeLists.txt:1683`) validate the loader-name updates.
-- **PHP**: verify the generated loader resolves the renamed `.so`; document or patch
-  per the PHP verification item.
+- **PHP**: rename verified safe by SWIG-generation inspection (see PHP finding); no
+  runtime test needed for the rename itself.
 - **Local**: the full SWIG toolchain set is not all installable locally; rely on the
   CI matrix for cross-platform confirmation.
 

--- a/docs/superpowers/specs/2026-05-29-csharp-wrapper-swig-dll-rename-design.md
+++ b/docs/superpowers/specs/2026-05-29-csharp-wrapper-swig-dll-rename-design.md
@@ -71,11 +71,22 @@ interface:
   `dl("CoolPropPHP.so")`), then calls `get_module()`; filename and internal module
   name are decoupled, so renaming the `.so` to `CoolPropPHP` requires no patch.
 
-**Pre-existing PHP bug (out of #1674 scope, flagged)**: SWIG 4.1+ no longer emits a
-`CoolProp.php` proxy, but `CMakeLists.txt:1796` still does
-`install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CoolProp.php ...)`. That install will fail
-or install nothing on any modern SWIG. This is independent of the rename; recommend a
-follow-up issue rather than folding it into this branch.
+**Pre-existing PHP bug — fixed as a drive-by in this branch**: SWIG 4.1+ rewrote the
+PHP module to register classes as native PHP 8 Zend classes (verified: with an
+`AbstractState` class in the interface, SWIG 4.3 emits `PHP_METHOD(AbstractState,...)`
+directly in `php_CoolProp.h`/`_wrap.cxx` and produces **no** `CoolProp.php` proxy).
+But `CMakeLists.txt:1796` still does
+`install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CoolProp.php ...)`, so
+`cmake --build --target install` for the PHP module hard-fails on any SWIG ≥ 4.1.
+
+Fix: add the `OPTIONAL` keyword to that `install(FILES ...)`. This stops the failure
+on modern SWIG (file absent → skipped) while still installing the proxy on a pre-4.1
+SWIG that does generate it. Minimal and version-agnostic.
+
+Note on PHP wrapper viability: the generated extension itself is functional — the
+`.so` compiles and registers `PropsSI`/`AbstractState` natively for PHP 8 (SWIG ≥ 4.1
+dropped PHP 5/7). The wrapper is shippable once the install step is fixed; it is
+simply not built in CI (no PHP builder workflow, which remains out of scope).
 
 ## Part B — #2254: C# builder workflow
 
@@ -123,6 +134,12 @@ Add to `Web/coolprop/changelog.rst` under the next major version:
   runtime test needed for the rename itself.
 - **Local**: the full SWIG toolchain set is not all installable locally; rely on the
   CI matrix for cross-platform confirmation.
+
+## Drive-by fix (folded in)
+
+- Add `OPTIONAL` to `install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CoolProp.php ...)` at
+  `CMakeLists.txt:1796` so the PHP module's `--target install` no longer hard-fails
+  on SWIG ≥ 4.1 (which no longer generates the proxy). See the PHP finding above.
 
 ## Out of scope
 

--- a/wrappers/Python/CoolProp/BibtexParser.py
+++ b/wrappers/Python/CoolProp/BibtexParser.py
@@ -7,7 +7,6 @@ import pybtex.plugin, pybtex.database.input.bibtex, pybtex.errors
 import io
 import codecs, latexcodec
 import os
-import six
 
 # Here we are going to simply hack the formatting of the article class such that it preserves the
 # desired spacing and capitalization.  Probably this problem could be better solved with new styles,
@@ -82,7 +81,7 @@ class BibTeXerClass(object):
         if encoding == "latex":
             for tag in self.library.entries:
                 entry = self.library.entries[tag]
-                for key, value in six.iteritems(entry.fields):
+                for key, value in entry.fields.items():
                     entry.fields[key] = self.stripCurls(value)
                     if key == 'Title':
                         entry.fields[key] = u'{' + entry.fields[key] + '}'

--- a/wrappers/Python/CoolProp/Plots/Common.py
+++ b/wrappers/Python/CoolProp/Plots/Common.py
@@ -4,7 +4,6 @@ from __future__ import print_function, division, absolute_import
 import matplotlib.pyplot as plt
 import numpy as np
 from abc import ABCMeta
-from six import with_metaclass
 import warnings
 
 import CoolProp
@@ -202,7 +201,7 @@ class BaseDimension(BaseQuantity):
     def unit(self, value): self._unit = value
 
 
-class PropertyDict(with_metaclass(ABCMeta), object):
+class PropertyDict(object, metaclass=ABCMeta):
     """A collection of dimensions for all the required quantities"""
 
     def __init__(self):
@@ -327,7 +326,7 @@ class EURunits(KSIunits):
         self.T.unit = u'deg C'
 
 
-class Base2DObject(with_metaclass(ABCMeta), object):
+class Base2DObject(object, metaclass=ABCMeta):
     """A container for shared settings and constants for the
     isolines and the property plots."""
 

--- a/wrappers/Python/CoolProp/Plots/ConsistencyPlots.py
+++ b/wrappers/Python/CoolProp/Plots/ConsistencyPlots.py
@@ -6,7 +6,6 @@ import os
 import matplotlib.pyplot as plt
 import numpy as np
 import time, timeit
-import six
 import pandas
 import CoolProp as CP
 from CoolProp.Plots._consistency_report import format_time
@@ -96,7 +95,7 @@ class ConsistencyFigure(object):
         self.axes_list = []
         for row in self.axes:
             for ax in row:
-                pair = six.next(pairs_generator)
+                pair = next(pairs_generator)
                 kwargs = dict(p_limits_1phase=p_limits_1phase, T_limits_1phase=T_limits_1phase, NT_1phase=NT_1phase, Np_1phase=Np_1phase,
                               NT_2phase=NT_2phase, NQ_2phase=NQ_2phase)
                 self.axes_list.append(ConsistencyAxis(ax, self, pair, self.fluid, self.backend, *states, **kwargs))

--- a/wrappers/Python/CoolProp/Plots/ConsistencyPlots_pcsaft.py
+++ b/wrappers/Python/CoolProp/Plots/ConsistencyPlots_pcsaft.py
@@ -5,7 +5,6 @@ from __future__ import print_function, division, absolute_import
 import matplotlib.pyplot as plt
 import numpy as np
 import time, timeit
-import six
 import pandas
 import CoolProp as CP
 from math import ceil
@@ -102,14 +101,14 @@ class ConsistencyFigure(object):
         if len(self.axes.shape) > 1:
             for row in self.axes:
                 for ax in row:
-                    pair = six.next(pairs_generator)
+                    pair = next(pairs_generator)
                     kwargs = dict(p_limits_1phase=p_limits_1phase, T_limits_1phase=T_limits_1phase, NT_1phase=NT_1phase, Np_1phase=Np_1phase,
                                   NT_2phase=NT_2phase, NQ_2phase=NQ_2phase)
                     self.axes_list.append(ConsistencyAxis(ax, self, pair, self.fluid, self.backend, self.additional_backend, *states, *states_pcsaft, **kwargs))
                     ax.set_title(pair)
         else:
             for ax in self.axes:
-                pair = six.next(pairs_generator)
+                pair = next(pairs_generator)
                 kwargs = dict(p_limits_1phase=p_limits_1phase, T_limits_1phase=T_limits_1phase, NT_1phase=NT_1phase, Np_1phase=Np_1phase,
                               NT_2phase=NT_2phase, NQ_2phase=NQ_2phase)
                 self.axes_list.append(ConsistencyAxis(ax, self, pair, self.fluid, self.backend, self.additional_backend, *states, *states_pcsaft, **kwargs))


### PR DESCRIPTION
## Summary

Two related, long-standing wrapper issues, fixed together for the 8.0.0 major release:

- **#2254** — the C# wrapper (and other SWIG wrappers) disappeared from the SourceForge downloads after the GitHub Actions migration because no C# builder workflow was ever ported. Adds `.github/workflows/csharp_builder.yml` (Windows/Linux/macOS matrix → merge into a single `Csharp` artifact → delete per-OS intermediates) and registers it in the `release_all_files.yml` collect matrix so it rsyncs to SourceForge again.
- **#1674** — every SWIG wrapper emitted a shared library literally named `CoolProp`, colliding with the conventional CoolProp shared library (the suspected root cause of #2326, `EntryPointNotFound`). Each is now language-prefixed via the CMake target `OUTPUT_NAME`, with the loader reference moved in lockstep:
  - C# & VB.NET → `CoolPropCsharp` (CMake `UseSWIG` auto-derives `-dllimport` from `OUTPUT_NAME`)
  - Java → `CoolPropJava` (`System.loadLibrary` in the example generator)
  - R → `CoolPropR` (lib rename **plus** a post-build patch of the generated `CoolProp.R` proxy's `PACKAGE='CoolProp'` → `'CoolPropR'`, since R resolves `.Call(PACKAGE=)` against the `dyn.load` basename, not the SWIG module name)
  - PHP → `CoolPropPHP` (loads by `extension=` filename; no loader patch needed)

  `%module CoolProp` and the public CoolProp API (classes, namespaces, functions) are intentionally **unchanged** — only the binary filename and its loader reference change.

Drive-by: PHP `install(FILES CoolProp.php ... OPTIONAL)` so `--target install` no longer hard-fails on SWIG ≥ 4.1 (which registers PHP classes natively and no longer emits the `CoolProp.php` proxy). Plus `8.0.0` changelog breaking-change + issues-closed entries and updated C#/VB.NET/Java/R/PHP doc pages.

This is a **breaking change** for consumers of the SWIG wrappers: update your `DllImport` (C#/VB.NET), `System.loadLibrary` (Java), or `dyn.load` (R) references to the new `CoolProp<Lang>` names.

## Test Plan

- [x] C# wrapper built locally (macOS): generated bindings show 501 `DllImport("CoolPropCsharp")` and **zero** `DllImport("CoolProp")`; `Example` compiled with `mcs` and run under `mono` loads `libCoolPropCsharp.dylib` and returns correct properties.
- [x] R wrapper built locally (R 4.5.1): installed `CoolProp.R` has 987 `PACKAGE='CoolPropR'` and zero `PACKAGE='CoolProp'`; `Example.R` returns correct water properties with no `.Call` errors.
- [x] Java (JNI symbol-based) and PHP (`extension=` filename-based) rename correctness confirmed by analysis; no runtime coupling to the library filename beyond the updated example loader.
- [x] `preflight.sh`: build + `[!slow][!benchmark]` Catch2 suite pass (default build unaffected; wrapper module blocks are OFF by default).
- [x] Adversarial code-review pass (caught and fixed the R `PACKAGE=` coupling).
- [ ] **CI watch item:** first run of `csharp_builder.yml` — confirm the pre-existing `generate_examples` step (which imports `six`) succeeds on the runners; add a `pip install six` step if it fails.

Closes #2254, #1674, #2326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated multi-platform C# wrapper builds in CI producing a single unified C# download artifact.

* **Behavior Changes**
  * SWIG-based wrappers (C#, VB.NET, Java, R, PHP) now use language-prefixed shared library names (e.g., CoolPropCsharp/CoolPropJava/CoolPropR/CoolPropPHP); update loader/binary references.
  * Legacy PHP proxy install made optional for newer toolchains.

* **Documentation**
  * Wrapper docs, examples, and changelog updated for new filenames and loader snippets.

* **Chores**
  * Removed legacy Python 2 compatibility helpers/dependencies (six, metaclass shims, iterator helpers).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3035?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->