### PR TITLE
docs(changelog): v8 Python nanobind migration notes (CoolProp-r9sq.4)

### DIFF
--- a/Web/coolprop/changelog.rst
+++ b/Web/coolprop/changelog.rst
@@ -17,6 +17,7 @@ Highlights:
 * New native desktop GUI built with Tauri + React (`#2715`), plus a much-expanded Mathcad wrapper and interactive 3D molecule viewers on the fluid documentation pages.
 * Build-system modernization: git submodules replaced by CPM.cmake (boost fetched as a trimmed subset from ``CoolProp/boost-headers``), Eigen bumped to 5.0.1, and a broad C++17 cleanup that also cuts compile times.
 * Repository-wide code-quality program: enforced ``clang-format`` (pre-commit + CI), diff-only ``clang-tidy``, ``cppcheck``, CodeQL, include-what-you-use, and a single-script ``dev/ci/preflight.sh`` pre-push gate.
+* **Python wrapper rebuilt on nanobind** — a modern, lower-maintenance binding that ships as a single stable-ABI (``abi3``) wheel per platform on Python ≥ 3.12 (one wheel instead of one per Python version).  The public import tree is preserved, so it is a drop-in for almost all code; the legacy non-SI ``Props`` / ``HAProps`` are removed (use ``PropsSI`` / ``HAPropsSI``).  See the behavior-changes note below.
 
 **Behavior changes (potentially breaking):**
 
@@ -40,6 +41,34 @@ Highlights:
   Update your ``DllImport`` (C#/VB.NET), ``System.loadLibrary`` (Java),
   or ``dyn.load`` (R) calls to the new name. See GitHub
   `#1674 <https://github.com/CoolProp/CoolProp/issues/1674>`_.
+
+* **Python wrapper: the interface is now built on nanobind.** The hand-written
+  Cython ``AbstractState`` interface has been replaced by a `nanobind
+  <https://github.com/wjakob/nanobind>`_ core, and the parallel (and
+  incomplete) pybind11 interface has been removed. The **public import tree is
+  preserved** — ``CoolProp.CoolProp`` (now the nanobind core),
+  ``CoolProp.AbstractState``, ``CoolProp.HumidAirProp``, ``CoolProp.State``,
+  ``CoolProp.Plots``, ``CoolProp.BibtexParser`` and the rest resolve at exactly
+  the same paths — so the large majority of user code needs no change.
+  Downstream Cython that ``cimport``\ s CoolProp's ``State`` /
+  ``AbstractState`` / ``constants_header`` surface (e.g. PDSim) also keeps
+  working: a link-free, capsule-forwarding ``State`` shim preserves the
+  cimportable contract. On Python ≥ 3.12 the wrapper ships as a single
+  stable-ABI (``abi3``) wheel per platform instead of one wheel per Python
+  version.
+
+  The following **removals are breaking** (all long-deprecated or never part of
+  the intended API):
+
+  - the non-SI free function ``Props`` (deprecated behind a warning for years) —
+    use ``PropsSI`` (SI units). The ``State`` class keeps its ``Props(key)``
+    *method* (a keyed-output accessor); only the free function is gone.
+  - the non-SI humid-air function ``HAProps`` — use ``HAPropsSI`` (SI units).
+    ``CoolProp.HumidAirProp.HAProps`` now raises with a message pointing at
+    ``HAPropsSI``; ``HAPropsSI``, ``HAProps_Aux`` and ``cair_sat`` are unchanged.
+  - ``re_split`` (an accidental re-export of Python's ``re.split``) and
+    ``rebuildState`` (an internal ``State``-unpickling helper) are no longer
+    exported from ``CoolProp.CoolProp``.
 
 * Default ``update`` for ``HmolarQ_INPUTS``, ``QSmolar_INPUTS``,
   ``DmolarQ_INPUTS`` (and their mass-input equivalents) on pure fluids


### PR DESCRIPTION
## What

Documents the v8 Python wrapper migration in the **8.0.0** changelog (`Web/coolprop/changelog.rst`):

- a **Highlights** bullet (nanobind rebuild; single abi3 wheel on Py ≥ 3.12; drop-in import tree; `Props`/`HAProps` removed)
- a detailed **"Behavior changes (potentially breaking)"** entry covering:
  - the nanobind core replacing the Cython `AbstractState` interface, and the pybind11 interface removed (#3092)
  - the **preserved public import tree** (drop-in for almost all code) + the link-free capsule-forwarding `State` shim that keeps PDSim's `cimport` contract working
  - the single **abi3** wheel on Python ≥ 3.12 (vs one wheel per version)
  - the **breaking removals** with migration paths: free `Props` → `PropsSI` (the `State.Props` *method* stays), `HAProps` → `HAPropsSI`, and `re_split`/`rebuildState` gone

Every factual claim was verified against the code in an adversarial review (State.Props method present; no free Props/HAProps bound; HAPropsSI/HAProps_Aux/cair_sat kept; pybind11 deleted; `STABLE_ABI` confirmed).

Refs bd CoolProp-r9sq.4 (epic CoolProp-r9sq).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Version 8.0.0 changelog updated with implementation changes and new stable ABI wheel support for Python 3.12+.

* **Breaking Changes**
  * Removed legacy `Props` and `HAProps` functions; use `PropsSI` and `HAPropsSI` instead.
  * Removed `re_split` and `rebuildState` exports.
  * Public import paths remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->