### PR TITLE
feat(GUI): publish consolidated updater latest.json on release (dzq.9, step 2/2)

### DIFF
--- a/.github/workflows/gui_builder.yml
+++ b/.github/workflows/gui_builder.yml
@@ -641,8 +641,10 @@ jobs:
             wrappers/GUI/src-tauri/target/release/bundle/deb/*.deb
             wrappers/GUI/src-tauri/target/release/bundle/rpm/*.rpm
             wrappers/GUI/src-tauri/target/release/bundle/appimage/*.AppImage
+            wrappers/GUI/src-tauri/target/release/bundle/appimage/*.AppImage.sig
             wrappers/GUI/src-tauri/target/release/bundle/msi/*.msi
             wrappers/GUI/src-tauri/target/release/bundle/nsis/*-setup.exe
+            wrappers/GUI/src-tauri/target/release/bundle/nsis/*-setup.exe.sig
           if-no-files-found: error
           retention-days: 7
 
@@ -685,6 +687,64 @@ jobs:
           ls -la release-files/
           [ "$(ls release-files | wc -l)" -ge 5 ] || { echo "expected at least 5 installer files"; exit 1; }
 
+      # Build the single updater manifest the app polls
+      # (plugins.updater.endpoints -> releases/latest/download/latest.json).
+      # `tauri build` emits the signed update bundles + .sig per platform but
+      # NOT latest.json (tauri-action only writes it when it manages the
+      # release, which we don't), so assemble it here: one manifest spanning
+      # all platforms, each url pointing at the release asset that the step
+      # above staged, each signature read from the bundle's .sig. The update
+      # bundles themselves (.app.tar.gz / -setup.exe / .AppImage) are already
+      # in release-files/ from the find above, so they get attached too.
+      - name: Generate updater manifest (latest.json)
+        env:
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+          python3 - <<'PY'
+          import json, os, glob, datetime
+          tag = os.environ["TAG"]
+          version = tag[len("gui-v"):] if tag.startswith("gui-v") else tag
+          base = f"https://github.com/{os.environ['REPO']}/releases/download/{tag}"
+          # Tauri v2 updater target -> the bundle glob it ships for that target.
+          targets = {
+              "darwin-aarch64": "**/*.app.tar.gz",   # macos-latest is arm64
+              "windows-x86_64": "**/*-setup.exe",     # NSIS installer
+              "linux-x86_64":   "**/*.AppImage",
+          }
+          platforms = {}
+          for tgt, pat in targets.items():
+              hits = [f for f in glob.glob(f"artifacts/{pat}", recursive=True)
+                      if os.path.isfile(f + ".sig")]
+              if not hits:
+                  print(f"::warning::no signed updater artifact for {tgt} ({pat}); omitting")
+                  continue
+              f = hits[0]
+              platforms[tgt] = {
+                  "signature": open(f + ".sig").read().strip(),
+                  "url": f"{base}/{os.path.basename(f)}",
+              }
+          # The release job only runs when all three matrix builds succeed, so
+          # every target must be present + signed; a missing one would silently
+          # strip a whole platform from auto-update. Fail the release instead.
+          missing = [t for t in targets if t not in platforms]
+          if missing:
+              raise SystemExit(f"latest.json: missing signed updater artifact(s) for {missing}; "
+                               "a release must publish all platforms — aborting.")
+          manifest = {
+              "version": version,
+              "notes": f"CoolProp GUI {version}",
+              "pub_date": datetime.datetime.now(datetime.timezone.utc)
+                          .strftime("%Y-%m-%dT%H:%M:%SZ"),
+              "platforms": platforms,
+          }
+          os.makedirs("release-files", exist_ok=True)
+          with open("release-files/latest.json", "w") as fh:
+              json.dump(manifest, fh, indent=2)
+          print(json.dumps(manifest, indent=2))
+          PY
+
       - name: Create draft release
         uses: softprops/action-gh-release@v3
         with:
@@ -695,6 +755,9 @@ jobs:
           files: release-files/*
           fail_on_unmatched_files: true
           body: |
-            CoolProp Desktop GUI release. Bundles are unsigned (Gatekeeper / SmartScreen workarounds documented in `wrappers/GUI/README.md`).
+            CoolProp Desktop GUI release. Includes `latest.json` for the in-app
+            auto-updater. macOS is signed + notarized; Windows is signed via
+            SignPath (test cert until the release cert is issued — see
+            `wrappers/GUI/README.md` for the Gatekeeper/SmartScreen status).
 
             <!-- Edit this body before publishing — testers only see what's here. -->


### PR DESCRIPTION
Completes the in-app auto-updater (CoolProp-dzq.9). Step 1 (#3051) enabled the build-side (pubkey, `createUpdaterArtifacts`, capabilities); this publishes the manifest the app polls.

## Why
`tauri build` emits the signed update bundles + per-platform `.sig` but **no `latest.json`** (tauri-action only writes it when *it* manages the release, which this consolidated-release workflow doesn't). Confirmed by inspecting real CI artifacts: all the `.sig` files are present, no `latest.json`. So the release job must assemble one.

## What
- **Keep the Linux/Windows updater `.sig`** in the per-build artifact (`*.AppImage.sig`, `*-setup.exe.sig`; macOS `*.app.tar.gz.sig` was already kept).
- **New release-job step** generates one `release-files/latest.json` spanning all Tauri targets:
  - `darwin-aarch64` → `*.app.tar.gz`, `windows-x86_64` → `*-setup.exe` (NSIS), `linux-x86_64` → `*.AppImage`
  - each `url` → the release asset the installer-`find` already staged; each `signature` → the bundle's `.sig`
  - **hard-fails if any platform is missing** (the release job only runs when all three builds succeed, so a missing updater artifact is an anomaly, not something to silently drop).
- Release body updated (signed/notarized + auto-update, not "unsigned").

## Validation
- YAML valid; the generator was **dry-run against real CI artifacts** → produced a correct 3-platform manifest with matching asset URLs + real signatures.
- Adversarial review: no blocking findings (schema matches tauri-plugin-updater v2.10.1; URL↔asset basenames consistent; NSIS-vs-MSI enforced by which `.sig` is uploaded; heredoc/quoting correct).

## Endgame
A `gui-v*` tag now produces a release with `latest.json` + signed bundles → an older install detects, verifies, downloads, and self-updates (the whole app incl. Rust + statically-linked CoolProp). That's dzq.9's acceptance criterion.

Known gap (tracked, CoolProp-z7ro): CI builds arm64 macOS only, so Intel Macs (`darwin-x86_64`) aren't served by the updater yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release artifact staging to include signed installer signatures for improved update mechanism reliability.
  * Implemented automated generation of update manifest for Tauri in-app auto-updater with per-platform validation.
  * Updated release documentation to reflect current signing and notarization status across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->