### PR TITLE
test(pdsim): pin CoolProp's Cython cimport surface with a contract test

### DIFF
--- a/dev/pdsim_cimport_contract/.gitignore
+++ b/dev/pdsim_cimport_contract/.gitignore
@@ -1,0 +1,5 @@
+build/
+pdsim_surface.cpp
+*.so
+__pycache__/
+.pytest_cache/

--- a/dev/pdsim_cimport_contract/SURFACE.md
+++ b/dev/pdsim_cimport_contract/SURFACE.md
@@ -99,9 +99,11 @@ input pair `PT_INPUTS`
 
 ```bash
 python dev/pdsim_cimport_contract/run_contract.py          # standalone
-python -m pytest dev/pdsim_cimport_contract/test_pdsim_contract.py
+RUN_PDSIM_CIMPORT_CONTRACT=1 python -m pytest dev/pdsim_cimport_contract/test_pdsim_contract.py
 ```
 
-The build auto-locates fmt/rapidjson from any in-repo `build*/_deps/…`; override
-with `COOLPROP_FMT_INCLUDE` / `COOLPROP_RAPIDJSON_INCLUDE` if needed.
-```
+The pytest wrapper is opt-in (skips unless `RUN_PDSIM_CIMPORT_CONTRACT` is set)
+so it isn't pulled into default collection — it compiles a shim against the
+installed CoolProp. The build auto-locates fmt/rapidjson from any in-repo
+`build*/_deps/…`; override with `COOLPROP_FMT_INCLUDE` / `COOLPROP_RAPIDJSON_INCLUDE`
+if needed.

--- a/dev/pdsim_cimport_contract/SURFACE.md
+++ b/dev/pdsim_cimport_contract/SURFACE.md
@@ -1,0 +1,107 @@
+# PDSim ↔ CoolProp Cython contract surface
+
+The exact C-level surface that **ibell/pdsim** consumes from CoolProp via
+`cimport` (extracted from `ibell/pdsim @ main`).  Dropping the hand-written
+Cython interface in v8 (→ nanobind/pybind11 core + a thin frozen `State` shim)
+**must preserve everything below**, or PDSim breaks at compile time — or worse,
+silently returns wrong numbers.
+
+`pdsim_surface.pyx` exercises this whole surface; `run_contract.py` checks the
+values. If a v8 change drifts the surface, the build fails; if it drifts the
+unit convention, the value checks fail.
+
+## cimports PDSim makes
+
+| Statement | Files |
+|---|---|
+| `from CoolProp.State cimport State` (and `as StateClass`) | recip/_recip, flow/flow{,_models}, core/containers |
+| `from CoolProp.CoolProp cimport State as State` | core/state_flooded |
+| `from CoolProp.constants_header cimport parameters` | core/containers |
+| `cimport CoolProp.constants_header as constants` | core/containers, core/state_flooded |
+| `from CoolProp cimport constants_header` | flow/flow_models |
+
+## `State` cdef class — members used
+
+**Construction:** `State(Fluid, {'T':T, 'D':rho})` (dict; keys T/D/P/H/S/Q)
+
+**Methods:** `update(dict)`, `update_Trho`, `update_ph`, `copy() -> State`,
+`Props(parameters)`, `set_Fluid(Fluid, backend)`,
+`get_T get_p get_h get_rho get_s get_u get_cp get_cp0 get_cv get_MM get_dpdT
+get_visc get_cond get_speed_sound get_Q`
+
+**Direct cdef attributes (read at C level):**
+`pAS` (the `AbstractState`), `T_`, `p_`, `rho_`, `Fluid` (bytes), `phase` (bytes)
+
+## `AbstractState` (reached through `State.pAS`, 24 call sites)
+
+`keyed_output(parameters)`, `rhomass()`, `cpmass()`, `cvmass()`, `T()`, `p()`,
+`update(input_pairs, v1, v2)`, `fluid_names()`,
+`first_partial_deriv(parameters, parameters, parameters)`
+
+> PDSim does **not** depend only on `State`; it dips into `AbstractState`
+> through `.pAS`. The frozen v8 shim must therefore expose a cimportable `pAS`
+> object carrying these methods too — not just `State`.
+
+## `constants_header` — names used
+
+Enum **types:** `parameters`, `input_pairs`
+**Values:** `iT iP iHmass iSmass iUmass iDmass iDmolar iCpmass iCp0mass iCvmass
+ispeed_sound iconductivity iviscosity imolar_mass iQ iP_critical iT_critical`,
+input pair `PT_INPUTS`
+
+## ⚠️ Findings that make this more than "keep the method names"
+
+1. **The legacy `State` class is kPa / kJ, NOT SI.** `get_p() = pAS.p()/1000`
+   (kPa), `get_h/get_u = …/1000` (kJ/kg), `get_s/get_cp/get_cv` likewise;
+   `get_dpdT = first_partial_deriv(iP,iT,iDmolar)/1000`. But `get_rho`,
+   `get_speed_sound`, **`Props()`**, and everything via **`.pAS`** are SI.
+   `p_` is kPa; `rho_` is SI. PDSim is written against this split. A shim that
+   forwards SI without the `/1000` factors makes PDSim wrong by 1000× **with no
+   crash** — the most dangerous possible regression. The value checks lock this.
+
+2. **No `CoolProp/__init__.pxd` ships**, so an external `cimport` of the
+   package only resolves when cython's `include_path` points at the cimport
+   root (site-packages). v8 should ship `__init__.pxd` (even empty) to make the
+   surface cleanly cimportable.
+
+3. **The public surface *leaks* implementation includes — fmt and rapidjson
+   are NOT part of PDSim's interface.** Nothing in the `State`/`AbstractState`
+   API signatures uses an fmt or rapidjson type; they are dragged in purely by
+   transitive `#include`:
+     * **rapidjson** ← `constants_header.pxd` does `cdef extern from
+       "Configuration.h"` just to read the `configuration_keys` enum, and
+       `Configuration.h` pulls `rapidjson_include.h`.
+     * **fmt** ← `AbstractState.h → CachedElement.h → CoolPropTools.h →
+       CPstrings.h`, whose inline `format()` helpers call `fmt::sprintf`.
+     * **C++17 `std::filesystem`** ← `CoolPropTools.h → CPfilepaths.h`
+       (`write_bytes_atomic`).
+
+   The fix is header hygiene, **not** bundling: split a lean
+   `configuration_keys` enum header (no rapidjson) for the pxd to extern from;
+   move the `format()` bodies out of `CPstrings.h` into a `.cpp`;
+   forward-declare/pimpl the `std::filesystem::path` parameter. After that a
+   downstream consumer (and the frozen v8 `State` shim) compiles with only
+   `CoolProp.get_include_directory()` and **zero** third-party `-I` flags.
+
+   This also unblocks retiring rapidjson (last release ~2016): once it no
+   longer appears in the *public/cimport* surface, swapping it out is a pure
+   implementation change — invisible to PDSim and to this contract test. The
+   fmt/rapidjson `-I` paths in `setup_contract.py` are a STOPGAP for today's
+   leakage; once the surface is cleaned, delete them and this test becomes the
+   regression guard that the leak has not returned.
+
+4. **The contract is link-free.** The built module links with no `-lCoolProp`
+   (`-undefined dynamic_lookup`); the cdef-class methods resolve at runtime
+   through Cython's vtable capsule. This is why the capsule-forwarding design
+   works without shipping a linkable library — PDSim never links CoolProp.
+
+## Running
+
+```bash
+python dev/pdsim_cimport_contract/run_contract.py          # standalone
+python -m pytest dev/pdsim_cimport_contract/test_pdsim_contract.py
+```
+
+The build auto-locates fmt/rapidjson from any in-repo `build*/_deps/…`; override
+with `COOLPROP_FMT_INCLUDE` / `COOLPROP_RAPIDJSON_INCLUDE` if needed.
+```

--- a/dev/pdsim_cimport_contract/pdsim_surface.pyx
+++ b/dev/pdsim_cimport_contract/pdsim_surface.pyx
@@ -1,0 +1,105 @@
+# distutils: language = c++
+# cython: language_level=3
+"""
+PDSim cimport contract — a frozen miniature of how ibell/pdsim consumes
+CoolProp's *Cython* surface at the C level.
+
+Why this file exists
+--------------------
+PDSim does not use the high-level Python API; it ``cimport``s CoolProp's
+``State`` / ``AbstractState`` cdef classes and the ``constants_header`` enum
+module, then calls their methods at C speed inside its ODE loops.  That makes
+those declarations a binary/source *contract*.  The v8 reorg (dropping the
+hand-written Cython interface in favour of nanobind/pybind11 + a thin frozen
+``State`` shim) MUST preserve this surface or PDSim breaks.
+
+This module reproduces *exactly* the members PDSim touches (extracted from
+ibell/pdsim @ main).  Two guard rails:
+
+  * COMPILE-TIME: if a v8 change drifts the cimportable ``State`` /
+    ``AbstractState`` / ``constants_header`` surface, this file fails to
+    compile -> the test errors out.  That is the "PDSim need not change"
+    guarantee, proven mechanically.
+  * BEHAVIOURAL: test_pdsim_contract.py runs the functions below and asserts
+    the values match the high-level ``PropsSI`` reference, proving any future
+    capsule-forwarding implementation is numerically correct.
+
+Keep this list in sync with SURFACE.md.  Anything added here should be a
+deliberate, reviewed widening of the contract.
+"""
+from CoolProp.State cimport State                   # the cdef class (CoolProp.State path)
+cimport CoolProp.constants_header as constants      # enum module (constants.iXxx)
+from CoolProp.constants_header cimport parameters   # enum used as a C type
+
+
+cpdef dict exercise(object Fluid, double T, double rho):
+    """Touch every single-phase State + .pAS member PDSim uses; return values."""
+    cdef State S = State(Fluid, {'T': T, 'D': rho})     # dict construction
+    cdef State S2
+
+    # --- the three update variants PDSim calls ---
+    S.update_Trho(T, rho)
+    cdef double p_from_Trho = S.get_p()
+    S.update({'T': T, 'D': rho})                        # dict update
+    S.update_ph(S.get_p(), S.get_h())                   # ph update
+
+    # --- direct cdef attribute reads (cached doubles + py attrs) ---
+    cdef double Tc = S.T_
+    cdef double pc = S.p_
+    cdef double rc = S.rho_
+    cdef object fluid_name = S.Fluid
+    cdef object phase = S.phase
+
+    # --- the State getter surface ---
+    cdef dict getters = {
+        'T': S.get_T(), 'p': S.get_p(), 'h': S.get_h(), 'rho': S.get_rho(),
+        's': S.get_s(), 'u': S.get_u(), 'cp': S.get_cp(), 'cp0': S.get_cp0(),
+        'cv': S.get_cv(), 'MM': S.get_MM(), 'dpdT': S.get_dpdT(),
+        'visc': S.get_visc(), 'cond': S.get_cond(),
+        'speed_sound': S.get_speed_sound(),
+    }
+
+    # --- Props(enum) ---
+    cdef double h_via_Props = S.Props(constants.iHmass)
+
+    # --- reach THROUGH .pAS to the AbstractState (PDSim does this 24x) ---
+    cdef double rho_pAS = S.pAS.rhomass()
+    cdef double cp_pAS = S.pAS.cpmass()
+    cdef double cv_pAS = S.pAS.cvmass()
+    cdef double T_pAS = S.pAS.T()
+    cdef double p_pAS = S.pAS.p()
+    cdef double ko_h = S.pAS.keyed_output(constants.iHmass)
+    cdef object names = S.pAS.fluid_names()
+    S.pAS.update(constants.PT_INPUTS, pc * 1000.0, Tc)  # AbstractState.update (SI: Pa)
+    # mirror State.get_dpdT exactly: first_partial_deriv(iP,iT,iDmolar) in SI
+    cdef double dpdT_pAS = S.pAS.first_partial_deriv(
+        constants.iP, constants.iT, constants.iDmolar)
+
+    # --- copy() returns a fresh State ---
+    S2 = S.copy()
+    cdef double h_copy = S2.get_h()
+
+    return {
+        'p_from_Trho': p_from_Trho, 'T_': Tc, 'p_': pc, 'rho_': rc,
+        'Fluid': fluid_name, 'phase': phase, 'getters': getters,
+        'h_via_Props': h_via_Props, 'rho_pAS': rho_pAS, 'cp_pAS': cp_pAS,
+        'cv_pAS': cv_pAS, 'T_pAS': T_pAS, 'p_pAS': p_pAS, 'ko_h': ko_h,
+        'names': list(names), 'dpdT_pAS': dpdT_pAS, 'h_copy': h_copy,
+    }
+
+
+cpdef dict exercise_twophase(object Fluid, double T, double Q):
+    """get_Q + two-phase construction (the one getter undefined single-phase)."""
+    cdef State S = State(Fluid, {'T': T, 'Q': Q})
+    return {'Q': S.get_Q(), 'T': S.get_T(), 'p': S.get_p()}
+
+
+cpdef double hot_loop(object Fluid, double T, double rho, int n):
+    """Mirror PDSim's inner pattern: repeated update_Trho + getters + .pAS."""
+    cdef State S = State(Fluid, {'T': T, 'D': rho})
+    cdef double acc = 0.0
+    cdef int i
+    for i in range(n):
+        S.update_Trho(T + 0.001 * i, rho)
+        acc += S.get_p() + S.get_h() + S.pAS.keyed_output(constants.iSmass)
+    return acc

--- a/dev/pdsim_cimport_contract/run_contract.py
+++ b/dev/pdsim_cimport_contract/run_contract.py
@@ -54,6 +54,7 @@ def check():
     expect("get_s [kJ/kg/K]", g["s"], SI("Smass") / 1000.0)
     expect("get_u [kJ/kg]", g["u"], SI("Umass") / 1000.0)
     expect("get_cp [kJ/kg/K]", g["cp"], SI("Cpmass") / 1000.0)
+    expect("get_cp0 [kJ/kg/K]", g["cp0"], SI("Cp0mass") / 1000.0)
     expect("get_cv [kJ/kg/K]", g["cv"], SI("Cvmass") / 1000.0)
     expect("get_speed_sound [m/s, SI]", g["speed_sound"], SI("speed_of_sound"))
     expect("get_rho [kg/m^3, SI]", g["rho"], RHO, rel=1e-9)

--- a/dev/pdsim_cimport_contract/run_contract.py
+++ b/dev/pdsim_cimport_contract/run_contract.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+PDSim cimport-contract runner (standalone + the worker the pytest wrapper calls).
+
+Builds pdsim_surface.pyx against the *installed* CoolProp and verifies the
+values it produces through the legacy Cython surface.  Run directly:
+
+    python dev/pdsim_cimport_contract/run_contract.py
+
+Exits 0 on success, 1 on any failure.  See SURFACE.md for the contract and
+test_pdsim_contract.py for why this is a subprocess (sys.path hygiene).
+"""
+import math
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+FLUID, T, RHO = "Water", 320.0, 1000.0   # compressed liquid: every property defined
+
+
+def build():
+    proc = subprocess.run(
+        [sys.executable, "setup_contract.py", "build_ext", "--inplace"],
+        cwd=HERE, capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(
+            "\n*** PDSim cimport contract FAILED TO COMPILE ***\n"
+            "The cimportable State / AbstractState / constants_header surface "
+            "drifted from what PDSim depends on:\n\n"
+            + proc.stdout[-4000:] + "\n" + proc.stderr[-4000:] + "\n")
+        raise SystemExit(1)
+
+
+def check():
+    sys.path.insert(0, HERE)
+    import pdsim_surface
+    from CoolProp.CoolProp import PropsSI
+
+    SI = lambda name: PropsSI(name, "T", T, "Dmass", RHO, FLUID)
+    out = pdsim_surface.exercise(FLUID, T, RHO)
+    g = out["getters"]
+
+    fails = []
+
+    def expect(label, got, want, rel=1e-6):
+        if not math.isclose(got, want, rel_tol=rel):
+            fails.append(f"{label}: got {got:.8g}, want {want:.8g}")
+
+    # --- THE contract: legacy State is kPa/kJ, pAS/Props are SI ---
+    expect("get_p [kPa]", g["p"], SI("P") / 1000.0)
+    expect("get_h [kJ/kg]", g["h"], SI("Hmass") / 1000.0)
+    expect("get_s [kJ/kg/K]", g["s"], SI("Smass") / 1000.0)
+    expect("get_u [kJ/kg]", g["u"], SI("Umass") / 1000.0)
+    expect("get_cp [kJ/kg/K]", g["cp"], SI("Cpmass") / 1000.0)
+    expect("get_cv [kJ/kg/K]", g["cv"], SI("Cvmass") / 1000.0)
+    expect("get_speed_sound [m/s, SI]", g["speed_sound"], SI("speed_of_sound"))
+    expect("get_rho [kg/m^3, SI]", g["rho"], RHO, rel=1e-9)
+
+    expect("cached T_", out["T_"], T, rel=1e-9)
+    expect("cached rho_", out["rho_"], RHO, rel=1e-9)
+    expect("cached p_ (kPa)", out["p_"], g["p"], rel=1e-9)
+
+    expect("Props() [SI]", out["h_via_Props"], SI("Hmass"))
+    expect("pAS.keyed_output [SI]", out["ko_h"], SI("Hmass"))
+    expect("pAS.rhomass [SI]", out["rho_pAS"], RHO, rel=1e-9)
+    expect("pAS.T [SI]", out["T_pAS"], T, rel=1e-9)
+    expect("pAS.cpmass [SI]", out["cp_pAS"], SI("Cpmass"))
+    expect("pAS.cvmass [SI]", out["cv_pAS"], SI("Cvmass"))
+
+    expect("get_dpdT == fpd(iP,iT,iDmolar)/1000", out["dpdT_pAS"] / 1000.0, g["dpdT"])
+    expect("copy().get_h [kJ/kg]", out["h_copy"], SI("Hmass") / 1000.0)
+
+    # two-phase get_Q + construction
+    tp = pdsim_surface.exercise_twophase(FLUID, 373.0, 0.4)
+    expect("two-phase get_Q", tp["Q"], 0.4, rel=1e-9)
+    expect("two-phase p [kPa]", tp["p"],
+           PropsSI("P", "T", 373.0, "Q", 0.4, FLUID) / 1000.0)
+
+    # hot loop (PDSim's inner pattern) just has to run and produce a finite sum
+    acc = pdsim_surface.hot_loop(FLUID, T, RHO, 1000)
+    if not (math.isfinite(acc) and acc != 0.0):
+        fails.append(f"hot_loop returned {acc}")
+
+    if not (out["names"] and FLUID.lower() in out["names"][0].lower()):
+        fails.append(f"fluid_names mismatch: {out['names']}")
+
+    if fails:
+        sys.stderr.write("\n*** PDSim contract VALUE MISMATCHES ***\n  "
+                         + "\n  ".join(fails) + "\n")
+        raise SystemExit(1)
+    print(f"PDSim cimport contract OK: {FLUID} @ T={T} K, rho={RHO} kg/m^3 "
+          f"-- full State/AbstractState/constants surface compiles, links "
+          f"(no -lCoolProp), and matches PropsSI under the legacy kPa/kJ "
+          f"unit convention.")
+
+
+if __name__ == "__main__":
+    build()
+    check()

--- a/dev/pdsim_cimport_contract/setup_contract.py
+++ b/dev/pdsim_cimport_contract/setup_contract.py
@@ -1,0 +1,87 @@
+"""
+Build the PDSim cimport-contract extension against the *installed* CoolProp.
+
+This mirrors exactly how ibell/pdsim builds: include dirs come from the
+installed CoolProp package (its shipped headers + the .pxd cimport surface),
+and crucially there is NO link step against libCoolProp -- the cimported cdef
+classes' methods resolve at runtime through Cython's vtable capsule.  If a
+future v8 build breaks that, this build (and the test) fails.
+
+    python setup_contract.py build_ext --inplace
+"""
+import os
+
+import CoolProp
+from setuptools import Extension, setup
+from Cython.Build import cythonize
+
+pkg = os.path.dirname(CoolProp.__file__)
+site_packages = os.path.dirname(pkg)   # cimport root: `CoolProp.State` etc. resolve here
+include_dirs = [
+    os.path.join(pkg, "include"),   # CoolProp C++ headers (AbstractState.h, ...)
+    pkg,
+    CoolProp.get_include_directory(),
+]
+
+
+def _find_dep_include(header_relpath, env_var, fetch_glob):
+    """STOPGAP for header leakage, not a real PDSim dependency.
+
+    CoolProp's public/cimport surface currently *leaks* fmt and rapidjson as
+    transitive includes (fmt via CPstrings.h's inline format() helpers;
+    rapidjson via constants_header.pxd -> Configuration.h, only for the
+    configuration_keys enum).  Neither appears in any State/AbstractState API
+    signature.  Until the headers are de-leaked (see SURFACE.md finding 3),
+    this build needs the extra -I paths; after that, delete these calls and the
+    contract still compiles with only CoolProp.get_include_directory()."""
+    import glob
+    import subprocess
+    # Search build trees in every checkout that shares this repo: this worktree
+    # AND the main checkout (a fresh worktree has no build*/_deps of its own).
+    roots = [os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 2)))]
+    for cmd in (["git", "rev-parse", "--show-toplevel"],
+                ["git", "rev-parse", "--git-common-dir"]):
+        try:
+            out = subprocess.check_output(cmd, cwd=os.path.dirname(__file__),
+                                          text=True, stderr=subprocess.DEVNULL).strip()
+            if out:
+                # --git-common-dir gives <main>/.git; its parent is the checkout
+                roots.append(os.path.dirname(out) if out.endswith(".git") else out)
+        except Exception:
+            pass
+    candidates = []
+    if os.environ.get(env_var):
+        candidates.append(os.environ[env_var])
+    candidates.append(os.path.join(pkg, "include"))          # the v8 goal: bundled
+    for root in dict.fromkeys(os.path.abspath(r) for r in roots):
+        candidates += glob.glob(os.path.join(root, fetch_glob))
+    candidates += ["/opt/homebrew/include", "/usr/local/include"]
+    for c in candidates:
+        if c and os.path.isfile(os.path.join(c, header_relpath)):
+            return c
+    raise SystemExit(
+        f"PDSim contract: could not find {header_relpath} (a CoolProp header "
+        f"dependency).  Set {env_var} to a dir containing it.")
+
+
+include_dirs.append(_find_dep_include(
+    "fmt/format.h", "COOLPROP_FMT_INCLUDE", "build*/_deps/fmt-src/include"))
+include_dirs.append(_find_dep_include(
+    "rapidjson/rapidjson.h", "COOLPROP_RAPIDJSON_INCLUDE", "build*/_deps/rapidjson-src/include"))
+
+ext = Extension(
+    "pdsim_surface",
+    ["pdsim_surface.pyx"],
+    language="c++",
+    include_dirs=include_dirs,
+    extra_compile_args=["-std=c++17"],   # CoolProp public headers use std::filesystem
+    # No libraries / library_dirs: the contract is link-free by design.
+)
+
+setup(
+    name="pdsim_surface",
+    # cython's include_path must point at the cimport root (site-packages) so
+    # `from CoolProp.State cimport State` and the package's own relative
+    # cimports (`from . cimport constants_header`) both resolve.
+    ext_modules=cythonize([ext], language_level=3, include_path=[site_packages]),
+)

--- a/dev/pdsim_cimport_contract/setup_contract.py
+++ b/dev/pdsim_cimport_contract/setup_contract.py
@@ -48,6 +48,8 @@ def _find_dep_include(header_relpath, env_var, fetch_glob):
                 # --git-common-dir gives <main>/.git; its parent is the checkout
                 roots.append(os.path.dirname(out) if out.endswith(".git") else out)
         except Exception:
+            # git missing / not a repo / command failed: best-effort only, fall
+            # back to the other root candidates (env var, pkg include, system).
             pass
     candidates = []
     if os.environ.get(env_var):

--- a/dev/pdsim_cimport_contract/test_pdsim_contract.py
+++ b/dev/pdsim_cimport_contract/test_pdsim_contract.py
@@ -1,0 +1,32 @@
+"""
+Pytest wrapper for the PDSim cimport contract.
+
+Why a subprocess?  This test must exercise the *installed* CoolProp, but it
+lives in a repo that also contains the uncompiled *source* CoolProp package.
+If the pytest process imported CoolProp directly, sys.path could shadow the
+installed build with the unbuilt source.  So the pytest process imports
+nothing from CoolProp -- it just runs run_contract.py (build + value checks)
+in a subprocess whose cwd makes the installed CoolProp authoritative, and
+asserts it exits 0.
+
+The real guarantees live in run_contract.py / pdsim_surface.pyx:
+  * compile failure  => the cimport surface drifted (PDSim would break)
+  * value mismatch   => the kPa/kJ unit contract drifted (PDSim silently wrong)
+"""
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_pdsim_cimport_contract():
+    proc = subprocess.run(
+        [sys.executable, "run_contract.py"],
+        cwd=HERE, capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, (
+        "PDSim cimport contract failed -- the v8 Cython surface or its unit "
+        "convention drifted from what PDSim depends on:\n\n"
+        + proc.stdout + "\n" + proc.stderr
+    )

--- a/dev/pdsim_cimport_contract/test_pdsim_contract.py
+++ b/dev/pdsim_cimport_contract/test_pdsim_contract.py
@@ -17,10 +17,16 @@ import os
 import subprocess
 import sys
 
+import pytest
+
 HERE = os.path.dirname(os.path.abspath(__file__))
 
 
 def test_pdsim_cimport_contract():
+    # Opt-in: this builds a Cython extension against the *installed* CoolProp via
+    # subprocess, so it must not run in default `pytest` collection / CI sweeps.
+    if not os.environ.get("RUN_PDSIM_CIMPORT_CONTRACT"):
+        pytest.skip("set RUN_PDSIM_CIMPORT_CONTRACT=1 to run (needs installed CoolProp + compiles a shim)")
     proc = subprocess.run(
         [sys.executable, "run_contract.py"],
         cwd=HERE, capture_output=True, text=True,


### PR DESCRIPTION
## Why

PDSim ([ibell/pdsim](https://github.com/ibell/pdsim)) is the one real downstream consumer of CoolProp's **Cython `cimport` surface** — it `cimport`s `State` / `AbstractState` / `constants_header` and calls their methods at C speed inside its ODE loops. Before reworking CoolProp's Python wrapper (the v8 plan: a nanobind/pybind11 core plus a thin frozen `State` shim), we want a mechanical guarantee that **PDSim need not change**.

This adds that guarantee as a compile-and-run contract test under `dev/pdsim_cimport_contract/`. It adds **no C++** and modifies no existing files — purely additive.

## What it does

- **`pdsim_surface.pyx`** — a miniature of PDSim's exact usage, extracted from `ibell/pdsim`, that `cimport`s the full surface PDSim depends on. Notably this includes reaching **through `State.pAS` to `AbstractState`** (24 call sites in PDSim — `keyed_output`, `rhomass`, `cpmass`, `cvmass`, `first_partial_deriv`, …), not just `State`.
- **`run_contract.py` / `test_pdsim_contract.py`** — build that module against the **installed** CoolProp (link-free: no `-lCoolProp`; the cdef-class methods resolve at runtime via Cython's vtable capsule), then check values against `PropsSI`.
- **`SURFACE.md`** — the extracted-surface manifest and findings.

## The two guard rails

1. **Surface drift → compile failure.** If a future change alters the cimportable `State`/`AbstractState`/`constants_header` declarations, the contract module fails to compile and the test errors out. No manual API diffing.
2. **Unit-convention drift → value failure.** The legacy `State` getters return **kPa / kJ** (`get_p = p()/1000`, `get_h = hmass()/1000`, …), while `get_rho`/`speed_sound` and everything via `.pAS`/`Props()` are **SI**. PDSim is written against this split, so a shim that forwarded SI without the `/1000` factors would make PDSim silently wrong by 1000× **with no crash** — the most dangerous possible regression. The value checks lock this exact convention.

## Findings surfaced (documented in SURFACE.md, not fixed here)

- The public headers **leak fmt and rapidjson** as transitive includes (fmt via `CPstrings.h`'s inline `format()` helpers; rapidjson via `constants_header.pxd → Configuration.h`, only to read the `configuration_keys` enum). Neither appears in any `State`/`AbstractState` API signature. They're removable with header hygiene — which also **unblocks retiring rapidjson** (last release ~2016), since once it's absent from the public surface, swapping it is a pure implementation change. The fmt/rapidjson include discovery in `setup_contract.py` is a documented **stopgap**; once the headers are de-leaked, deleting it leaves the contract compiling with only `CoolProp.get_include_directory()`, and this test becomes the regression guard that the leak hasn't returned.
- No `CoolProp/__init__.pxd` ships, so external `cimport` only resolves with cython's `include_path` at the cimport root. v8 should ship one.

## Notes for reviewers

- It's a **developer/opt-in tool**, not yet wired into the hard CI gate, because it needs the installed CoolProp plus (today) the stopgap fmt/rapidjson include paths. Run it with `python dev/pdsim_cimport_contract/run_contract.py`.
- Verified green locally (Water @ 320 K, 1000 kg/m³, compressed liquid). `dev/ci/preflight.sh --skip=build` reports 0 failures (no C/C++ in diff).

Tracked by bd `CoolProp-ppj9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an automated contract test and a standalone contract runner to validate Cython interface behavior (single-phase, two-phase, and performance loop) against the installed library.

* **Documentation**
  * Added detailed documentation describing the expected Cython interface surface, required imports, state behaviors, and how to run the contract checks.

* **Chores**
  * Added a build helper for compiling the contract extension and updated ignore rules to exclude build artifacts and generated files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->