### PR TITLE
fix(Plots): SyntaxWarnings + duplicate dict key in Python Plots package

### DIFF
--- a/wrappers/Python/CoolProp/Plots/PsychChart.py
+++ b/wrappers/Python/CoolProp/Plots/PsychChart.py
@@ -50,7 +50,7 @@ class PlotFormatting(object):
         ax.set_ylabel(r"$W$ ($m_{w}/m_{da}$) [-]")
 
     def __str__(self):
-        return indented_segment("""
+        return indented_segment(r"""
             ax.set_xlim(Tdb[0]-273.15,Tdb[-1]-273.15)
             ax.set_ylim(0,0.03)
             ax.set_xlabel(r"$T_{db}$ [$^{\circ}$C]")
@@ -90,7 +90,7 @@ class HumidityLabels(object):
             ax.text(T_K - 273.15, w, string, rotation=rot, ha='center', va='center', bbox=bbox_opts)
 
     def __str__(self):
-        return indented_segment("""
+        return indented_segment(r"""
                 xv = Tdb #[K]
                 for RH in {RHValues:s}:
                     yv = [HAPropsSI('W','T',T,'P',p,'R',RH) for T in Tdb]

--- a/wrappers/Python/CoolProp/Plots/SimpleCyclesCompression.py
+++ b/wrappers/Python/CoolProp/Plots/SimpleCyclesCompression.py
@@ -20,7 +20,7 @@ class BaseCompressionCycle(BaseCycle):
         BaseCycle.__init__(self, fluid_ref, graph_type, **kwargs)
 
     def eta_carnot_heating(self):
-        """Carnot efficiency
+        r"""Carnot efficiency
 
         Calculates the Carnot efficiency for a heating process, :math:`\eta_c = \frac{T_h}{T_h-T_c}`.
 
@@ -32,7 +32,7 @@ class BaseCompressionCycle(BaseCycle):
         return np.max(Tvector) / (np.max(Tvector) - np.min(Tvector))
 
     def eta_carnot_cooling(self):
-        """Carnot efficiency
+        r"""Carnot efficiency
 
         Calculates the Carnot efficiency for a cooling process, :math:`\eta_c = \frac{T_c}{T_h-T_c}`.
 

--- a/wrappers/Python/CoolProp/Plots/SimpleCyclesExpansion.py
+++ b/wrappers/Python/CoolProp/Plots/SimpleCyclesExpansion.py
@@ -20,7 +20,7 @@ class BasePowerCycle(BaseCycle):
         BaseCycle.__init__(self, fluid_ref, graph_type, **kwargs)
 
     def eta_carnot(self):
-        """Carnot efficiency
+        r"""Carnot efficiency
 
         Calculates the Carnot efficiency for the specified process, :math:`\eta_c = 1 - \frac{T_c}{T_h}`.
 
@@ -32,7 +32,7 @@ class BasePowerCycle(BaseCycle):
         return 1. - np.min(Tvector) / np.max(Tvector)
 
     def eta_thermal(self):
-        """Thermal efficiency
+        r"""Thermal efficiency
 
         The thermal efficiency for the specified process(es), :math:`\eta_{th} = \frac{\dot{W}_{exp} - \dot{W}_{pum}}{\dot{Q}_{in}}`.
 
@@ -163,7 +163,7 @@ class SimpleRankineCycle(BasePowerCycle):
         self.fill_states()
 
     def eta_thermal(self):
-        """Thermal efficiency
+        r"""Thermal efficiency
 
         The thermal efficiency for the specified process(es), :math:`\eta_{th} = \frac{\dot{W}_{exp} - \dot{W}_{pum}}{\dot{Q}_{in}}`.
 

--- a/wrappers/Python/CoolProp/Plots/psy.py
+++ b/wrappers/Python/CoolProp/Plots/psy.py
@@ -115,7 +115,7 @@ class PsyCoolprop(object):
               "P": 0.0,
 
               "tdb": 0.0,
-              "tdb": 0.0,
+              "tdp": 0.0,
               "twb": 0.0,
               "w": None,
               "HR": None,


### PR DESCRIPTION
## Summary

Ran CodeQL (`security-and-quality`) locally — same suites/config as the CI `codeql` job — plus a Python 3.12 compile pass over the shipped `wrappers/Python/CoolProp` package. Two classes of real defect surfaced in `Plots/`, both fixed here. 4 files, 8 lines.

### 1. `psy.py` — duplicate dict key (functional bug)
`PsyCoolprop.kwargs` had `"tdb": 0.0` twice, so the dew-point key `"tdp"` was **missing** from the defaults. Modes 3/4/5 (dew-point temperature) reach `self.kwargs["Tdp"] = self.kwargs["tdp"]` (a bare subscript, no default) → **`KeyError: 'tdp'`** unless the caller passed `tdp=` explicitly. Restored the missing `"tdp": 0.0` default. (CodeQL `py/duplicate-key-dict-literal`.)

### 2. SyntaxWarnings — `invalid escape sequence` (Python 3.12+)
7 warnings across 3 files, fired on import under 3.12+ and slated to become `SyntaxError`:
- `PsychChart.py` — two `__str__` code templates (`\circ`, `\phi`)
- `SimpleCyclesCompression.py` / `SimpleCyclesExpansion.py` — `:math:` LaTeX docstrings (`\eta`, `\frac`, `\dot`)

Fixed by making the strings raw (`r"""..."""`). **Bonus:** in the non-raw docstrings `\frac` was being parsed with `\f` = form-feed, silently corrupting the rendered LaTeX; raw preserves the literal.

## Verification
- `python3.12` compile of the whole package: **0 SyntaxWarnings** after the change (was 7).
- Raw-ification is behavior-preserving: the only backslashes in those strings are LaTeX (never intended Python escapes); the `.format(...)` on the PsychChart template is unaffected (raw changes backslash handling, not `{}` placeholders).
- Adversarial code review: no blocking findings.
- Preflight: clang-format/cppcheck/clang-tidy/semgrep auto-skip (no C/C++ in diff); C++ build/tests skipped (pure-Python change cannot affect the Catch2 suite).

bd: CoolProp-rxzc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed incorrect dew-point temperature mapping in psychrometric calculations that was preventing proper state initialization.

* **Documentation**
  * Improved rendering of mathematical equations in function documentation for better readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3037?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->