### PR TITLE
ci(docs): add plotly + joblib to the docs env — SVDSBTL validation notebooks render broken (CoolProp-56xb)

### DIFF
--- a/.github/workflows/docs_docker-run.yml
+++ b/.github/workflows/docs_docker-run.yml
@@ -98,11 +98,15 @@ jobs:
         # Build and install the wheel
         pip -vv wheel .
         pip install -vvv --force-reinstall --ignore-installed --upgrade --no-index `ls *.whl`
-        # sphinx-design is in conda_environment.yml, but that env is baked into
-        # the prebuilt docs container; the image isn't rebuilt for PRs, so install
-        # it at runtime here (same escape hatch as the packages above) to unblock
-        # the build until the next docs image rebuild on master.
-        pip install pydata-sphinx-theme tqdm ninja sphinx-design
+        # sphinx-design, plotly and joblib are in conda_environment.yml, but that
+        # env is baked into the prebuilt docs container; the image isn't rebuilt
+        # for PRs, so install them at runtime here (same escape hatch as the
+        # packages above) to unblock the build until the next docs image rebuild
+        # on master.  plotly+joblib are required by the SVDSBTL validation
+        # notebooks (SVDSBTLValidation, SVDSBTLHeatExchangerDemo); without them
+        # nbconvert --allow-errors silently renders those pages as import-error
+        # tracebacks.
+        pip install pydata-sphinx-theme tqdm ninja sphinx-design plotly joblib
         
     - name: Test the installed CoolProp version
       shell: bash

--- a/dev/docker/conda_environment.yml
+++ b/dev/docker/conda_environment.yml
@@ -7,6 +7,8 @@ dependencies:
   - scipy
   - numpy
   - matplotlib
+  - plotly
+  - joblib
   - ipython
   - pandas
   - pip


### PR DESCRIPTION
## Summary

The two SVDSBTL **plotly** notebooks have been rendering as **import-error tracebacks** in the docs, not figures:

- `Web/coolprop/SVDSBTLValidation.ipynb` (PR #3062)
- `Web/coolprop/SVDSBTLHeatExchangerDemo.ipynb` (PR #3060)

`dev/docker/conda_environment.yml` (the source for the prebuilt docs image) declares `matplotlib` but **never `plotly` or `joblib`**, so both notebooks fail at `import plotly` in the container. `Web/conf.py` executes every notebook with `jupyter nbconvert --allow-errors`, which swallows the `ModuleNotFoundError` into the cell output — so the docs build stays **green** while the pages render broken.

## Evidence (ground truth, not the green check)

Extracted the *executed* notebooks from the CI docs artifact (run `26778313303`):

| Notebook | Plots with | Result in container |
|---|---|---|
| `SVDSBTLHeatExchangerDemo` | plotly | `ModuleNotFoundError: No module named 'plotly'` → cascade |
| `SVDSBTLValidation` | plotly + joblib | `ModuleNotFoundError: No module named 'plotly'` → cascade |
| `SuperAncillary`, `SVDComponents` | matplotlib | clean |

Locally, with `plotly`+`joblib` installed, the HX demo executes with **0 errors and 2 plotly figures** (23.8 KB executed notebook vs. the 14.6 KB traceback-only version from the container).

## Fix (mirrors the existing `sphinx-design` pattern)

1. **`dev/docker/conda_environment.yml`** — add `plotly` + `joblib` (permanent; picked up at the next docs-image rebuild on master).
2. **`.github/workflows/docs_docker-run.yml`** — add `plotly joblib` to the runtime `pip install` escape hatch (immediate; PRs don't rebuild the baked image).

`joblib` is required by `SVDSBTLValidation` (loky-backed parallel grid build); `plotly` by both. This repairs the rendering for **both #3060 and #3062**.

## Test plan
- [x] Both YAML files parse (`yaml.safe_load`).
- [x] `plotly` + `joblib` import; HX notebook executes headlessly with 0 errors and renders plotly figures.
- [x] Confirmed `conda_environment.yml` is the single source of truth (`dev/docker/docs_01_base.Dockerfile` builds from it); no other docs requirements file needs the edit.
- [x] `./dev/ci/preflight.sh` — 6/6 skipped (no C/C++ in diff).
- [x] Adversarial review — no blocking findings.

Closes CoolProp-56xb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build and Conda environment configurations to include additional Python package dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->