### PR TITLE
CI: broaden + gate installed-header hygiene — no shipped header pulls nlohmann/valijson (CoolProp-xa8w.5)

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -476,3 +476,28 @@ jobs:
 
       - name: Check pinned fastchebpure release matches current EOS
         run: python3 dev/scripts/check_superanc_release_pin.py
+
+  installed-header-gate:
+    name: Installed-header hygiene gate
+    # Fail if any internal/JSON-pulling header (detail/json.h, or anything
+    # that #includes nlohmann/valijson) is shipped in the installed tree.
+    # This is the install-side companion to the symbol-leak gate
+    # (check-json-symbols.sh): the symbol gate catches runtime ABI leaks;
+    # this gate catches source-level leaks that would expose nlohmann/valijson
+    # to downstream consumers at compile time.  Real gate — no continue-on-error.
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Configure shared build
+        run: |
+          cmake -B build_shared -S . \
+            -DCOOLPROP_SHARED_LIBRARY=ON \
+            -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build shared library
+        run: cmake --build build_shared -j$(nproc)
+
+      - name: Run installed-header hygiene gate
+        run: ./dev/ci/check-installed-headers.sh build_shared

--- a/dev/ci/check-installed-headers.sh
+++ b/dev/ci/check-installed-headers.sh
@@ -1,14 +1,29 @@
 #!/usr/bin/env bash
 # Fail if forbidden internal headers are shipped in the installed tree.
 #
-# Enforced today: include/CoolProp/detail/json.h (which #includes
-# nlohmann/json.hpp + valijson) must NOT be installed.  detail/rapidjson.h MUST
-# still be installed (positive control — it is reachable via Configuration.h and
-# is only removed at Phase Final; its presence proves the exclude is specific,
-# not over-broad).
+# Two assertions:
 #
-# Fail-closed: a failed `cmake --install`, an empty install tree, or a missing
-# positive-control header is a FAILURE, never a vacuous pass (same discipline as
+#  1. detail/json.h must NOT ship.  That header #includes nlohmann/json.hpp
+#     and valijson; it is internal-only and is excluded by CMake's install
+#     rules.  Its presence in the installed tree is a hard failure.
+#
+#  2. No shipped header may #include nlohmann or valijson.  This is the
+#     install-side companion to the symbol-leak gate (check-json-symbols.sh):
+#     even if detail/json.h is correctly excluded, a newly added public header
+#     that transitively pulls nlohmann/valijson would be a regression.
+#
+# Generic positive control: at least ONE installed header matching
+# */detail/*.h (other than detail/json.h) must be present.  This proves the
+# CMake EXCLUDE is specific to json.h and is not over-broad (e.g. wiping the
+# whole detail/ subtree).  Candidates that satisfy this today:
+# detail/configuration_keys.h, detail/strings.h, detail/tools.h,
+# detail/CachedElement.h, detail/filepaths.h, detail/msgpack.h,
+# detail/PlatformDetermination.h, detail/state_capi.h, detail/atomic_write.h.
+# This control does NOT name detail/rapidjson.h because Phase Final will
+# delete that header; any of the above is sufficient.
+#
+# Fail-closed: a failed `cmake --install`, an empty install tree, or a
+# violated assertion is a FAILURE, never a vacuous pass (same discipline as
 # check-json-symbols.sh — no `|| true` that masks a real failure).
 set -euo pipefail
 
@@ -33,13 +48,15 @@ if [ "$NHEADERS" -eq 0 ]; then
     exit 1
 fi
 
-# Positive control: detail/rapidjson.h MUST ship (exclude must not be over-broad).
-if ! find "$PREFIX" -path '*/detail/rapidjson.h' | grep -q .; then
-    echo "FAIL: detail/rapidjson.h is absent from the install tree — exclude too broad or install layout changed." >&2
+# Generic positive control: at least one detail/*.h other than detail/json.h
+# must ship, proving the CMake EXCLUDE is specific to json.h, not over-broad.
+DETAIL_OTHER="$(find "$PREFIX" -path '*/detail/*.h' ! -name 'json.h' | head -1)"
+if [ -z "$DETAIL_OTHER" ]; then
+    echo "FAIL: no detail/*.h (other than json.h) found in the install tree — CMake EXCLUDE too broad or install layout changed." >&2
     exit 1
 fi
 
-# The assertion: detail/json.h must NOT ship.
+# Assertion 1: detail/json.h must NOT ship.
 LEAKED="$(find "$PREFIX" -path '*/detail/json.h' || true)"
 if [ -n "$LEAKED" ]; then
     echo "FAIL: detail/json.h is shipped in the installed headers (it pulls nlohmann/json.hpp + valijson):" >&2
@@ -47,9 +64,16 @@ if [ -n "$LEAKED" ]; then
     exit 1
 fi
 
-echo "OK: detail/json.h not installed; detail/rapidjson.h present (${NHEADERS} headers from ${BUILD_DIR})"
+# Assertion 2: no shipped header may #include nlohmann or valijson.
+# grep -El exits 1 on no match (the PASS case) and 0 on match (the FAIL case).
+# The `|| true` prevents set -e from aborting on the no-match exit code; the
+# actual gate is the `-n` test below, which is fail-closed.
+LEAKING_INCLUDES="$(grep -rEl '#[[:space:]]*include[[:space:]]*[<"]((nlohmann|valijson)/)' \
+    "$PREFIX" --include='*.h' --include='*.hpp' || true)"
+if [ -n "$LEAKING_INCLUDES" ]; then
+    echo "FAIL: installed header(s) #include nlohmann/valijson (must stay internal):" >&2
+    printf '%s\n' "$LEAKING_INCLUDES" >&2
+    exit 1
+fi
 
-# TODO(superancillary de-leak): once superancillary.h no longer #includes
-# nlohmann/json.hpp, broaden this to assert that NO shipped header pulls
-# nlohmann/valijson (grep the installed tree), making it the install-side
-# companion to the symbol-leak gate.
+echo "OK: detail/json.h not installed; no shipped header pulls nlohmann/valijson; detail/ control header present (${NHEADERS} headers from ${BUILD_DIR})"

--- a/dev/ci/preflight.sh
+++ b/dev/ci/preflight.sh
@@ -205,9 +205,9 @@ elif skip_check build; then
 elif [ ! -d build_shared ]; then
     skip "install-headers" "build_shared not available (run without --skip=json-symbols)"
 elif ./dev/ci/check-installed-headers.sh build_shared; then
-    ok "install-headers (detail/json.h not shipped)"
+    ok "install-headers (detail/json.h not shipped; no installed header pulls nlohmann/valijson)"
 else
-    fail "install-headers (detail/json.h shipped, or install failed; see /tmp/install-headers-check.log)"
+    fail "install-headers (detail/json.h shipped, or a header pulls nlohmann/valijson, or install failed; see /tmp/install-headers-check.log)"
 fi
 
 # ---------- check 3: Catch2 tests with auto-selected tag scope -------


### PR DESCRIPTION
## Summary

Broadens `dev/ci/check-installed-headers.sh` into a full install-side companion to the symbol-leak gate, and wires it into **CI** (it was preflight-only).

- **Generic positive control:** instead of naming `detail/rapidjson.h` (which Phase Final deletes), assert that *some* `detail/*.h` other than `json.h` ships — proves the install exclude is specific to `json.h`, not over-broad, and is robust to the rapidjson deletion (9 other `detail/*.h` satisfy it today).
- **New assertion:** FAIL if **any** installed header `#include`s `nlohmann/` or `valijson/` — the install-side guarantee that the JSON libraries stay internal. Holds on master now that superancillary is de-leaked (#3104) and `detail/json.h` is install-excluded (#3100).
- New `installed-header-gate` job in `dev_checks.yml` (build shared → run the script). Real gate, no `continue-on-error`.
- Removes the now-completed `TODO(superancillary de-leak)`.

## Fail-closed discipline
Every guard was adversarially tested to fire: bad build dir (`exit 2`), failed install, empty tree, over-broad exclude (no other `detail/*.h`), `detail/json.h` shipped, and a header that pulls nlohmann/valijson. The single `|| true` is on `grep -l`'s *no-match* (the PASS case) and cannot mask a real leak — verified.

## Verification
- Local: `OK: detail/json.h not installed; no shipped header pulls nlohmann/valijson; detail/ control header present (93 headers)`, exit 0.
- Adversarial review: no blocking findings (one minor noted trade-off: the basename-scoped `! -name json.h` slightly weakens — never disables — the positive control).

Independent of the RapidJSON-removal stack. Companion to #PR-xa8w.7; both touch `dev_checks.yml` (trivial rebase for whichever merges second).

## Test Plan
- [x] Local gate green; each guard verified to fire; YAML valid
- [ ] CI: `installed-header-gate` builds + installs and reports `OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation in continuous integration to verify internal headers are properly excluded from public package installations.
  * Enhanced header exclusion checks to ensure specified internal headers are not inadvertently shipped.
  * Improved error messaging in validation scripts for clearer feedback on installation validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->