### PR TITLE
ci(testpypi): scheduled keep-last-N prune of old dev/post releases

### DIFF
--- a/.github/workflows/testpypi_prune.yml
+++ b/.github/workflows/testpypi_prune.yml
@@ -1,8 +1,8 @@
 name: Prune old TestPyPI releases
 
 # TestPyPI enforces a per-project storage quota and every non-tag CI run
-# uploads the full wheel matrix (~43 files per .postNNN release).  This job
-# keeps only the newest N pre/post releases and deletes the rest.
+# uploads the full wheel matrix (~43 files per .dev<timestamp> nightly).  This
+# job keeps only the newest N development builds and deletes the rest.
 #
 # Deletion is NOT possible with the publish API token -- it requires a real
 # web session.  We use `pypi-cleanup`, authenticating as a dedicated bot
@@ -26,7 +26,7 @@ on:
   workflow_dispatch:
     inputs:
       keep:
-        description: 'Number of newest pre/post releases to retain'
+        description: 'Number of newest development builds to retain'
         required: false
         default: '10'
       do_delete:

--- a/.github/workflows/testpypi_prune.yml
+++ b/.github/workflows/testpypi_prune.yml
@@ -1,0 +1,115 @@
+name: Prune old TestPyPI releases
+
+# TestPyPI enforces a per-project storage quota and every non-tag CI run
+# uploads the full wheel matrix (~43 files per .postNNN release).  This job
+# keeps only the newest N pre/post releases and deletes the rest.
+#
+# Deletion is NOT possible with the publish API token -- it requires a real
+# web session.  We use `pypi-cleanup`, authenticating as a dedicated bot
+# account that is a maintainer on the CoolProp TestPyPI project.  Because
+# pypi-cleanup reads the 2FA code from stdin (no flag/env), we generate the
+# current TOTP from a stored secret with pyotp and pipe it in; the password
+# comes from $PYPI_CLEANUP_PASSWORD.
+#
+# Required repo secrets (set up the bot account first):
+#   TESTPYPI_BOT_USERNAME     - bot account login
+#   TESTPYPI_BOT_PASSWORD     - bot account password
+#   TESTPYPI_BOT_TOTP_SECRET  - the base32 TOTP provisioning secret for the bot's 2FA
+#
+# Safe rollout: scheduled runs arm deletion, manual runs are dry by default.
+# If the secrets are not yet configured, the destructive step logs a warning
+# and skips instead of hard-failing.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # Mondays 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      keep:
+        description: 'Number of newest pre/post releases to retain'
+        required: false
+        default: '10'
+      do_delete:
+        description: 'Actually delete (manual runs are dry-run unless true)'
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: testpypi-prune
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    # Least privilege: this job only talks to TestPyPI over HTTPS, never the
+    # GitHub API, so it needs no GITHUB_TOKEN scopes.
+    permissions: {}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests packaging pyotp 'pypi-cleanup==0.1.10'
+
+      - name: Compute prune set
+        id: plan
+        env:
+          KEEP: ${{ github.event.inputs.keep || '10' }}
+        run: |
+          set -euo pipefail
+          # stderr carries the human-readable keep/delete plan into the log;
+          # stdout is the anchored alternation regex (empty when nothing to do).
+          REGEX="$(python dev/testpypi_prune.py --keep "$KEEP")"
+          if [[ -z "$REGEX" ]]; then
+            echo "Nothing to prune; the project is already within the keep window."
+          fi
+          {
+            echo "regex<<__EOF__"
+            echo "$REGEX"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Dry-run (no auth) — list what pypi-cleanup would match
+        if: ${{ steps.plan.outputs.regex != '' }}
+        # Pass the regex via env (not ${{ }} command-line interpolation) so the
+        # machine-generated pattern never reaches the shell as literal text.
+        env:
+          REGEX: ${{ steps.plan.outputs.regex }}
+        run: |
+          set -euo pipefail
+          pypi-cleanup -t https://test.pypi.org/ -p CoolProp \
+            -r "$REGEX" --query-only -v
+
+      - name: Delete old releases
+        # Scheduled runs arm deletion; manual runs require do_delete=true.
+        if: >-
+          ${{ steps.plan.outputs.regex != '' &&
+              (github.event_name == 'schedule' || github.event.inputs.do_delete == 'true') }}
+        env:
+          BOT_USER: ${{ secrets.TESTPYPI_BOT_USERNAME }}
+          PYPI_CLEANUP_PASSWORD: ${{ secrets.TESTPYPI_BOT_PASSWORD }}
+          TOTP_SECRET: ${{ secrets.TESTPYPI_BOT_TOTP_SECRET }}
+          REGEX: ${{ steps.plan.outputs.regex }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${BOT_USER:-}" || -z "${PYPI_CLEANUP_PASSWORD:-}" || -z "${TOTP_SECRET:-}" ]]; then
+            echo "::warning::TESTPYPI_BOT_* secrets not configured; skipping deletion." \
+                 "Create the bot account and add the secrets to arm this step."
+            exit 0
+          fi
+          # Generate the current 2FA code and pipe it to pypi-cleanup's
+          # interactive "Authentication code:" prompt (password is read from
+          # $PYPI_CLEANUP_PASSWORD, so stdin is free for the one OTP read).
+          OTP="$(python -c 'import os, pyotp; print(pyotp.TOTP(os.environ["TOTP_SECRET"]).now())')"
+          printf '%s\n' "$OTP" | pypi-cleanup \
+            -t https://test.pypi.org/ \
+            -u "$BOT_USER" \
+            -p CoolProp \
+            -r "$REGEX" \
+            --do-it -y -v

--- a/dev/testpypi_prune.py
+++ b/dev/testpypi_prune.py
@@ -1,8 +1,9 @@
 """Compute which TestPyPI (or PyPI) CoolProp releases to prune.
 
 TestPyPI enforces a per-project storage quota, and every non-tag CI run
-uploads the full wheel matrix (~43 files per ``.postNNN`` release).  To stay
-under the ceiling we keep only the newest ``--keep`` *pre/post* releases and
+uploads the full wheel matrix (~43 files per ``.dev<timestamp>`` nightly).  To
+stay under the ceiling we keep only the newest ``--keep`` development builds
+(any non-final release -- ``.dev``/pre-release, and ``.post`` defensively) and
 delete the rest.
 
 This script is **read-only**.  It queries the public JSON API, decides the
@@ -30,9 +31,17 @@ from packaging import version
 
 
 def fetch_release_keys(package, pypi=False):
-    """Return the raw release-version strings from the JSON API."""
+    """Return the raw release-version strings from the JSON API.
+
+    A 404 means the project has no releases at all (a freshly-wiped or
+    brand-new project, e.g. before the first dev upload).  Treat that as an
+    empty release set so the prune is a clean no-op rather than a hard failure;
+    any other HTTP error still raises.
+    """
     host = "https://pypi.org" if pypi else "https://test.pypi.org"
     response = requests.get(f"{host}/pypi/{package}/json", timeout=30)
+    if response.status_code == 404:
+        return []
     response.raise_for_status()
     return list(response.json()["releases"].keys())
 
@@ -40,11 +49,11 @@ def fetch_release_keys(package, pypi=False):
 def select_delete_set(release_keys, keep):
     """Split release keys into (keep_keys, delete_keys).
 
-    Only dev/pre/post releases are candidates.  Candidates are ordered by
-    parsed version (for ``.postNNN`` timestamps that is chronological), the
-    newest ``keep`` are retained, and the remainder are returned as the
-    delete set.  Final releases are returned in neither list -- they are
-    untouchable.
+    Only non-final releases are candidates (``.dev``/pre-release, and ``.post``
+    defensively).  Candidates are ordered by parsed version (for the
+    ``.dev<timestamp>`` nightlies that is chronological), the newest ``keep``
+    are retained, and the remainder are returned as the delete set.  Final
+    releases are returned in neither list -- they are untouchable.
     """
     if keep < 1:
         raise ValueError("--keep must be >= 1 (refusing to delete everything)")
@@ -79,10 +88,10 @@ def build_regex(delete_keys):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Compute the TestPyPI/PyPI prune regex (keep newest N pre/post releases)")
+        description="Compute the TestPyPI/PyPI prune regex (keep newest N development builds)")
     parser.add_argument("--package", default="CoolProp", help="package name")
     parser.add_argument("--keep", type=int, default=10,
-                        help="number of newest pre/post releases to retain")
+                        help="number of newest development (non-final) builds to retain")
     parser.add_argument("--pypi", action="store_true",
                         help="target real PyPI instead of TestPyPI")
     args = parser.parse_args()
@@ -92,7 +101,7 @@ if __name__ == "__main__":
 
     remote = "PyPI" if args.pypi else "TestPyPI"
     print(f"{remote} {args.package}: {len(keys)} total releases; "
-          f"keeping {len(keep_keys)} newest pre/post, deleting {len(delete_keys)}.",
+          f"keeping {len(keep_keys)} newest dev builds, deleting {len(delete_keys)}.",
           file=sys.stderr)
     for k in delete_keys:
         print(f"  DELETE {k}", file=sys.stderr)

--- a/dev/testpypi_prune.py
+++ b/dev/testpypi_prune.py
@@ -1,0 +1,104 @@
+"""Compute which TestPyPI (or PyPI) CoolProp releases to prune.
+
+TestPyPI enforces a per-project storage quota, and every non-tag CI run
+uploads the full wheel matrix (~43 files per ``.postNNN`` release).  To stay
+under the ceiling we keep only the newest ``--keep`` *pre/post* releases and
+delete the rest.
+
+This script is **read-only**.  It queries the public JSON API, decides the
+delete set, and emits an anchored alternation regex on stdout for
+``pypi-cleanup -r`` to consume.  Final (non-dev/post/pre) releases are NEVER
+candidates for deletion, so a real tagged release can't be pruned by accident.
+
+Matching note: ``pypi-cleanup`` deletes a version ``k`` when ``regex.match(k)``
+is truthy (see its source) -- ``re.match`` anchors the *start* only, so we
+emit ``^(?:...)$`` (with a trailing ``$``) to avoid a prefix collision between
+sibling timestamps.  The alternatives are the PEP 440-*normalized* version
+strings, because ``pypi-cleanup`` matches against the normalized versions from
+the ``/simple/`` index rather than the raw ``/pypi/.../json`` keys.
+
+Usage::
+
+    python dev/testpypi_prune.py --keep 10            # regex -> stdout, plan -> stderr
+    python dev/testpypi_prune.py --keep 10 --pypi     # target real PyPI instead
+"""
+import sys
+import argparse
+
+import requests
+from packaging import version
+
+
+def fetch_release_keys(package, pypi=False):
+    """Return the raw release-version strings from the JSON API."""
+    host = "https://pypi.org" if pypi else "https://test.pypi.org"
+    response = requests.get(f"{host}/pypi/{package}/json", timeout=30)
+    response.raise_for_status()
+    return list(response.json()["releases"].keys())
+
+
+def select_delete_set(release_keys, keep):
+    """Split release keys into (keep_keys, delete_keys).
+
+    Only dev/pre/post releases are candidates.  Candidates are ordered by
+    parsed version (for ``.postNNN`` timestamps that is chronological), the
+    newest ``keep`` are retained, and the remainder are returned as the
+    delete set.  Final releases are returned in neither list -- they are
+    untouchable.
+    """
+    if keep < 1:
+        raise ValueError("--keep must be >= 1 (refusing to delete everything)")
+
+    # Map each release to its PEP 440-normalized string; skip anything
+    # unparseable rather than risk a mis-targeted delete.  We key the regex off
+    # the *normalized* form (str(version.parse(...))) because pypi-cleanup
+    # matches against the normalized versions from the /simple/ index, not the
+    # raw /pypi/.../json keys -- a non-normalized key (e.g. "6.4.1-1") would
+    # otherwise silently fail to match and the prune would under-delete.
+    candidates = []
+    for key in release_keys:
+        try:
+            v = version.parse(key)
+        except version.InvalidVersion:
+            continue
+        if v.is_prerelease or v.is_postrelease:
+            candidates.append((v, str(v)))
+
+    candidates.sort(key=lambda pair: pair[0])
+    keep_pairs = candidates[-keep:] if keep < len(candidates) else candidates
+    delete_pairs = candidates[:-keep] if keep < len(candidates) else []
+    return [s for _, s in keep_pairs], [s for _, s in delete_pairs]
+
+
+def build_regex(delete_keys):
+    """Anchored alternation matching exactly the delete-set keys."""
+    import re
+    alts = "|".join(re.escape(k) for k in delete_keys)
+    return f"^(?:{alts})$"
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Compute the TestPyPI/PyPI prune regex (keep newest N pre/post releases)")
+    parser.add_argument("--package", default="CoolProp", help="package name")
+    parser.add_argument("--keep", type=int, default=10,
+                        help="number of newest pre/post releases to retain")
+    parser.add_argument("--pypi", action="store_true",
+                        help="target real PyPI instead of TestPyPI")
+    args = parser.parse_args()
+
+    keys = fetch_release_keys(args.package, pypi=args.pypi)
+    keep_keys, delete_keys = select_delete_set(keys, args.keep)
+
+    remote = "PyPI" if args.pypi else "TestPyPI"
+    print(f"{remote} {args.package}: {len(keys)} total releases; "
+          f"keeping {len(keep_keys)} newest pre/post, deleting {len(delete_keys)}.",
+          file=sys.stderr)
+    for k in delete_keys:
+        print(f"  DELETE {k}", file=sys.stderr)
+    for k in keep_keys:
+        print(f"  keep   {k}", file=sys.stderr)
+
+    # stdout = machine-readable regex (empty when nothing to prune).
+    if delete_keys:
+        print(build_regex(delete_keys))


### PR DESCRIPTION
## Problem

TestPyPI enforces a per-project storage quota. Every non-tag CI run uploads the full wheel matrix (~43 files per nightly), and lingering CoolProp dev builds were piling up against the ceiling. There was only a *manual* `pypi-cleanup` step documented in `release.rst`.

## Change

- **`dev/testpypi_prune.py`** (read-only): queries the TestPyPI JSON API, keeps the newest `--keep` development builds, and emits an anchored alternation regex (`^(?:…)$`) of the delete set on stdout. Final releases are never candidates, so a real tagged release can't be pruned. The regex is built from **PEP 440-normalized** versions to match what `pypi-cleanup` sees from the `/simple/` index. A **404** from the JSON API (an empty/freshly-wiped project) is treated as "no releases" → clean no-op, not a hard failure.
- **`.github/workflows/testpypi_prune.yml`**: weekly cron + manual dispatch. Always runs an unauthenticated `--query-only` dry-run; the destructive step authenticates as a dedicated bot account and pipes a `pyotp`-generated 2FA code into `pypi-cleanup`'s interactive prompt (the publish token can't delete — deletion needs a web session).

### Safety posture (fail-closed)

- Manual dispatch is **dry-run** unless `do_delete=true`; scheduled runs arm deletion.
- Empty delete set (incl. the 404/empty-project case) → helper prints nothing → both steps skip (regex never reaches `-r`).
- `--keep < 1` raises, aborting under `set -euo pipefail` (no deletion).
- Delete step **skips with a warning** if the `TESTPYPI_BOT_*` secrets are absent.
- A destructive HTTP/auth failure in `pypi-cleanup` propagates non-zero (CI goes red, never green-no-op).
- `permissions: {}` (no GitHub API use); regex passed via env in both steps.

## Rollout

Pairs with #3130 (rename nightlies `.post<ts>` → `.dev<ts>`), now **merged**.

- ✅ Legacy `.post` builds purged from TestPyPI; quota reclaimed.
- This PR keeps the `.dev` set bounded going forward (default keep-last-10, weekly).

## Validation

- Live `--query-only` against TestPyPI confirmed exact match sets during development.
- Empty-project (404) path verified: clean `exit 0`, no regex, both steps skip.
- `actionlint` clean; `py_compile` clean.
- Bot account + `TESTPYPI_BOT_USERNAME/PASSWORD/TOTP_SECRET` secrets confirmed present (exact names the workflow reads).
- Adversarial review: no blocking findings; hardening applied (normalized matching, env-var regex, `permissions: {}`, graceful 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated weekly workflow to prune old TestPyPI development releases with configurable retention and manual run support.
  * Workflow performs a safe dry-run listing and only deletes when configured and credentials (including 2FA) are present, avoiding unintended destructive runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->