### PR TITLE
fix(python): name TestPyPI dev builds X.Y.Z.dev<ts> not .post<ts>

### DIFF
--- a/Web/develop/release.rst
+++ b/Web/develop/release.rst
@@ -56,10 +56,9 @@ the CoolProp library.
       zipped sources.
     - Bump the version number in the CMake file and commit.
     - Announce the new features if you like.
-    - Remove artifacts from TestPYPI. First with ``pypi-cleanup -t https://test.pypi.org -p coolprop --query-only -r ".*\.(dev|post)\d.*"``
+    - Remove artifacts from TestPYPI. First with ``pypi-cleanup -t https://test.pypi.org -p coolprop --query-only -r ".*\.dev\d.*"``
       to determine what will be deleted and then with your username ``-u username --do-it``
-      (and without ``--query-only``) to do it. The ``(dev|post)`` alternation
-      matches both the current ``X.Y.Z.dev<timestamp>`` nightlies and any legacy
-      ``X.Y.Z.post<timestamp>`` builds left over from the old naming scheme.
+      (and without ``--query-only``) to do it. The ``.dev`` pattern matches the
+      ``X.Y.Z.dev<timestamp>`` nightlies that CI publishes to TestPyPI.
 
 That's all folks.

--- a/Web/develop/release.rst
+++ b/Web/develop/release.rst
@@ -56,8 +56,10 @@ the CoolProp library.
       zipped sources.
     - Bump the version number in the CMake file and commit.
     - Announce the new features if you like.
-    - Remove artifacts from TestPYPI. First with ``pypi-cleanup -t https://test.pypi.org -p coolprop --query-only -r ".*post\d.*""`` 
-      to determine what will be deleted and then with your username ``-u username --do-it`` 
-      (and without ``--query-only``) to do it
+    - Remove artifacts from TestPYPI. First with ``pypi-cleanup -t https://test.pypi.org -p coolprop --query-only -r ".*\.(dev|post)\d.*"``
+      to determine what will be deleted and then with your username ``-u username --do-it``
+      (and without ``--query-only``) to do it. The ``(dev|post)`` alternation
+      matches both the current ``X.Y.Z.dev<timestamp>`` nightlies and any legacy
+      ``X.Y.Z.post<timestamp>`` builds left over from the old naming scheme.
 
 That's all folks.

--- a/dev/extract_version.py
+++ b/dev/extract_version.py
@@ -98,6 +98,29 @@ if __name__ == '__main__':
         exit(0)
 
     current_v = version.Version(current_v)
+    base_v = current_v.base_version
+
+    # TestPyPI development builds.  CI passes --version <timestamp>
+    # (date +%Y%m%d%H%M%S -- monotonic and unique), so the correctly-ordered,
+    # collision-free name is simply "<base>.dev<timestamp>": a PEP 440
+    # *developmental* release that sorts BEFORE the eventual "<base>" final.
+    #
+    # The previous scheme emitted "<base>.post<timestamp>", which PEP 440 sorts
+    # *after* a "<base>" that has not been released yet (PyPI is at 7.2.0 while
+    # the dev line targets 7.2.1), so the nightly would shadow the real 7.2.1 on
+    # any combined index.  It was also self-perpetuating: the "elif max_v.dev"
+    # branch below rewrites ".dev" back to ".post", so the scheme could never
+    # converge on ".dev" by incrementing.  Because the timestamp alone
+    # guarantees uniqueness we short-circuit here and never query or increment
+    # existing releases for this path.
+    if args.version and not args.pypi:
+        new_v = version.Version(f"{base_v}.dev{args.version}")
+        if args.replace_version:
+            print(f"Version to be injected on TestPyPi: {new_v}")
+            replace_version_file(new_v=new_v)
+        else:
+            print(new_v, end="")
+        exit(0)
 
     releases = parse_pypi_version(pypi=args.pypi)
 


### PR DESCRIPTION
## Problem

CoolProp's CMake base version is `7.2.1` (the unreleased dev line); PyPI is at `7.2.0`. But CI tags TestPyPI nightlies `7.2.1.post<timestamp>`, and PEP 440 sorts post-releases **above** the final:

```
7.2.1.dev*  <  7.2.1rc*  <  7.2.1  <  7.2.1.post*
```

So every nightly outranks the eventual real `7.2.1`. The documented nightly install uses `--pre --index-url test.pypi --extra-index-url pypi`, exactly the combined-index case where `7.2.1.post<ts>` would **permanently shadow** the real `7.2.1` once it ships (`pip -U` never moves onto it). The scheme was also self-perpetuating: `extract_version.py`'s `elif max_v.dev:` branch rewrites `.dev` back to `.post`, so incrementing could never converge on `.dev`.

## Change

`dev/extract_version.py`'s TestPyPI path (`--version <timestamp>`, no `--pypi`) now short-circuits to `f"{base}.dev{timestamp}"`:

- **Correct ordering** — `7.2.1.dev<ts>` sorts *before* the `7.2.1` final; once `7.2.1` ships, `--pre` installs prefer the final over the nightly.
- The CI timestamp (`date +%Y%m%d%H%M%S`) is monotonic and unique, so the early-exit **drops the per-build (Test)PyPI query + increment logic** — ~40 redundant network calls per wheel run (cf. CoolProp-7gk).
- The `--pypi` tagged-release path and `--cmake-only` are untouched.

Also updates the `release.rst` manual `pypi-cleanup` cleanup regex to `.*\.dev\d.*` to match the new nightly naming, and fixes a stray quote.

## Rollout

Pairs with #3131 (scheduled keep-last-N prune).

- ✅ **Legacy `.post` builds purged** — all 23 `7.2.1.post*` releases removed from TestPyPI (verified: `/simple/` index empty, per-release 404). The quota is reclaimed and the old builds can no longer shadow new `.dev` nightlies.
- **Merge order**: land this first so the next CI nightly publishes `7.2.1.dev<ts>` (the `7.2.1.dev0` husk left on TestPyPI would otherwise make the current logic emit `7.2.1.post1`), then merge #3131 so keep-last-N maintains a clean `.dev` set.

## Validation

- `extract_version.py --version 20260601232207` → `7.2.1.dev20260601232207`; monotonic across timestamps.
- PEP 440 ordering confirmed: `7.2.0 < 7.2.1.dev<ts> < 7.2.1`; old `.post<ts> > 7.2.1` (the bug).
- `--cmake-only` unchanged (`7.2.1-dev`).
- Adversarial review: no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release checklist with clarified instructions for TestPyPI artifact cleanup procedures and version naming patterns.

* **Chores**
  * Enhanced development release process to support improved nightly version generation with consistent `.dev` version naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->