### PR TITLE
ci(gui): Windows SignPath signing + fix macOS API-key notarization (CoolProp-dzq.7/.8)

### DIFF
--- a/.github/workflows/gui_builder.yml
+++ b/.github/workflows/gui_builder.yml
@@ -39,6 +39,12 @@ jobs:
   build:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    env:
+      # Exposed at job level so the Windows SignPath steps can gate on its
+      # presence in their `if:` conditions (the `env` context is available in
+      # `if`, the `secrets` context is not). Absent on forks / when the secret
+      # is unset, in which case signing no-ops and the build stays unsigned.
+      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -228,47 +234,77 @@ jobs:
           kill "$APP_PID" "$XVFB_PID" 2>/dev/null || true
           echo "OK: GUI started and screenshot captured"
 
-      # ─── Windows post-build signing ────────────────────────────────────────
-      # Sign the .exe and .msi with the runner's signtool when a code-signing
-      # cert is provided via secrets. Without WINDOWS_CERTIFICATE the step is
-      # a no-op and we ship unsigned binaries (SmartScreen will flag them).
+      # ─── Windows code signing via SignPath (gh CoolProp-dzq.8) ──────────────
+      # SignPath (Foundation OSS) keeps the certificate in its HSM and signs an
+      # *already-uploaded* GitHub artifact — it cannot sign in place the way
+      # signtool did. Flow: upload the unsigned bundle as a throwaway GH
+      # artifact, submit it to SignPath, download the signed bundle back, then
+      # overlay it onto the bundle dir so the Windows smoke test and the release
+      # upload both see signed binaries.
       #
-      # Required secrets to activate:
-      #   WINDOWS_CERTIFICATE          base64 of a .pfx with the signing cert
-      #   WINDOWS_CERTIFICATE_PASSWORD password used during the .pfx export
+      # All steps no-op gracefully when SIGNPATH_API_TOKEN is absent (forks,
+      # secret unset), leaving an unsigned-but-functional build.
       #
-      # SignPath OSS users: replace this step with the SignPath action — see
-      # wrappers/GUI/README.md.
-      - name: Sign Windows .exe and .msi
-        if: matrix.os == 'windows-latest'
+      # signing-policy-slug defaults to 'test-signing', which exercises the full
+      # pipeline with SignPath's untrusted test certificate — it will NOT clear
+      # SmartScreen. Once SignPath Foundation issues the release certificate, set
+      # the repo variable SIGNPATH_POLICY_SLUG=release-signing to go live; no
+      # code change required.
+      - name: Upload unsigned Windows bundle for SignPath
+        id: signpath_upload
+        if: matrix.os == 'windows-latest' && env.SIGNPATH_API_TOKEN != ''
+        uses: actions/upload-artifact@v7
+        with:
+          # Name kept outside the coolprop-gui-* pattern the release job globs,
+          # so this unsigned copy can never reach a release.
+          name: signpath-unsigned-windows
+          path: wrappers/GUI/src-tauri/target/release/bundle
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Sign Windows installers via SignPath
+        if: matrix.os == 'windows-latest' && env.SIGNPATH_API_TOKEN != ''
+        uses: signpath/github-action-submit-signing-request@v1
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: e6ed0285-8cc0-431c-b527-6502f5b77e94
+          project-slug: coolprop
+          signing-policy-slug: ${{ vars.SIGNPATH_POLICY_SLUG || 'test-signing' }}
+          github-artifact-id: ${{ steps.signpath_upload.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: signpath-signed
+
+      - name: Overlay signed Windows installers onto bundle
+        if: matrix.os == 'windows-latest' && env.SIGNPATH_API_TOKEN != ''
         shell: pwsh
-        env:
-          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
-          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
         run: |
-          if (-not $env:WINDOWS_CERTIFICATE) {
-            Write-Host "Windows signing: WINDOWS_CERTIFICATE not set — leaving unsigned."
-            exit 0
-          }
-          $pfx = "$env:RUNNER_TEMP\coolprop-cert.pfx"
-          [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE))
-          $signtool = (Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Recurse -Filter signtool.exe |
-            Where-Object { $_.DirectoryName -match '\\x64\\?$' } | Select-Object -First 1).FullName
-          if (-not $signtool) { throw "signtool.exe not found" }
+          # SignPath returns the signed copy of the whole uploaded artifact with
+          # its original layout (msi/, nsis/); copy it back over the bundle dir
+          # so downstream steps consume the signed binaries.
+          $signed = "$PWD\signpath-signed"
           $bundle = "$PWD\wrappers\GUI\src-tauri\target\release\bundle"
-          $targets = @()
-          $targets += Get-ChildItem -Path "$PWD\wrappers\GUI\src-tauri\target\release\*.exe" -File -ErrorAction SilentlyContinue
-          $targets += Get-ChildItem -Path "$bundle\msi\*.msi" -File -ErrorAction SilentlyContinue
-          $targets += Get-ChildItem -Path "$bundle\nsis\*.exe" -File -ErrorAction SilentlyContinue
-          if ($targets.Count -eq 0) { throw "No artifacts to sign" }
-          foreach ($f in $targets) {
-            Write-Host "Signing $($f.FullName)"
-            & $signtool sign /f $pfx /p $env:WINDOWS_CERTIFICATE_PASSWORD `
-              /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 $f.FullName
-            if ($LASTEXITCODE -ne 0) { throw "signtool failed for $($f.FullName)" }
+          if (-not (Test-Path $signed)) { throw "SignPath output dir not found: $signed" }
+          if (-not (Get-ChildItem $signed -Recurse -File)) { throw "SignPath output dir is empty: $signed" }
+          Copy-Item -Path "$signed\*" -Destination $bundle -Recurse -Force
+          Write-Host "Overlaid SignPath-signed artifacts onto $bundle"
+
+          # Verify the overlay actually replaced the installers with signed
+          # ones. Copy-Item overlays the tree rather than replacing it, so a
+          # layout mismatch in SignPath's output could otherwise leave the
+          # original UNSIGNED .msi/.exe in place and ship it under a "signed"
+          # banner. Fail loudly if any installer lacks an Authenticode
+          # signature. (A test-signing cert is untrusted but still produces a
+          # signature, so Status is NotSigned only when truly unsigned.)
+          $installers = @()
+          $installers += Get-ChildItem -Path "$bundle\msi\*.msi" -File -ErrorAction SilentlyContinue
+          $installers += Get-ChildItem -Path "$bundle\nsis\*.exe" -File -ErrorAction SilentlyContinue
+          if ($installers.Count -eq 0) { throw "No .msi/.exe installers found under $bundle to verify" }
+          foreach ($f in $installers) {
+            $sig = Get-AuthenticodeSignature $f.FullName
+            Write-Host "$($f.Name): $($sig.Status) — signer: $($sig.SignerCertificate.Subject)"
+            if ($sig.Status -eq 'NotSigned') { throw "Installer not signed after overlay: $($f.FullName)" }
           }
-          Remove-Item $pfx -Force
-          Write-Host "Windows signing: signed $($targets.Count) artifact(s)."
+          Write-Host "Verified $($installers.Count) signed installer(s)."
 
       # ─── macOS smoke test ──────────────────────────────────────────────────
       # Open the bundled .app, poll a screenshot + render check every 2s up

--- a/.github/workflows/gui_builder.yml
+++ b/.github/workflows/gui_builder.yml
@@ -116,27 +116,53 @@ jobs:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          # Notarization, app-password flow:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          # Notarization, API-key flow (alternative):
+          # Notarization, App Store Connect API-key flow (preferred):
+          #   APPLE_API_ISSUER     issuer UUID (above the keys table)
+          #   APPLE_API_KEY        the Key ID (short identifier), NOT the key body
+          #   APPLE_API_KEY_BASE64 base64 of the downloaded AuthKey_*.p8 — this
+          #                        step decodes it to a file and exports
+          #                        APPLE_API_KEY_PATH for tauri-action.
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          APPLE_API_KEY_PATH: ${{ secrets.APPLE_API_KEY_PATH }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          # Notarization, app-specific-password flow (alternative):
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
         run: |
+          set -euo pipefail
           if [ -z "${APPLE_CERTIFICATE:-}" ]; then
             echo "macOS signing: APPLE_CERTIFICATE not set — building unsigned."
             exit 0
           fi
+          # Forward the signing + plain-string notarization vars to later steps
+          # (tauri-action reads them straight from the environment).
           for var in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY \
-                     APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID \
-                     APPLE_API_ISSUER APPLE_API_KEY APPLE_API_KEY_PATH; do
+                     APPLE_TEAM_ID APPLE_ID APPLE_PASSWORD \
+                     APPLE_API_ISSUER APPLE_API_KEY; do
             val=$(printenv "$var" 2>/dev/null || true)
             if [ -n "$val" ]; then
               printf '%s<<__SIGN_EOF__\n%s\n__SIGN_EOF__\n' "$var" "$val" >> "$GITHUB_ENV"
             fi
           done
+          # API-key flow: tauri-action wants APPLE_API_KEY_PATH to point at the
+          # actual AuthKey_*.p8 on disk, so decode the base64 secret to a file
+          # and export the path. base64.b64decode tolerates wrapped/unwrapped
+          # input (it drops non-alphabet chars), sidestepping BSD-vs-GNU
+          # base64 flag differences on the macOS runner.
+          if [ -n "${APPLE_API_KEY_BASE64:-}" ]; then
+            # Fail fast on a half-configured API-key flow rather than letting
+            # tauri-action fail later with an opaque notarization error.
+            if [ -z "${APPLE_API_KEY:-}" ] || [ -z "${APPLE_API_ISSUER:-}" ]; then
+              echo "::error::APPLE_API_KEY_BASE64 is set but APPLE_API_KEY (Key ID) and/or APPLE_API_ISSUER is missing — the API-key notarization flow needs all three."
+              exit 1
+            fi
+            key_path="$RUNNER_TEMP/AuthKey.p8"
+            KEY_PATH="$key_path" python3 -c 'import base64,os; open(os.environ["KEY_PATH"],"wb").write(base64.b64decode(os.environ["APPLE_API_KEY_BASE64"]))'
+            chmod 600 "$key_path"
+            echo "APPLE_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
+            echo "macOS signing: decoded App Store Connect API key to $key_path."
+          fi
           echo "macOS signing: APPLE_* env forwarded to subsequent steps."
 
       # Builds the frontend (Vite), compiles CoolProp via build.rs (CMake),

--- a/.github/workflows/gui_builder.yml
+++ b/.github/workflows/gui_builder.yml
@@ -39,12 +39,6 @@ jobs:
   build:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    env:
-      # Exposed at job level so the Windows SignPath steps can gate on its
-      # presence in their `if:` conditions (the `env` context is available in
-      # `if`, the `secrets` context is not). Absent on forks / when the secret
-      # is unset, in which case signing no-ops and the build stays unsigned.
-      SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -134,6 +128,14 @@ jobs:
           if [ -z "${APPLE_CERTIFICATE:-}" ]; then
             echo "macOS signing: APPLE_CERTIFICATE not set — building unsigned."
             exit 0
+          fi
+          # API-key and app-password notarization are mutually exclusive. If
+          # both sets of secrets are present, tauri-action would silently pick
+          # one — masking a secrets mistake. Reject the ambiguous config.
+          if [ -n "${APPLE_API_KEY_BASE64:-}${APPLE_API_KEY:-}${APPLE_API_ISSUER:-}" ] \
+             && [ -n "${APPLE_ID:-}${APPLE_PASSWORD:-}" ]; then
+            echo "::error::Both API-key (APPLE_API_*) and app-password (APPLE_ID/APPLE_PASSWORD) notarization secrets are set — configure exactly one flow."
+            exit 1
           fi
           # Forward the signing + plain-string notarization vars to later steps
           # (tauri-action reads them straight from the environment).
@@ -276,9 +278,27 @@ jobs:
       # SmartScreen. Once SignPath Foundation issues the release certificate, set
       # the repo variable SIGNPATH_POLICY_SLUG=release-signing to go live; no
       # code change required.
+      # Confine SIGNPATH_API_TOKEN to this probe step (and the signing action's
+      # `with:` input below) rather than exposing it to every matrix job via a
+      # job-level env. Emits a boolean the Windows signing steps gate on.
+      # 'false' on forks / when the secret is unset -> bundle stays unsigned.
+      - name: Check SignPath availability
+        id: signpath_check
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        env:
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+        run: |
+          if [ -n "${SIGNPATH_API_TOKEN:-}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "SignPath: token not set — Windows bundle stays unsigned."
+          fi
+
       - name: Upload unsigned Windows bundle for SignPath
         id: signpath_upload
-        if: matrix.os == 'windows-latest' && env.SIGNPATH_API_TOKEN != ''
+        if: matrix.os == 'windows-latest' && steps.signpath_check.outputs.enabled == 'true'
         uses: actions/upload-artifact@v7
         with:
           # Name kept outside the coolprop-gui-* pattern the release job globs,
@@ -289,7 +309,7 @@ jobs:
           retention-days: 1
 
       - name: Sign Windows installers via SignPath
-        if: matrix.os == 'windows-latest' && env.SIGNPATH_API_TOKEN != ''
+        if: matrix.os == 'windows-latest' && steps.signpath_check.outputs.enabled == 'true'
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -301,7 +321,7 @@ jobs:
           output-artifact-directory: signpath-signed
 
       - name: Overlay signed Windows installers onto bundle
-        if: matrix.os == 'windows-latest' && env.SIGNPATH_API_TOKEN != ''
+        if: matrix.os == 'windows-latest' && steps.signpath_check.outputs.enabled == 'true'
         shell: pwsh
         run: |
           # SignPath returns the signed copy of the whole uploaded artifact with
@@ -328,7 +348,14 @@ jobs:
           foreach ($f in $installers) {
             $sig = Get-AuthenticodeSignature $f.FullName
             Write-Host "$($f.Name): $($sig.Status) — signer: $($sig.SignerCertificate.Subject)"
-            if ($sig.Status -eq 'NotSigned') { throw "Installer not signed after overlay: $($f.FullName)" }
+            # Hard-fail on a genuinely bad signature: NotSigned (overlay left
+            # the unsigned original) or HashMismatch (tampered/corrupt). A
+            # test-signing cert yields 'UnknownError' (untrusted chain) and a
+            # release cert yields 'Valid' — both acceptable, so don't reject
+            # everything that isn't 'Valid' (that would fail test-signing).
+            if ($sig.Status -eq 'NotSigned' -or $sig.Status -eq 'HashMismatch') {
+              throw "Installer signature invalid ($($sig.Status)) after overlay: $($f.FullName)"
+            }
           }
           Write-Host "Verified $($installers.Count) signed installer(s)."
 

--- a/.github/workflows/gui_builder.yml
+++ b/.github/workflows/gui_builder.yml
@@ -290,7 +290,7 @@ jobs:
 
       - name: Sign Windows installers via SignPath
         if: matrix.os == 'windows-latest' && env.SIGNPATH_API_TOKEN != ''
-        uses: signpath/github-action-submit-signing-request@v1
+        uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: e6ed0285-8cc0-431c-b527-6502f5b77e94

--- a/wrappers/GUI/README.md
+++ b/wrappers/GUI/README.md
@@ -172,6 +172,15 @@ certificate only after manually approving the project; once that lands, set the
 repo variable `SIGNPATH_POLICY_SLUG=release-signing` (Settings → Secrets and
 variables → Actions → Variables) to go live with no code change.
 
+**Signing the installed app binary too.** The CI step uploads the whole
+bundle (the `.msi` and the NSIS `-setup.exe`), so the *installed* executable
+(`coolprop-gui.exe`, embedded inside those installers) can be signed in the
+same request — no CI change needed. Enable it portal-side by ticking **"Sign
+nested files"** on the SignPath *artifact configuration*; SignPath then signs
+both the outer installer and the PE files it contains in a single pass. The
+workflow's post-overlay `Get-AuthenticodeSignature` check only verifies the
+outer installers; trust SignPath's nested-signing for the embedded binary.
+
 **Alternatives** (would require swapping the signing step): a direct
 Authenticode `.pfx` via `signtool` (set base64 `WINDOWS_CERTIFICATE` +
 `WINDOWS_CERTIFICATE_PASSWORD` secrets), or **Azure Trusted Signing**

--- a/wrappers/GUI/README.md
+++ b/wrappers/GUI/README.md
@@ -146,34 +146,36 @@ them to `tauri-action`, which signs the `.app`, staples the notarization
 ticket, and produces a `.dmg` that opens cleanly without the `xattr`
 workaround.
 
-#### Windows — Authenticode signing
+#### Windows — Authenticode signing via SignPath
 
-Two paths supported:
+The workflow signs Windows installers through **SignPath OSS** (free for
+qualifying open-source projects via
+[signpath.io](https://signpath.io/products/foundation)). SignPath keeps the
+certificate in its HSM and signs an *already-uploaded* GitHub artifact, so the
+*Sign Windows installers via SignPath* step uploads the unsigned bundle,
+submits it via `signpath/github-action-submit-signing-request`, and overlays
+the signed installers back onto the bundle dir before the Windows smoke test
+and the release upload. It activates when the `SIGNPATH_API_TOKEN` secret is
+present, and no-ops to an unsigned build when it isn't (forks, secret unset).
 
-- **Direct certificate (any Authenticode cert).** Set:
+| Setting                | Where                | Value                                              |
+|------------------------|----------------------|----------------------------------------------------|
+| `SIGNPATH_API_TOKEN`   | repo **secret**      | SignPath REST API token for the CI user            |
+| organization-id        | hard-coded in YAML   | CoolProp's SignPath org GUID                        |
+| project-slug           | hard-coded in YAML   | `coolprop`                                          |
+| `SIGNPATH_POLICY_SLUG` | repo **variable**    | signing policy slug; defaults to `test-signing`     |
 
-| Secret                          | Value                                       |
-|---------------------------------|---------------------------------------------|
-| `WINDOWS_CERTIFICATE`           | base64 of a `.pfx` containing the cert + key |
-| `WINDOWS_CERTIFICATE_PASSWORD`  | password used during the `.pfx` export       |
+The policy defaults to `test-signing`, which exercises the full pipeline using
+SignPath's **untrusted test certificate** — this validates the wiring but will
+*not* clear SmartScreen. SignPath Foundation issues the trusted release
+certificate only after manually approving the project; once that lands, set the
+repo variable `SIGNPATH_POLICY_SLUG=release-signing` (Settings → Secrets and
+variables → Actions → Variables) to go live with no code change.
 
-  Encode with PowerShell: `[Convert]::ToBase64String([IO.File]::ReadAllBytes('cert.pfx')) | Set-Clipboard`.
-  The workflow's *Sign Windows .exe and .msi* step decodes the cert into a
-  temp `.pfx`, locates `signtool.exe` from the bundled Windows Kits, and
-  signs the `target/release/*.exe`, `bundle/msi/*.msi`, and any
-  `bundle/nsis/*.exe` produced by `tauri build`. Timestamp server is
-  DigiCert's free endpoint.
-
-- **SignPath OSS (recommended for OSS projects without a paid cert).**
-  Free for qualifying OSS via [signpath.io](https://signpath.io/products/foundation).
-  Replace the *Sign Windows .exe and .msi* step with the
-  `signpath/github-action-submit-signing-request` action — see SignPath's
-  [GitHub action docs](https://about.signpath.io/documentation/build-system-integration#github-actions)
-  for the exact YAML; you'll set `SIGNPATH_*` secrets instead of
-  `WINDOWS_CERTIFICATE`.
-
-- **Azure Trusted Signing** is also a fit (pay-per-signature, no HSM
-  hardware) — analogous post-build step.
+**Alternatives** (would require swapping the signing step): a direct
+Authenticode `.pfx` via `signtool` (set base64 `WINDOWS_CERTIFICATE` +
+`WINDOWS_CERTIFICATE_PASSWORD` secrets), or **Azure Trusted Signing**
+(pay-per-signature, no HSM hardware).
 
 #### Linux
 

--- a/wrappers/GUI/README.md
+++ b/wrappers/GUI/README.md
@@ -118,11 +118,13 @@ One-time setup:
    → *Export*, choose Personal Information Exchange (.p12), set a password.
 4. **Base64-encode it for GitHub.**
    `base64 -i Cert.p12 | pbcopy` — paste into the GitHub secret value.
-5. **Generate a notarytool API key (recommended over app-passwords).**
+5. **Generate an App Store Connect API key (preferred over app-passwords —
+   it isn't tied to a person and won't break on 2FA / password changes).**
    App Store Connect → Users and Access → Integrations → App Store Connect
-   API → `+` → grant "Developer" role. Download the `.p8` once (you can't
-   get it back) and note the Issuer ID and Key ID. Base64 the `.p8`:
-   `base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy`.
+   API → `+` → grant the **Developer** role. Download the `.p8` once (you
+   can't get it back), and note the **Issuer ID** (the UUID above the keys
+   table) and the **Key ID** (the short identifier in the Key ID column).
+   Base64 the `.p8`: `base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy`.
 6. **Add the GitHub secrets** (Repo Settings → Secrets and variables →
    Actions → New repository secret):
 
@@ -135,11 +137,21 @@ One-time setup:
 
 Then **one** of the two notarization flows:
 
-- **API key flow (recommended):** `APPLE_API_KEY` (base64 of the `.p8`),
-  `APPLE_API_ISSUER` (Issuer ID UUID), `APPLE_API_KEY_PATH` (path the
-  workflow should write the decoded `.p8` to, e.g. `~/AuthKey.p8`).
-- **App-password flow:** `APPLE_ID` (Apple-ID email), `APPLE_PASSWORD`
-  (app-specific password from appleid.apple.com → Sign-In and Security).
+- **API-key flow (preferred):** three secrets —
+
+  | Secret                 | Value                                                       |
+  |------------------------|-------------------------------------------------------------|
+  | `APPLE_API_ISSUER`     | Issuer ID (UUID above the keys table)                       |
+  | `APPLE_API_KEY`        | **Key ID** — the short identifier, *not* the key body       |
+  | `APPLE_API_KEY_BASE64` | base64 of the downloaded `AuthKey_*.p8`                      |
+
+  The *Configure macOS signing* step decodes `APPLE_API_KEY_BASE64` to a
+  file on the runner and sets `APPLE_API_KEY_PATH` itself — you do **not**
+  add `APPLE_API_KEY_PATH` as a secret.
+
+- **App-specific-password flow (alternative):** `APPLE_ID` (Apple-ID email)
+  and `APPLE_PASSWORD` (app-specific password from appleid.apple.com →
+  Sign-In and Security). Uses `APPLE_TEAM_ID` from the table above.
 
 Once those exist, the workflow's *Configure macOS signing* step forwards
 them to `tauri-action`, which signs the `.app`, staples the notarization


### PR DESCRIPTION
## What

Rewires Windows code signing in `gui_builder.yml` from the in-place `signtool`/`.pfx` step to the **SignPath Foundation OSS** cloud-signing flow.

SignPath holds the certificate in its HSM and signs an *already-uploaded* GitHub artifact (it cannot sign in place), so the Windows job now:

1. **Uploads** the unsigned bundle as a throwaway GH artifact named `signpath-unsigned-windows` — deliberately *outside* the `coolprop-gui-*` glob the `release` job downloads, so an unsigned copy can never reach a release.
2. **Signs** it via `signpath/github-action-submit-signing-request@v1`, referencing that artifact's id.
3. **Overlays** the signed installers back onto the bundle dir, then **asserts** via `Get-AuthenticodeSignature` that every `.msi`/NSIS `.exe` is actually signed — failing loudly rather than silently shipping an unsigned installer under a "signed" banner.

Downstream (Windows MSI smoke test + release upload) consume the signed bundle.

## Configuration

| Setting | Where | Value |
|---|---|---|
| `SIGNPATH_API_TOKEN` | repo **secret** (added) | SignPath REST API token |
| organization-id / project-slug | hard-coded | org GUID / `coolprop` |
| `SIGNPATH_POLICY_SLUG` | repo **variable** | signing policy; **defaults to `test-signing`** |

The policy defaults to `test-signing`, which validates the full pipeline using SignPath's **untrusted test certificate** (does *not* clear SmartScreen). Once SignPath Foundation issues the trusted release certificate, set repo variable `SIGNPATH_POLICY_SLUG=release-signing` to go live — **no code change**.

All signing steps **no-op gracefully** when `SIGNPATH_API_TOKEN` is absent (forks, secret unset), leaving an unsigned-but-functional build. Trigger is `pull_request` (not `pull_request_target`), so fork PRs never receive the secret.

## Notes

- Tracks `CoolProp-dzq.8` (kept **open** until the release cert lands and SmartScreen acceptance is met).
- README Windows signing section rewritten: SignPath is now the documented active path; `signtool`/`.pfx` and Azure Trusted Signing demoted to alternatives.
- Pre-PR: `yaml.safe_load` validates the workflow; `preflight --skip=build,tests` clean (no C/C++ in diff); independent adversarial review returned no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Windows signing guidance to describe the new SignPath-based CI workflow, test vs. release policy behavior, nested-executable signing, and revised macOS notarization guidance noting the runner writes the App Store Connect API key path (do not store that path as a secret).

* **Chores**
  * CI now uses SignPath for Windows installer signing with strict verification and failure on unsigned/mismatched installers, supports no-op builds when signing credentials are absent, adds an App Store Connect API-key notarization path, and rejects ambiguous notarization configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->