### PR TITLE
docs(svdsbtl): regenerate SVDSBTLValidation.ipynb from generator + portable path (CoolProp-lr7l)

### DIFF
--- a/Web/coolprop/_gen/gen_SVDSBTLValidation.py
+++ b/Web/coolprop/_gen/gen_SVDSBTLValidation.py
@@ -1,10 +1,15 @@
-"""Generate the SVDSBTL validation notebook (6 fluids x {PT, HP} inputs, rho error).
+"""Generate the SVDSBTL validation notebook (8 fluids x {PT, HP} inputs, rho error).
 
 Writes ``Web/coolprop/SVDSBTLValidation.ipynb`` as a *stripped* notebook
-(no embedded outputs). The notebook carries per-notebook nbsphinx metadata
-that forces re-execution during ``make html`` (``execute='always'``, with a
-generous ``timeout`` because SVDSBTL surfaces lazily build the first time
-each (fluid, input_pair) is queried in a given environment).
+(no embedded outputs).  The docs build re-executes it in place on every
+``make html``: ``Web/conf.py`` walks every ``.ipynb`` and runs
+``jupyter nbconvert --execute`` (timeout bumped to 1 h, because SVDSBTL
+surfaces lazily build the first time each (fluid, input_pair) is queried
+in a given environment).  The committed copy therefore intentionally
+carries no outputs — they are regenerated at build time.
+
+This file is the single source of truth for the notebook; re-run it after
+any edit and commit the regenerated ``.ipynb`` (the two must stay in sync).
 
 Docs build environment must have:
   - CoolProp Python wrapper built from current source (``pip install .`` at repo root)
@@ -19,6 +24,8 @@ Local verification (renders the HTML the docs build would produce):
     --ExecutePreprocessor.timeout=3600 \\
     Web/coolprop/SVDSBTLValidation.ipynb
 """
+
+from pathlib import Path
 
 import nbformat as nbf
 
@@ -299,7 +306,7 @@ nb.cells.append(_md(
     "- Source generator: `Web/coolprop/_gen/gen_SVDSBTLValidation.py`.\n"
 ))
 
-out = '/Users/ianbell/Code/CoolProp/Web/coolprop/SVDSBTLValidation.ipynb'
+out = str(Path(__file__).resolve().parents[1] / 'SVDSBTLValidation.ipynb')
 with open(out, 'w') as f:
     nbf.write(nb, f)
 


### PR DESCRIPTION
## Summary

The committed `Web/coolprop/SVDSBTLValidation.ipynb` had **drifted from its generator** `Web/coolprop/_gen/gen_SVDSBTLValidation.py`. The two shipped inconsistent in #2964:

- the generator lists **8 fluids** (`Water, Argon, Hydrogen, R1234yf, R245fa, D6, CO2, Helium`) and emits a **stripped** notebook,
- but the committed `.ipynb` had only **6 fluids** *and* carried embedded execution outputs.

`Web/conf.py` re-executes every `.ipynb` via `jupyter nbconvert --execute` on `make html`, so the rendered page **silently dropped the CO2 and Helium panels** and the stale embedded outputs were dead weight.

This is a pre-existing docs bug on `master`, unrelated to any SVDSBTL backend work.

## Changes

- **Regenerate the notebook** from its generator: 8 fluids, stripped (902-line diff is almost entirely the removal of stale embedded outputs).
- **Make the generator portable**: the output path was a hardcoded `/Users/ianbell/Code/CoolProp/Web/coolprop/SVDSBTLValidation.ipynb` — the reason nobody re-ran it, hence the drift. Now derived from `Path(__file__).resolve().parents[1]`, matching the two figure generators in the same dir.
- **Correct the docstring**: it claimed per-notebook `execute='always'` nbsphinx metadata forced re-execution. No such metadata is emitted and there's no global `nbsphinx_execute`; the real mechanism is `conf.py`'s `nbconvert --execute` pre-pass (which the notebook's own closing cell already describes correctly).

## Validation

- **The 8-fluid notebook had never been executed** — CO2 and Helium were the never-validated additions. Confirmed both build clean `SVDSBTL&HEOS` surfaces for **both PT and HP** inputs (no surface-build failures, `err_msg=None`, finite error fields): CO2 ~1e-8 median rel-error, Helium ~3e-4 median (with the expected high-error edge cells the page exists to display).
- Generator output is **byte-stable / idempotent** (deterministic cell IDs, no timestamps/abspaths), `py_compile` clean, and `nbformat.validate` passes.
- `./dev/ci/preflight.sh` — 6/6 checks skipped (zero C/C++ in diff; build/tests cannot be affected by a Python+notebook change).
- Adversarial review pass — no blocking findings (path index, docstring-vs-`conf.py`, nbformat validity, determinism all independently verified).

Closes CoolProp-lr7l.

🤖 Generated with [Claude Code](https://claude.com/claude-code)