### PR TITLE
chore(blame): add #1280 Phase 1 header bulk-move (#3075) to ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -26,3 +26,8 @@ ee879788a10365c13f812993c4db6e69cb2d51a7
 # loop-convert, use-equals-default, use-using, etc.)
 # (CoolProp-0xu, #2926 layer 2, PR #3019)
 fe950bbfa4c2cf53a79fb5a3d848b7c945dd1ddf
+
+# Header reorg Phase 1: bulk move of ~28 public headers into include/CoolProp/
+# tiers (+ CP-/_include- renames) and the mechanical #include rewrite across
+# the core library. Predominantly a pure relocation. (GH #1280, CoolProp-dfw)
+2bfcc6f263ab9c3f58faebc01ca5b9ffa241961f


### PR DESCRIPTION
Adds the squash-merge SHA of #3075 (`2bfcc6f26`) to `.git-blame-ignore-revs`.

#3075 was a predominantly mechanical relocation of ~28 public headers into `include/CoolProp/` tiers plus the `#include` rewrite across the core library, so `git blame` should look through it (same pattern as the prior clang-tidy sweep entries, e.g. `dd66d8c7d`).

Deferred from the move PR itself because CoolProp squash-merges, so the entry must reference the squash-merge commit on master (which only exists post-merge), not the branch SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development configuration to improve git history annotation tracking for bulk refactoring commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->