### PR TITLE
fix(asan): build AddressSanitizer at -O2 (was silently -O0) — cuts ASan CI ~45min → ~10min

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -44,11 +44,12 @@ jobs:
     # Guardrail (CoolProp-xuu).  Without this the job inherits GitHub's 6-hour
     # default cap; when a test runs away the job is silently reported as
     # `cancelled` rather than a real failure (that is exactly how the
-    # detect_stack_use_after_return BDCSVD blow-up hid for so long).  The full
-    # ASan suite + REFPROP completes in ~12 min locally (~40-50 min expected on
-    # the slower 2-vCPU runner); 90 min is a ~2x headroom that still surfaces a
-    # genuine runaway fast and visibly instead of burning six hours.
-    timeout-minutes: 90
+    # detect_stack_use_after_return BDCSVD blow-up hid for so long).  With the
+    # Asan build now actually optimized (-O2; see the CMakeLists Asan flags fix)
+    # the full suite + REFPROP runs in ~3 min locally / ~10 min on the 2-vCPU
+    # runner, down from ~45 min when the build was silently -O0.  30 min is a
+    # ~3x headroom that still surfaces a genuine runaway fast and visibly.
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -72,7 +73,9 @@ jobs:
       - name: cmake config
         run: cd build && CXX=clang++ cmake .. -DCMAKE_BUILD_TYPE=Asan -DCOOLPROP_ASAN=ON -DCOOLPROP_CATCH_MODULE=ON
       - name: build all Catch tests
-        run: cmake --build build --config Asan
+        # -j$(nproc): every other build job already parallelises; the ASan job
+        # historically did not, leaving the compile serial on the multi-vCPU runner.
+        run: cmake --build build --config Asan -j$(nproc)
       - name: run all the compiled Catch tests with address sanitizer
         # detect_stack_use_after_return is deliberately NOT enabled here
         # (CoolProp-xuu).  With REFPROP present — which CI builds — the 5

--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -88,7 +88,19 @@ jobs:
         # rather than producing a real pass/fail.  ASan's heap/global/UAF
         # checks all still run; only the fake-stack (use-after-return)
         # instrumentation is dropped.
-        run: cd build && ASAN_OPTIONS=verbosity=1 ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-18 ./CatchTestRunner --benchmark-samples 1
+        #
+        # detect_odr_violation=1 (default is 2): at -O2 the compiler merges the
+        # two identical-content static (internal-linkage) arrays in vendored
+        # externals/miniz-3.1.1/miniz.c — s_tdefl_num_probes and
+        # s_tdefl_png_num_probes — onto one address.  ASan's level-2 *poisoning*
+        # ODR check then false-positives on the shared address (two distinct
+        # names, same storage).  Internal-linkage globals cannot ODR-violate
+        # across TUs by definition, so this is a benign false positive that only
+        # surfaced once the build was actually optimized.  Level 1 keeps the
+        # reliable *indicator*-based ODR detection — so a real duplicate-symbol
+        # violation (e.g. the JSON-symbol-visibility concern) still fails CI —
+        # and drops only the poisoning check.  See CoolProp-xma3.
+        run: cd build && ASAN_OPTIONS=verbosity=1:detect_odr_violation=1 ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-18 ./CatchTestRunner --benchmark-samples 1
 
   clang-format:
     name: clang-format (PR diff)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,21 +121,32 @@ if (COOLPROP_ASAN)
       endif()
   endif()
 
+  # Optimize the Asan build: -O2 -g -DNDEBUG (the RelWithDebInfo level, plus
+  # ASan).  ASan instrumentation is unaffected by optimization level, so this
+  # is the standard way to run ASan; -O is set EXPLICITLY rather than inherited
+  # from ${CMAKE_*_FLAGS_RELWITHDEBINFO} because this block executes before the
+  # project() call (line ~217) that canonically populates those per-config
+  # defaults -- depending on them here is order-fragile.  (Historically this
+  # referenced the mixed-case ${CMAKE_*_FLAGS_RelWithDebInfo}, an undefined ->
+  # empty variable, so the Asan build silently compiled at -O0.  That made the
+  # dense-SVD SVDSBTL surface builds crawl and was the primary reason the ASan
+  # CI job took ~45 min; with -O2 the full suite runs ~3 min locally / ~10 min
+  # on the 2-vCPU runner.)  Keep these in sync with RelWithDebInfo if it changes.
   set(CMAKE_C_FLAGS_ASAN
-      "${CMAKE_C_FLAGS_RelWithDebInfo} -fsanitize=address -fno-omit-frame-pointer" CACHE STRING
+      "-O2 -g -DNDEBUG -fsanitize=address -fno-omit-frame-pointer" CACHE STRING
       "Flags used by the C compiler for Asan build type or configuration." FORCE)
 
   set(CMAKE_CXX_FLAGS_ASAN
-      "${CMAKE_CXX_FLAGS_RelWithDebInfo} -fsanitize=address -fno-omit-frame-pointer" CACHE STRING
+      "-O2 -g -DNDEBUG -fsanitize=address -fno-omit-frame-pointer" CACHE STRING
       "Flags used by the C++ compiler for Asan build type or configuration." FORCE)
 
   set(CMAKE_EXE_LINKER_FLAGS_ASAN
-      "${CMAKE_EXE_LINKER_FLAGS_RelWithDebInfo} -fsanitize=address" CACHE STRING
+      "-fsanitize=address" CACHE STRING
       "Linker flags to be used to create executables for Asan build type." FORCE)
 
   set(CMAKE_SHARED_LINKER_FLAGS_ASAN
-      "${CMAKE_SHARED_LINKER_FLAGS_RelWithDebInfo} -fsanitize=address" CACHE STRING
-      "Linker lags to be used to create shared libraries for Asan build type." FORCE)
+      "-fsanitize=address" CACHE STRING
+      "Linker flags to be used to create shared libraries for Asan build type." FORCE)
 
 endif()
 


### PR DESCRIPTION
## Root cause

The `Asan` CMake build type set its flags from `${CMAKE_CXX_FLAGS_RelWithDebInfo}` (mixed-case). CMake stores per-config flags under the **upper-case** config name (`CMAKE_CXX_FLAGS_RELWITHDEBINFO`), so the mixed-case variable was undefined/empty and **the entire ASan build silently compiled at `-O0`**. The dense-SVD SVDSBTL surface builds (NT=200/NR=800/rank=20) crawl unoptimized — that, not parallelism, is why the ASan CI job took ~45 min (and occasionally flirted with the timeout guardrail).

## Fix

Set `-O2 -g -DNDEBUG -fsanitize=address -fno-omit-frame-pointer` **explicitly**. (Explicit rather than via `${...RELWITHDEBINFO}` because this block runs *before* the `project()` call that canonically populates those per-config defaults — depending on them here is order-fragile.) ASan instrumentation is unaffected by optimization level.

Also: parallelise the ASan build with `-j$(nproc)` (every other build job already does), and tighten the runaway guardrail `90 → 30 min` to match the new runtime while still surfacing a genuine hang fast and visibly (CoolProp-xuu).

## Effect (measured locally)

| | Full Catch2 suite | Heaviest tests |
|---|---|---|
| `-O0` (the bug) | **930 s** | Stability 105s · superanc-all-fluids 85s · AbstractState 83s |
| `-O2` (fixed) | **187.7 s** (5×) | enthalpy/entropy 22s · Stability 13s · superanc-water ~5s |

Same **124,698 assertions, 0 ASan errors**. Extrapolated to the 2-vCPU runner: **~10 min, down from ~45**.

## Debug quality is unchanged

`-g` + `-fno-omit-frame-pointer` are kept, so ASan reports stay fully symbolized at `-O2` — verified a real heap-overflow still reports `file:line` for both the faulting access and the allocation site. `llvm-symbolizer` reconstructs inlined frames. `-DNDEBUG` (RelWithDebInfo's level) disables `assert()`/`eigen_assert` as in any optimized build; ASan's memory diagnostics are untouched.

## Validation

- Clean first configure confirmed: `CMAKE_CXX_FLAGS_ASAN` carries `-O2` and `SVDSurfaceFactory.cpp` compiles at `-O2`.
- Full `-O2` ASan suite run: 360 passed / 31 skipped, 124,698 assertions, 0 ASan errors.
- Two adversarial review rounds (the second caught a CMake-ordering fragility, now hardened to explicit literal flags).

## History

This branch first explored a time-balanced sharded fan-out; CI revealed the shard timeouts traced back to this `-O0` build bug. Fixing the root cause made the sharding unnecessary (ASan is no longer the PR's long pole at ~10 min), so it was dropped — preserved in this branch's git history if ever needed.

Epic `CoolProp-dq9u`; related `CoolProp-xuu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized CI: reduced job timeout and enabled parallel compilation to speed builds.
  * Standardized sanitizers and compiler flags for the AddressSanitizer build to ensure consistent optimization and debugging behavior.

* **Bug Fixes**
  * Adjusted sanitizer runtime checks to reduce false-positive detections while preserving reliable error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->