### PR TITLE
fix(svdsbtl): reset HEOS state after a failed update in the envelope/floor walk loops (CoolProp-i9t8)

### DIFF
--- a/src/SBTL/SatBoundaryFactory.cpp
+++ b/src/SBTL/SatBoundaryFactory.cpp
@@ -185,8 +185,13 @@ std::unique_ptr<region::CubicSplineCurve> build_h_isotherm_floor(::CoolProp::Abs
             try {
                 heos.update(::CoolProp::PT_INPUTS, p, T_try);
                 return heos.hmass();
-            } catch (...) {  // NOLINT(bugprone-empty-catch)
-                // Below melting line at this p; bump T up and retry.
+            } catch (...) {
+                // Below melting line at this p; bump T up and retry.  Reset
+                // the state first: a failed update can leave a poisoned
+                // guess that makes the next (T_try, p) probe on this same
+                // reused state fail spuriously — the same retry-on-melting-
+                // reject hazard as build_rho_max_envelope (CoolProp-i9t8).
+                heos.clear();
             }
         }
         throw std::runtime_error("build_h_isotherm_floor: floor unreachable within " + std::to_string(walk_steps / 2) + " K of T_min");

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -888,8 +888,9 @@ std::unique_ptr<region::CubicSplineCurve> build_rho_max_envelope(::CoolProp::Abs
             try {
                 heos.update(::CoolProp::QT_INPUTS, 0.0, T_knots[k]);
                 p_floor = heos.p() * 1.001;
-            } catch (const ::CoolProp::CoolPropBaseError&) {  // NOLINT(bugprone-empty-catch)
-                p_floor = 1.0;                                // fluid without QT support at this T; defer to walk-down
+            } catch (const ::CoolProp::CoolPropBaseError&) {
+                p_floor = 1.0;  // fluid without QT support at this T; defer to walk-down
+                heos.clear();   // reset the poisoned density guess (CoolProp-i9t8)
             }
         } else {
             p_floor = 1.001 * p_crit;
@@ -914,8 +915,14 @@ std::unique_ptr<region::CubicSplineCurve> build_rho_max_envelope(::CoolProp::Abs
                     p_ok = p_try;
                     ok = true;
                 }
-            } catch (const ::CoolProp::CoolPropBaseError&) {  // NOLINT(bugprone-empty-catch)
-                // Below the melting line at this (T, p); drop p.
+            } catch (const ::CoolProp::CoolPropBaseError&) {
+                // Below the melting line at this (T, p); drop p.  Reset the
+                // state: a failed PT update (e.g. the melting-line reject at
+                // high p) leaves a corrupted density guess that would make
+                // the NEXT, valid, lower-p probe fail spuriously with
+                // "p is not a valid number" on the same reused state
+                // (CoolProp-i9t8).
+                heos.clear();
             }
             if (ok) break;
             p_bad = p_try;  // this p is unreachable
@@ -938,8 +945,9 @@ std::unique_ptr<region::CubicSplineCurve> build_rho_max_envelope(::CoolProp::Abs
                         p_ok = p_mid;
                         ok = true;
                     }
-                } catch (const ::CoolProp::CoolPropBaseError&) {  // NOLINT(bugprone-empty-catch)
+                } catch (const ::CoolProp::CoolPropBaseError&) {
                     // (T, p_mid) below the melting line; shrink the bracket.
+                    heos.clear();  // reset poisoned guess (CoolProp-i9t8)
                 }
                 if (!ok) p_bad = p_mid;
             }


### PR DESCRIPTION
## Problem

`build_rho_max_envelope` (SurfacePresets.cpp) and `build_h_isotherm_floor` (SatBoundaryFactory.cpp) walk over candidate `(T, p)` states on a **single reused** HEOS `AbstractState`, retrying after a melting-line reject to find the first reachable single-phase state at each knot. A failed `update()` (`"T below Tmelt(p)"` at high p) can leave that shared state poisoned — stale cached sub-state from the aborted flash — so the next valid probe can fail spuriously with `"p is not a valid number"`.

## Fix

Add `heos.clear()` in the four catch blocks that retry on the same state — `build_rho_max_envelope` (QT floor probe, walk-down, bisect) and `build_h_isotherm_floor` (T-walk). `clear()` resets the bulk values and cache, so a failed update can't poison the next.

## Scope / impact — defensive hygiene, **no behavior change, no rev bump**

The investigation (recorded on CoolProp-i9t8) showed this is a latent-robustness fix, not a current-behavior bug:
- `update()`'s `pre_update()` already clears `_rhomolar` every call, and the pure-fluid PT path always derives a fresh density seed (`solver_rho_Tp(..., guess=-1)`), so the converged ρ on a **successful** probe is independent of any prior poisoned state. `clear()` runs only on the error path and **cannot** change a converged value or flip a succeeding probe to a failure → envelope/floor splines are bit-identical → **no serializer rev bump**.
- The remaining *irrecoverable* poisoning only occurs within ~1e-8 of Tc, where HEOS PT cannot converge for **any** pressure (verified: 0/12 fresh-state pressures reachable at `Tc·(1−1e-9)` for Helium) — already the correct "no reachable p", handled by the near-critical NC margin (CoolProp-jh6a). Outside that zone a failed update recovers on its own.

## Verification

- Full `[SBTL]` suite: **5419 assertions pass**, no regression (it rebuilds CO2/Argon/Helium surfaces that exercise these catch blocks).
- `./dev/ci/preflight.sh`: **7/7 green**.
- Two rounds of adversarial review: the first proved behavior-neutrality (via `pre_update`/`solver_rho_Tp`) and flagged the `build_h_isotherm_floor` sibling as the same hazard; the re-review confirmed that added guard.

No new test: since `pre_update()` re-clears every call, no black-box test through the public `update()` API can distinguish with/without the fix — `[SBTL]` no-regression is the appropriate coverage. The guard matters for a future fluid whose melting line cuts in near a recoverable-but-poisoned knot.

Closes CoolProp-i9t8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)