### PR TITLE
feat(GUI): enable updater artifacts + pubkey + capability (dzq.9, step 1/2)

### DIFF
--- a/wrappers/GUI/src-tauri/capabilities/updater.json
+++ b/wrappers/GUI/src-tauri/capabilities/updater.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "updater",
+  "description": "Allow the in-app auto-updater to check for, download, and install updates, and to relaunch the app afterwards.",
+  "windows": ["main"],
+  "permissions": [
+    "updater:default",
+    "process:allow-restart"
+  ]
+}

--- a/wrappers/GUI/src-tauri/tauri.conf.json
+++ b/wrappers/GUI/src-tauri/tauri.conf.json
@@ -25,6 +25,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -38,7 +39,7 @@
       "endpoints": [
         "https://github.com/CoolProp/CoolProp/releases/latest/download/latest.json"
       ],
-      "pubkey": "REPLACE_ME_WITH_TAURI_UPDATER_PUBLIC_KEY"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDkxQjRFRTc0QTVCNDNFNTMKUldSVFByU2xkTzYwa1h5eWdoL0w4RVZJQTEzbTBXaW9XOXVWdjlGSkVxK1Z0MnRVcnRqRjNCc1IK"
     }
   }
 }


### PR DESCRIPTION
First of two steps to make the in-app auto-updater (CoolProp-dzq.9) actually work. The plugins, frontend `UpdateChecker`, and endpoint were already wired; this enables the **build side**.

## Changes
- **`tauri.conf.json`**: embed the real updater **public key** (replaces the `REPLACE_ME` placeholder) and set **`bundle.createUpdaterArtifacts: true`** so `tauri-action` emits the signed update bundles + per-platform `latest.json`. The `TAURI_SIGNING_PRIVATE_KEY` / `…_PASSWORD` secrets are configured (generated via `tauri signer generate`; the pubkey here pairs with them).
- **`capabilities/updater.json`** (new): grant `updater:default` + `process:allow-restart` to window `main`. The app had **no capabilities dir**, so the `UpdateChecker`'s `check()`/`relaunch()` would have been denied at runtime. (App-defined commands aren't permission-gated in Tauri 2 — confirmed — which is why the rest of the GUI worked without it.)

## Not in this PR (step 2)
The consolidated **`latest.json`** + `.sig` are **not yet published** to the GitHub Release, so updates don't resolve end-to-end yet. That's deliberately deferred: the per-platform `latest.json` files collide (each lists only its own OS), so step 2 must **generate a merged manifest** with correct release-asset URLs — and it interacts with PR #3049 (artifact curation). Tracked under dzq.9.

## Validation
- `tauri.conf.json` + capability JSON valid; permission identifiers are build-gated (a wrong one fails `tauri-build`).
- Adversarial review: no blocking findings.
- This PR's own CI build validates that updater-artifact creation + the capability compile/bundle cleanly with the signing key present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application updater is now fully configured and enabled. Users can check for available updates, download new versions, and install them. The application supports automatic restart after updates are installed to apply changes immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->