### PR TITLE
build(python): ship the v8 nanobind package as one cp312-abi3 wheel (r9sq.19)

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -132,8 +132,8 @@ jobs:
             name: CoolProp-${{ github.sha }}-clang_format.patch
             path: clang_format.patch
 
-  nanobind-pytest:
-    name: nanobind pytest suite
+  nanobind-abi3:
+    name: nanobind abi3 wheel (build once on 3.12, run on 3.12/3.13/3.14)
     # PR-only (same rationale as clang-format above): avoid master going red
     # retroactively. Open a draft PR to exercise it on a branch.
     if: github.event_name == 'pull_request'
@@ -144,21 +144,57 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Build the nanobind wheel and run the pytest suite
+      - name: Build the cp312-abi3 nanobind wheel (once, on 3.12)
         shell: bash
         run: |
           set -euo pipefail
-          uv venv --python 3.13
-          source .venv/bin/activate
-          uv pip install nanobind cython scikit-build-core ninja pytest mypy numpy
-          # Release: the wheel compiles the whole core (incl. SVDSBTL); Debug is
-          # very slow. COOLPROP_NANOBIND=ON selects the nanobind core + State shim.
-          uv build --wheel --no-build-isolation \
-            --config-setting=cmake.define.COOLPROP_NANOBIND=ON \
+          uv venv --python 3.12 .venv-build
+          source .venv-build/bin/activate
+          uv pip install nanobind cython scikit-build-core ninja
+          # COOLPROP_NANOBIND=ON is the SINGLE signal: it selects the nanobind
+          # core + abi3 Cython sidecars (USE_SABI) in CMake AND triggers
+          # scikit-build-core's wheel.py-api=cp312 override (pyproject.toml), so
+          # this produces ONE cp312-abi3 wheel covering 3.12/3.13/3.14. Release:
+          # the wheel compiles the whole core (incl. SVDSBTL); Debug is very slow.
+          COOLPROP_NANOBIND=ON uv build --wheel --no-build-isolation \
             --config-setting=cmake.define.CMAKE_BUILD_TYPE=Release \
             --out-dir dist .
-          uv pip install --force-reinstall dist/coolprop-*.whl
-          pytest wrappers/Python/pytest -q
+          ls -l dist/
+          # Fail loudly if the abi3 single-wheel promise regressed (e.g. a sidecar
+          # lost USE_SABI, or the wheel.py-api override stopped matching).
+          ls dist/coolprop-*-cp312-abi3-*.whl >/dev/null
+
+      - name: Run the pytest suite on 3.12, 3.13 and 3.14 against the one wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The crux of abi3: the SAME cp312 wheel must install and pass on every
+          # supported interpreter >= 3.12. A version-specific .so or wheel tag
+          # would make pip reject it on 3.13/3.14 here.
+          WHL=$(ls dist/coolprop-*-cp312-abi3-*.whl)
+          ran=0
+          for PY in 3.12 3.13 3.14; do
+            echo "::group::pytest on Python $PY (cp312-abi3 wheel)"
+            uv venv --python "$PY" ".venv-$PY"
+            source ".venv-$PY/bin/activate"
+            # Guard the runtime-dep install: a brand-new interpreter may transiently
+            # lack pytest/numpy cp wheels, which is a toolchain gap, not an abi3
+            # regression -- warn and skip that leg rather than redding the gate. The
+            # `ran` counter below still fails the job if NO interpreter could run, so
+            # a real total breakage can't pass silently. (mypy is best-effort too:
+            # test_stub.py importorskips it.)
+            if ! uv pip install pytest numpy "$WHL"; then
+              echo "::warning::runtime deps unavailable on Python $PY; skipping this leg (abi3 still proven on the other interpreters)"
+              deactivate; echo "::endgroup::"; continue
+            fi
+            uv pip install mypy || echo "::warning::mypy unavailable on $PY; test_stub mypy check will skip"
+            python -c "import sys; print('Python', sys.version.split()[0])"
+            pytest wrappers/Python/pytest -q
+            ran=$((ran + 1))
+            deactivate
+            echo "::endgroup::"
+          done
+          test "$ran" -gt 0 || { echo "::error::no Python interpreter could run the cp312-abi3 wheel"; exit 1; }
 
   clang-tidy:
     name: clang-tidy (diff-only, informational)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,28 @@ wheel.exclude = [
 provider = "coolprop_version_provider"
 provider-path = "dev"
 
+# v8 nanobind build, driven by a single COOLPROP_NANOBIND=ON environment signal
+# (bd CoolProp-r9sq.19).  Both overrides key on the same env var so the build
+# selection and the abi3 wheel tag cannot diverge:
+#
+#   1. select the nanobind package (any Python) by injecting the cmake define --
+#      overrides cannot see -D defines, so the env var is the canonical signal;
+#   2. on Python >= 3.12, also tag the wheel cp312-abi3.  scikit-build-core then
+#      sets SKBUILD_SABI_VERSION, which CMakeLists uses to build the Cython
+#      sidecars (State, _constants) limited-API -- so nanobind's STABLE_ABI core
+#      and the sidecars are all abi3 and ONE wheel covers 3.12/3.13/3.14.
+#
+# Gating (2) on Py>=3.12 leaves the legacy wheel and the 3.9-3.11 per-version
+# nanobind fallback (below nanobind's stable-ABI floor) untouched.
+[[tool.scikit-build.overrides]]
+if.env.COOLPROP_NANOBIND = true
+cmake.define.COOLPROP_NANOBIND = "ON"
+
+[[tool.scikit-build.overrides]]
+if.env.COOLPROP_NANOBIND = true
+if.python-version = ">=3.12"
+wheel.py-api = "cp312"
+
 [tool.cibuildwheel]
 # Build for multiple Python versions (CPython only)
 build = "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"

--- a/wrappers/Python/CMakeLists.txt
+++ b/wrappers/Python/CMakeLists.txt
@@ -31,6 +31,15 @@ find_package(Cython REQUIRED)
 # shipped (legacy Cython) wheel is completely unchanged.  When ON, the nanobind
 # core (CoolProp.<abi3>.so) replaces the legacy Cython CoolProp module and the
 # link-free State capsule shim is built as CoolProp.State.
+#
+# A `COOLPROP_NANOBIND=ON` *environment* build flips this on via a
+# scikit-build-core override (pyproject.toml) that injects
+# cmake.define.COOLPROP_NANOBIND=ON; the same env var (on Py>=3.12) also turns
+# on the abi3 wheel tag.  Both signals flow through ONE scikit-build-core
+# override block, so they cannot diverge.  `-DCOOLPROP_NANOBIND=ON` directly
+# (or via cmake.define) still works for nanobind selection; abi3-ness of the
+# Cython sidecars follows scikit-build-core's own SKBUILD_SABI_VERSION below, so
+# a define-only build simply yields a valid per-version nanobind wheel.
 option(COOLPROP_NANOBIND "Build the nanobind-based CoolProp package (core + State capsule shim)" OFF)
 
 # Set root directory
@@ -164,6 +173,14 @@ add_custom_command(
     VERBATIM
 )
 
+# Extra args injected into the Cython sidecars' Python_add_library() calls.
+# Empty for the legacy build (sidecars stay per-version, WITH_SOABI).  The
+# nanobind branch fills this with `USE_SABI <ver>` whenever scikit-build-core
+# tagged the wheel abi3 (SKBUILD_SABI_VERSION), so the State + _constants
+# extensions are limited-API and the whole wheel is a single cp312-abi3 artifact.
+# See the COOLPROP_NANOBIND branch below.
+set(_sidecar_sabi "")
+
 if(NOT COOLPROP_NANOBIND)
 
 # Generate CoolProp module
@@ -209,6 +226,28 @@ else()
 endif()
 
 else()  # COOLPROP_NANOBIND: nanobind core + capsule State shim
+
+# The nanobind core uses STABLE_ABI (abi3) on Python >= 3.12 automatically; for
+# the wheel to be a single cp312-abi3 artifact the two Cython sidecars (State,
+# _constants) must ALSO be limited-API.  Drive that off scikit-build-core's OWN
+# signal -- SKBUILD_SABI_VERSION, which it sets to e.g. "3.12" exactly when
+# wheel.py-api tagged the wheel abi3, and leaves empty otherwise.  Following the
+# wheel-tag decision (rather than re-deriving abi3 from the Python version or a
+# second env read) guarantees the .so ABI and the wheel tag can never disagree:
+# an abi3-tagged wheel always gets abi3 sidecars, a version-specific wheel always
+# gets per-version sidecars.  So Py<3.12, a define-only nanobind build (no abi3
+# tag), and a direct cmake build all correctly fall back to per-version sidecars.
+# USE_SABI (FindPython) defines Py_LIMITED_API, links Python::SABIModule, and
+# gives the module the .abi3 SOABI suffix.
+if(DEFINED SKBUILD_SABI_VERSION AND SKBUILD_SABI_VERSION)
+    if(NOT TARGET Python::SABIModule)
+        message(FATAL_ERROR
+            "scikit-build-core requested an abi3 wheel (SABI ${SKBUILD_SABI_VERSION}) "
+            "but the Development.SABIModule component (CMake >= 3.26) is missing, so "
+            "the Cython sidecars cannot be built limited-API; have CMake ${CMAKE_VERSION}.")
+    endif()
+    set(_sidecar_sabi USE_SABI ${SKBUILD_SABI_VERSION})
+endif()
 
 # ---- nanobind core (CoolProp.<abi3>.so) replaces the legacy Cython module ----
 execute_process(
@@ -257,7 +296,7 @@ add_custom_command(
     COMMENT "Cythonizing State.pyx (capsule shim)"
     VERBATIM
 )
-Python_add_library(State_module MODULE WITH_SOABI
+Python_add_library(State_module MODULE WITH_SOABI ${_sidecar_sabi}
     "${CMAKE_CURRENT_BINARY_DIR}/CoolProp/State.cpp"
 )
 target_include_directories(State_module PRIVATE
@@ -273,8 +312,9 @@ endif()
 
 endif()  # COOLPROP_NANOBIND
 
-# Create _constants extension module
-Python_add_library(_constants_module MODULE WITH_SOABI
+# Create _constants extension module.  `_sidecar_sabi` is empty for the legacy
+# build (per-version) and `USE_SABI <ver>` for the nanobind abi3 build.
+Python_add_library(_constants_module MODULE WITH_SOABI ${_sidecar_sabi}
     "${CMAKE_CURRENT_BINARY_DIR}/CoolProp/_constants.cpp"
 )
 

--- a/wrappers/Python/pytest/test_abi3.py
+++ b/wrappers/Python/pytest/test_abi3.py
@@ -1,0 +1,76 @@
+"""Guard the abi3 single-wheel invariant (bd CoolProp-r9sq.19).
+
+The v8 nanobind package, when built with ``COOLPROP_NANOBIND=ON`` on Python
+>= 3.12, ships as ONE ``cp312-abi3`` wheel that must run unchanged on
+3.12/3.13/3.14.  The load-bearing invariant this module enforces:
+
+    if the installed wheel is tagged abi3, every shipped extension module must
+    be limited-API (``.abi3.so``).
+
+A version-specific ``.so`` inside an abi3-tagged wheel imports fine on the build
+interpreter but fails to load on every *other* minor version -- exactly the
+silent cross-version breakage abi3 is meant to prevent, and the kind of mixed
+artifact that is otherwise invisible until a user on a different Python hits it.
+
+This is a *consistency* check, valid for any install.  A per-version nanobind
+wheel -- a define-only build (``-DCOOLPROP_NANOBIND=ON`` without the env signal
+that triggers ``wheel.py-api``), or any build on Python < 3.12 below nanobind's
+stable-ABI floor -- is correctly tagged version-specific and legitimately
+carries version-specific sidecars, so the invariant does not apply and the test
+skips.  That the *shipped* wheel actually IS abi3 is enforced separately by the
+``nanobind-abi3`` CI job, which asserts a ``cp312-abi3`` wheel is produced and
+then installs + runs it on 3.12, 3.13 AND 3.14.
+"""
+import sys
+import importlib
+import importlib.metadata as importlib_metadata
+
+import pytest
+
+# nanobind-only: the capsule State shim is absent in the legacy build, so this
+# whole module is skipped there rather than reported as a failure.
+pytest.importorskip("CoolProp.State", reason="legacy (non-nanobind) build")
+
+# The nanobind core, the capsule State shim, and the _constants cimport-surface
+# backing module -- all three ship inside the wheel.
+_MODULES = ["CoolProp.CoolProp", "CoolProp.State", "CoolProp._constants"]
+
+
+def _installed_wheel_is_abi3():
+    """True iff the installed CoolProp distribution's wheel tag is abi3.
+
+    Reads the wheel's recorded ``Tag:`` lines from its dist-info ``WHEEL`` file.
+    Returns False when there is no wheel metadata (editable / in-tree install)
+    or the dist cannot be found -- in those cases there is no abi3 claim to hold
+    the extensions to, so the invariant simply does not apply.
+    """
+    try:
+        wheel_meta = importlib_metadata.distribution("CoolProp").read_text("WHEEL") or ""
+    except importlib_metadata.PackageNotFoundError:  # pragma: no cover
+        return False
+    tags = [
+        line.split(":", 1)[1].strip()
+        for line in wheel_meta.splitlines()
+        if line.startswith("Tag:")
+    ]
+    return any("abi3" in t for t in tags)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith(("linux", "darwin")),
+    reason="abi3 SOABI filename check is POSIX-specific (.abi3.so)",
+)
+@pytest.mark.skipif(
+    not _installed_wheel_is_abi3(),
+    reason="per-version wheel (or no wheel metadata): version-specific .so are correct here",
+)
+@pytest.mark.parametrize("modname", _MODULES)
+def test_abi3_wheel_ships_only_abi3_extensions(modname):
+    """An abi3-tagged wheel must contain only limited-API ``.abi3.so``."""
+    mod = importlib.import_module(modname)
+    path = getattr(mod, "__file__", "") or ""
+    assert path.endswith(".abi3.so"), (
+        "%s loaded from %r inside an abi3-tagged wheel; expected a limited-API "
+        ".abi3.so.  A version-specific .so in an abi3 wheel imports on the build "
+        "interpreter but breaks on other minor versions (r9sq.19)." % (modname, path)
+    )


### PR DESCRIPTION
## What

Makes the v8 **nanobind** Python package fully **abi3** so a single `cp312-abi3` wheel covers Python 3.12/3.13/3.14. The nanobind core already used `STABLE_ABI`, but the two Cython sidecars (`State`, `_constants`) were version-specific — which silently broke the single-wheel promise (an abi3 core inside a wheel that still can't install cross-version). Caught in pre-PR review of the abi3-CI work (#r9sq.6).

This is **gated and default-off**: nothing builds nanobind/abi3 unless `COOLPROP_NANOBIND=ON` is set. The shipped legacy Cython wheel is byte-identical.

## Design — one signal, single source of truth

A single `COOLPROP_NANOBIND=ON` **environment** variable drives everything, so the `.so` ABI and the wheel tag *cannot* disagree:

- **`pyproject.toml`** — two `[[tool.scikit-build.overrides]]`, both keyed on `if.env.COOLPROP_NANOBIND=true`:
  1. inject `cmake.define.COOLPROP_NANOBIND=ON` (select the nanobind build, any Python);
  2. on `if.python-version >=3.12`, set `wheel.py-api=cp312` (tag the wheel abi3).
- **`wrappers/Python/CMakeLists.txt`** — the `COOLPROP_NANOBIND` option is plain again (no env parsing). The Cython sidecars take `USE_SABI ${SKBUILD_SABI_VERSION}` **only when scikit-build-core actually tagged the wheel abi3**. scikit-build-core derives the wheel tag *and* `SKBUILD_SABI_VERSION` from one computation over `wheel.py-api`, so an abi3 wheel always gets abi3 sidecars; a per-version build (define-only, or Py<3.12) gets per-version sidecars + an honest version-specific tag.

## CI — the cross-version proof

`dev_checks.yml` `nanobind-abi3` job builds the wheel **once on 3.12**, asserts it is `cp312-abi3`, then installs + runs the full pytest suite on **3.12 / 3.13 / 3.14** against that one wheel. Runtime-dep installs on a leg degrade to a warning if a brand-new interpreter lacks wheels, but the job fails if *no* leg ran.

`test_abi3.py` enforces the consistency invariant: if the installed wheel is abi3-tagged, every shipped extension must be a limited-API `.abi3.so` (skips for a per-version wheel).

## Validation (local)

- `COOLPROP_NANOBIND=ON` env alone → `coolprop-…-cp312-abi3-….whl`, all three `.so` are `.abi3.so`.
- That cp312 wheel installs and the **full suite passes on both 3.13.12 and 3.14.3** (39 passed / 2 skipped / 2 xfailed).
- The define-only path (`-DCOOLPROP_NANOBIND=ON` without the env) yields a **valid, honestly-tagged `cp313-cp313`** per-version wheel — not a broken mixed artifact.

Unblocks the abi3 matrix reduction in `r9sq.6`.

bd CoolProp-r9sq.19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional stable ABI (abi3) wheel building for enhanced cross-version Python compatibility
  * Extended testing and support to Python 3.14

* **Tests**
  * Enhanced test coverage across Python 3.12, 3.13, and 3.14
  * Added validation for stable ABI extension modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->