### PR TITLE
feat(svdsbtl): LOG primary-T axis on the DmassT SUPER region for wide-supercritical fluids (CoolProp-jh6a)

### DIFF
--- a/include/CoolProp/sbtl/SVDSurfaceSerializer.h
+++ b/include/CoolProp/sbtl/SVDSurfaceSerializer.h
@@ -208,7 +208,16 @@ class SVDSurfaceSerializer
     //           [0.99,1.01]·Tc band is now table-served (no HEOS) to
     //           ~1e-6..2e-5 for all fluids.  PT / HmassP and the non-DmassT
     //           presets are unchanged.
-    static constexpr int kRevision = 17;
+    //   rev 18: CoolProp-jh6a.  The DmassT parent SUPER region's primary-T
+    //           axis switches LINEAR → LOG.  For low-Tc / wide-supercritical
+    //           fluids (Helium: Tc 5.2 K, Tmax 2000 K, ~380× range) LINEAR
+    //           starved the near-Tc supercritical zone of grid lines, giving
+    //           ~1% pressure error across the whole SUPER region; LOG drops
+    //           it to ~1e-8.  No region-count change (same 6 regions), but
+    //           the SUPER grid sample positions and U/slopes shift, so
+    //           rev-17 caches must rebuild.  Modest-ratio fluids (Water ~3×,
+    //           CO2 ~6×) are unchanged in practice (LOG ≈ LINEAR there).
+    static constexpr int kRevision = 18;
 
     // Pack one surface into a zlib-compressed msgpack blob.
     static std::vector<char> save(const SVDSurface& surface);

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -1106,7 +1106,15 @@ SurfaceSpec dt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
     // evaluates directly (P = ρ²(∂α/∂ρ)RT), no inverter, no
     // rectangular bands, no -760 MPa cells.
     if (T_sup_hi > T_sup_lo) {
-        auto axis = region::AxisTransform::make(region::AxisScale::LINEAR, T_sup_lo, T_sup_hi);
+        // LOG primary-T axis (CoolProp-jh6a).  The supercritical T range is
+        // [1.01*Tc, Tmax]; for low-Tc fluids that ratio is huge (Helium
+        // Tc=5.2 K, Tmax=2000 K -> ~380x), and a LINEAR axis then starves
+        // the near-Tc supercritical zone (where properties vary fastest) of
+        // grid lines relative to the vast hot tail -> ~1% pressure error
+        // across Helium's whole SUPER region.  LOG distributes grid lines
+        // per-decade and drops that to ~1e-8.  For modest-ratio fluids
+        // (Water ~3x, CO2 ~6x) LOG ~ LINEAR, so it is a no-op there.
+        auto axis = region::AxisTransform::make(region::AxisScale::LOG, T_sup_lo, T_sup_hi);
         auto b_lo = build_rho_min_envelope(heos, T_sup_lo, T_sup_hi, p_min_eos);
         auto b_hi = build_rho_max_envelope(heos, T_sup_lo, T_sup_hi, p_max_target, WalkFloor::CRITICAL);
         // LOG secondary: rho_hi/rho_lo ~ 1e5 here (ideal-gas floor to

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -1346,6 +1346,43 @@ TEST_CASE("SVDSBTL DT two-phase routing holds inside the NC sub-Tc sliver (CoolP
     }
 }
 
+// Regression gate for CoolProp-jh6a: the DmassT parent SUPER region uses a
+// LOG primary-T axis so that wide-supercritical fluids stay accurate.
+// Helium is the witness: Tc=5.2 K, Tmax=2000 K (~380x), where a LINEAR
+// axis gave ~1% (p90 ~4%) pressure error across the whole SUPER region.
+// LOG holds ~1e-7.  This test sweeps the supercritical region well away
+// from the critical point and the dome and asserts <1e-3 -- a tolerance
+// that PASSES under LOG (~1e-7) and FAILS under the old LINEAR axis (~1e-2).
+TEST_CASE("SVDSBTL DT supercritical accuracy holds for wide-T-range fluids (CoolProp-jh6a)", "[SBTL][SVDSBTL][dt][supercritical][regression][slow]") {
+    for (const std::string& fluid : {std::string("Helium"), std::string("Hydrogen")}) {
+        auto svd = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", fluid));
+        auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", fluid));
+        const double Tc = heos->T_critical();
+        const double rho_c = heos->rhomass_critical();
+        int checked = 0;
+        for (double tf : {1.05, 1.15, 1.3}) {
+            const double T = tf * Tc;
+            for (double rf : {0.3, 0.6, 1.0, 1.5, 2.0}) {
+                const double rho = rf * rho_c;
+                double p_ref = 0.0;
+                try {
+                    heos->update(CoolProp::DmassT_INPUTS, rho, T);
+                    p_ref = heos->p();
+                } catch (...) {
+                    continue;  // outside HEOS validity (e.g. above the melting line)
+                }
+                if (!(p_ref > 0)) continue;
+                INFO(fluid << " T=" << T << " (" << tf << "Tc) rho=" << rho << " (" << rf << "rho_c) p_ref=" << p_ref);
+                REQUIRE_NOTHROW(svd->update(CoolProp::DmassT_INPUTS, rho, T));
+                CHECK(svd->p() == Approx(p_ref).epsilon(1e-3));
+                ++checked;
+            }
+        }
+        INFO(fluid << " supercritical points checked: " << checked);
+        REQUIRE(checked > 8);
+    }
+}
+
 // Tight tolerance comes in the multi-fluid sweep below — this one just
 // proves the wiring is end-to-end.
 TEST_CASE("SVDSBTL DT-indexed surface builds and evaluates for CO2", "[SBTL][SVDSBTL][dt][smoke][slow]") {


### PR DESCRIPTION
**Stacked on #3087** (CoolProp-4z79). This branch's diff is the 3 files below.

## Problem

While regenerating the DT validation panels after #3080 + #3087, 7 of 8 fluids came out clean but **Helium's entire supercritical region was ~1% error** (p90 ~4%, p99 ~11%) — a bright-yellow band in the panel.

Root cause (thanks @ibell): the parent SUPER region spans `T ∈ [1.01·Tc, Tmax]` on a **LINEAR** primary-T axis. For low-Tc fluids that range is enormous — **Helium: Tc=5.2 K, Tmax=2000 K, ~380×** — so a LINEAR axis starves the near-Tc supercritical zone (where ρ(T)/p(T) vary fastest) of grid lines relative to the vast hot tail. The other fluids have ratios of only ~3–6× (Water Tc=647, CO2 Tc=304), which is why Helium was the lone outlier.

## Fix

One line: switch that axis to **LOG**. Grid lines distribute per-decade, so the cold supercritical zone gets the resolution it needs.

| Helium `T/Tc ∈ [1.01,1.4]` | LINEAR | **LOG** |
|---|---|---|
| median | 0.8% | **2e-8** |
| p90 | 4% | **1.6e-7** |
| p99 | 11% | **2e-6** |

**~6 orders of magnitude.** For modest-ratio fluids (Water, CO2) LOG ≈ LINEAR — verified no change to their panels, so it's a no-op there.

## Verification

- New `[supercritical]` regression test (Helium + Hydrogen): sweeps the supercritical region away from the critical point/dome, asserts `<1e-3` — passes under LOG (~1e-7), would fail under the old LINEAR axis (~1e-2). **62 assertions.**
- Full `[SBTL]` suite: **5419 assertions pass**, no regression.
- `./dev/ci/preflight.sh`: **7/7 green**. Adversarial review: no blocking findings.

Serializer rev **17 → 18** (same region count; SUPER grid sample positions/slopes shift → caches rebuild).

Scope note: this fixes the supercritical **accuracy** half of CoolProp-jh6a. The separate Helium **low-density ideal-gas-tail gap** (ρ below the ρ_min envelope floor) remains on CoolProp-jh6a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pressure calculation accuracy for supercritical conditions, particularly for fluids with wide operating temperature ranges. Previously cached surface data will be regenerated automatically to reflect these improvements.

* **Tests**
  * Added regression testing to validate calculation accuracy across extended temperature conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->