### PR TITLE
De-leak nlohmann::json from installed superancillary.h

### DIFF
--- a/docs/superpowers/plans/2026-06-07-superancillary-deleak-nlohmann.md
+++ b/docs/superpowers/plans/2026-06-07-superancillary-deleak-nlohmann.md
@@ -1,0 +1,226 @@
+# De-leak nlohmann from installed superancillary.h — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove `#include "nlohmann/json.hpp"` and every `nlohmann::json` mention from the installed header `include/CoolProp/superancillary/superancillary.h`, so consumers no longer need nlohmann to compile against CoolProp's public headers.
+
+**Architecture:** Keep all templated/perf-critical evaluation inline in the header; move only the JSON-consuming construction out-of-line into a new non-installed `src/superancillary.cpp`, explicitly instantiated for the one `ArrayType` ever used (`std::vector<double>`). Because `ChebyshevApproximation1D` is non-assignable (`const` member), the out-of-line string ctor delegates to a private `SuperAncillary(LoadedData&&)` ctor that member-initializes — a plain-typed `LoadedData` bundle carries the parsed pieces across the seam with no nlohmann in the header.
+
+**Tech Stack:** C++17 templates + explicit instantiation, nlohmann/json (confined to the `.cpp`), Catch2 v3, CMake (`src/*.cpp` is auto-globbed — no CMake change).
+
+**Spec:** `docs/superpowers/specs/2026-06-07-superancillary-deleak-nlohmann-design.md`
+**Issue:** `CoolProp-xa8w.4`. **Branch:** `ihb/superancillary-deleak-nlohmann`.
+
+---
+
+## Task 1: Move JSON construction out-of-line; de-leak the header
+
+This is one atomic change — the header change, the new `.cpp`, and the test retargeting must land together (the header *declares* a ctor the `.cpp` *defines*, and the tests use the removed json ctor). Commit once, at the end, after the build is green.
+
+**Files:**
+- Modify: `include/CoolProp/superancillary/superancillary.h` (drop nlohmann include L46; remove `loader` L883-897 + json ctor L938-954; add `LoadedData` + delegating ctor; declare string ctor L959)
+- Create: `src/superancillary.cpp`
+- Modify: `src/Tests/CoolProp-Tests.cpp:3399, 3456, 3773`
+
+- [ ] **Step 1: Read the current header regions first**
+
+Read `include/CoolProp/superancillary/superancillary.h` lines 44-48, 805-960 to confirm the exact current text of the include, the member declarations (the order: `m_rhoL, m_rhoV, m_p`, the `m_hL…m_invlnp` optionals, `m_Tmin, m_Tcrit_num, m_rhocrit_num, m_pmin, m_pmax, m_check_points, m_lazy_build_mutex`, then a build-stamp member), the public `CheckPoint` struct (~L813), the private `loader` (L883-897), the `SuperAncillary(const nlohmann::json&)` ctor (L938-954), and the `SuperAncillary(const std::string&)` inline ctor (L959).
+
+- [ ] **Step 2: Remove the nlohmann include**
+
+In `superancillary.h`, delete line 46: `#include "nlohmann/json.hpp"`. (Verify nothing else in the header needs it after Steps 3-5.)
+
+- [ ] **Step 3: Delete the private `loader` member (L883-897)**
+
+Remove the entire `auto loader(const nlohmann::json& j, const std::string& key) { … }` method (and its preceding doc comment block at ~L880-882). Its logic moves to `src/superancillary.cpp` (Step 6).
+
+- [ ] **Step 4: Replace the json ctor with a `LoadedData` bundle + private delegating ctor**
+
+Replace the public `SuperAncillary(const nlohmann::json& j) : … { … }` (L938-954, including its `/// Reading in a data structure…` doc comment at L936-937) with the following. Place the public `struct LoadedData` and the private delegating ctor; the `LoadedData` field types reference `ChebyshevExpansion<ArrayType>` and `CheckPoint`, both already defined above in this header:
+
+```cpp
+   public:
+    /// Plain-typed bundle of already-parsed superancillary data. The non-installed
+    /// src/superancillary.cpp parses the JSON into one of these and delegates to the
+    /// private ctor below, keeping nlohmann::json out of this installed header.
+    struct LoadedData
+    {
+        std::vector<ChebyshevExpansion<ArrayType>> rhoL, rhoV, p;
+        double Tcrit_num = 0;
+        double rhocrit_num = 0;
+        std::vector<CheckPoint> check_points;
+    };
+
+   private:
+    /// Member-initializing ctor from a parsed LoadedData bundle. Member-init (not
+    /// assignment) is required because ChebyshevApproximation1D is non-assignable
+    /// (it has a const member). Init-list order matches member declaration order.
+    explicit SuperAncillary(LoadedData&& d)
+      : m_rhoL(std::move(d.rhoL)),
+        m_rhoV(std::move(d.rhoV)),
+        m_p(std::move(d.p)),
+        m_Tmin(m_p.xmin()),
+        m_Tcrit_num(d.Tcrit_num),
+        m_rhocrit_num(d.rhocrit_num),
+        m_pmin(m_p.eval(m_p.xmin())),
+        m_pmax(m_p.eval(m_p.xmax())),
+        m_check_points(std::move(d.check_points)) {}
+
+   public:
+```
+
+IMPORTANT: confirm the `private:`/`public:` transitions keep the rest of the class intact — the existing private member block (`m_rhoL` … the build-stamp) must remain private, and the existing public methods after the ctors must stay public. The cleanest edit is to insert the `LoadedData` struct into the existing `public:` section just above where the json ctor was, and the delegating ctor into the existing `private:` member section (or a private section adjacent to it). Match the surrounding access-specifier structure rather than blindly pasting the labels above; the goal is: `LoadedData` public, `SuperAncillary(LoadedData&&)` private.
+
+- [ ] **Step 5: Turn the string ctor into a declaration (L959)**
+
+Replace:
+```cpp
+    SuperAncillary(const std::string& s) : SuperAncillary(nlohmann::json::parse(s)) {};
+```
+with a declaration only (keep its doc comment):
+```cpp
+    explicit SuperAncillary(const std::string& s);
+```
+
+- [ ] **Step 6: Create `src/superancillary.cpp`**
+
+```cpp
+#include "CoolProp/superancillary/superancillary.h"
+#include "nlohmann/json.hpp"
+
+#include <string>
+#include <vector>
+
+namespace CoolProp {
+namespace superancillary {
+namespace {
+
+template <typename ArrayType>
+std::vector<ChebyshevExpansion<ArrayType>> load_expansions(const nlohmann::json& j, const std::string& key) {
+    std::vector<ChebyshevExpansion<ArrayType>> buf;
+    for (auto& block : j.at(key)) {
+        buf.emplace_back(block.at("xmin"), block.at("xmax"), block.at("coef"));
+    }
+    return buf;
+}
+
+template <typename ArrayType>
+typename SuperAncillary<ArrayType>::LoadedData parse_loaded(const std::string& s) {
+    nlohmann::json j = nlohmann::json::parse(s);
+    typename SuperAncillary<ArrayType>::LoadedData d;
+    d.rhoL = load_expansions<ArrayType>(j, "jexpansions_rhoL");
+    d.rhoV = load_expansions<ArrayType>(j, "jexpansions_rhoV");
+    d.p = load_expansions<ArrayType>(j, "jexpansions_p");
+    d.Tcrit_num = j.at("meta").at("Tcrittrue / K");
+    d.rhocrit_num = j.at("meta").at("rhocrittrue / mol/m^3");
+    if (j.contains("check_points")) {
+        for (const auto& pt : j.at("check_points")) {
+            d.check_points.push_back({pt.at("T / K").get<double>(), pt.at("p(mp) / Pa").get<double>(),
+                                      pt.at("rho'(mp) / mol/m^3").get<double>(), pt.at("rho''(mp) / mol/m^3").get<double>(),
+                                      pt.at("p(SA)/p(mp)").get<double>(), pt.at("rho'(SA)/rho'(mp)").get<double>(),
+                                      pt.at("rho''(SA)/rho''(mp)").get<double>()});
+        }
+    }
+    return d;
+}
+
+}  // namespace
+
+template <typename ArrayType>
+SuperAncillary<ArrayType>::SuperAncillary(const std::string& s) : SuperAncillary(parse_loaded<ArrayType>(s)) {}
+
+// The one and only ArrayType used across the codebase. Construction of
+// SuperAncillary<other types> from a string is intentionally not provided.
+template SuperAncillary<std::vector<double>>::SuperAncillary(const std::string&);
+
+}  // namespace superancillary
+}  // namespace CoolProp
+```
+
+- [ ] **Step 7: Retarget the 3 tests to the string ctor**
+
+In `src/Tests/CoolProp-Tests.cpp`:
+- Line 3399: `superancillary::SuperAncillary<std::vector<double>> anc{json};` → `superancillary::SuperAncillary<std::vector<double>> anc{json.dump()};`
+- Line 3456: same change (`anc{json}` → `anc{json.dump()}`).
+- Line 3773: `superancillary::SuperAncillary<std::vector<double>> anc{jsuper};` → `superancillary::SuperAncillary<std::vector<double>> anc{jsuper.dump()};`
+
+(These tests still parse/inspect json with nlohmann directly — that's fine, the test TU is non-installed. Only the *construction* changes to the string ctor.)
+
+- [ ] **Step 8: Build**
+
+Run: `cmake --build build_catch --target CatchTestRunner -j8`
+Expected: clean build. The new `src/superancillary.cpp` is auto-globbed by `file(GLOB … src/*.cpp)`. If the linker complains about an undefined `SuperAncillary<std::vector<double>>::SuperAncillary(const std::string&)`, the explicit instantiation in Step 6 is missing/mismatched. If it complains about `SuperAncillary<OtherType>`, some other ArrayType is string-constructed somewhere — search for it and add a matching `template …` instantiation line (the spec expects only `std::vector<double>`).
+
+- [ ] **Step 9: Header is nlohmann-free**
+
+Run: `grep -nE "nlohmann|#include .*json" include/CoolProp/superancillary/superancillary.h`
+Expected: no matches (doc-comment mentions of the word "JSON" in prose are acceptable; there must be no `#include` and no `nlohmann::` token).
+
+- [ ] **Step 10: Behavior parity — superancillary suites**
+
+Run: `./build_catch/CatchTestRunner "[superanc],[HSU_D_ptsweep],[SVDSBTL]" -s`
+Expected: all pass — the retargeted `[superanc]` water tests, the H/S/U superancillary sweep, and the SVDSBTL tests (which use the fluid superancillary) load and evaluate to identical numbers. If `[HSU_D_ptsweep]` is hidden (`[.]`), run it explicitly: `./build_catch/CatchTestRunner "[HSU_D_ptsweep]"`.
+
+- [ ] **Step 11: Symbol-leak gate stays clean**
+
+Run: `cmake -B build_shared -S . -DCOOLPROP_SHARED_LIBRARY=ON -DCMAKE_BUILD_TYPE=Release >/tmp/sh.log 2>&1 && cmake --build build_shared -j8 >>/tmp/sh.log 2>&1; ./dev/ci/check-json-symbols.sh "$(find build_shared \( -name 'libCoolProp.so' -o -name 'libCoolProp.dylib' \) | head -1)"`
+Expected: `OK: no symbols matching /nlohmann|valijson/`.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add include/CoolProp/superancillary/superancillary.h src/superancillary.cpp src/Tests/CoolProp-Tests.cpp
+git restore --staged .beads/issues.jsonl 2>/dev/null || true
+git commit -m "refactor(json): de-leak nlohmann from installed superancillary.h (CoolProp-xa8w.4)
+
+Move JSON construction out-of-line into src/superancillary.cpp (explicit
+instantiation for std::vector<double>); the installed header drops the
+nlohmann include and gains a plain LoadedData bundle + private delegating
+ctor. Construction is now string-only; 3 tests use the string ctor.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+Use `--no-verify` if the bd hook stages `.beads/issues.jsonl` (report it).
+
+---
+
+## Final Verification (before PR)
+
+- [ ] **Step 1: Full fast suite (cross-backend regression)**
+
+Run: `./build_catch/CatchTestRunner "~[slow]"`
+Expected: 0 failures. Superancillary feeds Helmholtz saturation, SVDSBTL, region boundary curves, and HS routines, so the whole suite exercises it.
+
+- [ ] **Step 2: Confirm no other installed header reintroduces nlohmann via superancillary**
+
+Run: `grep -rn "nlohmann" include/CoolProp/superancillary/`
+Expected: no matches anywhere under the superancillary include dir.
+
+- [ ] **Step 3: Preflight**
+
+Run: `./dev/ci/preflight.sh`
+Expected: build + json-symbols + tests pass. clang-tidy diff-only: the new `src/superancillary.cpp` and the header edits — confirm no *new* gating findings on added lines (the cross-reference technique: only findings git-blamed to this branch's commit gate CI).
+
+- [ ] **Step 4: Adversarial review (MANDATORY before `gh pr create`)**
+
+Per CLAUDE.md, dispatch the review subagent vs `master`. Focus:
+  - the delegating ctor's member-init reproduces the OLD json ctor field-by-field (rhoL/rhoV/p from the same keys; `m_Tmin = m_p.xmin()`; Tcrit/rhocrit from `meta`; `m_pmin`/`m_pmax` from `m_p.eval`; check_points loop identical) — a dropped/reordered field or a wrong `meta` key is a real bug;
+  - init-list order matches member declaration order (no `-Wreorder`);
+  - the explicit instantiation covers every `ArrayType` that is string-constructed anywhere (grep to be sure it's only `std::vector<double>`);
+  - the lazy caloric builds (m_hL/m_sL/…) and `get_check_points()` still behave identically;
+  - the header truly has zero nlohmann; `LoadedData` carries no json type.
+Then push + `gh pr create`, then re-review any post-review commits.
+
+- [ ] **Step 5: bd**
+
+`bd update CoolProp-xa8w.4 --notes "PR #<n> open…"`. File a small follow-on issue (or note on `rxxx`/this) to **broaden `dev/ci/check-installed-headers.sh`** to "no installed header pulls nlohmann/valijson" once BOTH this and `CoolProp-rxxx` have merged (flips the TODO already in that script).
+
+---
+
+## Self-Review (plan vs spec)
+
+**Spec coverage:** §3 header surgery → Task 1 Steps 2-5; §3 new `.cpp` + explicit instantiation → Step 6; §3 tests → Step 7; §6 verification (header-grep, parity, symbol gate, build) → Steps 9-11 + Final Verification; §7 guard-broadening follow-on → Final Verification Step 5.
+
+**Placeholder scan:** none — all code is shown in full (the `LoadedData` struct, the delegating ctor with the exact init-list, the whole `.cpp`, the three exact test edits). No "TODO/handle X" steps.
+
+**Type consistency:** `LoadedData` fields (`rhoL/rhoV/p` as `std::vector<ChebyshevExpansion<ArrayType>>`, `Tcrit_num`, `rhocrit_num`, `check_points`) match what `parse_loaded` populates and what the delegating ctor consumes (`std::move(d.rhoL)` → `m_rhoL`, `d.Tcrit_num` → `m_Tcrit_num`, etc.). The string ctor signature `SuperAncillary(const std::string&)` is identical in the header declaration (Step 5), the `.cpp` definition, and the explicit instantiation (Step 6). `load_expansions`/`parse_loaded` are defined before use in the `.cpp`.

--- a/docs/superpowers/specs/2026-06-07-superancillary-deleak-nlohmann-design.md
+++ b/docs/superpowers/specs/2026-06-07-superancillary-deleak-nlohmann-design.md
@@ -1,0 +1,174 @@
+# De-leak `nlohmann::json` from installed `superancillary.h` — Design
+
+**Date:** 2026-06-07
+**Status:** Approved design, ready for implementation planning
+**Epic:** `CoolProp-xa8w` (RapidJSON → nlohmann/json migration)
+**Issue:** `CoolProp-xa8w.4` (blocks Phase Final `CoolProp-xa8w.3`)
+
+---
+
+## 1. Goal
+
+Remove `#include "nlohmann/json.hpp"` (and every `nlohmann::json` mention) from the
+installed header `include/CoolProp/superancillary/superancillary.h`, so a consumer
+that includes `CoolProp.h` / `AbstractState.h` / `CoolPropFluid.h` (which transitively
+reach `superancillary.h`) no longer needs `nlohmann/json.hpp` on its include path to
+compile. This is a **compile-time / header-ABI** leak, not a symbol-export leak — the
+symbol-leak gate is already green (no nlohmann symbol is exported), because the only
+in-`libCoolProp` construction path (`CoolPropFluid.h::get_superanc()`) uses the
+`std::string` ctor whose signature carries no nlohmann, and the `nlohmann::json` ctor
+is instantiated only in the test binary. After this change, with `detail/json.h`
+already install-excluded (`CoolProp-rxxx`), **no installed header pulls nlohmann/valijson.**
+
+## 2. Key facts (verified)
+
+- `superancillary.h` is **header-only** and its classes are **templates**:
+  `ChebyshevExpansion<ArrayType>`, `ChebyshevApproximation1D<ArrayType>`,
+  `SuperAncillary<ArrayType>`.
+- **`SuperAncillary<ArrayType>` is only ever instantiated with `std::vector<double>`** —
+  `CoolPropFluid.h` (`SuperAncillary_t`), `SVDSBTLBackend`, both `region/*BoundaryCurve.h`,
+  and the tests all use `std::vector<double>`. (`MeltingCaloric` uses
+  `ChebyshevApproximation1D<Eigen::ArrayXd>` directly, but **not** `SuperAncillary`.) So the
+  explicit-instantiation set for `SuperAncillary` construction is exactly **one** type.
+- **nlohmann reaches only into `SuperAncillary`'s construction**, not the evaluation code
+  or the lower templates: `ChebyshevExpansion`'s ctor is `(double xmin, double xmax,
+  const ArrayType& coeff)` — `ArrayType`, not json (the loader relies on nlohmann's
+  implicit `json → ArrayType` conversion of `block.at("coef")`).
+- The nlohmann surface in the header is exactly: the `#include` (line 46), the private
+  `loader(const nlohmann::json&, key)` (883-897), the public
+  `SuperAncillary(const nlohmann::json&)` ctor (938-954), and the inline
+  `SuperAncillary(const std::string& s) : SuperAncillary(nlohmann::json::parse(s)) {}` (959).
+- **`ChebyshevApproximation1D` is non-assignable** — it has a `const double thresh_imag`
+  member (line 480). So `m_rhoL`/`m_rhoV`/`m_p` (of that type) must be **member-initialized
+  (constructed)**, never assigned. This rules out an "assign-in-body" out-of-line ctor and
+  dictates the delegating-ctor form below.
+- Construction is reached **inline** from `CoolPropFluid.h::get_superanc()` (line 433-438,
+  inline in an installed header) via `make_shared<SuperAncillary_t>(superancillaries_str)`.
+- **Direct `nlohmann::json` construction exists only in 3 tests** (`CoolProp-Tests.cpp:3399,
+  3456, 3773 — `SuperAncillary<…> anc{json}`). Production uses the string ctor.
+  region/SVDSBTL/MeltingCaloric only *use* `SuperAncillary` (methods / shared_ptr), never
+  construct it from json.
+
+## 3. Design — explicit instantiation of the out-of-line string ctor
+
+Keep every templated, perf-critical evaluation path inline in the header; move only the
+JSON-consuming construction out-of-line into one `.cpp` compiled into `libCoolProp`, and
+explicitly instantiate it for `std::vector<double>`.
+
+**`include/CoolProp/superancillary/superancillary.h` (installed):**
+- Remove `#include "nlohmann/json.hpp"` (line 46).
+- Remove the private `loader(const nlohmann::json&, …)` member (883-897).
+- Remove the public `SuperAncillary(const nlohmann::json&)` ctor (938-954).
+- Add a **public nested POD `struct LoadedData`** (templated, nlohmann-free) holding the
+  already-parsed pieces the ctor needs:
+  ```cpp
+  struct LoadedData {
+      std::vector<ChebyshevExpansion<ArrayType>> rhoL, rhoV, p;  // loader outputs
+      double Tcrit_num = 0, rhocrit_num = 0;
+      std::vector<CheckPoint> check_points;
+  };
+  ```
+- Add a **private delegating ctor** that member-initializes from it (inline, nlohmann-free —
+  this preserves the exact member-init semantics of the old json ctor, including the derived
+  `m_Tmin`/`m_pmin`/`m_pmax` from `m_p`):
+  ```cpp
+  explicit SuperAncillary(LoadedData&& d)
+    : m_rhoL(std::move(d.rhoL)), m_rhoV(std::move(d.rhoV)), m_p(std::move(d.p)),
+      m_Tmin(m_p.xmin()), m_Tcrit_num(d.Tcrit_num), m_rhocrit_num(d.rhocrit_num),
+      m_pmin(m_p.eval(m_p.xmin())), m_pmax(m_p.eval(m_p.xmax())),
+      m_check_points(std::move(d.check_points)) {}
+  ```
+  (Note: `m_rhoL` is `ChebyshevApproximation1D<ArrayType>` constructed from
+  `std::vector<ChebyshevExpansion<ArrayType>>&&` — the same converting construction the old
+  json ctor used via `loader(...)`.)
+- Replace the inline string ctor (959) with a **declaration only**:
+  `explicit SuperAncillary(const std::string& s);`.
+
+**New `src/superancillary.cpp` (non-installed; picked up by `file(GLOB src/*.cpp)` at
+CMakeLists.txt:297 — no CMake change):**
+```cpp
+#include "CoolProp/superancillary/superancillary.h"
+#include "nlohmann/json.hpp"
+namespace CoolProp { namespace superancillary {
+namespace {
+  template<typename ArrayType>
+  std::vector<ChebyshevExpansion<ArrayType>> load_expansions(const nlohmann::json& j, const std::string& key) {
+      std::vector<ChebyshevExpansion<ArrayType>> buf;
+      for (auto& block : j.at(key)) {
+          buf.emplace_back(block.at("xmin"), block.at("xmax"), block.at("coef"));
+      }
+      return buf;
+  }
+  template<typename ArrayType>
+  typename SuperAncillary<ArrayType>::LoadedData parse_loaded(const std::string& s) {
+      nlohmann::json j = nlohmann::json::parse(s);
+      typename SuperAncillary<ArrayType>::LoadedData d;
+      d.rhoL = load_expansions<ArrayType>(j, "jexpansions_rhoL");
+      d.rhoV = load_expansions<ArrayType>(j, "jexpansions_rhoV");
+      d.p    = load_expansions<ArrayType>(j, "jexpansions_p");
+      d.Tcrit_num   = j.at("meta").at("Tcrittrue / K");
+      d.rhocrit_num = j.at("meta").at("rhocrittrue / mol/m^3");
+      if (j.contains("check_points")) {
+          for (const auto& pt : j.at("check_points")) {
+              d.check_points.push_back({pt.at("T / K").get<double>(), pt.at("p(mp) / Pa").get<double>(),
+                  pt.at("rho'(mp) / mol/m^3").get<double>(), pt.at("rho''(mp) / mol/m^3").get<double>(),
+                  pt.at("p(SA)/p(mp)").get<double>(), pt.at("rho'(SA)/rho'(mp)").get<double>(),
+                  pt.at("rho''(SA)/rho''(mp)").get<double>()});
+          }
+      }
+      return d;
+  }
+}
+template<typename ArrayType>
+SuperAncillary<ArrayType>::SuperAncillary(const std::string& s) : SuperAncillary(parse_loaded<ArrayType>(s)) {}
+// The one and only instantiation actually used across the codebase.
+template SuperAncillary<std::vector<double>>::SuperAncillary(const std::string&);
+}}
+```
+The string ctor delegates to the private `LoadedData&&` ctor, so member-init (required by the
+non-assignable `ChebyshevApproximation1D`) is preserved.
+
+**Tests (`src/Tests/CoolProp-Tests.cpp:3399, 3456, 3773`):** change `SuperAncillary<…>
+anc{json}` → `anc{json.dump()}` (string ctor). The tests already hold the json; the re-parse
+cost is irrelevant in a test.
+
+## 4. What stays the same
+
+- All templated **evaluation** code (`eval_sat`, `get_T_from_p`, lazy caloric builds,
+  `ChebyshevExpansion`/`ChebyshevApproximation1D`) stays inline in the header — **no
+  de-inlining of the hot path.**
+- `CoolPropFluid.h::get_superanc()` stays inline and unchanged — it calls the `std::string`
+  ctor, now resolved against the explicitly-instantiated symbol in `libCoolProp`.
+- The symbol-leak gate stays green (the out-of-line ctor's signature is `const std::string&`;
+  its nlohmann use is internal to `superancillary.cpp` and inlined/static).
+
+## 5. Trade-off
+
+`SuperAncillary` construction is now **closed to `std::vector<double>`** (the only type ever
+used). Constructing `SuperAncillary<SomeOtherType>` from a string would fail to link unless a
+matching explicit instantiation is added. Acceptable — it is a CoolProp-internal performance
+class, never instantiated by consumers with custom array types.
+
+## 6. Testing & verification
+
+- **Header is nlohmann-free:** `grep -n "nlohmann\|json" include/CoolProp/superancillary/superancillary.h`
+  → no `#include`, no type usage (doc-comment mentions of "JSON format" are fine).
+- **Behavior parity (the safety net):** `[HSU_D_ptsweep]` (superancillary H/S/U sweep),
+  `[SVDSBTL]`, `[HS]`/`[HS_dbg]`, and the saturation tests must stay green — every fluid's
+  superancillary must load and evaluate to identical numbers. The 3 retargeted tests must pass.
+- **Symbol gate stays clean:** `./dev/ci/check-json-symbols.sh` on `build_shared` → still 0.
+- **Build:** the new `src/superancillary.cpp` compiles and links; `make_shared<SuperAncillary_t>(str)`
+  in consumer TUs links against its instantiated ctor (no nlohmann needed to compile a consumer).
+- **Preflight + adversarial review** (focus: the delegating-ctor member-init reproduces the old
+  json ctor's field-by-field semantics; the explicit instantiation covers every used `ArrayType`;
+  no behavior change in the lazy caloric builds).
+
+## 7. Out of scope / follow-on
+
+- **Broaden `dev/ci/check-installed-headers.sh`** (the `rxxx` guard) from "`detail/json.h` not
+  shipped" to "**no installed header pulls nlohmann/valijson**" — this becomes *true* only once
+  BOTH `rxxx` (excludes `detail/json.h`) and this change (de-leaks `superancillary.h`) have
+  merged. File/track as a small follow-on that lands after both, flipping the `TODO` already left
+  in that script.
+- `detail/rapidjson.h` still ships (rapidjson, not nlohmann) until Phase Final (`xa8w.3`).
+- The broader consumer-compile gate (coordinated with the nanobind interface) remains deferred.

--- a/include/CoolProp/superancillary/superancillary.h
+++ b/include/CoolProp/superancillary/superancillary.h
@@ -43,7 +43,6 @@ Subsequent edits by Ian Bell
 #include <Eigen/Dense>
 
 #include "boost/math/tools/toms748_solve.hpp"
-#include "nlohmann/json.hpp"
 
 namespace CoolProp {
 namespace superancillary {
@@ -821,6 +820,18 @@ class SuperAncillary
         double rhoV_SA_ratio;  ///< rho''(SA) / rho''(mp) as reported by fastchebpure
     };
 
+    /// Plain-typed bundle of already-parsed superancillary data. The non-installed
+    /// src/superancillary.cpp parses the JSON into one of these and constructs a
+    /// SuperAncillary from it via the private delegating ctor below, keeping the
+    /// JSON-library type out of this installed header.
+    struct LoadedData
+    {
+        std::vector<ChebyshevExpansion<ArrayType>> rhoL, rhoV, p;
+        double Tcrit_num = 0;
+        double rhocrit_num = 0;
+        std::vector<CheckPoint> check_points;
+    };
+
    private:
     /// These ones must always be present
     ChebyshevApproximation1D<ArrayType> m_rhoL,  ///< Approximation of \f$\rho'(T)\f$
@@ -876,25 +887,22 @@ class SuperAncillary
     /// observers can read it.
     mutable std::atomic<unsigned int> m_caloric_build_count{0};
 
-    /** A convenience function to load a ChebyshevExpansion from a JSON data structure
-     \param j The JSON data
-     \param key The key to be loaded from the superancillary block, probably one of "jexpansions_rhoL", "jexpansions_rhoV", or "jexpansions_p"
-     */
-    auto loader(const nlohmann::json& j, const std::string& key) {
-        std::vector<ChebyshevExpansion<ArrayType>> buf;
-        // If you want to use Eigen...
-        // auto toeig = [](const nlohmann::json &j) -> Eigen::ArrayXd{
-        //     auto vec = j.get<std::vector<double>>();
-        //     return Eigen::Map<const Eigen::ArrayXd>(&vec[0], vec.size());
-        // };
-        // for (auto& block : j[key]){
-        //     buf.emplace_back(block.at("xmin"), block.at("xmax"), toeig(block.at("coef")));
-        // }
-        for (auto& block : j[key]) {
-            buf.emplace_back(block.at("xmin"), block.at("xmax"), block.at("coef"));
-        }
-        return buf;
-    }
+    /// Member-initializing constructor from an already-parsed LoadedData bundle.
+    /// Member-init (not assignment) is required because ChebyshevApproximation1D is
+    /// non-assignable (it has a const member). The init-list order matches the member
+    /// declaration order above. Reproduces the field-by-field semantics of the former
+    /// JSON-consuming constructor; the JSON parsing now lives in the non-installed
+    /// src/superancillary.cpp, keeping the JSON-library type out of this header.
+    explicit SuperAncillary(LoadedData&& d)
+      : m_rhoL(std::move(d.rhoL)),
+        m_rhoV(std::move(d.rhoV)),
+        m_p(std::move(d.p)),
+        m_Tmin(m_p.xmin()),
+        m_Tcrit_num(d.Tcrit_num),
+        m_rhocrit_num(d.rhocrit_num),
+        m_pmin(m_p.eval(m_p.xmin())),
+        m_pmax(m_p.eval(m_p.xmax())),
+        m_check_points(std::move(d.check_points)) {}
 
     /** Make an inverse ChebyshevApproximation1D for T(p)
      \param Ndegree The degree of the expansion in each interval. In double precision, 12 to 16 is a good plan if you will not be doing eigenvalue rootfinding. If you will be doing eigenvalue rootfinding, use a lower degree expansion, 8 is good.
@@ -933,30 +941,14 @@ class SuperAncillary
     // using PropertyPairs = properties::PropertyPairs; ///< A convenience alias to save some typing
 
    public:
-    /// Reading in a data structure in the JSON format of https://pubs.aip.org/aip/jpr/article/53/1/013102/3270194
-    /// which includes sets of Chebyshev expansions for rhoL, rhoV, and p
-    SuperAncillary(const nlohmann::json& j)
-      : m_rhoL(std::move(loader(j, "jexpansions_rhoL"))),
-        m_rhoV(std::move(loader(j, "jexpansions_rhoV"))),
-        m_p(std::move(loader(j, "jexpansions_p"))),
-        m_Tmin(m_p.xmin()),
-        m_Tcrit_num(j.at("meta").at("Tcrittrue / K")),
-        m_rhocrit_num(j.at("meta").at("rhocrittrue / mol/m^3")),
-        m_pmin(m_p.eval(m_p.xmin())),
-        m_pmax(m_p.eval(m_p.xmax())) {
-        if (j.contains("check_points")) {
-            for (const auto& pt : j.at("check_points")) {
-                m_check_points.push_back({pt.at("T / K").get<double>(), pt.at("p(mp) / Pa").get<double>(), pt.at("rho'(mp) / mol/m^3").get<double>(),
-                                          pt.at("rho''(mp) / mol/m^3").get<double>(), pt.at("p(SA)/p(mp)").get<double>(),
-                                          pt.at("rho'(SA)/rho'(mp)").get<double>(), pt.at("rho''(SA)/rho''(mp)").get<double>()});
-            }
-        }
-    };
-
-    /** Load the superancillary with the data passed in as a string blob. This constructor delegates directly to the the one that consumes JSON
+    /** Load the superancillary with the data passed in as a string blob of JSON. The
+     * JSON parsing is defined out-of-line in the non-installed src/superancillary.cpp and
+     * explicitly instantiated for std::vector<double>, so this installed header carries no
+     * JSON-library type. (Construction is therefore available only for the instantiated
+     * ArrayType(s).)
      * \param s The string-encoded JSON data for the superancillaries
      */
-    SuperAncillary(const std::string& s) : SuperAncillary(nlohmann::json::parse(s)) {};
+    explicit SuperAncillary(const std::string& s);
 
     /** Get a const reference to a ChebyshevApproximation1D
      

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -3396,7 +3396,7 @@ class PropertyLimitsFixture
 TEST_CASE_METHOD(SuperAncillaryOnFixture, "Check superancillary for water", "[superanc]") {
 
     auto json = nlohmann::json::parse(get_fluid_param_string("WATER", "JSON"))[0].at("EOS")[0].at("SUPERANCILLARY");
-    superancillary::SuperAncillary<std::vector<double>> anc{json};
+    superancillary::SuperAncillary<std::vector<double>> anc{json.dump()};
     shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "Water"));
     shared_ptr<CoolProp::AbstractState> IF97(CoolProp::AbstractState::factory("IF97", "Water"));
     auto& rHEOS = *dynamic_cast<HelmholtzEOSMixtureBackend*>(AS.get());
@@ -3453,7 +3453,7 @@ TEST_CASE_METHOD(SuperAncillaryOnFixture, "Benchmark class construction", "[supe
 TEST_CASE_METHOD(SuperAncillaryOffFixture, "Check superancillary-like calculations with superancillary disabled for water", "[superanc]") {
 
     auto json = nlohmann::json::parse(get_fluid_param_string("WATER", "JSON"))[0].at("EOS")[0].at("SUPERANCILLARY");
-    superancillary::SuperAncillary<std::vector<double>> anc{json};
+    superancillary::SuperAncillary<std::vector<double>> anc{json.dump()};
     shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "Water"));
     shared_ptr<CoolProp::AbstractState> IF97(CoolProp::AbstractState::factory("IF97", "Water"));
     auto& approxrhoL = anc.get_approx1d('D', 0);
@@ -3770,7 +3770,7 @@ TEST_CASE_METHOD(SuperAncillaryOnFixture, "Superancillary eval matches extended-
         // than silently skip — a new fluid added without re-running
         // inject_superanc_check_points.py should not slip past this test.
         REQUIRE(jsuper.contains("check_points"));
-        superancillary::SuperAncillary<std::vector<double>> anc{jsuper};
+        superancillary::SuperAncillary<std::vector<double>> anc{jsuper.dump()};
         for (const auto& pt : anc.get_check_points()) {
             CAPTURE(pt.T);
             const double tol_p = std::max(std::abs(pt.p_SA_ratio - 1.0), floor_tol) * safety_factor;

--- a/src/superancillary.cpp
+++ b/src/superancillary.cpp
@@ -1,0 +1,58 @@
+/// Out-of-line, JSON-consuming construction for SuperAncillary.
+///
+/// The installed header include/CoolProp/superancillary/superancillary.h keeps all
+/// templated, perf-critical evaluation inline but carries NO nlohmann::json type, so
+/// consumers do not need nlohmann to compile against CoolProp's public headers. The
+/// string-blob constructor's definition lives here (where nlohmann is available) and is
+/// explicitly instantiated for the one ArrayType used across the codebase.
+
+#include "CoolProp/superancillary/superancillary.h"
+#include "nlohmann/json.hpp"
+
+#include <string>
+#include <vector>
+
+namespace CoolProp {
+namespace superancillary {
+namespace {
+
+template <typename ArrayType>
+std::vector<ChebyshevExpansion<ArrayType>> load_expansions(const nlohmann::json& j, const std::string& key) {
+    std::vector<ChebyshevExpansion<ArrayType>> buf;
+    for (auto& block : j.at(key)) {
+        buf.emplace_back(block.at("xmin"), block.at("xmax"), block.at("coef"));
+    }
+    return buf;
+}
+
+template <typename ArrayType>
+typename SuperAncillary<ArrayType>::LoadedData parse_loaded(const std::string& s) {
+    nlohmann::json j = nlohmann::json::parse(s);
+    typename SuperAncillary<ArrayType>::LoadedData d;
+    d.rhoL = load_expansions<ArrayType>(j, "jexpansions_rhoL");
+    d.rhoV = load_expansions<ArrayType>(j, "jexpansions_rhoV");
+    d.p = load_expansions<ArrayType>(j, "jexpansions_p");
+    d.Tcrit_num = j.at("meta").at("Tcrittrue / K");
+    d.rhocrit_num = j.at("meta").at("rhocrittrue / mol/m^3");
+    if (j.contains("check_points")) {
+        for (const auto& pt : j.at("check_points")) {
+            d.check_points.push_back({pt.at("T / K").get<double>(), pt.at("p(mp) / Pa").get<double>(),
+                                      pt.at("rho'(mp) / mol/m^3").get<double>(), pt.at("rho''(mp) / mol/m^3").get<double>(),
+                                      pt.at("p(SA)/p(mp)").get<double>(), pt.at("rho'(SA)/rho'(mp)").get<double>(),
+                                      pt.at("rho''(SA)/rho''(mp)").get<double>()});
+        }
+    }
+    return d;
+}
+
+}  // namespace
+
+template <typename ArrayType>
+SuperAncillary<ArrayType>::SuperAncillary(const std::string& s) : SuperAncillary(parse_loaded<ArrayType>(s)) {}
+
+// The one and only ArrayType string-constructed across the codebase. Constructing
+// SuperAncillary<other types> from a string is intentionally not provided.
+template SuperAncillary<std::vector<double>>::SuperAncillary(const std::string&);
+
+}  // namespace superancillary
+}  // namespace CoolProp


### PR DESCRIPTION
## Summary

Removes `#include "nlohmann/json.hpp"` (and every `nlohmann` token) from the installed header `include/CoolProp/superancillary/superancillary.h`, so a consumer that includes `CoolProp.h` / `AbstractState.h` / `CoolPropFluid.h` (which transitively reach it) no longer needs nlohmann on its include path to compile. Part of the RapidJSON → nlohmann/json epic (`CoolProp-xa8w.4`); blocks Phase Final.

- **Header-only template, construction moved out-of-line.** `SuperAncillary<ArrayType>` is a header-only template whose JSON-consuming construction was reached *inline* from `CoolPropFluid.h::get_superanc()`. The string ctor's definition (the JSON parsing) moves to a new non-installed `src/superancillary.cpp` and is **explicitly instantiated** for the single `ArrayType` used everywhere (`std::vector<double>`). All perf-critical templated *evaluation* stays inline — nothing hot is de-inlined.
- **`LoadedData` + delegating ctor.** The former public `SuperAncillary(const nlohmann::json&)` ctor and private `loader` are removed. A public plain-typed `struct LoadedData` carries the parsed pieces across the seam; a private `SuperAncillary(LoadedData&&)` member-initializes from it. Member-init (not assign-in-body) is required because `ChebyshevApproximation1D` is non-assignable (`const` member). The string ctor is now declared-only.
- **Construction is string-only** now; the 3 tests that built from a parsed json object switch to `anc{json.dump()}`.

After this lands (with `CoolProp-rxxx`, which install-excludes `detail/json.h`), **no installed header pulls nlohmann/valijson** — the `dev/ci/check-installed-headers.sh` guard can then be broadened from "`detail/json.h` not shipped" to "no shipped header pulls nlohmann/valijson" (tracked follow-on).

## Notes for reviewers

- **Behavior parity verified.** The delegating ctor reproduces the old json ctor field-by-field (same `jexpansions_*` keys, same `meta` keys, the 7-field `CheckPoint` aggregate in the same order, `m_Tmin`/`m_pmin`/`m_pmax` derived from `m_p` in the same init-list order). `[superanc]` and `[SVDSBTL]` are green; the full `~[slow]` suite is 118,225 assertions / 0 failures.
- **`[HSU_D_ptsweep]` (hidden `[.]` diagnostic):** shows 37 pre-existing domain-edge failures **identical on master** (verified by a clean master-vs-branch rebuild) — not introduced here.
- **Symbol-leak gate stays green** (the out-of-line ctor's signature is `const std::string&`; the nlohmann use is confined to anonymous-namespace helpers in the `.cpp`).
- **Trade-off:** `SuperAncillary` string-construction is now closed to `std::vector<double>` (the only type ever used) — documented in the header and the `.cpp`.

## Test Plan

- [x] Build (Catch + shared) clean; `src/superancillary.cpp` auto-globbed (no CMake change)
- [x] Header has zero `nlohmann` tokens; `include/CoolProp/superancillary/` grep-clean
- [x] `[superanc]` 6/6, `[SVDSBTL]` all pass; `~[slow]` 118,225 assertions / 0 failures
- [x] `[HSU_D_ptsweep]` failures confirmed identical on master (pre-existing)
- [x] Symbol-leak gate: 0 nlohmann/valijson exported
- [x] 0 gating clang-tidy findings on added lines (CI diff-only); adversarial review — no blocking findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Added detailed implementation plan and design specification documenting optimization of core library header dependencies.

**Refactor**
- Removed JSON library dependency from core installed headers, reducing external dependency requirements while maintaining complete API compatibility, functionality, and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->