### PR TITLE
feat(python): complete nanobind package to match the legacy import tree (CoolProp-r9sq.3)

### DIFF
--- a/wrappers/Python/CMakeLists.txt
+++ b/wrappers/Python/CMakeLists.txt
@@ -325,6 +325,20 @@ install(FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/CoolProp/constants.py"
     "${CMAKE_CURRENT_SOURCE_DIR}/CoolProp/constants_header.pxd"
     DESTINATION CoolProp)
+# HumidAirProp re-export shim (SI surface from the core; non-SI HAProps removed)
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/_nanobind/HumidAirProp.py"
+    DESTINATION CoolProp)
+# Pure-Python submodules, shipped unchanged from the source package so the v8
+# import tree matches the legacy one (CoolProp.Plots/BibtexParser/GUI/tests).
+# tests/ is required: it is the q2sh "existing suite runs green" done-gate.
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/CoolProp/Plots"
+    DESTINATION CoolProp FILES_MATCHING PATTERN "*.py" PATTERN "psyrc")
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/CoolProp/GUI"
+    DESTINATION CoolProp FILES_MATCHING PATTERN "*.py")
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/CoolProp/tests"
+    DESTINATION CoolProp FILES_MATCHING PATTERN "*.py")
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/CoolProp/BibtexParser.py"
+    DESTINATION CoolProp)
 
 endif()  # COOLPROP_NANOBIND
 

--- a/wrappers/Python/_nanobind/HumidAirProp.py
+++ b/wrappers/Python/_nanobind/HumidAirProp.py
@@ -1,0 +1,21 @@
+"""
+``CoolProp.HumidAirProp`` -- humid-air properties (v8 nanobind package).
+
+The SI entry points come straight from the nanobind core (the same C++
+``HumidAir::`` functions the legacy Cython module wrapped), so this keeps the
+legacy import path ``CoolProp.HumidAirProp.HAPropsSI`` working unchanged.
+
+The legacy non-SI ``HAProps`` was removed in v8 (CoolProp is SI-only); calling
+it raises a clear error pointing at ``HAPropsSI`` rather than silently 404-ing.
+"""
+from .CoolProp import HAPropsSI, HAProps_Aux, cair_sat
+
+__all__ = ['HAPropsSI', 'HAProps_Aux', 'cair_sat', 'HAProps']
+
+
+def HAProps(*args, **kwargs):
+    """Removed in v8 -- use :func:`HAPropsSI` (SI units) instead."""
+    raise NotImplementedError(
+        "HAProps (non-SI humid-air properties) was removed in CoolProp v8; "
+        "use HAPropsSI with SI units instead."
+    )

--- a/wrappers/Python/_nanobind/__init__.py
+++ b/wrappers/Python/_nanobind/__init__.py
@@ -1,29 +1,93 @@
 """
 Package init for the nanobind-based CoolProp build (COOLPROP_NANOBIND=ON).
 
-The hand-written Cython AbstractState layer is gone; `CoolProp.CoolProp` is the
-nanobind core (which also exports the `_capi` PyCapsule), and `CoolProp.State` is
-the link-free capsule shim.  This intentionally stays minimal -- the full set of
-legacy conveniences (AbstractState/HumidAirProp re-exports, etc.) is the nanobind
-parity-completion work (bd CoolProp-q2sh), not State packaging.
+This mirrors the legacy (Cython) ``CoolProp/__init__.py`` surface verbatim so the
+v8 package presents the *same* import tree: ``CoolProp.CoolProp`` is the nanobind
+core (it also exports the ``_capi`` PyCapsule used by the ``State`` shim),
+``CoolProp.HumidAirProp`` is a thin SI re-export shim, ``CoolProp.State`` is the
+capsule shim, and the pure-Python submodules (``Plots``, ``BibtexParser``,
+``GUI``, ``tests``) are shipped unchanged.  Keep this in lock-step with the
+legacy ``__init__.py`` (see bd CoolProp-r9sq.3, the import-tree parity gate).
 """
 from __future__ import absolute_import
 
-# Order matters: import the core first so its `_capi` capsule exists before the
-# State shim (which does `import CoolProp`) is imported below.  `import *` also
-# brings get_global_param_string into the package namespace.
-from .CoolProp import *      # nanobind core: PropsSI, the bound API, enums, _capi
-from . import State          # the capsule State shim (CoolProp.State.State)
-from . import constants      # generated runtime enum values
+# If there is a constants.[pyd|so|dylib] in the main directory, it will be imported instead of the constants.py file.
+# It should be removed as it is from the older version of CoolProp
+from . import constants
+if constants.__file__.rsplit('.', 1)[1] not in ['pyc', 'pyo', 'py']:
+
+    import os
+    try:
+        os.remove(constants.__file__)
+        print("constants shared library has been removed.  Please restart your python code")
+    except:
+        print("Unable to remove" + constants.__file__ + ". Please manually remove it")
+    quit()
+
+from .CoolProp import AbstractState
+from . import CoolProp
+from . import HumidAirProp
+from . import State
 from .constants import *
 
-__version__ = get_global_param_string('version')
-__gitrevision__ = get_global_param_string('gitrevision')
+__fluids__ = CoolProp.get_global_param_string('fluids_list').split(',')
+__incompressibles_pure__ = CoolProp.get_global_param_string('incompressible_list_pure').split(',')
+__incompressibles_solution__ = CoolProp.get_global_param_string('incompressible_list_solution').split(',')
+__version__ = CoolProp.get_global_param_string('version')
+__gitrevision__ = CoolProp.get_global_param_string('gitrevision')
+
+def get(s):
+    """
+    This is just a shorthand function for getting a parameter from
+    ``CoolProp.get_global_param_string``
+    """
+    return CoolProp.get_global_param_string(s)
+
+
+def test():
+    """
+    Run the tests in the test folder
+    """
+    from .tests import runner
+    runner.run()
 
 
 def get_include_directory():
-    """Path to the bundled CoolProp headers (for compiling extensions that
-    cimport CoolProp.State or include the C-ABI header)."""
+    """
+    Get the include directory for CoolProp header files that are needed if you want
+    to compile anything else that uses the CoolProp Cython extension type
+
+    Returns
+    -------
+    include_directory: The path to the include folder for CoolProp
+    """
     import os
-    head, _ = os.path.split(__file__)
+    head, file = os.path.split(__file__)
     return os.path.join(head, 'include')
+
+
+def copy_BibTeX_library(file=None, folder=None):
+    """
+    Copy the CoolProp BibTeX library file to the file given by ``file``, or the folder given by ``folder``
+
+    If no inputs are provided, the file will be copied to the current working
+    directory
+
+    Parameters
+    ----------
+    file : string
+        Provide if you want to put the file into a given file
+    folder : string
+        Provide if you want to put the CoolPropBibTeXLibrary.bib file into the given folder
+
+    """
+    import os, shutil
+    path_to_bib = os.path.join(os.path.split(__file__)[0], 'CoolPropBibTeXLibrary.bib')
+    if file is None and folder is None:
+        shutil.copy2(path_to_bib, os.path.abspath(os.curdir))
+    elif file and folder is None:
+        shutil.copy2(path_to_bib, file)
+    elif folder and file is None:
+        shutil.copy2(path_to_bib, folder)
+    else:
+        raise ValueError('can only provide one of file or folder')


### PR DESCRIPTION
## What

Makes the v8 (nanobind) Python package present the **same import tree** as the legacy (Cython) package, so downstream code keeps importing unchanged. This is the import-tree / object-hierarchy acceptance gate (`CoolProp-r9sq.3`).

- **`_nanobind/__init__.py`** — rewritten to mirror the legacy `__init__` surface verbatim: re-exports `AbstractState`, `CoolProp`, `HumidAirProp`, `State`, `constants.*`; `__fluids__`/`__incompressibles__`/`__version__`/`__gitrevision__`; `get`/`test`/`get_include_directory`/`copy_BibTeX_library`.
- **`_nanobind/HumidAirProp.py`** — new SI re-export shim (`HAPropsSI`, `HAProps_Aux`, `cair_sat` from the core). The non-SI `HAProps` raises a clear "use HAPropsSI" error (removed for v8 — SI-only).
- ship the pure-Python submodules unchanged (`Plots` incl. `psyrc`, `GUI`, `tests`, `BibtexParser`) so `CoolProp.{Plots,GUI,tests,BibtexParser}` resolve as before.

## Verification (vs the stock 7.2.0 import-tree reference)

- **0 modules missing, 0 modules extra** — module tree matches exactly.
- **0 top-level names missing** beyond the approved drops (`Props`, `HAProps`, `re_split`, `rebuildState`).
- The only "extras" are newer-master **enum values** (`Qmass` input pairs, SVDSBTL/`fast_evaluate` keys) — version noise, not deviations.
- `Plots`/`BibtexParser` require their optional deps (`matplotlib`/`pybtex`) exactly as the legacy package did.
- `HAPropsSI` works; `HAProps` raises the migration error; `copy_BibTeX_library` + the bundled `.bib` ship.

## Notes / remaining gate work

- The existing test suite is mostly **`nose`-based** (dead on modern Python), so the q2sh "existing suite green" check shifts to the new **pytest** suite (`CoolProp-r9sq.5`).
- The **Sphinx apidoc diff** (the other gate check) remains; it needs the docs build.

Refs bd CoolProp-r9sq.3 (epic CoolProp-r9sq). Builds on #3090 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added utility functions for executing tests, accessing package parameters, and managing bibliography files.
  * Expanded humid air properties module with additional calculation functions.
  * Package metadata now accessible via version and revision attributes.

* **Breaking Changes**
  * Legacy humid air property function removed; use SI unit-based alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->