### PR TITLE
Phase 5: Configuration / SchemaValidation / SVDSBTL off RapidJSON

### DIFF
--- a/docs/superpowers/plans/2026-06-07-rapidjson-to-nlohmann-phase5-configuration.md
+++ b/docs/superpowers/plans/2026-06-07-rapidjson-to-nlohmann-phase5-configuration.md
@@ -1,0 +1,325 @@
+# RapidJSON → nlohmann — Phase 5 (Configuration / SchemaValidation / SVDSBTL) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the last rapidjson consumers (Configuration, SchemaValidation, SVDSBTL options, MixtureParameters, a REFPROP test parse) onto nlohmann/Valijson; make `Configuration.h`/`SchemaValidation.h` JSON-library-free; delete the two Phase-2-4 `validate_schema` casts.
+
+**Architecture:** The rapidjson-typed public functions are removed outright (no C++ callers). SchemaValidation re-backs its string API with Valijson (`cpjson::validate_schema`) + nlohmann canonicalization (`cpjson::parse(s).dump()` — nlohmann's `std::map`-backed objects serialize keys sorted at every level). Configuration's per-item serialize/deserialize moves to non-installed `.cpp` free functions using `ConfigurationItem`'s accessors. The loaders' `validate_schema` casts become unambiguous once `Configuration.h` stops pulling `detail/rapidjson.h`.
+
+**Tech Stack:** C++17, nlohmann/json + Valijson via `include/CoolProp/detail/json.h`'s `cpjson::`, Catch2 v3, CMake (Release).
+
+**Spec:** `docs/superpowers/specs/2026-06-07-rapidjson-to-nlohmann-phase5-configuration-design.md`
+**Epic:** `CoolProp-xa8w.2`. **Branch:** `ihb/json-phase5-configuration-off-rapidjson`.
+
+---
+
+## Idiom map (for the mechanical conversions — same as Phase 2-4)
+
+| rapidjson | nlohmann |
+|-----------|----------|
+| `rapidjson::Document dd; dd.Parse<0>(s.c_str()); … HasParseError()` | `nlohmann::json dd = cpjson::parse(s);` (throws `ValueError`) |
+| `v.IsObject()/IsArray()/IsBool()/IsInt()/IsDouble()/IsString()` | `v.is_object()/is_array()/is_boolean()/is_number_integer()/is_number()/is_string()` |
+| `v.GetBool()/GetInt()/GetDouble()/GetString()` | `cpjson::get_*` or `v.get<bool>()/get<int>()/get<double>()/get<std::string>()` |
+| `for (auto it=v.MemberBegin(); it!=v.MemberEnd(); ++it) { it->name.GetString(); it->value … }` | `for (auto& [name, value] : v.items()) { … }` |
+| `for (auto it=v.Begin(); it!=v.End(); ++it) { *it }` | `for (const auto& el : v) { … }` |
+| `val.AddMember(name, v, alloc)` | `obj[name] = v;` |
+| `cpjson::to_string(doc)` / writer | `doc.dump()` |
+
+---
+
+## Task 1: SchemaValidation → Valijson + string-only API
+
+**Files:**
+- Modify: `include/CoolProp/SchemaValidation.h` (remove rapidjson include + the 3 rapidjson-typed decls)
+- Rewrite: `src/SchemaValidation.cpp`
+- Modify: `src/Tests/CoolProp-Tests-SchemaValidation.cpp`
+
+- [ ] **Step 1: Header — string-only, JSON-library-free**
+
+In `SchemaValidation.h`: delete `#include "CoolProp/detail/rapidjson.h"` (line 7); delete the declarations of `validate_against_schema(const rapidjson::Value&, const rapidjson::Document&)` (26), `validate_against_schema(const rapidjson::Value&, const std::string&)` (32), and `to_canonical_json(const rapidjson::Value&)` (48). Keep only `validate_json_against_schema(const std::string&, const std::string&)` and `to_canonical_json_str(const std::string&)`. Remove any now-unused `#if !defined(SWIG)` guards that only wrapped the deleted decls.
+
+- [ ] **Step 2: Rewrite `src/SchemaValidation.cpp`**
+
+Replace the entire file body with the collapsed nlohmann/Valijson version:
+```cpp
+#include "CoolProp/SchemaValidation.h"
+
+#include <string>
+
+#include "CoolProp/Exceptions.h"
+#include "CoolProp/detail/json.h"
+
+namespace CoolProp {
+
+void validate_json_against_schema(const std::string& instance_json, const std::string& schema_json) {
+    std::string errstr;
+    // cpjson::validate_schema(schemaJson, inputJson, errstr) — Valijson-backed.
+    cpjson::schema_validation_code code = cpjson::validate_schema(schema_json, instance_json, errstr);
+    if (code != cpjson::SCHEMA_VALIDATION_OK) {
+        throw ValueError(std::string("schema validation failed: ") + errstr);
+    }
+}
+
+std::string to_canonical_json_str(const std::string& json_str) {
+    // nlohmann::json is std::map-backed, so object keys serialize sorted at every
+    // level — this is the canonical (deterministic, key-sorted) form. Arrays keep order.
+    return cpjson::parse(json_str).dump();
+}
+
+}  // namespace CoolProp
+```
+(Deletes `copy_sorted`, `pointer_to_string`, `parse_json`, and both rapidjson-typed overloads. NOTE the argument order: `cpjson::validate_schema(schema, instance, errstr)` — schema first.)
+
+- [ ] **Step 3: Update the `[SchemaValidation]` test**
+
+In `src/Tests/CoolProp-Tests-SchemaValidation.cpp`: delete the local `rapidjson::Document parse(const std::string&)` helper (lines ~52-56) and the rapidjson include. Replace each `validate_against_schema(parse(inst), std::string(kSchema))` with `validate_json_against_schema(inst, std::string(kSchema))`, and each `to_canonical_json(parse(s))` with `to_canonical_json_str(s)`. The `REQUIRE_NOTHROW`/`REQUIRE_THROWS` structure is unchanged. For canonical-output assertions: if the test compares an EXACT canonical string, update the expected value to nlohmann's `dump()` output (number formatting may differ from rapidjson) — run the test to capture the actual canonical string and confirm it is sorted/deterministic; if the test only asserts "two equivalent inputs produce equal output" (determinism), no expected-string change is needed.
+
+- [ ] **Step 4: Build + test**
+
+Run: `cmake --build build_catch --target CatchTestRunner -j8 && ./build_catch/CatchTestRunner "[SchemaValidation]" -s`
+Expected: clean build; all sections pass (valid passes, invalid throws, canonical sorted/deterministic).
+
+- [ ] **Step 5: Commit**
+```bash
+git add include/CoolProp/SchemaValidation.h src/SchemaValidation.cpp src/Tests/CoolProp-Tests-SchemaValidation.cpp
+git restore --staged .beads/issues.jsonl 2>/dev/null || true
+git commit -m "refactor(json): SchemaValidation off rapidjson — Valijson + nlohmann, string-only API (CoolProp-xa8w.2)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Configuration → nlohmann internal, string-only public API
+
+**Files:**
+- Modify: `include/CoolProp/Configuration.h` (remove rapidjson include + the public `*_as_json(Document&)` decls + the `ConfigurationItem::add_to_json`/`set_from_json` methods)
+- Modify: `src/Configuration.cpp` (nlohmann internals; de-published per-item free functions)
+- Modify: `src/CoolProp.i` (remove the two `%ignore`s)
+
+- [ ] **Step 1: Confirm `ConfigurationItem`'s public accessors**
+
+Read `include/CoolProp/Configuration.h` around the `ConfigurationItem` class (the cast operators / getters used by `get_config_bool/integer/double/string` — e.g. `static_cast<double>(item)`, `get_key()`, the `type`). Confirm there is a public way to read the item's **type** and its typed value. If a public `ConfigurationDataTypes get_type() const { return type; }` accessor is absent, ADD one (small, non-JSON) — the de-published free functions need it.
+
+- [ ] **Step 2: Header — remove the rapidjson surface**
+
+In `Configuration.h`: delete `#include "CoolProp/detail/rapidjson.h"` (line 10); delete the public `void get_config_as_json(rapidjson::Document&)` (346) and `void set_config_json(rapidjson::Document&)` (365) declarations; delete the `ConfigurationItem::add_to_json(rapidjson::Value&, rapidjson::Document&)` (124-154) and `set_from_json(rapidjson::Value&)` (155-190) methods entirely (and their `#if !defined(SWIG)` wrapper if it now wraps nothing). Keep `get_config_as_json_string()` / `set_config_as_json_string(const std::string&)`. The installed `Configuration.h` must end up with **no `rapidjson`/`nlohmann` token**.
+
+- [ ] **Step 3: `Configuration.cpp` — de-published per-item free functions (nlohmann)**
+
+Add `#include "CoolProp/detail/json.h"` to the `.cpp`. Add file-local free functions reproducing the old methods' logic, idiom-mapped, using `ConfigurationItem`'s accessors:
+```cpp
+namespace {
+void item_to_json(const ConfigurationItem& item, nlohmann::json& obj) {
+    const std::string name = config_key_to_string(item.get_key());
+    switch (item.get_type()) {
+        case CONFIGURATION_BOOL_TYPE:    obj[name] = static_cast<bool>(item); break;
+        case CONFIGURATION_INTEGER_TYPE: obj[name] = static_cast<int>(item); break;
+        case CONFIGURATION_DOUBLE_TYPE:  obj[name] = static_cast<double>(item); break;
+        case CONFIGURATION_STRING_TYPE:  obj[name] = static_cast<std::string>(item); break;
+        case CONFIGURATION_ENDOFLIST_TYPE:
+        case CONFIGURATION_NOT_DEFINED_TYPE: throw ValueError();
+    }
+}
+void item_from_json(ConfigurationItem& item, const nlohmann::json& val) {
+    switch (item.get_type()) {
+        case CONFIGURATION_BOOL_TYPE:
+            if (!val.is_boolean()) throw ValueError(format("Input is not boolean"));
+            item.set_bool(val.get<bool>()); break;
+        case CONFIGURATION_INTEGER_TYPE:
+            if (!val.is_number_integer()) throw ValueError(format("Input is not integer"));
+            item.set_integer(val.get<int>()); break;
+        case CONFIGURATION_DOUBLE_TYPE:
+            if (!val.is_number()) throw ValueError(format("Input [%s] is not double (or castable)", val.dump().c_str()));
+            item.set_double(val.get<double>()); break;
+        case CONFIGURATION_STRING_TYPE:
+            if (!val.is_string()) throw ValueError(format("Input is not string"));
+            item.set_string(val.get<std::string>()); break;
+        case CONFIGURATION_ENDOFLIST_TYPE:
+        case CONFIGURATION_NOT_DEFINED_TYPE: throw ValueError();
+    }
+}
+}  // namespace
+```
+IMPORTANT: use whatever the ACTUAL `ConfigurationItem` typed getters/setters are named (the cast operators `static_cast<T>(item)` are confirmed used elsewhere; the setters may be `set_bool`/`set_integer`/… or assignment — read the class and match). `val.is_number()` covers the old `IsDouble() || IsInt()`.
+
+- [ ] **Step 4: `Configuration.cpp` — string functions on nlohmann; delete the rapidjson ones**
+
+Replace `get_config_as_json(rapidjson::Document&)` + `get_config_as_json_string()` (105-117) with:
+```cpp
+std::string get_config_as_json_string() {
+    nlohmann::json doc = nlohmann::json::object();
+    for (auto& kv : _get_config()->get_items()) {
+        item_to_json(kv.second, doc);
+    }
+    return doc.dump();
+}
+```
+Replace `set_config_as_json(rapidjson::Value&)` + `set_config_as_json_string(const std::string&)` (118-153) with:
+```cpp
+void set_config_as_json_string(const std::string& s) {
+    nlohmann::json doc = cpjson::parse(s);
+    // First check that all keys are valid
+    for (auto& [name, value] : doc.items()) {
+        try {
+            _get_config()->get_item(config_string_to_key(name));
+        } catch (std::exception& e) {
+            throw ValueError(format("Unable to parse json file with error: %s", e.what()));
+        }
+    }
+    // Now set the values
+    for (auto& [name, value] : doc.items()) {
+        ConfigurationItem& item = _get_config()->get_item(config_string_to_key(name));
+        try {
+            item_from_json(item, value);
+        } catch (std::exception& e) {
+            throw ValueError(format("Unable to parse json file with error: %s", e.what()));
+        }
+    }
+}
+```
+(The public `get_config_as_json(Document&)`/`set_config_as_json(Value&)` are gone; the string functions are the only public JSON config API.)
+
+- [ ] **Step 5: `src/CoolProp.i` — remove the dead `%ignore`s**
+
+Delete lines 13-14:
+```
+%ignore CoolProp::set_config_json(rapidjson::Document &);
+%ignore CoolProp::get_config_as_json(rapidjson::Document &);
+```
+
+- [ ] **Step 6: Build + config round-trip test**
+
+Run: `cmake --build build_catch --target CatchTestRunner -j8`
+Then exercise the config JSON round-trip (find the covering test; config is tested via backends + any `[configuration]`/`[config]` tag):
+`./build_catch/CatchTestRunner "[configuration],[config]"` (if no such tag, run `"~[slow]"` later in Final Verification — the change is exercised broadly). Confirm `get_config_as_json_string`/`set_config_as_json_string` round-trip a config unchanged.
+Then: `grep -n "rapidjson\|nlohmann" include/CoolProp/Configuration.h` → no matches.
+
+- [ ] **Step 7: Commit**
+```bash
+git add include/CoolProp/Configuration.h src/Configuration.cpp src/CoolProp.i
+git restore --staged .beads/issues.jsonl 2>/dev/null || true
+git commit -m "refactor(json): Configuration off rapidjson — string-only public API, nlohmann internal (CoolProp-xa8w.2)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: SVDSBTL + MixtureParameters + REFPROP → nlohmann
+
+**Files:**
+- Modify: `src/Backends/SVDSBTL/SVDSBTLBackend.cpp` (include; `resolve_grid`; the validate/canonical calls)
+- Modify: `src/Backends/Helmholtz/MixtureParameters.cpp` (predefined-mixtures parse)
+- Modify: `src/Backends/REFPROP/REFPROPMixtureBackend.cpp:~2920` (one parse)
+
+- [ ] **Step 1: SVDSBTL**
+
+In `SVDSBTLBackend.cpp`: replace `#include "CoolProp/detail/rapidjson.h"` (38) with `#include "CoolProp/detail/json.h"`. The options path currently parses the validated options string into a `rapidjson::Document opts`, then calls `validate_against_schema(opts, kSVDSBTLOptionsSchemaJson)` + `to_canonical_json(opts)` (lines ~180-181). Switch to the **string** API on the options string `opts_str`:
+```cpp
+CoolProp::validate_json_against_schema(opts_str, std::string(kSVDSBTLOptionsSchemaJson));
+std::string canonical = CoolProp::to_canonical_json_str(opts_str);
+```
+Convert `resolve_grid(const rapidjson::Document& opts)` → `resolve_grid(const nlohmann::json& opts)`: `opts["grid"].IsObject()` → `opts.contains("grid") && opts.at("grid").is_object()`; `grid["NT"].GetInt()` → `cpjson::get_integer(grid, "NT")` (and NR/rank). Parse the (canonical or validated) options string with `cpjson::parse` where the code currently built the rapidjson Document, and pass the nlohmann node to `resolve_grid`. Read the surrounding factory/options code to wire `opts_str` through correctly.
+
+- [ ] **Step 2: MixtureParameters**
+
+In `MixtureParameters.cpp`: replace the rapidjson include with `detail/json.h`; convert the predefined-mixtures `rapidjson::Document`/`Value` parse + iteration (lines ~25, 34-39) to `cpjson::parse` + range-for + `cpjson::get_*`, per the idiom map. Read the functions and apply the same mechanical conversion used for the Phase 2-4 loaders (preserve every `HasMember`→`contains` guard).
+
+- [ ] **Step 3: REFPROP**
+
+In `REFPROPMixtureBackend.cpp` near line 2920: convert the single `rapidjson` parse of a fluid-param JSON string to `cpjson::parse(...)` + nlohmann access. (This is inside a test/diagnostic path — keep the assertion behavior identical.)
+
+- [ ] **Step 4: Build + tests**
+
+Run: `cmake --build build_catch --target CatchTestRunner -j8 && ./build_catch/CatchTestRunner "[SBTL]"`  (the SBTL **umbrella** per CLAUDE.md, not just `[SVDSBTL]`), then `./build_catch/CatchTestRunner "[SVDSBTL][options]"` and the mixture tests (e.g. `"[mixture]"` smoke). Expected: pass; SVDSBTL options validate/round-trip identically; predefined mixtures load identically.
+Then: `grep -rn "rapidjson" src/Backends/SVDSBTL/ src/Backends/Helmholtz/MixtureParameters.cpp src/Backends/REFPROP/REFPROPMixtureBackend.cpp` → no matches.
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/Backends/SVDSBTL/SVDSBTLBackend.cpp src/Backends/Helmholtz/MixtureParameters.cpp src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+git restore --staged .beads/issues.jsonl 2>/dev/null || true
+git commit -m "refactor(json): SVDSBTL options + MixtureParameters + REFPROP parse off rapidjson (CoolProp-xa8w.2)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Delete the two `validate_schema` casts (the payoff)
+
+**Files:**
+- Modify: `src/Backends/PCSAFT/PCSAFTLibrary.cpp` (the cast in `add_fluids_from_JSON_string`)
+- Modify: `src/Backends/Cubics/CubicsLibrary.cpp` (the cast in `add_fluids_from_JSON_string`)
+
+- [ ] **Step 1: PCSAFT — call `validate_schema` directly**
+
+In `PCSAFTLibrary.cpp`, replace the cast block:
+```cpp
+    auto validate_schema_nlohmann =
+      static_cast<cpjson::schema_validation_code (*)(std::string_view, std::string_view, std::string&)>(&cpjson::validate_schema);
+    cpjson::schema_validation_code val_code = validate_schema_nlohmann(pcsaft_fluids_schema_JSON, JSON, errstr);
+```
+with:
+```cpp
+    cpjson::schema_validation_code val_code = cpjson::validate_schema(pcsaft_fluids_schema_JSON, JSON, errstr);
+```
+and delete the explanatory comment about the ambiguity (the FluidLibrary.h→Configuration.h→rapidjson chain that caused it is now gone).
+
+- [ ] **Step 2: Cubics — same**
+
+In `CubicsLibrary.cpp`, replace its `validate_schema_nlohmann` cast block with the direct `cpjson::validate_schema(cubic_fluids_schema_JSON, JSON, errstr);` call; delete the comment.
+
+- [ ] **Step 3: Build + verify the casts compiled away cleanly**
+
+Run: `cmake --build build_catch --target CatchTestRunner -j8 && ./build_catch/CatchTestRunner "[PCSAFT],[cubic],[json_validation]"`
+Expected: clean build (no ambiguity error — proving the rapidjson overload is no longer visible in these TUs), tests pass.
+
+- [ ] **Step 4: Commit**
+```bash
+git add src/Backends/PCSAFT/PCSAFTLibrary.cpp src/Backends/Cubics/CubicsLibrary.cpp
+git restore --staged .beads/issues.jsonl 2>/dev/null || true
+git commit -m "refactor(json): drop the validate_schema overload-disambiguation casts (CoolProp-xa8w.2)
+
+The casts existed only because Configuration.h pulled detail/rapidjson.h into
+these TUs (via FluidLibrary.h), making both validate_schema overloads visible.
+Phase 5 removed that path, so the nlohmann/Valijson overload is unambiguous.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final Verification (before PR)
+
+- [ ] **Step 1: The exhaustive rapidjson grep — only the detail headers remain**
+
+Run: `git grep -l "rapidjson" -- 'include/**' 'src/**'`
+Expected: ONLY `include/CoolProp/detail/rapidjson.h`, `include/rapidjson_include.h`, `include/CoolProp/detail/json.h` (the enum-guard comment), and `src/Backends/PCSAFT/PCSAFTFluidFactory.h` (a comment). NO Configuration/SchemaValidation/SVDSBTL/MixtureParameters/REFPROP/loader-cast references. If anything else appears, it was missed — convert it.
+
+- [ ] **Step 2: Installed headers JSON-library-free**
+
+Run: `grep -n "rapidjson\|nlohmann" include/CoolProp/Configuration.h include/CoolProp/SchemaValidation.h`
+Expected: no matches.
+
+- [ ] **Step 3: Full fast suite + symbol gate**
+
+Run: `./build_catch/CatchTestRunner "~[slow]"` (0 failures) and `./dev/ci/check-json-symbols.sh "$(find build_shared -name 'libCoolProp.*' | head -1)"` after a shared build (still 0 nlohmann/valijson exported).
+
+- [ ] **Step 4: Preflight + adversarial review (MANDATORY)**
+
+`./dev/ci/preflight.sh`, then dispatch the review vs `master`. Focus: (a) `item_from_json` type checks match the old rapidjson ones (`is_number()` = old `IsDouble()||IsInt()`; bool/int/string guards preserved); (b) the canonical-JSON output is genuinely sorted/deterministic and the SVDSBTL cache-key/opthash change (rapidjson→nlohmann number formatting) is acknowledged (cache invalidation only, not correctness); (c) the two casts compiled away because the overload is truly gone (not silently still-ambiguous); (d) `ConfigurationItem` accessors used match the real interface. Then push + `gh pr create`, then re-review the delta.
+
+- [ ] **Step 5: bd**
+
+`bd update CoolProp-xa8w.2 --notes "PR #<n>…"`. Note in `xa8w.3` (Phase Final) that the tree is now one mechanical deletion away (only `detail/rapidjson.h` + the shim + the enum guard remain).
+
+---
+
+## Self-Review (plan vs spec)
+
+**Spec coverage:** §3 Configuration → Task 2; §3 SchemaValidation → Task 1; §3 SVDSBTL/MixtureParameters/REFPROP → Task 3; §3 cast deletion → Task 4; §5 verification (exhaustive grep, installed-header check, suite, symbol gate) → Final Verification; §1 string-only public API → Tasks 1-2 (rapidjson decls removed, string API kept).
+
+**Placeholder scan:** none — SchemaValidation.cpp is given in full; the Configuration free functions + string fns are given in full (with the explicit caveat to match the real `ConfigurationItem` setter names); SVDSBTL/MixtureParameters/REFPROP use the idiom map (the implementer reads each site and applies it, as in Phase 2-4).
+
+**Type consistency:** `cpjson::validate_schema(schema, instance, errstr)` arg order is used consistently (Task 1, and the loaders in Task 4); `item_to_json`/`item_from_json` signatures match their call sites in `get/set_config_as_json_string`; `to_canonical_json_str`/`validate_json_against_schema` are the string API referenced by SVDSBTL (Task 3) and the test (Task 1).

--- a/docs/superpowers/specs/2026-06-07-rapidjson-to-nlohmann-phase5-configuration-design.md
+++ b/docs/superpowers/specs/2026-06-07-rapidjson-to-nlohmann-phase5-configuration-design.md
@@ -1,0 +1,139 @@
+# RapidJSON → nlohmann — Phase 5 (Configuration / SchemaValidation / SVDSBTL off rapidjson) — Design
+
+**Date:** 2026-06-07
+**Status:** Approved design, ready for implementation planning
+**Epic:** `CoolProp-xa8w` (RapidJSON → nlohmann/json migration) · child `CoolProp-xa8w.2`
+**Predecessors (merged):** Phase 0-4 (loaders, value-type boundaries, superancillary de-leak).
+
+---
+
+## 1. Goal
+
+Move the **last rapidjson consumers** off RapidJSON: `Configuration`,
+`SchemaValidation`, the SVDSBTL options path, `MixtureParameters`, and a REFPROP
+test parse. Make the public `Configuration` and `SchemaValidation` installed
+headers **string-based** (no rapidjson — or nlohmann — type in any installed
+signature). After this phase, the only file that still references rapidjson is
+`detail/rapidjson.h` itself (plus the deprecated `rapidjson_include.h` shim and
+the enum-guard comment in `detail/json.h`) — all deleted in Phase Final
+(`CoolProp-xa8w.3`).
+
+The **payoff**: with `Configuration.h` no longer pulling `detail/rapidjson.h`
+into the loader TUs, the two Phase-2-4 `validate_schema` function-pointer casts
+(PCSAFT, Cubics) become unambiguous and are **deleted** — the proof the
+migration has fully landed.
+
+## 2. Key facts (verified)
+
+- **The rapidjson-typed public functions have no real C++ callers.**
+  - `Configuration::get_config_as_json(rapidjson::Document&)` /
+    `set_config_json(rapidjson::Document&)` (Configuration.h:346/365): the only
+    references are `%ignore` lines in `src/CoolProp.i:13-14`. → **removed outright.**
+  - `SchemaValidation::validate_against_schema(const rapidjson::Value&, …)` /
+    `to_canonical_json(const rapidjson::Value&)` (SchemaValidation.h:26/32/48):
+    two internal callers — `SVDSBTLBackend.cpp:180-181` and the `[SchemaValidation]`
+    test — both migrate to the **string-based** API. → **removed outright.**
+- **The string-based public API already exists** and is the SWIG-exposed,
+  supported surface: `get_config_as_json_string()`, `set_config_as_json_string(std::string)`,
+  `validate_json_against_schema(std::string, std::string)`, `to_canonical_json_str(std::string)`.
+- **`Configuration.h` is the transitive rapidjson source** for the loader TUs:
+  `FluidLibrary.h` → `Configuration.h` → `detail/rapidjson.h`, which is why
+  PCSAFTLibrary.cpp / CubicsLibrary.cpp see both `validate_schema` overloads and
+  needed the cast. Dropping `detail/rapidjson.h` from `Configuration.h` removes
+  that path.
+- **`to_canonical_json` simplifies under nlohmann:** `nlohmann::json` is
+  `std::map`-backed, so object keys serialize **sorted at every nesting level** —
+  the canonical form is just `cpjson::parse(s).dump()` (no manual recursive sort).
+- **SchemaValidation's validator** moves rapidjson `SchemaDocument`/`SchemaValidator`
+  → **Valijson** (the same engine Phase 2-4 adopted for the loaders), reusing
+  `cpjson::validate_schema` semantics.
+
+## 3. Components
+
+### Configuration (`include/CoolProp/Configuration.h`, `src/Configuration.cpp`)
+- **Header:** delete `get_config_as_json(rapidjson::Document&)` and
+  `set_config_json(rapidjson::Document&)`; drop `#include "CoolProp/detail/rapidjson.h"`.
+  Retype `ConfigurationItem::add_to_json`/`set_from_json` to nlohmann **and move
+  their bodies out of the installed header into the `.cpp`** (so no
+  `nlohmann::json` type appears in the installed header — these become declared
+  in the header only if needed, or fully `.cpp`-internal). Net: the installed
+  `Configuration.h` carries **no JSON-library type** — only the `std::string`
+  config API.
+- **.cpp:** convert serialize (`add_to_json`/`get_config_as_json`) and
+  deserialize (`set_from_json`/`set_config_as_json`) to nlohmann; keep the
+  `*_as_json_string` public functions (now nlohmann-backed). Include
+  `detail/json.h` (non-installed) in the `.cpp`.
+- **`src/CoolProp.i`:** remove the two `%ignore` lines for the deleted rapidjson
+  overloads.
+
+### SchemaValidation (`include/CoolProp/SchemaValidation.h`, `src/SchemaValidation.cpp`)
+- **Header:** delete the three rapidjson-typed functions; keep the string API
+  (`validate_json_against_schema`, `to_canonical_json_str`); drop the rapidjson
+  include. Installed header becomes JSON-library-free.
+- **.cpp:** `validate_json_against_schema` → Valijson (via `cpjson::validate_schema`
+  or a direct Valijson call); `to_canonical_json_str` → `cpjson::parse(s).dump()`
+  (sorted-key canonical). Include `detail/json.h`.
+
+### SVDSBTL (`src/Backends/SVDSBTL/SVDSBTLBackend.cpp`)
+- Replace `validate_against_schema(opts /*rapidjson*/, schema)` +
+  `to_canonical_json(opts)` with the **string** API on the options string from
+  the factory. `resolve_grid(const rapidjson::Document&)` → takes
+  `const nlohmann::json&` and reads `grid.NT/NR/rank` via nlohmann. Drop
+  `#include "CoolProp/detail/rapidjson.h"`; include `detail/json.h`.
+
+### MixtureParameters (`src/Backends/Helmholtz/MixtureParameters.cpp`)
+- Convert the predefined-mixtures JSON parsing/iteration from rapidjson to
+  nlohmann (`cpjson::parse` + range-for + `cpjson::get_*`), idiom-mapped as in
+  Phase 2-4.
+
+### REFPROP (`src/Backends/REFPROP/REFPROPMixtureBackend.cpp:2920`)
+- Convert the single rapidjson parse of a fluid-param JSON string to nlohmann.
+
+### The cast deletion (the payoff)
+- `src/Backends/PCSAFT/PCSAFTLibrary.cpp` and
+  `src/Backends/Cubics/CubicsLibrary.cpp`: delete the
+  `static_cast<… (*)(std::string_view, …)>(&cpjson::validate_schema)` indirection
+  and call `cpjson::validate_schema(...)` directly (now the only overload visible),
+  removing the explanatory comments about the ambiguity.
+
+### Tests
+- `src/Tests/CoolProp-Tests-SchemaValidation.cpp`: drop its `rapidjson::Document
+  parse()` helper; call `validate_json_against_schema(instance_str, schema_str)`
+  and `to_canonical_json_str(str)`. Assertions unchanged in intent (valid passes,
+  invalid throws, canonical is sorted/deterministic).
+
+## 4. Sequencing (one PR, logical commits)
+
+1. **SchemaValidation** → Valijson + string-only public API (+ test).
+2. **Configuration** → nlohmann internal + string-only public API (+ `CoolProp.i`).
+3. **SVDSBTL + MixtureParameters + REFPROP** → nlohmann.
+4. **Delete the two `validate_schema` casts** (verify they compile away cleanly).
+
+Each commit keeps the tree green.
+
+## 5. Testing & verification
+
+- **Behavior parity:** `[SchemaValidation]`, `[SVDSBTL]`/`[SVDSBTL][options]`,
+  `[SBTL]` umbrella (per CLAUDE.md, SBTL changes run the umbrella tag), the
+  mixture tests (predefined mixtures load identically), `[PCSAFT]`/`[cubic]`
+  (the cast change is behaviour-neutral). Config get/set round-trip
+  (`get_config_as_json_string`/`set_config_as_json_string`) unchanged.
+- **Canonical-JSON equivalence:** confirm `to_canonical_json_str` produces
+  sorted-key output matching the previous rapidjson canonical form (the test
+  asserts determinism + sorting).
+- **Installed-header check:** `Configuration.h` and `SchemaValidation.h` contain
+  no `rapidjson`/`nlohmann` token.
+- **Exhaustive grep:** after this phase,
+  `git grep -l "rapidjson" include src` returns only `detail/rapidjson.h`,
+  `rapidjson_include.h`, the `detail/json.h` enum-guard comment, and
+  `PCSAFTFluidFactory.h`'s comment — nothing else.
+- **Symbol gate** stays green; full `~[slow]` suite green.
+- Per-commit `./dev/ci/preflight.sh` + the mandatory adversarial review.
+
+## 6. Out of scope (Phase Final, `xa8w.3`)
+
+Delete `detail/rapidjson.h` + `rapidjson_include.h`, drop the
+`CPJSON_SCHEMA_VALIDATION_CODE_DEFINED` dual-enum guard (make the enum
+unconditional in `detail/json.h`), tighten the symbol gate pattern to include
+`rapidjson`, and the deferred getter-layer decision. Phase 5 leaves the tree in
+the state where Phase Final is a near-mechanical deletion.

--- a/include/CoolProp/Configuration.h
+++ b/include/CoolProp/Configuration.h
@@ -6,10 +6,6 @@
 #include <cstdlib>
 #include <unordered_map>
 
-#if !defined(SWIG)  // Hide this for swig - Swig gets confused
-#    include "CoolProp/detail/rapidjson.h"
-#endif
-
 /* See http://stackoverflow.com/a/148610
  * See http://stackoverflow.com/questions/147267/easy-way-to-use-variables-of-enum-types-as-string-in-c#202511
  * This will be used to generate an enum like:
@@ -121,75 +117,6 @@ class ConfigurationItem
     configuration_keys get_key() const {
         return this->key;
     }
-#if !defined(SWIG)
-    /// Cast to rapidjson::Value
-    void add_to_json(rapidjson::Value& val, rapidjson::Document& d) const {
-        std::string name_string = config_key_to_string(key);
-        rapidjson::Value name(name_string.c_str(), d.GetAllocator());
-        switch (type) {
-            case CONFIGURATION_BOOL_TYPE: {
-                rapidjson::Value v(v_bool);
-                val.AddMember(name, v, d.GetAllocator());
-                break;
-            }
-            case CONFIGURATION_INTEGER_TYPE: {
-                rapidjson::Value v(v_integer);
-                val.AddMember(name, v, d.GetAllocator());
-                break;
-            }
-            case CONFIGURATION_DOUBLE_TYPE: {
-                rapidjson::Value v(v_double);  // Try to upcast
-                val.AddMember(name, v, d.GetAllocator());
-                break;
-            }
-            case CONFIGURATION_STRING_TYPE: {
-                rapidjson::Value v(v_string.c_str(), d.GetAllocator());
-                val.AddMember(name, v, d.GetAllocator());
-                break;
-            }
-            case CONFIGURATION_ENDOFLIST_TYPE:
-            case CONFIGURATION_NOT_DEFINED_TYPE:
-                throw ValueError();
-        }
-    }
-    void set_from_json(rapidjson::Value& val) {
-        switch (type) {
-            case CONFIGURATION_BOOL_TYPE:
-                if (!val.IsBool()) {
-                    throw ValueError(format("Input is not boolean"));
-                };
-                v_bool = val.GetBool();
-                break;
-            case CONFIGURATION_INTEGER_TYPE:
-                if (!val.IsInt()) {
-                    throw ValueError(format("Input is not integer"));
-                };
-                v_integer = val.GetInt();
-                break;
-            case CONFIGURATION_DOUBLE_TYPE: {
-                if (!val.IsDouble() && !val.IsInt()) {
-                    throw ValueError(format("Input [%s] is not double (or something that can be cast to double)", cpjson::to_string(val).c_str()));
-                };
-                if (val.IsDouble()) {
-                    v_double = val.GetDouble();
-                } else {
-                    v_double = static_cast<double>(val.GetInt());
-                }
-                break;
-            }
-            case CONFIGURATION_STRING_TYPE:
-                if (!val.IsString()) {
-                    throw ValueError(format("Input is not string"));
-                };
-                v_string = val.GetString();
-                break;
-            case CONFIGURATION_ENDOFLIST_TYPE:
-            case CONFIGURATION_NOT_DEFINED_TYPE:
-                throw ValueError();
-        }
-    }
-#endif  // !defined(SWIG)
-
    private:
     void check_data_type(ConfigurationDataTypes type) const {
         if (type != this->type) {
@@ -342,9 +269,6 @@ int get_config_int(configuration_keys key);
 double get_config_double(configuration_keys key);
 /// Return the value of a string configuration key
 std::string get_config_string(configuration_keys key);
-#if !defined(SWIG)  // Hide this for swig - Swig gets confused
-void get_config_as_json(rapidjson::Document& doc);
-#endif
 /// Get all the values in the configuration as a json-formatted string
 std::string get_config_as_json_string();
 
@@ -360,10 +284,6 @@ void set_config_int(configuration_keys key, int val);
 void set_config_double(configuration_keys key, double val);
 /// Set the value of a string configuration value
 void set_config_string(configuration_keys key, const std::string& val);
-/// Set values in the configuration based on a json file
-#if !defined(SWIG)  // Hide this for swig - Swig gets confused
-void set_config_json(rapidjson::Document& doc);
-#endif
 /// Set the entire configuration based on a json-formatted string
 void set_config_as_json_string(const std::string& s);
 }  // namespace CoolProp

--- a/include/CoolProp/Configuration.h
+++ b/include/CoolProp/Configuration.h
@@ -117,6 +117,7 @@ class ConfigurationItem
     configuration_keys get_key() const {
         return this->key;
     }
+
    private:
     void check_data_type(ConfigurationDataTypes type) const {
         if (type != this->type) {

--- a/include/CoolProp/SchemaValidation.h
+++ b/include/CoolProp/SchemaValidation.h
@@ -3,62 +3,14 @@
 
 #include <string>
 
-#if !defined(SWIG)
-#    include "CoolProp/detail/rapidjson.h"
-#endif
-
 namespace CoolProp {
-
-#if !defined(SWIG)
-
-// Strict-mode JSON Schema validation.
-//
-// Validates `instance` against `schema` using RapidJSON's built-in
-// validator.  On a validation failure, throws CoolProp::ValueError with
-// a message that quotes both the schema-pointer and the instance-pointer
-// of the failing assertion (e.g. "/critical_patch/tolerance does not
-// satisfy schema /properties/critical_patch/properties/tolerance: type
-// expected number, got string").
-//
-// The schema is consumed as a parsed Document so multiple validations
-// against the same schema can share parse cost.  Caller owns both
-// documents.
-void validate_against_schema(const rapidjson::Value& instance, const rapidjson::Document& schema);
-
-// Convenience overload — parse `schema_json` once and validate.  Useful
-// for the per-backend entry points where the schema is a constant
-// string literal compiled into the binary.  Throws ValueError if
-// schema_json itself is invalid JSON.
-void validate_against_schema(const rapidjson::Value& instance, const std::string& schema_json);
-
-// Produce a deterministic string representation of `value` for hashing
-// and reproducibility.  Object keys are sorted recursively; arrays
-// preserve order; numbers use RapidJSON's default formatting (already
-// deterministic within a single build).  Strings are UTF-8 verbatim
-// (no NFC normalisation performed — see note).
-//
-// This is *not* strict RFC 8785 (JCS): number normalisation skips
-// the ECMAScript JSON.stringify rules, and string content isn't
-// NFC-normalised.  It's "canonical within a CoolProp process" — the
-// same logical-options-value produces the same bytes inside one
-// binary, which is what cache hashing needs.  The form is not part
-// of any external on-wire format, so this scope is sufficient.
-//
-// Returns the canonical string (UTF-8, no trailing newline).
-std::string to_canonical_json(const rapidjson::Value& value);
-
-// Convenience overload — parse `json_str` and canonicalise.  Throws
-// ValueError if `json_str` is invalid JSON.
-std::string to_canonical_json(const std::string& json_str);
-
-#endif  // !SWIG
 
 // Schema-validation helpers that work on JSON strings — exposed even
 // to SWIG since they take only std::string.  Internally they parse,
-// validate, and (for to_canonical_json_str) re-serialise.
+// validate, and (for to_canonical_json_str) re-serialise into a
+// canonical form with object keys sorted at every level.
 //
-// Mirrors the typed API above for callers that don't want to touch
-// rapidjson directly (e.g. wrappers, tests).
+// Throws CoolProp::ValueError on schema violation or invalid JSON.
 void validate_json_against_schema(const std::string& instance_json, const std::string& schema_json);
 
 std::string to_canonical_json_str(const std::string& json_str);

--- a/src/Backends/Cubics/CubicsLibrary.cpp
+++ b/src/Backends/Cubics/CubicsLibrary.cpp
@@ -132,16 +132,7 @@ namespace {
 /// the get_library() singleton (which would recurse into its own constructor).
 void add_fluids_from_JSON_string(CubicsLibraryClass& dest, const std::string_view& JSON) {
     std::string errstr;
-    // FluidLibrary.h transitively includes detail/rapidjson.h (via
-    // Configuration.h), so both validate_schema overloads are visible here and
-    // the call is ambiguous. The two overloads differ ONLY in their string_view
-    // parameters: rapidjson takes `const std::string_view&`, nlohmann takes
-    // `std::string_view` by value. The cast's by-value signature therefore
-    // selects the nlohmann/Valijson overload. Remove this cast (the call becomes
-    // unambiguous) once detail/rapidjson.h is deleted at Phase Final.
-    auto validate_schema_nlohmann =
-      static_cast<cpjson::schema_validation_code (*)(std::string_view, std::string_view, std::string&)>(&cpjson::validate_schema);
-    cpjson::schema_validation_code val_code = validate_schema_nlohmann(cubic_fluids_schema_JSON, JSON, errstr);
+    cpjson::schema_validation_code val_code = cpjson::validate_schema(cubic_fluids_schema_JSON, JSON, errstr);
     if (val_code == cpjson::SCHEMA_VALIDATION_OK) {
         nlohmann::json dd = cpjson::parse(JSON);
         try {

--- a/src/Backends/Helmholtz/MixtureParameters.cpp
+++ b/src/Backends/Helmholtz/MixtureParameters.cpp
@@ -1,5 +1,5 @@
 #include "MixtureParameters.h"
-#include "CoolProp/detail/rapidjson.h"
+#include "CoolProp/detail/json.h"
 #include "CoolProp/detail/strings.h"
 #include "mixture_departure_functions_JSON.h"  // Creates the variable mixture_departure_functions_JSON
 #include "mixture_binary_pairs_JSON.h"         // Creates the variable mixture_binary_pairs_JSON
@@ -23,29 +23,24 @@ class PredefinedMixturesLibrary
     }
 
     void load_from_string(const std::string_view& str) {
-        rapidjson::Document doc;
-        doc.Parse<0>(str.data(), str.size());
-        if (doc.HasParseError()) {
-            std::cout << str << '\n';
-            throw ValueError("Unable to parse predefined mixture string");
-        }
+        nlohmann::json doc = cpjson::parse(str);
         load_from_JSON(doc);
     }
 
-    void load_from_JSON(rapidjson::Document& doc) {
-        if (!doc.IsArray() || !doc[0].IsObject()) {
+    void load_from_JSON(const nlohmann::json& doc) {
+        if (!doc.is_array() || !doc[0].is_object()) {
             throw ValueError("You must provide an array of objects");
         }
         // Iterate over the papers in the listing
-        for (rapidjson::Value::ValueIterator itr = doc.Begin(); itr != doc.End(); ++itr) {
+        for (const auto& el : doc) {
             // Instantiate the empty dictionary to be filled
             Dictionary dict;
             // Get the name
-            std::string name = cpjson::get_string(*itr, "name") + ".mix";
+            std::string name = cpjson::get_string(el, "name") + ".mix";
             // Get the fluid names
-            dict.add_string_vector("fluids", cpjson::get_string_array(*itr, "fluids"));
+            dict.add_string_vector("fluids", cpjson::get_string_array(el, "fluids"));
             // Get the mole fractions
-            dict.add_double_vector("mole_fractions", cpjson::get_double_array(*itr, "mole_fractions"));
+            dict.add_double_vector("mole_fractions", cpjson::get_double_array(el, "mole_fractions"));
             // Add to the map
             predefined_mixture_map.emplace(name, dict);
             // Also add the uppercase version to the map
@@ -100,12 +95,7 @@ class MixtureBinaryPairLibrary
     };
 
     void load_from_string(const std::string_view& str) {
-        rapidjson::Document doc;
-        doc.Parse<0>(str.data(), str.size());
-        if (doc.HasParseError()) {
-            std::cout << str << '\n';
-            throw ValueError("Unable to parse binary interaction function string");
-        }
+        nlohmann::json doc = cpjson::parse(str);
         load_from_JSON(doc);
     }
 
@@ -123,25 +113,25 @@ class MixtureBinaryPairLibrary
      *
      * The data structure also includes space for a string that gives the pointer to the departure function to be used for this binary pair.
      */
-    void load_from_JSON(rapidjson::Document& doc) {
+    void load_from_JSON(const nlohmann::json& doc) {
 
         // Iterate over the papers in the listing
-        for (rapidjson::Value::ValueIterator itr = doc.Begin(); itr != doc.End(); ++itr) {
+        for (const auto& el : doc) {
             // Get the empty dictionary to be filled by the appropriate reducing parameter filling function
             Dictionary dict;
 
             // Get the vector of CAS numbers
             std::vector<std::string> CAS;
-            CAS.push_back(cpjson::get_string(*itr, "CAS1"));
-            CAS.push_back(cpjson::get_string(*itr, "CAS2"));
-            std::string name1 = cpjson::get_string(*itr, "Name1");
-            std::string name2 = cpjson::get_string(*itr, "Name2");
+            CAS.push_back(cpjson::get_string(el, "CAS1"));
+            CAS.push_back(cpjson::get_string(el, "CAS2"));
+            std::string name1 = cpjson::get_string(el, "Name1");
+            std::string name2 = cpjson::get_string(el, "Name2");
 
             // Sort the CAS number vector
             std::sort(CAS.begin(), CAS.end());
 
             // A sort was carried out, names/CAS were swapped
-            bool swapped = CAS[0].compare(cpjson::get_string(*itr, "CAS1")) != 0;
+            bool swapped = CAS[0].compare(cpjson::get_string(el, "CAS1")) != 0;
 
             if (swapped) {
                 std::swap(name1, name2);
@@ -150,24 +140,24 @@ class MixtureBinaryPairLibrary
             // Populate the dictionary with common terms
             dict.add_string("name1", name1);
             dict.add_string("name2", name2);
-            dict.add_string("BibTeX", cpjson::get_string(*itr, "BibTeX"));
-            dict.add_number("F", cpjson::get_double(*itr, "F"));
+            dict.add_string("BibTeX", cpjson::get_string(el, "BibTeX"));
+            dict.add_number("F", cpjson::get_double(el, "F"));
             if (std::abs(dict.get_number("F")) > DBL_EPSILON) {
-                dict.add_string("function", cpjson::get_string(*itr, "function"));
+                dict.add_string("function", cpjson::get_string(el, "function"));
             }
 
-            if (itr->HasMember("xi") && itr->HasMember("zeta")) {
+            if (el.contains("xi") && el.contains("zeta")) {
                 dict.add_string("type", "Lemmon-xi-zeta");
                 // Air and HFC mixtures from Lemmon - we could also directly do the conversion
-                dict.add_number("xi", cpjson::get_double(*itr, "xi"));
-                dict.add_number("zeta", cpjson::get_double(*itr, "zeta"));
-            } else if (itr->HasMember("gammaT") && itr->HasMember("gammaV") && itr->HasMember("betaT") && itr->HasMember("betaV")) {
+                dict.add_number("xi", cpjson::get_double(el, "xi"));
+                dict.add_number("zeta", cpjson::get_double(el, "zeta"));
+            } else if (el.contains("gammaT") && el.contains("gammaV") && el.contains("betaT") && el.contains("betaV")) {
                 dict.add_string("type", "GERG-2008");
-                dict.add_number("gammaV", cpjson::get_double(*itr, "gammaV"));
-                dict.add_number("gammaT", cpjson::get_double(*itr, "gammaT"));
+                dict.add_number("gammaV", cpjson::get_double(el, "gammaV"));
+                dict.add_number("gammaT", cpjson::get_double(el, "gammaT"));
 
-                double betaV = cpjson::get_double(*itr, "betaV");
-                double betaT = cpjson::get_double(*itr, "betaT");
+                double betaV = cpjson::get_double(el, "betaV");
+                double betaT = cpjson::get_double(el, "betaT");
                 if (swapped) {
                     dict.add_number("betaV", 1 / betaV);
                     dict.add_number("betaT", 1 / betaT);
@@ -425,54 +415,49 @@ class MixtureDepartureFunctionsLibrary
     };
 
     void load_from_string(const std::string_view& str) {
-        rapidjson::Document doc;
-        doc.Parse<0>(str.data(), str.size());
-        if (doc.HasParseError()) {
-            std::cout << str << '\n';
-            throw ValueError("Unable to parse departure function string");
-        }
+        nlohmann::json doc = cpjson::parse(str);
         load_from_JSON(doc);
     }
-    void load_from_JSON(rapidjson::Document& doc) {
+    void load_from_JSON(const nlohmann::json& doc) {
         // Iterate over the departure functions in the listing
-        for (rapidjson::Value::ValueIterator itr = doc.Begin(); itr != doc.End(); ++itr) {
+        for (const auto& el : doc) {
             // Get the empty dictionary to be filled in
             Dictionary dict;
 
             // Populate the dictionary with common terms
-            std::string Name = cpjson::get_string(*itr, "Name");
-            std::string type = cpjson::get_string(*itr, "type");
+            std::string Name = cpjson::get_string(el, "Name");
+            std::string type = cpjson::get_string(el, "type");
             dict.add_string("Name", Name);
-            dict.add_string("BibTeX", cpjson::get_string(*itr, "BibTeX"));
-            dict.add_string_vector("aliases", cpjson::get_string_array(*itr, "aliases"));
+            dict.add_string("BibTeX", cpjson::get_string(el, "BibTeX"));
+            dict.add_string_vector("aliases", cpjson::get_string_array(el, "aliases"));
             dict.add_string("type", type);
 
             // Terms for the power (common to both types)
-            dict.add_double_vector("n", cpjson::get_double_array(*itr, "n"));
-            dict.add_double_vector("d", cpjson::get_double_array(*itr, "d"));
-            dict.add_double_vector("t", cpjson::get_double_array(*itr, "t"));
+            dict.add_double_vector("n", cpjson::get_double_array(el, "n"));
+            dict.add_double_vector("d", cpjson::get_double_array(el, "d"));
+            dict.add_double_vector("t", cpjson::get_double_array(el, "t"));
 
             // Now we need to load additional terms
             if (!type.compare("GERG-2008")) {
                 // Number of terms that are power terms
-                dict.add_number("Npower", cpjson::get_double(*itr, "Npower"));
+                dict.add_number("Npower", cpjson::get_double(el, "Npower"));
                 // Terms for the gaussian
-                dict.add_double_vector("eta", cpjson::get_double_array(*itr, "eta"));
-                dict.add_double_vector("epsilon", cpjson::get_double_array(*itr, "epsilon"));
-                dict.add_double_vector("beta", cpjson::get_double_array(*itr, "beta"));
-                dict.add_double_vector("gamma", cpjson::get_double_array(*itr, "gamma"));
+                dict.add_double_vector("eta", cpjson::get_double_array(el, "eta"));
+                dict.add_double_vector("epsilon", cpjson::get_double_array(el, "epsilon"));
+                dict.add_double_vector("beta", cpjson::get_double_array(el, "beta"));
+                dict.add_double_vector("gamma", cpjson::get_double_array(el, "gamma"));
             } else if (type == "Gaussian+Exponential") {
                 // Number of terms that are power terms
-                dict.add_number("Npower", cpjson::get_double(*itr, "Npower"));
+                dict.add_number("Npower", cpjson::get_double(el, "Npower"));
                 // The decay strength parameters
-                dict.add_double_vector("l", cpjson::get_double_array(*itr, "l"));
+                dict.add_double_vector("l", cpjson::get_double_array(el, "l"));
                 // Terms for the gaussian part
-                dict.add_double_vector("eta", cpjson::get_double_array(*itr, "eta"));
-                dict.add_double_vector("epsilon", cpjson::get_double_array(*itr, "epsilon"));
-                dict.add_double_vector("beta", cpjson::get_double_array(*itr, "beta"));
-                dict.add_double_vector("gamma", cpjson::get_double_array(*itr, "gamma"));
+                dict.add_double_vector("eta", cpjson::get_double_array(el, "eta"));
+                dict.add_double_vector("epsilon", cpjson::get_double_array(el, "epsilon"));
+                dict.add_double_vector("beta", cpjson::get_double_array(el, "beta"));
+                dict.add_double_vector("gamma", cpjson::get_double_array(el, "gamma"));
             } else if (!type.compare("Exponential")) {
-                dict.add_double_vector("l", cpjson::get_double_array(*itr, "l"));
+                dict.add_double_vector("l", cpjson::get_double_array(el, "l"));
             } else {
                 throw ValueError(format("It was not possible to parse departure function with type [%s]", type.c_str()));
             }
@@ -812,62 +797,54 @@ void set_departure_functions(const std::string& string_data) {
         parse_HMX_BNC(string_data, BIP, functions);
 
         {
-            rapidjson::Document doc;
-            doc.SetArray();
+            nlohmann::json doc = nlohmann::json::array();
             for (const auto& bip : BIP) {
-                rapidjson::Value el;
-                el.SetObject();
-                el.AddMember("CAS1", rapidjson::Value(bip.CAS1.c_str(), doc.GetAllocator()).Move(), doc.GetAllocator());
-                el.AddMember("CAS2", rapidjson::Value(bip.CAS2.c_str(), doc.GetAllocator()).Move(), doc.GetAllocator());
-                el.AddMember("Name1", "??", doc.GetAllocator());
-                el.AddMember("Name2", "??", doc.GetAllocator());
-                el.AddMember("betaT", bip.betaT, doc.GetAllocator());
-                el.AddMember("gammaT", bip.gammaT, doc.GetAllocator());
-                el.AddMember("betaV", bip.betaV, doc.GetAllocator());
-                el.AddMember("gammaV", bip.gammaV, doc.GetAllocator());
-                el.AddMember("F", bip.Fij, doc.GetAllocator());
-                el.AddMember("function", rapidjson::Value(bip.model.c_str(), doc.GetAllocator()).Move(), doc.GetAllocator());
-                std::string tex_string = "(from HMX.BNC format)::" + strjoin(bip.comments, "\n");
-                el.AddMember("BibTeX", rapidjson::Value(tex_string.c_str(), doc.GetAllocator()).Move(), doc.GetAllocator());
-                doc.PushBack(el, doc.GetAllocator());
+                nlohmann::json el;
+                el["CAS1"] = bip.CAS1;
+                el["CAS2"] = bip.CAS2;
+                el["Name1"] = "??";
+                el["Name2"] = "??";
+                el["betaT"] = bip.betaT;
+                el["gammaT"] = bip.gammaT;
+                el["betaV"] = bip.betaV;
+                el["gammaV"] = bip.gammaV;
+                el["F"] = bip.Fij;
+                el["function"] = bip.model;
+                el["BibTeX"] = "(from HMX.BNC format)::" + strjoin(bip.comments, "\n");
+                doc.push_back(std::move(el));
             }
             mixturebinarypairlibrary.load_from_JSON(doc);
         }
         {
-            rapidjson::Document doc;
-            doc.SetArray();
+            nlohmann::json doc = nlohmann::json::array();
             for (const auto& func : functions) {
-                rapidjson::Value el;
-                el.SetObject();
-                el.AddMember("Name", rapidjson::Value(func.model.c_str(), doc.GetAllocator()).Move(), doc.GetAllocator());
-                std::vector<std::string> aliases;
-                cpjson::set_string_array("aliases", aliases, el, doc);
-                cpjson::set_double_array("n", func.a, el, doc);
-                cpjson::set_double_array("d", func.d, el, doc);
-                cpjson::set_double_array("t", func.t, el, doc);
+                nlohmann::json el;
+                el["Name"] = func.model;
+                el["aliases"] = nlohmann::json::array();
+                el["n"] = func.a;
+                el["d"] = func.d;
+                el["t"] = func.t;
                 if (func.Nterms_special > 0 || func.Nterms_power == 3) {
-                    el.AddMember("type", "GERG-2008", doc.GetAllocator());
-                    el.AddMember("Npower", func.Npower, doc.GetAllocator());
+                    el["type"] = "GERG-2008";
+                    el["Npower"] = func.Npower;
                     if (func.Nterms_power == 3 && func.Nspecial == 0) {
-                        std::vector<double> zeros(func.a.size(), 0);
-                        cpjson::set_double_array("eta", zeros, el, doc);
-                        cpjson::set_double_array("epsilon", zeros, el, doc);
-                        cpjson::set_double_array("beta", zeros, el, doc);
-                        cpjson::set_double_array("gamma", zeros, el, doc);
+                        std::vector<double> zeros(func.a.size(), 0.0);
+                        el["eta"] = zeros;
+                        el["epsilon"] = zeros;
+                        el["beta"] = zeros;
+                        el["gamma"] = zeros;
                     } else {
-                        cpjson::set_double_array("eta", func.eta, el, doc);
-                        cpjson::set_double_array("epsilon", func.epsilon, el, doc);
-                        cpjson::set_double_array("beta", func.beta, el, doc);
-                        cpjson::set_double_array("gamma", func.gamma, el, doc);
+                        el["eta"] = func.eta;
+                        el["epsilon"] = func.epsilon;
+                        el["beta"] = func.beta;
+                        el["gamma"] = func.gamma;
                     }
                 } else {
-                    el.AddMember("type", "Exponential", doc.GetAllocator());
-                    cpjson::set_double_array("l", func.e, el, doc);
+                    el["type"] = "Exponential";
+                    el["l"] = func.e;
                 }
-
-                std::string tex_string = "(from HMX.BNC format)::" + strjoin(func.comments, "\n");
-                el.AddMember("BibTeX", rapidjson::Value(tex_string.c_str(), doc.GetAllocator()).Move(), doc.GetAllocator());
-                doc.PushBack(el, doc.GetAllocator());
+                el["BibTeX"] = "(from HMX.BNC format)::" + strjoin(func.comments, "\n");
+                doc.push_back(std::move(el));
             }
             mixturedeparturefunctionslibrary.load_from_JSON(doc);
         }

--- a/src/Backends/Helmholtz/MixtureParameters.cpp
+++ b/src/Backends/Helmholtz/MixtureParameters.cpp
@@ -1,4 +1,5 @@
 #include "MixtureParameters.h"
+#include "CoolProp/detail/rapidjson.h"
 #include "CoolProp/detail/strings.h"
 #include "mixture_departure_functions_JSON.h"  // Creates the variable mixture_departure_functions_JSON
 #include "mixture_binary_pairs_JSON.h"         // Creates the variable mixture_binary_pairs_JSON

--- a/src/Backends/PCSAFT/PCSAFTLibrary.cpp
+++ b/src/Backends/PCSAFT/PCSAFTLibrary.cpp
@@ -30,16 +30,7 @@ namespace {
 /// the get_library() singleton (which would recurse into its own constructor).
 void add_fluids_from_JSON_string(PCSAFTLibraryClass& dest, const std::string_view& JSON) {
     std::string errstr;
-    // FluidLibrary.h transitively includes detail/rapidjson.h (via
-    // Configuration.h), so both validate_schema overloads are visible here and
-    // the call is ambiguous. The two overloads differ ONLY in their string_view
-    // parameters: rapidjson takes `const std::string_view&`, nlohmann takes
-    // `std::string_view` by value. The cast's by-value signature therefore
-    // selects the nlohmann/Valijson overload. Remove this cast (the call becomes
-    // unambiguous) once detail/rapidjson.h is deleted at Phase Final.
-    auto validate_schema_nlohmann =
-      static_cast<cpjson::schema_validation_code (*)(std::string_view, std::string_view, std::string&)>(&cpjson::validate_schema);
-    cpjson::schema_validation_code val_code = validate_schema_nlohmann(pcsaft_fluids_schema_JSON, JSON, errstr);
+    cpjson::schema_validation_code val_code = cpjson::validate_schema(pcsaft_fluids_schema_JSON, JSON, errstr);
     if (val_code == cpjson::SCHEMA_VALIDATION_OK) {
         nlohmann::json dd = cpjson::parse(JSON);
         try {

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -29,6 +29,7 @@ surface tension                 N/m
 #undef REFPROP_CSTYLE_REFERENCES
 
 #include "CoolProp/detail/tools.h"
+#include "CoolProp/detail/rapidjson.h"
 #include "REFPROPMixtureBackend.h"
 #include "REFPROPBackend.h"
 #include "CoolProp/Exceptions.h"

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -29,7 +29,7 @@ surface tension                 N/m
 #undef REFPROP_CSTYLE_REFERENCES
 
 #include "CoolProp/detail/tools.h"
-#include "CoolProp/detail/rapidjson.h"
+#include "CoolProp/detail/json.h"
 #include "REFPROPMixtureBackend.h"
 #include "REFPROPBackend.h"
 #include "CoolProp/Exceptions.h"
@@ -2918,10 +2918,9 @@ TEST_CASE("Check REFPROP and CoolProp values agree", "[REFPROP]") {
             double h_CP = S1->hmass();
             double s_CP = S1->smass();
             auto j = S1->fluid_param_string("JSON");
-            rapidjson::Document doc;
-            doc.Parse<0>(j.c_str());
-            auto& v = doc[0]["EOS"][0]["alpha0"];
-            auto s = cpjson::to_string(v);
+            const nlohmann::json doc = cpjson::parse(j);
+            const auto& v = doc.at(0).at("EOS").at(0).at("alpha0");
+            auto s = cpjson::json2string(v);
             CAPTURE(s);
 
             shared_ptr<CoolProp::AbstractState> S2(CoolProp::AbstractState::factory("REFPROP", RPName));

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -35,7 +35,7 @@
 #include "CoolProp/schemas/SVDSBTLOptions.h"
 #include "CoolProp/DataStructures.h"
 #include "CoolProp/Exceptions.h"
-#include "CoolProp/detail/rapidjson.h"
+#include "CoolProp/detail/json.h"
 
 // File-scope suppression for bugprone-unchecked-optional-access: the
 // optionals on PointEvaluation are filled by resolve_point_() based on
@@ -129,13 +129,13 @@ void polish_patch_state_(::CoolProp::AbstractState& s, double p, double h) {
 // Read `grid.NT/NR/rank` out of a validated options document.  Missing
 // keys (and missing `grid` itself) leave the corresponding default in
 // place — the validator has already rejected anything ill-formed.
-ResolvedGrid resolve_grid(const rapidjson::Document& opts) {
+ResolvedGrid resolve_grid(const nlohmann::json& opts) {
     ResolvedGrid g = kDefaultGrid;
-    if (opts.IsObject() && opts.HasMember("grid") && opts["grid"].IsObject()) {
-        const auto& grid = opts["grid"];
-        if (grid.HasMember("NT")) g.NT = static_cast<std::size_t>(grid["NT"].GetInt());
-        if (grid.HasMember("NR")) g.NR = static_cast<std::size_t>(grid["NR"].GetInt());
-        if (grid.HasMember("rank")) g.rank = grid["rank"].GetInt();
+    if (opts.is_object() && opts.contains("grid") && opts.at("grid").is_object()) {
+        const auto& grid = opts.at("grid");
+        if (grid.contains("NT")) g.NT = static_cast<std::size_t>(cpjson::get_integer(grid, "NT"));
+        if (grid.contains("NR")) g.NR = static_cast<std::size_t>(cpjson::get_integer(grid, "NR"));
+        if (grid.contains("rank")) g.rank = cpjson::get_integer(grid, "rank");
     }
     return g;
 }
@@ -311,19 +311,18 @@ void SVDSBTLBackend::build_critical_patch_(const std::string& options_canonical)
     std::string patch_source;
 
     if (!options_canonical.empty()) {
-        rapidjson::Document opts;
-        opts.Parse(options_canonical.c_str(), options_canonical.size());
-        if (opts.IsObject() && opts.HasMember("critical_patch") && opts["critical_patch"].IsObject()) {
-            const auto& cp = opts["critical_patch"];
-            if (cp.HasMember("mode") && cp["mode"].IsString()) {
-                mode = cp["mode"].GetString();
+        const nlohmann::json opts = cpjson::parse(options_canonical);
+        if (opts.is_object() && opts.contains("critical_patch") && opts.at("critical_patch").is_object()) {
+            const auto& cp = opts.at("critical_patch");
+            if (cp.contains("mode") && cp.at("mode").is_string()) {
+                mode = cp.at("mode").get<std::string>();
             }
-            if (cp.HasMember("source") && cp["source"].IsString()) {
-                patch_source = cp["source"].GetString();
+            if (cp.contains("source") && cp.at("source").is_string()) {
+                patch_source = cp.at("source").get<std::string>();
             }
-            if (cp.HasMember("bbox") && cp["bbox"].IsArray() && cp["bbox"].Size() == 4) {
+            if (cp.contains("bbox") && cp.at("bbox").is_array() && cp.at("bbox").size() == 4) {
                 for (std::size_t i = 0; i < 4; ++i) {
-                    bbox_mult[i] = cp["bbox"][static_cast<rapidjson::SizeType>(i)].GetDouble();
+                    bbox_mult[i] = cp.at("bbox").at(i).get<double>();
                 }
                 user_supplied_bbox = true;
             }
@@ -904,8 +903,7 @@ void SVDSBTLBackend::ensure_surface_(CoolProp::input_pairs pair) {
 
     if (!surface) {
         auto source = source_reference_();
-        rapidjson::Document opts;
-        opts.Parse(options_canonical_.empty() ? "{}" : options_canonical_.c_str());
+        const nlohmann::json opts = cpjson::parse(options_canonical_.empty() ? "{}" : options_canonical_);
         const ResolvedGrid grid = resolve_grid(opts);
         surface = std::make_unique<cp_sbtl::SVDSurface>(build_surface_for_pair_(*source, source_backend_, pair, grid));
         try {

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -173,12 +173,8 @@ std::string parse_and_canonicalise(const std::string& options_json) {
     if (options_json.empty()) {
         return "{}";
     }
-    rapidjson::Document opts;
-    if (opts.Parse(options_json.c_str(), options_json.size()).HasParseError()) {
-        throw ValueError("SVDSBTL options: invalid JSON (offset " + std::to_string(opts.GetErrorOffset()) + ")");
-    }
-    CoolProp::validate_against_schema(opts, kSVDSBTLOptionsSchemaJson);
-    return CoolProp::to_canonical_json(opts);
+    CoolProp::validate_json_against_schema(options_json, kSVDSBTLOptionsSchemaJson);
+    return CoolProp::to_canonical_json_str(options_json);
 }
 
 // FNV-1a 64 over the canonical options blob — mirrors the opthash the

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -1,5 +1,64 @@
 #include "CoolProp/Configuration.h"
+#include "CoolProp/detail/json.h"
 #include "src/Backends/REFPROP/REFPROPMixtureBackend.h"
+
+namespace {
+
+void item_to_json(const CoolProp::ConfigurationItem& item, nlohmann::json& obj) {
+    const std::string name = CoolProp::config_key_to_string(item.get_key());
+    switch (item.get_type()) {
+        case CONFIGURATION_BOOL_TYPE:
+            obj[name] = static_cast<bool>(item);
+            break;
+        case CONFIGURATION_INTEGER_TYPE:
+            obj[name] = static_cast<int>(item);
+            break;
+        case CONFIGURATION_DOUBLE_TYPE:
+            obj[name] = static_cast<double>(item);
+            break;
+        case CONFIGURATION_STRING_TYPE:
+            obj[name] = static_cast<std::string>(item);
+            break;
+        case CONFIGURATION_ENDOFLIST_TYPE:
+        case CONFIGURATION_NOT_DEFINED_TYPE:
+            throw CoolProp::ValueError();
+    }
+}
+
+void item_from_json(CoolProp::ConfigurationItem& item, const nlohmann::json& val) {
+    switch (item.get_type()) {
+        case CONFIGURATION_BOOL_TYPE:
+            if (!val.is_boolean()) {
+                throw CoolProp::ValueError(format("Input is not boolean"));
+            }
+            item.set_bool(val.get<bool>());
+            break;
+        case CONFIGURATION_INTEGER_TYPE:
+            if (!val.is_number_integer()) {
+                throw CoolProp::ValueError(format("Input is not integer"));
+            }
+            item.set_integer(val.get<int>());
+            break;
+        case CONFIGURATION_DOUBLE_TYPE:
+            if (!val.is_number()) {
+                throw CoolProp::ValueError(
+                  format("Input [%s] is not double (or something that can be cast to double)", val.dump().c_str()));
+            }
+            item.set_double(val.get<double>());
+            break;
+        case CONFIGURATION_STRING_TYPE:
+            if (!val.is_string()) {
+                throw CoolProp::ValueError(format("Input is not string"));
+            }
+            item.set_string(val.get<std::string>());
+            break;
+        case CONFIGURATION_ENDOFLIST_TYPE:
+        case CONFIGURATION_NOT_DEFINED_TYPE:
+            throw CoolProp::ValueError();
+    }
+}
+
+}  // namespace
 
 namespace CoolProp {
 
@@ -102,54 +161,34 @@ double get_config_double(configuration_keys key) {
 std::string get_config_string(configuration_keys key) {
     return static_cast<std::string>(_get_config()->get_item(key));
 }
-void get_config_as_json(rapidjson::Document& doc) {
-    // Get the items
-    std::unordered_map<configuration_keys, ConfigurationItem> items = _get_config()->get_items();
-    for (auto it = items.begin(); it != items.end(); ++it) {
-        it->second.add_to_json(doc, doc);
-    }
-}
 std::string get_config_as_json_string() {
-    rapidjson::Document doc;
-    doc.SetObject();
-    get_config_as_json(doc);
-    return cpjson::to_string(doc);
-}
-void set_config_as_json(rapidjson::Value& val) {
-
-    // First check that all keys are valid
-    for (rapidjson::Value::MemberIterator it = val.MemberBegin(); it != val.MemberEnd(); ++it) {
-        try {
-            // Try to get the key for the string
-            std::string s = std::string(it->name.GetString());
-            configuration_keys key = config_string_to_key(s);
-            // Try to retrieve the item from the config for this key
-            _get_config()->get_item(key);
-        } catch (std::exception& e) {
-            throw ValueError(format("Unable to parse json file with error: %s", e.what()));
-        }
+    nlohmann::json doc = nlohmann::json::object();
+    for (auto& kv : _get_config()->get_items()) {
+        item_to_json(kv.second, doc);
     }
-
-    // Now we actually set the values
-    for (rapidjson::Value::MemberIterator it = val.MemberBegin(); it != val.MemberEnd(); ++it) {
-        // Try to get the key for the string
-        std::string s = std::string(it->name.GetString());
-        configuration_keys key = config_string_to_key(s);
-        // Try to retrieve the item from the config for this key
-        ConfigurationItem& item = _get_config()->get_item(key);
-        try {
-            // Set the value from what is stored in the json value
-            item.set_from_json(it->value);
-        } catch (std::exception& e) {
-            throw ValueError(format("Unable to parse json file with error: %s", e.what()));
-        }
-    }
+    return doc.dump();
 }
 void set_config_as_json_string(const std::string& s) {
-    // Init the rapidjson doc
-    rapidjson::Document doc;
-    doc.Parse<0>(s.c_str());
-    set_config_as_json(doc);
+    nlohmann::json doc = cpjson::parse(s);
+
+    // First pass: validate all keys
+    for (auto& [name, value] : doc.items()) {
+        try {
+            _get_config()->get_item(config_string_to_key(name));
+        } catch (std::exception& e) {
+            throw ValueError(format("Unable to parse json file with error: %s", e.what()));
+        }
+    }
+
+    // Second pass: set the values
+    for (auto& [name, value] : doc.items()) {
+        ConfigurationItem& item = _get_config()->get_item(config_string_to_key(name));
+        try {
+            item_from_json(item, value);
+        } catch (std::exception& e) {
+            throw ValueError(format("Unable to parse json file with error: %s", e.what()));
+        }
+    }
 }
 
 }  // namespace CoolProp

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -41,8 +41,7 @@ void item_from_json(CoolProp::ConfigurationItem& item, const nlohmann::json& val
             break;
         case CONFIGURATION_DOUBLE_TYPE:
             if (!val.is_number()) {
-                throw CoolProp::ValueError(
-                  format("Input [%s] is not double (or something that can be cast to double)", val.dump().c_str()));
+                throw CoolProp::ValueError(format("Input [%s] is not double (or something that can be cast to double)", val.dump().c_str()));
             }
             item.set_double(val.get<double>());
             break;

--- a/src/CoolProp.i
+++ b/src/CoolProp.i
@@ -10,9 +10,6 @@
 %ignore CoolProp::AbstractState::set_mass_fractions(const std::vector<CoolPropDbl> &);
 %ignore CoolProp::AbstractState::set_volu_fractions(const std::vector<CoolPropDbl> &);
 
-%ignore CoolProp::set_config_json(rapidjson::Document &);
-%ignore CoolProp::get_config_as_json(rapidjson::Document &);
-
 // fast_evaluate is a C++-only raw-pointer batch API; SWIG's default
 // typemaps for `const double*` / `int*` produce wrappers that don't
 // compile on at least the R binding (int -> SEXP).  Scripted-language

--- a/src/SchemaValidation.cpp
+++ b/src/SchemaValidation.cpp
@@ -1,126 +1,25 @@
 #include "CoolProp/SchemaValidation.h"
 
-#include <algorithm>
-#include <cstddef>
 #include <string>
-#include <vector>
 
 #include "CoolProp/Exceptions.h"
-#include "CoolProp/detail/rapidjson.h"
+#include "CoolProp/detail/json.h"
 
 namespace CoolProp {
 
-namespace {
-
-// Recursively copy `src` into `dst`, sorting object members by key
-// (lexicographic byte-wise) at every level.  Arrays preserve order.
-// `allocator` is the target document's allocator.
-void copy_sorted(const rapidjson::Value& src, rapidjson::Value& dst, rapidjson::Document::AllocatorType& allocator) {
-    if (src.IsObject()) {
-        dst.SetObject();
-        // Collect member references, sort by key, then copy in order.
-        std::vector<std::pair<std::string, const rapidjson::Value*>> kv;
-        kv.reserve(src.MemberCount());
-        for (auto it = src.MemberBegin(); it != src.MemberEnd(); ++it) {
-            kv.emplace_back(std::string(it->name.GetString(), it->name.GetStringLength()), &it->value);
-        }
-        std::sort(kv.begin(), kv.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
-        for (const auto& [key, val_ptr] : kv) {
-            rapidjson::Value name_copy;
-            name_copy.SetString(key.c_str(), static_cast<rapidjson::SizeType>(key.size()), allocator);
-            rapidjson::Value sub;
-            copy_sorted(*val_ptr, sub, allocator);
-            dst.AddMember(name_copy, sub, allocator);
-        }
-        return;
-    }
-    if (src.IsArray()) {
-        dst.SetArray();
-        for (auto it = src.Begin(); it != src.End(); ++it) {
-            rapidjson::Value sub;
-            copy_sorted(*it, sub, allocator);
-            dst.PushBack(sub, allocator);
-        }
-        return;
-    }
-    // Scalar: copy via the document's allocator.
-    dst.CopyFrom(src, allocator);
-}
-
-// RapidJSON validator helper — convert a SchemaPointer / DocumentPointer
-// to a string for inclusion in the error message.
-std::string pointer_to_string(const rapidjson::GenericPointer<rapidjson::Value>& p) {
-    rapidjson::StringBuffer sb;
-    p.StringifyUriFragment(sb);
-    return {sb.GetString(), sb.GetSize()};
-}
-
-rapidjson::Document parse_json(const std::string& s, const char* what) {
-    rapidjson::Document d;
-    if (d.Parse(s.c_str(), s.size()).HasParseError()) {
-        throw ValueError(std::string("parse_json: failed to parse ") + what + " (offset " + std::to_string(d.GetErrorOffset()) + ")");
-    }
-    return d;
-}
-
-}  // namespace
-
-// ---------------------------------------------------------------------------
-// Schema validation
-// ---------------------------------------------------------------------------
-
-void validate_against_schema(const rapidjson::Value& instance, const rapidjson::Document& schema) {
-    rapidjson::SchemaDocument schema_doc(schema);
-    rapidjson::SchemaValidator validator(schema_doc);
-    if (instance.Accept(validator)) {
-        return;
-    }
-    // Build a useful error: schema-pointer + instance-pointer + keyword.
-    const std::string sp = pointer_to_string(validator.GetInvalidSchemaPointer());
-    const std::string ip = pointer_to_string(validator.GetInvalidDocumentPointer());
-    const char* kw = validator.GetInvalidSchemaKeyword();
-    throw ValueError(std::string("schema validation failed: instance ") + (ip.empty() ? "/" : ip) + " violates schema " + (sp.empty() ? "/" : sp)
-                     + " (keyword: " + (kw ? kw : "<unknown>") + ")");
-}
-
-void validate_against_schema(const rapidjson::Value& instance, const std::string& schema_json) {
-    rapidjson::Document schema = parse_json(schema_json, "schema");
-    validate_against_schema(instance, schema);
-}
-
-// ---------------------------------------------------------------------------
-// Canonical JSON
-// ---------------------------------------------------------------------------
-
-std::string to_canonical_json(const rapidjson::Value& value) {
-    rapidjson::Document sorted;
-    rapidjson::Document::AllocatorType& alloc = sorted.GetAllocator();
-    rapidjson::Value root;
-    copy_sorted(value, root, alloc);
-    sorted.Swap(root);
-
-    rapidjson::StringBuffer sb;
-    rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
-    sorted.Accept(writer);
-    return {sb.GetString(), sb.GetSize()};
-}
-
-std::string to_canonical_json(const std::string& json_str) {
-    rapidjson::Document d = parse_json(json_str, "input");
-    return to_canonical_json(d);
-}
-
-// ---------------------------------------------------------------------------
-// SWIG-friendly string overloads
-// ---------------------------------------------------------------------------
-
 void validate_json_against_schema(const std::string& instance_json, const std::string& schema_json) {
-    rapidjson::Document instance = parse_json(instance_json, "instance");
-    validate_against_schema(instance, schema_json);
+    std::string errstr;
+    // cpjson::validate_schema(schemaJson, inputJson, errstr) — Valijson-backed. Schema first.
+    cpjson::schema_validation_code code = cpjson::validate_schema(schema_json, instance_json, errstr);
+    if (code != cpjson::SCHEMA_VALIDATION_OK) {
+        throw ValueError(std::string("schema validation failed: ") + errstr);
+    }
 }
 
 std::string to_canonical_json_str(const std::string& json_str) {
-    return to_canonical_json(json_str);
+    // nlohmann::json is std::map-backed, so object keys serialize sorted at every
+    // level — the canonical (deterministic, key-sorted) form. Arrays keep order.
+    return cpjson::parse(json_str).dump();
 }
 
 }  // namespace CoolProp

--- a/src/Tests/CoolProp-Tests-SchemaValidation.cpp
+++ b/src/Tests/CoolProp-Tests-SchemaValidation.cpp
@@ -68,8 +68,7 @@ TEST_CASE("validate_against_schema: fully populated valid instance passes", "[Sc
 }
 
 TEST_CASE("validate_against_schema: unknown top-level key throws", "[SchemaValidation]") {
-    REQUIRE_THROWS_AS(CoolProp::validate_json_against_schema(R"({"schema": 1, "frobnitz": true})", std::string(kSchema)),
-                      CoolProp::ValueError);
+    REQUIRE_THROWS_AS(CoolProp::validate_json_against_schema(R"({"schema": 1, "frobnitz": true})", std::string(kSchema)), CoolProp::ValueError);
 }
 
 TEST_CASE("validate_against_schema: unknown nested key throws", "[SchemaValidation]") {
@@ -78,15 +77,13 @@ TEST_CASE("validate_against_schema: unknown nested key throws", "[SchemaValidati
 }
 
 TEST_CASE("validate_against_schema: type mismatch throws", "[SchemaValidation]") {
-    REQUIRE_THROWS_AS(
-        CoolProp::validate_json_against_schema(R"({"schema": 1, "grid": {"NT": "two-hundred"}})", std::string(kSchema)),
-        CoolProp::ValueError);
+    REQUIRE_THROWS_AS(CoolProp::validate_json_against_schema(R"({"schema": 1, "grid": {"NT": "two-hundred"}})", std::string(kSchema)),
+                      CoolProp::ValueError);
 }
 
 TEST_CASE("validate_against_schema: enum violation throws", "[SchemaValidation]") {
-    REQUIRE_THROWS_AS(
-        CoolProp::validate_json_against_schema(R"({"schema": 1, "critical_patch": {"mode": "ON"}})", std::string(kSchema)),
-        CoolProp::ValueError);
+    REQUIRE_THROWS_AS(CoolProp::validate_json_against_schema(R"({"schema": 1, "critical_patch": {"mode": "ON"}})", std::string(kSchema)),
+                      CoolProp::ValueError);
 }
 
 TEST_CASE("validate_against_schema: required key missing throws", "[SchemaValidation]") {
@@ -94,9 +91,8 @@ TEST_CASE("validate_against_schema: required key missing throws", "[SchemaValida
 }
 
 TEST_CASE("validate_against_schema: bbox wrong size throws", "[SchemaValidation]") {
-    REQUIRE_THROWS_AS(
-        CoolProp::validate_json_against_schema(R"({"schema": 1, "critical_patch": {"bbox": [1, 2, 3]}})", std::string(kSchema)),
-        CoolProp::ValueError);
+    REQUIRE_THROWS_AS(CoolProp::validate_json_against_schema(R"({"schema": 1, "critical_patch": {"bbox": [1, 2, 3]}})", std::string(kSchema)),
+                      CoolProp::ValueError);
 }
 
 TEST_CASE("validate_against_schema: invalid schema JSON throws", "[SchemaValidation]") {

--- a/src/Tests/CoolProp-Tests-SchemaValidation.cpp
+++ b/src/Tests/CoolProp-Tests-SchemaValidation.cpp
@@ -1,5 +1,5 @@
-// Catch2 tests for CoolProp::validate_against_schema and
-// CoolProp::to_canonical_json (CoolProp-bh2).
+// Catch2 tests for CoolProp::validate_json_against_schema and
+// CoolProp::to_canonical_json_str (CoolProp-bh2).
 
 #if defined(ENABLE_CATCH)
 
@@ -9,7 +9,6 @@
 
 #    include "CoolProp/SchemaValidation.h"
 #    include "CoolProp/Exceptions.h"
-#    include "CoolProp/detail/rapidjson.h"
 
 namespace {
 
@@ -49,107 +48,100 @@ constexpr const char* kSchema = R"({
   }
 })";
 
-rapidjson::Document parse(const std::string& s) {
-    rapidjson::Document d;
-    d.Parse(s.c_str(), s.size());
-    REQUIRE_FALSE(d.HasParseError());
-    return d;
-}
-
 }  // namespace
 
 // ---------------------------------------------------------------------------
-// validate_against_schema
+// validate_json_against_schema
 // ---------------------------------------------------------------------------
 
 TEST_CASE("validate_against_schema: minimal valid instance passes", "[SchemaValidation]") {
-    auto inst = parse(R"({"schema": 1})");
-    REQUIRE_NOTHROW(CoolProp::validate_against_schema(inst, std::string(kSchema)));
+    REQUIRE_NOTHROW(CoolProp::validate_json_against_schema(R"({"schema": 1})", std::string(kSchema)));
 }
 
 TEST_CASE("validate_against_schema: fully populated valid instance passes", "[SchemaValidation]") {
-    auto inst = parse(R"({
+    REQUIRE_NOTHROW(CoolProp::validate_json_against_schema(R"({
         "schema": 1,
         "grid": {"NT": 200, "NR": 800, "rank": 20},
         "critical_patch": {"mode": "auto", "tolerance": 1e-3, "bbox": [0.95, 1.05, 0.75, 1.15]}
-    })");
-    REQUIRE_NOTHROW(CoolProp::validate_against_schema(inst, std::string(kSchema)));
+    })",
+                                                           std::string(kSchema)));
 }
 
 TEST_CASE("validate_against_schema: unknown top-level key throws", "[SchemaValidation]") {
-    auto inst = parse(R"({"schema": 1, "frobnitz": true})");
-    REQUIRE_THROWS_AS(CoolProp::validate_against_schema(inst, std::string(kSchema)), CoolProp::ValueError);
+    REQUIRE_THROWS_AS(CoolProp::validate_json_against_schema(R"({"schema": 1, "frobnitz": true})", std::string(kSchema)),
+                      CoolProp::ValueError);
 }
 
 TEST_CASE("validate_against_schema: unknown nested key throws", "[SchemaValidation]") {
-    auto inst = parse(R"({"schema": 1, "grid": {"NT": 200, "extra": 3}})");
-    REQUIRE_THROWS_AS(CoolProp::validate_against_schema(inst, std::string(kSchema)), CoolProp::ValueError);
+    REQUIRE_THROWS_AS(CoolProp::validate_json_against_schema(R"({"schema": 1, "grid": {"NT": 200, "extra": 3}})", std::string(kSchema)),
+                      CoolProp::ValueError);
 }
 
 TEST_CASE("validate_against_schema: type mismatch throws", "[SchemaValidation]") {
-    auto inst = parse(R"({"schema": 1, "grid": {"NT": "two-hundred"}})");
-    REQUIRE_THROWS_AS(CoolProp::validate_against_schema(inst, std::string(kSchema)), CoolProp::ValueError);
+    REQUIRE_THROWS_AS(
+        CoolProp::validate_json_against_schema(R"({"schema": 1, "grid": {"NT": "two-hundred"}})", std::string(kSchema)),
+        CoolProp::ValueError);
 }
 
 TEST_CASE("validate_against_schema: enum violation throws", "[SchemaValidation]") {
-    auto inst = parse(R"({"schema": 1, "critical_patch": {"mode": "ON"}})");
-    REQUIRE_THROWS_AS(CoolProp::validate_against_schema(inst, std::string(kSchema)), CoolProp::ValueError);
+    REQUIRE_THROWS_AS(
+        CoolProp::validate_json_against_schema(R"({"schema": 1, "critical_patch": {"mode": "ON"}})", std::string(kSchema)),
+        CoolProp::ValueError);
 }
 
 TEST_CASE("validate_against_schema: required key missing throws", "[SchemaValidation]") {
-    auto inst = parse(R"({"grid": {"NT": 200}})");
-    REQUIRE_THROWS_AS(CoolProp::validate_against_schema(inst, std::string(kSchema)), CoolProp::ValueError);
+    REQUIRE_THROWS_AS(CoolProp::validate_json_against_schema(R"({"grid": {"NT": 200}})", std::string(kSchema)), CoolProp::ValueError);
 }
 
 TEST_CASE("validate_against_schema: bbox wrong size throws", "[SchemaValidation]") {
-    auto inst = parse(R"({"schema": 1, "critical_patch": {"bbox": [1, 2, 3]}})");
-    REQUIRE_THROWS_AS(CoolProp::validate_against_schema(inst, std::string(kSchema)), CoolProp::ValueError);
+    REQUIRE_THROWS_AS(
+        CoolProp::validate_json_against_schema(R"({"schema": 1, "critical_patch": {"bbox": [1, 2, 3]}})", std::string(kSchema)),
+        CoolProp::ValueError);
 }
 
 TEST_CASE("validate_against_schema: invalid schema JSON throws", "[SchemaValidation]") {
-    auto inst = parse(R"({"schema": 1})");
-    REQUIRE_THROWS_AS(CoolProp::validate_against_schema(inst, std::string("not json")), CoolProp::ValueError);
+    REQUIRE_THROWS_AS(CoolProp::validate_json_against_schema(R"({"schema": 1})", std::string("not json")), CoolProp::ValueError);
 }
 
 // ---------------------------------------------------------------------------
-// to_canonical_json
+// to_canonical_json_str
 // ---------------------------------------------------------------------------
 
 TEST_CASE("to_canonical_json: sorts object keys", "[SchemaValidation]") {
-    const auto a = CoolProp::to_canonical_json(std::string(R"({"b": 2, "a": 1, "c": 3})"));
+    const auto a = CoolProp::to_canonical_json_str(R"({"b": 2, "a": 1, "c": 3})");
     REQUIRE(a == R"({"a":1,"b":2,"c":3})");
 }
 
 TEST_CASE("to_canonical_json: sorts nested object keys recursively", "[SchemaValidation]") {
-    const auto a = CoolProp::to_canonical_json(std::string(R"({"outer": {"z": 1, "a": 2}, "inner": 3})"));
+    const auto a = CoolProp::to_canonical_json_str(R"({"outer": {"z": 1, "a": 2}, "inner": 3})");
     REQUIRE(a == R"({"inner":3,"outer":{"a":2,"z":1}})");
 }
 
 TEST_CASE("to_canonical_json: preserves array order", "[SchemaValidation]") {
-    const auto a = CoolProp::to_canonical_json(std::string(R"([3, 1, 2])"));
+    const auto a = CoolProp::to_canonical_json_str(R"([3, 1, 2])");
     REQUIRE(a == R"([3,1,2])");
 }
 
 TEST_CASE("to_canonical_json: logically-equal inputs produce identical output", "[SchemaValidation]") {
-    const auto a = CoolProp::to_canonical_json(std::string(R"({"grid":{"NT":200,"rank":20,"NR":800}})"));
-    const auto b = CoolProp::to_canonical_json(std::string(R"({"grid":{"rank":20,"NR":800,"NT":200}})"));
+    const auto a = CoolProp::to_canonical_json_str(R"({"grid":{"NT":200,"rank":20,"NR":800}})");
+    const auto b = CoolProp::to_canonical_json_str(R"({"grid":{"rank":20,"NR":800,"NT":200}})");
     REQUIRE(a == b);
 }
 
 TEST_CASE("to_canonical_json: idempotent — re-canonicalising returns the same bytes", "[SchemaValidation]") {
-    const auto a = CoolProp::to_canonical_json(std::string(R"({"b":2,"a":1})"));
-    const auto b = CoolProp::to_canonical_json(a);
+    const auto a = CoolProp::to_canonical_json_str(R"({"b":2,"a":1})");
+    const auto b = CoolProp::to_canonical_json_str(a);
     REQUIRE(a == b);
 }
 
 TEST_CASE("to_canonical_json: handles all JSON scalar types", "[SchemaValidation]") {
-    const auto a = CoolProp::to_canonical_json(std::string(R"({"i":1,"f":1.5,"s":"x","b":true,"n":null,"a":[1,2]})"));
+    const auto a = CoolProp::to_canonical_json_str(R"({"i":1,"f":1.5,"s":"x","b":true,"n":null,"a":[1,2]})");
     // Sorted: a, b, f, i, n, s
     REQUIRE(a == R"({"a":[1,2],"b":true,"f":1.5,"i":1,"n":null,"s":"x"})");
 }
 
 TEST_CASE("to_canonical_json: invalid JSON throws", "[SchemaValidation]") {
-    REQUIRE_THROWS_AS(CoolProp::to_canonical_json(std::string("{not: json}")), CoolProp::ValueError);
+    REQUIRE_THROWS_AS(CoolProp::to_canonical_json_str(std::string("{not: json}")), CoolProp::ValueError);
 }
 
 #endif  // ENABLE_CATCH


### PR DESCRIPTION
## Summary

Phase 5 of the RapidJSON → nlohmann/json migration (epic `CoolProp-xa8w.2`): move the **last rapidjson consumers** off RapidJSON. After this, **no rapidjson *code* remains outside `detail/rapidjson.h` + the `rapidjson_include.h` shim** — Phase Final is a near-mechanical deletion.

- **SchemaValidation** → Valijson + nlohmann; **string-only public API**. `validate_json_against_schema` routes through `cpjson::validate_schema` (Valijson); `to_canonical_json_str` = `cpjson::parse(s).dump()` (nlohmann's `std::map`-backed objects serialize keys sorted at every level). The rapidjson-typed public functions are removed outright (no external C++ callers).
- **Configuration** → nlohmann internal; **string-only public API**. The rapidjson-typed `get_config_as_json(Document&)`/`set_config_json(Document&)` (referenced only by `%ignore`s) and the `ConfigurationItem::add_to_json`/`set_from_json` methods are removed; per-item serialize/deserialize moves to `.cpp` free functions using `ConfigurationItem`'s accessors. `Configuration.h` is now JSON-library-free.
- **SVDSBTL options + MixtureParameters + a REFPROP test parse** → nlohmann (idiom-mapped, guards preserved).
- **The payoff:** the two Phase-2-4 `validate_schema` function-pointer casts (PCSAFT, Cubics) are **deleted** — the branch compiling without them is the proof that `Configuration.h` no longer drags `detail/rapidjson.h` into those TUs.

`Configuration.h` and `SchemaValidation.h` now carry **no rapidjson/nlohmann token** in their installed ABI.

## Notes for reviewers

- **Behaviour parity verified** per-component (adversarial review, no blocking findings): SchemaValidation arg-order + canonical key-sorting; Configuration per-item type branches incl. DOUBLE accepting int-or-double; MixtureParameters departure-function records carry every key the reader consumes; SVDSBTL `resolve_grid`/`bbox` guards equivalent.
- **Documented trade-offs:** (1) `set_config_as_json_string` now *throws* on malformed JSON (old rapidjson `Parse<0>` silently no-op'd) — fail-loud improvement; (2) the SVDSBTL options `opthash` changes (rapidjson→nlohmann number formatting) → a one-time cache rebuild, not a correctness change; (3) `is_number_integer()` is marginally more permissive than `IsInt()` for out-of-range ints (can't occur with CoolProp's small config integers).
- Remaining `rapidjson` text is comments only (`detail/json.h` enum-guard, factory comment, two now-stale explanatory comments) — Phase Final removes them with `detail/rapidjson.h`.

## Test Plan

- [x] `[SchemaValidation]`, `[configuration]`, `[SBTL]` umbrella, `[SVDSBTL][options]`, `[mixture]`, `[predefined_mixtures]`, `[PCSAFT]`, `[cubic]`, `[json_validation]` — all green
- [x] Full `~[slow]` suite: 118,411 assertions / 0 failures
- [x] Symbol-leak gate: 0 nlohmann/valijson exported
- [x] Exhaustive `git grep rapidjson` → only `detail/rapidjson.h` + the shim contain code; `Configuration.h`/`SchemaValidation.h` JSON-library-free
- [x] The two `validate_schema` casts compile away (proof the rapidjson overload is gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed typed RapidJSON public APIs — only string-based JSON interfaces remain.

* **Documentation**
  * Added Phase 5 implementation plan and design spec for the RapidJSON → nlohmann migration.

* **Chores**
  * Replaced internal RapidJSON usage with nlohmann/cpjson across configuration, schema validation, parsing, and backend code paths.

* **Tests**
  * Updated schema-validation and canonicalization tests to use string-based JSON APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->