### PR TITLE
fix(python): vectorized array PropsSI/HAPropsSI (CoolProp-r9sq.12)

### DIFF
--- a/src/nanobind_interface.cxx
+++ b/src/nanobind_interface.cxx
@@ -55,6 +55,12 @@ static std::vector<double> _to_vec(nb::handle o, bool& is_seq) {
         return {d};
     }
     is_seq = true;
+    // Reject multi-dimensional arrays rather than silently flattening them
+    // (matches the legacy "Input is not one-dimensional" ValueError).
+    if (nb::hasattr(o, "ndim") && nb::cast<long>(nb::getattr(o, "ndim")) > 1) {
+        PyErr_SetString(PyExc_ValueError, "vectorized PropsSI/HAPropsSI input is not one-dimensional");
+        throw nb::python_error();
+    }
     return nb::cast<std::vector<double>>(o);
 }
 
@@ -68,7 +74,9 @@ static void _broadcast_to(std::vector<double>& v, std::size_t n, const char* whi
         v.assign(n, val);
         return;
     }
-    throw std::invalid_argument(std::string("vectorized input ") + which + " has an incompatible length");
+    // Match the legacy Cython wrapper, which raises TypeError on a length mismatch.
+    PyErr_SetString(PyExc_TypeError, (std::string("vectorized input ") + which + " has an incompatible length").c_str());
+    throw nb::python_error();
 }
 
 // ---- State C-ABI capsule (bridge for the frozen Cython `State` compat shim) --

--- a/src/nanobind_interface.cxx
+++ b/src/nanobind_interface.cxx
@@ -15,6 +15,8 @@
 #    include <nanobind/stl/tuple.h>
 #    include <nanobind/stl/pair.h>
 #    include <nanobind/stl/map.h>
+#    include <nanobind/ndarray.h>  // vectorized PropsSI returns a numpy array
+#    include <algorithm>
 #    include <array>
 namespace nb = nanobind;
 
@@ -42,6 +44,31 @@ static std::vector<std::string> _split_str(const std::string& s, char delim) {
         out.push_back(cur);
     }
     return out;
+}
+
+// Scalar-or-sequence -> vector<double> for the vectorized PropsSI/HAPropsSI
+// overloads; is_seq reports whether the input was array-like (vs a scalar).
+static std::vector<double> _to_vec(nb::handle o, bool& is_seq) {
+    double d;
+    if (nb::try_cast<double>(o, d)) {
+        is_seq = false;
+        return {d};
+    }
+    is_seq = true;
+    return nb::cast<std::vector<double>>(o);
+}
+
+// Broadcast a size-1 vector up to length n; lengths other than 1 or n are an error.
+static void _broadcast_to(std::vector<double>& v, std::size_t n, const char* which) {
+    if (v.size() == n) {
+        return;
+    }
+    if (v.size() == 1) {
+        double val = v[0];  // copy first: v[0] aliases the vector that assign() clears
+        v.assign(n, val);
+        return;
+    }
+    throw std::invalid_argument(std::string("vectorized input ") + which + " has an incompatible length");
 }
 
 // ---- State C-ABI capsule (bridge for the frozen Cython `State` compat shim) --
@@ -519,6 +546,42 @@ void init_CoolProp(nb::module_& m) {
     m.def("generate_update_pair", &generate_update_pair<double>);
     m.def("Props1SI", &Props1SI);
     m.def("PropsSI", &PropsSI);
+    // Vectorized PropsSI: list/ndarray Prop1/Prop2 (with scalar broadcast) dispatch
+    // to the C++ PropsSImulti path and return a numpy array, matching the legacy
+    // Cython wrapper. Registered after the scalar overload so scalars bind there.
+    m.def("PropsSI", [](const std::string& Output, const std::string& Name1, nb::object Prop1, const std::string& Name2, nb::object Prop2,
+                        const std::string& FluidName) {
+        bool s1 = false, s2 = false;
+        std::vector<double> v1 = _to_vec(Prop1, s1);
+        std::vector<double> v2 = _to_vec(Prop2, s2);
+        // Empty state inputs -> empty array (mirrors the legacy #2417 short-circuit).
+        if ((s1 && v1.empty()) || (s2 && v2.empty())) {
+            auto* empty = new double[1];
+            nb::capsule owner(empty, [](void* p) noexcept { delete[] static_cast<double*>(p); });
+            return nb::ndarray<nb::numpy, double>(empty, {static_cast<std::size_t>(0)}, owner);
+        }
+        std::size_t n = std::max(v1.size(), v2.size());
+        _broadcast_to(v1, n, "Prop1");
+        _broadcast_to(v2, n, "Prop2");
+        std::string backend, fluid;
+        extract_backend(FluidName, backend, fluid);
+        std::vector<double> fractions{1.0};
+        std::string delimited = extract_fractions(fluid, fractions);
+        std::vector<std::string> fluids = _split_str(delimited, '&');
+        std::vector<std::vector<double>> out = PropsSImulti({Output}, Name1, v1, Name2, v2, backend, fluids, fractions);
+        if (out.empty() || out[0].empty()) {
+            throw std::runtime_error(get_global_param_string("errstring"));
+        }
+        // PropsSImulti returns a matrix indexed [input][output]; a single Output
+        // means one column, so take out[i][0] across the inputs.
+        std::size_t n_out = out.size();
+        auto* data = new double[n_out];
+        for (std::size_t i = 0; i < n_out; ++i) {
+            data[i] = out[i][0];
+        }
+        nb::capsule owner(data, [](void* p) noexcept { delete[] static_cast<double*>(p); });
+        return nb::ndarray<nb::numpy, double>(data, {n_out}, owner);
+    });
     // Legacy compatibility: the Cython PropsSI also accepted the 2-arg trivial
     // form PropsSI("Tcrit", "Water") (order-lenient).  Restore it as an overload
     // dispatching to Props1SI so e.g. PropsSI("M", fluid) keeps working.
@@ -536,6 +599,22 @@ void init_CoolProp(nb::module_& m) {
     m.def("saturation_ancillary", &saturation_ancillary);
     m.def("add_fluids_as_JSON", &add_fluids_as_JSON);
     m.def("HAPropsSI", &HumidAir::HAPropsSI);
+    // Vectorized HAPropsSI: array inputs loop over the scalar C++ HAPropsSI and
+    // return a list, matching the legacy Cython wrapper (no vectorized C++ path).
+    m.def("HAPropsSI", [](const std::string& Output, const std::string& N1, nb::object V1, const std::string& N2, nb::object V2,
+                          const std::string& N3, nb::object V3) {
+        bool s1 = false, s2 = false, s3 = false;
+        std::vector<double> v1 = _to_vec(V1, s1), v2 = _to_vec(V2, s2), v3 = _to_vec(V3, s3);
+        std::size_t n = std::max({v1.size(), v2.size(), v3.size()});
+        _broadcast_to(v1, n, "Input1");
+        _broadcast_to(v2, n, "Input2");
+        _broadcast_to(v3, n, "Input3");
+        std::vector<double> out(n);
+        for (std::size_t i = 0; i < n; ++i) {
+            out[i] = HumidAir::HAPropsSI(Output, N1, v1[i], N2, v2[i], N3, v3[i]);
+        }
+        return out;
+    });
     // HAProps (non-SI humid air) intentionally NOT bound -- removed for v8 (SI-only); use HAPropsSI.
     m.def("HAProps_Aux", [](std::string out_string, double T, double p, double psi_w) {
         std::array<char, 1000> units{};


### PR DESCRIPTION
## Problem (major compat regression)

Legacy `PropsSI`/`HAPropsSI` accept list/numpy-array inputs and vectorize; the nanobind bindings only had the scalar C++ forms, so array inputs raised `TypeError`. Vectorized property evaluation over arrays of states is idiomatic scientific-Python usage — found by the `r9sq.11` overload-parity audit.

## Fix

- **`PropsSI`**: a 6-arg overload accepting list/`ndarray` `Prop1`/`Prop2` (with scalar **broadcast**), dispatching to the C++ `PropsSImulti` path and returning a **numpy `ndarray`** (matching legacy). Empty input → empty array (mirrors the #2417 short-circuit). Registered after the scalar overload, so scalar `float`/`int` calls still bind to the fast scalar path.
- **`HAPropsSI`**: an overload that loops the scalar C++ `HAPropsSI` over array inputs and returns a **`list`** (matching legacy, which has no vectorized C++ path).
- helpers `_to_vec` (scalar-or-sequence → `vector<double>`) and `_broadcast_to`.

## Verification (element-wise vs legacy)

| call | result |
|---|---|
| `PropsSI('D','T',[300,310],'P',101325,'Water')` | `ndarray [996.5569, 993.3836]` |
| `PropsSI('D','T',[300,310],'P',[1e5,2e5],'Water')` (broadcast) | `ndarray [996.5563, 993.4271]` |
| `HAPropsSI('H','T',[300,310],'P',101325,'W',0.01)` | `list [52509.07, 62762.97]` |
| empty / scalar / 2-arg | `[]` / float / float — unchanged |

All match the legacy Cython wrapper. Adversarial review passed (overload ordering, ndarray ownership, the broadcast self-alias fix, exception mapping all verified).

This is the last major high-level-API "drop-in" gap, and it unblocks `r9sq.13` (the doc-example compat suite — the array examples now pass instead of `xfail`).

Refs bd CoolProp-r9sq.12 (epic CoolProp-r9sq).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `PropsSI` and `HAPropsSI` now accept arrays or lists for inputs, enabling batch computation of thermodynamic properties.
  * Inputs are broadcast where appropriate; scalar values are auto-broadcast to match array lengths.
  * Empty-array inputs return an empty result.
  * `PropsSI` returns a 1D numeric array for vector calls; `HAPropsSI` returns a list of per-item results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->