### PR TITLE
fix(ci): match SONAME-versioned libCoolProp.so.<ver> in the symbol-leak gate find

### DIFF
--- a/.github/workflows/csharp_builder.yml
+++ b/.github/workflows/csharp_builder.yml
@@ -75,8 +75,10 @@ jobs:
         run: |
           set -euo pipefail
           # The shared object keeps the platform 'lib' prefix on ELF/Mach-O
-          # (PREFIX "" is Windows-only) → libCoolPropCsharp.{so,dylib}.
-          wrapper=$(find build install_root -type f \( -name '*CoolPropCsharp.so' -o -name '*CoolPropCsharp.dylib' \) | head -1)
+          # (PREFIX "" is Windows-only) → libCoolPropCsharp.{so,dylib}. Include
+          # the SONAME-versioned forms (libCoolPropCsharp.so.<ver>, the regular
+          # file behind the symlink) so -type f still finds it if versioned.
+          wrapper=$(find build install_root -type f \( -name '*CoolPropCsharp.so' -o -name '*CoolPropCsharp.so.*' -o -name '*CoolPropCsharp.dylib' -o -name '*CoolPropCsharp.*.dylib' \) | head -1)
           if [ -z "$wrapper" ]; then
             echo "FAIL: CoolPropCsharp shared object not found under build/ or install_root/" >&2
             exit 1

--- a/.github/workflows/library_shared.yml
+++ b/.github/workflows/library_shared.yml
@@ -63,7 +63,10 @@ jobs:
       shell: bash
       run: |
         set -euo pipefail
-        lib=$(find build install_root -type f \( -name 'libCoolProp.so' -o -name 'libCoolProp.dylib' \) | head -1)
+        # Match the SONAME-versioned real file too: install gives libCoolProp.so
+        # as a symlink to libCoolProp.so.<ver> (the regular file), and -type f
+        # excludes the symlink — so name the versioned forms explicitly.
+        lib=$(find build install_root -type f \( -name 'libCoolProp.so' -o -name 'libCoolProp.so.*' -o -name 'libCoolProp.dylib' -o -name 'libCoolProp.*.dylib' \) | head -1)
         if [ -z "$lib" ]; then
           echo "FAIL: libCoolProp shared object not found under build/ or install_root/" >&2
           exit 1


### PR DESCRIPTION
## Summary

The libCoolProp symbol-leak gate added in #3116 **fails on every Linux `library_shared` run** with `FAIL: libCoolProp shared object not found` — a real bug in the gate's `find`, not a symbol leak.

`cmake --install` ships a **SONAME-versioned** shared library: the regular file is `libCoolProp.so.7.2.1dev` and `libCoolProp.so` is a **symlink** to it. The gate's `find -type f -name 'libCoolProp.so'` matches **neither** — `-type f` excludes the symlink, and the real file has a version suffix. So the gate fail-closed (correctly — no vacuous pass) but never gated anything.

**macOS ships an unversioned `libCoolProp.dylib`** (a regular file), which is exactly why local Mach-O verification passed and the bug was Linux/ELF-only.

Fix: add the versioned globs `libCoolProp.so.*` / `libCoolProp.*.dylib` to the find (same hardening applied to the C# wrapper gate for the same class).

## Verification
- New find matches the local macOS `libCoolProp.dylib` → gate `OK` (0 nlohmann/valijson/rapidjson).
- Against a simulated SOVERSION layout (`libCoolProp.so.7.2.1dev` + `libCoolProp.so` symlink): **old** find → empty (the bug); **new** find → the real `.so.7.2.1dev`.
- Both workflows YAML-valid.

## Test Plan
- [x] Local: new find resolves the real binary on macOS; old vs new verified on a simulated SOVERSION tree
- [ ] CI: `library_shared` gate green on ubuntu (ELF) **and** macOS; C# wrapper gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)