### PR TITLE
chore(json): remove vestigial RapidJSON references + close nanobind hide-gap (post CoolProp-xa8w)

### DIFF
--- a/Web/coolprop/BackendOptions.rst
+++ b/Web/coolprop/BackendOptions.rst
@@ -115,8 +115,9 @@ logging.  The shared helper:
 
 * Sorts object keys recursively.
 * Preserves array order.
-* Uses RapidJSON's default formatting for scalars (deterministic
-  within a single CoolProp build).
+* Uses nlohmann/json's ``std::map``-backed object serialisation, which
+  sorts keys at every nesting level (deterministic within a single
+  CoolProp build).
 
 It is **not** strict `RFC 8785 (JCS)
 <https://datatracker.ietf.org/doc/html/rfc8785>`_ — no NFC string
@@ -158,11 +159,11 @@ override the options-aware ``AbstractStateGenerator`` virtual:
        AbstractState* get_AbstractState(
            const std::vector<std::string>& fluid_names,
            const std::string& options_json) override {
-           rapidjson::Document opts;
-           if (!options_json.empty()) opts.Parse(options_json);
-           else                       opts.SetObject();
-           validate_against_schema(opts, kMyBackendOptionsSchemaJson);
-           // ...construct using the parsed options...
+           // Validate the options JSON string against the backend's schema
+           // (throws CoolProp::ValueError on a mismatch).
+           CoolProp::validate_json_against_schema(options_json, kMyBackendOptionsSchemaJson);
+           // ...parse internally if needed (auto opts = cpjson::parse(options_json);)
+           // and construct using the validated options...
        }
        AbstractState* get_AbstractState(
            const std::vector<std::string>& fluid_names) override {

--- a/dev/ci/check-installed-headers.sh
+++ b/dev/ci/check-installed-headers.sh
@@ -19,8 +19,8 @@
 # detail/configuration_keys.h, detail/strings.h, detail/tools.h,
 # detail/CachedElement.h, detail/filepaths.h, detail/msgpack.h,
 # detail/PlatformDetermination.h, detail/state_capi.h, detail/atomic_write.h.
-# This control does NOT name detail/rapidjson.h because Phase Final will
-# delete that header; any of the above is sufficient.
+# This control does NOT name detail/rapidjson.h (that header was deleted in
+# Phase Final); any of the above is sufficient.
 #
 # Fail-closed: a failed `cmake --install`, an empty install tree, or a
 # violated assertion is a FAILURE, never a vacuous pass (same discipline as

--- a/dev/ci/preflight.sh
+++ b/dev/ci/preflight.sh
@@ -154,8 +154,9 @@ fi
 # shared object, so this MUST inspect a .so/.dylib — never the static
 # .a (the Catch runner links the archive).  preflight builds the Catch
 # runner against a static/object lib, so we maintain a dedicated
-# build_shared dir for this gate.  RapidJSON is intentionally NOT in the
-# default pattern (it is still exported today, by design, mid-migration).
+# build_shared dir for this gate.  The gate's default pattern is
+# `nlohmann|valijson|rapidjson`; RapidJSON has been removed, so its
+# symbols must not be exported either.
 step "JSON symbol leak (shared library)"
 if skip_check json-symbols; then
     skip "json-symbols" "--skip=json-symbols"

--- a/dev/generate_headers.py
+++ b/dev/generate_headers.py
@@ -56,7 +56,7 @@ values = [
     # all_fluids is embedded as CBOR (all_fluids_CBOR.h via zvalues below); the
     # uncompressed all_fluids_JSON.h string header is no longer consumed by any
     # source and is not generated. The remaining *_JSON.h headers are still used
-    # by the (rapidjson-based) incompressible / mixture / cubic / PC-SAFT loaders.
+    # by the (nlohmann/json-based) incompressible / mixture / cubic / PC-SAFT loaders.
     ('all_incompressibles.json', 'all_incompressibles_JSON.h', 'all_incompressibles_JSON'),
     ('mixtures/mixture_departure_functions.json', 'mixture_departure_functions_JSON.h', 'mixture_departure_functions_JSON'),
     ('mixtures/mixture_binary_pairs.json', 'mixture_binary_pairs_JSON.h', 'mixture_binary_pairs_JSON'),

--- a/dev/pdsim_cimport_contract/SURFACE.md
+++ b/dev/pdsim_cimport_contract/SURFACE.md
@@ -64,31 +64,28 @@ input pair `PT_INPUTS`
    root (site-packages). v8 should ship `__init__.pxd` (even empty) to make the
    surface cleanly cimportable.
 
-3. **The public surface *leaks* implementation includes — fmt and rapidjson
-   are NOT part of PDSim's interface.** Nothing in the `State`/`AbstractState`
-   API signatures uses an fmt or rapidjson type; they are dragged in purely by
-   transitive `#include`:
-     * **rapidjson** ← `constants_header.pxd` does `cdef extern from
-       "Configuration.h"` just to read the `configuration_keys` enum, and
-       `Configuration.h` pulls `rapidjson_include.h`.
+3. **The public surface *leaks* fmt — it is NOT part of PDSim's interface.**
+   Nothing in the `State`/`AbstractState` API signatures uses an fmt type;
+   it is dragged in purely by transitive `#include`:
      * **fmt** ← `AbstractState.h → CachedElement.h → CoolPropTools.h →
        CPstrings.h`, whose inline `format()` helpers call `fmt::sprintf`.
      * **C++17 `std::filesystem`** ← `CoolPropTools.h → CPfilepaths.h`
        (`write_bytes_atomic`).
 
-   The fix is header hygiene, **not** bundling: split a lean
-   `configuration_keys` enum header (no rapidjson) for the pxd to extern from;
-   move the `format()` bodies out of `CPstrings.h` into a `.cpp`;
-   forward-declare/pimpl the `std::filesystem::path` parameter. After that a
-   downstream consumer (and the frozen v8 `State` shim) compiles with only
-   `CoolProp.get_include_directory()` and **zero** third-party `-I` flags.
+   **RapidJSON leak resolved (v8 migration).** The former rapidjson leak via
+   `Configuration.h → rapidjson_include.h` was eliminated by the v8
+   RapidJSON→nlohmann/json migration: JSON types no longer appear in installed
+   headers, and link-time symbol hiding (`coolprop_hide_json_symbols`) keeps
+   nlohmann/valijson out of the dynamic export table.
 
-   This also unblocks retiring rapidjson (last release ~2016): once it no
-   longer appears in the *public/cimport* surface, swapping it out is a pure
-   implementation change — invisible to PDSim and to this contract test. The
-   fmt/rapidjson `-I` paths in `setup_contract.py` are a STOPGAP for today's
-   leakage; once the surface is cleaned, delete them and this test becomes the
-   regression guard that the leak has not returned.
+   The remaining fix is header hygiene for fmt: move the `format()` bodies out
+   of `CPstrings.h` into a `.cpp` and forward-declare/pimpl the
+   `std::filesystem::path` parameter. After that a downstream consumer (and the
+   frozen v8 `State` shim) compiles with only `CoolProp.get_include_directory()`
+   and **zero** third-party `-I` flags. The fmt `-I` path in `setup_contract.py`
+   is a STOPGAP for today's remaining leakage; once the surface is cleaned,
+   delete it and this test becomes the regression guard that the leak has not
+   returned.
 
 4. **The contract is link-free.** The built module links with no `-lCoolProp`
    (`-undefined dynamic_lookup`); the cdef-class methods resolve at runtime
@@ -104,6 +101,5 @@ RUN_PDSIM_CIMPORT_CONTRACT=1 python -m pytest dev/pdsim_cimport_contract/test_pd
 
 The pytest wrapper is opt-in (skips unless `RUN_PDSIM_CIMPORT_CONTRACT` is set)
 so it isn't pulled into default collection — it compiles a shim against the
-installed CoolProp. The build auto-locates fmt/rapidjson from any in-repo
-`build*/_deps/…`; override with `COOLPROP_FMT_INCLUDE` / `COOLPROP_RAPIDJSON_INCLUDE`
-if needed.
+installed CoolProp. The build auto-locates fmt from any in-repo
+`build*/_deps/…`; override with `COOLPROP_FMT_INCLUDE` if needed.

--- a/dev/pdsim_cimport_contract/setup_contract.py
+++ b/dev/pdsim_cimport_contract/setup_contract.py
@@ -27,13 +27,12 @@ include_dirs = [
 def _find_dep_include(header_relpath, env_var, fetch_glob):
     """STOPGAP for header leakage, not a real PDSim dependency.
 
-    CoolProp's public/cimport surface currently *leaks* fmt and rapidjson as
-    transitive includes (fmt via CPstrings.h's inline format() helpers;
-    rapidjson via constants_header.pxd -> Configuration.h, only for the
-    configuration_keys enum).  Neither appears in any State/AbstractState API
-    signature.  Until the headers are de-leaked (see SURFACE.md finding 3),
-    this build needs the extra -I paths; after that, delete these calls and the
-    contract still compiles with only CoolProp.get_include_directory()."""
+    CoolProp's public/cimport surface currently *leaks* fmt as a transitive
+    include (fmt via CPstrings.h's inline format() helpers).  It does NOT
+    appear in any State/AbstractState API signature.  Until the header is
+    de-leaked (see SURFACE.md finding 3), this build needs the extra -I path;
+    after that, delete these calls and the contract still compiles with only
+    CoolProp.get_include_directory()."""
     import glob
     import subprocess
     # Search build trees in every checkout that shares this repo: this worktree
@@ -68,8 +67,6 @@ def _find_dep_include(header_relpath, env_var, fetch_glob):
 
 include_dirs.append(_find_dep_include(
     "fmt/format.h", "COOLPROP_FMT_INCLUDE", "build*/_deps/fmt-src/include"))
-include_dirs.append(_find_dep_include(
-    "rapidjson/rapidjson.h", "COOLPROP_RAPIDJSON_INCLUDE", "build*/_deps/rapidjson-src/include"))
 
 ext = Extension(
     "pdsim_surface",

--- a/dev/state_capsule/increment3.py
+++ b/dev/state_capsule/increment3.py
@@ -61,8 +61,7 @@ def build_extensions():
     from Cython.Build import cythonize
 
     incs = [INCLUDE, os.path.join(sys.prefix, "include", f"python{sys.version_info.major}.{sys.version_info.minor}")]
-    for hdr, g in [("fmt/format.h", "build*/_deps/fmt-src/include"),
-                   ("rapidjson/rapidjson.h", "build*/_deps/rapidjson-src/include")]:
+    for hdr, g in [("fmt/format.h", "build*/_deps/fmt-src/include")]:
         d = find_dep(hdr, g)
         if d:
             incs.append(d)

--- a/src/Backends/PCSAFT/PCSAFTFluidFactory.h
+++ b/src/Backends/PCSAFT/PCSAFTFluidFactory.h
@@ -3,7 +3,7 @@
 
 // NON-INSTALLED factory that builds a PCSAFTFluid from nlohmann::json. Lives
 // under src/ so the nlohmann::json type never appears in the installed
-// PCSAFTFluid.h. Mirrors the (now-removed) rapidjson constructor.
+// PCSAFTFluid.h. Mirrors the former JSON-document constructor this factory replaced.
 
 #include "CoolProp/detail/json.h"
 #include "CoolProp/fluids/PCSAFTFluid.h"

--- a/src/Tests/CoolProp-Tests-CBOR.cpp
+++ b/src/Tests/CoolProp-Tests-CBOR.cpp
@@ -1,4 +1,4 @@
-// Byte-equivalence gate (RapidJSON->nlohmann Phase 1): the embedded CBOR blob
+// Byte-equivalence gate: the embedded CBOR blob
 // must decode to exactly the source dev/all_fluids.json (value-equality). Catches
 // encoder/decoder drift (cbor2/nlohmann version bumps) and staleness.
 #if defined(ENABLE_CATCH)

--- a/src/Tests/CoolProp-Tests-JSONHelpers.cpp
+++ b/src/Tests/CoolProp-Tests-JSONHelpers.cpp
@@ -1,5 +1,4 @@
-// Catch2 tests for the nlohmann-backed cpjson helpers and Valijson schema
-// validation (RapidJSON→nlohmann migration, Phase 0).
+// Catch2 tests for the nlohmann-backed cpjson helpers and Valijson schema validation.
 
 #if defined(ENABLE_CATCH)
 

--- a/src/Tests/CoolProp-Tests-SVDSBTLOptions.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTLOptions.cpp
@@ -50,10 +50,9 @@ TEST_CASE("SVDSBTL options: schema validation rejects bad payloads", "[SVDSBTL][
         REQUIRE_THROWS_AS(factory(R"({"grid":{"NT":1}})"), CoolProp::ValueError);
     }
     SECTION("grid.NT above schema maximum (would overflow GetInt() otherwise)") {
-        // Schema caps NT at 100_000 so RapidJSON's GetInt() (int32) is
-        // safe inside resolve_grid().  Without this the validator would
-        // accept NT >= 2 unbounded and GetInt() could hit a RapidJSON
-        // assertion on values past INT32_MAX.
+        // Schema caps NT at 100_000 so integer parsing in resolve_grid()
+        // stays within range.  Without this cap the validator would accept
+        // NT >= 2 unbounded, and values past INT32_MAX would overflow.
         REQUIRE_THROWS_AS(factory(R"({"grid":{"NT":2147483648}})"), CoolProp::ValueError);
         REQUIRE_THROWS_AS(factory(R"({"grid":{"NR":2147483648}})"), CoolProp::ValueError);
         REQUIRE_THROWS_AS(factory(R"({"grid":{"rank":2147483648}})"), CoolProp::ValueError);

--- a/wrappers/Python/nanobind/CMakeLists.txt
+++ b/wrappers/Python/nanobind/CMakeLists.txt
@@ -47,3 +47,8 @@ nanobind_add_module(CoolProp STABLE_ABI ${COOLPROP_APP_SOURCES} "${ROOT_DIR}/src
 # generated headers (gitrevision.h, cpversion.h, all_fluids_JSON*.h, ...).
 # Depend on the core's generator target so a fresh checkout builds in one shot.
 add_dependencies(CoolProp generate_headers)
+
+# Hide nlohmann/valijson symbols from the module's dynamic export table (link-time
+# export control), matching the main wrappers/Python build. nanobind already
+# compiles -fvisibility=hidden, so this is defense-in-depth + consistency.
+coolprop_hide_json_symbols(CoolProp)


### PR DESCRIPTION
## Summary

Post-migration polish from a four-agent vestigial-code sweep of the completed RapidJSON → nlohmann/json + Valijson epic. The migration itself was clean (zero dangling references to the deleted `CP_JSON_LOCAL`, `CPJSON_SCHEMA_VALIDATION_CODE_DEFINED`, `detail/rapidjson.h`, `rapidjson_include.h`, the pragma, or the casts). What remained was stale comments/docs and one consistency gap:

**One real (consistency) fix:**
- `wrappers/Python/nanobind/CMakeLists.txt` — the standalone nanobind build compiled `${COOLPROP_APP_SOURCES}` (the JSON loaders) without `coolprop_hide_json_symbols(CoolProp)`, unlike the main Python build. Added it. *(Not a live leak — nanobind already compiles `-fvisibility=hidden` — but defense-in-depth + consistency.)*

**Stale comments / docs that referenced removed things:**
- `dev/ci/preflight.sh` — comment claimed RapidJSON was *intentionally excluded* from the gate pattern "mid-migration"; the gate now **includes** rapidjson. Corrected.
- `Web/coolprop/BackendOptions.rst` — replaced a `rapidjson::Document opts; opts.Parse(...)` code example that **would not compile** with the current string-based `validate_json_against_schema(...)` API; fixed the "RapidJSON formatting" canonical-JSON note to describe nlohmann's `std::map`-backed serialisation.
- `dev/ci/check-installed-headers.sh` — "Phase Final *will* delete…" → past tense.
- `dev/generate_headers.py` — "(rapidjson-based) loaders" → "(nlohmann/json-based)".
- `src/Tests/CoolProp-Tests-CBOR.cpp`, `-JSONHelpers.cpp` — dropped "RapidJSON→nlohmann Phase 0/1" markers.
- `src/Tests/CoolProp-Tests-SVDSBTLOptions.cpp` — reworded a `GetInt()`/RapidJSON-assertion comment to be library-neutral (assertions unchanged).
- `src/Backends/PCSAFT/PCSAFTFluidFactory.h` — "(now-removed) rapidjson constructor" → library-neutral wording.
- `dev/pdsim_cimport_contract/{setup_contract.py,SURFACE.md}`, `dev/state_capsule/increment3.py` — removed the now-dead `rapidjson/rapidjson.h` dependency search + updated the "leak unsolved/STOPGAP" note to "resolved by the v8 migration".

**Deliberately left untouched:**
- The SVDSBTL **"Phase 2a/2b/2c"** markers in `CoolProp-Tests-SBTL*.cpp` / `src/SBTL/*.cpp` — those are from the SVDSBTL backend work, **not** this epic.
- `dev/json_migration_bench/` (intentional nlohmann-vs-rapidjson benchmark artifact) and accurate historical references (changelog, `dependencies.cmake` "replacement for rapidjson" note, the gate scripts that now list rapidjson as a must-not-export symbol).
- `dev/codelite/coolprop.project` — a stale CodeLite IDE project file lists rapidjson include paths; out of scope (no build/runtime effect; the build is CMake-based). Noted for a future IDE-config sweep if desired.

## Test Plan
- [x] `git grep rapidjson` survivors all reviewed — only legitimate historical/changelog/gate references remain
- [x] `ast.parse` clean on touched `.py`; `bash -n` clean on touched scripts; rST code-block indentation sane
- [x] No production C++ logic changed (comments/docs/additive CMake call/dead-code only); logic-bearing changes reviewed
- [ ] CI: docs build renders BackendOptions.rst; library/wrapper builds unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * JSON object serialization now produces deterministically sorted keys at all nesting levels for consistent output.
  * JSON validation now operates directly on input strings for improved efficiency.

* **Documentation**
  * Updated backend documentation to reflect current JSON validation approach.
  * Clarified build configuration requirements and symbol handling in compiled modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->