### PR TITLE
ci(asan): raise timeout 30 → 90 min (fixes false-timeout on master)

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -44,12 +44,16 @@ jobs:
     # Guardrail (CoolProp-xuu).  Without this the job inherits GitHub's 6-hour
     # default cap; when a test runs away the job is silently reported as
     # `cancelled` rather than a real failure (that is exactly how the
-    # detect_stack_use_after_return BDCSVD blow-up hid for so long).  With the
-    # Asan build now actually optimized (-O2; see the CMakeLists Asan flags fix)
-    # the full suite + REFPROP runs in ~3 min locally / ~10 min on the 2-vCPU
-    # runner, down from ~45 min when the build was silently -O0.  30 min is a
-    # ~3x headroom that still surfaces a genuine runaway fast and visibly.
-    timeout-minutes: 30
+    # detect_stack_use_after_return BDCSVD blow-up hid for so long).
+    # On the 2-vCPU runner with the optimized (-O2) Asan build the measured
+    # steps are REFPROP+config ~1 min and compile ~7.5 min; the single-threaded
+    # test run is the long pole and is much slower per-core than a dev laptop
+    # (~187 s locally).  A prior 30 min cap cancelled the job mid-test (the
+    # test run alone was still going at 21.5 min), so the full duration is not
+    # yet known precisely.  90 min is a deliberately safe envelope that still
+    # surfaces a genuine runaway well under GitHub's 6-hour default; re-tighten
+    # once a clean run reports the true wall time.
+    timeout-minutes: 90
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
## Problem

The `30 min` cap added with the `-O2` fix (#3129) is too tight and **cancelled the `asan` job mid-test on master** — master's ASan check is red from a *false timeout*, not a real failure.

## Why the estimate was wrong

The first `-O2` CI run finished in 8m47s, but it **aborted early on a benign ODR false positive** — ODR detection fires at global-registration, *before* any test runs — so it never timed a full test run. Once `detect_odr_violation=1` let the suite run to completion, the step breakdown on the 2-vCPU runner was:

| Step | Time |
|---|---|
| REFPROP + cmake config | ~1 min |
| ASan `-O2` compile (`-j`) | ~7.5 min |
| single-threaded test run | **still going at 21.5 min** when the 30-min cap cancelled it |

The test run is much slower per-core on the runner than on a dev laptop (~187 s locally), and it was **cancelled unfinished**, so the true full duration isn't yet known.

## Fix

Restore a deliberately safe **90 min** envelope (the value the job used before #3129) so the job completes reliably and we can measure the real wall time, then re-tighten with data. Still well under GitHub's 6-hour default, so a genuine runaway is still surfaced.

## Note

The `-O2` fix (#3129) works as intended — the test run is far faster than the old `-O0` build that rode toward the 6-hour cap. Pushing the wall time down further (the test run is single-threaded ~25 min) is a separate question: time-balanced sharding is now viable since `-O2` made per-test costs uniform.

Related: #3129, CoolProp-xuu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased automated test timeout to reduce premature job cancellations during long-running test steps.
  * Updated CI guardrail messaging to reflect measured step durations and clarify why the previous timeout was insufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->