### PR TITLE
fix(GUI): restore zoom on psychrometric chart (uirevision + scrollZoom) [CoolProp-crpx]

### DIFF
--- a/wrappers/GUI/src/components/HumidAirCalculator.tsx
+++ b/wrappers/GUI/src/components/HumidAirCalculator.tsx
@@ -521,6 +521,12 @@ export default function HumidAirCalculator() {
         <Plot
           data={plotData}
           layout={{
+            // Constant uirevision preserves the user's zoom/pan across the
+            // frequent re-renders this component does (hover readout, recompute,
+            // panel resize). Without it Plotly re-applies the hardcoded
+            // xaxis.range below on every render and snaps the view back — which
+            // looked like "zoom is broken".
+            uirevision: "humidair",
             margin: { l: 60, r: 70, t: 30, b: 50 },
             xaxis: {
               title: { text: "Dry-bulb temperature (K)" },
@@ -534,7 +540,9 @@ export default function HumidAirCalculator() {
             paper_bgcolor: "#fff",
             font: { size: 12 },
           }}
-          config={{ responsive: true, displayModeBar: false }}
+          // scrollZoom: wheel-zoom; drag-select zoom and double-click-to-reset
+          // work too (displayModeBar stays off to keep the chart uncluttered).
+          config={{ responsive: true, displayModeBar: false, scrollZoom: true }}
           style={{ width: "100%", height: "100%" }}
           useResizeHandler
           onInitialized={(_, gd) => { graphDivRef.current = gd as HTMLDivElement; }}


### PR DESCRIPTION
## Bug

The Humid Air **psychrometric chart can't be zoomed** — the view snaps straight back.

## Root cause

The `<Plot>` in `HumidAirCalculator.tsx` rebuilds its `layout` inline on **every render** with a hardcoded `xaxis.range` and **no `uirevision`**. The component re-renders constantly (throttled hover readout, recompute, splitter drag), and on each render Plotly re-applies the supplied range — discarding whatever the user zoomed/panned to. Net effect: zoom appears broken.

## Fix

- Add a **constant `uirevision: "humidair"`** so Plotly preserves user zoom/pan across re-renders (user interaction takes precedence over the seeded `range` while `uirevision` is unchanged). The hardcoded range now only sets the *initial* view.
- Add **`scrollZoom: true`** for wheel zoom. Drag-select zoom and **double-click-to-reset** already work, so a zoomed view is always recoverable. Mode bar stays hidden (unchanged look).

Constant (not per-recompute) `uirevision` is the right choice here: the chart is single-domain (no fluid selector), so keeping the user's zoom after a recompute is the desirable behavior.

## Validation

- `tsc` + `vite build` clean; **16/16** vitest pass.
- `uirevision` / `scrollZoom` confirmed valid in the bundled Plotly types.
- Adversarial review: no blocking issues; Saturation charts correctly out of scope (their `config={p.config}` is domain data, a separate Plot wiring).

Closes CoolProp-crpx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HumidAirCalculator chart now preserves your zoom and pan state when the application updates, maintaining your view during interactions.
  * Wheel scroll interaction is now enabled for intuitive chart navigation and zooming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->