### PR TITLE
docs(changelog): finalize the v8 nanobind notes

### DIFF
--- a/Web/coolprop/changelog.rst
+++ b/Web/coolprop/changelog.rst
@@ -56,7 +56,12 @@ Highlights:
   working: a link-free, capsule-forwarding ``State`` shim preserves the
   cimportable contract. On Python ≥ 3.12 the wrapper ships as a single
   stable-ABI (``abi3``) wheel per platform instead of one wheel per Python
-  version.
+  version (Python 3.9–3.11 get per-version wheels, below nanobind's
+  stable-ABI floor).
+
+  ``AbstractState`` is now a genuine Python *type*: ``AbstractState("HEOS",
+  "Water")`` still constructs a state, but ``isinstance(x, AbstractState)``
+  now works too (previously the factory was a function and the check raised).
 
   The following **removals are breaking** (all long-deprecated or never part of
   the intended API):


### PR DESCRIPTION
Small changelog finalization for the v8 nanobind migration (the umbrella is #2736).

Adds to the existing `8.0.0` Python-wrapper entry:
- `AbstractState` is now a genuine Python **type** — `AbstractState("HEOS","Water")` still constructs, but `isinstance(x, AbstractState)` now works too (was a factory function before; #3133).
- Clarifies the wheel story: 3.12+ ship one `cp312-abi3` wheel; 3.9–3.11 get per-version wheels (below nanobind's stable-ABI floor).

Docs only — `[skip ci]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog for version 8.0.0 with breaking-change notes clarifying that Python 3.12+ distributions ship as a single stable-ABI wheel per platform, while Python 3.9–3.11 continue with per-version wheels
  * Documented that `AbstractState` is now a genuine Python type, enabling `isinstance()` checks while maintaining backward compatibility for existing construction patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->