### PR TITLE
fix(svdsbtl): log-scale DmassT secondary axis to fix low-density pressure error (CoolProp-wvtz)

### DIFF
--- a/include/CoolProp/region/Region.h
+++ b/include/CoolProp/region/Region.h
@@ -18,8 +18,18 @@ namespace region {
 //     interval.
 //   - Secondary axis b is bounded below by `b_lo(a)` and above by
 //     `b_hi(a)`, two BoundaryCurves that are explicit functions of a.
-//     The normalised coordinate eta = (b - b_lo(a)) / (b_hi(a) - b_lo(a))
-//     lives in [0, 1] when (a, b) is inside the region.
+//     The normalised coordinate eta lives in [0, 1] when (a, b) is inside
+//     the region.  Its scale is selectable (default LINEAR):
+//       LINEAR : eta = (b - b_lo(a)) / (b_hi(a) - b_lo(a))
+//       LOG    : eta = (log b - log b_lo(a)) / (log b_hi(a) - log b_lo(a))
+//     LOG is the right choice when b spans orders of magnitude *and* the
+//     tabulated property tracks b geometrically — e.g. the DmassT preset's
+//     VAPOR/SUPER regions, where rho_hi/rho_lo ~ 1e5 and p ∝ rho in the
+//     ideal-gas tail.  Under LINEAR that tail collapses below the first
+//     grid node and the EXP-SVD can't resolve the multi-decade pressure
+//     swing (CoolProp-wvtz); LOG gives it uniform-in-decade resolution.
+//     Only LINEAR and LOG are supported on the secondary axis (the POWER
+//     scales are primary-axis-only).
 //
 // Dispatch:
 //   `aabb_contains` is the cheap first-pass filter — four comparisons
@@ -45,7 +55,11 @@ class Region
         double b_max;
     };
 
-    Region(AxisTransform primary, std::unique_ptr<BoundaryCurve> b_lo, std::unique_ptr<BoundaryCurve> b_hi);
+    // secondary_scale selects how eta normalises the secondary axis
+    // (LINEAR default; LOG for wide-dynamic-range axes — see class
+    // docstring).  Throws std::invalid_argument for any other scale.
+    Region(AxisTransform primary, std::unique_ptr<BoundaryCurve> b_lo, std::unique_ptr<BoundaryCurve> b_hi,
+           AxisScale secondary_scale = AxisScale::LINEAR);
 
     Region(const Region&) = delete;
     Region& operator=(const Region&) = delete;
@@ -77,6 +91,9 @@ class Region
     [[nodiscard]] const AxisTransform& primary() const noexcept {
         return primary_;
     }
+    [[nodiscard]] AxisScale secondary_scale() const noexcept {
+        return secondary_scale_;
+    }
     [[nodiscard]] const BoundaryCurve& b_lo() const noexcept {
         return *b_lo_;
     }
@@ -89,6 +106,7 @@ class Region
 
    private:
     AxisTransform primary_;
+    AxisScale secondary_scale_;
     std::unique_ptr<BoundaryCurve> b_lo_;
     std::unique_ptr<BoundaryCurve> b_hi_;
     BBox bbox_;

--- a/include/CoolProp/sbtl/SVDSurfaceSerializer.h
+++ b/include/CoolProp/sbtl/SVDSurfaceSerializer.h
@@ -186,7 +186,19 @@ class SVDSurfaceSerializer
     //           large enough to keep the SuperAncillary sat-curve
     //           well-defined, and tightening reduces the patch-only
     //           sliver around pc.
-    static constexpr int kRevision = 15;
+    //   rev 16: CoolProp-wvtz.  Region gains a selectable secondary-axis
+    //           (eta) scale, packed as a 9th region-blob element.  The
+    //           DmassT preset's VAPOR + SUPER regions switch to
+    //           AxisScale::LOG so the near-ideal-gas low-density tail
+    //           (rho_hi/rho_lo ~ 1e5, p ∝ rho) gets uniform-in-decade
+    //           sampling instead of collapsing below the first linear-eta
+    //           grid node.  The stored grid sample positions and U/slopes
+    //           for those regions change, and the on-wire region array
+    //           grows from 8 to 9 elements, so rev-15 caches must rebuild.
+    //           HEOS DmassT low-density pressure error drops from
+    //           ~40 %–2400 % to ~1e-5.  PT / HmassP surfaces are
+    //           byte-identical (their regions stay LINEAR).
+    static constexpr int kRevision = 16;
 
     // Pack one surface into a zlib-compressed msgpack blob.
     static std::vector<char> save(const SVDSurface& surface);

--- a/include/CoolProp/sbtl/SurfaceSpec.h
+++ b/include/CoolProp/sbtl/SurfaceSpec.h
@@ -31,10 +31,14 @@ struct RegionSpec
     region::AxisTransform primary{region::AxisScale::LINEAR, 0.0, 1.0, 0.0, 1.0, 1.0};
     std::unique_ptr<region::BoundaryCurve> b_lo;
     std::unique_ptr<region::BoundaryCurve> b_hi;
+    // Secondary-axis (eta) normalisation scale.  LINEAR by default; set
+    // LOG for wide-dynamic-range secondary axes (see region::Region).
+    region::AxisScale secondary{region::AxisScale::LINEAR};
 
     RegionSpec() = default;
-    RegionSpec(region::AxisTransform p, std::unique_ptr<region::BoundaryCurve> lo, std::unique_ptr<region::BoundaryCurve> hi)
-      : primary(p), b_lo(std::move(lo)), b_hi(std::move(hi)) {}
+    RegionSpec(region::AxisTransform p, std::unique_ptr<region::BoundaryCurve> lo, std::unique_ptr<region::BoundaryCurve> hi,
+               region::AxisScale sec = region::AxisScale::LINEAR)
+      : primary(p), b_lo(std::move(lo)), b_hi(std::move(hi)), secondary(sec) {}
     RegionSpec(const RegionSpec&) = delete;
     RegionSpec& operator=(const RegionSpec&) = delete;
     RegionSpec(RegionSpec&&) = default;

--- a/src/Region/Region.cpp
+++ b/src/Region/Region.cpp
@@ -23,20 +23,37 @@ Region::BBox compute_bbox(const AxisTransform& primary, const BoundaryCurve& b_l
 // check to the hot path.
 constexpr Region::BBox kEmptyBBox = {1.0, -1.0, 1.0, -1.0};
 
-Region::Region(AxisTransform primary, std::unique_ptr<BoundaryCurve> b_lo, std::unique_ptr<BoundaryCurve> b_hi)
-  : primary_(primary), b_lo_(std::move(b_lo)), b_hi_(std::move(b_hi)), bbox_((b_lo_ && b_hi_) ? compute_bbox(primary_, *b_lo_, *b_hi_) : kEmptyBBox) {
+Region::Region(AxisTransform primary, std::unique_ptr<BoundaryCurve> b_lo, std::unique_ptr<BoundaryCurve> b_hi, AxisScale secondary_scale)
+  : primary_(primary),
+    secondary_scale_(secondary_scale),
+    b_lo_(std::move(b_lo)),
+    b_hi_(std::move(b_hi)),
+    bbox_((b_lo_ && b_hi_) ? compute_bbox(primary_, *b_lo_, *b_hi_) : kEmptyBBox) {
     if (!b_lo_ || !b_hi_) {
         throw std::invalid_argument("Region: b_lo and b_hi BoundaryCurves must be non-null");
     }
+    // The secondary axis only supports the two scales whose forward/
+    // inverse maps are closed-form on dynamic [b_lo(a), b_hi(a)] bounds.
+    // POWER / POWER_LO are anchored to a fixed critical-scaling endpoint
+    // and are primary-axis-only.
+    if (secondary_scale_ != AxisScale::LINEAR && secondary_scale_ != AxisScale::LOG) {
+        throw std::invalid_argument("Region: secondary axis scale must be LINEAR or LOG");
+    }
 }
 
-Region::Region(Region&& other) noexcept : primary_(other.primary_), b_lo_(std::move(other.b_lo_)), b_hi_(std::move(other.b_hi_)), bbox_(other.bbox_) {
+Region::Region(Region&& other) noexcept
+  : primary_(other.primary_),
+    secondary_scale_(other.secondary_scale_),
+    b_lo_(std::move(other.b_lo_)),
+    b_hi_(std::move(other.b_hi_)),
+    bbox_(other.bbox_) {
     other.bbox_ = kEmptyBBox;
 }
 
 Region& Region::operator=(Region&& other) noexcept {
     if (this != &other) {
         primary_ = other.primary_;
+        secondary_scale_ = other.secondary_scale_;
         b_lo_ = std::move(other.b_lo_);
         b_hi_ = std::move(other.b_hi_);
         bbox_ = other.bbox_;
@@ -61,14 +78,22 @@ std::pair<double, double> Region::to_normalized(double a, double b) const noexce
     const double xi = primary_.forward(a);
     const double b_lo_val = b_lo_->eval(a);
     const double b_hi_val = b_hi_->eval(a);
-    const double span = b_hi_val - b_lo_val;
+    // Apply the secondary scale to the value and both bounds, then
+    // normalise linearly in the transformed coordinate.  LINEAR is the
+    // identity (g = id); LOG uses g = std::log (b_lo_val > 0 holds for
+    // every density / pressure secondary axis that opts into LOG — a
+    // non-positive argument yields NaN, treated as an out-of-region miss).
+    const double gb = (secondary_scale_ == AxisScale::LOG) ? std::log(b) : b;
+    const double g_lo = (secondary_scale_ == AxisScale::LOG) ? std::log(b_lo_val) : b_lo_val;
+    const double g_hi = (secondary_scale_ == AxisScale::LOG) ? std::log(b_hi_val) : b_hi_val;
+    const double span = g_hi - g_lo;
     // Guard against a degenerate boundary span: if the two curves
     // converge at this a (e.g. a critical-point pinch), eta is
     // undefined.  Return NaN so callers see an obvious failure rather
     // than a silently-wrong eta = 0 that propagates into an SVD lookup
     // and produces garbage with no signal.
-    const double tol = std::numeric_limits<double>::epsilon() * (1.0 + std::abs(b_lo_val) + std::abs(b_hi_val));
-    const double eta = (std::abs(span) <= tol) ? std::numeric_limits<double>::quiet_NaN() : ((b - b_lo_val) / span);
+    const double tol = std::numeric_limits<double>::epsilon() * (1.0 + std::abs(g_lo) + std::abs(g_hi));
+    const double eta = (std::abs(span) <= tol) ? std::numeric_limits<double>::quiet_NaN() : ((gb - g_lo) / span);
     return {xi, eta};
 }
 
@@ -76,7 +101,18 @@ std::pair<double, double> Region::from_normalized(double xi, double eta) const n
     const double a = primary_.inverse(xi);
     const double b_lo_val = b_lo_->eval(a);
     const double b_hi_val = b_hi_->eval(a);
-    const double b = b_lo_val + eta * (b_hi_val - b_lo_val);
+    // Inverse of to_normalized's secondary map.  LINEAR: b = b_lo +
+    // eta·(b_hi − b_lo).  LOG: interpolate in log space then exponentiate,
+    // i.e. b = b_lo·(b_hi / b_lo)^eta — the geometric mean weighting that
+    // gives the ideal-gas tail uniform-in-decade sample spacing.
+    double b = 0.0;
+    if (secondary_scale_ == AxisScale::LOG) {
+        const double g_lo = std::log(b_lo_val);
+        const double g_hi = std::log(b_hi_val);
+        b = std::exp(g_lo + eta * (g_hi - g_lo));
+    } else {
+        b = b_lo_val + eta * (b_hi_val - b_lo_val);
+    }
     return {a, b};
 }
 

--- a/src/SBTL/SVDSurfaceFactory.cpp
+++ b/src/SBTL/SVDSurfaceFactory.cpp
@@ -296,7 +296,7 @@ SVDSurface build_surface(::CoolProp::AbstractState& heos, SurfaceSpec spec, cons
     for (std::size_t r = 0; r < spec.regions.size(); ++r) {
         // Move the RegionSpec's boundary curves into a real Region,
         // then immediately add it to the surface.
-        region::Region region(spec.regions[r].primary, std::move(spec.regions[r].b_lo), std::move(spec.regions[r].b_hi));
+        region::Region region(spec.regions[r].primary, std::move(spec.regions[r].b_lo), std::move(spec.regions[r].b_hi), spec.regions[r].secondary);
         // Sample HEOS for this region BEFORE moving it into the
         // surface — we need the (a, b) → from_normalized while we
         // still hold an immediate reference.

--- a/src/SBTL/SVDSurfaceSerializer.cpp
+++ b/src/SBTL/SVDSurfaceSerializer.cpp
@@ -156,7 +156,7 @@ void pack_decomp(Packer& pk, std::size_t region_idx, ::CoolProp::parameters prop
 template <typename Packer>
 void pack_region(Packer& pk, const region::Region& r) {
     const auto& axis = r.primary();
-    pk.pack_array(8);
+    pk.pack_array(9);
     pk.pack(static_cast<std::uint8_t>(axis.scale));
     pk.pack(axis.a_lo);
     pk.pack(axis.a_hi);
@@ -165,6 +165,9 @@ void pack_region(Packer& pk, const region::Region& r) {
     pk.pack(axis.inv_span_t);
     pack_curve(pk, r.b_lo());
     pack_curve(pk, r.b_hi());
+    // Secondary-axis (eta) scale — element [8], appended in rev 16.
+    // LINEAR (0) for every pre-rev-16 surface; DmassT VAPOR/SUPER use LOG.
+    pk.pack(static_cast<std::uint8_t>(r.secondary_scale()));
 }
 
 template <typename Packer>
@@ -310,7 +313,10 @@ std::unique_ptr<region::BoundaryCurve> unpack_curve(const msgpack::object& o,
 }
 
 region::Region unpack_region(const msgpack::object& o, const std::shared_ptr<region::SuperancillaryBoundaryCurve::SuperAncillary_t>& sa) {
-    check_array(o, 8, "region");
+    // 9 elements since rev 16 (secondary-axis scale at [8]).  The load()
+    // revision gate rejects pre-rev-16 streams before they reach here, so
+    // the 9th element is always present.
+    check_array(o, 9, "region");
     const auto scale = static_cast<region::AxisScale>(as<std::uint8_t>(o.via.array.ptr[0]));
     const auto a_lo = as<double>(o.via.array.ptr[1]);
     const auto a_hi = as<double>(o.via.array.ptr[2]);
@@ -320,7 +326,8 @@ region::Region unpack_region(const msgpack::object& o, const std::shared_ptr<reg
     // trip diagnostics only.
     auto b_lo = unpack_curve(o.via.array.ptr[6], sa);
     auto b_hi = unpack_curve(o.via.array.ptr[7], sa);
-    return {axis, std::move(b_lo), std::move(b_hi)};
+    const auto secondary = static_cast<region::AxisScale>(as<std::uint8_t>(o.via.array.ptr[8]));
+    return {axis, std::move(b_lo), std::move(b_hi), secondary};
 }
 
 svd::SVDDecomposition unpack_decomp(const msgpack::object& o, std::size_t* out_region_idx, ::CoolProp::parameters* out_prop) {

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -1079,7 +1079,11 @@ SurfaceSpec dt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
         auto axis = region::AxisTransform::make(region::AxisScale::LINEAR, T_sub_lo, T_sub_hi);
         auto b_lo = build_rho_min_envelope(heos, T_sub_lo, T_sub_hi, p_min_eos);
         auto b_hi = build_rho_sat_V(heos, T_sub_lo, T_sub_hi);
-        spec.regions.emplace_back(axis, std::move(b_lo), std::move(b_hi));
+        // LOG secondary: rho spans from the near-ideal-gas floor
+        // rho(T, p_min_eos) up to rho_sat,V — orders of magnitude at low
+        // T — and p ∝ rho there.  Linear-eta strands that tail below the
+        // first grid node (CoolProp-wvtz); log-eta resolves it.
+        spec.regions.emplace_back(axis, std::move(b_lo), std::move(b_hi), region::AxisScale::LOG);
     }
     // SUPER (T > T_critical).  Secondary D bounded by the two HEOS-
     // validity isobars.  No dome above Tc — single region across the
@@ -1091,7 +1095,11 @@ SurfaceSpec dt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
         auto axis = region::AxisTransform::make(region::AxisScale::LINEAR, T_sup_lo, T_sup_hi);
         auto b_lo = build_rho_min_envelope(heos, T_sup_lo, T_sup_hi, p_min_eos);
         auto b_hi = build_rho_max_envelope(heos, T_sup_lo, T_sup_hi, p_max_target, WalkFloor::CRITICAL);
-        spec.regions.emplace_back(axis, std::move(b_lo), std::move(b_hi));
+        // LOG secondary: rho_hi/rho_lo ~ 1e5 here (ideal-gas floor to
+        // compressed-supercritical ceiling) with p ∝ rho in the tail.
+        // This is the region whose low-rho edge dominated the DT
+        // validation error band (CoolProp-wvtz).
+        spec.regions.emplace_back(axis, std::move(b_lo), std::move(b_hi), region::AxisScale::LOG);
     }
 
     spec.update_state = [](::CoolProp::AbstractState& s, double T, double D) {

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -1304,6 +1304,57 @@ TEST_CASE("SVDSBTL DT-indexed surface builds and evaluates for CO2", "[SBTL][SVD
     }
 }
 
+// Regression gate for CoolProp-wvtz: the low-density (near-ideal-gas)
+// edge of the DT preset's VAPOR/SUPER regions.  The secondary (density)
+// axis is normalised η = (ρ − ρ_lo)/(ρ_hi − ρ_lo); with a LINEAR scale
+// and ρ_hi/ρ_lo ~ 1e5 the entire ideal-gas tail (where p ∝ ρ sweeps
+// several decades) collapses below the first sampled grid node, so the
+// EXP-SVD extrapolates and p(ρ, T) was off by 40 %–2400 % there
+// (SVDSBTLValidation DT panels showed a high-error band at low ρ).
+// A LOG secondary axis (this fix) gives the tail real resolution and
+// makes log p ≈ log ρ + const linear in η, so the EXP-SVD is near-exact.
+// Probe densities are derived from a low p_target via HEOS PT so they
+// land in genuine single-phase low-ρ territory, mirroring the validation
+// methodology.
+TEST_CASE("SVDSBTL DT low-density pressure matches HEOS (CoolProp-wvtz)", "[SBTL][SVDSBTL][dt][low_density][regression][slow]") {
+    struct Case
+    {
+        const char* fluid;
+        double T_factor;  // probe temperature as a multiple of Tc
+        const char* region;
+    };
+    // Reliably-broken pre-fix cases (rev-15 linear-η): Water's wide SUPER/
+    // VAPOR regions show 20×–2000× error in the first cell; Argon's SUPER
+    // shows ~17 %.  Each probe sits just above the region's low-density
+    // floor ρ_lo — exactly where the validation heatmap's left edge lives.
+    for (const Case& c : {Case{"Water", 1.05, "SUPER"}, Case{"Water", 0.85, "VAPOR"}, Case{"Argon", 1.05, "SUPER"}}) {
+        auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", c.fluid));
+        auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", c.fluid));
+        const double T = c.T_factor * heos->T_critical();
+
+        // Replicate the preset's low-density floor: p_min_eos ≈ p_sat at
+        // the triple point.  ρ_lo = ρ(T, p_floor) is the region's bottom
+        // boundary; probe a hair above it (1.3·ρ_lo) so the point is
+        // unambiguously inside the atlas yet inside the first η cell, the
+        // near-ideal-gas tail where the linear-η surface failed.
+        heos->update(CoolProp::QT_INPUTS, 0.0, heos->Ttriple() * 1.001);
+        const double p_floor = heos->p() * 1.02;
+        heos->update(CoolProp::PT_INPUTS, p_floor, T);
+        const double rho = 1.3 * heos->rhomass();
+
+        heos->update(CoolProp::DmassT_INPUTS, rho, T);
+        const double p_ref = heos->p();
+        svd->update(CoolProp::DmassT_INPUTS, rho, T);
+        const double p_svd = svd->p();
+        INFO(c.fluid << " " << c.region << " T=" << T << " ρ=" << rho << " p_ref=" << p_ref << " p_svd=" << p_svd
+                     << " rel_err=" << std::abs(p_svd - p_ref) / p_ref);
+        CHECK(std::isfinite(p_svd));
+        CHECK(p_svd > 0.0);
+        CHECK(p_svd == Approx(p_ref).epsilon(5e-3));
+        CHECK(svd->rhomass() == rho);  // density input echoed back
+    }
+}
+
 // Regression gate for issue #1301 (CoolProp-i7j): a random (T, ρ)
 // sweep over yufang67's exact bounds (T ∈ [220, 500] K, ρ ∈ [0.01,
 // 1200] kg/m³) spanning subcritical liquid / vapor / two-phase dome


### PR DESCRIPTION
## Problem

The SVDSBTL **DmassT (ρ,T)** validation panels show a high-error band on the **low-density (left) edge** for many fluids — Water/Argon/Hydrogen/D6 had p90 pressure errors of **10–23%**, with the worst corners up to **2400×**. The liquid side was already excellent (~1e-8).

**Root cause** (confirmed by an instrumented (T,ρ) sweep, not assumed): the DmassT preset normalised its secondary (density) axis **linearly**, `η = (ρ − ρ_lo)/(ρ_hi − ρ_lo)`. In the VAPOR/SUPER regions `ρ_hi/ρ_lo ~ 1e5` (near-ideal-gas floor at ρ(T,p_triple) up to the compressed ceiling) while **p ∝ ρ** in the tail, so the entire ideal-gas tail collapsed *below the first sampled grid node* and the rank-truncated EXP-SVD extrapolated — returning a flat, wrong pressure. The error is a clean monotone function of η: catastrophic in the first cell, then ≤1e-5 everywhere past the first grid line.

This is **not** the liquid boundary-residual ceiling of CoolProp-8vg (that's a ~1e-8 effect); it's a grid-resolution/axis-scaling issue the DmassT preset author already flagged as the "low-D ideal-gas territory not covered" gap.

## Fix

Make the secondary η scale **selectable**: `region::Region` gains an `AxisScale` member (LINEAR default, **LOG** supported), applied in `to_normalized`/`from_normalized`. The DmassT **VAPOR + SUPER** regions opt into LOG, giving the ideal-gas tail uniform-in-decade resolution; since `log p ≈ log ρ + const` there, the EXP-SVD becomes near-exact. **LIQUID stays LINEAR** (already ~1e-8). PT/HmassP surfaces are **byte-identical** (their regions stay LINEAR).

The change threads a `secondary` field through `RegionSpec` → the factory, serializes a 9th region-blob element, and bumps the serializer revision **15 → 16** to invalidate stale linear-η DmassT caches (handled transparently by the existing rebuild-on-load-failure path).

## Result

| Probe | before | after |
|---|---|---|
| Water VAPOR low-ρ | ~32× | **6.6e-14** |
| Water SUPER low-ρ | ~2240× | ~1e-5 |
| Argon SUPER low-ρ | ~0.17 | **3.2e-7** |

## Verification

- New `[low_density]` regression test (Water SUPER/VAPOR + Argon SUPER), probes derived from the region's actual ρ_lo floor so they're unambiguously in-envelope and in the first η cell.
- Full **`[SBTL]` suite: 4750 assertions pass**, no regression in DT LIQUID/dome/high-ρ, PT, HP, or the serializer cache round-trip.
- `./dev/ci/preflight.sh`: 6/6 green (clang-format 18.1.8, build, tests, cppcheck, clang-tidy, semgrep).
- Adversarial code review: no blocking findings (LOG round-trip exactness, move-op member order, serializer slot alignment, defaulted-arg back-compat, noexcept safety all verified).

## Follow-up (not in this PR)

Regenerate `Web/coolprop/SVDSBTLValidation.ipynb` to refresh the published DT panels (the docs build re-executes it; needs the Python wrapper rebuilt with this change).

Closes CoolProp-wvtz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secondary axis normalization now supports configurable scaling modes (LINEAR and LOG).
  * Low-density vapor and super regions now use logarithmic scaling for improved accuracy.

* **Tests**
  * Added regression test for low-density pressure behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->