### PR TITLE
test(python): harvest doc .ipython examples into a pytest compat suite (CoolProp-r9sq.13)

### DIFF
--- a/wrappers/Python/pytest/test_doc_examples.py
+++ b/wrappers/Python/pytest/test_doc_examples.py
@@ -122,7 +122,7 @@ _XFAIL = {
 def _params():
     params = []
     for p in _PAGES:
-        rel = os.path.relpath(p, _WEB)
+        rel = os.path.relpath(p, _WEB).replace(os.sep, "/")  # forward slashes on Windows too
         marks = [pytest.mark.xfail(reason=_XFAIL[rel], strict=True)] if rel in _XFAIL else []
         params.append(pytest.param(p, id=rel, marks=marks))
     return params
@@ -145,9 +145,17 @@ def test_doc_page_examples(rst_path):
     try:
         exec(compile(code, rst_path, "exec"), ns)
     except Exception as e:  # noqa: BLE001 -- this is the compat signal
-        # Absent optional libs (matplotlib/pybtex/scipy/...) surface as ImportError
-        # and are skipped by type. REFPROP load failures are RuntimeError, so match
-        # those by message. Everything else is a genuine compat failure -> raise.
-        if isinstance(e, (ImportError, ModuleNotFoundError)) or "refprop" in str(e).lower():
+        # Skip ONLY for a genuinely-optional dependency or REFPROP. A broken
+        # CoolProp import (or a removed API imported by an example) is a real
+        # compat failure and must NOT be masked as a skip.
+        optional_roots = {"matplotlib", "pybtex", "scipy", "pandas"}
+        missing_root = (getattr(e, "name", None) or "").split(".")[0]
+        msg = str(e).lower()
+        is_optional = (
+            (isinstance(e, ModuleNotFoundError) and missing_root in optional_roots)
+            or (isinstance(e, ImportError) and any(r in msg for r in optional_roots))
+            or "refprop" in msg
+        )
+        if is_optional:
             pytest.skip("requires an absent optional dependency / REFPROP: %s" % str(e)[:80])
         raise

--- a/wrappers/Python/pytest/test_doc_examples.py
+++ b/wrappers/Python/pytest/test_doc_examples.py
@@ -1,0 +1,153 @@
+"""
+Doc-example compat suite for the v8 (nanobind) CoolProp Python interface
+(bd CoolProp-r9sq.13).
+
+Rather than building the whole Sphinx site, this harvests the executable code
+from the docs' ``.. ipython::`` directives and replays it under pytest -- a fast,
+CI-cheap, comprehensive integration test of the high-level API as it is actually
+used in the documentation. Any example that fails to run against the installed
+CoolProp surfaces a compat gap (the original motivation: the array-``PropsSI`` /
+2-arg-``PropsSI`` regressions would have shown up here as failures).
+
+Bar: run-without-exception (the values are the C++ core's concern). One test per
+doc page, replaying that page's ``.ipython`` blocks in order in a shared
+namespace (matching the Sphinx directive's per-document state). Pages whose
+examples need an absent optional dependency (matplotlib, pybtex, scipy) or
+REFPROP are skipped, not failed.
+"""
+import os
+import re
+import glob
+
+import pytest
+
+# Locate the repo's Web/ docs relative to this file (dev-only test; the .rst
+# sources are not shipped in the wheel).
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_WEB = os.path.normpath(os.path.join(_HERE, "..", "..", "..", "Web"))
+
+# Prompt lines inside an .ipython block: "In [1]: code" or "   ...: code".
+_PROMPT = re.compile(r"^\s*(?:In \[\d+\]|\.\.\.)\s*:\s?(.*)$")
+
+
+
+def _extract_ipython_code(rst_text):
+    """Return the concatenated executable code from all non-verbatim
+    ``.. ipython::`` blocks in a single .rst document, in order."""
+    lines = rst_text.splitlines()
+    code_chunks = []
+    i, n = 0, len(lines)
+    while i < n:
+        if lines[i].lstrip().startswith(".. ipython::"):
+            i += 1
+            verbatim = False
+            # directive option lines (":verbatim:", ":okexcept:", ...)
+            while i < n and lines[i].strip().startswith(":"):
+                if "verbatim" in lines[i]:
+                    verbatim = True
+                i += 1
+            # the indented directive body (until a non-indented, non-blank line)
+            body = []
+            while i < n:
+                ln = lines[i]
+                if ln.strip() == "":
+                    body.append("")
+                    i += 1
+                    continue
+                if not ln.startswith((" ", "\t")):
+                    break
+                body.append(ln)
+                i += 1
+            if not verbatim:
+                chunk = _parse_block(body)
+                if chunk.strip():
+                    code_chunks.append(chunk)
+        else:
+            i += 1
+    return "\n".join(code_chunks)
+
+
+def _parse_block(body):
+    """Pull the Python out of one block's body: keep only prompt lines, strip
+    the ``In [n]:``/``...:`` prefix (preserving the code's own indentation),
+    and drop ``@verbatim`` sub-blocks."""
+    out = []
+    skip = False
+    for ln in body:
+        s = ln.strip()
+        if s.startswith("@verbatim"):
+            skip = True
+            continue
+        if s.startswith("@"):  # @suppress/@doctest/@savefig markers -> drop the marker
+            continue
+        m = _PROMPT.match(ln)
+        if m is None:
+            # blank line ends a verbatim run; non-prompt text is output/comment
+            if s == "":
+                skip = False
+            continue
+        if skip:
+            continue
+        code = m.group(1)
+        # Drop IPython magics / shell escapes (e.g. ``%run``, ``%timeit``, ``!cmd``);
+        # they are not Python and are not part of the API surface under test.
+        if code.lstrip().startswith(("%", "!")):
+            continue
+        out.append(code)
+    return "\n".join(out)
+
+
+def _doc_pages():
+    pages = []
+    for path in sorted(glob.glob(os.path.join(_WEB, "**", "*.rst"), recursive=True)):
+        try:
+            text = open(path, encoding="utf-8").read()
+        except (OSError, UnicodeDecodeError):
+            continue
+        if ".. ipython::" in text:
+            pages.append(path)
+    return pages
+
+
+_PAGES = _doc_pages()
+
+# Compat gaps the harvester surfaced; xfail (strict) until fixed -- when the gap
+# is closed the page xpasses, turning the suite red so the xfail entry is removed.
+_XFAIL = {
+    "coolprop/LowLevelAPI.rst": "bd CoolProp-r9sq.15 (generate_update_pair binding broken)",
+    "coolprop/HighLevelAPI.rst": "bd CoolProp-r9sq.16 (set_reference_state D-form -> std::bad_cast)",
+}
+
+
+def _params():
+    params = []
+    for p in _PAGES:
+        rel = os.path.relpath(p, _WEB)
+        marks = [pytest.mark.xfail(reason=_XFAIL[rel], strict=True)] if rel in _XFAIL else []
+        params.append(pytest.param(p, id=rel, marks=marks))
+    return params
+
+
+@pytest.mark.skipif(not _PAGES, reason="Web/ docs not found next to the repo")
+@pytest.mark.parametrize("rst_path", _params())
+def test_doc_page_examples(rst_path):
+    code = _extract_ipython_code(open(rst_path, encoding="utf-8").read())
+    if not code.strip():
+        pytest.skip("no executable .ipython code")
+    # Headless plotting; never pop a window.
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+    except ImportError:
+        pass
+    ns = {"__name__": "__doc_example__"}
+    try:
+        exec(compile(code, rst_path, "exec"), ns)
+    except Exception as e:  # noqa: BLE001 -- this is the compat signal
+        # Absent optional libs (matplotlib/pybtex/scipy/...) surface as ImportError
+        # and are skipped by type. REFPROP load failures are RuntimeError, so match
+        # those by message. Everything else is a genuine compat failure -> raise.
+        if isinstance(e, (ImportError, ModuleNotFoundError)) or "refprop" in str(e).lower():
+            pytest.skip("requires an absent optional dependency / REFPROP: %s" % str(e)[:80])
+        raise


### PR DESCRIPTION
## What

A fast, CI-cheap alternative to building the whole Sphinx site as a compat gate: **harvest the executable code from the docs' `.. ipython::` directives and replay it under pytest** — a comprehensive integration test of the high-level API *as the docs actually use it*. Any example that fails against the installed CoolProp surfaces a compat gap (the array-/2-arg-`PropsSI` regressions would have shown up here).

- one test per doc page, replaying its `.ipython` blocks in order in a shared namespace (matches the Sphinx directive's per-document state); bar = **runs-without-exception**
- parses `In []:`/`...:` prompts (preserving code indentation), skips `:verbatim:`/`@verbatim` blocks, `@suppress`/`@savefig`/`@doctest` markers, and IPython magics (`%`/`!`); matplotlib under `Agg`
- pages needing an absent optional dep (matplotlib/pybtex/scipy → `ImportError`) or REFPROP are **skipped**, not failed

## Result on the current nanobind build

**10 pages pass, 2 skip** (optional deps), **2 xfail** (strict) tracking gaps the harvester *found*:
- `LowLevelAPI` — `generate_update_pair` binding broken (out-params not wrapped) → **bd CoolProp-r9sq.15**
- `HighLevelAPI` — `set_reference_state` 5-arg D-form → `std::bad_cast` → **bd CoolProp-r9sq.16**

`xfail` is strict, so when a gap is fixed the page turns the suite red → prompting removal of the xfail entry (the suite *flips to pass* as gaps close).

Lives in `wrappers/Python/pytest/` (dev test; reads the repo's `Web/*.rst`, not shipped) and runs in the `nanobind-pytest` CI job. Adversarial review passed (parser correctness, exec isolation, strict-xfail key matching, path resolution).

Refs bd CoolProp-r9sq.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an automated test suite that extracts and runs Python examples from documentation pages to validate compatibility with the public API. Handles known compatibility regressions (marked xfail), skips examples when optional dependencies or external backends are absent, and configures plotting for headless test environments to reduce false failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->