### PR TITLE
test(python): pytest suite for the nanobind interface + CI job (CoolProp-r9sq.5)

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -132,6 +132,34 @@ jobs:
             name: CoolProp-${{ github.sha }}-clang_format.patch
             path: clang_format.patch
 
+  nanobind-pytest:
+    name: nanobind pytest suite
+    # PR-only (same rationale as clang-format above): avoid master going red
+    # retroactively. Open a draft PR to exercise it on a branch.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build the nanobind wheel and run the pytest suite
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv venv --python 3.13
+          source .venv/bin/activate
+          uv pip install nanobind cython scikit-build-core ninja pytest
+          # Release: the wheel compiles the whole core (incl. SVDSBTL); Debug is
+          # very slow. COOLPROP_NANOBIND=ON selects the nanobind core + State shim.
+          uv build --wheel --no-build-isolation \
+            --config-setting=cmake.define.COOLPROP_NANOBIND=ON \
+            --config-setting=cmake.define.CMAKE_BUILD_TYPE=Release \
+            --out-dir dist .
+          uv pip install --force-reinstall dist/coolprop-*.whl
+          pytest wrappers/Python/pytest -q
+
   clang-tidy:
     name: clang-tidy (diff-only, informational)
     # Runs clang-tidy on lines changed in the PR via clang-tidy-diff.py and

--- a/wrappers/Python/pytest/README.md
+++ b/wrappers/Python/pytest/README.md
@@ -1,0 +1,33 @@
+# nanobind interface pytest suite
+
+Modern pytest tests for the v8 (nanobind) CoolProp Python interface. The legacy
+`CoolProp/tests/` suite is mostly `nose`-based (dead on Python 3.12+), so this is
+the test-verification vehicle for the nanobind migration (bd CoolProp-r9sq.5),
+and it backfills the q2sh "existing suite green" acceptance check.
+
+## What it covers
+
+- High-level API: `PropsSI`, `HAPropsSI`
+- `AbstractState` low-level surface, including the q2sh parity additions
+  (idealgas/residual decompositions, `get_fluid_constant`, `neff`, the
+  `set_reference_state(FluidName, *args)` dispatcher)
+- module-level convenience wrappers (`FluidsList`, `get_aliases`,
+  `get_REFPROPname`, `get_BibTeXKey`, `get_config_int`)
+- the capsule `State` shim unit conventions (kPa/kJ getters, g/mol `get_MM`,
+  SI `.pAS`) — the split the original PDSim regression hinged on
+- the approved v8 removals (`Props`/`HAProps` absent; `HAProps` raises)
+
+The v8-specific removal tests `skipif` the legacy build, so the file is safe to
+point at either wheel.
+
+## Running
+
+Build and install a nanobind wheel, then run pytest against it:
+
+```bash
+# from the repo root, in a venv with: nanobind, cython, scikit-build-core, uv, pytest
+uv build --wheel --no-build-isolation \
+    --config-setting=cmake.define.COOLPROP_NANOBIND=ON --out-dir dist .
+pip install --force-reinstall dist/coolprop-*.whl
+pytest wrappers/Python/pytest -q
+```

--- a/wrappers/Python/pytest/test_nanobind_interface.py
+++ b/wrappers/Python/pytest/test_nanobind_interface.py
@@ -1,0 +1,179 @@
+"""
+pytest suite for the v8 (nanobind) CoolProp Python interface.
+
+Runs against an *installed* CoolProp built with ``-DCOOLPROP_NANOBIND=ON`` (see
+README.md in this directory).  Most assertions hold for the legacy build too;
+the v8-specific cases (the ``Props``/``HAProps`` removals) are skipped when run
+against a legacy wheel so the file is safe to point at either.
+
+Covers: the high-level API, the AbstractState low-level surface including the
+q2sh parity additions (idealgas/residual decompositions, fluid-constant
+accessors, ``neff``, the ``set_reference_state`` dispatcher), the module-level
+convenience wrappers, the capsule ``State`` shim unit conventions (the kPa/kJ /
+g/mol / kW/m/K split that the original PDSim regression hinged on), and the
+approved v8 removals.
+"""
+import math
+
+import pytest
+
+import CoolProp
+from CoolProp import CoolProp as CP
+
+# v8 (nanobind) build is identified by the free ``Props`` having been removed.
+is_legacy = hasattr(CP, "Props")
+v8_only = pytest.mark.skipif(is_legacy, reason="v8 (nanobind) build only")
+
+
+# --------------------------------------------------------------------------- #
+# High-level API
+# --------------------------------------------------------------------------- #
+def test_propssi_liquid_water():
+    # liquid water density at 300 K, 1 atm
+    assert CP.PropsSI("D", "T", 300.0, "P", 101325.0, "Water") == pytest.approx(996.5, rel=1e-3)
+
+
+def test_propssi_co2():
+    assert CP.PropsSI("D", "T", 320.0, "P", 6e6, "CO2") == pytest.approx(139.1, rel=1e-2)
+
+
+def test_hapropssi_wetbulb():
+    assert CP.HAPropsSI("B", "T", 300.0, "P", 101325.0, "W", 0.01) == pytest.approx(291.706, rel=1e-4)
+
+
+# --------------------------------------------------------------------------- #
+# AbstractState low-level surface
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def water():
+    return CP.AbstractState("HEOS", "Water")
+
+
+def test_abstractstate_update_pt(water):
+    water.update(CP.PT_INPUTS, 101325.0, 300.0)
+    assert water.rhomass() == pytest.approx(996.5, rel=1e-3)
+    assert water.T() == pytest.approx(300.0)
+
+
+def test_get_fluid_constant(water):
+    assert water.get_fluid_constant(0, CP.iT_critical) == pytest.approx(647.096, rel=1e-4)
+
+
+def test_neff_finite(water):
+    water.update(CP.DmassT_INPUTS, 2.0, 600.0)
+    assert math.isfinite(water.neff())
+
+
+# --- q2sh parity additions: the idealgas + residual decomposition ---
+@pytest.mark.parametrize(
+    "D, T, label",
+    [(0.5, 400.0, "superheated vapor"), (950.0, 400.0, "compressed liquid"), (2.0, 600.0, "vapor")],
+)
+def test_h_eq_ideal_plus_residual_singlephase(D, T, label):
+    AS = CP.AbstractState("HEOS", "Water")
+    AS.update(CP.DmassT_INPUTS, D, T)
+    assert AS.hmolar() == pytest.approx(AS.hmolar_idealgas() + AS.hmolar_residual(), rel=1e-9)
+    assert AS.smolar() == pytest.approx(AS.smolar_idealgas() + AS.smolar_residual(), rel=1e-9)
+
+
+def test_h_neq_ideal_plus_residual_twophase():
+    # At (D=2, T=400) water is two-phase (p == Psat); hmolar() is the
+    # quality-weighted mixture, so the EOS-at-(tau,delta) parts do NOT sum to it.
+    AS = CP.AbstractState("HEOS", "Water")
+    AS.update(CP.DmassT_INPUTS, 2.0, 400.0)
+    assert 0.0 < AS.Q() < 1.0
+    assert AS.hmolar() != pytest.approx(AS.hmolar_idealgas() + AS.hmolar_residual(), rel=1e-3)
+
+
+# --- set_reference_state unified (FluidName, *args) dispatcher ---
+def test_set_reference_state_string_dispatch():
+    try:
+        CP.set_reference_state("Propane", "IIR")  # arity 1 -> set_reference_stateS
+    finally:
+        CP.set_reference_state("Propane", "DEF")  # reset global state
+
+
+def test_set_reference_state_bad_arity_raises():
+    with pytest.raises(ValueError):
+        CP.set_reference_state("Propane", 1.0, 2.0, 3.0)  # arity 3 -> invalid
+
+
+# --------------------------------------------------------------------------- #
+# Module-level convenience wrappers
+# --------------------------------------------------------------------------- #
+def test_fluidslist():
+    fl = CP.FluidsList()
+    assert "Water" in fl
+    assert "" not in fl  # the empty-input split fix: no stray '' entry
+
+
+def test_get_aliases():
+    assert "R744" in CP.get_aliases("CO2")
+
+
+def test_get_refpropname():
+    assert CP.get_REFPROPname("R134a") == "R134A"
+
+
+def test_get_bibtexkey():
+    assert CP.get_BibTeXKey("Water", "EOS")  # non-empty string
+
+
+def test_config_int_bound():
+    # smoke: the int-config accessors are bound (a value round-trip needs a known
+    # integer config key, which the public enum does not expose stably)
+    assert callable(CP.get_config_int) and callable(CP.set_config_int)
+
+
+# --------------------------------------------------------------------------- #
+# Capsule State shim -- the legacy unit conventions PDSim depends on
+# --------------------------------------------------------------------------- #
+def test_state_unit_conventions():
+    from CoolProp.State import State
+
+    S = State("Water", {"T": 320.0, "D": 1000.0})
+    # kPa / kJ getters vs the SI Props()
+    assert S.get_p() == pytest.approx(S.Props(CP.iP) / 1000.0, rel=1e-9)
+    assert S.get_h() == pytest.approx(S.Props(CP.iHmass) / 1000.0, rel=1e-9)
+    # get_MM is g/mol == 1000x the SI molar mass from the same handle (~18.015)
+    assert S.get_MM() == pytest.approx(S.pAS.keyed_output(CP.imolar_mass) * 1000.0, rel=1e-9)
+    assert S.get_MM() == pytest.approx(18.015, rel=1e-3)
+    # get_rho and .pAS are SI
+    assert S.get_rho() == pytest.approx(1000.0, rel=1e-9)
+    assert S.pAS.rhomass() == pytest.approx(1000.0, rel=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# Approved v8 removals
+# --------------------------------------------------------------------------- #
+@v8_only
+def test_free_props_removed():
+    assert not hasattr(CP, "Props")  # non-SI Props (deprecated for years) gone
+
+
+@v8_only
+def test_core_haprops_removed():
+    assert not hasattr(CP, "HAProps")  # non-SI humid air gone from the core
+
+
+@v8_only
+def test_haprops_submodule_raises():
+    import CoolProp.HumidAirProp as HA
+
+    with pytest.raises(NotImplementedError):
+        HA.HAProps("B", "T", 300.0, "P", 101325.0, "W", 0.01)
+
+
+def test_hapropssi_kept_on_submodule():
+    import CoolProp.HumidAirProp as HA
+
+    assert HA.HAPropsSI("B", "T", 300.0, "P", 101325.0, "W", 0.01) == pytest.approx(291.706, rel=1e-4)
+
+
+# --------------------------------------------------------------------------- #
+# Import-tree smoke (the r9sq.3 parity, exercised at runtime)
+# --------------------------------------------------------------------------- #
+def test_toplevel_surface_present():
+    for name in ("AbstractState", "CoolProp", "HumidAirProp", "State", "get", "copy_BibTeX_library",
+                 "__fluids__", "__version__"):
+        assert hasattr(CoolProp, name), name


### PR DESCRIPTION
## What

A modern **pytest** suite for the v8 (nanobind) Python interface. The legacy `CoolProp/tests` suite is mostly `nose`-based (dead on Python 3.12+), so this is the test-verification vehicle for the migration — it backfills the q2sh "existing suite green" acceptance check.

`wrappers/Python/pytest/test_nanobind_interface.py` (23 tests):
- high-level API (`PropsSI`, `HAPropsSI`)
- `AbstractState` incl. the q2sh parity additions: the idealgas/residual identity (`hmolar == hmolar_idealgas + hmolar_residual` to 1e-9 in single phase; deliberately **not** in two-phase, where `hmolar` is quality-weighted), `get_fluid_constant`, `neff`, and the `set_reference_state(FluidName, *args)` dispatcher (string vs 4-double; bad arity → `ValueError`)
- module conveniences (`FluidsList`, `get_aliases`, `get_REFPROPname`, `get_BibTeXKey`)
- the capsule `State` shim unit conventions (kPa/kJ getters, g/mol `get_MM`, SI `.pAS`) — the split the original PDSim regression hinged on
- the approved v8 removals (free `Props` / core `HAProps` absent; `HAProps` submodule raises; `HAPropsSI` kept). v8-only cases `skipif` the legacy build.

## CI

A PR-gated `nanobind-pytest` job in `dev_checks.yml` builds the nanobind wheel (`COOLPROP_NANOBIND=ON`, Release) and runs the suite. All 23 pass locally.

## Stacking

Based on `ihb/nanobind-package-parity` (**#3093**, the r9sq.3 package completion) — the suite needs the `HumidAirProp` submodule + completed top-level surface. **Retarget to master once #3093 merges.**

Refs bd CoolProp-r9sq.5 (epic CoolProp-r9sq).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for the nanobind Python interface, validating core functionality, API behavior, and numerical accuracy.

* **Documentation**
  * Added documentation and step-by-step instructions for running the nanobind pytest suite.

* **Chores**
  * Added continuous integration validation job to test the nanobind interface during pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->