### PR TITLE
fix(python): generate_update_pair tuple return + iphase_not_imposed enum (CoolProp-r9sq.15, r9sq.17)

### DIFF
--- a/src/nanobind_interface.cxx
+++ b/src/nanobind_interface.cxx
@@ -340,6 +340,7 @@ void init_CoolProp(nb::module_& m) {
       .value("iphase_gas", phases::iphase_gas)
       .value("iphase_twophase", phases::iphase_twophase)
       .value("iphase_unknown", phases::iphase_unknown)
+      .value("iphase_not_imposed", phases::iphase_not_imposed)
       .export_values();
 
     nb::class_<AbstractState>(m, "_AbstractState")
@@ -551,7 +552,14 @@ void init_CoolProp(nb::module_& m) {
     m.def("get_parameter_index", &get_parameter_index);
     m.def("get_phase_index", &get_phase_index);
     m.def("is_trivial_parameter", &is_trivial_parameter);
-    m.def("generate_update_pair", &generate_update_pair<double>);
+    // generate_update_pair has two out-reference params and returns the input_pair;
+    // wrap it to return (input_pair, out1, out2) like the legacy Cython wrapper
+    // (binding &generate_update_pair<double> directly exposes an unusable signature).
+    m.def("generate_update_pair", [](parameters key1, double value1, parameters key2, double value2) {
+        double out1 = 0.0, out2 = 0.0;
+        input_pairs pair = generate_update_pair<double>(key1, value1, key2, value2, out1, out2);
+        return nb::make_tuple(pair, out1, out2);
+    });
     m.def("Props1SI", &Props1SI);
     m.def("PropsSI", &PropsSI);
     // Vectorized PropsSI: list/ndarray Prop1/Prop2 (with scalar broadcast) dispatch

--- a/wrappers/Python/pytest/test_doc_examples.py
+++ b/wrappers/Python/pytest/test_doc_examples.py
@@ -114,7 +114,7 @@ _PAGES = _doc_pages()
 # Compat gaps the harvester surfaced; xfail (strict) until fixed -- when the gap
 # is closed the page xpasses, turning the suite red so the xfail entry is removed.
 _XFAIL = {
-    "coolprop/LowLevelAPI.rst": "bd CoolProp-r9sq.15 (generate_update_pair binding broken)",
+    "coolprop/LowLevelAPI.rst": "bd CoolProp-r9sq.18 (remaining low-level gaps; generate_update_pair + iphase_not_imposed fixed)",
     "coolprop/HighLevelAPI.rst": "bd CoolProp-r9sq.16 (set_reference_state D-form -> std::bad_cast)",
 }
 


### PR DESCRIPTION
## What

Two compat gaps the **`r9sq.13` doc-example harvester** surfaced while driving `LowLevelAPI.rst`:

- **`generate_update_pair`** (`r9sq.15`): was bound as `&generate_update_pair<double>`, whose C++ signature has two `double&` *out-params* and returns the `input_pair` — so the Python form was unusable (`TypeError`). Now a lambda calls it with local out-vars and returns `(input_pair, out1, out2)`, matching the legacy Cython wrapper. Verified: `generate_update_pair(iT,300,iDmolar,1e-6)` → `(DmolarT_INPUTS, 1e-6, 300.0)`.
- **`phases` enum** (`r9sq.17`): nanobind's `phases` enum was missing `iphase_not_imposed` (present in legacy); `specify_phase(iphase_not_imposed)` raised `TypeError`. Added the member (the only one of the 9 that was missing).

## Harvester status

With these, `LowLevelAPI.rst` clears further but still `xfail`s on the **next** gap — `PyGuessesStructure` (legacy name) vs `GuessesStructure` (nanobind), tracked in **`CoolProp-r9sq.18`** along with an audit of the rest of the low-level page. The harvester drives this parity work one gap at a time; suite remains green (10 passed / 2 skipped / 2 xfail). The separately-tracked `set_reference_state` D-form `bad_cast` (`r9sq.16`) is state-dependent and deferred.

Adversarial review passed (signature/order match legacy, enum value valid, xfail unchanged).

Refs bd CoolProp-r9sq.15, CoolProp-r9sq.17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `iphase_not_imposed` phase state to the available phase options.
  * `generate_update_pair` function now returns all computed values as a tuple: the input pair plus two additional output parameters.

* **Tests**
  * Updated test compatibility tracking to reflect fixes for phase state handling and pair generation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->