### PR TITLE
feat(python): make nanobind AbstractState a real type (CoolProp-r9sq.28)

### DIFF
--- a/src/nanobind_interface.cxx
+++ b/src/nanobind_interface.cxx
@@ -478,7 +478,14 @@ void init_CoolProp(nb::module_& m) {
     m.attr("PyPhaseEnvelopeData") = m.attr("PhaseEnvelopeData");
     m.attr("PySpinodalData") = m.attr("SpinodalData");
 
-    nb::class_<AbstractState>(m, "_AbstractState")
+    // bd CoolProp-r9sq.28: register AbstractState as a real TYPE with a factory
+    // constructor (nb::new_), not a module-level factory FUNCTION returning a
+    // private _AbstractState.  So `AbstractState("HEOS","Water")` still builds a
+    // state AND `isinstance(x, AbstractState)` works (it previously raised
+    // "arg 2 must be a type", forcing callers like Plots/Common.py to reach into
+    // the private class).  nb::new_ binds __new__ to `factory` + a no-op __init__.
+    nb::class_<AbstractState>(m, "AbstractState")
+      .def(nb::new_(&factory))
       .def("set_T", &AbstractState::set_T)
       .def("backend_name", &AbstractState::backend_name)
       .def("using_mole_fractions", &AbstractState::using_mole_fractions)
@@ -738,7 +745,9 @@ void init_CoolProp(nb::module_& m) {
       .def("d4alphar_dDelta_dTau3", &AbstractState::d4alphar_dDelta_dTau3)
       .def("d4alphar_dTau4", &AbstractState::d4alphar_dTau4);
 
-    m.def("AbstractState", &factory);
+    // NOTE: `AbstractState(backend, fluids)` is the class constructor registered
+    // above via nb::new_(&factory) -- no separate module-level factory function
+    // (bd CoolProp-r9sq.28), so isinstance(x, AbstractState) works.
 
     m.def("get_config_as_json_string", &get_config_as_json_string);
     m.def("set_config_as_json_string", &set_config_as_json_string);

--- a/wrappers/Python/CMakeLists.txt
+++ b/wrappers/Python/CMakeLists.txt
@@ -279,9 +279,10 @@ nanobind_add_stub(
     PYTHON_PATH "$<TARGET_FILE_DIR:CoolProp_module>"
     DEPENDS CoolProp_module
     MARKER_FILE "${CMAKE_CURRENT_BINARY_DIR}/py.typed"
-    # INCLUDE_PRIVATE emits the underscore-named _AbstractState class that the
-    # AbstractState() factory returns; the pattern file replaces the auto
-    # PropsSI/HAPropsSI overloads (object-typed -> overlap) with typed ones.
+    # INCLUDE_PRIVATE emits underscore-named members (e.g. the _capi capsule);
+    # the pattern file replaces the auto PropsSI/HAPropsSI overloads
+    # (object-typed -> overlap) with typed ones.  (AbstractState is now a public
+    # type with a factory constructor -- bd CoolProp-r9sq.28 -- not a private class.)
     INCLUDE_PRIVATE
     PATTERN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/_nanobind/stub_patterns.txt"
 )

--- a/wrappers/Python/_nanobind/stub_patterns.txt
+++ b/wrappers/Python/_nanobind/stub_patterns.txt
@@ -20,7 +20,7 @@ CoolProp\.__prefix__:
 CoolProp\._capi$:
     _capi: object = ...
 
-CoolProp\._AbstractState\.get_spinodal_data$:
+CoolProp\.AbstractState\.get_spinodal_data$:
     def get_spinodal_data(self) -> object: ...
 
 CoolProp\.PropsSI$:


### PR DESCRIPTION
## What

In the v8 nanobind core, `AbstractState` was a module-level factory **function** and the extension type was registered under the private name `_AbstractState`. So `AbstractState("HEOS","Water")` worked, but `isinstance(x, AbstractState)` raised `arg 2 must be a type` — forcing callers (e.g. `CoolProp.Plots.Common`) to reach into the private `_AbstractState` class for instance checks.

This registers the class **publicly as `AbstractState` with a factory constructor** via `nb::new_(&factory)`. nanobind binds `__new__` to the factory plus a no-op `__init__`, so:

- `AbstractState("HEOS","Water")` still constructs a state (unchanged), **and**
- `isinstance(x, AbstractState)` now works.

The separate module-level factory function is removed (the class constructor replaces it); the `_AbstractState` name is gone.

## Why

@ibell flagged the factory-not-a-type situation in review of #3125 as something to avoid at the root. This is that root fix. Once merged, #3125's `Plots/Common.py` reverts to a plain `isinstance(fluid_ref, AbstractState)` (the original master line works unchanged).

## Validation

- `isinstance` works for pure **and** mixture states; construction + `update` unchanged.
- **2000× construct/destroy** with no leak/crash — `nb::new_`'s fixup policy adopts ownership (`take_ownership`), and `AbstractState`'s destructor is virtual (`AbstractState.h:731`), so the concrete backend is destroyed exactly once. Same ownership the old factory relied on, no regression.
- The **State capsule shim is unaffected** (it forwards through `_capi`, not the class).
- Generated stub emits `class AbstractState` and no `_AbstractState`.
- Full pytest suite green (**125 passed, 4 skipped**); clang-format clean; adversarial code-review pass with no blocking findings.

bd CoolProp-r9sq.28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `AbstractState` is now a proper Python class with type constructor support. Users can instantiate it directly using `AbstractState("backend","fluids")` and perform `isinstance()` checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->