### PR TITLE
ci(docs): cache SVDSBTL surfaces across builds (CoolProp-onkt)

### DIFF
--- a/.github/workflows/docs_docker-run.yml
+++ b/.github/workflows/docs_docker-run.yml
@@ -27,7 +27,18 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
+    env:
+      # Persist the (expensive, cold-built) SVDSBTL SVD surfaces under the
+      # workspace so actions/cache can cache them across builds.  The
+      # SVDSBTLValidation / SVDSBTLHeatExchangerDemo notebooks read this via
+      # os.environ (and joblib loky workers inherit it); their default
+      # ~/.CoolProp/SVDTables-docs lives in the container home, which is NOT
+      # on the cacheable workspace.  Must be an absolute path inside the
+      # container — github.workspace is the bind-mounted workspace, so the
+      # host-side actions/cache step sees the same files.
+      COOLPROP_ALTERNATIVE_SVDTABLES_DIRECTORY: ${{ github.workspace }}/.svdtables-cache
+
     container:
       image: ghcr.io/coolprop/coolprop_docs_02_builder:dev
       # options: --user 1001 --group 1001
@@ -66,7 +77,23 @@ jobs:
         key: cached-props-${{ hashFiles('dev/fluids/*.json', 'dev/incompressible_liquids/json/*.json') }}
         restore-keys: |
           cached-props-
-        
+
+    # Cache the SVDSBTL SVD surfaces (COOLPROP_ALTERNATIVE_SVDTABLES_DIRECTORY,
+    # set at job level).  Without this they are rebuilt cold every run (~370 s
+    # per panel of SVDSBTLValidation / SVDSBTLHeatExchangerDemo).  Surfaces are
+    # serialized and content-addressed, but the on-disk opthash covers only the
+    # grid options — NOT the EOS coefficients or the SVDSBTL algorithm — so the
+    # key busts on the fluid JSONs + SVDSBTL/SBTL/Region sources + the notebook
+    # generator (fluid/grid list).  No restore-keys fallback ON PURPOSE: a
+    # partial restore could seed a surface that is stale w.r.t. an EOS/algorithm
+    # change the opthash cannot see.  Exact key only => any relevant change
+    # triggers a clean cold rebuild; otherwise surfaces load in ~80 ms.
+    - uses: actions/cache@v5
+      if: ${{ !env.ACT }}
+      with:
+        path: .svdtables-cache
+        key: svd-tables-${{ hashFiles('dev/fluids/*.json', 'src/SBTL/**', 'src/Backends/SVDSBTL/**', 'src/Region/**', 'include/CoolProp/sbtl/**', 'Web/coolprop/_gen/gen_SVDSBTLValidation.py') }}
+
     - name: Schedule calculations
       id: schedule_calculation
       shell: bash


### PR DESCRIPTION
## Summary

The docs `actions/cache` step covered the consistency plots + incompressibles but **not** the SVDSBTL SVD surfaces — the notebooks serialize those to `~/.CoolProp/SVDTables-docs`, in the **container home**, off the cacheable workspace. So every docs build rebuilt all 8 fluids' surfaces **cold**: ~370 s per `SVDSBTLValidation` / `SVDSBTLHeatExchangerDemo` panel (~14 min wall, `wall-clock: 864 s` on the 4-core runner). The notebook docstring's "surfaces persist across builds" was only ever true on a dev machine.

## Change

1. **Pin** `COOLPROP_ALTERNATIVE_SVDTABLES_DIRECTORY` (job-level `env`) to `${{ github.workspace }}/.svdtables-cache` — a **workspace** path so the host-side `actions/cache` sees the same files the container writes (`github.workspace` is the bind-mounted workspace). The notebooks read this via `os.environ.setdefault`; joblib loky workers inherit it.
2. Add `actions/cache@v5` for `.svdtables-cache`.

## Cache-key safety (the subtle part)

The on-disk surface filename is `<fluid>.<source>.<input_pair>.<opthash>.svd.bin.z`, where `opthash = fnv1a_64(options_canonical)` — it hashes **only the grid options**, *not* the EOS coefficients or the SVDSBTL algorithm (the `"SVDS"` magic only guards the serialization format). So a persisted surface could be silently stale w.r.t. an EOS/algorithm change.

To stay correct, the cache key busts on `dev/fluids/*.json` + `src/SBTL/**` + `src/Backends/SVDSBTL/**` + `src/Region/**` + `include/CoolProp/sbtl/**` + the notebook generator, and uses **no `restore-keys` fallback** (a partial restore could seed a stale surface the opthash can't detect). Exact key only ⇒ any relevant change → clean cold rebuild; otherwise surfaces load in ~80 ms.

Trade-off: touching any one fluit's EOS or any SVDSBTL source rebuilds all surfaces on that run. Safe and rare; the incremental alternative needs the opthash to fold in an EOS+algorithm hash first (a separate C++ change).

## Verification

Verified the env var threads the full chain locally, exactly as CI runs it — set the var in the shell, ran a notebook via `jupyter nbconvert --execute`:

```
KERNEL sees cache dir = /tmp/svdtables_envtest                     ← nbconvert subprocess → kernel
LOKY WORKER for Nitrogen saw env = /tmp/svdtables_envtest          ← joblib loky worker inherited it
FILES IN ENV CACHE DIR: Nitrogen.…PT_INPUTS.svd.bin.z, …HmassP…    ← surfaces written to the env dir
~/.CoolProp/SVDTables-docs/Nitrogen* → no matches                  ← not the home default
```

Benefits both the `SVDSBTLValidation` and `SVDSBTLHeatExchangerDemo` pages.

## Test plan
- [x] YAML parses; `env` is a job-key sibling of `runs-on`/`container`/`steps`; cache step well-formed.
- [x] hashFiles globs all resolve to real files (non-degenerate key); no path/key collision with `cached-props`.
- [x] End-to-end env propagation (shell → nbconvert → kernel → loky workers → SVDSBTL write dir) verified locally.
- [x] `./dev/ci/preflight.sh` 6/6 skipped (no C/C++); adversarial review — no blocking findings (container-path semantics confirmed).

Closes CoolProp-onkt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow caching to persist generated artifacts across runs, reducing rebuild time when source dependencies remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->