### PR TITLE
docs(superanc): bump fastchebpure pin to 2026.06.02-v2 — R1130(E) + R1336mzz(Z) plots (fastchebpure#8)

### DIFF
--- a/Web/scripts/fluid_properties.Superancillary.py
+++ b/Web/scripts/fluid_properties.Superancillary.py
@@ -12,7 +12,7 @@ root_dir = os.path.abspath(os.path.join(web_dir, '..'))
 fluids_path = os.path.join(web_dir, 'fluid_properties', 'fluids')
 plots_path = os.path.join(web_dir, 'fluid_properties', 'fluids', 'Superancillaryplots')
 
-outputversion = '2026.06.02'
+outputversion = '2026.06.02-v2'
 if not Path(f'{outputversion}.zip').exists():
     print('Downloading the chebyshev output file to ', Path('.').absolute())
     urllib.request.urlretrieve(f'https://github.com/CoolProp/fastchebpure/archive/refs/tags/{outputversion}.zip', f'{outputversion}.zip')


### PR DESCRIPTION
Closes the completeness follow-up from #3063 / fastchebpure#8.

`2026.06.02-v2` adds the two SA-bearing fluids that were absent from every prior fastchebpure release — `R1130(E)` and `R1336mzz(Z)` — whose docs deviation plots until now rendered the Layer-0 "reference not in pinned release" placeholder. (Their embedded superancillaries were already correct and hash-verified; only the public extended-precision reference was missing.)

## Verification
Ran the repo's own gate (`dev/scripts/check_superanc_release_pin.py`, added in #3067) at the new pin:
- **130 SA-bearing fluids matched, 0 stale, 0 absent, exit 0.**
- `R1130(E)` and `R1336mzz(Z)` both ship exps + check and their `source_eos_hash` equals CoolProp HEAD.

So every SA-bearing CoolProp fluid now has a fresh, verified extended-precision reference — no placeholders remain.

- Adversarial review: no blocking findings (one-line version-string bump, fully propagated; no stale references).
- `./dev/ci/preflight.sh`: passed (no C/C++ in diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)