### PR TITLE
fix(python): restore the 2-arg trivial PropsSI overload (CoolProp-r9sq.11)

### DIFF
--- a/src/nanobind_interface.cxx
+++ b/src/nanobind_interface.cxx
@@ -519,6 +519,10 @@ void init_CoolProp(nb::module_& m) {
     m.def("generate_update_pair", &generate_update_pair<double>);
     m.def("Props1SI", &Props1SI);
     m.def("PropsSI", &PropsSI);
+    // Legacy compatibility: the Cython PropsSI also accepted the 2-arg trivial
+    // form PropsSI("Tcrit", "Water") (order-lenient).  Restore it as an overload
+    // dispatching to Props1SI so e.g. PropsSI("M", fluid) keeps working.
+    m.def("PropsSI", [](const std::string& Output, const std::string& FluidName) { return Props1SI(Output, FluidName); });
     m.def("PhaseSI", &PhaseSI);
     m.def("PropsSImulti", &PropsSImulti);
     m.def("get_global_param_string", &get_global_param_string);


### PR DESCRIPTION
## Problem (compatibility regression)

Legacy (Cython) `PropsSI` accepted the **2-arg trivial-property form** `PropsSI("Tcrit", "Water")` (order-lenient) — one of the most common CoolProp idioms, used throughout the docs and user code. The nanobind binding only exposed the C++ **6-arg** `PropsSI`, so the 2-arg form raised `TypeError`. That breaks the "drop-in for almost all code" promise.

(Root cause: q2sh's *signature*-parity bar compared the 6-arg signature and didn't catch that legacy `PropsSI` *also* has a 2-arg overload. Note `Props1SI` is a nanobind/pybind-only name that doesn't exist on legacy, so it isn't a substitute for users.)

Surfaced while migrating the legacy nose tests to pytest (`r9sq.8`), which use the 2-arg form.

## Fix

Add a 2-arg `PropsSI` overload dispatching to `Props1SI` (itself order-lenient), so the trivial form works again and matches legacy bit-for-bit. The 6-arg form is unchanged; the arities are disjoint so dispatch is unambiguous.

## Verification (vs legacy)

- `PropsSI('Tcrit','Water')` = 647.096 — **both** arg orders
- `PropsSI('M','R134a')` = 0.102032
- 6-arg `PropsSI('D','T',300,'P',101325,'Water')` still works (996.557)

## Follow-up

`r9sq.11` also flags a **broader overload audit**: q2sh's per-signature parity may have missed *other* legacy convenience overloads (e.g. array `PropsSI`, `PhaseSI`, `HAPropsSI` variants). To be checked separately. This PR fixes the confirmed-critical `PropsSI` 2-arg case and unblocks the `r9sq.8` test migration.

Refs bd CoolProp-r9sq.11 (epic CoolProp-r9sq).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the two-argument `PropsSI` function, enabling users to query fluid properties using Output and FluidName parameters directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->