### PR TITLE
feat(svdsbtl): close the DmassT near-critical temperature gap with NC table regions (CoolProp-4z79)

### DIFF
--- a/include/CoolProp/sbtl/SVDSurfaceSerializer.h
+++ b/include/CoolProp/sbtl/SVDSurfaceSerializer.h
@@ -198,7 +198,17 @@ class SVDSurfaceSerializer
     //           HEOS DmassT low-density pressure error drops from
     //           ~40 %–2400 % to ~1e-5.  PT / HmassP surfaces are
     //           byte-identical (their regions stay LINEAR).
-    static constexpr int kRevision = 16;
+    //   rev 17: CoolProp-4z79.  The DmassT preset gains three near-critical
+    //           (NC) sub-regions that close the previously-uncovered
+    //           ±0.1%·Tc band: POWER-axis NC_LIQUID/NC_VAPOR carry the
+    //           dome-bounded sides up to ~Tc, and a POWER_LO isobar-bounded
+    //           NC_SUPER spans the critical isotherm itself.  HEOS-source
+    //           DmassT region count grows (3 → 6), so the on-wire region
+    //           list differs and rev-16 caches must rebuild.  The whole
+    //           [0.99,1.01]·Tc band is now table-served (no HEOS) to
+    //           ~1e-6..2e-5 for all fluids.  PT / HmassP and the non-DmassT
+    //           presets are unchanged.
+    static constexpr int kRevision = 17;
 
     // Pack one surface into a zlib-compressed msgpack blob.
     static std::vector<char> save(const SVDSurface& surface);

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -1142,6 +1142,86 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
         }
     }
 
+    // --- DT dome PRE-CHECK (must run BEFORE the atlas resolve).  For
+    // DmassT / DmolarT a point with T < T_critical and rho between the
+    // saturation densities (rho_sat,V(T) < D < rho_sat,L(T)) is two-phase.
+    // The dome-bounded LIQUID/VAPOR/NC regions stop at the sat boundary,
+    // but the isobar-bounded NC_SUPER region (CoolProp-4z79) dips below Tc
+    // and its AABB SPANS the dome, so without this pre-check a dome point
+    // would atlas-resolve to NC_SUPER and be read as single-phase off an
+    // interpolated-across-the-dome surface value instead of P_sat(T).
+    // P is well-defined (= P_sat(T)); Q comes from the lever rule on
+    // specific volume (NOT density — v is the additive quantity).  Routes
+    // through the same DomeBlend machinery the HmassP path uses;
+    // evaluate_property_ reads p / Q / blended caloric props off the
+    // endpoints. ---
+    if (input_pair == CoolProp::DmassT_INPUTS || input_pair == CoolProp::DmolarT_INPUTS) {
+        const double T_query = *pt.T;
+        const double M = calc_molar_mass();
+        const double rho_mol_query = *pt.rho_mass / M;
+        try {
+            auto src = source_reference_();
+            if (T_query < src->T_critical()) {
+                // rho_sat endpoints at T.  sat_eval_('D', ...) returns
+                // MOLAR density (mol/m^3) — same basis as the HmassP
+                // dome path's rhoL_mol / rhoV_mol.  Mirror that path's
+                // source-QT fallback: when the SA/surrogate sat provider
+                // can't supply an endpoint, take it from the source QT
+                // flash so DT two-phase queries still resolve on sources
+                // without a usable saturation provider.
+                double rhoL_mol = sat_eval_(T_query, 'D', 0);
+                double rhoV_mol = sat_eval_(T_query, 'D', 1);
+                if (!std::isfinite(rhoL_mol) || !std::isfinite(rhoV_mol)) {
+                    src->update(CoolProp::QT_INPUTS, 0.0, T_query);
+                    rhoL_mol = src->rhomolar();
+                    src->update(CoolProp::QT_INPUTS, 1.0, T_query);
+                    rhoV_mol = src->rhomolar();
+                }
+                if (std::isfinite(rhoL_mol) && std::isfinite(rhoV_mol) && rhoV_mol < rho_mol_query && rho_mol_query < rhoL_mol) {
+                    // Two-phase.  P_sat(T) from the source QT flash.
+                    src->update(CoolProp::QT_INPUTS, 0.0, T_query);
+                    const double p_sat = src->p();
+                    pt.kind = PointEvaluation::Kind::DomeBlend;
+                    pt.status = CoolProp::fast_evaluate_ok;
+                    pt.p = p_sat;
+                    pt.T = T_query;
+                    pt.T_sat = T_query;
+                    // Lever rule on specific volume (the additive
+                    // quantity): v = (1-Q)*vL + Q*vV.  Q is basis-
+                    // independent, so molar volumes give the same Q.
+                    const double v = 1.0 / rho_mol_query;
+                    const double vL = 1.0 / rhoL_mol;
+                    const double vV = 1.0 / rhoV_mol;
+                    pt.Q = (v - vL) / (vV - vL);
+                    // sat_eval_('H', ...) is already molar — don't scale.
+                    // Same source-QT fallback as the rho endpoints above.
+                    double hL_mol = sat_eval_(T_query, 'H', 0);
+                    double hV_mol = sat_eval_(T_query, 'H', 1);
+                    if (!std::isfinite(hL_mol) || !std::isfinite(hV_mol)) {
+                        src->update(CoolProp::QT_INPUTS, 0.0, T_query);
+                        hL_mol = src->hmolar();
+                        src->update(CoolProp::QT_INPUTS, 1.0, T_query);
+                        hV_mol = src->hmolar();
+                    }
+                    pt.hL_mol = hL_mol;
+                    pt.hV_mol = hV_mol;
+                    pt.rhoL_mol = rhoL_mol;
+                    pt.rhoV_mol = rhoV_mol;
+                    // Fill h_mass from the lever rule so iHmass/iHmolar
+                    // resolve via the top-level short-circuit (the
+                    // DomeBlend switch has no enthalpy arm — it
+                    // delegates to pt.h_mass, which the HmassP dome
+                    // path sets at resolve time and we must mirror).
+                    pt.h_mass = ((1.0 - pt.Q) * *pt.hL_mol + pt.Q * *pt.hV_mol) / M;
+                    return pt;
+                }
+            }
+        } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
+            // Sat endpoints / source unavailable — fall through to the
+            // atlas resolve (best available; a true dome point is rare).
+        }
+    }
+
     // Atlas resolve.  region_idx < 0 means the point landed inside
     // the saturation dome (for HmassP) or outside every region's bbox
     // (for PT or genuinely OOB HmassP).
@@ -1235,81 +1315,6 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
         }
     }
 
-    // --- DT dome routing.  For DmassT / DmolarT an atlas miss inside
-    // the subcritical envelope means the (D, T) point landed in the
-    // two-phase dome (rho_sat,V(T) < D < rho_sat,L(T)).  The LIQUID /
-    // VAPOR sub-regions stop at the dome boundary by construction, so
-    // any miss with T < T_critical and D between the sat densities is
-    // two-phase.  P is well-defined (= P_sat(T)); Q comes from the
-    // lever rule on specific volume (NOT density — v is the additive
-    // quantity).  Routes through the same DomeBlend machinery the
-    // HmassP path uses; evaluate_property_ reads p / Q / blended
-    // caloric props off the endpoints. ---
-    if (input_pair == CoolProp::DmassT_INPUTS || input_pair == CoolProp::DmolarT_INPUTS) {
-        const double T_query = *pt.T;
-        const double M = calc_molar_mass();
-        const double rho_mol_query = *pt.rho_mass / M;
-        try {
-            auto src = source_reference_();
-            if (T_query < src->T_critical()) {
-                // rho_sat endpoints at T.  sat_eval_('D', ...) returns
-                // MOLAR density (mol/m^3) — same basis as the HmassP
-                // dome path's rhoL_mol / rhoV_mol.  Mirror that path's
-                // source-QT fallback: when the SA/surrogate sat provider
-                // can't supply an endpoint, take it from the source QT
-                // flash so DT two-phase queries still resolve on sources
-                // without a usable saturation provider.
-                double rhoL_mol = sat_eval_(T_query, 'D', 0);
-                double rhoV_mol = sat_eval_(T_query, 'D', 1);
-                if (!std::isfinite(rhoL_mol) || !std::isfinite(rhoV_mol)) {
-                    src->update(CoolProp::QT_INPUTS, 0.0, T_query);
-                    rhoL_mol = src->rhomolar();
-                    src->update(CoolProp::QT_INPUTS, 1.0, T_query);
-                    rhoV_mol = src->rhomolar();
-                }
-                if (std::isfinite(rhoL_mol) && std::isfinite(rhoV_mol) && rhoV_mol < rho_mol_query && rho_mol_query < rhoL_mol) {
-                    // Two-phase.  P_sat(T) from the source QT flash.
-                    src->update(CoolProp::QT_INPUTS, 0.0, T_query);
-                    const double p_sat = src->p();
-                    pt.kind = PointEvaluation::Kind::DomeBlend;
-                    pt.status = CoolProp::fast_evaluate_ok;
-                    pt.p = p_sat;
-                    pt.T = T_query;
-                    pt.T_sat = T_query;
-                    // Lever rule on specific volume (the additive
-                    // quantity): v = (1-Q)*vL + Q*vV.  Q is basis-
-                    // independent, so molar volumes give the same Q.
-                    const double v = 1.0 / rho_mol_query;
-                    const double vL = 1.0 / rhoL_mol;
-                    const double vV = 1.0 / rhoV_mol;
-                    pt.Q = (v - vL) / (vV - vL);
-                    // sat_eval_('H', ...) is already molar — don't scale.
-                    // Same source-QT fallback as the rho endpoints above.
-                    double hL_mol = sat_eval_(T_query, 'H', 0);
-                    double hV_mol = sat_eval_(T_query, 'H', 1);
-                    if (!std::isfinite(hL_mol) || !std::isfinite(hV_mol)) {
-                        src->update(CoolProp::QT_INPUTS, 0.0, T_query);
-                        hL_mol = src->hmolar();
-                        src->update(CoolProp::QT_INPUTS, 1.0, T_query);
-                        hV_mol = src->hmolar();
-                    }
-                    pt.hL_mol = hL_mol;
-                    pt.hV_mol = hV_mol;
-                    pt.rhoL_mol = rhoL_mol;
-                    pt.rhoV_mol = rhoV_mol;
-                    // Fill h_mass from the lever rule so iHmass/iHmolar
-                    // resolve via the top-level short-circuit (the
-                    // DomeBlend switch has no enthalpy arm — it
-                    // delegates to pt.h_mass, which the HmassP dome
-                    // path sets at resolve time and we must mirror).
-                    pt.h_mass = ((1.0 - pt.Q) * *pt.hL_mol + pt.Q * *pt.hV_mol) / M;
-                    return pt;
-                }
-            }
-        } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
-            // Sat endpoints / source unavailable — fall through to OOB.
-        }
-    }
     pt.kind = PointEvaluation::Kind::OutOfRange;
     pt.status = CoolProp::fast_evaluate_out_of_range;
     return pt;

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -1004,21 +1004,35 @@ SurfaceSpec dt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
 
     // Sub-critical T range with margins away from triple / critical.
     const double T_sub_lo = std::max(T_min_eos, T_triple * 1.001);
-    const double T_sub_hi = Tc * 0.999;
+    const double T_sub_hi = Tc * 0.99;  // parent (LINEAR) -> NC (POWER) handoff
     // Super-critical T range with margin above critical / below T_max.
-    const double T_sup_lo = Tc * 1.001;
+    const double T_sup_lo = Tc * 1.01;  // NC (POWER_LO) -> parent (LINEAR) handoff
     const double T_sup_hi = T_max_eos - 0.5;
-    // KNOWN GAP (CoolProp-i7j follow-up): the [0.999, 1.001]·Tc band is
-    // intentionally uncovered.  The LIQUID/VAPOR dome boundaries
-    // (ρ_sat,L, ρ_sat,V) pinch to ρ_c there, so the dome-bounded
-    // sub-regions degenerate to zero width and the SVD η-normalisation
-    // is ill-conditioned.  Unlike PT/HmassP, DmassT is NOT yet wired
-    // into build_critical_patch_, so single-phase DmassT queries in
-    // this ±0.1%·Tc band currently return OutOfRange rather than
-    // routing to the source backend.  Coverage impact is ~0.2% of the
-    // (D, T) envelope; closing it (a DmassT critical-patch bbox) is
-    // filed as a follow-up and is best done alongside the PT/HP patch
-    // machinery.
+    // NC (near-critical) T sub-band, carried by POWER/POWER_LO regions
+    // that crowd grid lines toward Tc.  The dome-bounded subcritical NC
+    // stops a hair below Tc (extending the saturation-boundary regions to
+    // exactly Tc makes the dome degenerate and the SVD build throws for
+    // some fluids, e.g. Argon).  The isobar-bounded "supercritical" NC
+    // region then extends DOWN across Tc from the same handoff: it has no
+    // saturation boundary, so the dome sits inside it as a lever-rule-
+    // routed NaN hole, and it covers the critical isotherm at ALL
+    // densities — closing the gap with no degenerate-boundary build.
+    // Handoff sits 1 microK below Tc, NOT at Tc*(1-1e-9): for Helium the
+    // HEOS PT density solver fails within ~1 nanoK of Tc (critical-region
+    // stiffness) and a failed PT update poisons the shared state's density
+    // guess, which would abort the envelope build.  1e-6 clears both; the
+    // isobar NC region still spans Tc, so the critical isotherm is covered
+    // by interpolation.
+    const double T_nc_sub_hi = Tc * (1.0 - 1.0e-6);
+    const double T_nc_sup_lo = T_nc_sub_hi;
+    // (Historical note, CoolProp-4z79: the ±0.1%·Tc band used to be left
+    // uncovered — the dome-bounded LIQUID/VAPOR regions can't extend to Tc
+    // because ρ_sat,L/ρ_sat,V pinch to ρ_c and the η-normalisation
+    // degenerates.  The NC regions below now close it: POWER/POWER_LO
+    // sub-regions carry the dome-bounded sides up to ~Tc, and an
+    // isobar-bounded NC_SUPER region spans Tc itself with the dome as an
+    // internal lever-rule hole.  No DmassT critical-patch / HEOS fallback
+    // is needed.)
 
     // p envelope for the non-dome D extents.  Sub-critical fluids
     // have well-defined p_triple from PQ flash at T_triple; use that
@@ -1099,6 +1113,47 @@ SurfaceSpec dt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
         // compressed-supercritical ceiling) with p ∝ rho in the tail.
         // This is the region whose low-rho edge dominated the DT
         // validation error band (CoolProp-wvtz).
+        spec.regions.emplace_back(axis, std::move(b_lo), std::move(b_hi), region::AxisScale::LOG);
+    }
+    // NC (near-critical) sub-regions (CoolProp-4z79).  These carry the
+    // *table* through [0.99, 1.01]*Tc — the band the parent LINEAR regions
+    // leave as a gap — using a POWER/POWER_LO primary T axis that crowds
+    // grid lines toward Tc, the direct analog of CoolProp-4u9's PH/PT NC
+    // regions.  The POWER(beta=1/3) crowding resolves the rho_sat
+    // boundary's vertical tangent (drho_sat/dT -> inf as T->Tc): a plain
+    // LINEAR extension of the parent regions hits 2-5% error there, POWER
+    // holds ~1e-6.  No critical patch / HEOS fallback is needed — the
+    // surrogate covers the whole band, including the critical isotherm, to
+    // ~1e-6..2e-5 (well inside the IAPWS 200 ppm budget) for all fluids.
+    //
+    // NC_LIQUID: [T_sub_hi, ~Tc), POWER (crowd toward a_hi=Tc).  Dome-side
+    // boundary rho_sat,L; stops a microK below Tc (see T_nc_sub_hi).
+    if (T_nc_sub_hi > T_sub_hi) {
+        auto axis = region::AxisTransform::make(region::AxisScale::POWER, T_sub_hi, T_nc_sub_hi);
+        auto b_lo = build_rho_sat_L(heos, T_sub_hi, T_nc_sub_hi);
+        auto b_hi = build_rho_max_envelope(heos, T_sub_hi, T_nc_sub_hi, p_max_target, WalkFloor::SAT_L);
+        spec.regions.emplace_back(axis, std::move(b_lo), std::move(b_hi), region::AxisScale::LOG);
+    }
+    // NC_VAPOR: [T_sub_hi, ~Tc), POWER.
+    if (T_nc_sub_hi > T_sub_hi) {
+        auto axis = region::AxisTransform::make(region::AxisScale::POWER, T_sub_hi, T_nc_sub_hi);
+        auto b_lo = build_rho_min_envelope(heos, T_sub_hi, T_nc_sub_hi, p_min_eos);
+        auto b_hi = build_rho_sat_V(heos, T_sub_hi, T_nc_sub_hi);
+        spec.regions.emplace_back(axis, std::move(b_lo), std::move(b_hi), region::AxisScale::LOG);
+    }
+    // NC_SUPER: [~Tc, T_sup_lo], POWER_LO (crowd toward a_lo=Tc).  This is
+    // the region that closes the gap AT the critical isotherm: it is
+    // bounded by the two HEOS-validity isobars (NOT the saturation curve),
+    // so it spans from a microK below Tc up across Tc to the parent SUPER
+    // handoff, covering every density.  The two-phase dome that lives in
+    // its lower (sub-Tc) sliver is an internal NaN hole, routed by the
+    // lever rule before the surface is ever consulted — so extending an
+    // isobar-bounded region across Tc never touches the degenerate dome
+    // boundary that makes a saturation-bounded region throw at Tc.
+    if (T_sup_lo > T_nc_sup_lo) {
+        auto axis = region::AxisTransform::make(region::AxisScale::POWER_LO, T_nc_sup_lo, T_sup_lo);
+        auto b_lo = build_rho_min_envelope(heos, T_nc_sup_lo, T_sup_lo, p_min_eos);
+        auto b_hi = build_rho_max_envelope(heos, T_nc_sup_lo, T_sup_lo, p_max_target, WalkFloor::CRITICAL);
         spec.regions.emplace_back(axis, std::move(b_lo), std::move(b_hi), region::AxisScale::LOG);
     }
 

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -1267,8 +1267,85 @@ TEST_CASE("SVDSBTL pc-strip routes through critical patch", "[SVDSBTL][CoolProp-
 
 // -- DT-indexed surface (CoolProp-i7j) ------------------------------------
 
-// Smoke test: DT surface for CO2 builds, single supercritical probe
-// returns finite values matching HEOS to better than 1e-3 relative.
+// Regression gate for CoolProp-4z79: the near-critical band [0.99,1.01]*Tc
+// used to be a structural GAP in the DmassT atlas (the dome-bounded
+// LIQUID/VAPOR regions can't reach Tc — rho_sat,L/V pinch to rho_c).  The
+// NC sub-regions (POWER/POWER_LO T axis + an isobar-bounded region that
+// spans Tc) now carry the *table* through the whole band, including the
+// critical isotherm, at all densities — no HEOS fallback.  This test
+// asserts BOTH: (1) no gap — every single-phase (T,rho) in the band is
+// served (svd->update does not throw); (2) accuracy — p(rho,T) matches
+// HEOS to <1e-4 (the observed worst is ~2e-5; the IAPWS budget is 2e-4).
+// Helium is included on purpose: its critical-region PT solver fails
+// within ~1 nanoK of Tc, which earlier aborted the surface build (the
+// 1e-6 NC handoff margin fixes it).
+TEST_CASE("SVDSBTL DT near-critical band is gap-free and accurate (CoolProp-4z79)", "[SBTL][SVDSBTL][dt][near_critical][regression][slow]") {
+    for (const std::string& fluid : {std::string("Water"), std::string("CarbonDioxide"), std::string("Helium")}) {
+        auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", fluid));
+        auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", fluid));
+        const double Tc = heos->T_critical();
+        const double rho_c = heos->rhomass_critical();
+        int single_phase_points = 0;
+        for (double tf : {0.99, 0.999, 0.9999, 1.0, 1.0001, 1.001, 1.01}) {
+            const double T = tf * Tc;
+            for (double rf : {0.1, 0.3, 0.6, 0.9, 1.0, 1.1, 1.5, 2.0}) {
+                const double rho = rf * rho_c;
+                double p_ref = 0.0;
+                try {
+                    heos->update(CoolProp::DmassT_INPUTS, rho, T);
+                    if (heos->Q() > 0.0 && heos->Q() < 1.0) continue;  // dome: lever-rule routed
+                    p_ref = heos->p();
+                } catch (...) {
+                    continue;  // outside HEOS validity
+                }
+                INFO(fluid << " T=" << T << " (" << tf << "Tc)  rho=" << rho << " (" << rf << "rho_c)  p_ref=" << p_ref);
+                // (1) no gap: the surrogate MUST serve this single-phase point.
+                REQUIRE_NOTHROW(svd->update(CoolProp::DmassT_INPUTS, rho, T));
+                const double p_svd = svd->p();
+                // (2) accuracy: table holds <1e-4 across the band, incl. the cusp.
+                CHECK(std::isfinite(p_svd));
+                CHECK(p_svd == Approx(p_ref).epsilon(1e-4));
+                CHECK(svd->rhomass() == rho);  // density input echoed back
+                ++single_phase_points;
+            }
+        }
+        INFO(fluid << " single-phase points checked: " << single_phase_points);
+        REQUIRE(single_phase_points > 20);  // guard against the sweep silently skipping everything
+    }
+}
+
+// CoolProp-4z79 dome-routing guard: the isobar-bounded NC_SUPER region
+// dips below Tc, so its AABB spans the two-phase dome.  A two-phase DT
+// query in that sub-Tc sliver must still be routed to the lever rule
+// (p = P_sat(T), Q from the lever rule), NOT read as single-phase off the
+// surface's interpolated-across-the-dome cells.  This is the exact hole
+// the resolve-order dome PRE-CHECK closes; the [near_critical] sweep above
+// skips dome points and can't see it, so it is gated explicitly here.
+TEST_CASE("SVDSBTL DT two-phase routing holds inside the NC sub-Tc sliver (CoolProp-4z79)",
+          "[SBTL][SVDSBTL][dt][near_critical][dome][regression][slow]") {
+    for (const std::string& fluid : {std::string("Water"), std::string("CarbonDioxide")}) {
+        auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", fluid));
+        auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", fluid));
+        const double Tc = heos->T_critical();
+        const double rho_c = heos->rhomass_critical();
+        // Just below Tc but inside the NC_SUPER span (Tc*(1-1e-6) .. Tc),
+        // at rho_c — squarely inside the (vanishing) dome there.
+        for (double tf : {1.0 - 5.0e-7, 1.0 - 1.0e-7}) {
+            const double T = tf * Tc;
+            heos->update(CoolProp::DmassT_INPUTS, rho_c, T);
+            if (!(heos->Q() > 0.0 && heos->Q() < 1.0)) continue;  // require it actually be two-phase
+            const double p_sat = heos->p();
+            const double Q_ref = heos->Q();
+            INFO(fluid << " T=" << T << " (" << tf << "Tc) rho=rho_c=" << rho_c << " expect two-phase p_sat=" << p_sat);
+            REQUIRE_NOTHROW(svd->update(CoolProp::DmassT_INPUTS, rho_c, T));
+            CHECK(svd->Q() > 0.0);
+            CHECK(svd->Q() < 1.0);
+            CHECK(svd->p() == Approx(p_sat).epsilon(1e-3));  // P_sat(T), not an interpolated surface value
+            CHECK(svd->Q() == Approx(Q_ref).epsilon(1e-2));
+        }
+    }
+}
+
 // Tight tolerance comes in the multi-fluid sweep below — this one just
 // proves the wiring is end-to-end.
 TEST_CASE("SVDSBTL DT-indexed surface builds and evaluates for CO2", "[SBTL][SVDSBTL][dt][smoke][slow]") {
@@ -1507,23 +1584,24 @@ TEST_CASE("find_rho_satL_extrema_T returns water anomaly, none for other fluids"
 }
 
 // LIQUID-split geometry: the dt_subcritical preset must emit one extra
-// LIQUID sub-region per rho_sat,L(T) extremum.  Water (one anomaly)
-// gets LIQUID_LO + LIQUID_HI + VAPOR + SUPER = 4 regions; CO2 (no
-// anomaly) gets LIQUID + VAPOR + SUPER = 3.  This is the structural
-// guard that the anomaly split actually happens — without it, a
-// single LIQUID region would straddle the density-maximum hairpin and
-// the SVD couldn't represent the resulting discontinuity.
+// LIQUID sub-region per rho_sat,L(T) extremum, plus the three fixed NC
+// near-critical regions (NC_LIQUID + NC_VAPOR + NC_SUPER, CoolProp-4z79).
+// Water (one anomaly) gets LIQUID_LO + LIQUID_HI + VAPOR + SUPER + 3 NC = 7
+// regions; CO2 (no anomaly) gets LIQUID + VAPOR + SUPER + 3 NC = 6.  This
+// is the structural guard that the anomaly split actually happens —
+// without it, a single LIQUID region would straddle the density-maximum
+// hairpin and the SVD couldn't represent the resulting discontinuity.
 TEST_CASE("dt_subcritical splits LIQUID at the water density anomaly", "[SBTL][SVDSBTL][dt][anomaly]") {
-    SECTION("water emits 4 regions (LIQUID split into LO + HI)") {
+    SECTION("water emits 7 regions (LIQUID split LO + HI, + 3 NC)") {
         auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
         auto spec = CoolProp::sbtl::presets::dt_subcritical(*heos);
-        REQUIRE(spec.regions.size() == 4);
+        REQUIRE(spec.regions.size() == 7);
         REQUIRE(spec.input_pair == CoolProp::DmassT_INPUTS);
     }
-    SECTION("CO2 emits 3 regions (single LIQUID)") {
+    SECTION("CO2 emits 6 regions (single LIQUID, + 3 NC)") {
         auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "CarbonDioxide"));
         auto spec = CoolProp::sbtl::presets::dt_subcritical(*heos);
-        REQUIRE(spec.regions.size() == 3);
+        REQUIRE(spec.regions.size() == 6);
     }
 }
 


### PR DESCRIPTION
**Stacked on #3080** (the log-secondary DmassT fix). Review/merge that first; this branch's diff is the 4 files below.

## Problem

The SVDSBTL DmassT (ρ,T) validation panels show a horizontal white stripe at **T/Tc ≈ 1** — the band `[0.999, 1.001]·Tc` was a structural **gap** at *all* densities. The dome-bounded LIQUID/VAPOR regions can't extend to Tc (ρ_sat,L and ρ_sat,V pinch to ρ_c, the η-normalisation degenerates), and the supercritical region started at `1.001·Tc`, so single-phase DmassT queries in the band returned OutOfRange.

## Fix — near-critical (NC) *table* regions, no HEOS patch

Handled the way the PH/PT presets already cover their critical region (#2984-era CoolProp-4u9): NC sub-regions carry the **table** through the band. We measured that a HEOS patch is **not** needed — the table holds ~1e-6 right through the critical isotherm.

- **NC_LIQUID / NC_VAPOR** — `POWER(β=1/3)` primary-T axis crowding grid lines toward Tc, dome-bounded, up to ~Tc. The POWER crowding resolves the ρ_sat boundary's vertical tangent (`dρ_sat/dT → ∞`); a plain LINEAR extension hits 2–5 % error there, POWER holds ~1e-6.
- **NC_SUPER** — `POWER_LO`, **isobar-bounded** (not saturation-bounded), spanning from a µK below Tc up across the critical isotherm. Having no saturation boundary, it covers Tc at every density without touching the degenerate dome boundary that makes a saturation-bounded region throw at Tc.

**Two-phase routing.** Because NC_SUPER's AABB dips below Tc it spans the two-phase dome, and the atlas resolves surface-first — so a sub-Tc dome query would be read as single-phase off interpolated-across-the-dome cells. The DmassT/DmolarT dome detection is therefore moved to a **PRE-CHECK before the atlas resolve**, routing dome points to the lever rule (`p = P_sat(T)`) regardless of which region's AABB covers them. (Caught in adversarial review; gated by a new `[dome]` regression test.)

## Result

Whole `[0.99, 1.01]·Tc` band is **table-served (no HEOS), gap-free**, to **~1e-6 … 2e-5** — well inside the IAPWS 200 ppm budget — for **all eight** validation fluids:

| Water | Argon | Hydrogen | R1234yf | R245fa | D6 | CO2 | Helium |
|---|---|---|---|---|---|---|---|
| 1.8e-6 | 1.2e-6 | 1.7e-6 | 1.2e-5 | 4.0e-6 | 1.9e-5 | 8e-7 | 1.2e-6 |

Helium needed a `Tc·(1−1e-6)` NC handoff margin: its critical-region PT density solver fails within ~1 nK of Tc and a failed PT update poisons the shared HEOS state's density guess, which aborted the envelope build. The isobar NC region still spans Tc, so the critical isotherm is covered by interpolation. The underlying walk-poisoning is filed as a follow-up.

## Verification

- New `[near_critical]` + `[dome]` regression tests (Water/CO2/Helium): no-gap (`REQUIRE_NOTHROW`), accuracy <1e-4, and two-phase routing in the sub-Tc sliver. **607 assertions.**
- Full `[SBTL]` suite: **5357 assertions pass**, no regression (incl. the updated region-count structural guard 4→7 / 3→6).
- `./dev/ci/preflight.sh`: **6/6 green**.
- Two rounds of adversarial review: the first found the two-phase-routing hole (fixed); the re-review confirmed the fix correct and complete, no blocking findings.

Serializer rev **16 → 17** (HEOS DmassT region count 3 → 6 → on-wire region list differs → caches rebuild). PT/HmassP and non-DmassT presets unchanged.

Closes CoolProp-4z79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded thermodynamic coverage in near-critical regions for improved calculation accuracy near the critical point

* **Bug Fixes**
  * Improved two-phase state detection for density-temperature queries to prevent incorrect single-phase region assignments

* **Chores**
  * Cache version updated; previously cached data must be rebuilt to reflect internal structural changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->