### PR TITLE
ci(gui): make SignPath signing opt-in via [gui-sign] marker

### DIFF
--- a/.github/workflows/gui_builder.yml
+++ b/.github/workflows/gui_builder.yml
@@ -271,7 +271,8 @@ jobs:
       # upload both see signed binaries.
       #
       # All steps no-op gracefully when SIGNPATH_API_TOKEN is absent (forks,
-      # secret unset), leaving an unsigned-but-functional build.
+      # secret unset) OR when the opt-in marker is missing (see the probe step
+      # above) — leaving an unsigned-but-functional build and sending no email.
       #
       # signing-policy-slug defaults to 'test-signing', which exercises the full
       # pipeline with SignPath's untrusted test certificate — it will NOT clear
@@ -288,12 +289,34 @@ jobs:
         shell: bash
         env:
           SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # On a PR the checked-out HEAD is a synthetic merge commit, so resolve
+          # the PR's real head SHA; on push/tag use the pushed SHA.
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          if [ -n "${SIGNPATH_API_TOKEN:-}" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
+          if [ -z "${SIGNPATH_API_TOKEN:-}" ]; then
             echo "enabled=false" >> "$GITHUB_OUTPUT"
             echo "SignPath: token not set — Windows bundle stays unsigned."
+            exit 0
+          fi
+          # Opt-in signing. SignPath has no per-state notification filter, so a
+          # signing request (and its email) fires ONLY when explicitly asked:
+          # the HEAD commit message carries the [gui-sign] marker, or this is a
+          # gui-v* release tag (releases are always signed). Routine GUI pushes
+          # then build unsigned and send no email. The commit message is read
+          # via the API so this works on PRs (merge-commit checkout) too.
+          msg=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}" --jq '.commit.message' 2>/dev/null || echo "")
+          sign=false
+          case "${GITHUB_REF:-}" in
+            refs/tags/gui-v*) sign=true ;;
+          esac
+          if printf '%s' "$msg" | grep -qF '[gui-sign]'; then sign=true; fi
+          if [ "$sign" = true ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "SignPath: signing enabled ([gui-sign] marker or gui-v* tag)."
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "SignPath: opt-in marker absent — skipping signing (no email). Add [gui-sign] to the commit message, or push a gui-v* tag, to sign + exercise SignPath."
           fi
 
       - name: Upload unsigned Windows bundle for SignPath

--- a/wrappers/GUI/README.md
+++ b/wrappers/GUI/README.md
@@ -170,6 +170,17 @@ the signed installers back onto the bundle dir before the Windows smoke test
 and the release upload. It activates when the `SIGNPATH_API_TOKEN` secret is
 present, and no-ops to an unsigned build when it isn't (forks, secret unset).
 
+**Signing is opt-in** to avoid a SignPath email on every GUI build (SignPath
+has no per-state notification filter). A signing request fires only when:
+
+- the triggering commit's message contains the marker **`[gui-sign]`**, or
+- the build is for a **`gui-v*` release tag** (releases are always signed).
+
+Routine GUI commits therefore build unsigned and send no email; add
+`[gui-sign]` to a commit message (or push a release tag) when you want to
+exercise/validate SignPath. macOS notarization is *not* gated this way — it
+runs on every build whenever the Apple secrets are present.
+
 | Setting                | Where                | Value                                              |
 |------------------------|----------------------|----------------------------------------------------|
 | `SIGNPATH_API_TOKEN`   | repo **secret**      | SignPath REST API token for the CI user            |


### PR DESCRIPTION
## Why

SignPath emails the requester on **every** signing request and offers no per-state notification filter (confirmed: no such option in the portal). Signing on every GUI build floods the maintainer's inbox.

## What

Gate the **SignPath (Windows)** signing behind an explicit opt-in, evaluated in the existing `Check SignPath availability` probe step. `enabled=true` only when:

- the **HEAD commit message contains `[gui-sign]`**, or
- the build is a **`gui-v*` release tag** (releases always sign, regardless of message).

Otherwise the Windows bundle builds **unsigned** and no signing request — hence no email — is made. The three downstream Windows steps (upload/sign/overlay) already gate on `steps.signpath_check.outputs.enabled`.

The commit message is read via `gh api` on the resolved head SHA (`github.event.pull_request.head.sha || github.sha`), so the marker is detected correctly despite the synthetic merge-commit checkout on PRs. The gate **fails closed** (any `gh`/auth error → no signing), and a `gui-v*` tag signs without needing `gh` at all.

**macOS notarization is intentionally NOT gated** — it runs on every build whenever the Apple secrets are present (per maintainer request).

## Usage

- Routine GUI work: nothing to do — builds unsigned, no email.
- Want to exercise/validate SignPath: put **`[gui-sign]`** in the commit message, or push a `gui-v*` tag.

## Validation

- `yaml.safe_load` parses; `shellcheck -s bash` clean on the probe step; marker logic unit-sanity-checked.
- Independent adversarial review: no blocking findings (head-SHA resolution correct across push/PR/tag/dispatch; exactly one `enabled` output on every path; release tags always sign; macOS untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GUI build signing documentation to clarify opt-in signing mechanism using commit markers and release tags.

* **Chores**
  * Enhanced GUI build workflow to support optional code signing for desktop releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->