### PR TITLE
ci(gui): curate per-build bundle artifact to installers only

### DIFF
--- a/.github/workflows/gui_builder.yml
+++ b/.github/workflows/gui_builder.yml
@@ -528,7 +528,25 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: coolprop-gui-${{ matrix.os }}
-          path: wrappers/GUI/src-tauri/target/release/bundle
+          # Upload only the user-facing installers (+ the updater .tar.gz/.sig
+          # the release job consumes), NOT the whole bundle tree. Two reasons:
+          #  - the raw macos/CoolProp.app directory is BROKEN once GitHub
+          #    re-zips the artifact (a macOS app bundle loses its signature /
+          #    executable bits through a plain zip) — the .dmg is the correct,
+          #    self-contained macOS format to ship;
+          #  - bundle_dmg.sh / icon.icns / create-dmg are build scaffolding.
+          # Including all of that made the download confusing about what to open.
+          # Each glob matches only on the OS that produces it; if-no-files-found
+          # checks the aggregate, so every OS still uploads its installer(s).
+          path: |
+            wrappers/GUI/src-tauri/target/release/bundle/dmg/*.dmg
+            wrappers/GUI/src-tauri/target/release/bundle/macos/*.app.tar.gz
+            wrappers/GUI/src-tauri/target/release/bundle/macos/*.app.tar.gz.sig
+            wrappers/GUI/src-tauri/target/release/bundle/deb/*.deb
+            wrappers/GUI/src-tauri/target/release/bundle/rpm/*.rpm
+            wrappers/GUI/src-tauri/target/release/bundle/appimage/*.AppImage
+            wrappers/GUI/src-tauri/target/release/bundle/msi/*.msi
+            wrappers/GUI/src-tauri/target/release/bundle/nsis/*-setup.exe
           if-no-files-found: error
           retention-days: 7
 

--- a/wrappers/GUI/README.md
+++ b/wrappers/GUI/README.md
@@ -82,19 +82,39 @@ Produces a bundle for the host platform under
 CI (`.github/workflows/gui_builder.yml`) builds these bundles on every push
 to GUI-affecting paths and uploads them as artifacts.
 
-### Running an unsigned macOS bundle (CI artifact)
+### Downloading a build
 
-CI artifacts are not currently signed or notarized. macOS Gatekeeper will
-block them on first launch ("App is damaged" or "from an unidentified
-developer"). To launch:
+For end users the intended channel is a **GitHub Release** (created by
+pushing a `gui-v*` tag): each installer is attached as a *direct* download —
+the macOS `.dmg`, the Windows `.msi` / `-setup.exe`, the Linux `.deb` /
+`.rpm` / `.AppImage`.
+
+The per-build **CI artifacts** (`coolprop-gui-<os>`) are for testing. GitHub
+always wraps an artifact in a `.zip`, so you download e.g.
+`coolprop-gui-macos-latest.zip` and unzip it. The artifact is curated to the
+installers only:
+
+- **macOS** — open `dmg/CoolProp_*.dmg`, then drag the app to Applications.
+  Do **not** try to launch a `.app` pulled straight out of a zip: a macOS app
+  bundle loses the bits that make it launchable through a plain zip, so the
+  `.dmg` is the correct, self-contained format. (`*.app.tar.gz` is the
+  auto-updater payload, not a download.)
+- **Windows** — run `msi/CoolProp_*.msi` (or `nsis/CoolProp_*-setup.exe`).
+- **Linux** — install `deb/*.deb` or `rpm/*.rpm`, or run `appimage/*.AppImage`.
+
+### Gatekeeper / SmartScreen on unsigned builds
+
+A build produced without active signing is **unsigned**, and macOS Gatekeeper
+blocks an unsigned `.dmg`/`.app` on first launch ("App is damaged" / "from an
+unidentified developer"). Clear quarantine to run it:
 
 ```sh
-xattr -dr com.apple.quarantine /path/to/CoolProp.app
-open /path/to/CoolProp.app
+xattr -dr com.apple.quarantine /Applications/CoolProp.app
+open /Applications/CoolProp.app
 ```
 
-The same applies if you run a `.app` extracted from a CI-built `.dmg` —
-strip quarantine on the installed copy after dragging it to Applications.
+Signed + notarized builds (release tags) open with no workaround. See **Code
+signing (production)** below for what enables signing.
 
 ### Code signing (production)
 


### PR DESCRIPTION
## Why

Downloading the `coolprop-gui-macos-latest` artifact gave a confusing zip: the whole `bundle/` tree with build scaffolding (`bundle_dmg.sh`, `icon.icns`, `create-dmg`), the auto-updater `.app.tar.gz`, and a **raw `macos/CoolProp.app`** — which is *broken* once GitHub re-zips the artifact (a macOS app bundle loses its signature/executable bits through a plain zip) — with the actual `.dmg` buried among them. Not obvious what to open.

## What

Upload **only the user-facing installers** (+ the updater `.tar.gz`/`.sig` the release job stages): `dmg`, `deb`, `rpm`, `AppImage`, `msi`, `-setup.exe`. Each glob matches only on the OS that produces it; `if-no-files-found` checks the aggregate, so every OS still uploads its installer(s).

- The release job's `find` covers all 7 distributable types → **releases unchanged** (count stays 6–7 ≥ 5).
- Smoke tests read the *local* bundle dir and run before this upload → unaffected.
- Windows uploads the **signed** installers (overlay runs first).

README: replaced the stale "unsigned macOS bundle" note with a **Downloading a build** section — Releases give a direct `.dmg`; CI artifacts are inherently zipped, so on macOS open `dmg/CoolProp_*.dmg` (don't run a zip-extracted `.app`) — plus a Gatekeeper note.

## Validation

- `yaml.safe_load` parses; release-job `find` cross-checked against the curated globs.
- Independent adversarial review: no blocking findings (aggregate `if-no-files-found` semantics correct so jobs won't fail; curated set is a superset of the release `find`; all glob subdirs are the real Tauri output dirs; signed Windows installers uploaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for downloading builds from GitHub Releases
  * Provided per-OS installation guidance (macOS, Windows, Linux)
  * Clarified handling of signed and unsigned builds

* **Chores**
  * Refined artifact collection for release distribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->