### PR TITLE
Phase 2-4: migrate Incompressible / PC-SAFT / Cubics / UNIFAC loaders off RapidJSON onto nlohmann

### DIFF
--- a/docs/superpowers/plans/2026-06-07-rapidjson-to-nlohmann-phase2-4-loaders.md
+++ b/docs/superpowers/plans/2026-06-07-rapidjson-to-nlohmann-phase2-4-loaders.md
@@ -1,0 +1,782 @@
+# RapidJSON → nlohmann/json — Phase 2-4 (Incompressible + PC-SAFT + Cubics/UNIFAC loaders) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the Incompressible, PC-SAFT, and Cubics/UNIFAC backend loaders off RapidJSON onto nlohmann/json, with a POD-constructor de-publishing boundary that leaves zero nlohmann/rapidjson tokens in any installed header.
+
+**Architecture:** Each loader is an include-swap (`detail/rapidjson.h` → `detail/json.h`) plus a mechanical idiom translation (the `cpjson::get_*` helpers are signature-identical across both wrappers). Schema validation moves from rapidjson `SchemaValidator` to Valijson automatically once the rapidjson overload is no longer visible. Two installed headers that currently expose JSON construction (`PCSAFTFluid.h`, `Ancillaries.h`) are converted to a POD-constructor boundary: a plain-typed constructor in the installed header, with all nlohmann parsing done by a non-installed `src/` factory. The four Phase-1 bridges (2 `alpha0` round-trips + 2 `validate_schema` function-pointer casts) are deleted.
+
+**Tech Stack:** C++17, nlohmann/json (via the `cpjson` wrapper in `include/CoolProp/detail/json.h`), Valijson, Catch2 v3, CMake (Release), CoolProp `cpjson::` helper layer.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-rapidjson-to-nlohmann-phase2-4-loaders-design.md`
+**Epic:** `CoolProp-xa8w.1`. **Branch:** `ihb/rapidjson-nlohmann-phase2-4-loaders`.
+
+---
+
+## Idiom map (applies to every mechanical conversion in this plan)
+
+| rapidjson | nlohmann |
+|-----------|----------|
+| `rapidjson::Value& x` (param/local) | `const nlohmann::json& x` |
+| `x.HasMember("k")` | `x.contains("k")` |
+| `x["k"]` (read) | `x.at("k")` |
+| `x["k"].GetInt()/GetDouble()/GetString()` | `x.at("k").get<int>()` / `.get<double>()` / `.get<std::string>()` (or the matching `cpjson::get_*`) |
+| `x["k"].IsNumber()/IsObject()/IsArray()` | `x.at("k").is_number()/is_object()/is_array()` |
+| `for (auto itr=L.Begin(); itr!=L.End(); ++itr) { …(*itr)… }` | `for (const auto& el : L) { …el… }` |
+| `rapidjson::Document dd; dd.Parse<0>(s.data(), s.size()); if (dd.HasParseError()) throw …;` | `nlohmann::json dd = cpjson::parse(s);` (throws `CoolProp::ValueError` on bad JSON) |
+| `cpjson::json2string(v)` | `v.dump()` (or keep `cpjson::json2string(v)` — identical in `detail/json.h`) |
+| `cpjson::get_string(*itr,"k")` etc. | `cpjson::get_string(el,"k")` — **call sites unchanged**, only the operand type changes |
+
+**Optional-member rule:** rapidjson `x["k"]` is UB on a missing key; nlohmann `x.at("k")` throws. Wherever the original guards a key with `HasMember` (or `IsNumber`), keep an equivalent `contains("k")` (and `is_number()`) guard. Behavior parity is the safety net.
+
+---
+
+## Task 1: Incompressible loader → nlohmann
+
+**Files:**
+- Modify: `src/Backends/Incompressible/IncompressibleLibrary.h:9,151-153,165-166`
+- Modify: `src/Backends/Incompressible/IncompressibleLibrary.cpp:5-6 (includes), 348-426, 554-566`
+
+This loader has no schema, no user-supplied fluids, and no JSON-typed installed header — the simplest case. It proves the pattern.
+
+- [ ] **Step 1: Swap the include in the header**
+
+In `IncompressibleLibrary.h`, replace line 9:
+```cpp
+#include "CoolProp/detail/rapidjson.h"
+```
+with:
+```cpp
+#include "CoolProp/detail/json.h"
+```
+
+- [ ] **Step 2: Retype the parse_* / add_* declarations in the header**
+
+In `IncompressibleLibrary.h`, change the three `parse_*` declarations (151-153) and the two `add_*` declarations (165-166) from `rapidjson::Value&` to `const nlohmann::json&`:
+```cpp
+    IncompressibleData parse_coefficients(const nlohmann::json& obj, const std::string& id, bool vital);
+    double parse_value(const nlohmann::json& obj, const std::string& id, bool vital, double def);
+    composition_types parse_ifrac(const nlohmann::json& obj, const std::string& id);
+```
+```cpp
+    /// Add all the fluid entries in the nlohmann::json array passed in
+    void add_many(const nlohmann::json& listing);
+    void add_one(const nlohmann::json& fluid_json);
+```
+Also update the doc comment at lines 132-133 (`rapidjson::Value`/`rapidjson array` → `nlohmann::json`).
+
+- [ ] **Step 3: Convert the include and parse_coefficients in the .cpp**
+
+In `IncompressibleLibrary.cpp`, ensure the include is `detail/json.h` (the `#include "CoolProp/detail/rapidjson.h"` near the top, ~line 6, becomes `detail/json.h`; if `all_incompressibles_JSON.h` is the only other JSON include, leave it).
+
+Replace `parse_coefficients` (348-393) — note the nested-member access `obj[id]["coeffs"]` → `obj.at(id).at("coeffs")` and the `HasMember` guards → `contains`:
+```cpp
+IncompressibleData JSONIncompressibleLibrary::parse_coefficients(const nlohmann::json& obj, const std::string& id, bool vital) {
+    IncompressibleData fluidData;
+    if (obj.contains(id)) {
+        const nlohmann::json& entry = obj.at(id);
+        if (entry.contains("type")) {
+            if (entry.contains("coeffs")) {
+                std::string type = cpjson::get_string(entry, "type");
+                if (!type.compare("polynomial")) {
+                    fluidData.type = CoolProp::IncompressibleData::INCOMPRESSIBLE_POLYNOMIAL;
+                    fluidData.coeffs = vec_to_eigen(cpjson::get_double_array2D(entry.at("coeffs")));
+                    return fluidData;
+                } else if (!type.compare("exponential")) {
+                    fluidData.type = CoolProp::IncompressibleData::INCOMPRESSIBLE_EXPONENTIAL;
+                    fluidData.coeffs = vec_to_eigen(cpjson::get_double_array(entry.at("coeffs")));
+                    return fluidData;
+                } else if (!type.compare("logexponential")) {
+                    fluidData.type = CoolProp::IncompressibleData::INCOMPRESSIBLE_LOGEXPONENTIAL;
+                    fluidData.coeffs = vec_to_eigen(cpjson::get_double_array(entry.at("coeffs")));
+                    return fluidData;
+                } else if (!type.compare("exppolynomial")) {
+                    fluidData.type = CoolProp::IncompressibleData::INCOMPRESSIBLE_EXPPOLYNOMIAL;
+                    fluidData.coeffs = vec_to_eigen(cpjson::get_double_array2D(entry.at("coeffs")));
+                    return fluidData;
+                } else if (!type.compare("polyoffset")) {
+                    fluidData.type = CoolProp::IncompressibleData::INCOMPRESSIBLE_POLYOFFSET;
+                    fluidData.coeffs = vec_to_eigen(cpjson::get_double_array(entry.at("coeffs")));
+                    return fluidData;
+                } else if (vital) {
+                    throw ValueError(format("The type [%s] is not understood for [%s] of incompressible fluids. Please check your JSON file.",
+                                            type.c_str(), id.c_str()));
+                }
+            } else {
+                throw ValueError(format("Your file does not have an entry for \"coeffs\" in [%s], which is vital for this function.", id.c_str()));
+            }
+        } else {
+            throw ValueError(format("Your file does not have an entry for \"type\" in [%s], which is vital for this function.", id.c_str()));
+        }
+    } else {
+        if (vital) {
+            throw ValueError(format("Your file does not have information for [%s], which is vital for an incompressible fluid.", id.c_str()));
+        }
+    }
+    return fluidData;
+}
+```
+
+- [ ] **Step 4: Convert parse_value, parse_ifrac, add_many in the .cpp**
+
+`parse_value` (396-406):
+```cpp
+double JSONIncompressibleLibrary::parse_value(const nlohmann::json& obj, const std::string& id, bool vital, double def = 0.0) {
+    if (obj.contains(id)) {
+        return cpjson::get_double(obj, id);
+    } else {
+        if (vital) {
+            throw ValueError(format("Your file does not have information for [%s], which is vital for an incompressible fluid.", id.c_str()));
+        } else {
+            return def;
+        }
+    }
+}
+```
+`parse_ifrac` (409): only the parameter type changes — `rapidjson::Value& obj` → `const nlohmann::json& obj`; body unchanged.
+`add_many` (422-426):
+```cpp
+void JSONIncompressibleLibrary::add_many(const nlohmann::json& listing) {
+    for (const auto& fluid_json : listing) {
+        add_one(fluid_json);
+    }
+}
+```
+`add_one` (428): change the signature `rapidjson::Value& fluid_json` → `const nlohmann::json& fluid_json`; the body uses only `cpjson::get_string(fluid_json, …)` and the `parse_*` helpers, so it is otherwise unchanged.
+
+- [ ] **Step 5: Convert load_incompressible_library in the .cpp**
+
+Replace (554-566):
+```cpp
+void load_incompressible_library() {
+    // This json formatted string comes from the all_incompressibles_JSON.h header
+    nlohmann::json dd = cpjson::parse(all_incompressibles_JSON);
+    try {
+        library.add_many(dd);
+    } catch (std::exception& e) {
+        std::cout << e.what() << '\n';
+    }
+}
+```
+(`cpjson::parse` throws `ValueError` on malformed JSON, replacing the explicit `HasParseError` check.)
+
+- [ ] **Step 6: Build**
+
+Run: `cmake -B build_catch -S . -DCOOLPROP_CATCH_MODULE=ON -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release && cmake --build build_catch --target CatchTestRunner -j8`
+Expected: clean build.
+
+- [ ] **Step 7: Run the incompressible suite (behavior parity)**
+
+Run: `./build_catch/CatchTestRunner "[INCOMP]"`
+Expected: all assertions pass (every incompressible fluid loads with identical numbers). The `[1374]` Melinder-source-data and `[1578]`/`[2209]` tests are the key parity checks.
+
+- [ ] **Step 8: Verify the loader is rapidjson-free**
+
+Run: `grep -rn "rapidjson" src/Backends/Incompressible/`
+Expected: no matches.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Backends/Incompressible/IncompressibleLibrary.h src/Backends/Incompressible/IncompressibleLibrary.cpp
+git commit -m "refactor(json): incompressible loader off rapidjson onto nlohmann (CoolProp-xa8w.1)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Ancillaries.h POD-constructor retrofit (remove the json_fwd downstream dependency)
+
+**Files:**
+- Modify: `include/CoolProp/fluids/Ancillaries.h:11-23 (remove json_fwd + friend), 89-126 (enum public + Values struct + ctor decl)`
+- Modify: `src/Backends/Helmholtz/Fluids/Ancillaries.cpp` (add the out-of-line ctor)
+- Modify: `src/Backends/Helmholtz/Fluids/FluidLibraryFactories.h:32-70 (rewrite make_saturation_ancillary to call the POD ctor)`
+
+`SaturationAncillaryFunction` currently friends `cpjson::make_saturation_ancillary(const nlohmann::json&)` and `#include <nlohmann/json_fwd.hpp>`. That header is reachable downstream via `CoolPropFluid.h`, imposing a `json_fwd.hpp` build dependency on consumers. Replace the friend boundary with a POD `Values` bundle + a constructor, so the installed header has no nlohmann token.
+
+- [ ] **Step 1: Remove the json_fwd include and the cpjson friend forward-declaration**
+
+In `Ancillaries.h`, delete lines 11-23 (the `// Forward declaration …` comment block, `#include <nlohmann/json_fwd.hpp>`, the `namespace CoolProp { class SaturationAncillaryFunction; }` forward decl, and the `namespace cpjson { … make_saturation_ancillary … }` block).
+
+- [ ] **Step 2: Make the type enum public and add the POD Values bundle + constructor declaration**
+
+In `SaturationAncillaryFunction`, move the `ancillaryfunctiontypes` enum (108-114) into the `public:` section, and add a POD `Values` bundle plus a constructor that consumes it. Replace the `private:`…`public:` boundary around the enum and the existing default ctor (89-126) so it reads:
+
+```cpp
+class SaturationAncillaryFunction
+{
+   public:
+    enum ancillaryfunctiontypes
+    {
+        TYPE_NOT_SET = 0,
+        TYPE_NOT_EXPONENTIAL,     ///< It is a non-exponential type of equation
+        TYPE_EXPONENTIAL,         ///< It is an exponential type equation, with or without the T_c/T term
+        TYPE_RATIONAL_POLYNOMIAL  ///< It is a rational polynomial equation
+    };
+
+    /// Plain-typed bundle of already-parsed ancillary values. This is the
+    /// de-publishing boundary: the non-installed factory
+    /// cpjson::make_saturation_ancillary (FluidLibraryFactories.h) does all the
+    /// nlohmann parsing and hands one of these across, keeping every JSON type
+    /// out of this installed header.
+    struct Values
+    {
+        ancillaryfunctiontypes type = TYPE_NOT_SET;
+        Eigen::MatrixXd num_coeffs, den_coeffs;
+        std::vector<double> n, t;
+        CoolPropDbl max_abs_error = _HUGE;
+        bool using_tau_r = false;
+        CoolPropDbl reducing_value = _HUGE, T_r = _HUGE;
+        CoolPropDbl Tmin = _HUGE, Tmax = _HUGE;
+    };
+
+   private:
+    Eigen::MatrixXd num_coeffs,   ///< Coefficients for numerator in rational polynomial
+      den_coeffs;                 ///< Coefficients for denominator in rational polynomial
+    std::vector<double> n, t, s;  // For TYPE_NOT_EXPONENTIAL & TYPE_EXPONENTIAL
+    union
+    {
+        CoolPropDbl max_abs_error;  ///< For TYPE_RATIONAL_POLYNOMIAL
+        struct
+        {
+            bool using_tau_r;
+            CoolPropDbl reducing_value, T_r;
+            std::size_t N;
+        };
+    };
+    CoolPropDbl Tmax, Tmin;
+    ancillaryfunctiontypes type;  ///< The type of ancillary curve being used
+
+   public:
+    SaturationAncillaryFunction()
+      : type(TYPE_NOT_SET), Tmin(_HUGE), Tmax(_HUGE){};
+
+    /// Build from a plain-typed Values bundle (defined out-of-line in
+    /// Ancillaries.cpp). All JSON parsing happens in the non-installed factory.
+    explicit SaturationAncillaryFunction(const Values& v);
+```
+Then continue with the rest of the existing class body (`bool enabled()` onward at line 128) unchanged. Delete the old `friend …` declaration (126).
+
+- [ ] **Step 3: Define the constructor out-of-line in Ancillaries.cpp**
+
+Add to `src/Backends/Helmholtz/Fluids/Ancillaries.cpp` (in `namespace CoolProp`), reproducing the field assignments the factory used to make, including the computed `N` and `s`:
+```cpp
+SaturationAncillaryFunction::SaturationAncillaryFunction(const Values& v) {
+    type = v.type;
+    Tmin = v.Tmin;
+    Tmax = v.Tmax;
+    if (type == TYPE_RATIONAL_POLYNOMIAL) {
+        num_coeffs = v.num_coeffs;
+        den_coeffs = v.den_coeffs;
+        max_abs_error = v.max_abs_error;
+    } else {
+        n = v.n;
+        t = v.t;
+        N = n.size();
+        s = n;
+        reducing_value = v.reducing_value;
+        using_tau_r = v.using_tau_r;
+        T_r = v.T_r;
+    }
+}
+```
+(The `union` is written through the matching active member per branch — exactly as the old friend factory did.)
+
+- [ ] **Step 4: Rewrite make_saturation_ancillary to build a Values and call the ctor**
+
+In `FluidLibraryFactories.h`, replace `make_saturation_ancillary` (32-70) so it populates a `SaturationAncillaryFunction::Values` and constructs from it (no private-member access, so the friend is gone):
+```cpp
+/// Build a SaturationAncillaryFunction from its JSON description. Parses into a
+/// plain-typed SaturationAncillaryFunction::Values bundle and constructs from
+/// it, so no nlohmann type crosses the installed-header boundary.
+inline CoolProp::SaturationAncillaryFunction make_saturation_ancillary(const nlohmann::json& j) {
+    CoolProp::SaturationAncillaryFunction::Values vals;
+    std::string type = cpjson::get_string(j, "type");
+    if (!type.compare("rational_polynomial")) {
+        vals.type = CoolProp::SaturationAncillaryFunction::TYPE_RATIONAL_POLYNOMIAL;
+        vals.num_coeffs = CoolProp::vec_to_eigen(cpjson::get_double_array(j.at("A")));
+        vals.den_coeffs = CoolProp::vec_to_eigen(cpjson::get_double_array(j.at("B")));
+        vals.max_abs_error = cpjson::get_double(j, "max_abs_error");
+        try {
+            vals.Tmin = cpjson::get_double(j, "Tmin");
+            vals.Tmax = cpjson::get_double(j, "Tmax");
+        } catch (...) {
+            vals.Tmin = _HUGE;
+            vals.Tmax = _HUGE;
+        }
+    } else {
+        if (!type.compare("rhoLnoexp"))
+            vals.type = CoolProp::SaturationAncillaryFunction::TYPE_NOT_EXPONENTIAL;
+        else
+            vals.type = CoolProp::SaturationAncillaryFunction::TYPE_EXPONENTIAL;
+        vals.n = cpjson::get_double_array(j.at("n"));
+        vals.t = cpjson::get_double_array(j.at("t"));
+        if (vals.n.size() != vals.t.size()) {
+            throw CoolProp::ValueError("Ancillary 'n' and 't' arrays must have equal length");
+        }
+        vals.Tmin = cpjson::get_double(j, "Tmin");
+        vals.Tmax = cpjson::get_double(j, "Tmax");
+        vals.reducing_value = cpjson::get_double(j, "reducing_value");
+        vals.using_tau_r = cpjson::get_bool(j, "using_tau_r");
+        vals.T_r = cpjson::get_double(j, "T_r");
+    }
+    return CoolProp::SaturationAncillaryFunction(vals);
+}
+```
+Update the file-top comment block (4-8) to drop the "friends these free functions … populate the otherwise-private … fields directly" wording (the `make_surface_tension_correlation` factory already needs no friend since `SurfaceTensionCorrelation` has public members; `make_saturation_ancillary` now also needs none).
+
+- [ ] **Step 5: Build**
+
+Run: `cmake --build build_catch --target CatchTestRunner -j8`
+Expected: clean build.
+
+- [ ] **Step 6: Run the ancillary-touching suites (behavior parity)**
+
+Run: `./build_catch/CatchTestRunner "[ancillaries],[fast]" ; ./build_catch/CatchTestRunner "[ancillary]"`
+Expected: pass. If neither tag matches in this checkout, run a saturation-pressure smoke instead: `./build_catch/CatchTestRunner "[helmholtz]"` and confirm no regressions. The decisive parity check is that ancillary-derived saturation values are unchanged.
+
+- [ ] **Step 7: Verify the installed header is nlohmann-free**
+
+Run: `grep -n "nlohmann\|json_fwd\|rapidjson" include/CoolProp/fluids/Ancillaries.h`
+Expected: no matches.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add include/CoolProp/fluids/Ancillaries.h src/Backends/Helmholtz/Fluids/Ancillaries.cpp src/Backends/Helmholtz/Fluids/FluidLibraryFactories.h
+git commit -m "refactor(json): Ancillaries.h POD-ctor boundary — drop json_fwd downstream dep (CoolProp-xa8w.1)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: PC-SAFT loader → nlohmann + PCSAFTFluid POD ctor + factory + Valijson
+
+**Files:**
+- Modify: `include/CoolProp/fluids/PCSAFTFluid.h:8 (drop rapidjson include), 35-37 (replace JSON ctor with POD ctor)`
+- Create: `src/Backends/PCSAFT/PCSAFTFluidFactory.h` (non-installed `cpjson::make_pcsaft_fluid`)
+- Modify: `src/Backends/PCSAFT/PCSAFTFluid.cpp` (drop the rapidjson ctor; keep calc_water_sigma)
+- Modify: `src/Backends/PCSAFT/PCSAFTLibrary.h:10,28,38 (includes + member signatures)`
+- Modify: `src/Backends/PCSAFT/PCSAFTLibrary.cpp:7 (include), 30-56 (validation→Valijson), 111-213 (add_many), 340-403 (binary pairs)`
+
+- [ ] **Step 1: Replace the JSON ctor with a POD ctor in the installed header**
+
+In `PCSAFTFluid.h`, delete line 8 (`#include "CoolProp/detail/rapidjson.h"`). Replace the JSON constructor (36):
+```cpp
+    PCSAFTFluid(rapidjson::Value::ValueIterator itr);
+```
+with a POD constructor:
+```cpp
+    PCSAFTFluid(std::string name, std::string CAS, CoolPropDbl molemass,
+                std::vector<std::string> aliases, PCSAFTValues params)
+      : name(std::move(name)), CAS(std::move(CAS)), molemass(molemass),
+        aliases(std::move(aliases)), params(std::move(params)) {}
+```
+(`PCSAFTValues` is already declared above in this header. No JSON type appears.)
+
+- [ ] **Step 2: Create the non-installed factory PCSAFTFluidFactory.h**
+
+Create `src/Backends/PCSAFT/PCSAFTFluidFactory.h` carrying the old ctor body, idiom-mapped, building the POD pieces and calling the POD ctor:
+```cpp
+#ifndef PCSAFTFLUIDFACTORY_H
+#define PCSAFTFLUIDFACTORY_H
+
+// NON-INSTALLED factory that builds a PCSAFTFluid from nlohmann::json. Lives
+// under src/ so the nlohmann::json type never appears in the installed
+// PCSAFTFluid.h. Mirrors the (now-removed) rapidjson constructor.
+
+#include "CoolProp/detail/json.h"
+#include "CoolProp/fluids/PCSAFTFluid.h"
+
+namespace cpjson {
+
+inline CoolProp::PCSAFTFluid make_pcsaft_fluid(const nlohmann::json& fluid) {
+    CoolProp::PCSAFTValues params;
+    params.m = cpjson::get_double(fluid, "m");
+    params.sigma = cpjson::get_double(fluid, "sigma");
+    params.u = cpjson::get_double(fluid, "u");
+
+    params.uAB = (fluid.contains("uAB") && fluid.at("uAB").is_number()) ? cpjson::get_double(fluid, "uAB") : 0.;
+    params.volA = (fluid.contains("volA") && fluid.at("volA").is_number()) ? cpjson::get_double(fluid, "volA") : 0.;
+    params.assocScheme = fluid.contains("assocScheme") ? cpjson::get_string_array(fluid, "assocScheme") : std::vector<std::string>{};
+    params.dipm = (fluid.contains("dipm") && fluid.at("dipm").is_number()) ? cpjson::get_double(fluid, "dipm") : 0.;
+    params.dipnum = (fluid.contains("dipnum") && fluid.at("dipnum").is_number()) ? cpjson::get_double(fluid, "dipnum") : 0.;
+    params.z = (fluid.contains("charge") && fluid.at("charge").is_number()) ? cpjson::get_double(fluid, "charge") : 0.;
+
+    return CoolProp::PCSAFTFluid(cpjson::get_string(fluid, "name"), cpjson::get_string(fluid, "CAS"),
+                                 cpjson::get_double(fluid, "molemass"), cpjson::get_string_array(fluid, "aliases"),
+                                 std::move(params));
+}
+
+}  // namespace cpjson
+
+#endif  // PCSAFTFLUIDFACTORY_H
+```
+
+- [ ] **Step 3: Remove the rapidjson ctor from PCSAFTFluid.cpp**
+
+In `PCSAFTFluid.cpp`, delete the `#include "CoolProp/detail/rapidjson.h"` (6) and the entire `PCSAFTFluid::PCSAFTFluid(rapidjson::Value::ValueIterator itr)` definition (10-55). Keep `calc_water_sigma` (57-65) and the includes it needs (`<cmath>`, `PCSAFTFluid.h`).
+
+- [ ] **Step 4: Convert the PCSAFTLibrary header**
+
+In `PCSAFTLibrary.h`: replace line 10 `#include "CoolProp/detail/rapidjson.h"` with `#include "CoolProp/detail/json.h"`. Retype:
+```cpp
+    void load_from_JSON(const nlohmann::json& doc);   // was rapidjson::Document&
+```
+```cpp
+    int add_many(const nlohmann::json& listing);       // was rapidjson::Value&
+```
+
+- [ ] **Step 5: Convert validation to Valijson + parse in PCSAFTLibrary.cpp**
+
+In `PCSAFTLibrary.cpp`: replace line 7 `#include "CoolProp/detail/rapidjson.h"` with `#include "CoolProp/detail/json.h"`, and add `#include "PCSAFTFluidFactory.h"`. Rewrite `add_fluids_from_JSON_string` (30-56), dropping the function-pointer cast (the rapidjson overload is no longer visible, so the call binds to Valijson):
+```cpp
+void add_fluids_from_JSON_string(PCSAFTLibraryClass& dest, const std::string_view& JSON) {
+    std::string errstr;
+    cpjson::schema_validation_code val_code = cpjson::validate_schema(pcsaft_fluids_schema_JSON, JSON, errstr);
+    if (val_code == cpjson::SCHEMA_VALIDATION_OK) {
+        nlohmann::json dd = cpjson::parse(JSON);
+        try {
+            dest.add_many(dd);
+        } catch (std::exception& e) {
+            std::cout << e.what() << '\n';
+        }
+    } else {
+        if (get_debug_level() > 0) {
+            throw ValueError(format("Unable to load PC-SAFT library with error: %s", errstr.c_str()));
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Convert add_many in PCSAFTLibrary.cpp**
+
+Change the signature (111) and the loop/construction (114-116); the rest of the body (the already-present checks, removal, index bookkeeping) is unchanged because it uses `fluid.getName()`/`getCAS()`/`getAliases()`:
+```cpp
+int PCSAFTLibraryClass::add_many(const nlohmann::json& listing) {
+    int counter = 0;
+    std::string fluid_name;
+    for (const auto& fluid_json : listing) {
+        try {
+            PCSAFTFluid fluid = cpjson::make_pcsaft_fluid(fluid_json);
+            fluid_name = fluid.getName();
+            // … (lines 119-207 unchanged) …
+        } catch (const std::exception& e) {
+            throw ValueError(format("Unable to load fluid [%s] due to error: %s", fluid_name.c_str(), e.what()));
+        }
+    }
+    return counter;
+}
+```
+
+- [ ] **Step 7: Convert the binary-pairs loaders in PCSAFTLibrary.cpp**
+
+`load_from_JSON` (340-394): change `rapidjson::Document& doc` → `const nlohmann::json& doc`, the loop to `for (const auto& el : doc)`, each `*itr` → `el`, and the two `itr->HasMember("kij"/"kijT")` → `el.contains("kij"/"kijT")`. The `cpjson::get_string(el, …)` / `cpjson::get_double(el, …)` calls are otherwise unchanged.
+`load_from_string` (396-403):
+```cpp
+void PCSAFTLibraryClass::load_from_string(const std::string_view& str) {
+    nlohmann::json doc = cpjson::parse(str);
+    load_from_JSON(doc);
+}
+```
+
+- [ ] **Step 8: Build**
+
+Run: `cmake --build build_catch --target CatchTestRunner -j8`
+Expected: clean build.
+
+- [ ] **Step 9: Run the PCSAFT suite (behavior parity)**
+
+Run: `./build_catch/CatchTestRunner "[PCSAFT]"`
+Expected: pass (the `[Qmass][PCSAFT][mixture]` test and any PCSAFT flash/property checks load fluids identically).
+
+- [ ] **Step 10: Verify rapidjson-free + installed header clean**
+
+Run: `grep -rn "rapidjson" src/Backends/PCSAFT/ ; grep -n "nlohmann\|rapidjson" include/CoolProp/fluids/PCSAFTFluid.h`
+Expected: no matches in either.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add include/CoolProp/fluids/PCSAFTFluid.h src/Backends/PCSAFT/PCSAFTFluidFactory.h src/Backends/PCSAFT/PCSAFTFluid.cpp src/Backends/PCSAFT/PCSAFTLibrary.h src/Backends/PCSAFT/PCSAFTLibrary.cpp
+git commit -m "refactor(json): PC-SAFT loader off rapidjson; PCSAFTFluid POD ctor + Valijson (CoolProp-xa8w.1)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Cubics/UNIFAC loaders → nlohmann + delete the alpha0 bridges + Valijson
+
+**Files:**
+- Modify: `src/Backends/Cubics/CubicsLibrary.cpp:6 (include), 29-94 (add_many + alpha0 bridge), 111-116 (get_JSONstring), 144-172 (validation→Valijson)`
+- Modify: `src/Backends/Cubics/UNIFACLibrary.h:6,91,94 (include + populate/jsonize sigs)`
+- Modify: `src/Backends/Cubics/UNIFACLibrary.cpp:7-90 (jsonize/populate + alpha0 bridge)`
+
+- [ ] **Step 1: Swap the Cubics include**
+
+In `CubicsLibrary.cpp`, replace line 6 `#include "CoolProp/detail/rapidjson.h"` with `#include "CoolProp/detail/json.h"`.
+
+- [ ] **Step 2: Convert CubicsLibraryClass::add_many and delete its alpha0 bridge**
+
+Replace `add_many` (29-94). Note: `alpha0` now passes the nlohmann node directly to `parse_alpha0` (bridge deleted), and `json2string(*itr)` → `el.dump()`:
+```cpp
+    int add_many(const nlohmann::json& listing) {
+        int counter = 0;
+        for (const auto& el : listing) {
+            CubicsValues val;
+            val.Tc = cpjson::get_double(el, "Tc");
+            val.pc = cpjson::get_double(el, "pc");
+            val.acentric = cpjson::get_double(el, "acentric");
+            val.molemass = cpjson::get_double(el, "molemass");
+            val.name = cpjson::get_string(el, "name");
+            val.aliases = cpjson::get_string_array(el, "aliases");
+            val.CAS = cpjson::get_string(el, "CAS");
+            if (el.contains("rhomolarc") && el.at("rhomolarc").is_number()) {
+                val.rhomolarc = cpjson::get_double(el, "rhomolarc");
+            }
+            if (el.contains("alpha") && el.at("alpha").is_object()) {
+                const nlohmann::json& alpha = el.at("alpha");
+                val.alpha_type = cpjson::get_string(alpha, "type");
+                val.alpha_coeffs = cpjson::get_double_array(alpha, "c");
+            } else {
+                val.alpha_type = "default";
+            }
+            if (el.contains("alpha0") && el.at("alpha0").is_array()) {
+                val.alpha0 = JSONFluidLibrary::parse_alpha0(el.at("alpha0"));
+            }
+            std::pair<std::map<std::string, CubicsValues>::iterator, bool> ret;
+            ret = fluid_map.emplace(upper(val.name), val);
+            if (ret.second == false && get_config_bool(OVERWRITE_FLUIDS)) {
+                fluid_map.erase(ret.first);
+                ret = fluid_map.emplace(upper(val.name), val);
+                if (get_debug_level() > 0) {
+                    std::cout << "added the cubic fluid: " + val.name << '\n';
+                }
+                assert(ret.second == true);
+            }
+            for (auto it = val.aliases.begin(); it != val.aliases.end(); ++it) {
+                if (aliases_map.find(*it) == aliases_map.end()) {
+                    aliases_map.emplace(*it, upper(val.name));
+                }
+            }
+            std::pair<std::map<std::string, std::string>::iterator, bool> addJson;
+            addJson = JSONstring_map.emplace(upper(val.name), el.dump());
+            if (addJson.second == false && get_config_bool(OVERWRITE_FLUIDS)) {
+                JSONstring_map.erase(addJson.first);
+                addJson = JSONstring_map.emplace(upper(val.name), el.dump());
+                if (get_debug_level() > 0) {
+                    std::cout << "added the cubic fluid: " + val.name << '\n';
+                }
+                assert(addJson.second == true);
+            }
+            counter++;
+        }
+        return counter;
+    };
+```
+
+- [ ] **Step 3: Convert get_JSONstring (wrap-in-array) in CubicsLibrary.cpp**
+
+Replace the rapidjson array-wrapping (111-116) with nlohmann:
+```cpp
+        // Then, wrap the single fluid object in an array, as callers expect
+        nlohmann::json doc = cpjson::parse(it->second);
+        nlohmann::json doc2 = nlohmann::json::array();
+        doc2.push_back(doc);
+        return doc2.dump();
+```
+(Deletes the `cpjson::JSON_string_to_rapidjson` / `doc.GetAllocator()` calls.)
+
+- [ ] **Step 4: Convert Cubics validation to Valijson + parse**
+
+Rewrite `add_fluids_from_JSON_string` (148-172), dropping the function-pointer cast:
+```cpp
+void add_fluids_from_JSON_string(CubicsLibraryClass& dest, const std::string_view& JSON) {
+    std::string errstr;
+    cpjson::schema_validation_code val_code = cpjson::validate_schema(cubic_fluids_schema_JSON, JSON, errstr);
+    if (val_code == cpjson::SCHEMA_VALIDATION_OK) {
+        nlohmann::json dd = cpjson::parse(JSON);
+        try {
+            dest.add_many(dd);
+        } catch (std::exception& /* e */) {
+            throw ValueError(format("Unable to load cubics library with error: %s", errstr.c_str()));
+        }
+    } else {
+        throw ValueError(format("Unable to validate cubics library against schema with error: %s", errstr.c_str()));
+    }
+}
+```
+
+- [ ] **Step 5: Convert the UNIFAC header**
+
+In `UNIFACLibrary.h`: replace line 6 `#include "CoolProp/detail/rapidjson.h"` with `#include "CoolProp/detail/json.h"`. Retype:
+```cpp
+    void jsonize(std::string& s, nlohmann::json& doc);
+```
+```cpp
+    /// Populate internal data structures based on nlohmann::json arrays
+    void populate(const nlohmann::json& group_data, const nlohmann::json& interaction_data, const nlohmann::json& decomp_data);
+```
+
+- [ ] **Step 6: Convert UNIFACLibrary.cpp jsonize + populate, delete the alpha0 bridge**
+
+`jsonize` (7-14):
+```cpp
+void UNIFACParameterLibrary::jsonize(std::string& s, nlohmann::json& d) {
+    d = cpjson::parse(s);
+}
+```
+`populate(nlohmann::json…)` (15-82): change the three params to `const nlohmann::json&`; convert each `for (rapidjson::Value::ValueIterator itr = X.Begin(); …)` to `for (const auto& el : X)`; each `(*itr)["k"].GetInt()/GetDouble()/GetString()` → `el.at("k").get<int>()/get<double>()/get<std::string>()`; `(*itr).HasMember("userid")` → `el.contains("userid")`; the `alpha` block uses `el.at("alpha")` with `is_object()`; **delete the alpha0 bridge** (63-70) and replace with the direct call:
+```cpp
+        if (el.contains("alpha0") && el.at("alpha0").is_array()) {
+            c.alpha0 = CoolProp::JSONFluidLibrary::parse_alpha0(el.at("alpha0"));
+        }
+```
+and the nested `groups` loop:
+```cpp
+        const nlohmann::json& groups = el.at("groups");
+        for (const auto& g : groups) {
+            int count = g.at("count").get<int>();
+            int sgi = g.at("sgi").get<int>();
+            if (has_group(sgi)) {
+                ComponentGroup cg(count, get_group(sgi));
+                c.groups.push_back(cg);
+            }
+        }
+```
+`populate(std::string…)` (83-92):
+```cpp
+void UNIFACParameterLibrary::populate(std::string& group_data, std::string& interaction_data, std::string& decomp_data) {
+    nlohmann::json group_JSON, interaction_JSON, decomp_JSON;
+    jsonize(group_data, group_JSON);
+    jsonize(interaction_data, interaction_JSON);
+    jsonize(decomp_data, decomp_JSON);
+    populate(group_JSON, interaction_JSON, decomp_JSON);
+    m_populated = true;
+}
+```
+
+- [ ] **Step 7: Build**
+
+Run: `cmake --build build_catch --target CatchTestRunner -j8`
+Expected: clean build.
+
+- [ ] **Step 8: Run the Cubics + UNIFAC suites (behavior parity)**
+
+Run: `./build_catch/CatchTestRunner "[cubic],[cubic_superanc],[cubic_DmolarT],[UNIFAC]"`
+Expected: pass (the Poling UNIFAC example `[UNIFAC]`, cubic superancillary `[2739]`, and cubic DmolarT `[2673]` checks load identically).
+
+- [ ] **Step 9: Verify rapidjson-free + bridges gone**
+
+Run: `grep -rn "rapidjson\|Removed once\|migrates off rapidjson\|validate_schema_rapidjson" src/Backends/Cubics/`
+Expected: no matches.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/Backends/Cubics/CubicsLibrary.cpp src/Backends/Cubics/UNIFACLibrary.h src/Backends/Cubics/UNIFACLibrary.cpp
+git commit -m "refactor(json): Cubics/UNIFAC loaders off rapidjson; delete alpha0 bridges + Valijson (CoolProp-xa8w.1)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: User-fluid validation test (guard the schema-engine swap)
+
+**Files:**
+- Modify: `src/Tests/CoolProp-Tests.cpp` (add a new `TEST_CASE` near the other `[PCSAFT]`/`[cubic]` cases)
+
+The user-supplied-fluid validation path moved from rapidjson `SchemaValidator` to Valijson. This test feeds a structurally-invalid payload to the public `add_fluids_as_JSON` entry points and asserts a clean throw — proving the Valijson path rejects bad input rather than crashing or silently accepting.
+
+- [ ] **Step 1: Write the test**
+
+Add to `src/Tests/CoolProp-Tests.cpp`:
+```cpp
+TEST_CASE("User-fluid schema validation rejects malformed payloads (Valijson)", "[json_validation]") {
+    SECTION("PC-SAFT: missing required fields throws") {
+        // valid JSON, but a fluid object missing required PC-SAFT parameters (m, sigma, u, …)
+        std::string bad = R"([{"name": "Bogus", "CAS": "000-00-0"}])";
+        CHECK_THROWS(CoolProp::PCSAFTLibrary::add_fluids_as_JSON(bad));
+    }
+    SECTION("PC-SAFT: structurally invalid JSON throws") {
+        std::string notjson = R"(this is not json)";
+        CHECK_THROWS(CoolProp::PCSAFTLibrary::add_fluids_as_JSON(notjson));
+    }
+    SECTION("Cubic: missing required fields throws") {
+        std::string bad = R"([{"name": "Bogus"}])";
+        CHECK_THROWS(CoolProp::CubicLibrary::add_fluids_as_JSON(bad));
+    }
+}
+```
+Ensure the test file already includes the loader headers; if not, add `#include "Backends/PCSAFT/PCSAFTLibrary.h"` and `#include "Backends/Cubics/CubicsLibrary.h"` near the other backend includes. (The cubic loader throws on schema-validation failure unconditionally; the PCSAFT loader throws on bad input when `get_debug_level() > 0`, but `add_fluids_as_JSON` parse failure throws regardless via `cpjson::parse` — the missing-fields case relies on the schema gate. If the PCSAFT missing-fields `SECTION` does not throw at default debug level, wrap it with `set_debug_level(1)` before and restore after.)
+
+- [ ] **Step 2: Build**
+
+Run: `cmake --build build_catch --target CatchTestRunner -j8`
+Expected: clean build.
+
+- [ ] **Step 3: Run the new test**
+
+Run: `./build_catch/CatchTestRunner "[json_validation]" -s`
+Expected: all three sections pass (each `CHECK_THROWS` fires). If the PCSAFT missing-fields section does not throw, apply the `set_debug_level(1)` guard noted in Step 1 and re-run.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Tests/CoolProp-Tests.cpp
+git commit -m "test(json): user-fluid schema validation rejects malformed PCSAFT/cubic payloads (CoolProp-xa8w.1)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final Verification (before PR)
+
+- [ ] **Step 1: Full fast suite**
+
+Run: `./build_catch/CatchTestRunner "~[slow]"`
+Expected: no regressions across all backends.
+
+- [ ] **Step 2: Symbol-leak gate (shared library)**
+
+Build the shared library and run the gate (it greps `nm -D` for exported `nlohmann`/`valijson`):
+Run: `./dev/ci/check-json-symbols.sh`
+Expected: PASS — zero exported nlohmann/valijson symbols. (If `make_pcsaft_fluid` or a factory leaks, confirm it is `inline` and only used within `libCoolProp`; mark `CP_JSON_LOCAL` on any out-of-line method that would otherwise emit a symbol.)
+
+- [ ] **Step 3: Installed-header cleanliness**
+
+Run: `grep -rn "nlohmann\|rapidjson\|json_fwd" include/CoolProp/fluids/PCSAFTFluid.h include/CoolProp/fluids/Ancillaries.h`
+Expected: no matches.
+
+- [ ] **Step 4: Loaders rapidjson-free**
+
+Run: `grep -rln "rapidjson" src/Backends/Incompressible/ src/Backends/PCSAFT/ src/Backends/Cubics/`
+Expected: no matches.
+
+- [ ] **Step 5: Preflight**
+
+Run: `./dev/ci/preflight.sh`
+Expected: PASS (clang-format, build, the SBTL umbrella tag is not implicated here but the changed-path auto-selection will pick the right Catch scope; cppcheck/clang-tidy/semgrep on changed files clean).
+
+- [ ] **Step 6: Adversarial review (MANDATORY before `gh pr create`)**
+
+Per CLAUDE.md, dispatch the review subagent against the diff vs `master` (this branch's base). Address or justify every blocking finding, paying attention to: the optional-member `contains`-guard parity (a dropped guard turns a missing key into a thrown exception — a behavior change), the union write in the `SaturationAncillaryFunction(Values)` ctor (correct active member per branch), and any factory that could export an nlohmann symbol.
+
+- [ ] **Step 7: Update the bd issue + finish the branch**
+
+Use superpowers:finishing-a-development-branch to push and open the PR. After PR creation, re-review any commits added after Step 6 (per CLAUDE.md "re-review the delta").
+
+---
+
+## Self-Review (plan vs spec)
+
+**Spec coverage:** §2 mechanical conversion → Tasks 1/3/4 + idiom map; §3 Valijson cast-deletion → Tasks 3.5, 4.4; §4 bridge deletion → Tasks 4.2, 4.6 (+ casts in 3.5/4.4); §5 POD boundary (PCSAFTFluid) → Task 3.1-3.2; §5 Ancillaries retrofit → Task 2; §6 components → all tasks; §7 four-commit sequencing → Tasks 1-4 each commit (Task 5 adds the test commit); §8 testing/symbol-gate/grep → Tasks' parity steps + Final Verification; §9 deferred consumer-compile gate → not implemented here (correctly out of scope, tracked on `xa8w.3`).
+
+**Type consistency:** `cpjson::make_pcsaft_fluid(const nlohmann::json&) → PCSAFTFluid` (Task 3.2) matches its call site (Task 3.6) and the POD ctor (Task 3.1). `SaturationAncillaryFunction::Values` fields (Task 2.2) match the ctor assignments (Task 2.3) and the factory population (Task 2.4). `add_many(const nlohmann::json&)`, `load_from_JSON(const nlohmann::json&)`, `populate(const nlohmann::json&…)`, `jsonize(std::string&, nlohmann::json&)` signatures are consistent between their header declarations and .cpp definitions.
+
+**Placeholder scan:** none — every code step shows complete code; the one conditional (PCSAFT debug-level guard in Task 5) is spelled out with its fallback.

--- a/docs/superpowers/specs/2026-06-06-rapidjson-to-nlohmann-phase2-4-loaders-design.md
+++ b/docs/superpowers/specs/2026-06-06-rapidjson-to-nlohmann-phase2-4-loaders-design.md
@@ -1,0 +1,185 @@
+# RapidJSON → nlohmann/json — Phase 2-4 (Incompressible + PC-SAFT + Cubics/UNIFAC loaders) — Design
+
+**Date:** 2026-06-06
+**Status:** Approved design, ready for implementation planning
+**Epic:** `CoolProp-xa8w` (RapidJSON → nlohmann/json migration) · this is child `CoolProp-xa8w.1`
+**Parent design:** `docs/superpowers/specs/2026-06-04-rapidjson-to-nlohmann-migration-design.md`
+**Predecessors (merged):** Phase 0 scaffolding (PR #3084), Phase 1 Helmholtz loader + CBOR (PR #3086).
+
+---
+
+## 1. Goal
+
+Convert the three remaining JSON-string-fed backend loaders — **Incompressible**,
+**PC-SAFT**, and **Cubics/UNIFAC** — off RapidJSON onto nlohmann/json, in one PR.
+After this lands, RapidJSON survives only in SVDSBTL / Configuration /
+SchemaValidation (Phase 5) ahead of the Final deletion. No nlohmann (or
+rapidjson) type may appear in any installed header, and no nlohmann/valijson
+symbol may be exported from `libCoolProp`.
+
+These loaders embed **plain, uncompressed `*_JSON.h` string headers** (no zlib),
+all small (incompressibles ~175 KB, cubic/pcsaft smaller). So unlike Phase 1's
+all_fluids, **there is no CBOR conversion** — just swap the parser. The data
+stays human-readable in the embedded header; nlohmann parses ~175 KB in well
+under a millisecond.
+
+## 2. Why the conversion is mechanical
+
+Every `cpjson::get_*` helper has an **identical signature** in `detail/json.h`
+(nlohmann) and `detail/rapidjson.h`. So each loader is: swap the include, retype
+parse-entry parameters, translate the small set of direct rapidjson API calls,
+and the `cpjson::get_*` call sites are unchanged. The idiom map (same as Phase 1):
+
+| rapidjson | nlohmann |
+|-----------|----------|
+| `rapidjson::Value& x` (param) | `const nlohmann::json& x` |
+| `v.HasMember("k")` | `v.contains("k")` |
+| `v["k"]` (read) | `v.at("k")` |
+| `v["k"].GetString()/GetInt()/GetDouble()` | `cpjson::get_string/get_integer/get_double(v,"k")` (or `v.at("k").get<T>()`) |
+| `v.IsObject()/IsArray()` | `v.is_object()/is_array()` |
+| `for (auto itr=v.Begin(); itr!=v.End(); ++itr) { Value& c=*itr; … }` | `for (const auto& c : v) { … }` |
+| `rapidjson::Document dd; dd.Parse<0>(s.data(), s.size()); if (dd.HasParseError()) …` | `nlohmann::json dd = cpjson::parse(s);` (throws `ValueError` on bad JSON) |
+| `cpjson::json2string(v)` | `v.dump()` |
+
+**Optional-member discipline:** rapidjson `v["k"]` (UB on missing) → nlohmann
+`v.at("k")` (throws). Every optional key must keep its `contains("k")` guard, as
+in the rapidjson original — verified per method, with the behavior-parity suite
+as the net.
+
+## 3. Schema validation → Valijson (the casts delete themselves)
+
+PC-SAFT (`PCSAFTLibrary.cpp:36-38`) and Cubics (`CubicsLibrary.cpp:154-156`)
+validate user-supplied fluids against their embedded schemas. Today they call
+`cpjson::validate_schema` through an explicit **function-pointer cast** to
+disambiguate the rapidjson and nlohmann overloads (a Phase-1 bridge, because the
+loader TU saw both). Once these loaders stop including `detail/rapidjson.h`, only
+the nlohmann (Valijson) `cpjson::validate_schema` overload is visible — so the
+cast is **deleted**, and validation runs on Valijson with no other change (same
+enum, same signature, same `schema_validation_code` return).
+
+## 4. Delete the Phase-1 temporary bridges
+
+Phase 1 left removable bridges in these files (grep "Removed once" /
+"migrates off rapidjson"); they delete cleanly once the loaders are nlohmann-native:
+
+| File:line | Bridge |
+|-----------|--------|
+| `CubicsLibrary.cpp:50-57` | `alpha0` rapidjson→`json2string`→`cpjson::parse`→nlohmann round-trip feeding `JSONFluidLibrary::parse_alpha0` |
+| `UNIFACLibrary.cpp:63-70` | same `alpha0` round-trip |
+| `CubicsLibrary.cpp:154-156` | `validate_schema` function-pointer cast |
+| `PCSAFTLibrary.cpp:36-37` | `validate_schema` function-pointer cast |
+
+After conversion, the cubic/UNIFAC loaders pass their (now nlohmann) `alpha0`
+node directly to `JSONFluidLibrary::parse_alpha0(const nlohmann::json&)`.
+
+## 5. The de-publishing boundary — POD constructor, zero nlohmann in installed headers
+
+`include/CoolProp/fluids/PCSAFTFluid.h` (installed) has a public constructor
+`PCSAFTFluid(rapidjson::Value::ValueIterator)` and `#include
+"CoolProp/detail/rapidjson.h"`. Its fields are **protected** (getters only).
+
+**Decision: POD-constructor boundary (not `json_fwd`+friend).** Add to the
+installed header a plain constructor taking already-parsed values —
+`PCSAFTFluid(std::string name, std::string CAS, CoolPropDbl molemass,
+std::vector<std::string> aliases, PCSAFTValues params)` — all POD/std types
+(`PCSAFTValues` is already a public struct in this header). The nlohmann parsing
+lives **entirely** in a new non-installed `src/` factory
+`cpjson::make_pcsaft_fluid(const nlohmann::json&)` (under
+`src/Backends/PCSAFT/`), which extracts the fields and calls the POD ctor. The
+installed header **drops the rapidjson include and gains no nlohmann at all —
+not even `<nlohmann/json_fwd.hpp>`**.
+
+**Why POD and not `json_fwd`+friend:** the `json_fwd` pattern (used for Phase 1's
+`SaturationAncillaryFunction`) leaves `#include <nlohmann/json_fwd.hpp>` in the
+installed header. CoolProp's install ships only `include/CoolProp/**` — it does
+**not** ship nlohmann's headers (nlohmann is a build-only CPM dep) — so any
+downstream consumer whose TU reaches that header would need `json_fwd.hpp` on its
+own include path to compile. The POD boundary makes the installed header
+self-contained: **downstream consumers need nothing from nlohmann.** (Not the
+full library, not even the forward-decl header.)
+
+**Retrofit `Ancillaries.h` to match.** Phase 1's
+`include/CoolProp/fluids/Ancillaries.h` currently `#include
+<nlohmann/json_fwd.hpp>` and friends `cpjson::make_saturation_ancillary(const
+nlohmann::json&)`. It is reachable from `include/CoolProp/CoolPropFluid.h`, so it
+imposes the same latent `json_fwd` dependency on downstream consumers. This phase
+**converts `SaturationAncillaryFunction` to the same POD-constructor boundary**:
+a POD/Eigen-typed constructor in `Ancillaries.h` (no nlohmann include, no friend),
+with `cpjson::make_saturation_ancillary` (in the existing non-installed
+`FluidLibraryFactories.h`) parsing and calling it. Net: the installed
+fluid-model headers `Ancillaries.h` and `PCSAFTFluid.h` are nlohmann-free.
+
+Incompressible and Cubics/UNIFAC need **no** de-publishing: `IncompressibleFluid`
+constructs internally via setters (no JSON ctor in any installed header), and
+Cubics/UNIFAC have no per-fluid public JSON constructors (string-based interface).
+
+## 6. Components & Boundaries
+
+- **`src/Backends/Incompressible/IncompressibleLibrary.{h,cpp}`** — swap include
+  to `detail/json.h`; `parse_coefficients`/`parse_value`/`parse_ifrac`/`add_many`
+  take `const nlohmann::json&`; `load_incompressible_library()` uses
+  `cpjson::parse`.
+- **`src/Backends/PCSAFT/PCSAFTLibrary.{h,cpp}` + `PCSAFTFluid.cpp`** — swap
+  include; `add_many`/binary-pairs loops → nlohmann; `add_fluids_from_JSON_string`
+  uses `cpjson::parse` + Valijson `validate_schema` (drop the cast); construct
+  fluids via `cpjson::make_pcsaft_fluid`.
+- **`include/CoolProp/fluids/PCSAFTFluid.h`** (installed) — drop rapidjson
+  include; replace the JSON ctor with the POD ctor; **no nlohmann**.
+- **New `src/Backends/PCSAFT/PCSAFTFluidFactory.h`** (non-installed) —
+  `cpjson::make_pcsaft_fluid(const nlohmann::json&)` (the old ctor body, idiom-mapped).
+- **`src/Backends/Cubics/CubicsLibrary.cpp` + `UNIFACLibrary.{h,cpp}`** — swap
+  includes; `add_many`/`populate`/`jsonize` → nlohmann (`cpjson::parse`); drop the
+  2 alpha0 bridges + the cast; Valijson validation.
+- **`include/CoolProp/fluids/Ancillaries.h` + `Ancillaries.cpp` +
+  `src/Backends/Helmholtz/Fluids/FluidLibraryFactories.h`** — retrofit
+  `SaturationAncillaryFunction` to the POD-constructor boundary (remove `json_fwd`
+  + friend; factory calls the POD ctor).
+
+## 7. Sequencing (one PR, four commits)
+
+Each commit keeps the tree green and bisectable:
+1. **Incompressible loader** — simplest; no schema/bridges/factory. Validates the pattern.
+2. **Ancillaries.h POD retrofit** — small, self-contained; removes the Phase-1
+   `json_fwd` downstream dependency. (Independent of the loaders; sequenced early
+   so the de-publishing pattern is proven before PCSAFTFluid reuses it.)
+3. **PC-SAFT loader** — parser swap + `PCSAFTFluid` POD ctor + `make_pcsaft_fluid`
+   factory + Valijson validation + drop its cast.
+4. **Cubics/UNIFAC loader** — parser swap + Valijson validation + delete the 2
+   alpha0 bridges + the cast.
+
+## 8. Testing & Verification
+
+- **Behavior parity (the safety net):** the existing `[INCOMP]`, `[cubic*]`,
+  `[PCSAFT]`, `[UNIFAC]` Catch2 suites must stay green at every commit — every
+  fluid loads with identical numbers.
+- **User-fluid validation test (new):** the schema-validation path for
+  user-supplied fluids moves engine (rapidjson → Valijson), so add a Catch2 test
+  feeding a deliberately-malformed PC-SAFT and a malformed cubic payload to the
+  public `add_fluids_as_JSON` entry points and asserting a clean failure with a
+  useful (Valijson) error message — guarding error quality across the engine swap.
+- **Symbol-leak gate:** the shared-library gate stays green — no `nlohmann`/
+  `valijson` symbol exported. The new `make_pcsaft_fluid` factory must not export
+  (inline in Release; mark `CP_JSON_LOCAL` if any out-of-line method of a
+  JSON-taking class would otherwise emit a symbol).
+- **Installed-header check:** grep confirms `PCSAFTFluid.h` and `Ancillaries.h`
+  contain no `nlohmann`/`rapidjson` token after the retrofit.
+- **Grep:** the three loaders' files are rapidjson-free; the 4 named Phase-1
+  bridges are gone.
+- **Per-commit:** `./dev/ci/preflight.sh` + the strengthened adversarial review
+  (CLAUDE.md), including the fail-open gate question.
+
+## 9. Out of Scope / Deferred (tracked)
+
+- **Consumer-compile end-to-end gate** — a dependent library compiling against
+  the install prefix with **no** nlohmann/rapidjson on its include path. This can
+  only pass once the *entire* reachable installed surface is self-contained:
+  `Ancillaries.h` + `PCSAFTFluid.h` (this phase), **`superancillary.h`** (native
+  nlohmann, `SuperAncillary(const nlohmann::json&)` public ctor — `CoolProp-rxxx`),
+  and **`detail/rapidjson.h` deleted + `detail/` install-excluded** (Phase Final
+  `CoolProp-xa8w.3`). Added as an acceptance item on `xa8w.3`. **Coordinate with
+  the in-flight nanobind interface session** — that interface is a genuine
+  downstream consumer of CoolProp's public headers and can serve as (or inform)
+  this gate, rather than building a duplicate synthetic consumer project.
+- Phase 5 (SVDSBTL + Configuration → string-based public surface) and Phase Final
+  (delete RapidJSON, drop the dual-enum guard, getter-layer decision) — `xa8w.2`,
+  `xa8w.3`.

--- a/include/CoolProp/fluids/Ancillaries.h
+++ b/include/CoolProp/fluids/Ancillaries.h
@@ -8,20 +8,6 @@
 #include "Eigen/Core"
 #include "CoolProp/numerics/PolyMath.h"
 
-// Forward declaration so that the (non-installed) factory in
-// FluidLibraryFactories.h can be friended below without dragging the full
-// nlohmann/json header into this installed header. The factory needs to
-// populate SaturationAncillaryFunction's private members directly.
-#include <nlohmann/json_fwd.hpp>
-
-namespace CoolProp {
-class SaturationAncillaryFunction;
-}  // namespace CoolProp
-
-namespace cpjson {
-CoolProp::SaturationAncillaryFunction make_saturation_ancillary(const nlohmann::json& j);
-}  // namespace cpjson
-
 namespace CoolProp {
 
 /**
@@ -88,6 +74,31 @@ class SurfaceTensionCorrelation
 */
 class SaturationAncillaryFunction
 {
+   public:
+    enum ancillaryfunctiontypes
+    {
+        TYPE_NOT_SET = 0,
+        TYPE_NOT_EXPONENTIAL,     ///< It is a non-exponential type of equation
+        TYPE_EXPONENTIAL,         ///< It is an exponential type equation, with or without the T_c/T term
+        TYPE_RATIONAL_POLYNOMIAL  ///< It is a rational polynomial equation
+    };
+
+    /// Plain-typed bundle of already-parsed ancillary values. This is the
+    /// de-coupling boundary: the non-installed factory
+    /// cpjson::make_saturation_ancillary (FluidLibraryFactories.h) does all the
+    /// nlohmann parsing and hands one of these across, keeping every JSON type
+    /// out of this installed header.
+    struct Values
+    {
+        ancillaryfunctiontypes type = TYPE_NOT_SET;
+        Eigen::MatrixXd num_coeffs, den_coeffs;
+        std::vector<double> n, t;
+        CoolPropDbl max_abs_error = _HUGE;
+        bool using_tau_r = false;
+        CoolPropDbl reducing_value = _HUGE, T_r = _HUGE;
+        CoolPropDbl Tmin = _HUGE, Tmax = _HUGE;
+    };
+
    private:
     Eigen::MatrixXd num_coeffs,   ///< Coefficients for numerator in rational polynomial
       den_coeffs;                 ///< Coefficients for denominator in rational polynomial
@@ -105,25 +116,17 @@ class SaturationAncillaryFunction
     };
     CoolPropDbl Tmax,  ///< The maximum temperature in K
       Tmin;            ///< The minimum temperature in K
-    enum ancillaryfunctiontypes
-    {
-        TYPE_NOT_SET = 0,
-        TYPE_NOT_EXPONENTIAL,     ///< It is a non-exponential type of equation
-        TYPE_EXPONENTIAL,         ///< It is an exponential type equation, with or without the T_c/T term
-        TYPE_RATIONAL_POLYNOMIAL  ///< It is a rational polynomial equation
-    };
     ancillaryfunctiontypes type;  ///< The type of ancillary curve being used
+
    public:
     SaturationAncillaryFunction()
       : type(TYPE_NOT_SET), Tmin(_HUGE), Tmax(_HUGE) {
 
         };
 
-    // The JSON-construction logic lives in the non-installed factory
-    // cpjson::make_saturation_ancillary (FluidLibraryFactories.h); it is
-    // friended here so it can populate the private members below directly,
-    // keeping the nlohmann::json type out of this installed header.
-    friend SaturationAncillaryFunction cpjson::make_saturation_ancillary(const nlohmann::json& j);
+    /// Build from a plain-typed Values bundle (defined out-of-line in
+    /// Ancillaries.cpp). All JSON parsing happens in the non-installed factory.
+    explicit SaturationAncillaryFunction(const Values& v);
 
     /// Return true if the ancillary is enabled (type is not TYPE_NOT_SET)
     bool enabled() {

--- a/include/CoolProp/fluids/Ancillaries.h
+++ b/include/CoolProp/fluids/Ancillaries.h
@@ -33,6 +33,21 @@ class SurfaceTensionCorrelation
     std::string BibTeX;          ///< The BiBTeX key for the surface tension curve in use
 
     SurfaceTensionCorrelation() : Tc(_HUGE), N(0) {}
+
+    /// Plain-typed bundle of already-parsed surface-tension values, mirroring
+    /// the SaturationAncillaryFunction::Values boundary: the non-installed
+    /// factory cpjson::make_surface_tension_correlation parses JSON into this
+    /// and constructs, so no JSON type crosses this installed header.
+    struct Values
+    {
+        std::vector<CoolPropDbl> a, n;
+        CoolPropDbl Tc = _HUGE;
+        std::string BibTeX;
+    };
+
+    explicit SurfaceTensionCorrelation(const Values& v)
+      : a(v.a), n(v.n), s(v.n), Tc(v.Tc), N(v.n.size()), BibTeX(v.BibTeX) {}
+
     /// Actually evaluate the surface tension equation
     CoolPropDbl evaluate(CoolPropDbl T) {
         if (a.empty()) {

--- a/include/CoolProp/fluids/PCSAFTFluid.h
+++ b/include/CoolProp/fluids/PCSAFTFluid.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include <map>
 
-#include "CoolProp/detail/rapidjson.h"
+#include "CoolProp/detail/tools.h"
 
 namespace CoolProp {
 
@@ -33,7 +33,10 @@ class PCSAFTFluid
 
    public:
     PCSAFTFluid() = default;
-    PCSAFTFluid(rapidjson::Value::ValueIterator itr);
+    PCSAFTFluid(std::string name, std::string CAS, CoolPropDbl molemass,
+                std::vector<std::string> aliases, PCSAFTValues params)
+      : name(std::move(name)), CAS(std::move(CAS)), molemass(molemass),
+        aliases(std::move(aliases)), params(std::move(params)) {}
     ~PCSAFTFluid() = default;
 
     std::string getName() const {

--- a/include/CoolProp/fluids/PCSAFTFluid.h
+++ b/include/CoolProp/fluids/PCSAFTFluid.h
@@ -32,11 +32,21 @@ class PCSAFTFluid
     PCSAFTValues params;
 
    public:
+    /// Plain-typed bundle of already-parsed PC-SAFT fluid values. The
+    /// non-installed factory cpjson::make_pcsaft_fluid (PCSAFTFluidFactory.h)
+    /// does the nlohmann parsing and hands one of these across, keeping every
+    /// JSON type out of this installed header.
+    struct Values
+    {
+        std::string name, CAS;
+        CoolPropDbl molemass = 0;
+        std::vector<std::string> aliases;
+        PCSAFTValues params;
+    };
+
     PCSAFTFluid() = default;
-    PCSAFTFluid(std::string name, std::string CAS, CoolPropDbl molemass,
-                std::vector<std::string> aliases, PCSAFTValues params)
-      : name(std::move(name)), CAS(std::move(CAS)), molemass(molemass),
-        aliases(std::move(aliases)), params(std::move(params)) {}
+    explicit PCSAFTFluid(const Values& v)
+      : name(v.name), CAS(v.CAS), molemass(v.molemass), aliases(v.aliases), params(v.params) {}
     ~PCSAFTFluid() = default;
 
     std::string getName() const {

--- a/src/Backends/Cubics/CubicsLibrary.cpp
+++ b/src/Backends/Cubics/CubicsLibrary.cpp
@@ -3,7 +3,7 @@
 #include "CubicsLibrary.h"
 #include "all_cubics_JSON.h"           // Makes a std::string variable called all_cubics_JSON
 #include "cubic_fluids_schema_JSON.h"  // Makes a std::string variable called cubic_fluids_schema_JSON
-#include "CoolProp/detail/rapidjson.h"
+#include "CoolProp/detail/json.h"
 #include "CoolProp/detail/strings.h"
 #include "CoolProp/CoolProp.h"
 #include "CoolProp/Configuration.h"
@@ -26,39 +26,33 @@ class CubicsLibraryClass
     bool is_empty() {
         return empty;
     };
-    int add_many(rapidjson::Value& listing) {
+    int add_many(const nlohmann::json& listing) {
         int counter = 0;
-        for (rapidjson::Value::ValueIterator itr = listing.Begin(); itr != listing.End(); ++itr) {
+        for (const auto& el : listing) {
             CubicsValues val;
-            val.Tc = cpjson::get_double(*itr, "Tc");
-            val.pc = cpjson::get_double(*itr, "pc");
-            val.acentric = cpjson::get_double(*itr, "acentric");
-            val.molemass = cpjson::get_double(*itr, "molemass");
-            val.name = cpjson::get_string(*itr, "name");
-            val.aliases = cpjson::get_string_array(*itr, "aliases");
-            val.CAS = cpjson::get_string(*itr, "CAS");
-            if (itr->HasMember("rhomolarc") && (*itr)["rhomolarc"].IsNumber()) {
-                val.rhomolarc = cpjson::get_double(*itr, "rhomolarc");
+            val.Tc = cpjson::get_double(el, "Tc");
+            val.pc = cpjson::get_double(el, "pc");
+            val.acentric = cpjson::get_double(el, "acentric");
+            val.molemass = cpjson::get_double(el, "molemass");
+            val.name = cpjson::get_string(el, "name");
+            val.aliases = cpjson::get_string_array(el, "aliases");
+            val.CAS = cpjson::get_string(el, "CAS");
+            if (el.contains("rhomolarc") && el.at("rhomolarc").is_number()) {
+                val.rhomolarc = cpjson::get_double(el, "rhomolarc");
             }
-            if (itr->HasMember("alpha") && (*itr)["alpha"].IsObject()) {
-                rapidjson::Value& alpha = (*itr)["alpha"];
+            if (el.contains("alpha") && el.at("alpha").is_object()) {
+                const nlohmann::json& alpha = el.at("alpha");
                 val.alpha_type = cpjson::get_string(alpha, "type");
                 val.alpha_coeffs = cpjson::get_double_array(alpha, "c");
             } else {
                 val.alpha_type = "default";
             }
-            if (itr->HasMember("alpha0") && (*itr)["alpha0"].IsArray()) {
-                // JSONFluidLibrary::parse_alpha0 now consumes nlohmann::json, but the
-                // cubic loader is still rapidjson-based; bridge the single call by
-                // round-tripping the alpha0 node through a string. (Removed once the
-                // cubic loader migrates off rapidjson.)
-                nlohmann::json alpha0_json = cpjson::parse(cpjson::json2string((*itr)["alpha0"]));
-                val.alpha0 = JSONFluidLibrary::parse_alpha0(alpha0_json);
+            if (el.contains("alpha0") && el.at("alpha0").is_array()) {
+                val.alpha0 = JSONFluidLibrary::parse_alpha0(el.at("alpha0"));
             }
             std::pair<std::map<std::string, CubicsValues>::iterator, bool> ret;
             ret = fluid_map.emplace(upper(val.name), val);
             if (ret.second == false && get_config_bool(OVERWRITE_FLUIDS)) {
-                // Already there, see http://www.cplusplus.com/reference/map/map/insert/
                 fluid_map.erase(ret.first);
                 ret = fluid_map.emplace(upper(val.name), val);
                 if (get_debug_level() > 0) {
@@ -66,28 +60,21 @@ class CubicsLibraryClass
                 }
                 assert(ret.second == true);
             }
-
             for (auto it = val.aliases.begin(); it != val.aliases.end(); ++it) {
                 if (aliases_map.find(*it) == aliases_map.end()) {
-                    // It's not already in aliases map
                     aliases_map.emplace(*it, upper(val.name));
                 }
             }
-
-            // Add/Replace name->JSONstring mapping to easily pull out if the user wants it
-            // Convert fuid_json to a string and store it in the map.
             std::pair<std::map<std::string, std::string>::iterator, bool> addJson;
-            addJson = JSONstring_map.emplace(upper(val.name), cpjson::json2string(*itr));
+            addJson = JSONstring_map.emplace(upper(val.name), el.dump());
             if (addJson.second == false && get_config_bool(OVERWRITE_FLUIDS)) {
-                // Already there, see http://www.cplusplus.com/reference/map/map/insert/
                 JSONstring_map.erase(addJson.first);
-                addJson = JSONstring_map.emplace(upper(val.name), cpjson::json2string(*itr));
+                addJson = JSONstring_map.emplace(upper(val.name), el.dump());
                 if (get_debug_level() > 0) {
                     std::cout << "added the cubic fluid: " + val.name << '\n';
                 }
                 assert(addJson.second == true);
             }
-
             counter++;
         }
         return counter;
@@ -107,13 +94,11 @@ class CubicsLibraryClass
                 throw ValueError(format("Fluid identifier [%s] was not found in CubicsLibrary", uppercase_identifier.c_str()));
             }
         }
-        // Then, load the fluids we would like to add
-        rapidjson::Document doc;
-        cpjson::JSON_string_to_rapidjson(it->second, doc);
-        rapidjson::Document doc2;
-        doc2.SetArray();
-        doc2.PushBack(doc, doc.GetAllocator());
-        return cpjson::json2string(doc2);
+        // Then, wrap the single fluid object in an array, as callers expect
+        nlohmann::json doc = cpjson::parse(it->second);
+        nlohmann::json doc2 = nlohmann::json::array();
+        doc2.push_back(doc);
+        return doc2.dump();
     }
 
     CubicsValues get(const std::string& identifier) {
@@ -147,24 +132,22 @@ namespace {
 /// the get_library() singleton (which would recurse into its own constructor).
 void add_fluids_from_JSON_string(CubicsLibraryClass& dest, const std::string_view& JSON) {
     std::string errstr;
-    // FluidLibrary.h (transitively) now also pulls in the nlohmann cpjson
-    // wrapper, whose validate_schema overload is ambiguous with the rapidjson
-    // one for these string arguments. Select the rapidjson overload explicitly
-    // until the cubic loader migrates off rapidjson.
-    auto validate_schema_rapidjson =
-      static_cast<cpjson::schema_validation_code (*)(const std::string_view&, const std::string_view&, std::string&)>(&cpjson::validate_schema);
-    cpjson::schema_validation_code val_code = validate_schema_rapidjson(cubic_fluids_schema_JSON, JSON, errstr);
+    // FluidLibrary.h transitively includes detail/rapidjson.h (via
+    // Configuration.h), so both validate_schema overloads are visible here and
+    // the call is ambiguous. The two overloads differ ONLY in their string_view
+    // parameters: rapidjson takes `const std::string_view&`, nlohmann takes
+    // `std::string_view` by value. The cast's by-value signature therefore
+    // selects the nlohmann/Valijson overload. Remove this cast (the call becomes
+    // unambiguous) once detail/rapidjson.h is deleted at Phase Final.
+    auto validate_schema_nlohmann =
+      static_cast<cpjson::schema_validation_code (*)(std::string_view, std::string_view, std::string&)>(&cpjson::validate_schema);
+    cpjson::schema_validation_code val_code = validate_schema_nlohmann(cubic_fluids_schema_JSON, JSON, errstr);
     if (val_code == cpjson::SCHEMA_VALIDATION_OK) {
-        rapidjson::Document dd;
-        dd.Parse<0>(JSON.data(), JSON.size());
-        if (dd.HasParseError()) {
-            throw ValueError("Cubics JSON is not valid JSON");
-        } else {
-            try {
-                dest.add_many(dd);
-            } catch (std::exception& /* e */) {
-                throw ValueError(format("Unable to load cubics library with error: %s", errstr.c_str()));
-            }
+        nlohmann::json dd = cpjson::parse(JSON);
+        try {
+            dest.add_many(dd);
+        } catch (std::exception& e) {
+            throw ValueError(format("Unable to load cubics library with error: %s", e.what()));
         }
     } else {
         throw ValueError(format("Unable to validate cubics library against schema with error: %s", errstr.c_str()));

--- a/src/Backends/Cubics/UNIFACLibrary.cpp
+++ b/src/Backends/Cubics/UNIFACLibrary.cpp
@@ -4,74 +4,64 @@
 
 namespace UNIFACLibrary {
 
-void UNIFACParameterLibrary::jsonize(std::string& s, rapidjson::Document& d) {
-    d.Parse<0>(s.c_str());
-    if (d.HasParseError()) {
-        throw -1;
-    } else {
-        return;
-    }
+void UNIFACParameterLibrary::jsonize(std::string& s, nlohmann::json& d) {
+    d = cpjson::parse(s);
 }
-void UNIFACParameterLibrary::populate(rapidjson::Value& group_data, rapidjson::Value& interaction_data, rapidjson::Value& comp_data) {
+void UNIFACParameterLibrary::populate(const nlohmann::json& group_data, const nlohmann::json& interaction_data, const nlohmann::json& comp_data) {
     if (CoolProp::get_config_bool(VTPR_ALWAYS_RELOAD_LIBRARY)) {
         groups.clear();
         interaction_parameters.clear();
         components.clear();
     }
     // Schema should have been used to validate the data already, so by this point we are can safely consume the data without checking ...
-    for (rapidjson::Value::ValueIterator itr = group_data.Begin(); itr != group_data.End(); ++itr) {
+    for (const auto& el : group_data) {
         Group g;
-        g.sgi = (*itr)["sgi"].GetInt();
-        g.mgi = (*itr)["mgi"].GetInt();
-        g.R_k = (*itr)["R_k"].GetDouble();
-        g.Q_k = (*itr)["Q_k"].GetDouble();
+        g.sgi = el.at("sgi").get<int>();
+        g.mgi = el.at("mgi").get<int>();
+        g.R_k = el.at("R_k").get<double>();
+        g.Q_k = el.at("Q_k").get<double>();
         groups.push_back(g);
     }
-    for (rapidjson::Value::ValueIterator itr = interaction_data.Begin(); itr != interaction_data.End(); ++itr) {
+    for (const auto& el : interaction_data) {
         InteractionParameters ip;
-        ip.mgi1 = (*itr)["mgi1"].GetInt();
-        ip.mgi2 = (*itr)["mgi2"].GetInt();
-        ip.a_ij = (*itr)["a_ij"].GetDouble();
-        ip.a_ji = (*itr)["a_ji"].GetDouble();
-        ip.b_ij = (*itr)["b_ij"].GetDouble();
-        ip.b_ji = (*itr)["b_ji"].GetDouble();
-        ip.c_ij = (*itr)["c_ij"].GetDouble();
-        ip.c_ji = (*itr)["c_ji"].GetDouble();
+        ip.mgi1 = el.at("mgi1").get<int>();
+        ip.mgi2 = el.at("mgi2").get<int>();
+        ip.a_ij = el.at("a_ij").get<double>();
+        ip.a_ji = el.at("a_ji").get<double>();
+        ip.b_ij = el.at("b_ij").get<double>();
+        ip.b_ji = el.at("b_ji").get<double>();
+        ip.c_ij = el.at("c_ij").get<double>();
+        ip.c_ji = el.at("c_ji").get<double>();
         interaction_parameters.push_back(ip);
     }
-    for (rapidjson::Value::ValueIterator itr = comp_data.Begin(); itr != comp_data.End(); ++itr) {
+    for (const auto& el : comp_data) {
         Component c;
-        c.inchikey = (*itr)["inchikey"].GetString();
-        c.registry_number = (*itr)["registry_number"].GetString();
-        c.name = (*itr)["name"].GetString();
-        c.Tc = (*itr)["Tc"].GetDouble();
-        c.pc = (*itr)["pc"].GetDouble();
-        c.acentric = (*itr)["acentric"].GetDouble();
-        c.molemass = (*itr)["molemass"].GetDouble();
+        c.inchikey = el.at("inchikey").get<std::string>();
+        c.registry_number = el.at("registry_number").get<std::string>();
+        c.name = el.at("name").get<std::string>();
+        c.Tc = el.at("Tc").get<double>();
+        c.pc = el.at("pc").get<double>();
+        c.acentric = el.at("acentric").get<double>();
+        c.molemass = el.at("molemass").get<double>();
         // userid is an optional user identifier
-        if ((*itr).HasMember("userid")) {
-            c.userid = (*itr)["userid"].GetString();
+        if (el.contains("userid")) {
+            c.userid = el.at("userid").get<std::string>();
         }
         // If provided, store information about the alpha function in use
-        if ((*itr).HasMember("alpha") && (*itr)["alpha"].IsObject()) {
-            rapidjson::Value& alpha = (*itr)["alpha"];
+        if (el.contains("alpha") && el.at("alpha").is_object()) {
+            const nlohmann::json& alpha = el.at("alpha");
             c.alpha_type = cpjson::get_string(alpha, "type");
             c.alpha_coeffs = cpjson::get_double_array(alpha, "c");
         } else {
             c.alpha_type = "default";
         }
-        if ((*itr).HasMember("alpha0") && (*itr)["alpha0"].IsArray()) {
-            // JSONFluidLibrary::parse_alpha0 now consumes nlohmann::json, but the
-            // UNIFAC loader is still rapidjson-based; bridge the single call by
-            // round-tripping the alpha0 node through a string. (Removed once the
-            // UNIFAC loader migrates off rapidjson.)
-            nlohmann::json alpha0_json = cpjson::parse(cpjson::json2string((*itr)["alpha0"]));
-            c.alpha0 = CoolProp::JSONFluidLibrary::parse_alpha0(alpha0_json);
+        if (el.contains("alpha0") && el.at("alpha0").is_array()) {
+            c.alpha0 = CoolProp::JSONFluidLibrary::parse_alpha0(el.at("alpha0"));
         }
-        rapidjson::Value& groups = (*itr)["groups"];
-        for (rapidjson::Value::ValueIterator itrg = groups.Begin(); itrg != groups.End(); ++itrg) {
-            int count = (*itrg)["count"].GetInt();
-            int sgi = (*itrg)["sgi"].GetInt();
+        const nlohmann::json& comp_groups = el.at("groups");
+        for (const auto& g : comp_groups) {
+            int count = g.at("count").get<int>();
+            int sgi = g.at("sgi").get<int>();
             if (has_group(sgi)) {
                 ComponentGroup cg(count, get_group(sgi));
                 c.groups.push_back(cg);
@@ -81,11 +71,9 @@ void UNIFACParameterLibrary::populate(rapidjson::Value& group_data, rapidjson::V
     }
 }
 void UNIFACParameterLibrary::populate(std::string& group_data, std::string& interaction_data, std::string& decomp_data) {
-    rapidjson::Document group_JSON;
+    nlohmann::json group_JSON, interaction_JSON, decomp_JSON;
     jsonize(group_data, group_JSON);
-    rapidjson::Document interaction_JSON;
     jsonize(interaction_data, interaction_JSON);
-    rapidjson::Document decomp_JSON;
     jsonize(decomp_data, decomp_JSON);
     populate(group_JSON, interaction_JSON, decomp_JSON);
     m_populated = true;

--- a/src/Backends/Cubics/UNIFACLibrary.cpp
+++ b/src/Backends/Cubics/UNIFACLibrary.cpp
@@ -13,39 +13,39 @@ void UNIFACParameterLibrary::populate(const nlohmann::json& group_data, const nl
         interaction_parameters.clear();
         components.clear();
     }
-    // Schema should have been used to validate the data already, so by this point we are can safely consume the data without checking ...
+    // Callers are expected to validate against the UNIFAC schema before calling populate; the cpjson::get_* helpers below still throw CoolProp::ValueError on missing/mistyped fields as a safety net.
     for (const auto& el : group_data) {
         Group g;
-        g.sgi = el.at("sgi").get<int>();
-        g.mgi = el.at("mgi").get<int>();
-        g.R_k = el.at("R_k").get<double>();
-        g.Q_k = el.at("Q_k").get<double>();
+        g.sgi = cpjson::get_integer(el, "sgi");
+        g.mgi = cpjson::get_integer(el, "mgi");
+        g.R_k = cpjson::get_double(el, "R_k");
+        g.Q_k = cpjson::get_double(el, "Q_k");
         groups.push_back(g);
     }
     for (const auto& el : interaction_data) {
         InteractionParameters ip;
-        ip.mgi1 = el.at("mgi1").get<int>();
-        ip.mgi2 = el.at("mgi2").get<int>();
-        ip.a_ij = el.at("a_ij").get<double>();
-        ip.a_ji = el.at("a_ji").get<double>();
-        ip.b_ij = el.at("b_ij").get<double>();
-        ip.b_ji = el.at("b_ji").get<double>();
-        ip.c_ij = el.at("c_ij").get<double>();
-        ip.c_ji = el.at("c_ji").get<double>();
+        ip.mgi1 = cpjson::get_integer(el, "mgi1");
+        ip.mgi2 = cpjson::get_integer(el, "mgi2");
+        ip.a_ij = cpjson::get_double(el, "a_ij");
+        ip.a_ji = cpjson::get_double(el, "a_ji");
+        ip.b_ij = cpjson::get_double(el, "b_ij");
+        ip.b_ji = cpjson::get_double(el, "b_ji");
+        ip.c_ij = cpjson::get_double(el, "c_ij");
+        ip.c_ji = cpjson::get_double(el, "c_ji");
         interaction_parameters.push_back(ip);
     }
     for (const auto& el : comp_data) {
         Component c;
-        c.inchikey = el.at("inchikey").get<std::string>();
-        c.registry_number = el.at("registry_number").get<std::string>();
-        c.name = el.at("name").get<std::string>();
-        c.Tc = el.at("Tc").get<double>();
-        c.pc = el.at("pc").get<double>();
-        c.acentric = el.at("acentric").get<double>();
-        c.molemass = el.at("molemass").get<double>();
+        c.inchikey = cpjson::get_string(el, "inchikey");
+        c.registry_number = cpjson::get_string(el, "registry_number");
+        c.name = cpjson::get_string(el, "name");
+        c.Tc = cpjson::get_double(el, "Tc");
+        c.pc = cpjson::get_double(el, "pc");
+        c.acentric = cpjson::get_double(el, "acentric");
+        c.molemass = cpjson::get_double(el, "molemass");
         // userid is an optional user identifier
         if (el.contains("userid")) {
-            c.userid = el.at("userid").get<std::string>();
+            c.userid = cpjson::get_string(el, "userid");
         }
         // If provided, store information about the alpha function in use
         if (el.contains("alpha") && el.at("alpha").is_object()) {
@@ -60,8 +60,8 @@ void UNIFACParameterLibrary::populate(const nlohmann::json& group_data, const nl
         }
         const nlohmann::json& comp_groups = el.at("groups");
         for (const auto& g : comp_groups) {
-            int count = g.at("count").get<int>();
-            int sgi = g.at("sgi").get<int>();
+            int count = cpjson::get_integer(g, "count");
+            int sgi = cpjson::get_integer(g, "sgi");
             if (has_group(sgi)) {
                 ComponentGroup cg(count, get_group(sgi));
                 c.groups.push_back(cg);

--- a/src/Backends/Cubics/UNIFACLibrary.h
+++ b/src/Backends/Cubics/UNIFACLibrary.h
@@ -6,6 +6,13 @@
 #include "CoolProp/detail/json.h"
 #include "CoolProp/CoolPropFluid.h"
 
+// Visibility helper: hide internal nlohmann-taking methods from the exported ABI
+#if defined(__GNUC__) || defined(__clang__)
+#    define CP_JSON_LOCAL __attribute__((visibility("hidden")))
+#else
+#    define CP_JSON_LOCAL
+#endif
+
 namespace UNIFACLibrary {
 
 /// A structure containing references for a single group (its multiplicity, main group index, etc.)
@@ -88,10 +95,11 @@ struct UNIFACParameterLibrary
     std::vector<Component> components;                          ///< The collection of components that are included in this library
 
     /// Convert string to JSON document
-    void jsonize(std::string& s, nlohmann::json& doc);
+    CP_JSON_LOCAL void jsonize(std::string& s, nlohmann::json& doc);
 
     /// Populate internal data structures based on nlohmann::json arrays
-    void populate(const nlohmann::json& group_data, const nlohmann::json& interaction_data, const nlohmann::json& decomp_data);
+    CP_JSON_LOCAL void populate(const nlohmann::json& group_data, const nlohmann::json& interaction_data, const nlohmann::json& decomp_data);
+#undef CP_JSON_LOCAL
 
    public:
     UNIFACParameterLibrary() : m_populated(false) {};

--- a/src/Backends/Cubics/UNIFACLibrary.h
+++ b/src/Backends/Cubics/UNIFACLibrary.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 
-#include "CoolProp/detail/rapidjson.h"
+#include "CoolProp/detail/json.h"
 #include "CoolProp/CoolPropFluid.h"
 
 namespace UNIFACLibrary {
@@ -88,10 +88,10 @@ struct UNIFACParameterLibrary
     std::vector<Component> components;                          ///< The collection of components that are included in this library
 
     /// Convert string to JSON document
-    void jsonize(std::string& s, rapidjson::Document& doc);
+    void jsonize(std::string& s, nlohmann::json& doc);
 
-    /// Populate internal data structures based on rapidjson Documents
-    void populate(rapidjson::Value& group_data, rapidjson::Value& interaction_data, rapidjson::Value& decomp_data);
+    /// Populate internal data structures based on nlohmann::json arrays
+    void populate(const nlohmann::json& group_data, const nlohmann::json& interaction_data, const nlohmann::json& decomp_data);
 
    public:
     UNIFACParameterLibrary() : m_populated(false) {};

--- a/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
+++ b/src/Backends/Helmholtz/Fluids/Ancillaries.cpp
@@ -17,6 +17,29 @@ using std::shared_ptr;
 
 namespace CoolProp {
 
+// The anonymous union (max_abs_error vs. {using_tau_r, reducing_value, T_r, N})
+// is intentionally written one active member per branch; the `type` discriminant
+// gates every read, so the inactive members are never accessed. clang-tidy's
+// union-access / member-init guidance does not model discriminated unions, so it
+// is suppressed across this constructor.
+// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init,cppcoreguidelines-pro-type-union-access)
+SaturationAncillaryFunction::SaturationAncillaryFunction(const Values& v) : type(v.type), Tmin(v.Tmin), Tmax(v.Tmax) {
+    if (type == TYPE_RATIONAL_POLYNOMIAL) {
+        num_coeffs = v.num_coeffs;
+        den_coeffs = v.den_coeffs;
+        max_abs_error = v.max_abs_error;
+    } else {
+        n = v.n;
+        t = v.t;
+        N = n.size();
+        s = n;
+        reducing_value = v.reducing_value;
+        using_tau_r = v.using_tau_r;
+        T_r = v.T_r;
+    }
+}
+// NOLINTEND(cppcoreguidelines-pro-type-member-init,cppcoreguidelines-pro-type-union-access)
+
 double SaturationAncillaryFunction::evaluate(double T) {
     if (type == TYPE_NOT_SET) {
         throw ValueError(format("type not set"));

--- a/src/Backends/Helmholtz/Fluids/FluidLibraryFactories.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibraryFactories.h
@@ -3,9 +3,10 @@
 
 // NON-INSTALLED factory helpers that build fluid-model objects from
 // nlohmann::json. These live under src/ (not include/) so that the
-// nlohmann::json type never appears in a public/installed header. The
-// installed Ancillaries.h friends these free functions so they can populate
-// the otherwise-private SaturationAncillaryFunction fields directly.
+// nlohmann::json type never appears in a public/installed header.
+// Neither factory requires friendship: make_surface_tension_correlation uses
+// only public members, and make_saturation_ancillary builds a plain-typed
+// SaturationAncillaryFunction::Values bundle and constructs from it.
 
 #include "CoolProp/detail/json.h"
 #include "CoolProp/fluids/Ancillaries.h"
@@ -29,44 +30,41 @@ inline CoolProp::SurfaceTensionCorrelation make_surface_tension_correlation(cons
     return out;
 }
 
-/// Build a SaturationAncillaryFunction from its JSON description. Reproduces
-/// the (now-removed) SaturationAncillaryFunction(rapidjson::Value&)
-/// constructor body with the nlohmann idiom map applied. SaturationAncillaryFunction
-/// friends this function so it can write the class's private members.
+/// Build a SaturationAncillaryFunction from its JSON description. Parses into a
+/// plain-typed SaturationAncillaryFunction::Values bundle and constructs from
+/// it, so no nlohmann type crosses the installed-header boundary.
 inline CoolProp::SaturationAncillaryFunction make_saturation_ancillary(const nlohmann::json& j) {
-    CoolProp::SaturationAncillaryFunction out;
+    CoolProp::SaturationAncillaryFunction::Values vals;
     std::string type = cpjson::get_string(j, "type");
     if (!type.compare("rational_polynomial")) {
-        out.type = CoolProp::SaturationAncillaryFunction::TYPE_RATIONAL_POLYNOMIAL;
-        out.num_coeffs = CoolProp::vec_to_eigen(cpjson::get_double_array(j.at("A")));
-        out.den_coeffs = CoolProp::vec_to_eigen(cpjson::get_double_array(j.at("B")));
-        out.max_abs_error = cpjson::get_double(j, "max_abs_error");
+        vals.type = CoolProp::SaturationAncillaryFunction::TYPE_RATIONAL_POLYNOMIAL;
+        vals.num_coeffs = CoolProp::vec_to_eigen(cpjson::get_double_array(j.at("A")));
+        vals.den_coeffs = CoolProp::vec_to_eigen(cpjson::get_double_array(j.at("B")));
+        vals.max_abs_error = cpjson::get_double(j, "max_abs_error");
         try {
-            out.Tmin = cpjson::get_double(j, "Tmin");
-            out.Tmax = cpjson::get_double(j, "Tmax");
+            vals.Tmin = cpjson::get_double(j, "Tmin");
+            vals.Tmax = cpjson::get_double(j, "Tmax");
         } catch (...) {
-            out.Tmin = _HUGE;
-            out.Tmax = _HUGE;
+            vals.Tmin = _HUGE;
+            vals.Tmax = _HUGE;
         }
     } else {
         if (!type.compare("rhoLnoexp"))
-            out.type = CoolProp::SaturationAncillaryFunction::TYPE_NOT_EXPONENTIAL;
+            vals.type = CoolProp::SaturationAncillaryFunction::TYPE_NOT_EXPONENTIAL;
         else
-            out.type = CoolProp::SaturationAncillaryFunction::TYPE_EXPONENTIAL;
-        out.n = cpjson::get_double_array(j.at("n"));
-        out.t = cpjson::get_double_array(j.at("t"));
-        if (out.n.size() != out.t.size()) {
+            vals.type = CoolProp::SaturationAncillaryFunction::TYPE_EXPONENTIAL;
+        vals.n = cpjson::get_double_array(j.at("n"));
+        vals.t = cpjson::get_double_array(j.at("t"));
+        if (vals.n.size() != vals.t.size()) {
             throw CoolProp::ValueError("Ancillary 'n' and 't' arrays must have equal length");
         }
-        out.N = out.n.size();
-        out.s = out.n;
-        out.Tmin = cpjson::get_double(j, "Tmin");
-        out.Tmax = cpjson::get_double(j, "Tmax");
-        out.reducing_value = cpjson::get_double(j, "reducing_value");
-        out.using_tau_r = cpjson::get_bool(j, "using_tau_r");
-        out.T_r = cpjson::get_double(j, "T_r");
+        vals.Tmin = cpjson::get_double(j, "Tmin");
+        vals.Tmax = cpjson::get_double(j, "Tmax");
+        vals.reducing_value = cpjson::get_double(j, "reducing_value");
+        vals.using_tau_r = cpjson::get_bool(j, "using_tau_r");
+        vals.T_r = cpjson::get_double(j, "T_r");
     }
-    return out;
+    return CoolProp::SaturationAncillaryFunction(vals);
 }
 
 }  // namespace cpjson

--- a/src/Backends/Helmholtz/Fluids/FluidLibraryFactories.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibraryFactories.h
@@ -7,27 +7,32 @@
 // Neither factory requires friendship: make_surface_tension_correlation uses
 // only public members, and make_saturation_ancillary builds a plain-typed
 // SaturationAncillaryFunction::Values bundle and constructs from it.
+//
+// Convention: every value type constructed from JSON exposes a nested public
+// `struct Values` (plain/POD fields) plus a single `explicit T(const Values&)`
+// ctor; these factories own all nlohmann parsing and hand a Values across, so
+// no JSON type appears in any installed header. (This is distinct from the
+// CP_JSON_LOCAL hidden-visibility treatment used on internal *loader* methods
+// that must take nlohmann::json directly to consume parsed arrays.)
 
 #include "CoolProp/detail/json.h"
 #include "CoolProp/fluids/Ancillaries.h"
 
 namespace cpjson {
 
-/// Build a SurfaceTensionCorrelation from its JSON description. Mirrors the
-/// (now-removed) inline rapidjson constructor that previously lived in
-/// include/CoolProp/fluids/Ancillaries.h.
+/// Build a SurfaceTensionCorrelation from its JSON description. Parses into a
+/// plain-typed SurfaceTensionCorrelation::Values bundle and constructs from
+/// it, so no nlohmann type crosses the installed-header boundary.
 inline CoolProp::SurfaceTensionCorrelation make_surface_tension_correlation(const nlohmann::json& j) {
-    CoolProp::SurfaceTensionCorrelation out;
-    out.a = cpjson::get_long_double_array(j.at("a"));
-    out.n = cpjson::get_long_double_array(j.at("n"));
-    if (out.a.size() != out.n.size()) {
+    CoolProp::SurfaceTensionCorrelation::Values vals;
+    vals.a = cpjson::get_long_double_array(j.at("a"));
+    vals.n = cpjson::get_long_double_array(j.at("n"));
+    if (vals.a.size() != vals.n.size()) {
         throw CoolProp::ValueError("Surface tension 'a' and 'n' arrays must have equal length");
     }
-    out.Tc = cpjson::get_double(j, "Tc");
-    out.BibTeX = cpjson::get_string(j, "BibTeX");
-    out.N = out.n.size();
-    out.s = out.n;
-    return out;
+    vals.Tc = cpjson::get_double(j, "Tc");
+    vals.BibTeX = cpjson::get_string(j, "BibTeX");
+    return CoolProp::SurfaceTensionCorrelation(vals);
 }
 
 /// Build a SaturationAncillaryFunction from its JSON description. Parses into a

--- a/src/Backends/Incompressible/IncompressibleLibrary.cpp
+++ b/src/Backends/Incompressible/IncompressibleLibrary.cpp
@@ -2,7 +2,7 @@
 #include "CoolProp/numerics/MatrixMath.h"
 #include "CoolProp/DataStructures.h"
 //#include "crossplatform_shared_ptr.h"
-#include "CoolProp/detail/rapidjson.h"
+#include "CoolProp/detail/json.h"
 #include "all_incompressibles_JSON.h"  // Makes a std::string variable called all_incompressibles_JSON
 
 #include <mutex>
@@ -345,38 +345,36 @@ JSONIncompressibleLibrary::~JSONIncompressibleLibrary() {
 };
 
 /// A general function to parse the json files that hold the coefficient matrices
-IncompressibleData JSONIncompressibleLibrary::parse_coefficients(rapidjson::Value& obj, const std::string& id, bool vital) {
+IncompressibleData JSONIncompressibleLibrary::parse_coefficients(const nlohmann::json& obj, const std::string& id, bool vital) {
     IncompressibleData fluidData;
-    if (obj.HasMember(id.c_str())) {
-        //rapidjson::Value value = obj[id.c_str()];
-        if (obj[id.c_str()].HasMember("type")) {
-            if (obj[id.c_str()].HasMember("coeffs")) {
-                std::string type = cpjson::get_string(obj[id.c_str()], "type");
+    if (obj.contains(id)) {
+        const nlohmann::json& entry = obj.at(id);
+        if (entry.contains("type")) {
+            if (entry.contains("coeffs")) {
+                std::string type = cpjson::get_string(entry, "type");
                 if (!type.compare("polynomial")) {
                     fluidData.type = CoolProp::IncompressibleData::INCOMPRESSIBLE_POLYNOMIAL;
-                    fluidData.coeffs = vec_to_eigen(cpjson::get_double_array2D(obj[id.c_str()]["coeffs"]));
+                    fluidData.coeffs = vec_to_eigen(cpjson::get_double_array2D(entry.at("coeffs")));
                     return fluidData;
                 } else if (!type.compare("exponential")) {
                     fluidData.type = CoolProp::IncompressibleData::INCOMPRESSIBLE_EXPONENTIAL;
-                    fluidData.coeffs = vec_to_eigen(cpjson::get_double_array(obj[id.c_str()]["coeffs"]));
+                    fluidData.coeffs = vec_to_eigen(cpjson::get_double_array(entry.at("coeffs")));
                     return fluidData;
                 } else if (!type.compare("logexponential")) {
                     fluidData.type = CoolProp::IncompressibleData::INCOMPRESSIBLE_LOGEXPONENTIAL;
-                    fluidData.coeffs = vec_to_eigen(cpjson::get_double_array(obj[id.c_str()]["coeffs"]));
+                    fluidData.coeffs = vec_to_eigen(cpjson::get_double_array(entry.at("coeffs")));
                     return fluidData;
                 } else if (!type.compare("exppolynomial")) {
                     fluidData.type = CoolProp::IncompressibleData::INCOMPRESSIBLE_EXPPOLYNOMIAL;
-                    fluidData.coeffs = vec_to_eigen(cpjson::get_double_array2D(obj[id.c_str()]["coeffs"]));
+                    fluidData.coeffs = vec_to_eigen(cpjson::get_double_array2D(entry.at("coeffs")));
                     return fluidData;
                 } else if (!type.compare("polyoffset")) {
                     fluidData.type = CoolProp::IncompressibleData::INCOMPRESSIBLE_POLYOFFSET;
-                    fluidData.coeffs = vec_to_eigen(cpjson::get_double_array(obj[id.c_str()]["coeffs"]));
+                    fluidData.coeffs = vec_to_eigen(cpjson::get_double_array(entry.at("coeffs")));
                     return fluidData;
                 } else if (vital) {
                     throw ValueError(format("The type [%s] is not understood for [%s] of incompressible fluids. Please check your JSON file.",
                                             type.c_str(), id.c_str()));
-                } else {
-                    //std::cout << format("The type [%s] is not understood for [%s] of incompressible fluids. Please check your JSON file.\n", type.c_str(), id.c_str());
                 }
             } else {
                 throw ValueError(format("Your file does not have an entry for \"coeffs\" in [%s], which is vital for this function.", id.c_str()));
@@ -393,8 +391,8 @@ IncompressibleData JSONIncompressibleLibrary::parse_coefficients(rapidjson::Valu
 }
 
 /// Get a double from the JSON storage if it is defined, otherwise return def
-double JSONIncompressibleLibrary::parse_value(rapidjson::Value& obj, const std::string& id, bool vital, double def = 0.0) {
-    if (obj.HasMember(id.c_str())) {
+double JSONIncompressibleLibrary::parse_value(const nlohmann::json& obj, const std::string& id, bool vital, double def = 0.0) {
+    if (obj.contains(id)) {
         return cpjson::get_double(obj, id);
     } else {
         if (vital) {
@@ -406,7 +404,7 @@ double JSONIncompressibleLibrary::parse_value(rapidjson::Value& obj, const std::
 }
 
 /// Get an integer from the JSON storage to identify the composition
-composition_types JSONIncompressibleLibrary::parse_ifrac(rapidjson::Value& obj, const std::string& id) {
+composition_types JSONIncompressibleLibrary::parse_ifrac(const nlohmann::json& obj, const std::string& id) {
     std::string res = cpjson::get_string(obj, id);
     if (!res.compare("mass")) return IFRAC_MASS;
     if (!res.compare("mole")) return IFRAC_MOLE;
@@ -418,14 +416,14 @@ composition_types JSONIncompressibleLibrary::parse_ifrac(rapidjson::Value& obj, 
     return IFRAC_UNDEFINED;
 }
 
-/// Add all the fluid entries in the rapidjson::Value instance passed in
-void JSONIncompressibleLibrary::add_many(rapidjson::Value& listing) {
-    for (rapidjson::Value::ValueIterator itr = listing.Begin(); itr != listing.End(); ++itr) {
-        add_one(*itr);
+/// Add all the fluid entries in the nlohmann::json array passed in
+void JSONIncompressibleLibrary::add_many(const nlohmann::json& listing) {
+    for (const auto& fluid_json : listing) {
+        add_one(fluid_json);
     }
 };
 
-void JSONIncompressibleLibrary::add_one(rapidjson::Value& fluid_json) {
+void JSONIncompressibleLibrary::add_one(const nlohmann::json& fluid_json) {
     _is_empty = false;
 
     // Get the next index for this fluid
@@ -552,17 +550,12 @@ static void ensure_library_loaded() {
 }
 
 void load_incompressible_library() {
-    rapidjson::Document dd;
-    // This json formatted string comes from the all_incompressibles_JSON.h header which is a C++-escaped version of the JSON file
-    dd.Parse<0>(all_incompressibles_JSON.data(), all_incompressibles_JSON.size());
-    if (dd.HasParseError()) {
-        throw ValueError("Unable to load all_incompressibles_JSON.json");
-    } else {
-        try {
-            library.add_many(dd);
-        } catch (std::exception& e) {
-            std::cout << e.what() << '\n';
-        }
+    // This json formatted string comes from the all_incompressibles_JSON.h header
+    nlohmann::json dd = cpjson::parse(all_incompressibles_JSON);
+    try {
+        library.add_many(dd);
+    } catch (std::exception& e) {
+        std::cout << e.what() << '\n';
     }
     // TODO: Implement LiBr in the source code!
     //library.add_obj(LiBrSolution());

--- a/src/Backends/Incompressible/IncompressibleLibrary.h
+++ b/src/Backends/Incompressible/IncompressibleLibrary.h
@@ -8,6 +8,13 @@
 
 #include "CoolProp/detail/json.h"
 
+// Visibility helper: hide internal nlohmann-taking methods from the exported ABI
+#if defined(__GNUC__) || defined(__clang__)
+#    define CP_JSON_LOCAL __attribute__((visibility("hidden")))
+#else
+#    define CP_JSON_LOCAL
+#endif
+
 #include <map>
 
 namespace CoolProp {
@@ -148,9 +155,9 @@ class JSONIncompressibleLibrary
 
    protected:
     /// A general function to parse the json files that hold the coefficient matrices
-    IncompressibleData parse_coefficients(const nlohmann::json& obj, const std::string& id, bool vital);
-    double parse_value(const nlohmann::json& obj, const std::string& id, bool vital, double def);
-    composition_types parse_ifrac(const nlohmann::json& obj, const std::string& id);
+    CP_JSON_LOCAL IncompressibleData parse_coefficients(const nlohmann::json& obj, const std::string& id, bool vital);
+    CP_JSON_LOCAL double parse_value(const nlohmann::json& obj, const std::string& id, bool vital, double def);
+    CP_JSON_LOCAL composition_types parse_ifrac(const nlohmann::json& obj, const std::string& id);
 
    public:
     // Default constructor;
@@ -162,8 +169,9 @@ class JSONIncompressibleLibrary
     };
 
     /// Add all the fluid entries in the nlohmann::json array passed in
-    void add_many(const nlohmann::json& listing);
-    void add_one(const nlohmann::json& fluid_json);
+    CP_JSON_LOCAL void add_many(const nlohmann::json& listing);
+    CP_JSON_LOCAL void add_one(const nlohmann::json& fluid_json);
+#undef CP_JSON_LOCAL
     void add_obj(const IncompressibleFluid& fluid_obj);
 
     /** \brief Get an IncompressibleFluid instance stored in this library

--- a/src/Backends/Incompressible/IncompressibleLibrary.h
+++ b/src/Backends/Incompressible/IncompressibleLibrary.h
@@ -6,7 +6,7 @@
 #include "CoolProp/fluids/IncompressibleFluid.h"
 //#include "crossplatform_shared_ptr.h"
 
-#include "CoolProp/detail/rapidjson.h"
+#include "CoolProp/detail/json.h"
 
 #include <map>
 
@@ -129,8 +129,8 @@ extern int get_debug_level();
 /// A container for the fluid parameters for the incompressible fluids
 /**
 This container holds copies of all of the fluid instances for the fluids that are loaded in incompressible.
-New fluids can be added by passing in a rapidjson::Value instance to the add_one function, or
-a rapidjson array of fluids to the add_many function.
+New fluids can be added by passing in a nlohmann::json instance to the add_one function, or
+a nlohmann::json array of fluids to the add_many function.
 */
 
 //typedef shared_ptr<IncompressibleFluid> IncompressibleFluidPointer;
@@ -148,9 +148,9 @@ class JSONIncompressibleLibrary
 
    protected:
     /// A general function to parse the json files that hold the coefficient matrices
-    IncompressibleData parse_coefficients(rapidjson::Value& obj, const std::string& id, bool vital);
-    double parse_value(rapidjson::Value& obj, const std::string& id, bool vital, double def);
-    composition_types parse_ifrac(rapidjson::Value& obj, const std::string& id);
+    IncompressibleData parse_coefficients(const nlohmann::json& obj, const std::string& id, bool vital);
+    double parse_value(const nlohmann::json& obj, const std::string& id, bool vital, double def);
+    composition_types parse_ifrac(const nlohmann::json& obj, const std::string& id);
 
    public:
     // Default constructor;
@@ -161,9 +161,9 @@ class JSONIncompressibleLibrary
         return _is_empty;
     };
 
-    /// Add all the fluid entries in the rapidjson::Value instance passed in
-    void add_many(rapidjson::Value& listing);
-    void add_one(rapidjson::Value& fluid_json);
+    /// Add all the fluid entries in the nlohmann::json array passed in
+    void add_many(const nlohmann::json& listing);
+    void add_one(const nlohmann::json& fluid_json);
     void add_obj(const IncompressibleFluid& fluid_obj);
 
     /** \brief Get an IncompressibleFluid instance stored in this library

--- a/src/Backends/PCSAFT/PCSAFTFluid.cpp
+++ b/src/Backends/PCSAFT/PCSAFTFluid.cpp
@@ -3,56 +3,8 @@
 #include <cmath>
 
 #include "CoolProp/fluids/PCSAFTFluid.h"
-#include "CoolProp/detail/rapidjson.h"
 
 namespace CoolProp {
-
-PCSAFTFluid::PCSAFTFluid(rapidjson::Value::ValueIterator itr) {
-    name = cpjson::get_string(*itr, "name");
-    CAS = cpjson::get_string(*itr, "CAS");
-    params.m = cpjson::get_double(*itr, "m");
-    params.sigma = cpjson::get_double(*itr, "sigma");
-    params.u = cpjson::get_double(*itr, "u");
-
-    if (itr->HasMember("uAB") && (*itr)["uAB"].IsNumber()) {
-        params.uAB = cpjson::get_double(*itr, "uAB");
-    } else {
-        params.uAB = 0.;
-    }
-
-    if (itr->HasMember("volA") && (*itr)["volA"].IsNumber()) {
-        params.volA = cpjson::get_double(*itr, "volA");
-    } else {
-        params.volA = 0.;
-    }
-
-    if (itr->HasMember("assocScheme")) {
-        params.assocScheme = cpjson::get_string_array(*itr, "assocScheme");
-    } else {
-        params.assocScheme = {};
-    }
-
-    if (itr->HasMember("dipm") && (*itr)["dipm"].IsNumber()) {
-        params.dipm = cpjson::get_double(*itr, "dipm");
-    } else {
-        params.dipm = 0.;
-    }
-
-    if (itr->HasMember("dipnum") && (*itr)["dipnum"].IsNumber()) {
-        params.dipnum = cpjson::get_double(*itr, "dipnum");
-    } else {
-        params.dipnum = 0.;
-    }
-
-    if (itr->HasMember("charge") && (*itr)["charge"].IsNumber()) {
-        params.z = cpjson::get_double(*itr, "charge");
-    } else {
-        params.z = 0.;
-    }
-
-    molemass = cpjson::get_double(*itr, "molemass");
-    aliases = cpjson::get_string_array(*itr, "aliases");
-}
 
 void PCSAFTFluid::calc_water_sigma(double t) {
     if (t > 473.16) {

--- a/src/Backends/PCSAFT/PCSAFTFluidFactory.h
+++ b/src/Backends/PCSAFT/PCSAFTFluidFactory.h
@@ -1,0 +1,33 @@
+#ifndef PCSAFTFLUIDFACTORY_H
+#define PCSAFTFLUIDFACTORY_H
+
+// NON-INSTALLED factory that builds a PCSAFTFluid from nlohmann::json. Lives
+// under src/ so the nlohmann::json type never appears in the installed
+// PCSAFTFluid.h. Mirrors the (now-removed) rapidjson constructor.
+
+#include "CoolProp/detail/json.h"
+#include "CoolProp/fluids/PCSAFTFluid.h"
+
+namespace cpjson {
+
+inline CoolProp::PCSAFTFluid make_pcsaft_fluid(const nlohmann::json& fluid) {
+    CoolProp::PCSAFTValues params;
+    params.m = cpjson::get_double(fluid, "m");
+    params.sigma = cpjson::get_double(fluid, "sigma");
+    params.u = cpjson::get_double(fluid, "u");
+
+    params.uAB = (fluid.contains("uAB") && fluid.at("uAB").is_number()) ? cpjson::get_double(fluid, "uAB") : 0.;
+    params.volA = (fluid.contains("volA") && fluid.at("volA").is_number()) ? cpjson::get_double(fluid, "volA") : 0.;
+    params.assocScheme = fluid.contains("assocScheme") ? cpjson::get_string_array(fluid, "assocScheme") : std::vector<std::string>{};
+    params.dipm = (fluid.contains("dipm") && fluid.at("dipm").is_number()) ? cpjson::get_double(fluid, "dipm") : 0.;
+    params.dipnum = (fluid.contains("dipnum") && fluid.at("dipnum").is_number()) ? cpjson::get_double(fluid, "dipnum") : 0.;
+    params.z = (fluid.contains("charge") && fluid.at("charge").is_number()) ? cpjson::get_double(fluid, "charge") : 0.;
+
+    return CoolProp::PCSAFTFluid(cpjson::get_string(fluid, "name"), cpjson::get_string(fluid, "CAS"),
+                                 cpjson::get_double(fluid, "molemass"), cpjson::get_string_array(fluid, "aliases"),
+                                 std::move(params));
+}
+
+}  // namespace cpjson
+
+#endif  // PCSAFTFLUIDFACTORY_H

--- a/src/Backends/PCSAFT/PCSAFTFluidFactory.h
+++ b/src/Backends/PCSAFT/PCSAFTFluidFactory.h
@@ -23,9 +23,13 @@ inline CoolProp::PCSAFTFluid make_pcsaft_fluid(const nlohmann::json& fluid) {
     params.dipnum = (fluid.contains("dipnum") && fluid.at("dipnum").is_number()) ? cpjson::get_double(fluid, "dipnum") : 0.;
     params.z = (fluid.contains("charge") && fluid.at("charge").is_number()) ? cpjson::get_double(fluid, "charge") : 0.;
 
-    return CoolProp::PCSAFTFluid(cpjson::get_string(fluid, "name"), cpjson::get_string(fluid, "CAS"),
-                                 cpjson::get_double(fluid, "molemass"), cpjson::get_string_array(fluid, "aliases"),
-                                 std::move(params));
+    CoolProp::PCSAFTFluid::Values vals;
+    vals.name = cpjson::get_string(fluid, "name");
+    vals.CAS = cpjson::get_string(fluid, "CAS");
+    vals.molemass = cpjson::get_double(fluid, "molemass");
+    vals.aliases = cpjson::get_string_array(fluid, "aliases");
+    vals.params = std::move(params);
+    return CoolProp::PCSAFTFluid(vals);
 }
 
 }  // namespace cpjson

--- a/src/Backends/PCSAFT/PCSAFTLibrary.cpp
+++ b/src/Backends/PCSAFT/PCSAFTLibrary.cpp
@@ -4,7 +4,8 @@
 #include "all_pcsaft_JSON.h"                   // Makes a std::string variable called all_pcsaft_JSON
 #include "pcsaft_fluids_schema_JSON.h"         // Makes a std::string variable called pcsaft_fluids_schema_JSON
 #include "mixture_binary_pairs_pcsaft_JSON.h"  // Makes a std::string variable called mixture_binary_pairs_pcsaft_JSON
-#include "CoolProp/detail/rapidjson.h"
+#include "CoolProp/detail/json.h"
+#include "PCSAFTFluidFactory.h"
 #include "CoolProp/detail/strings.h"
 #include "CoolProp/CoolProp.h"
 #include "CoolProp/Configuration.h"
@@ -29,24 +30,22 @@ namespace {
 /// the get_library() singleton (which would recurse into its own constructor).
 void add_fluids_from_JSON_string(PCSAFTLibraryClass& dest, const std::string_view& JSON) {
     std::string errstr;
-    // FluidLibrary.h (transitively) now also pulls in the nlohmann cpjson
-    // wrapper, whose validate_schema overload is ambiguous with the rapidjson
-    // one for these string arguments. Select the rapidjson overload explicitly
-    // until the PCSAFT loader migrates off rapidjson.
-    auto validate_schema_rapidjson =
-      static_cast<cpjson::schema_validation_code (*)(const std::string_view&, const std::string_view&, std::string&)>(&cpjson::validate_schema);
-    cpjson::schema_validation_code val_code = validate_schema_rapidjson(pcsaft_fluids_schema_JSON, JSON, errstr);
+    // FluidLibrary.h transitively includes detail/rapidjson.h (via
+    // Configuration.h), so both validate_schema overloads are visible here and
+    // the call is ambiguous. The two overloads differ ONLY in their string_view
+    // parameters: rapidjson takes `const std::string_view&`, nlohmann takes
+    // `std::string_view` by value. The cast's by-value signature therefore
+    // selects the nlohmann/Valijson overload. Remove this cast (the call becomes
+    // unambiguous) once detail/rapidjson.h is deleted at Phase Final.
+    auto validate_schema_nlohmann =
+      static_cast<cpjson::schema_validation_code (*)(std::string_view, std::string_view, std::string&)>(&cpjson::validate_schema);
+    cpjson::schema_validation_code val_code = validate_schema_nlohmann(pcsaft_fluids_schema_JSON, JSON, errstr);
     if (val_code == cpjson::SCHEMA_VALIDATION_OK) {
-        rapidjson::Document dd;
-        dd.Parse<0>(JSON.data(), JSON.size());
-        if (dd.HasParseError()) {
-            throw ValueError("Unable to load all_pcsaft_JSON.json");
-        } else {
-            try {
-                dest.add_many(dd);
-            } catch (std::exception& e) {
-                std::cout << e.what() << '\n';
-            }
+        nlohmann::json dd = cpjson::parse(JSON);
+        try {
+            dest.add_many(dd);
+        } catch (std::exception& e) {
+            std::cout << e.what() << '\n';
         }
     } else {
         if (get_debug_level() > 0) {
@@ -108,12 +107,12 @@ void add_fluids_as_JSON(const std::string_view& JSON) {
     add_fluids_from_JSON_string(get_library(), JSON);
 }
 
-int PCSAFTLibraryClass::add_many(rapidjson::Value& listing) {
+int PCSAFTLibraryClass::add_many(const nlohmann::json& listing) {
     int counter = 0;
     std::string fluid_name;
-    for (rapidjson::Value::ValueIterator itr = listing.Begin(); itr != listing.End(); ++itr) {
+    for (const auto& fluid_json : listing) {
         try {
-            PCSAFTFluid fluid(itr);
+            PCSAFTFluid fluid = cpjson::make_pcsaft_fluid(fluid_json);
             fluid_name = fluid.getName();
 
             // If the fluid is ok...
@@ -337,23 +336,23 @@ void PCSAFTLibraryClass::set_binary_interaction_pcsaft(const std::string& CAS1, 
     }
 }
 
-void PCSAFTLibraryClass::load_from_JSON(rapidjson::Document& doc) {
-    for (rapidjson::Value::ValueIterator itr = doc.Begin(); itr != doc.End(); ++itr) {
+void PCSAFTLibraryClass::load_from_JSON(const nlohmann::json& doc) {
+    for (const auto& el : doc) {
         // Get the empty dictionary to be filled by the appropriate interaction parameter
         Dictionary dict;
 
         // Get the vector of CAS numbers
         std::vector<std::string> CAS;
-        CAS.push_back(cpjson::get_string(*itr, "CAS1"));
-        CAS.push_back(cpjson::get_string(*itr, "CAS2"));
-        std::string name1 = cpjson::get_string(*itr, "Name1");
-        std::string name2 = cpjson::get_string(*itr, "Name2");
+        CAS.push_back(cpjson::get_string(el, "CAS1"));
+        CAS.push_back(cpjson::get_string(el, "CAS2"));
+        std::string name1 = cpjson::get_string(el, "Name1");
+        std::string name2 = cpjson::get_string(el, "Name2");
 
         // Sort the CAS number vector
         std::sort(CAS.begin(), CAS.end());
 
         // A sort was carried out, names/CAS were swapped
-        bool swapped = CAS[0].compare(cpjson::get_string(*itr, "CAS1")) != 0;
+        bool swapped = CAS[0].compare(cpjson::get_string(el, "CAS1")) != 0;
 
         if (swapped) {
             std::swap(name1, name2);
@@ -362,14 +361,14 @@ void PCSAFTLibraryClass::load_from_JSON(rapidjson::Document& doc) {
         // Populate the dictionary with common terms
         dict.add_string("name1", name1);
         dict.add_string("name2", name2);
-        dict.add_string("BibTeX", cpjson::get_string(*itr, "BibTeX"));
-        if (itr->HasMember("kij")) {
-            dict.add_number("kij", cpjson::get_double(*itr, "kij"));
+        dict.add_string("BibTeX", cpjson::get_string(el, "BibTeX"));
+        if (el.contains("kij")) {
+            dict.add_number("kij", cpjson::get_double(el, "kij"));
         } else {
             std::cout << "Loading error: binary pair of " << name1 << " & " << name2 << "does not provide kij" << '\n';
         }
-        if (itr->HasMember("kijT")) {
-            dict.add_number("kijT", cpjson::get_double(*itr, "kijT"));
+        if (el.contains("kijT")) {
+            dict.add_number("kijT", cpjson::get_double(el, "kijT"));
         }
 
         auto it = m_binary_pair_map.find(CAS);
@@ -394,11 +393,7 @@ void PCSAFTLibraryClass::load_from_JSON(rapidjson::Document& doc) {
 }
 
 void PCSAFTLibraryClass::load_from_string(const std::string_view& str) {
-    rapidjson::Document doc;
-    doc.Parse<0>(str.data(), str.size());
-    if (doc.HasParseError()) {
-        throw ValueError("Unable to parse PC-SAFT binary interaction parameter string");
-    }
+    nlohmann::json doc = cpjson::parse(str);
     load_from_JSON(doc);
 }
 

--- a/src/Backends/PCSAFT/PCSAFTLibrary.h
+++ b/src/Backends/PCSAFT/PCSAFTLibrary.h
@@ -7,7 +7,7 @@
 #include <string>
 #include "CoolProp/fluids/PCSAFTFluid.h"
 #include "CoolProp/detail/tools.h"
-#include "CoolProp/detail/rapidjson.h"
+#include "CoolProp/detail/json.h"
 
 namespace CoolProp {
 
@@ -25,7 +25,7 @@ class PCSAFTLibraryClass
     /// Map from sorted pair of CAS numbers to interaction parameter map.  The interaction parameter map is a map from key (string) to value (double)
     std::map<std::vector<std::string>, std::vector<Dictionary>> m_binary_pair_map;
 
-    void load_from_JSON(rapidjson::Document& doc);
+    void load_from_JSON(const nlohmann::json& doc);
     void load_from_string(const std::string_view& str);
 
    public:
@@ -35,7 +35,7 @@ class PCSAFTLibraryClass
         return empty;
     };
 
-    int add_many(rapidjson::Value& listing);
+    int add_many(const nlohmann::json& listing);
 
     PCSAFTFluid& get(const std::string& key);
     PCSAFTFluid& get(std::size_t key);

--- a/src/Backends/PCSAFT/PCSAFTLibrary.h
+++ b/src/Backends/PCSAFT/PCSAFTLibrary.h
@@ -9,6 +9,13 @@
 #include "CoolProp/detail/tools.h"
 #include "CoolProp/detail/json.h"
 
+// Visibility helper: hide internal nlohmann-taking methods from the exported ABI
+#if defined(__GNUC__) || defined(__clang__)
+#    define CP_JSON_LOCAL __attribute__((visibility("hidden")))
+#else
+#    define CP_JSON_LOCAL
+#endif
+
 namespace CoolProp {
 
 std::string get_mixture_binary_pair_pcsaft(const std::string& CAS1, const std::string& CAS2, const std::string& key);
@@ -25,7 +32,7 @@ class PCSAFTLibraryClass
     /// Map from sorted pair of CAS numbers to interaction parameter map.  The interaction parameter map is a map from key (string) to value (double)
     std::map<std::vector<std::string>, std::vector<Dictionary>> m_binary_pair_map;
 
-    void load_from_JSON(const nlohmann::json& doc);
+    CP_JSON_LOCAL void load_from_JSON(const nlohmann::json& doc);
     void load_from_string(const std::string_view& str);
 
    public:
@@ -35,7 +42,8 @@ class PCSAFTLibraryClass
         return empty;
     };
 
-    int add_many(const nlohmann::json& listing);
+    CP_JSON_LOCAL int add_many(const nlohmann::json& listing);
+#undef CP_JSON_LOCAL
 
     PCSAFTFluid& get(const std::string& key);
     PCSAFTFluid& get(std::size_t key);

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5001,6 +5001,37 @@ TEST_CASE("Qmass: SRK cubic mixture output works after Q-pair flash", "[Qmass][c
     CHECK(AS2->Q() == Catch::Approx(0.0).epsilon(1e-10));
 }
 
+TEST_CASE("User-fluid schema validation rejects malformed PCSAFT/cubic payloads", "[json_validation]") {
+    // --- Cubic (SRK) ---
+    // 1. Structurally invalid JSON must throw unconditionally.
+    SECTION("Cubic SRK - invalid JSON syntax throws") {
+        CHECK_THROWS_AS(CoolProp::add_fluids_as_JSON("SRK", "this is not json"), CoolProp::ValueError);
+    }
+    // 2. Valid JSON array but missing required schema fields (Tc_units, pc_units,
+    //    molemass_units, acentric) — the Valijson validator catches the omissions
+    //    and add_fluids_from_JSON_string throws unconditionally for cubics.
+    SECTION("Cubic SRK - schema-invalid payload (missing required fields) throws") {
+        // Provides name, CAS, Tc, pc, molemass but omits the *_units fields and
+        // acentric, all of which are listed in the cubic schema's "required" array.
+        const std::string bad_cubic =
+          R"([{"name":"BadFluid","CAS":"000-00-0","Tc":400.0,"pc":3e6,"molemass":0.04}])";
+        CHECK_THROWS_AS(CoolProp::add_fluids_as_JSON("SRK", bad_cubic), CoolProp::ValueError);
+    }
+
+    // --- PC-SAFT ---
+    // The PCSAFT loader only throws on validation failure when debug_level > 0.
+    // Save the current level and restore it after the section — even if a
+    // CHECK fails, the SECTION exits normally and the restore still runs.
+    const int saved_debug = CoolProp::get_debug_level();
+
+    // 3. Structurally invalid JSON under debug_level > 0 must throw.
+    SECTION("PCSAFT - invalid JSON syntax throws at debug_level > 0") {
+        CoolProp::set_debug_level(1);
+        CHECK_THROWS_AS(CoolProp::add_fluids_as_JSON("PCSAFT", "this is not json"), CoolProp::ValueError);
+        CoolProp::set_debug_level(saved_debug);
+    }
+}
+
 TEST_CASE("Water TS_INPUTS flash near 631-634 K is smooth (no spike to 6e13 Pa)", "[water_flash][2079]") {
     // Issue #2079: previously CP.PropsSI('P','T',T,'S',6763.617,'Water')
     // for T in {631, 632, 633, 634} returned ~6e13 Pa (vs ~3.1 MPa

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5019,16 +5019,40 @@ TEST_CASE("User-fluid schema validation rejects malformed PCSAFT/cubic payloads"
     }
 
     // --- PC-SAFT ---
-    // The PCSAFT loader only throws on validation failure when debug_level > 0.
-    // Save the current level and restore it after the section — even if a
-    // CHECK fails, the SECTION exits normally and the restore still runs.
-    const int saved_debug = CoolProp::get_debug_level();
+    // The PCSAFT loader only throws on validation failure when debug_level > 0
+    // (at level 0 it silently returns); raise it for these checks and restore
+    // unconditionally via RAII, so other tests are unaffected even if the
+    // assertion throws an unexpected type.
 
     // 3. Structurally invalid JSON under debug_level > 0 must throw.
     SECTION("PCSAFT - invalid JSON syntax throws at debug_level > 0") {
+        // PCSAFT's loader only surfaces validation failures when debug_level > 0
+        // (at level 0 it silently returns); raise it for this check and restore
+        // unconditionally via RAII, so other tests are unaffected even if the
+        // assertion throws an unexpected type.
+        struct DebugLevelGuard {
+            int saved;
+            DebugLevelGuard() : saved(CoolProp::get_debug_level()) {}
+            ~DebugLevelGuard() { CoolProp::set_debug_level(saved); }
+        } guard;
         CoolProp::set_debug_level(1);
         CHECK_THROWS_AS(CoolProp::add_fluids_as_JSON("PCSAFT", "this is not json"), CoolProp::ValueError);
-        CoolProp::set_debug_level(saved_debug);
+    }
+
+    // 4. Valid JSON array but missing required schema fields (m, sigma, sigma_units,
+    //    u, u_units, molemass, molemass_units) — the PCSAFT schema marks these in its
+    //    "required" array, so Valijson rejects the payload and the loader throws when
+    //    debug_level > 0.
+    SECTION("PCSAFT - schema-invalid payload (missing required fields) throws at debug_level > 0") {
+        struct DebugLevelGuard {
+            int saved;
+            DebugLevelGuard() : saved(CoolProp::get_debug_level()) {}
+            ~DebugLevelGuard() { CoolProp::set_debug_level(saved); }
+        } guard;
+        CoolProp::set_debug_level(1);
+        // Provides name and CAS but omits m, sigma, sigma_units, u, u_units,
+        // molemass, molemass_units — all listed in the PCSAFT schema's "required" array.
+        CHECK_THROWS_AS(CoolProp::add_fluids_as_JSON("PCSAFT", R"([{"name":"Bogus","CAS":"000-00-0"}])"), CoolProp::ValueError);
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 2-4 of the RapidJSON → nlohmann/json migration (epic `CoolProp-xa8w`; follows Phase 0 #3084 and Phase 1 #3086). Converts the three remaining JSON-string-fed backend loaders onto nlohmann and tightens the installed-header ABI so downstream consumers need **no** JSON library.

- **Loader conversions** (mechanical include-swap + idiom translation; `cpjson::get_*` helpers are signature-identical across `detail/rapidjson.h` and `detail/json.h`):
  - **Incompressible** (`IncompressibleLibrary`)
  - **PC-SAFT** (`PCSAFTLibrary` + `PCSAFTFluid`)
  - **Cubics / UNIFAC** (`CubicsLibrary`, `UNIFACLibrary`)
- **De-publishing → POD-constructor boundary** so installed headers carry **zero** nlohmann/rapidjson tokens (downstream TUs no longer need even `nlohmann/json_fwd.hpp`):
  - `include/CoolProp/fluids/PCSAFTFluid.h`: `PCSAFTFluid(rapidjson::Value::ValueIterator)` → a plain POD ctor; JSON parsing moves to a non-installed `src/` factory `cpjson::make_pcsaft_fluid`.
  - `include/CoolProp/fluids/Ancillaries.h`: **retrofitted** to drop the `json_fwd`+friend boundary Phase 1 left (it was reachable downstream via `CoolPropFluid.h`) in favour of a `SaturationAncillaryFunction::Values` POD bundle + ctor.
- **Schema validation → Valijson** for user-supplied PC-SAFT/cubic fluids (the rapidjson `SchemaValidator` path is retired; the function-pointer cast now selects the nlohmann/Valijson overload — see note below).
- **Deletes the two Phase-1 `alpha0` round-trip bridges** in `CubicsLibrary`/`UNIFACLibrary`; `parse_alpha0` now consumes the nlohmann node directly.
- **Symbol-leak gate fix:** the loader member functions taking `const nlohmann::json&` are annotated `CP_JSON_LOCAL` (hidden visibility), matching Phase 1's treatment of `JSONFluidLibrary::add_many/add_one` — `nm -D libCoolProp` now exports **0** nlohmann/valijson symbols.
- **New test** (`[json_validation]`): the public `add_fluids_as_JSON` rejects malformed PC-SAFT/cubic payloads via Valijson (verified-firing assertions).

After this, RapidJSON survives only in SVDSBTL / Configuration / SchemaValidation (Phase 5, `CoolProp-xa8w.2`) ahead of the Final deletion (`CoolProp-xa8w.3`).

Design + plan: `docs/superpowers/specs/2026-06-06-rapidjson-to-nlohmann-phase2-4-loaders-design.md`, `docs/superpowers/plans/2026-06-07-rapidjson-to-nlohmann-phase2-4-loaders.md`.

## Notes for reviewers

- **`validate_schema` cast retained (not deleted).** The plan predicted the function-pointer cast would self-delete; it doesn't, because `FluidLibrary.h` still pulls `detail/rapidjson.h` transitively via `Configuration.h` (Phase 5 work), so both overloads stay visible. The cast is **retargeted** to the nlohmann by-value `std::string_view` overload (a function-pointer cast requires exact type match, so it cannot silently bind rapidjson — it would be a compile error). It is removed when `detail/rapidjson.h` is deleted at Phase Final. Documented in-code at both call sites.
- **Behaviour tightening (UNIFAC):** `UNIFACParameterLibrary::populate` now reads scalar fields via `cpjson::get_integer/get_double/get_string` instead of raw `.get<T>()`, so the unvalidated VTPR user-file path yields a clean `CoolProp::ValueError` rather than a raw nlohmann exception. Side effect: an integer field written as a float (e.g. `"sgi": 1.0`) is now rejected with a clear error instead of being silently coerced. UNIFAC's shipped data uses proper integers; flagging for awareness.
- **Installed-header self-containment** (`PCSAFTFluid.h`, `Ancillaries.h`) is a step toward the deferred **consumer-compile end-to-end gate** (`CoolProp-xa8w.3`), to be coordinated with the in-flight nanobind interface. `superancillary.h` + the `detail/` headers still pull JSON and are addressed at Phase Final.

## Test Plan

- [x] `[INCOMP]`, `[PCSAFT]`, `[cubic]`/`[cubic_superanc]`/`[cubic_DmolarT]`, `[UNIFAC]`, `[ancillaries]`, `[json_validation]` — all green, behaviour parity preserved
- [x] Full `~[slow]` suite: 118,225 assertions, 0 failures
- [x] Symbol-leak gate on `libCoolProp.dylib`: `OK: no symbols matching /nlohmann|valijson/`
- [x] Installed headers `PCSAFTFluid.h` / `Ancillaries.h` contain no nlohmann/rapidjson token
- [x] Per-task spec + code-quality reviews, whole-diff adversarial review, post-review delta re-review — no blocking findings

> CI clang-tidy (diff-only) is clean on this branch; the only findings on added lines are noise-filtered Catch2 macro expansions. (Local whole-file preflight surfaces pre-existing lint on unchanged lines in the touched legacy files, which CI's diff-only/informational gates do not block.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON schema validation and error handling for custom fluid payloads—malformed or schema-invalid inputs are now reliably rejected with clearer errors.

* **Documentation**
  * Added detailed design and implementation plans documenting the JSON migration and validation approach.

* **Tests**
  * New schema-validation tests ensure malformed cubic and PC‑SAFT payloads are detected (including debug-mode checks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->