### PR TITLE
ci(python): v8 go-live — publish nanobind wheels (r9sq.6)

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -132,8 +132,8 @@ jobs:
             name: CoolProp-${{ github.sha }}-clang_format.patch
             path: clang_format.patch
 
-  nanobind-abi3:
-    name: nanobind abi3 wheel (build once on 3.12, run on 3.12/3.13/3.14)
+  nanobind-wheels:
+    name: nanobind wheels (build the publish matrix, test 3.9-3.14)
     # PR-only (same rationale as clang-format above): avoid master going red
     # retroactively. Open a draft PR to exercise it on a branch.
     if: github.event_name == 'pull_request'
@@ -144,47 +144,60 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Build the cp312-abi3 nanobind wheel (once, on 3.12)
+      - name: Build the nanobind wheel matrix (3.9-3.11 per-version + cp312-abi3)
         shell: bash
         run: |
           set -euo pipefail
-          uv venv --python 3.12 .venv-build
-          source .venv-build/bin/activate
-          uv pip install nanobind cython scikit-build-core ninja
-          # COOLPROP_NANOBIND=ON is the SINGLE signal: it selects the nanobind
-          # core + abi3 Cython sidecars (USE_SABI) in CMake AND triggers
-          # scikit-build-core's wheel.py-api=cp312 override (pyproject.toml), so
-          # this produces ONE cp312-abi3 wheel covering 3.12/3.13/3.14. Release:
-          # the wheel compiles the whole core (incl. SVDSBTL); Debug is very slow.
-          COOLPROP_NANOBIND=ON uv build --wheel --no-build-isolation \
-            --config-setting=cmake.define.CMAKE_BUILD_TYPE=Release \
-            --out-dir dist .
+          # Mirror the published v8 matrix (bd CoolProp-r9sq.6): per-version wheels
+          # for 3.9-3.11 (below nanobind's stable-ABI floor) and ONE cp312-abi3
+          # wheel for 3.12+. COOLPROP_NANOBIND=ON drives both the nanobind CMake
+          # build and (on Py>=3.12) the abi3 wheel tag via the pyproject overrides.
+          # Release: the wheel compiles the whole core (incl. SVDSBTL); Debug is slow.
+          for PY in 3.9 3.10 3.11 3.12; do
+            echo "::group::build nanobind wheel on Python $PY"
+            uv venv --python "$PY" ".venv-build-$PY"
+            source ".venv-build-$PY/bin/activate"
+            uv pip install nanobind cython scikit-build-core ninja
+            COOLPROP_NANOBIND=ON uv build --wheel --no-build-isolation \
+              --config-setting=cmake.define.CMAKE_BUILD_TYPE=Release \
+              --out-dir dist .
+            deactivate
+            echo "::endgroup::"
+          done
           ls -l dist/
           # Fail loudly if the abi3 single-wheel promise regressed (e.g. a sidecar
           # lost USE_SABI, or the wheel.py-api override stopped matching).
           ls dist/coolprop-*-cp312-abi3-*.whl >/dev/null
 
-      - name: Run the pytest suite on 3.12, 3.13 and 3.14 against the one wheel
+      - name: Run the pytest suite on 3.9-3.14 against the matching wheel
         shell: bash
         run: |
           set -euo pipefail
-          # The crux of abi3: the SAME cp312 wheel must install and pass on every
-          # supported interpreter >= 3.12. A version-specific .so or wheel tag
-          # would make pip reject it on 3.13/3.14 here.
-          WHL=$(ls dist/coolprop-*-cp312-abi3-*.whl)
+          # 3.9-3.11 use their own per-version wheel; 3.12/3.13/3.14 all install the
+          # single cp312-abi3 wheel (the crux of abi3 -- it must work on each).
           ran=0
-          for PY in 3.12 3.13 3.14; do
-            echo "::group::pytest on Python $PY (cp312-abi3 wheel)"
+          for PY in 3.9 3.10 3.11 3.12 3.13 3.14; do
+            case "$PY" in
+              3.9 | 3.10 | 3.11)
+                tag="cp${PY/./}"
+                WHL=$(ls dist/coolprop-*-"${tag}"-"${tag}"-*.whl 2>/dev/null || true)
+                ;;
+              *)
+                WHL=$(ls dist/coolprop-*-cp312-abi3-*.whl 2>/dev/null || true)
+                ;;
+            esac
+            if [ -z "$WHL" ]; then
+              echo "::warning::no nanobind wheel found for Python $PY"
+              continue
+            fi
+            echo "::group::pytest on Python $PY ($(basename "$WHL"))"
             uv venv --python "$PY" ".venv-$PY"
             source ".venv-$PY/bin/activate"
             # Guard the runtime-dep install: a brand-new interpreter may transiently
-            # lack pytest/numpy cp wheels, which is a toolchain gap, not an abi3
-            # regression -- warn and skip that leg rather than redding the gate. The
-            # `ran` counter below still fails the job if NO interpreter could run, so
-            # a real total breakage can't pass silently. (mypy is best-effort too:
-            # test_stub.py importorskips it.)
+            # lack pytest/numpy cp wheels (a toolchain gap, not a regression) -- warn
+            # and skip that leg. The `ran` counter still fails the job if NO leg ran.
             if ! uv pip install pytest numpy "$WHL"; then
-              echo "::warning::runtime deps unavailable on Python $PY; skipping this leg (abi3 still proven on the other interpreters)"
+              echo "::warning::runtime deps unavailable on Python $PY; skipping this leg"
               deactivate; echo "::endgroup::"; continue
             fi
             uv pip install mypy || echo "::warning::mypy unavailable on $PY; test_stub mypy check will skip"
@@ -194,7 +207,7 @@ jobs:
             deactivate
             echo "::endgroup::"
           done
-          test "$ran" -gt 0 || { echo "::error::no Python interpreter could run the cp312-abi3 wheel"; exit 1; }
+          test "$ran" -gt 0 || { echo "::error::no Python interpreter could run a nanobind wheel"; exit 1; }
 
   clang-tidy:
     name: clang-tidy (diff-only, informational)

--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -165,8 +165,13 @@ jobs:
             echo "::endgroup::"
           done
           ls -l dist/
-          # Fail loudly if the abi3 single-wheel promise regressed (e.g. a sidecar
-          # lost USE_SABI, or the wheel.py-api override stopped matching).
+          # Hard-gate EVERY expected wheel (under `set -e` a missing/mis-tagged one
+          # fails the step): the per-version wheels for 3.9-3.11 AND the cp312-abi3
+          # wheel. Without this, a per-version tagging regression would only warn in
+          # the test step below (whose final guard is just `ran > 0`).
+          for tag in cp39 cp310 cp311; do
+            ls dist/coolprop-*-"${tag}"-"${tag}"-*.whl >/dev/null
+          done
           ls dist/coolprop-*-cp312-abi3-*.whl >/dev/null
 
       - name: Run the pytest suite on 3.9-3.14 against the matching wheel

--- a/.github/workflows/python_buildwheels.yml
+++ b/.github/workflows/python_buildwheels.yml
@@ -65,14 +65,18 @@ jobs:
           fi
           echo "Mode: $(if $full; then echo full; else echo subset; fi)"
           echo "full=$full" >> "$GITHUB_OUTPUT"
+          # v8 go-live (bd CoolProp-r9sq.6): the wheels are now nanobind. The cp312
+          # build is abi3-tagged (one cp312-abi3 wheel covers 3.12/3.13/3.14), so
+          # 3.13/3.14 are dropped from the matrix to avoid building duplicate abi3
+          # wheels; 3.9-3.11 stay per-version (below nanobind's stable-ABI floor).
           if $full; then
-            echo 'py_versions=[39, 310, 311, 312, 313, 314]' >> "$GITHUB_OUTPUT"
+            echo 'py_versions=[39, 310, 311, 312]' >> "$GITHUB_OUTPUT"
             echo 'ubuntu_archs=["x86_64"]' >> "$GITHUB_OUTPUT"
             echo 'ubuntu_arm_archs=["aarch64"]' >> "$GITHUB_OUTPUT"
             echo 'windows_archs=["AMD64", "x86", "ARM64"]' >> "$GITHUB_OUTPUT"
             echo 'macos_archs=["x86_64", "arm64"]' >> "$GITHUB_OUTPUT"
           else
-            echo 'py_versions=[313]' >> "$GITHUB_OUTPUT"
+            echo 'py_versions=[312]' >> "$GITHUB_OUTPUT"
             echo 'ubuntu_archs=["x86_64"]' >> "$GITHUB_OUTPUT"
             echo 'ubuntu_arm_archs=["aarch64"]' >> "$GITHUB_OUTPUT"
             echo 'windows_archs=["AMD64"]' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/python_cibuildwheel.yml
+++ b/.github/workflows/python_cibuildwheel.yml
@@ -88,11 +88,16 @@ jobs:
         PIP_TIMEOUT: 60
         PIP_DEFAULT_TIMEOUT: 60
         MACOSX_DEPLOYMENT_TARGET: 11.0
-        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=11.0 SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk CPM_SOURCE_CACHE=$HOME/.cache/CPM PIP_RETRIES=10 PIP_TIMEOUT=60 PIP_DEFAULT_TIMEOUT=60
+        # COOLPROP_NANOBIND=ON is the v8 go-live signal (bd CoolProp-r9sq.6): it
+        # drives both the nanobind CMake build and (on Py>=3.12) the abi3 wheel tag
+        # via the scikit-build-core overrides in pyproject.toml.  Set on every
+        # platform so the published wheel is the nanobind core + State shim.
+        CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=11.0 SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk CPM_SOURCE_CACHE=$HOME/.cache/CPM PIP_RETRIES=10 PIP_TIMEOUT=60 PIP_DEFAULT_TIMEOUT=60 COOLPROP_NANOBIND=ON
         CIBW_BEFORE_BUILD_LINUX: >
           pip install ninja &&
           git config --global --add safe.directory "*"
-        CIBW_ENVIRONMENT_LINUX: COOLPROP_CMAKE=default,NATIVE CPM_SOURCE_CACHE=/root/.cache/CPM PIP_RETRIES=10 PIP_TIMEOUT=60 PIP_DEFAULT_TIMEOUT=60
+        CIBW_ENVIRONMENT_LINUX: COOLPROP_CMAKE=default,NATIVE CPM_SOURCE_CACHE=/root/.cache/CPM PIP_RETRIES=10 PIP_TIMEOUT=60 PIP_DEFAULT_TIMEOUT=60 COOLPROP_NANOBIND=ON
+        CIBW_ENVIRONMENT_WINDOWS: COOLPROP_NANOBIND=ON PIP_RETRIES=10 PIP_TIMEOUT=60 PIP_DEFAULT_TIMEOUT=60
         # Linux wheels build inside the manylinux container, which does not
         # inherit host env vars; forward the resolved version through so the
         # version provider sees it. macOS/Windows build on the host directly.
@@ -101,7 +106,9 @@ jobs:
         CIBW_ARCHS_MACOS: ${{ inputs.arch }} # x86_64 arm64 # universal2 is redundant
         CIBW_ARCHS_WINDOWS: ${{ inputs.arch }} # AMD64 x86 # ARM64 creates problems with msgpack-c
         CIBW_ARCHS_LINUX: ${{ inputs.arch }} # i686 x86_64 aarch64 ppc64le s390x
-        CIBW_TEST_COMMAND: python -c "import CoolProp; assert '?' not in CoolProp.__gitrevision__"
+        # Smoke-test the published v8 wheel: it imports, the nanobind PropsSI works
+        # (returns a float for int args), and the State capsule shim loads.
+        CIBW_TEST_COMMAND: python -c "import CoolProp; from CoolProp.CoolProp import PropsSI; from CoolProp.State import State; assert '?' not in CoolProp.__gitrevision__; assert isinstance(PropsSI('T','P',101325,'Q',0,'Water'), float)"
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_MANYLINUX_I686_IMAGE: manylinux2014
         CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "cython>=0.29"]
+# nanobind is required for the v8 core (built whenever COOLPROP_NANOBIND=ON,
+# which is now the default for the published wheels -- bd CoolProp-r9sq.6).
+requires = ["scikit-build-core>=0.10", "cython>=0.29", "nanobind>=2.0"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/src/nanobind_interface.cxx
+++ b/src/nanobind_interface.cxx
@@ -940,8 +940,10 @@ void init_CoolProp(nb::module_& m) {
             // so numpy scalars / 1-element arrays (e.g. a density from PropsSI) are
             // accepted, matching the legacy Cython `<double>obj` coercion. nb::cast<double>
             // would raise std::bad_cast on a non-float object (bd CoolProp-r9sq.16).
-            set_reference_stateD(FluidName, nb::cast<double>(nb::float_(args[0])), nb::cast<double>(nb::float_(args[1])),
-                                 nb::cast<double>(nb::float_(args[2])), nb::cast<double>(nb::float_(args[3])));
+            // Take an nb::handle explicitly: MSVC won't function-style-cast an
+            // args[] accessor straight to nb::float_, but accessor->handle is implicit.
+            auto _as_double = [](nb::handle h) { return nb::cast<double>(nb::float_(h)); };
+            set_reference_stateD(FluidName, _as_double(args[0]), _as_double(args[1]), _as_double(args[2]), _as_double(args[3]));
         } else {
             throw std::invalid_argument("Invalid number of inputs to set_reference_state");
         }

--- a/wrappers/Python/CMakeLists.txt
+++ b/wrappers/Python/CMakeLists.txt
@@ -269,6 +269,14 @@ target_link_libraries(CoolProp_module PRIVATE miniz)
 set_target_properties(CoolProp_module PROPERTIES OUTPUT_NAME "CoolProp" PREFIX "")
 coolprop_hide_json_symbols(CoolProp_module)
 
+if(WIN32)
+    # The nanobind module compiles the whole core (incl. fmtlib, which static_asserts
+    # unless built /utf-8) plus the large nanobind_interface.cxx TU (needs /bigobj).
+    # The legacy Cython branch sets these on its CoolProp_module; the nanobind branch
+    # must too, otherwise the Windows wheel build fails (bd CoolProp-r9sq.6).
+    target_compile_options(CoolProp_module PRIVATE /utf-8 /bigobj)
+endif()
+
 # ---- PEP 561 type stub for the nanobind core (parity with the legacy wheel) ----
 # The core .so is self-contained (no Python-level imports at init), so nanobind's
 # stubgen can import it directly from the build dir to emit CoolProp.pyi.


### PR DESCRIPTION
## ⚠️ This is the v8 cutover go-live

Flips the **published PyPI wheels** from the legacy Cython interface to the **nanobind v8 core + State capsule shim**. After this merges and master publishes, every CoolProp wheel on PyPI is nanobind.

**Merge order:** this MUST merge **after** the parity PRs — **#3121** (State shim), **#3122** (LowLevelAPI), **#3125** (Plots) — so the published wheel ships the *complete* v8 interface. (#3120 parity batch + #3114 abi3 are already in master.)

## The change

| File | What |
|------|------|
| `pyproject.toml` | `nanobind>=2.0` added to build-requires (needed whenever `COOLPROP_NANOBIND=ON`). |
| `python_cibuildwheel.yml` | `COOLPROP_NANOBIND=ON` in the build env on **all** platforms (Linux/macOS/Windows); stronger post-build smoke (`PropsSI`→float, `State` imports). |
| `python_buildwheels.yml` | publish matrix `[39,310,311,312]` (subset `[312]`) — 3.13/3.14 are covered by the one cp312-abi3 wheel, so dropped to avoid duplicate abi3 builds. |
| `dev_checks.yml` | the PR nanobind job now builds the **full publish matrix** (3.9-3.11 per-version + cp312-abi3) and runs the pytest suite on **3.9-3.14**. |

## Published matrix
```
cp39 / cp310 / cp311  ->  per-version nanobind wheels
cp312                 ->  cp312-abi3  (pip serves it to 3.12 / 3.13 / 3.14)
```

## Validation
- **3.9, 3.10, 3.11**: each builds a per-version nanobind wheel, imports, `PropsSI`→373.124, `State` works, and the **full pytest suite passes (95 passed)** — the previously-untested floor is now exercised (and the CI job exercises it on every PR).
- **cp312-abi3**: runs on 3.12/3.13/3.14 (validated earlier in #3114).
- Adversarial review: env propagation, abi3 dedup, manylinux cmake≥3.26 (ships 4.3.2), wheel-tag matching, and the legacy sdist path all sound — no blocking findings.

`requires-python` is unchanged (`>=3.8`; 3.8 continues to get the sdist as before).

bd CoolProp-r9sq.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened CI to build and test wheels across Python 3.9–3.14 for wider compatibility.
  * Enabled nanobind (v2+) in build configuration so published wheels include native bindings by default.
  * Aligned Windows build settings to improve native wheel build reliability.
  * CI now gracefully skips tester legs when required runtime deps are unavailable and provides generalized diagnostics.

* **Tests**
  * Expanded post-build smoke checks to validate native bindings and import shim behavior across platforms.

* **Bug Fixes**
  * Improved stability of native binding argument handling for reference-state calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->