### PR TITLE
docs(python): v8 update — Props/HAProps removed, use the SI functions (CoolProp-r9sq.9)

### DIFF
--- a/Web/coolprop/wrappers/Python/index.rst
+++ b/Web/coolprop/wrappers/Python/index.rst
@@ -278,40 +278,24 @@ Suppressing warning messages
 ----------------------------
 
 The calling code can suppress or ignore these warning messages by overriding the default
-warnings filter and changing the behavior of the warnings module.  As an example, the
-following script will result in a `DeprecationWarning` on each call to the deprecated function
-Props()::
-
-    from CoolProp.CoolProp import Props
-    Rho = Props('D','T',298.15,'P',10000,'R744')
-    print("R744 Density at {} K and {} kPa      = {} kg/m³".format(298.15, 10000, Rho))
-    H = Props('H','T',298.15,'Q',1,'R134a');
-    print("R134a Saturated Liquid Enthalpy at {} K = {} kJ/kg".format(298.15, H))
-
-Example output::
-
-    TestProps.py:14: DeprecationWarning: Props() function is deprecated; Use the PropsSI() function
-    Rho = Props('D','T',298.15,'P',10000,'R744')
-    R744 Density at 298.15 K and 10000 kPa      = 817.6273812375758 kg/m³
-    TestProps.py:16: DeprecationWarning: Props() function is deprecated; Use the PropsSI() function
-    H = Props('H','T',298.15,'Q',1,'R134a');
-    R134a Saturated Liquid Enthalpy at 298.15 K = 412.33395323186807 kJ/kg
-
-Legacy applications can create a filter override to ignore *all* deprecation warnings by including
-the following code just *after* the last import from CoolProp, but *before* any calls to CoolProp::
+warnings filter and changing the behavior of the warnings module.  A legacy or third-party
+caller can ignore *all* deprecation warnings by including the following code *after* the last
+import from CoolProp, but *before* any calls to CoolProp::
 
     import warnings
     warnings.filterwarnings('ignore', category=DeprecationWarning)
 
-To suppress, for example, *only* deprecation warning messages that contain the string "Props()",
-the second parameter to filterwarnings() can be a pattern matching regular expression::
+The second parameter to ``filterwarnings()`` can be a regular expression matching only
+selected messages, and the first parameter (``ignore``) can be set to ``once`` to issue a
+given message only once and then ignore further instances.
 
-    import warnings
-    warnings.filterwarnings('ignore', '.*Props()*.', category=DeprecationWarning)
+.. note::
 
-This filter will suppress any `DeprecationWarning` messages that contain the string "Props()" but will
-allow all other warning messages to be displayed.  The first parameter, `ignore`, can also be set to
-`once`, which will result in a given message to be issued only once and then ignored on further instances.
+   The non-SI ``Props()`` and ``HAProps()`` functions — long deprecated — were **removed in
+   CoolProp 8.0**.  Use the SI functions ``PropsSI()`` and ``HAPropsSI()`` instead, with all
+   inputs and outputs in base SI units (Pa, K, J, kg).  For example the old
+   ``Props('D', 'T', 298.15, 'P', 10000, 'R744')`` (pressure in kPa) becomes
+   ``PropsSI('D', 'T', 298.15, 'P', 10e6, 'R744')`` (pressure in Pa).
 
 See `Python >>> Module Warnings <https://docs.python.org/3/library/warnings.html#module-warnings>`_ for more information on using `filterwarnings()`
 


### PR DESCRIPTION
## What

The Python wrapper docs' **"Suppressing warning messages"** subsection was built entirely around the deprecated `Props()` function and its `DeprecationWarning`. In v8 `Props()` (and `HAProps()`) are **removed outright**, so there is no warning to suppress and the example would mislead.

- Drop the `Props()` example + its captured deprecation-warning output.
- Keep the generic `warnings.filterwarnings(...)` guidance (still valid for any CoolProp warnings).
- Add a `.. note::` that the non-SI `Props`/`HAProps` were **removed in CoolProp 8.0** → use `PropsSI`/`HAPropsSI`, showing the unit change: `Props(...,'P',10000,...)` (kPa) → `PropsSI(...,'P',10e6,...)` (Pa).

Consistent with the 8.0.0 changelog (#3096) which documents the same removal; unit conversion + RST validity verified.

## Out of scope (tracked under `r9sq.7`)

Non-doc-build legacy-usage stragglers that still call `HAProps`: `Web/fluid_properties/Validation/NelsonValidation.py` (standalone validation script) and a disabled notebook. They don't break the Sphinx build today; converting them to `HAPropsSI` is legacy-usage cleanup.

Refs bd CoolProp-r9sq.9 (epic CoolProp-r9sq).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Python wrapper documentation with clearer deprecation guidance and migration instructions
  * Non-SI `Props()` and `HAProps()` functions were removed in CoolProp 8.0
  * Users must migrate to `PropsSI()` and `HAPropsSI()` with SI base units
  * Added concrete example demonstrating pressure unit conversion from Props() to PropsSI()
  * Streamlined deprecation warning suppression documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->