### PR TITLE
Option A: link-time export control for JSON symbols (delete the visibility pragma + CP_JSON_LOCAL)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,6 +383,8 @@ set(COOLPROP_INCLUDE_DIRECTORIES
 #######################################
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
                       "${CMAKE_CURRENT_SOURCE_DIR}/dev/cmake/Modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(CoolPropJSONVisibility)
 
 message(STATUS "Looking for Python")
 find_package(Python REQUIRED COMPONENTS Interpreter)
@@ -720,6 +722,7 @@ if(COOLPROP_OBJECT_LIBRARY
   if(NOT COOLPROP_OBJECT_LIBRARY)
     target_link_libraries(${LIB_NAME} ${CMAKE_DL_LIBS})
   endif()
+  coolprop_hide_json_symbols(${LIB_NAME})
 
   # For windows systems, bug workaround for Eigen
   if(MSVC90)
@@ -1411,6 +1414,7 @@ if(COOLPROP_OCTAVE_MODULE)
   else()
     swig_link_libraries(CoolProp ${OCTAVE_LIBRARIES})
   endif()
+  coolprop_hide_json_symbols(CoolProp)
 
   set_target_properties(CoolProp PROPERTIES SUFFIX ".oct" PREFIX "")
   add_dependencies(${app_name} generate_headers generate_examples)
@@ -1457,6 +1461,7 @@ if(COOLPROP_CSHARP_MODULE)
 
   swig_add_module(CoolProp csharp ${I_FILE} ${APP_SOURCES})
   set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolPropCsharp")
+  coolprop_hide_json_symbols(CoolProp)
 
   add_definitions(-DNO_ERROR_CATCHING)
 
@@ -1546,6 +1551,7 @@ if(COOLPROP_VBDOTNET_MODULE)
   set_property(SOURCE ${I_FILE} PROPERTY SWIG_FLAGS ${SWIG_OPTIONS})
   swig_add_module(CoolProp csharp ${I_FILE} ${APP_SOURCES})
   set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolPropCsharp")
+  coolprop_hide_json_symbols(CoolProp)
 
   add_definitions(-DNO_ERROR_CATCHING)
 
@@ -1622,6 +1628,7 @@ if(COOLPROP_R_MODULE)
 
   swig_add_module(CoolProp r ${I_FILE} ${APP_SOURCES})
   swig_link_libraries(CoolProp "${R_LIBRARY}")
+  coolprop_hide_json_symbols(CoolProp)
   set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolPropR")
 
   # No lib prefix for the shared library
@@ -1682,6 +1689,7 @@ if(COOLPROP_JAVA_MODULE)
   set(SWIG_MODULE_CoolProp_EXTRA_DEPS ${SWIG_DEPENDENCIES})
   swig_add_module(CoolProp java ${I_FILE} ${APP_SOURCES})
   set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolPropJava")
+  coolprop_hide_json_symbols(CoolProp)
 
   if(WIN32)
     set_target_properties(CoolProp PROPERTIES PREFIX "")
@@ -1831,6 +1839,7 @@ if(COOLPROP_PHP_MODULE)
   set(SWIG_MODULE_CoolProp_EXTRA_DEPS ${SWIG_DEPENDENCIES})
   swig_add_module(CoolProp php ${I_FILE} ${APP_SOURCES})
   set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolPropPHP")
+  coolprop_hide_json_symbols(CoolProp)
 
   if(WIN32)
     set_target_properties(CoolProp PROPERTIES PREFIX "")
@@ -2031,6 +2040,7 @@ if(COOLPROP_MATHEMATICA_MODULE)
   include_directories(${APP_INCLUDE_DIRS})
   add_library(CoolProp SHARED ${APP_SOURCES})
   add_dependencies(CoolProp generate_headers)
+  coolprop_hide_json_symbols(CoolProp)
 
   if(MSVC)
     add_custom_command(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -849,6 +849,7 @@ if(COOLPROP_DEBIAN_PACKAGE)
   endif()
   list(APPEND APP_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/CoolPropLib.cpp")
   add_library(${app_name} SHARED ${APP_SOURCES})
+  coolprop_hide_json_symbols(${app_name})
   set_target_properties(
     ${app_name} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -DCOOLPROP_LIB")
   set_target_properties(
@@ -920,6 +921,7 @@ if(COOLPROP_PRIME_MODULE)
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/wrappers/MathCAD/CoolPropMathcad.cpp")
   add_library(CoolPropMathcadWrapper SHARED ${APP_SOURCES})
+  coolprop_hide_json_symbols(CoolPropMathcadWrapper)
   include_directories("${COOLPROP_PRIME_ROOT}/Custom Functions")
   target_link_libraries(CoolPropMathcadWrapper
                         "${COOLPROP_PRIME_ROOT}/Custom Functions/mcaduser.lib")
@@ -957,6 +959,7 @@ if(COOLPROP_MATHCAD15_MODULE)
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/wrappers/MathCAD/CoolPropMathcad.cpp")
   add_library(CoolPropMathcadWrapper SHARED ${APP_SOURCES})
+  coolprop_hide_json_symbols(CoolPropMathcadWrapper)
   include_directories("${COOLPROP_MATHCAD15_ROOT}/userefi/microsft/include")
   target_link_libraries(
     CoolPropMathcadWrapper
@@ -987,6 +990,7 @@ if(COOLPROP_EES_MODULE)
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_SOURCE}")
   add_library(COOLPROP_EES SHARED ${APP_SOURCES})
+  coolprop_hide_json_symbols(COOLPROP_EES)
   # Modify the target and add dependencies
   add_dependencies(COOLPROP_EES generate_headers)
   set_target_properties(

--- a/cmake/CoolPropJSONVisibility.cmake
+++ b/cmake/CoolPropJSONVisibility.cmake
@@ -1,0 +1,19 @@
+# Hide nlohmann/valijson symbols from a shared product's dynamic export table at
+# LINK time (replaces the compile-time visibility pragma; see CoolProp-xa8w.6).
+# ELF: --version-script hide-list; Mach-O: -unexported_symbols_list. MSVC: no-op
+# (exports are opt-in via src/CoolPropLib.def).
+function(coolprop_hide_json_symbols target)
+    if(NOT TARGET ${target})
+        return()
+    endif()
+    if(APPLE)
+        set(_exp "${CMAKE_SOURCE_DIR}/dev/linker/coolprop_hide_json.exp")
+        target_link_options(${target} PRIVATE "LINKER:-unexported_symbols_list,${_exp}")
+        set_property(TARGET ${target} APPEND PROPERTY LINK_DEPENDS "${_exp}")
+    elseif(UNIX)
+        set(_map "${CMAKE_SOURCE_DIR}/dev/linker/coolprop_hide_json.map")
+        target_link_options(${target} PRIVATE "LINKER:--version-script=${_map}")
+        set_property(TARGET ${target} APPEND PROPERTY LINK_DEPENDS "${_map}")
+    endif()
+    # MSVC/WIN32: nothing.
+endfunction()

--- a/cmake/CoolPropJSONVisibility.cmake
+++ b/cmake/CoolPropJSONVisibility.cmake
@@ -2,16 +2,32 @@
 # LINK time (replaces the compile-time visibility pragma; see CoolProp-xa8w.6).
 # ELF: --version-script hide-list; Mach-O: -unexported_symbols_list. MSVC: no-op
 # (exports are opt-in via src/CoolPropLib.def).
+#
+# Paths are resolved relative to THIS module file so the helper works whether
+# included from the repo-root CMakeLists or the Python wrapper's own cmake
+# project (where CMAKE_SOURCE_DIR is the wrapper dir, not the repo root).
+# CMAKE_CURRENT_LIST_DIR evaluates at parse time here (outside the function
+# body), so it correctly captures <repo>/cmake regardless of where the caller
+# lives.  The function captures it via _COOLPROP_JSON_LINKER_DIR.
+get_filename_component(_COOLPROP_JSON_LINKER_DIR
+    "${CMAKE_CURRENT_LIST_DIR}/../dev/linker" ABSOLUTE)
+
 function(coolprop_hide_json_symbols target)
     if(NOT TARGET ${target})
         return()
     endif()
     if(APPLE)
-        set(_exp "${CMAKE_SOURCE_DIR}/dev/linker/coolprop_hide_json.exp")
+        set(_exp "${_COOLPROP_JSON_LINKER_DIR}/coolprop_hide_json.exp")
+        if(NOT EXISTS "${_exp}")
+            message(FATAL_ERROR "coolprop_hide_json_symbols: hide-list not found: ${_exp}")
+        endif()
         target_link_options(${target} PRIVATE "LINKER:-unexported_symbols_list,${_exp}")
         set_property(TARGET ${target} APPEND PROPERTY LINK_DEPENDS "${_exp}")
     elseif(UNIX)
-        set(_map "${CMAKE_SOURCE_DIR}/dev/linker/coolprop_hide_json.map")
+        set(_map "${_COOLPROP_JSON_LINKER_DIR}/coolprop_hide_json.map")
+        if(NOT EXISTS "${_map}")
+            message(FATAL_ERROR "coolprop_hide_json_symbols: hide-list not found: ${_map}")
+        endif()
         target_link_options(${target} PRIVATE "LINKER:--version-script=${_map}")
         set_property(TARGET ${target} APPEND PROPERTY LINK_DEPENDS "${_map}")
     endif()

--- a/dev/linker/coolprop_hide_json.exp
+++ b/dev/linker/coolprop_hide_json.exp
@@ -1,0 +1,2 @@
+*nlohmann*
+*valijson*

--- a/dev/linker/coolprop_hide_json.map
+++ b/dev/linker/coolprop_hide_json.map
@@ -1,0 +1,5 @@
+{
+  local:
+    *nlohmann*;
+    *valijson*;
+};

--- a/docs/superpowers/plans/2026-06-07-json-optionA-link-export-control.md
+++ b/docs/superpowers/plans/2026-06-07-json-optionA-link-export-control.md
@@ -1,0 +1,190 @@
+# Option A — link-time JSON-symbol export control — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the fragile compile-time `#pragma GCC visibility push(hidden)` + `CP_JSON_LOCAL` + the rj2i pre-include stopgap with **link-time export control**: a per-shared-product linker hide-list for nlohmann/valijson symbols. Mechanism-proof against the libc-poisoning failure (CoolProp-rj2i) and immune to dependency bumps.
+
+**Architecture:** A reusable CMake helper `coolprop_hide_json_symbols(<target>)` attaches, per shared product, an ELF `--version-script` (`{ local: *nlohmann*; *valijson*; };`) or a Mach-O `-unexported_symbols_list` (`*nlohmann*`/`*valijson*`). Windows (MSVC) is a no-op (opt-in `.def` exports). With link-time hiding in place, the compile-time visibility machinery is deleted: the pragma + stopgap pre-includes in `detail/json.h`, and the `CP_JSON_LOCAL` macro + its uses across the 4 loader headers.
+
+**Tech Stack:** CMake (`target_link_options`, ELF version scripts / Mach-O `-unexported_symbols_list`), the symbol-leak gate (`dev/ci/check-json-symbols.sh`).
+
+**Spec/design:** `docs/superpowers/specs/2026-06-07-json-symbol-visibility-strategy-reassessment-design.md` (§2-5, Option A).
+**Issue:** `CoolProp-xa8w.6`. **Branch:** `ihb/json-optionA-link-export-control` (stacked on the Phase 5 branch).
+
+**Verification reality:** this is an ELF/glibc-class change; the dev machine is macOS/Mach-O. **Local proof = the Mach-O symbol gate on `libCoolProp.dylib` stays green AFTER the pragma is deleted** (which proves the link-time hide-list works, since compile-time hiding is gone). The ELF version script + the Octave `.oct` link are verified in **CI** (the docs build + the symbol gate). Iterate against CI.
+
+---
+
+## Task 1: Symbol-list files + the CMake helper
+
+**Files:**
+- Create: `dev/linker/coolprop_hide_json.map` (ELF version script)
+- Create: `dev/linker/coolprop_hide_json.exp` (Mach-O unexported list)
+- Create: `cmake/CoolPropJSONVisibility.cmake` (the helper)
+- Modify: `CMakeLists.txt` (include the helper module once, near the top after `CMAKE_MODULE_PATH` is set)
+
+- [ ] **Step 1: ELF version script `dev/linker/coolprop_hide_json.map`**
+```
+{
+  local:
+    *nlohmann*;
+    *valijson*;
+};
+```
+(Anonymous version with only a `local:` list — GNU ld keeps all unmatched symbols at their default (exported) binding, and forces matching ones local/hidden. Matches MANGLED names, which contain the literal `nlohmann`/`valijson`.)
+
+- [ ] **Step 2: Mach-O unexported list `dev/linker/coolprop_hide_json.exp`**
+```
+*nlohmann*
+*valijson*
+```
+(`-unexported_symbols_list` glob patterns over mangled symbol names; `*nlohmann*` matches `__ZN8nlohmann…`.)
+
+- [ ] **Step 3: `cmake/CoolPropJSONVisibility.cmake`**
+```cmake
+# Hide nlohmann/valijson symbols from a shared product's dynamic export table at
+# LINK time (replaces the compile-time visibility pragma; see CoolProp-xa8w.6).
+# ELF: --version-script hide-list; Mach-O: -unexported_symbols_list. MSVC: no-op
+# (exports are opt-in via src/CoolPropLib.def).
+function(coolprop_hide_json_symbols target)
+    if(NOT TARGET ${target})
+        return()
+    endif()
+    if(APPLE)
+        set(_exp "${CMAKE_CURRENT_SOURCE_DIR}/dev/linker/coolprop_hide_json.exp")
+        target_link_options(${target} PRIVATE "LINKER:-unexported_symbols_list,${_exp}")
+        set_property(TARGET ${target} APPEND PROPERTY LINK_DEPENDS "${_exp}")
+    elseif(UNIX)
+        set(_map "${CMAKE_CURRENT_SOURCE_DIR}/dev/linker/coolprop_hide_json.map")
+        target_link_options(${target} PRIVATE "LINKER:--version-script=${_map}")
+        set_property(TARGET ${target} APPEND PROPERTY LINK_DEPENDS "${_map}")
+    endif()
+    # MSVC/WIN32: nothing — only .def-listed symbols are exported.
+endfunction()
+```
+(`CMAKE_CURRENT_SOURCE_DIR` resolves to the repo root for the top-level CMakeLists and to the wrapper dir for `wrappers/Python` — so use an absolute path via `${CMAKE_SOURCE_DIR}` instead if called from a subdirectory. **Use `${CMAKE_SOURCE_DIR}` in the helper** so it works from any CMakeLists. Adjust the two `set(_exp …)`/`set(_map …)` lines to `${CMAKE_SOURCE_DIR}/dev/linker/…`.)
+
+- [ ] **Step 4: include the module in `CMakeLists.txt`**
+
+After the `list(APPEND CMAKE_MODULE_PATH …)` / project setup near the top, add:
+```cmake
+include(CoolPropJSONVisibility)
+```
+(Confirm `CMAKE_MODULE_PATH` includes `${CMAKE_SOURCE_DIR}/cmake`; if the helper isn't found, add `list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")` first. The Python wrapper already does `list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")` then includes CPM — it can `include(CoolPropJSONVisibility)` after adding the ROOT cmake dir to its module path.)
+
+- [ ] **Step 5: configure-only smoke**
+
+Run: `cmake -B build_shared -S . -DCOOLPROP_SHARED_LIBRARY=ON -DCMAKE_BUILD_TYPE=Release` — expect clean configure (the helper parses; no target yet wired — that's Task 2). Commit after Task 2 (these files are inert until applied).
+
+---
+
+## Task 2: Apply the helper to every shared product
+
+**Files:** `CMakeLists.txt` (libCoolProp + Octave/Java/C#/R/PHP swig targets), `wrappers/Python/CMakeLists.txt` (Cython + nanobind modules)
+
+For EACH shared product, add `coolprop_hide_json_symbols(<target>)` right after the target is created / its libraries are linked. The SWIG targets are all named `CoolProp`; the main lib is `${LIB_NAME}`; the Python modules are `CoolProp_module`.
+
+- [ ] **Step 1: libCoolProp** — after `add_library(${LIB_NAME} SHARED …)` (~CMakeLists.txt:651) and its `target_link_libraries`, add `coolprop_hide_json_symbols(${LIB_NAME})`.
+- [ ] **Step 2: Octave** — after `swig_add_library(CoolProp LANGUAGE octave …)` + `swig_link_libraries` (~1409), add `coolprop_hide_json_symbols(CoolProp)`. (This is THE product whose link broke; it must be covered.)
+- [ ] **Step 3: Java** (`swig_add_module(CoolProp java …)` ~1680), **C#** (~1455/1544), **R** (~1620), **PHP** (~1829): add `coolprop_hide_json_symbols(CoolProp)` after each module's creation/link (inside each `if(COOLPROP_*_MODULE)` block, so only configured ones apply).
+- [ ] **Step 4: Python** (`wrappers/Python/CMakeLists.txt`): add `coolprop_hide_json_symbols(CoolProp_module)` after `Python_add_library(CoolProp_module …)` (~184) and after `nanobind_add_module(CoolProp_module …)` (~218). Ensure the helper is `include()`d there (add `list(APPEND CMAKE_MODULE_PATH "${ROOT_DIR}/cmake")` + `include(CoolPropJSONVisibility)` near its top).
+- [ ] **Step 5: build + Mach-O gate (the local proof that hiding still works WITH the pragma still present)**
+
+Run: `cmake -B build_shared -S . -DCOOLPROP_SHARED_LIBRARY=ON -DCMAKE_BUILD_TYPE=Release && cmake --build build_shared -j8 && ./dev/ci/check-json-symbols.sh "$(find build_shared -name 'libCoolProp.dylib' | head -1)"`
+Expected: `OK` (0 nlohmann/valijson exported). At this point BOTH the pragma AND the version script hide them — the next task removes the pragma and the gate must STILL be green (proving the link-time hide is doing the work).
+
+- [ ] **Step 6: Commit** (Tasks 1+2 together — the files + their application)
+```bash
+git add dev/linker/ cmake/CoolPropJSONVisibility.cmake CMakeLists.txt wrappers/Python/CMakeLists.txt
+git restore --staged .beads/issues.jsonl 2>/dev/null || true
+git commit -m "build(json): add link-time export control for nlohmann/valijson symbols (CoolProp-xa8w.6)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Delete the compile-time visibility machinery
+
+**Files:** `include/CoolProp/detail/json.h` (pragma + stopgap), the 4 loader headers (`CP_JSON_LOCAL`).
+
+- [ ] **Step 1: `detail/json.h` — delete the stopgap pre-include block AND the pragma**
+
+Remove the `// STOPGAP (CoolProp-rj2i) …` comment block and ALL the pre-includes it added (`<cassert> <cmath> <cstddef> <cstdint> <cstdio> <cstdlib> <cstring> <exception> <iostream> <limits> <memory> <new> <stdexcept> <string> <string_view> <system_error> <typeinfo> <vector>`), AND the `#if defined(__GNUC__)… pragma GCC visibility push(hidden) …#endif` / `…pop…#endif` wrappers (lines ~17-25 and ~49-51 and ~59-61). Keep the actual includes:
+```cpp
+#include <nlohmann/json.hpp>
+#include <valijson/adapters/nlohmann_json_adapter.hpp>
+#include <valijson/schema.hpp>
+#include <valijson/schema_parser.hpp>
+#include <valijson/validator.hpp>
+```
+(now at default visibility — hidden at link by the version script). Re-add only the standard headers the file's OWN code actually needs (`<string>`, `<string_view>`, `<vector>`, `<cstdint>` if used by the `cpjson` helpers below — check what `detail/json.h`'s own code uses and keep those; drop the rest). Update the file-top comment block (the "Symbol-leak strategy" note) to describe the link-time approach.
+
+- [ ] **Step 2: Delete `CP_JSON_LOCAL` in the 4 loader headers**
+
+In each of `src/Backends/Helmholtz/Fluids/FluidLibrary.h`, `src/Backends/Incompressible/IncompressibleLibrary.h`, `src/Backends/PCSAFT/PCSAFTLibrary.h`, `src/Backends/Cubics/UNIFACLibrary.h`: delete the `#if defined(__GNUC__)… #define CP_JSON_LOCAL …#endif` macro definition block, remove the `CP_JSON_LOCAL ` prefix from every method declaration that has it, and delete the `#undef CP_JSON_LOCAL` line. Also update the comment in `src/Backends/Helmholtz/Fluids/FluidLibraryFactories.h` (~line 15) that references the `CP_JSON_LOCAL` treatment.
+
+- [ ] **Step 3: Build + the decisive Mach-O gate**
+
+Run: `cmake --build build_shared -j8 && ./dev/ci/check-json-symbols.sh "$(find build_shared -name 'libCoolProp.dylib' | head -1)"`
+Expected: clean build AND `OK` (0 nlohmann/valijson exported). **This is the key local proof:** with the pragma and `CP_JSON_LOCAL` GONE, the only thing hiding the symbols is the link-time version script — a green gate confirms it works. If the gate now FAILS (symbols leaked), the version script / unexported list isn't matching — fix the pattern (check `nm -gU libCoolProp.dylib | c++filt | grep -E 'nlohmann|valijson'` to see what leaked and adjust the `.exp`/`.map` globs).
+Also build the Catch runner (`cmake --build build_catch --target CatchTestRunner -j8`) — confirm deleting the pragma/CP_JSON_LOCAL doesn't break compilation.
+
+- [ ] **Step 4: Commit**
+```bash
+git add include/CoolProp/detail/json.h src/Backends/Helmholtz/Fluids/FluidLibrary.h src/Backends/Helmholtz/Fluids/FluidLibraryFactories.h src/Backends/Incompressible/IncompressibleLibrary.h src/Backends/PCSAFT/PCSAFTLibrary.h src/Backends/Cubics/UNIFACLibrary.h
+git restore --staged .beads/issues.jsonl 2>/dev/null || true
+git commit -m "refactor(json): delete the visibility pragma + CP_JSON_LOCAL — link-time export control replaces them (CoolProp-xa8w.6)
+
+Removes the rj2i pre-include stopgap, the GCC visibility pragma around the
+nlohmann/valijson includes (which poisoned __assert_fail in non-NDEBUG loader
+builds), and the CP_JSON_LOCAL per-method attributes. Symbols are now hidden at
+link time per shared product (Task 1-2), which cannot poison system externs.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Extend the symbol gate to a wrapper product
+
+**Files:** `dev/ci/preflight.sh` (the json-symbols step), optionally `dev/ci/check-json-symbols.sh` (unchanged — it already takes any product path).
+
+The gate today inspects only `libCoolProp` — which is why the `.oct` leak/poison was invisible. Add the **Octave `.oct`** (the product that broke) to the gate, gracefully skipping when Octave/SWIG aren't installed.
+
+- [ ] **Step 1: preflight — build + gate the Octave module when available**
+
+In the `json-symbols` step of `dev/ci/preflight.sh`, after the existing `libCoolProp` check, add a sub-check: if `swig` and `octave-config` (or `octave`) are on PATH, configure+build a `build_octave` with `-DCOOLPROP_OCTAVE_MODULE=ON` and run `./dev/ci/check-json-symbols.sh` on the resulting `CoolProp.oct`. Skip (not fail) with a clear message when the Octave toolchain is absent (so it runs in CI, skips on dev machines without Octave). Fail-closed if the build is attempted and fails, or if the `.oct` exports nlohmann/valijson.
+
+- [ ] **Step 2: Verify the step skips cleanly locally** (no Octave on the dev machine → skip message, not fail) and document that CI (which has Octave) runs it.
+
+- [ ] **Step 3: Commit**
+```bash
+git add dev/ci/preflight.sh
+git restore --staged .beads/issues.jsonl 2>/dev/null || true
+git commit -m "ci(json): extend the symbol-leak gate to the Octave .oct wrapper (CoolProp-xa8w.6)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final Verification (before PR)
+
+- [ ] **Step 1: Mach-O symbol gate green with the pragma gone** (done in Task 3) — re-confirm `OK` on a fresh `build_shared`.
+- [ ] **Step 2: No compile-time visibility machinery left**
+  Run: `grep -rn "CP_JSON_LOCAL\|pragma GCC visibility" include src | grep -v "FluidLibrary.h:.*comment"` → expect nothing (all pragma/CP_JSON_LOCAL gone; the only `visibility` left should be the linker files / none).
+- [ ] **Step 3: Full fast suite** `./build_catch/CatchTestRunner "~[slow]"` → 0 failures (deleting the pragma is behaviour-neutral).
+- [ ] **Step 4: Preflight + adversarial review (MANDATORY).** Focus: (a) the version-script/`.exp` globs actually hide nlohmann/valijson AND keep the public C API + `CoolProp::*` exported (the gate's nm check + the Catch tests linking against the lib prove the public API survives); (b) the helper is applied to EVERY shared product (none missed — a missed product re-leaks/re-exposes); (c) `target_link_options` LINKER: prefix is correct for both ELF and Mach-O; (d) no fail-open in the extended gate (Octave skip is legitimate-absent only, not masking a build failure); (e) deleting the pragma did not leave `detail/json.h` needing a header it dropped.
+- [ ] **Step 5: Push + PR (stacked on the Phase 5 branch).** `git push -u origin ihb/json-optionA-link-export-control`; `gh pr create --base ihb/json-phase5-configuration-off-rapidjson …` (the parent in the stack). In the PR body, be explicit that the ELF link + the Octave `.oct` are verified by **CI** (the docs build + the symbol gate), not locally. After CI runs, **re-check the docs "Documentation builds (HTML)" job goes green** — that is the end-to-end proof Option A fixed the poisoning durably (and the stopgap can later be considered redundant). Re-review any post-review commits.
+- [ ] **Step 6: bd.** `bd update CoolProp-xa8w.6 --notes "PR #…"`; note that `w0cm` (the poisoning guard) is now moot — the pragma is gone — and can close once this merges; note `rj2i` is permanently fixed (the stopgap is deleted here, superseded by link-time control).
+
+---
+
+## Self-Review (plan vs design)
+
+**Design coverage:** reassessment §2 (Option A mechanism) → Tasks 1-2 (helper + per-product); §3/§5 (delete pragma + CP_JSON_LOCAL + stopgap) → Task 3; "extend the gate to wrappers" → Task 4; "w0cm moot / rj2i permanent" → Final Verification §6.
+
+**Placeholder scan:** the per-product line numbers are approximate (the implementer confirms each target's exact creation site); the symbol-list globs and the helper are given in full. No "TODO" left in shipped code.
+
+**Risk/verification consistency:** every step that can be checked on macOS (configure, build, Mach-O symbol gate, Catch suite) is a local gate; the ELF version script + Octave `.oct` are explicitly deferred to CI, stated in Task intro, Task 3 Step 3, and Final Verification Step 5.

--- a/include/CoolProp/detail/json.h
+++ b/include/CoolProp/detail/json.h
@@ -17,7 +17,9 @@
 #include "CoolProp/Exceptions.h"
 #include "CoolProp/detail/tools.h"  // for CoolProp::format / CoolPropDbl
 
+#include <cstddef>
 #include <cstdint>
+#include <exception>
 #include <limits>
 #include <stdexcept>
 #include <string>

--- a/include/CoolProp/detail/json.h
+++ b/include/CoolProp/detail/json.h
@@ -3,61 +3,32 @@
 
 // Internal, NON-INSTALLED wrapper around nlohmann/json.
 //
-// Symbol-leak strategy (see migration spec §4): nlohmann is included under
-// hidden ELF/Mach-O visibility so none of its (weak/inline) symbols are
-// exported from CoolProp's shared products. Combined with nlohmann's own
-// versioned inline namespace (nlohmann::json_abi_v3_x_x), this prevents the
-// cross-library ODR/symbol clashes that motivated the migration. Do NOT
-// rename nlohmann's namespace here: Valijson's nlohmann adapter references
-// nlohmann::json literally and a rename would break it.
+// Symbol-leak strategy: nlohmann and valijson symbols are hidden at LINK time
+// per shared product via cmake/CoolPropJSONVisibility.cmake, which applies an
+// ELF --version-script (Linux/ELF) or a Mach-O -unexported_symbols_list
+// (macOS) hide-list to every shared product. This replaces the former
+// compile-time GCC visibility pragma (which poisoned __assert_fail in
+// non-NDEBUG loader builds). Combined with nlohmann's own versioned inline
+// namespace (nlohmann::json_abi_v3_x_x), this prevents cross-library
+// ODR/symbol clashes. Do NOT rename nlohmann's namespace here: Valijson's
+// nlohmann adapter references nlohmann::json literally and a rename would
+// break it.
 
 #include "CoolProp/Exceptions.h"
 #include "CoolProp/detail/tools.h"  // for CoolProp::format / CoolPropDbl
 
-// STOPGAP (CoolProp-rj2i): pre-include — at DEFAULT visibility, BEFORE the
-// hidden-visibility pragma below — the system headers that nlohmann/json and
-// valijson reach. GCC pins a symbol's ELF visibility at its FIRST declaration
-// in a TU. <cassert> re-declares __assert_fail UNGUARDED on every include (to
-// support NDEBUG toggling), so if its first declaration lands inside the hidden
-// region (as it did once these headers were pulled into the loader TUs),
-// __assert_fail becomes GLOBAL HIDDEN UND and the non-NDEBUG shared link (e.g.
-// the docs Octave .oct) cannot bind it. Pinning these externs here keeps them
-// DEFAULT. <cassert> is the essential one (uniquely unguarded); the rest are
-// defense-in-depth for differing include orders. This block AND the pragma are
-// deleted by the link-time export-control rework (Option A) — see
-// docs/superpowers/specs/2026-06-07-json-symbol-visibility-strategy-reassessment-design.md
-#include <cassert>
-#include <cmath>
-#include <cstddef>
 #include <cstdint>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <exception>
-#include <iostream>
 #include <limits>
-#include <memory>
-#include <new>
 #include <stdexcept>
 #include <string>
 #include <string_view>
-#include <system_error>
-#include <typeinfo>
 #include <vector>
-
-#if defined(__GNUC__) || defined(__clang__)
-#    pragma GCC visibility push(hidden)
-#endif
 
 #include <nlohmann/json.hpp>
 #include <valijson/adapters/nlohmann_json_adapter.hpp>
 #include <valijson/schema.hpp>
 #include <valijson/schema_parser.hpp>
 #include <valijson/validator.hpp>
-
-#if defined(__GNUC__) || defined(__clang__)
-#    pragma GCC visibility pop
-#endif
 
 namespace cpjson {
 

--- a/src/Backends/Cubics/UNIFACLibrary.h
+++ b/src/Backends/Cubics/UNIFACLibrary.h
@@ -6,7 +6,6 @@
 #include "CoolProp/detail/json.h"
 #include "CoolProp/CoolPropFluid.h"
 
-
 namespace UNIFACLibrary {
 
 /// A structure containing references for a single group (its multiplicity, main group index, etc.)

--- a/src/Backends/Cubics/UNIFACLibrary.h
+++ b/src/Backends/Cubics/UNIFACLibrary.h
@@ -6,12 +6,6 @@
 #include "CoolProp/detail/json.h"
 #include "CoolProp/CoolPropFluid.h"
 
-// Visibility helper: hide internal nlohmann-taking methods from the exported ABI
-#if defined(__GNUC__) || defined(__clang__)
-#    define CP_JSON_LOCAL __attribute__((visibility("hidden")))
-#else
-#    define CP_JSON_LOCAL
-#endif
 
 namespace UNIFACLibrary {
 
@@ -95,11 +89,10 @@ struct UNIFACParameterLibrary
     std::vector<Component> components;                          ///< The collection of components that are included in this library
 
     /// Convert string to JSON document
-    CP_JSON_LOCAL void jsonize(std::string& s, nlohmann::json& doc);
+    void jsonize(std::string& s, nlohmann::json& doc);
 
     /// Populate internal data structures based on nlohmann::json arrays
-    CP_JSON_LOCAL void populate(const nlohmann::json& group_data, const nlohmann::json& interaction_data, const nlohmann::json& decomp_data);
-#undef CP_JSON_LOCAL
+    void populate(const nlohmann::json& group_data, const nlohmann::json& interaction_data, const nlohmann::json& decomp_data);
 
    public:
     UNIFACParameterLibrary() : m_populated(false) {};

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.h
@@ -16,12 +16,6 @@ using std::shared_ptr;
 #include "Backends/Cubics/GeneralizedCubic.h"
 #include "CoolProp/fluids/Helmholtz.h"
 
-// Visibility helper: hide internal nlohmann-taking methods from the exported ABI
-#if defined(__GNUC__) || defined(__clang__)
-#    define CP_JSON_LOCAL __attribute__((visibility("hidden")))
-#else
-#    define CP_JSON_LOCAL
-#endif
 
 namespace CoolProp {
 
@@ -1206,11 +1200,9 @@ class JSONFluidLibrary
     static void add_many(const std::string& JSON_string);
 
     /// Add all the fluid entries in the nlohmann::json instance passed in
-    CP_JSON_LOCAL void add_many(const nlohmann::json& listing);
+    void add_many(const nlohmann::json& listing);
 
-    CP_JSON_LOCAL void add_one(const nlohmann::json& fluid_json);
-
-#undef CP_JSON_LOCAL
+    void add_one(const nlohmann::json& fluid_json);
 
     std::string get_JSONstring(const std::string& key) {
         // Try to find it

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.h
@@ -16,7 +16,6 @@ using std::shared_ptr;
 #include "Backends/Cubics/GeneralizedCubic.h"
 #include "CoolProp/fluids/Helmholtz.h"
 
-
 namespace CoolProp {
 
 // Forward declaration of the necessary debug function to avoid including the whole header

--- a/src/Backends/Helmholtz/Fluids/FluidLibraryFactories.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibraryFactories.h
@@ -12,8 +12,8 @@
 // `struct Values` (plain/POD fields) plus a single `explicit T(const Values&)`
 // ctor; these factories own all nlohmann parsing and hand a Values across, so
 // no JSON type appears in any installed header. (This is distinct from the
-// CP_JSON_LOCAL hidden-visibility treatment used on internal *loader* methods
-// that must take nlohmann::json directly to consume parsed arrays.)
+// link-time export control via cmake/CoolPropJSONVisibility.cmake that hides
+// nlohmann/valijson symbols per shared product at link time.)
 
 #include "CoolProp/detail/json.h"
 #include "CoolProp/fluids/Ancillaries.h"

--- a/src/Backends/Incompressible/IncompressibleLibrary.h
+++ b/src/Backends/Incompressible/IncompressibleLibrary.h
@@ -8,7 +8,6 @@
 
 #include "CoolProp/detail/json.h"
 
-
 #include <map>
 
 namespace CoolProp {

--- a/src/Backends/Incompressible/IncompressibleLibrary.h
+++ b/src/Backends/Incompressible/IncompressibleLibrary.h
@@ -8,12 +8,6 @@
 
 #include "CoolProp/detail/json.h"
 
-// Visibility helper: hide internal nlohmann-taking methods from the exported ABI
-#if defined(__GNUC__) || defined(__clang__)
-#    define CP_JSON_LOCAL __attribute__((visibility("hidden")))
-#else
-#    define CP_JSON_LOCAL
-#endif
 
 #include <map>
 
@@ -155,9 +149,9 @@ class JSONIncompressibleLibrary
 
    protected:
     /// A general function to parse the json files that hold the coefficient matrices
-    CP_JSON_LOCAL IncompressibleData parse_coefficients(const nlohmann::json& obj, const std::string& id, bool vital);
-    CP_JSON_LOCAL double parse_value(const nlohmann::json& obj, const std::string& id, bool vital, double def);
-    CP_JSON_LOCAL composition_types parse_ifrac(const nlohmann::json& obj, const std::string& id);
+    IncompressibleData parse_coefficients(const nlohmann::json& obj, const std::string& id, bool vital);
+    double parse_value(const nlohmann::json& obj, const std::string& id, bool vital, double def);
+    composition_types parse_ifrac(const nlohmann::json& obj, const std::string& id);
 
    public:
     // Default constructor;
@@ -169,9 +163,8 @@ class JSONIncompressibleLibrary
     };
 
     /// Add all the fluid entries in the nlohmann::json array passed in
-    CP_JSON_LOCAL void add_many(const nlohmann::json& listing);
-    CP_JSON_LOCAL void add_one(const nlohmann::json& fluid_json);
-#undef CP_JSON_LOCAL
+    void add_many(const nlohmann::json& listing);
+    void add_one(const nlohmann::json& fluid_json);
     void add_obj(const IncompressibleFluid& fluid_obj);
 
     /** \brief Get an IncompressibleFluid instance stored in this library

--- a/src/Backends/PCSAFT/PCSAFTLibrary.h
+++ b/src/Backends/PCSAFT/PCSAFTLibrary.h
@@ -9,7 +9,6 @@
 #include "CoolProp/detail/tools.h"
 #include "CoolProp/detail/json.h"
 
-
 namespace CoolProp {
 
 std::string get_mixture_binary_pair_pcsaft(const std::string& CAS1, const std::string& CAS2, const std::string& key);

--- a/src/Backends/PCSAFT/PCSAFTLibrary.h
+++ b/src/Backends/PCSAFT/PCSAFTLibrary.h
@@ -9,12 +9,6 @@
 #include "CoolProp/detail/tools.h"
 #include "CoolProp/detail/json.h"
 
-// Visibility helper: hide internal nlohmann-taking methods from the exported ABI
-#if defined(__GNUC__) || defined(__clang__)
-#    define CP_JSON_LOCAL __attribute__((visibility("hidden")))
-#else
-#    define CP_JSON_LOCAL
-#endif
 
 namespace CoolProp {
 
@@ -32,7 +26,7 @@ class PCSAFTLibraryClass
     /// Map from sorted pair of CAS numbers to interaction parameter map.  The interaction parameter map is a map from key (string) to value (double)
     std::map<std::vector<std::string>, std::vector<Dictionary>> m_binary_pair_map;
 
-    CP_JSON_LOCAL void load_from_JSON(const nlohmann::json& doc);
+    void load_from_JSON(const nlohmann::json& doc);
     void load_from_string(const std::string_view& str);
 
    public:
@@ -42,8 +36,7 @@ class PCSAFTLibraryClass
         return empty;
     };
 
-    CP_JSON_LOCAL int add_many(const nlohmann::json& listing);
-#undef CP_JSON_LOCAL
+    int add_many(const nlohmann::json& listing);
 
     PCSAFTFluid& get(const std::string& key);
     PCSAFTFluid& get(std::size_t key);

--- a/wrappers/Python/CMakeLists.txt
+++ b/wrappers/Python/CMakeLists.txt
@@ -40,6 +40,9 @@ set(ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
 include("${ROOT_DIR}/cmake/CPM.cmake")
 include("${ROOT_DIR}/cmake/dependencies.cmake")
 
+list(APPEND CMAKE_MODULE_PATH "${ROOT_DIR}/cmake")
+include(CoolPropJSONVisibility)
+
 # ============================================================================
 # Generate headers and constants (only when dependencies change)
 # ============================================================================
@@ -195,6 +198,7 @@ target_include_directories(CoolProp_module PRIVATE
 )
 
 target_link_libraries(CoolProp_module PRIVATE miniz)
+coolprop_hide_json_symbols(CoolProp_module)
 
 # Set output name to CoolProp (not CoolProp_module)
 set_target_properties(CoolProp_module PROPERTIES
@@ -225,6 +229,7 @@ target_include_directories(CoolProp_module PRIVATE
 )
 target_link_libraries(CoolProp_module PRIVATE miniz)
 set_target_properties(CoolProp_module PROPERTIES OUTPUT_NAME "CoolProp" PREFIX "")
+coolprop_hide_json_symbols(CoolProp_module)
 
 # ---- PEP 561 type stub for the nanobind core (parity with the legacy wheel) ----
 # The core .so is self-contained (no Python-level imports at init), so nanobind's


### PR DESCRIPTION
## Summary

Replaces the fragile **compile-time** `#pragma GCC visibility push(hidden)` + `CP_JSON_LOCAL` (which poisoned `__assert_fail` in non-NDEBUG loader builds — `CoolProp-rj2i`, the Octave/docs link failure) with **link-time export control**, then deletes the pragma, the rj2i pre-include stopgap, and `CP_JSON_LOCAL`.

**Stacked on #3108 (Phase 5)** — review against that branch; base auto-updates to master when #3108 merges.

- **CMake helper** `coolprop_hide_json_symbols(<target>)` (`cmake/CoolPropJSONVisibility.cmake`) applies, per shared product, an ELF `--version-script` (`{ local: *nlohmann*; *valijson*; };`) or a Mach-O `-unexported_symbols_list`; MSVC is a no-op (opt-in `.def`). Applied to **every** shared product that embeds the loaders: libCoolProp, Octave, Java, C#, VB.NET, R, PHP, Mathematica, Mathcad, the Debian package `.so`, EES, and the Python module (Cython + nanobind).
- **Deleted** the visibility pragma + stopgap pre-includes in `detail/json.h` and the `CP_JSON_LOCAL` macro + uses across the 4 loader headers. With the pragma gone, no compile-time visibility region wraps system headers — **the `__assert_fail` poisoning cannot recur**, and the link-time hide-list is orthogonal (operates on the dynamic symbol table, immune to dependency bumps).

## Verification

- **The decisive local proof:** with the pragma + `CP_JSON_LOCAL` *gone*, the Mach-O symbol gate on `libCoolProp.dylib` stays **green (0 nlohmann/valijson exported)** — the link-time hide-list does the work. Full `~[slow]` suite: 0 failures.
- **Local verification is Mach-O only** (this is an ELF/glibc-class change; dev machine is macOS). The **ELF version script + the Octave `.oct` link are verified by CI** (the docs "Documentation builds (HTML)" job is the end-to-end proof the poisoning is durably fixed).
- The blocking review finding was fixed: the helper resolves the hide-list path relative to its **module file** (`CMAKE_CURRENT_LIST_DIR`), not `CMAKE_SOURCE_DIR` — which under scikit-build (`cmake.source-dir = "wrappers/Python"`) is the wrapper dir, not the repo root — plus a fail-loud `EXISTS` guard. (`link.txt` confirmed → repo-root hide-list.)

## Follow-ups (filed)

- **Extend the symbol gate to the Octave `.oct`** in preflight/CI (today it only checks `libCoolProp` — which is why the `.oct` leak/poison was invisible). Deferred to its own PR (CI-script change, only testable against CI). 
- `CoolProp-w0cm` (the poisoning CI guard) becomes **moot** when this merges — the pragma is gone; close it then. `rj2i` is **permanently fixed** here (the stopgap is deleted, superseded by link-time control).

## Test Plan

- [x] Mach-O symbol gate green **with the pragma deleted** (the link-time hide-list proof)
- [x] `~[slow]` suite 0 failures; loader smoke green; clean build (Catch + shared)
- [x] `link.txt` resolves the hide-list to the repo root (the wheel-build path bug fixed)
- [x] No `CP_JSON_LOCAL` / `pragma GCC visibility` remains
- [ ] **CI: docs "Documentation builds (HTML)" green** (the ELF/Octave end-to-end proof)
- [ ] CI: ELF version-script keeps the public API exported (symbol gate on the Linux `.so`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)