### PR TITLE
fix(python): ship fmt headers from the CPM source (constants_header cimport)

### DIFF
--- a/wrappers/Python/CMakeLists.txt
+++ b/wrappers/Python/CMakeLists.txt
@@ -340,8 +340,12 @@ install(DIRECTORY "${ROOT_DIR}/include/"
     PATTERN "*_JSON_z.h" EXCLUDE
 )
 
-# Install fmtlib headers (for packaging)
-install(DIRECTORY "${ROOT_DIR}/externals/fmtlib/include/fmt"
+# Install fmtlib headers (for packaging).  fmt is CPM-fetched (fmt_SOURCE_DIR);
+# the old externals/fmtlib path was stale, so no fmt shipped -- which broke
+# downstream Cython that cimports constants_header (DataStructures.h ->
+# numerics.h -> detail/strings.h -> fmt/format.h, header-only via FMT_HEADER_ONLY
+# unless NO_FMTLIB).  Affected the legacy wheel too; this fixes both.
+install(DIRECTORY "${fmt_SOURCE_DIR}/include/fmt"
     DESTINATION CoolProp/include
     FILES_MATCHING
     PATTERN "*.h"


### PR DESCRIPTION
## Problem

The Python wheel installed fmt headers from `externals/fmtlib/include/fmt`, a path that **no longer exists** — fmt is CPM-fetched. So the wheel shipped **no fmt headers at all**. Any downstream Cython that `cimport`s `constants_header` then failed to compile, because the transitive include chain is:

```
CoolProp/DataStructures.h
  -> CoolProp/numerics/numerics.h
    -> CoolProp/detail/strings.h
      -> fmt/format.h        # header-only (FMT_HEADER_ONLY), unless NO_FMTLIB
```

That is exactly **PDSim's `flow_models` pattern**, so the wheel was not yet a true drop-in for code that builds against the CoolProp headers.

This is **pre-existing** — it affected the legacy (Cython) wheel too, not just the nanobind build.

## Fix

Point the install at `${fmt_SOURCE_DIR}/include/fmt` — the CPM source dir, already used in `COOLPROP_INCLUDE_DIRS` for the compile step (so it's known-populated). The install rule is common to both the legacy and nanobind (`COOLPROP_NANOBIND`) builds, so both wheels are fixed.

## Validation

- The wheel now ships `CoolProp/include/fmt/*.h`.
- A `from CoolProp cimport constants_header` + `from CoolProp.State cimport State` extension (PDSim's pattern) **compiles and runs** against the installed wheel: `get_p() = 245.77 kPa`, `keyed_output(iSmass) = 5335.09 J/kg/K` for Water at T=400 K, ρ=2 kg/m³.

This change only touches `wrappers/Python/CMakeLists.txt` (the wheel build); it cannot affect the Catch/C++ build or test suite (those use the root CMakeLists).

Refs bd CoolProp-r9sq.1 (epic CoolProp-r9sq — nanobind Python interface migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed packaging to use current library headers from the build process instead of potentially outdated sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->