### PR TITLE
fix(python): fix real type findings ty surfaced in pure-Python wrappers

### DIFF
--- a/wrappers/Python/CoolProp/BibtexParser.py
+++ b/wrappers/Python/CoolProp/BibtexParser.py
@@ -192,7 +192,10 @@ class BibTeXerClass(object):
 
         if fmt == "latex":
             contents = contents.replace(u"\\newblock ", "")
-            contents = codecs.encode(contents, "latex")
+            # latexcodec's "latex" codec encodes str -> bytes (ASCII LaTeX); decode
+            # back to str so the trailing newline strip below works and getEntry
+            # returns a consistent str type across all formats.
+            contents = codecs.encode(contents, "latex").decode("utf-8")
         elif fmt == "html":
             contents = contents.replace(u"<dd>", "")
             contents = contents.replace(u"</dd>", "")

--- a/wrappers/Python/CoolProp/Plots/Common.py
+++ b/wrappers/Python/CoolProp/Plots/Common.py
@@ -92,10 +92,7 @@ def interpolate_values_1d(x, y, x_points=None, kind='linear'):
 
 
 def is_string(in_obj):
-    try:
-        return isinstance(in_obj, basestring)
-    except NameError:
-        return isinstance(in_obj, str)
+    return isinstance(in_obj, str)
     # except:
     #    return False
 

--- a/wrappers/Python/CoolProp/Plots/ConsistencyPlots_pcsaft.py
+++ b/wrappers/Python/CoolProp/Plots/ConsistencyPlots_pcsaft.py
@@ -444,7 +444,7 @@ class ConsistencyAxis(object):
         state = self.state
 
         try:
-            if state_pcsaft.fluid_param_string('pure') == 'false':
+            if state.fluid_param_string('pure') == 'false':
                 print("Not a pure-fluid, skipping two-phase evaluation")
                 return
         except:

--- a/wrappers/Python/CoolProp/Plots/SimpleCyclesCompression.py
+++ b/wrappers/Python/CoolProp/Plots/SimpleCyclesCompression.py
@@ -202,8 +202,8 @@ class SimpleCompressionCycle(BaseCompressionCycle):
 
         if not SI:
             conv_t = self._system[CoolProp.iT].to_SI
-            Te = conv_p(Te)
-            Tc = conv_p(Tc)
+            Te = conv_t(Te)
+            Tc = conv_t(Tc)
 
         # Get the saturation conditions
         self.state.update(CoolProp.QT_INPUTS, 1.0, Te)

--- a/wrappers/Python/CoolProp/__init__.py
+++ b/wrappers/Python/CoolProp/__init__.py
@@ -77,6 +77,6 @@ def copy_BibTeX_library(file=None, folder=None):
     elif file and folder is None:
         shutil.copy2(path_to_bib, file)
     elif folder and file is None:
-        shutil.copy2(path_to_bib, os.path.join(folder, file))
+        shutil.copy2(path_to_bib, folder)
     else:
         raise ValueError('can only provide one of file or folder')


### PR DESCRIPTION
## What

Astral's [`ty`](https://docs.astral.sh/ty/) type checker surfaces several **genuine latent runtime bugs** in the hand-written Python wrapper layer (`wrappers/Python/CoolProp/`). This PR fixes them — code only, no tooling/CI changes.

| File | Bug | Fix |
|------|-----|-----|
| `Plots/SimpleCyclesCompression.py` | `conv_p` is undefined in the non-SI branch (only `conv_t` is bound) → latent `NameError` for any `SI=False` call | `conv_p(Te/Tc)` → `conv_t(...)` (Te/Tc are temperatures) |
| `Plots/ConsistencyPlots_pcsaft.py` | `state_pcsaft` is undefined; the local is `state` → `NameError` silently swallowed by a bare `except`, so the pure-fluid guard never fired | `state_pcsaft` → `state` |
| `__init__.py` | In the `file is None` branch, `os.path.join(folder, file)` joined against `None` → `TypeError` | copy into `folder` directly (matches sibling branches + docstring) |
| `BibtexParser.py` | The latex path left `contents` as `bytes` (`codecs.encode(..., "latex")`), crashing the later str `.replace` → latex format was broken | decode back to `str`; `getEntry` now returns a consistent `str` across all formats |
| `Plots/Common.py` | Dead Py2 `basestring` branch (Py2.7 EOL) | simplify to `isinstance(in_obj, str)` |

## Effect

Resolves **7 ty diagnostics** (103 → 96 on the package) with **0 new diagnostics**. Each fix targets a real defect; none of the broken paths had a working caller (they raised `NameError`/`TypeError`), so there is no behavior regression on Python 3 — verified by two independent adversarial reviews.

## Scope / follow-ups

This is the "fix real findings" slice of the larger *add-ty* effort (CoolProp-doit). Deliberately **out of scope**, tracked as separate beads:
- `[tool.ty]` config + narrow compiled-module suppression (bucket 1) — `CoolProp-m2h5`
- Py2 dead-code removal: `psy.py`, `execfile`/`PsychScript` chain, dead `nose` imports, removed `CoolProp.Plots` API (bucket 2) — `CoolProp-jh1g`
- wx GUI type cleanup — `CoolProp-oi42`
- Blocking ty gate in `python_buildwheels.yml` + `preflight.sh` — `CoolProp-34ua`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected temperature unit conversion functions in thermodynamic compression cycle calculations, ensuring proper temperature versus pressure conversion usage
  * Fixed state variable references in two-phase consistency checks for improved accuracy
  * Resolved file path destination handling in bibliography library copy operations
  * Enhanced consistency of text encoding and data processing throughout the library

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoolProp/CoolProp/pull/3038?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->