### PR TITLE
feat(python): ship PEP 561 type stubs for the v8 wheel via nanobind stubgen (CoolProp-r9sq.10)

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -150,7 +150,7 @@ jobs:
           set -euo pipefail
           uv venv --python 3.13
           source .venv/bin/activate
-          uv pip install nanobind cython scikit-build-core ninja pytest
+          uv pip install nanobind cython scikit-build-core ninja pytest mypy numpy
           # Release: the wheel compiles the whole core (incl. SVDSBTL); Debug is
           # very slow. COOLPROP_NANOBIND=ON selects the nanobind core + State shim.
           uv build --wheel --no-build-isolation \

--- a/wrappers/Python/CMakeLists.txt
+++ b/wrappers/Python/CMakeLists.txt
@@ -226,6 +226,18 @@ target_include_directories(CoolProp_module PRIVATE
 target_link_libraries(CoolProp_module PRIVATE miniz)
 set_target_properties(CoolProp_module PROPERTIES OUTPUT_NAME "CoolProp" PREFIX "")
 
+# ---- PEP 561 type stub for the nanobind core (parity with the legacy wheel) ----
+# The core .so is self-contained (no Python-level imports at init), so nanobind's
+# stubgen can import it directly from the build dir to emit CoolProp.pyi.
+nanobind_add_stub(
+    CoolProp_stub
+    MODULE CoolProp
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/CoolProp.pyi"
+    PYTHON_PATH "$<TARGET_FILE_DIR:CoolProp_module>"
+    DEPENDS CoolProp_module
+    MARKER_FILE "${CMAKE_CURRENT_BINARY_DIR}/py.typed"
+)
+
 # ---- capsule State shim -> CoolProp.State (link-free; forwards through _capi) ----
 # No CoolProp C++ is compiled in here; the shim only needs the C-ABI struct
 # header and grabs the function table from the already-imported core at runtime.
@@ -327,6 +339,9 @@ install(FILES
     DESTINATION CoolProp)
 # HumidAirProp re-export shim (SI surface from the core; non-SI HAProps removed)
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/_nanobind/HumidAirProp.py"
+    DESTINATION CoolProp)
+# PEP 561 type stub for the nanobind core + py.typed marker (generated above)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/CoolProp.pyi" "${CMAKE_CURRENT_BINARY_DIR}/py.typed"
     DESTINATION CoolProp)
 # Pure-Python submodules, shipped unchanged from the source package so the v8
 # import tree matches the legacy one (CoolProp.Plots/BibtexParser/GUI/tests).

--- a/wrappers/Python/CMakeLists.txt
+++ b/wrappers/Python/CMakeLists.txt
@@ -236,6 +236,11 @@ nanobind_add_stub(
     PYTHON_PATH "$<TARGET_FILE_DIR:CoolProp_module>"
     DEPENDS CoolProp_module
     MARKER_FILE "${CMAKE_CURRENT_BINARY_DIR}/py.typed"
+    # INCLUDE_PRIVATE emits the underscore-named _AbstractState class that the
+    # AbstractState() factory returns; the pattern file replaces the auto
+    # PropsSI/HAPropsSI overloads (object-typed -> overlap) with typed ones.
+    INCLUDE_PRIVATE
+    PATTERN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/_nanobind/stub_patterns.txt"
 )
 
 # ---- capsule State shim -> CoolProp.State (link-free; forwards through _capi) ----

--- a/wrappers/Python/_nanobind/stub_patterns.txt
+++ b/wrappers/Python/_nanobind/stub_patterns.txt
@@ -13,6 +13,7 @@
 CoolProp\.__prefix__:
     import numpy
     from numpy.typing import NDArray
+    from collections.abc import Sequence
     _Scalar = float
     _Num = float | Sequence[float] | NDArray[numpy.float64]
 

--- a/wrappers/Python/_nanobind/stub_patterns.txt
+++ b/wrappers/Python/_nanobind/stub_patterns.txt
@@ -1,0 +1,37 @@
+# nanobind stubgen pattern file (bd CoolProp-r9sq.10).
+#
+# Fixes applied to the auto-generated stub so it type-checks (mypy.stubtest):
+#  - re-add the numpy / NDArray imports (stubgen prunes them once the PropsSI/
+#    HAPropsSI overloads that used them are replaced below) + the _Scalar/_Num
+#    aliases.
+#  - replace the auto PropsSI/HAPropsSI overloads (object-typed -> overlap with
+#    incompatible return types) with explicitly-typed scalar/array overloads
+#    (mirrors dev/stubs/overloads_coolprop.pyi).
+#  - give the private _capi capsule a valid type (was the undefined PyCapsule).
+#  - fix get_spinodal_data, whose return leaks the unbound C++ type name.
+
+CoolProp\.__prefix__:
+    import numpy
+    from numpy.typing import NDArray
+    _Scalar = float
+    _Num = float | Sequence[float] | NDArray[numpy.float64]
+
+CoolProp\._capi$:
+    _capi: object = ...
+
+CoolProp\._AbstractState\.get_spinodal_data$:
+    def get_spinodal_data(self) -> object: ...
+
+CoolProp\.PropsSI$:
+    @overload
+    def PropsSI(Output: str, FluidName: str, /) -> float: ...
+    @overload
+    def PropsSI(Output: str, Name1: str, Prop1: _Scalar, Name2: str, Prop2: _Scalar, FluidName: str, /) -> float: ...  # type: ignore[overload-overlap]
+    @overload
+    def PropsSI(Output: str, Name1: str, Prop1: _Num, Name2: str, Prop2: _Num, FluidName: str, /) -> NDArray[numpy.float64]: ...
+
+CoolProp\.HAPropsSI$:
+    @overload
+    def HAPropsSI(Output: str, Name1: str, Value1: _Scalar, Name2: str, Value2: _Scalar, Name3: str, Value3: _Scalar, /) -> float: ...  # type: ignore[overload-overlap]
+    @overload
+    def HAPropsSI(Output: str, Name1: str, Value1: _Num, Name2: str, Value2: _Num, Name3: str, Value3: _Num, /) -> NDArray[numpy.float64]: ...

--- a/wrappers/Python/pytest/test_stub.py
+++ b/wrappers/Python/pytest/test_stub.py
@@ -24,7 +24,9 @@ _PYI = os.path.join(_PKG, "CoolProp.pyi")
 
 def _stub_toplevel_names():
     names = set()
-    for n in ast.parse(open(_PYI, encoding="utf-8").read()).body:
+    with open(_PYI, encoding="utf-8") as f:
+        tree = ast.parse(f.read())
+    for n in tree.body:
         if isinstance(n, (ast.FunctionDef, ast.ClassDef)):
             names.add(n.name)
         elif isinstance(n, ast.AnnAssign) and isinstance(n.target, ast.Name):
@@ -37,7 +39,8 @@ def _stub_toplevel_names():
 def test_stub_and_marker_ship_and_parse():
     assert os.path.exists(_PYI), "CoolProp.pyi not shipped in the wheel"
     assert os.path.exists(os.path.join(_PKG, "py.typed")), "py.typed marker not shipped"
-    ast.parse(open(_PYI, encoding="utf-8").read())  # valid Python (raises on failure)
+    with open(_PYI, encoding="utf-8") as f:
+        ast.parse(f.read())  # valid Python (raises on failure)
 
 
 def test_stub_symbol_parity_with_runtime():

--- a/wrappers/Python/pytest/test_stub.py
+++ b/wrappers/Python/pytest/test_stub.py
@@ -1,0 +1,64 @@
+"""
+Confirm the v8 nanobind type stub is valid and matches the runtime (bd
+CoolProp-r9sq.10).
+
+Note on tooling: nanobind functions are opaque to ``inspect.signature`` (they
+present as ``(*args, **kwargs)``), so ``mypy.stubtest``'s signature comparison
+does NOT apply to a nanobind stub. Instead we confirm the properties that
+actually matter:
+  1. ``CoolProp.pyi`` + ``py.typed`` ship and the stub parses;
+  2. every public runtime symbol is present in the stub (symbol parity);
+  3. a type checker resolves the key polymorphic overloads -- ``PropsSI`` scalar
+     -> ``float`` and array -> ``ndarray`` -- which is the point of the stub.
+"""
+import ast
+import os
+
+import pytest
+
+import CoolProp.CoolProp as CP
+
+_PKG = os.path.dirname(CP.__file__)
+_PYI = os.path.join(_PKG, "CoolProp.pyi")
+
+
+def _stub_toplevel_names():
+    names = set()
+    for n in ast.parse(open(_PYI, encoding="utf-8").read()).body:
+        if isinstance(n, (ast.FunctionDef, ast.ClassDef)):
+            names.add(n.name)
+        elif isinstance(n, ast.AnnAssign) and isinstance(n.target, ast.Name):
+            names.add(n.target.id)
+        elif isinstance(n, ast.Assign):
+            names.update(t.id for t in n.targets if isinstance(t, ast.Name))
+    return names
+
+
+def test_stub_and_marker_ship_and_parse():
+    assert os.path.exists(_PYI), "CoolProp.pyi not shipped in the wheel"
+    assert os.path.exists(os.path.join(_PKG, "py.typed")), "py.typed marker not shipped"
+    ast.parse(open(_PYI, encoding="utf-8").read())  # valid Python (raises on failure)
+
+
+def test_stub_symbol_parity_with_runtime():
+    names = _stub_toplevel_names()
+    runtime = {n for n in dir(CP) if not n.startswith("__")}
+    missing = sorted(runtime - names)
+    assert not missing, "runtime symbols missing from the stub: %s" % missing
+
+
+def test_stub_overloads_typecheck():
+    """mypy resolves PropsSI scalar->float and array->ndarray against the stub."""
+    mypy_api = pytest.importorskip("mypy.api")
+    snippet = (
+        "from CoolProp.CoolProp import PropsSI\n"
+        "reveal_type(PropsSI('Tcrit', 'Water'))\n"
+        "reveal_type(PropsSI('D', 'T', 300.0, 'P', 101325.0, 'Water'))\n"
+        "reveal_type(PropsSI('D', 'T', [300.0, 310.0], 'P', 101325.0, 'Water'))\n"
+    )
+    out, _err, _code = mypy_api.run(["-c", snippet])
+    revealed = [ln for ln in out.splitlines() if "Revealed type" in ln]
+    assert len(revealed) == 3, out
+    assert "float" in revealed[0]                       # 2-arg trivial
+    assert "float" in revealed[1]                       # scalar inputs
+    assert "ndarray" in revealed[2]                     # array input


### PR DESCRIPTION
## What

The nanobind wheel shipped **no type stubs**, while the legacy wheel ships `CoolProp.pyi` — a regression in IDE/type-checker support for v8. This restores parity using nanobind's own stub generator.

- `nanobind_add_stub(...)` generates `CoolProp.pyi` from the built core `.so` at build time (the core is self-contained, so stubgen imports it directly from the build dir), plus a `py.typed` marker.
- both are installed into the wheel (`CoolProp/CoolProp.pyi`, `CoolProp/py.typed`).

## Result

The generated stub (~980 lines) auto-reflects the **full bound surface**, including the overloads added across this epic:

```python
def PropsSI(arg0: str, arg1: str, arg2: float, arg3: str, arg4: float, arg5: str, /) -> float: ...
def PropsSI(arg0: str, arg1: str, arg2: object, arg3: str, arg4: object, arg5: str, /) -> NDArray[numpy.float64]: ...
def PropsSI(arg0: str, arg1: str, /) -> float: ...
def HAPropsSI(...): ...
class _AbstractState: ...
```

Per the agreed plan, the existing Cython `dev/stubs` pipeline **stays**; the two coexist until the legacy interface is removed (`r9sq.7`).

Scoped strictly to the `COOLPROP_NANOBIND` branch (legacy wheel untouched). Adversarial review confirmed build-before-install ordering (the stub target is in `ALL`), safe build-time import, and cross-platform soundness.

Refs bd CoolProp-r9sq.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ship PEP 561 type information with the package (generated .pyi and py.typed) so IDEs and type checkers receive distributed stubs.
  * Improve distributed stub typings to distinguish scalar vs numeric/array inputs and better represent internal objects for more accurate type checking.
* **Tests**
  * Add validation tests ensuring the shipped stub/marker exist, match exported symbols, and verify overload resolution via static type checks.
* **Chores**
  * CI test setup updated to include required numeric tooling for type checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->