### PR TITLE
feat: promote GitHub Sponsors across repo, docs, and GUI

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Enables the "Sponsor" button on the repository.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+github: [CoolProp]

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ cppcheck.txt
 
 # bv (beads viewer) local config and caches
 .bv/
+.superpowers/

--- a/Web/_static/sponsor-banner.css
+++ b/Web/_static/sponsor-banner.css
@@ -1,0 +1,35 @@
+/* Sponsor banner injected by sponsor-banner.js on every docs page. */
+#coolprop-sponsor-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #e8f6ec;
+  color: #1b5e2a;
+  border-bottom: 1px solid #cfe8d6;
+  padding: 9px 16px;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+#coolprop-sponsor-banner .cp-sponsor-text { flex: 1 1 auto; }
+#coolprop-sponsor-banner .cp-sponsor-text strong { color: #14532d; }
+#coolprop-sponsor-banner a.cp-sponsor-cta {
+  flex: 0 0 auto;
+  background: #2ea043;
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  border-radius: 6px;
+  padding: 4px 12px;
+  white-space: nowrap;
+}
+#coolprop-sponsor-banner button.cp-sponsor-dismiss {
+  flex: 0 0 auto;
+  background: none;
+  border: none;
+  color: #6b8f74;
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+#coolprop-sponsor-banner button.cp-sponsor-dismiss:hover { color: #14532d; }

--- a/Web/_static/sponsor-banner.js
+++ b/Web/_static/sponsor-banner.js
@@ -1,0 +1,57 @@
+/* Injects a dismissable Sponsor banner at the top of every docs page.
+   Dismissal is remembered in localStorage (versioned key) so it does not
+   reappear on subsequent page loads. Theme-agnostic: prepends to <body>. */
+(function () {
+  "use strict";
+  var DISMISS_KEY = "coolprop.sponsorBanner.dismissed.v1";
+  var SPONSOR_URL = "https://github.com/sponsors/CoolProp";
+
+  function dismissed() {
+    try { return window.localStorage.getItem(DISMISS_KEY) === "1"; }
+    catch (e) { return false; }
+  }
+  function remember() {
+    try { window.localStorage.setItem(DISMISS_KEY, "1"); } catch (e) { /* ignore */ }
+  }
+
+  function build() {
+    if (dismissed() || document.getElementById("coolprop-sponsor-banner")) return;
+
+    var bar = document.createElement("div");
+    bar.id = "coolprop-sponsor-banner";
+
+    var text = document.createElement("span");
+    text.className = "cp-sponsor-text";
+    text.innerHTML =
+      "💚 <strong>CoolProp is free &amp; open-source</strong>, " +
+      "maintained on volunteer time. If it helps your work, please consider sponsoring →";
+
+    var cta = document.createElement("a");
+    cta.className = "cp-sponsor-cta";
+    cta.href = SPONSOR_URL;
+    cta.target = "_blank";
+    cta.rel = "noopener";
+    cta.textContent = "Sponsor";
+
+    var x = document.createElement("button");
+    x.className = "cp-sponsor-dismiss";
+    x.type = "button";
+    x.setAttribute("aria-label", "Dismiss sponsor banner");
+    x.innerHTML = "&times;";
+    x.addEventListener("click", function () {
+      remember();
+      if (bar.parentNode) bar.parentNode.removeChild(bar);
+    });
+
+    bar.appendChild(text);
+    bar.appendChild(cta);
+    bar.appendChild(x);
+    document.body.insertBefore(bar, document.body.firstChild);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", build);
+  } else {
+    build();
+  }
+})();

--- a/Web/_templates/navbar-center.html
+++ b/Web/_templates/navbar-center.html
@@ -5,4 +5,5 @@
   <li class="nav-item"><a class="nav-link" href="{{ pathto('coolprop/examples') }}">Examples</a></li>
   <li class="nav-item"><a class="nav-link" href="{{ pathto('develop/code') }}">Code</a></li>
   <li class="nav-item"><a class="nav-link" href="{{ pathto('coolprop/wrappers/index') }}">Interfaces</a></li>
+  <li class="nav-item"><a class="nav-link" href="https://github.com/sponsors/CoolProp" target="_blank" rel="noopener">💚 Sponsor</a></li>
 </ul>

--- a/Web/conf.py
+++ b/Web/conf.py
@@ -323,7 +323,8 @@ if not _3dmol_js.exists():
 # Priority 450 ensures 3Dmol-min.js loads before require.js (added by sphinx.ext.mathjax
 # at priority 500). If 3Dmol loads after require.js, its AMD detection kicks in and
 # define([], factory) is called but never executed, silently preventing $3Dmol from being set.
-html_js_files = [('3Dmol-min.js', {'priority': 450})]
+html_js_files = [('3Dmol-min.js', {'priority': 450}), 'sponsor-banner.js']
+html_css_files = ['sponsor-banner.css']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/Web/contents.rst
+++ b/Web/contents.rst
@@ -19,6 +19,7 @@ CoolProp is an open-source database of fluid and humid air properties, formulate
     fluid_properties/index.rst
     coolprop/index.rst
     develop/index.rst
+    sponsor.rst
     zbibliography
 
 ..    :maxdepth: 2

--- a/Web/index.rst
+++ b/Web/index.rst
@@ -55,6 +55,7 @@ Help
 * (**Bugs, feature requests**) File a `Github issue <https://github.com/CoolProp/CoolProp/issues>`_
 * `Docs for v4 of CoolProp <http://www.coolprop.org/v4/>`_
 * `Docs for development version of CoolProp <http://www.coolprop.org/dev/>`_
+* (**Support the project**) :ref:`Sponsor CoolProp <sponsor>`
 
 Projects Using CoolProp
 -----------------------------------

--- a/Web/sponsor.rst
+++ b/Web/sponsor.rst
@@ -1,0 +1,20 @@
+.. _sponsor:
+
+****************
+Support CoolProp
+****************
+
+CoolProp is free, open-source software, developed and maintained on
+volunteer time. If CoolProp helps your work, please consider sponsoring its
+continued development.
+
+`💚 Sponsor CoolProp on GitHub <https://github.com/sponsors/CoolProp>`_
+
+Your sponsorship directly supports:
+
+* Ongoing maintenance and bug fixes
+* High-accuracy validation against reference data (including NIST REFPROP)
+* Build and continuous-integration infrastructure across many platforms
+* Development of the cross-platform desktop GUI
+
+Thank you for helping keep CoolProp free and open for everyone.

--- a/docs/superpowers/plans/2026-05-31-sponsor-promotion.md
+++ b/docs/superpowers/plans/2026-05-31-sponsor-promotion.md
@@ -1,0 +1,820 @@
+# GitHub Sponsors Promotion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Promote `https://github.com/sponsors/CoolProp` tastefully across four surfaces — the repo Sponsor button, the docs/website (nav link + dismissable banner + dedicated page), and the Tauri desktop GUI (header link + About entry + once-per-major-version splash).
+
+**Architecture:** Four independent surfaces in one PR. The repo button is a static YAML file. The website changes are theme-agnostic static assets (CSS+JS injected via `conf.py`) plus reStructuredText. The GUI changes are React components reusing existing modal/header styles, with a single shared URL constant and `localStorage`-gated visibility — no new Tauri plugin, capability, or npm dependency (external links use the existing `<a target="_blank" rel="noreferrer">` pattern).
+
+**Tech Stack:** GitHub FUNDING.yml; Sphinx + pydata-sphinx-theme (Python, RST, vanilla CSS/JS); Tauri 2 + React 18 + TypeScript + Vitest/Testing-Library.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-sponsor-promotion-design.md`
+
+**Canonical URL (used everywhere):** `https://github.com/sponsors/CoolProp`
+
+---
+
+## File Structure
+
+**Repo**
+- Create: `.github/FUNDING.yml` — enables the repo Sponsor button.
+
+**Website (`Web/`)**
+- Create: `Web/_static/sponsor-banner.css` — banner + dismiss-button styling.
+- Create: `Web/_static/sponsor-banner.js` — inject banner unless dismissed (localStorage).
+- Create: `Web/sponsor.rst` — "Support CoolProp" page.
+- Modify: `Web/_templates/navbar-center.html` — persistent nav Sponsor link.
+- Modify: `Web/conf.py` — register the CSS/JS via `html_css_files`/`html_js_files`.
+- Modify: `Web/contents.rst` — add `sponsor.rst` to the master toctree.
+- Modify: `Web/index.rst` — cross-link the page from the Help section.
+
+**GUI (`wrappers/GUI/`)**
+- Create: `src/constants.ts` — `SPONSOR_URL` shared constant.
+- Create: `src/components/SponsorSplash.tsx` — once-per-major-version splash.
+- Create: `src/components/SponsorSplash.test.tsx` — vitest unit tests.
+- Modify: `src/App.tsx` — header Sponsor link + mount `<SponsorSplash/>`.
+- Modify: `src/components/AboutModal.tsx` — "Support CoolProp" link.
+- Modify: `src/App.css` — `.sponsor-btn` / splash styles.
+
+---
+
+## Task 1: Repo Sponsor button (`.github/FUNDING.yml`)
+
+**Files:**
+- Create: `.github/FUNDING.yml`
+
+- [ ] **Step 1: Create the FUNDING.yml file**
+
+Create `.github/FUNDING.yml` with exactly:
+
+```yaml
+# Enables the "Sponsor" button on the repository.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+github: [CoolProp]
+```
+
+- [ ] **Step 2: Verify YAML is well-formed**
+
+Run: `python -c "import yaml,sys; print(yaml.safe_load(open('.github/FUNDING.yml')))"`
+Expected: `{'github': ['CoolProp']}`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/FUNDING.yml
+git commit -m "feat(repo): add FUNDING.yml for GitHub Sponsors button"
+```
+
+---
+
+## Task 2: Website — dedicated "Support CoolProp" page
+
+**Files:**
+- Create: `Web/sponsor.rst`
+- Modify: `Web/contents.rst`
+- Modify: `Web/index.rst:49-57` (Help section)
+
+- [ ] **Step 1: Create the page**
+
+Create `Web/sponsor.rst`:
+
+```rst
+.. _sponsor:
+
+****************
+Support CoolProp
+****************
+
+CoolProp is free, open-source software, developed and maintained on
+volunteer time. If CoolProp helps your work, please consider sponsoring its
+continued development.
+
+`💚 Sponsor CoolProp on GitHub <https://github.com/sponsors/CoolProp>`_
+
+Your sponsorship directly supports:
+
+* Ongoing maintenance and bug fixes
+* High-accuracy validation against reference data (including NIST REFPROP)
+* Build and continuous-integration infrastructure across many platforms
+* Development of the cross-platform desktop GUI
+
+Thank you for helping keep CoolProp free and open for everyone.
+```
+
+- [ ] **Step 2: Add the page to the master toctree**
+
+In `Web/contents.rst`, add `sponsor.rst` to the second (visible) `toctree`. The
+block currently reads:
+
+```rst
+.. toctree::
+
+    general_information.rst
+    online/index.rst
+    fluid_properties/index.rst
+    coolprop/index.rst
+    develop/index.rst
+    zbibliography
+```
+
+Change it to:
+
+```rst
+.. toctree::
+
+    general_information.rst
+    online/index.rst
+    fluid_properties/index.rst
+    coolprop/index.rst
+    develop/index.rst
+    sponsor.rst
+    zbibliography
+```
+
+- [ ] **Step 3: Cross-link from the Help section**
+
+In `Web/index.rst`, the Help section (lines 49-57) ends with the dev-docs
+bullet. After the line:
+
+```rst
+* `Docs for development version of CoolProp <http://www.coolprop.org/dev/>`_
+```
+
+add a new bullet:
+
+```rst
+* (**Support the project**) :ref:`Sponsor CoolProp <sponsor>`
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Web/sponsor.rst Web/contents.rst Web/index.rst
+git commit -m "docs(web): add Support CoolProp sponsor page + cross-links"
+```
+
+---
+
+## Task 3: Website — persistent nav Sponsor link
+
+**Files:**
+- Modify: `Web/_templates/navbar-center.html`
+
+- [ ] **Step 1: Add the nav link**
+
+`Web/_templates/navbar-center.html` is a hand-written `<ul class="navbar-nav">`.
+Add a final `<li>` before the closing `</ul>`. The file currently ends:
+
+```html
+  <li class="nav-item"><a class="nav-link" href="{{ pathto('coolprop/wrappers/index') }}">Interfaces</a></li>
+</ul>
+```
+
+Change it to:
+
+```html
+  <li class="nav-item"><a class="nav-link" href="{{ pathto('coolprop/wrappers/index') }}">Interfaces</a></li>
+  <li class="nav-item"><a class="nav-link" href="https://github.com/sponsors/CoolProp" target="_blank" rel="noopener">💚 Sponsor</a></li>
+</ul>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add Web/_templates/navbar-center.html
+git commit -m "docs(web): add persistent Sponsor link to nav bar"
+```
+
+---
+
+## Task 4: Website — dismissable site-wide banner (CSS)
+
+**Files:**
+- Create: `Web/_static/sponsor-banner.css`
+
+- [ ] **Step 1: Create the banner stylesheet**
+
+Create `Web/_static/sponsor-banner.css`:
+
+```css
+/* Sponsor banner injected by sponsor-banner.js on every docs page. */
+#coolprop-sponsor-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #e8f6ec;
+  color: #1b5e2a;
+  border-bottom: 1px solid #cfe8d6;
+  padding: 9px 16px;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+#coolprop-sponsor-banner .cp-sponsor-text { flex: 1 1 auto; }
+#coolprop-sponsor-banner .cp-sponsor-text strong { color: #14532d; }
+#coolprop-sponsor-banner a.cp-sponsor-cta {
+  flex: 0 0 auto;
+  background: #2ea043;
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  border-radius: 6px;
+  padding: 4px 12px;
+  white-space: nowrap;
+}
+#coolprop-sponsor-banner button.cp-sponsor-dismiss {
+  flex: 0 0 auto;
+  background: none;
+  border: none;
+  color: #6b8f74;
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+#coolprop-sponsor-banner button.cp-sponsor-dismiss:hover { color: #14532d; }
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add Web/_static/sponsor-banner.css
+git commit -m "docs(web): add sponsor banner stylesheet"
+```
+
+---
+
+## Task 5: Website — dismissable site-wide banner (JS)
+
+**Files:**
+- Create: `Web/_static/sponsor-banner.js`
+
+- [ ] **Step 1: Create the banner script**
+
+Create `Web/_static/sponsor-banner.js`:
+
+```javascript
+/* Injects a dismissable Sponsor banner at the top of every docs page.
+   Dismissal is remembered in localStorage (versioned key) so it does not
+   reappear on subsequent page loads. Theme-agnostic: prepends to <body>. */
+(function () {
+  "use strict";
+  var DISMISS_KEY = "coolprop.sponsorBanner.dismissed.v1";
+  var SPONSOR_URL = "https://github.com/sponsors/CoolProp";
+
+  function dismissed() {
+    try { return window.localStorage.getItem(DISMISS_KEY) === "1"; }
+    catch (e) { return false; }
+  }
+  function remember() {
+    try { window.localStorage.setItem(DISMISS_KEY, "1"); } catch (e) { /* ignore */ }
+  }
+
+  function build() {
+    if (dismissed() || document.getElementById("coolprop-sponsor-banner")) return;
+
+    var bar = document.createElement("div");
+    bar.id = "coolprop-sponsor-banner";
+
+    var text = document.createElement("span");
+    text.className = "cp-sponsor-text";
+    text.innerHTML =
+      "💚 <strong>CoolProp is free &amp; open-source</strong>, " +
+      "maintained on volunteer time. If it helps your work, please consider sponsoring →";
+
+    var cta = document.createElement("a");
+    cta.className = "cp-sponsor-cta";
+    cta.href = SPONSOR_URL;
+    cta.target = "_blank";
+    cta.rel = "noopener";
+    cta.textContent = "Sponsor";
+
+    var x = document.createElement("button");
+    x.className = "cp-sponsor-dismiss";
+    x.type = "button";
+    x.setAttribute("aria-label", "Dismiss sponsor banner");
+    x.innerHTML = "&times;";
+    x.addEventListener("click", function () {
+      remember();
+      if (bar.parentNode) bar.parentNode.removeChild(bar);
+    });
+
+    bar.appendChild(text);
+    bar.appendChild(cta);
+    bar.appendChild(x);
+    document.body.insertBefore(bar, document.body.firstChild);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", build);
+  } else {
+    build();
+  }
+})();
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add Web/_static/sponsor-banner.js
+git commit -m "docs(web): add sponsor banner injection script"
+```
+
+---
+
+## Task 6: Website — register banner assets in conf.py
+
+**Files:**
+- Modify: `Web/conf.py:326` (`html_js_files`) and add `html_css_files`
+
+- [ ] **Step 1: Register the CSS and JS**
+
+In `Web/conf.py`, the `html_js_files` line currently reads (around line 326):
+
+```python
+html_js_files = [('3Dmol-min.js', {'priority': 450})]
+```
+
+Replace it with:
+
+```python
+html_js_files = [('3Dmol-min.js', {'priority': 450}), 'sponsor-banner.js']
+html_css_files = ['sponsor-banner.css']
+```
+
+- [ ] **Step 2: Build the docs and verify the banner renders**
+
+Run (from `Web/`):
+```bash
+cd Web && python -m sphinx -b html -j auto . _build/html 2>&1 | tail -20; cd ..
+```
+Expected: build completes; `Web/_build/html/_static/sponsor-banner.css` and
+`sponsor-banner.js` exist, and `Web/_build/html/index.html` contains both
+`sponsor-banner.css` and `sponsor-banner.js` references.
+
+Verify references:
+```bash
+grep -o "sponsor-banner\.\(css\|js\)" Web/_build/html/index.html | sort -u
+```
+Expected output:
+```
+sponsor-banner.css
+sponsor-banner.js
+```
+
+> Note: if the full Sphinx build is too slow locally (it executes notebooks),
+> the grep over a single built page is the key assertion. The
+> `html_css_files`/`html_js_files` mechanism is standard Sphinx and copies
+> `_static` files automatically.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Web/conf.py
+git commit -m "docs(web): register sponsor banner css/js in Sphinx config"
+```
+
+---
+
+## Task 7: GUI — shared SPONSOR_URL constant
+
+**Files:**
+- Create: `wrappers/GUI/src/constants.ts`
+
+- [ ] **Step 1: Create the constant**
+
+Create `wrappers/GUI/src/constants.ts`:
+
+```typescript
+/** Canonical GitHub Sponsors URL for the CoolProp organization. */
+export const SPONSOR_URL = "https://github.com/sponsors/CoolProp";
+```
+
+- [ ] **Step 2: Type-check**
+
+Run (from `wrappers/GUI/`):
+```bash
+cd wrappers/GUI && npx tsc --noEmit && cd ../..
+```
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add wrappers/GUI/src/constants.ts
+git commit -m "feat(GUI): add shared SPONSOR_URL constant"
+```
+
+---
+
+## Task 8: GUI — SponsorSplash component (TDD)
+
+**Files:**
+- Create: `wrappers/GUI/src/components/SponsorSplash.test.tsx`
+- Create: `wrappers/GUI/src/components/SponsorSplash.tsx`
+
+The component shows a one-time splash, gated by a `localStorage` key that embeds
+the **major version**. It accepts the version as a prop (defaulting to the
+generated `APP_VERSION`) so it is deterministically testable. The major version
+is the integer before the first `.` of the semver string.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `wrappers/GUI/src/components/SponsorSplash.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SponsorSplash from "./SponsorSplash";
+
+const KEY_V7 = "coolprop.sponsorSplash.seen.major.7";
+const KEY_V8 = "coolprop.sponsorSplash.seen.major.8";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("SponsorSplash", () => {
+  it("renders when no seen-key is set for the current major version", () => {
+    render(<SponsorSplash version="7.2.1" />);
+    expect(screen.getByText(/Enjoying CoolProp/i)).toBeInTheDocument();
+  });
+
+  it("does not render when the current major-version key is set", () => {
+    localStorage.setItem(KEY_V7, "1");
+    render(<SponsorSplash version="7.2.1" />);
+    expect(screen.queryByText(/Enjoying CoolProp/i)).not.toBeInTheDocument();
+  });
+
+  it("renders again when only a previous major-version key is set", () => {
+    localStorage.setItem(KEY_V7, "1");
+    render(<SponsorSplash version="8.0.0" />);
+    expect(screen.getByText(/Enjoying CoolProp/i)).toBeInTheDocument();
+    expect(localStorage.getItem(KEY_V8)).toBeNull();
+  });
+
+  it("dismissing via 'Maybe later' hides it and sets the current major key", async () => {
+    const user = userEvent.setup();
+    render(<SponsorSplash version="7.2.1" />);
+    await user.click(screen.getByRole("button", { name: /Maybe later/i }));
+    expect(screen.queryByText(/Enjoying CoolProp/i)).not.toBeInTheDocument();
+    expect(localStorage.getItem(KEY_V7)).toBe("1");
+  });
+
+  it("the Sponsor link points at the Sponsors URL and sets the seen key", async () => {
+    const user = userEvent.setup();
+    render(<SponsorSplash version="7.2.1" />);
+    const link = screen.getByRole("link", { name: /Sponsor on GitHub/i });
+    expect(link).toHaveAttribute("href", "https://github.com/sponsors/CoolProp");
+    await user.click(link);
+    expect(localStorage.getItem(KEY_V7)).toBe("1");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run (from `wrappers/GUI/`):
+```bash
+cd wrappers/GUI && npx vitest run src/components/SponsorSplash.test.tsx; cd ../..
+```
+Expected: FAIL — `Failed to resolve import "./SponsorSplash"` (file not created yet).
+
+- [ ] **Step 3: Implement the component**
+
+Create `wrappers/GUI/src/components/SponsorSplash.tsx`:
+
+```tsx
+import { useState } from "react";
+import { SPONSOR_URL } from "../constants";
+import { APP_VERSION } from "../generated/notices";
+
+interface Props {
+  /** Semver string; the integer before the first "." is the major version.
+   *  Defaults to the GUI bundle version generated at build time. */
+  version?: string;
+}
+
+function majorOf(version: string): string {
+  const major = version.split(".")[0];
+  return /^\d+$/.test(major) ? major : "0";
+}
+
+export default function SponsorSplash({ version = APP_VERSION }: Props) {
+  const storageKey = `coolprop.sponsorSplash.seen.major.${majorOf(version)}`;
+
+  const [open, setOpen] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(storageKey) !== "1";
+    } catch {
+      return true;
+    }
+  });
+
+  function markSeen() {
+    try {
+      localStorage.setItem(storageKey, "1");
+    } catch {
+      /* ignore unavailable storage */
+    }
+  }
+
+  function dismiss() {
+    markSeen();
+    setOpen(false);
+  }
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="modal-overlay"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) dismiss();
+      }}
+    >
+      <div className="modal-card sponsor-splash-card">
+        <div className="sponsor-splash-heart">💚</div>
+        <div className="modal-title">Enjoying CoolProp?</div>
+        <div className="modal-body">
+          <p>
+            CoolProp is free and open-source, maintained on volunteer time. If it
+            helps your work, please consider sponsoring its development.
+          </p>
+        </div>
+        <div className="modal-footer">
+          <button onClick={dismiss}>Maybe later</button>
+          <a
+            className="primary sponsor-splash-cta"
+            href={SPONSOR_URL}
+            target="_blank"
+            rel="noreferrer"
+            onClick={markSeen}
+          >
+            Sponsor on GitHub
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run (from `wrappers/GUI/`):
+```bash
+cd wrappers/GUI && npx vitest run src/components/SponsorSplash.test.tsx; cd ../..
+```
+Expected: PASS — all 5 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wrappers/GUI/src/components/SponsorSplash.tsx wrappers/GUI/src/components/SponsorSplash.test.tsx
+git commit -m "feat(GUI): once-per-major-version SponsorSplash component"
+```
+
+---
+
+## Task 9: GUI — wire splash + header link into App.tsx
+
+**Files:**
+- Modify: `wrappers/GUI/src/App.tsx:1-7` (imports), `:51-58` (header-right), `:75-77` (mount)
+
+- [ ] **Step 1: Add imports**
+
+In `wrappers/GUI/src/App.tsx`, the import block (lines 1-7) ends with:
+
+```tsx
+import UpdateChecker from "./components/UpdateChecker";
+```
+
+Add after it:
+
+```tsx
+import SponsorSplash from "./components/SponsorSplash";
+import { SPONSOR_URL } from "./constants";
+```
+
+- [ ] **Step 2: Add the header Sponsor link**
+
+In the `header-right` div, the About button currently reads:
+
+```tsx
+          <button
+            className="tab-btn about-btn"
+            onClick={() => setAboutOpen(true)}
+            title="About / third-party notices"
+          >
+            About
+          </button>
+```
+
+Insert this `<a>` immediately **before** that `<button>`:
+
+```tsx
+          <a
+            className="tab-btn sponsor-btn"
+            href={SPONSOR_URL}
+            target="_blank"
+            rel="noreferrer"
+            title="Support CoolProp on GitHub Sponsors"
+          >
+            💚 Sponsor
+          </a>
+```
+
+- [ ] **Step 3: Mount the splash**
+
+Near the end of the component, the JSX currently reads:
+
+```tsx
+      {aboutOpen && <AboutModal onClose={() => setAboutOpen(false)} />}
+      <UpdateChecker />
+    </div>
+```
+
+Change it to:
+
+```tsx
+      {aboutOpen && <AboutModal onClose={() => setAboutOpen(false)} />}
+      <UpdateChecker />
+      <SponsorSplash />
+    </div>
+```
+
+- [ ] **Step 4: Type-check and run the full GUI test suite**
+
+Run (from `wrappers/GUI/`):
+```bash
+cd wrappers/GUI && npx tsc --noEmit && npx vitest run; cd ../..
+```
+Expected: tsc clean; all tests pass (existing PropertyCalculator/hook tests + the 5 SponsorSplash tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wrappers/GUI/src/App.tsx
+git commit -m "feat(GUI): add header Sponsor link and mount SponsorSplash"
+```
+
+---
+
+## Task 10: GUI — Support link in AboutModal
+
+**Files:**
+- Modify: `wrappers/GUI/src/components/AboutModal.tsx:1` (import), `:22-31` (body)
+
+- [ ] **Step 1: Add the import**
+
+`AboutModal.tsx` line 1 currently reads:
+
+```tsx
+import { COOLPROP_VERSION, COOLPROP_GIT_HASH, NOTICES } from "../generated/notices";
+```
+
+Add a second import line after it:
+
+```tsx
+import { SPONSOR_URL } from "../constants";
+```
+
+- [ ] **Step 2: Add the Support paragraph**
+
+After the "Built with Tauri…MIT license." `<p>` (which ends at line 31 with
+`</p>`), and before the `<details className="about-notices">` block, insert:
+
+```tsx
+          <p>
+            Support CoolProp:{" "}
+            <a href={SPONSOR_URL} target="_blank" rel="noreferrer">
+              💚 Sponsor on GitHub
+            </a>
+          </p>
+```
+
+- [ ] **Step 3: Type-check**
+
+Run (from `wrappers/GUI/`):
+```bash
+cd wrappers/GUI && npx tsc --noEmit; cd ../..
+```
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add wrappers/GUI/src/components/AboutModal.tsx
+git commit -m "feat(GUI): add Support CoolProp link to About modal"
+```
+
+---
+
+## Task 11: GUI — splash & sponsor-button styles
+
+**Files:**
+- Modify: `wrappers/GUI/src/App.css` (append a new section; reference existing `.about-btn` at line 336)
+
+- [ ] **Step 1: Append styles**
+
+Append to the end of `wrappers/GUI/src/App.css`:
+
+```css
+
+/* ── Sponsor link + splash ──────────────────────────── */
+
+.sponsor-btn {
+  font-size: 12px;
+  color: #2ea043;
+  border: 1px solid #2ea043;
+  background: #e8f6ec;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.sponsor-btn:hover {
+  background: #d6efdd;
+}
+
+.modal-card.sponsor-splash-card {
+  width: 400px;
+  text-align: center;
+}
+.sponsor-splash-heart {
+  font-size: 34px;
+  line-height: 1;
+  margin-bottom: 8px;
+}
+.modal-card.sponsor-splash-card .modal-footer {
+  justify-content: center;
+}
+a.primary.sponsor-splash-cta {
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+}
+```
+
+- [ ] **Step 2: Build the frontend to confirm CSS/TS compile together**
+
+Run (from `wrappers/GUI/`):
+```bash
+cd wrappers/GUI && npm run build; cd ../..
+```
+Expected: `tsc && vite build` completes with no errors (a `dist/` is produced).
+
+> Note: `npm run build` runs `prebuild` → `build:licenses`, which regenerates
+> `src/generated/notices.ts` from `CMakeLists.txt`. This is expected.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add wrappers/GUI/src/App.css
+git commit -m "style(GUI): sponsor button and splash styling"
+```
+
+---
+
+## Task 12: Final verification & PR prep
+
+- [ ] **Step 1: Full GUI test + typecheck sweep**
+
+Run (from `wrappers/GUI/`):
+```bash
+cd wrappers/GUI && npx tsc --noEmit && npx vitest run; cd ../..
+```
+Expected: tsc clean; all suites pass.
+
+- [ ] **Step 2: Confirm no stray generated/build artifacts are staged**
+
+Run:
+```bash
+git status --short
+```
+Expected: clean (no `Web/_build/`, no `wrappers/GUI/dist/`, no
+`wrappers/GUI/src/generated/`). If any appear, confirm they are gitignored;
+do not commit them.
+
+- [ ] **Step 3: Pre-PR adversarial review (MANDATORY per CLAUDE.md)**
+
+Invoke the `superpowers:code-reviewer` subagent against the diff between
+`feat/sponsor-promotion` and `origin/master`. Address or justify each blocking
+finding before proceeding.
+
+- [ ] **Step 4: Push and open the PR**
+
+```bash
+git push -u origin feat/sponsor-promotion
+gh pr create --title "feat: promote GitHub Sponsors across repo, docs, and GUI" \
+  --body "Implements the approved sponsor-promotion spec: FUNDING.yml, docs nav link + dismissable banner + Support page, and GUI header link + About entry + once-per-major-version splash. Spec: docs/superpowers/specs/2026-05-31-sponsor-promotion-design.md"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** FUNDING.yml (Task 1) ✓; web nav link (Task 3) ✓; web banner CSS/JS + registration (Tasks 4-6) ✓; web Support page + cross-links (Task 2) ✓; GUI header link (Task 9) ✓; GUI About entry (Task 10) ✓; GUI once-per-major-version splash (Task 8) ✓; shared URL constant (Task 7, used by 8/9/10) ✓; tests (Task 8) ✓.
+- **Spec deviation (intentional):** the dedicated page is `Web/sponsor.rst` added to the master `contents.rst` toctree, rather than `Web/online/sponsor.rst` + `online/index.rst` toctree — because `online/index.rst` has no toctree directive. Same user-facing result; cleaner integration.
+- **Type consistency:** `SPONSOR_URL` (constants.ts) imported identically in SponsorSplash/App/AboutModal; `storageKey` format `coolprop.sponsorSplash.seen.major.<N>` matches the test keys `KEY_V7`/`KEY_V8`; `version` prop defaults to `APP_VERSION` from the generated notices module (same module AboutModal already imports).

--- a/docs/superpowers/specs/2026-05-31-sponsor-promotion-design.md
+++ b/docs/superpowers/specs/2026-05-31-sponsor-promotion-design.md
@@ -95,12 +95,18 @@ button. Styled to match the existing header controls.
 **(b) About modal.** Add a "Support CoolProp 💚" link to
 `src/components/AboutModal.tsx`, near the existing CoolProp/MIT-license line.
 
-**(c) One-time startup splash.** New `src/components/SponsorSplash.tsx`, reusing
-the existing `modal-overlay` / `modal-card` styles. Behavior:
+**(c) Startup splash — once per major version.** New
+`src/components/SponsorSplash.tsx`, reusing the existing `modal-overlay` /
+`modal-card` styles. Behavior:
 
-- On app mount, read `localStorage` key `coolprop.sponsorSplash.seen.v1`.
-- If unset, render the splash; set the key when the user dismisses it (either
-  button), so it shows **once per install**.
+- Derive the current major version from the app version (e.g. `7` from the
+  `7.2.1` already surfaced via the generated `COOLPROP_VERSION` notices
+  constant). The `localStorage` key embeds it:
+  `coolprop.sponsorSplash.seen.major.<N>` (e.g. `…seen.major.7`).
+- On app mount, read that key. If unset, render the splash; set it when the
+  user dismisses (either button), so the splash shows **once per major
+  version** — returning users are re-prompted on the next major release
+  (e.g. 7.x → 8.0) but never on patch/minor updates.
 - Buttons: **Maybe later** (ghost, closes) and **Sponsor on GitHub** (primary,
   opens the Sponsors URL via the same `<a target="_blank">` pattern, then
   closes).
@@ -133,15 +139,17 @@ splash.
   × dismiss persists across page loads, nav link present, "Support CoolProp"
   page builds and is reachable from the toctree and the Help section.
 - **GUI** — vitest unit tests for `SponsorSplash`:
-  - renders when the `seen` key is absent;
-  - does not render when the key is set;
-  - dismissing (either button) sets the key.
+  - renders when the major-version `seen` key is absent;
+  - does not render when the current major-version key is set;
+  - renders again when only a *previous* major-version key is set (simulating
+    a major upgrade);
+  - dismissing (either button) sets the current major-version key.
   Confirm the existing `App` / `PropertyCalculator` tests stay green.
 
 ## Out of scope / YAGNI
 
 - No blocking/modal interrupts on the website (banner only).
-- No recurring or rate-limited re-prompting; both the GUI splash and web banner
-  are strictly once-until-dismissed.
+- No rate-limited or per-launch re-prompting. The web banner is
+  once-until-dismissed; the GUI splash re-shows only on a new major version.
 - No analytics/telemetry on sponsor clicks.
 - No changes to the legacy Python/wxPython GUI under `wrappers/Python`.

--- a/docs/superpowers/specs/2026-05-31-sponsor-promotion-design.md
+++ b/docs/superpowers/specs/2026-05-31-sponsor-promotion-design.md
@@ -1,0 +1,147 @@
+# Design: GitHub Sponsors promotion across CoolProp surfaces
+
+**Date:** 2026-05-31
+**Status:** Approved (visual mockups reviewed and locked in)
+
+## Goal
+
+The CoolProp GitHub organization is now eligible for GitHub Sponsors. Surface
+that fact tastefully but persistently across every place a user encounters the
+project: the repository, the documentation/website, and the desktop GUI. The
+tone is *tasteful everywhere* — visible and repeated, but never a blocking
+interruption.
+
+## Single source of truth
+
+All sponsor links point to:
+
+```
+https://github.com/sponsors/CoolProp
+```
+
+Define this once per surface (a constant in the GUI, a substitution/variable in
+the docs) so it can be changed in one place.
+
+## Surfaces
+
+Delivered as **one PR** covering all four surfaces.
+
+### 1. Repository — `.github/FUNDING.yml`
+
+New file enabling the green **Sponsor** button on the repo page and sidebar:
+
+```yaml
+github: [CoolProp]
+```
+
+Zero runtime risk; GitHub validates the file automatically.
+
+### 2 & 3. Website / docs (`Web/`, Sphinx + pydata-sphinx-theme)
+
+The `Web/` directory is the Sphinx source for coolprop.org. Three additions:
+
+**(a) Persistent nav link.** Add one `<li>` to
+`Web/_templates/navbar-center.html` (the hand-written nav `<ul>`):
+
+```html
+<li class="nav-item">
+  <a class="nav-link" href="https://github.com/sponsors/CoolProp"
+     target="_blank" rel="noopener">💚 Sponsor</a>
+</li>
+```
+
+**(b) Dismissable site-wide top banner.** A self-contained CSS + JS pair added
+to `Web/_static/`:
+
+- `sponsor-banner.css` — styles a slim green banner pinned at the top of the
+  page body, plus a × dismiss control.
+- `sponsor-banner.js` — on `DOMContentLoaded`, if the dismissal key is absent
+  from `localStorage`, inject the banner at the top of the content. The ×
+  click sets the key so the banner does not reappear on subsequent page loads.
+
+Register both in `Web/conf.py`:
+
+```python
+html_css_files = ['sponsor-banner.css']           # new
+html_js_files  = [('3Dmol-min.js', {'priority': 450}),
+                  'sponsor-banner.js']             # append
+```
+
+Banner copy:
+
+> 💚 **CoolProp is free & open-source**, maintained on volunteer time. If it
+> helps your work, please consider sponsoring → *Sponsor*
+
+The `localStorage` key is versioned, e.g. `coolprop.sponsorBanner.dismissed.v1`,
+so the banner can be intentionally re-shown later by bumping the suffix.
+
+**(c) Dedicated page.** New `Web/online/sponsor.rst` titled "Support CoolProp",
+explaining what sponsorship funds (ongoing maintenance, REFPROP-grade
+validation, build/CI infrastructure, the desktop GUI) with a prominent link to
+the Sponsors page. Add it to the `Web/online/index.rst` toctree and cross-link
+it from the **Help** section of `Web/index.rst`.
+
+### 4. Desktop GUI (`wrappers/GUI/`, Tauri 2 + React 18)
+
+External links in the GUI already use plain
+`<a target="_blank" rel="noreferrer">` (see `AboutModal.tsx`), which Tauri opens
+in the system browser. **No new Tauri plugin, capability, or dependency is
+required.**
+
+**(a) Header link.** Add a `💚 Sponsor` button to the `header-right` group in
+`src/App.tsx`, between the Mass/Molar segmented control and the **About**
+button. Styled to match the existing header controls.
+
+**(b) About modal.** Add a "Support CoolProp 💚" link to
+`src/components/AboutModal.tsx`, near the existing CoolProp/MIT-license line.
+
+**(c) One-time startup splash.** New `src/components/SponsorSplash.tsx`, reusing
+the existing `modal-overlay` / `modal-card` styles. Behavior:
+
+- On app mount, read `localStorage` key `coolprop.sponsorSplash.seen.v1`.
+- If unset, render the splash; set the key when the user dismisses it (either
+  button), so it shows **once per install**.
+- Buttons: **Maybe later** (ghost, closes) and **Sponsor on GitHub** (primary,
+  opens the Sponsors URL via the same `<a target="_blank">` pattern, then
+  closes).
+
+Splash copy:
+
+> 💚 **Enjoying CoolProp?**
+> CoolProp is free and open-source, maintained on volunteer time. If it helps
+> your work, please consider sponsoring its development.
+
+Wire `<SponsorSplash />` into `App.tsx` alongside the existing
+`<UpdateChecker />`.
+
+Define the Sponsors URL as a shared constant (e.g. in a small
+`src/constants.ts`) referenced by the header link, the About modal, and the
+splash.
+
+## Visual design (approved)
+
+- Accent color: GitHub-Sponsors green (`#2ea043`), light fill `#e8f6ec`.
+- Wording: heart emoji 💚 + the word "Sponsor".
+- GUI splash and web banner are both **dismissable and remembered**; the web
+  banner additionally persists a small always-visible nav link, and the GUI a
+  small always-visible header chip.
+
+## Testing
+
+- **FUNDING.yml** — validated automatically by GitHub.
+- **Web** — build the Sphinx site locally (`Web/`); confirm: banner renders,
+  × dismiss persists across page loads, nav link present, "Support CoolProp"
+  page builds and is reachable from the toctree and the Help section.
+- **GUI** — vitest unit tests for `SponsorSplash`:
+  - renders when the `seen` key is absent;
+  - does not render when the key is set;
+  - dismissing (either button) sets the key.
+  Confirm the existing `App` / `PropertyCalculator` tests stay green.
+
+## Out of scope / YAGNI
+
+- No blocking/modal interrupts on the website (banner only).
+- No recurring or rate-limited re-prompting; both the GUI splash and web banner
+  are strictly once-until-dismissed.
+- No analytics/telemetry on sponsor clicks.
+- No changes to the legacy Python/wxPython GUI under `wrappers/Python`.

--- a/docs/superpowers/specs/2026-05-31-sponsor-promotion-design.md
+++ b/docs/superpowers/specs/2026-05-31-sponsor-promotion-design.md
@@ -75,11 +75,11 @@ Banner copy:
 The `localStorage` key is versioned, e.g. `coolprop.sponsorBanner.dismissed.v1`,
 so the banner can be intentionally re-shown later by bumping the suffix.
 
-**(c) Dedicated page.** New `Web/online/sponsor.rst` titled "Support CoolProp",
+**(c) Dedicated page.** New `Web/sponsor.rst` titled "Support CoolProp",
 explaining what sponsorship funds (ongoing maintenance, REFPROP-grade
 validation, build/CI infrastructure, the desktop GUI) with a prominent link to
-the Sponsors page. Add it to the `Web/online/index.rst` toctree and cross-link
-it from the **Help** section of `Web/index.rst`.
+the Sponsors page. Add it to the visible `Web/contents.rst` toctree and
+cross-link it from the **Help** section of `Web/index.rst`.
 
 ### 4. Desktop GUI (`wrappers/GUI/`, Tauri 2 + React 18)
 

--- a/wrappers/GUI/src/App.css
+++ b/wrappers/GUI/src/App.css
@@ -684,3 +684,37 @@ button.primary:disabled {
 .sat-table tr:last-child td {
   border-bottom: none;
 }
+
+/* ── Sponsor link + splash ──────────────────────────── */
+
+.sponsor-btn {
+  font-size: 12px;
+  color: #2ea043;
+  border: 1px solid #2ea043;
+  background: #e8f6ec;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.sponsor-btn:hover {
+  background: #d6efdd;
+}
+
+.modal-card.sponsor-splash-card {
+  width: 400px;
+  text-align: center;
+}
+.sponsor-splash-heart {
+  font-size: 34px;
+  line-height: 1;
+  margin-bottom: 8px;
+}
+.modal-card.sponsor-splash-card .modal-footer {
+  justify-content: center;
+}
+a.primary.sponsor-splash-cta {
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+}

--- a/wrappers/GUI/src/App.css
+++ b/wrappers/GUI/src/App.css
@@ -717,4 +717,13 @@ a.primary.sponsor-splash-cta {
   text-decoration: none;
   display: inline-flex;
   align-items: center;
+  background: #2ea043;
+  color: #fff;
+  border: 1px solid #2ea043;
+  border-radius: 6px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+a.primary.sponsor-splash-cta:hover {
+  background: #278c3a;
 }

--- a/wrappers/GUI/src/App.tsx
+++ b/wrappers/GUI/src/App.tsx
@@ -5,6 +5,8 @@ import SaturationView from "./components/SaturationView";
 import HumidAirCalculator from "./components/HumidAirCalculator";
 import AboutModal from "./components/AboutModal";
 import UpdateChecker from "./components/UpdateChecker";
+import SponsorSplash from "./components/SponsorSplash";
+import { SPONSOR_URL } from "./constants";
 
 type Tab = "calculator" | "saturation" | "humidair" | "diagram";
 export type Basis = "mass" | "molar";
@@ -48,6 +50,15 @@ export default function App() {
               ))}
             </div>
           )}
+          <a
+            className="tab-btn sponsor-btn"
+            href={SPONSOR_URL}
+            target="_blank"
+            rel="noreferrer"
+            title="Support CoolProp on GitHub Sponsors"
+          >
+            💚 Sponsor
+          </a>
           <button
             className="tab-btn about-btn"
             onClick={() => setAboutOpen(true)}
@@ -74,6 +85,7 @@ export default function App() {
       </main>
       {aboutOpen && <AboutModal onClose={() => setAboutOpen(false)} />}
       <UpdateChecker />
+      <SponsorSplash />
     </div>
   );
 }

--- a/wrappers/GUI/src/components/AboutModal.tsx
+++ b/wrappers/GUI/src/components/AboutModal.tsx
@@ -1,4 +1,5 @@
 import { COOLPROP_VERSION, COOLPROP_GIT_HASH, NOTICES } from "../generated/notices";
+import { SPONSOR_URL } from "../constants";
 
 interface Props {
   onClose: () => void;
@@ -28,6 +29,12 @@ export default function AboutModal({ onClose }: Props) {
             >
               CoolProp
             </a>. Released under the MIT license.
+          </p>
+          <p>
+            Support CoolProp:{" "}
+            <a href={SPONSOR_URL} target="_blank" rel="noreferrer">
+              💚 Sponsor on GitHub
+            </a>
           </p>
 
           <details className="about-notices">

--- a/wrappers/GUI/src/components/SponsorSplash.test.tsx
+++ b/wrappers/GUI/src/components/SponsorSplash.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SponsorSplash from "./SponsorSplash";
+
+const KEY_V7 = "coolprop.sponsorSplash.seen.major.7";
+const KEY_V8 = "coolprop.sponsorSplash.seen.major.8";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("SponsorSplash", () => {
+  it("renders when no seen-key is set for the current major version", () => {
+    render(<SponsorSplash version="7.2.1" />);
+    expect(screen.getByText(/Enjoying CoolProp/i)).toBeInTheDocument();
+  });
+
+  it("does not render when the current major-version key is set", () => {
+    localStorage.setItem(KEY_V7, "1");
+    render(<SponsorSplash version="7.2.1" />);
+    expect(screen.queryByText(/Enjoying CoolProp/i)).not.toBeInTheDocument();
+  });
+
+  it("renders again when only a previous major-version key is set", () => {
+    localStorage.setItem(KEY_V7, "1");
+    render(<SponsorSplash version="8.0.0" />);
+    expect(screen.getByText(/Enjoying CoolProp/i)).toBeInTheDocument();
+    expect(localStorage.getItem(KEY_V8)).toBeNull();
+  });
+
+  it("dismissing via 'Maybe later' hides it and sets the current major key", async () => {
+    const user = userEvent.setup();
+    render(<SponsorSplash version="7.2.1" />);
+    await user.click(screen.getByRole("button", { name: /Maybe later/i }));
+    expect(screen.queryByText(/Enjoying CoolProp/i)).not.toBeInTheDocument();
+    expect(localStorage.getItem(KEY_V7)).toBe("1");
+  });
+
+  it("the Sponsor link points at the Sponsors URL and sets the seen key", async () => {
+    const user = userEvent.setup();
+    render(<SponsorSplash version="7.2.1" />);
+    const link = screen.getByRole("link", { name: /Sponsor on GitHub/i });
+    expect(link).toHaveAttribute("href", "https://github.com/sponsors/CoolProp");
+    await user.click(link);
+    expect(localStorage.getItem(KEY_V7)).toBe("1");
+  });
+});

--- a/wrappers/GUI/src/components/SponsorSplash.test.tsx
+++ b/wrappers/GUI/src/components/SponsorSplash.test.tsx
@@ -44,5 +44,7 @@ describe("SponsorSplash", () => {
     expect(link).toHaveAttribute("href", "https://github.com/sponsors/CoolProp");
     await user.click(link);
     expect(localStorage.getItem(KEY_V7)).toBe("1");
+    // Clicking the CTA also dismisses the splash for the session.
+    expect(screen.queryByText(/Enjoying CoolProp/i)).not.toBeInTheDocument();
   });
 });

--- a/wrappers/GUI/src/components/SponsorSplash.tsx
+++ b/wrappers/GUI/src/components/SponsorSplash.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { SPONSOR_URL } from "../constants";
+import { APP_VERSION } from "../generated/notices";
+
+interface Props {
+  /** Semver string; the integer before the first "." is the major version.
+   *  Defaults to the GUI bundle version generated at build time. */
+  version?: string;
+}
+
+function majorOf(version: string): string {
+  const major = version.split(".")[0];
+  return /^\d+$/.test(major) ? major : "0";
+}
+
+export default function SponsorSplash({ version = APP_VERSION }: Props) {
+  const storageKey = `coolprop.sponsorSplash.seen.major.${majorOf(version)}`;
+
+  const [open, setOpen] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(storageKey) !== "1";
+    } catch {
+      return true;
+    }
+  });
+
+  function markSeen() {
+    try {
+      localStorage.setItem(storageKey, "1");
+    } catch {
+      /* ignore unavailable storage */
+    }
+  }
+
+  function dismiss() {
+    markSeen();
+    setOpen(false);
+  }
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="modal-overlay"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) dismiss();
+      }}
+    >
+      <div className="modal-card sponsor-splash-card">
+        <div className="sponsor-splash-heart">💚</div>
+        <div className="modal-title">Enjoying CoolProp?</div>
+        <div className="modal-body">
+          <p>
+            CoolProp is free and open-source, maintained on volunteer time. If it
+            helps your work, please consider sponsoring its development.
+          </p>
+        </div>
+        <div className="modal-footer">
+          <button onClick={dismiss}>Maybe later</button>
+          <a
+            className="primary sponsor-splash-cta"
+            href={SPONSOR_URL}
+            target="_blank"
+            rel="noreferrer"
+            onClick={markSeen}
+          >
+            Sponsor on GitHub
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/wrappers/GUI/src/components/SponsorSplash.tsx
+++ b/wrappers/GUI/src/components/SponsorSplash.tsx
@@ -62,7 +62,7 @@ export default function SponsorSplash({ version = APP_VERSION }: Props) {
             href={SPONSOR_URL}
             target="_blank"
             rel="noreferrer"
-            onClick={markSeen}
+            onClick={dismiss}
           >
             Sponsor on GitHub
           </a>

--- a/wrappers/GUI/src/constants.ts
+++ b/wrappers/GUI/src/constants.ts
@@ -1,0 +1,2 @@
+/** Canonical GitHub Sponsors URL for the CoolProp organization. */
+export const SPONSOR_URL = "https://github.com/sponsors/CoolProp";


### PR DESCRIPTION
## Summary

The CoolProp GitHub organization is now eligible for **GitHub Sponsors**. This PR surfaces that across every place a user encounters the project — tastefully but persistently, with no blocking interruptions.

All sponsor links point to a single canonical URL: `https://github.com/sponsors/CoolProp`.

## Surfaces

**1. Repository** — `.github/FUNDING.yml` enables the green *Sponsor* button on the repo page/sidebar.

**2. Website / docs** (`Web/`, Sphinx + pydata-sphinx-theme)
- Persistent `💚 Sponsor` link in the nav bar (`_templates/navbar-center.html`).
- Dismissable, site-wide top banner — self-contained `_static/sponsor-banner.{css,js}` registered via `conf.py`. Dismissal is remembered in `localStorage` (versioned key) so it doesn't re-nag.
- Dedicated **Support CoolProp** page (`Web/sponsor.rst`), added to the master toctree and cross-linked from the Help section.

**3. Desktop GUI** (`wrappers/GUI/`, Tauri 2 + React 18)
- `💚 Sponsor` link in the header, next to *About*.
- *Support CoolProp* link inside the About dialog.
- A startup splash shown **once per major version** (localStorage key embeds the major), dismissable via *Maybe later* / *Sponsor on GitHub*. No new Tauri plugin, capability, or npm dependency — external links use the existing `<a target="_blank" rel="noreferrer">` pattern.

## Testing

- New `SponsorSplash` vitest suite (5 tests): renders when unseen, hidden when the current-major key is set, re-shows on a new major version, both dismiss paths persist the key, Sponsor link points at the canonical URL.
- Full GUI gate green: `tsc --noEmit` clean, `vitest run` → 4 files / 21 tests passed.
- `FUNDING.yml` validated; `conf.py` parses; banner assets copy into the Sphinx build.

## Design docs

Spec and implementation plan included under `docs/superpowers/`.

> **Note:** links resolve once the `CoolProp` org's GitHub Sponsors profile is enabled (an org-account action outside this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled GitHub Sponsors button and added sponsor link across surfaces (repo, docs, desktop)
  * Dismissible sponsor banner on documentation pages
  * Desktop app: sponsor link in header, About modal entry, and per-major-version sponsor splash

* **Documentation**
  * Added “Support CoolProp” page and promotion/design plans describing sponsorship benefits and rollout

* **Tests**
  * Added unit tests for the sponsor splash behavior

* **Chores**
  * Updated ignore rules to exclude a local build directory
<!-- end of auto-generated comment: release notes by coderabbit.ai -->