### PR TITLE
ci(asan): parallelise SVDSBTL surface sampling (≈3× under ASan)

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -104,7 +104,15 @@ jobs:
         # reliable *indicator*-based ODR detection — so a real duplicate-symbol
         # violation (e.g. the JSON-symbol-visibility concern) still fails CI —
         # and drops only the poisoning check.  See CoolProp-xma3.
-        run: cd build && ASAN_OPTIONS=verbosity=1:detect_odr_violation=1 ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-18 ./CatchTestRunner --benchmark-samples 1
+        #
+        # COOLPROP_SVDSBTL_SAMPLING_THREADS=$(nproc): the SVDSBTL surface builds
+        # (the test run's long pole — each fills a 200x800 grid by sampling the
+        # source EOS) sample serially by default.  Enabling the existing parallel
+        # sampler across the runner's cores cuts that wall time (the parallel
+        # path is gated to non-REFPROP sources, so the REFPROP surfaces stay
+        # serial).  Running it here also exercises the parallel sampler under
+        # ASan's heap/UAF checks.
+        run: cd build && COOLPROP_SVDSBTL_SAMPLING_THREADS=$(nproc) ASAN_OPTIONS=verbosity=1:detect_odr_violation=1 ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-18 ./CatchTestRunner --benchmark-samples 1
 
   clang-format:
     name: clang-format (PR diff)


### PR DESCRIPTION
## What

The ASan test run's long pole is the cold SVDSBTL surface builds — each fills a 200×800 grid by sampling the source EOS, **single-threaded by default** (`SVDSBTL_SAMPLING_THREADS=1`). CoolProp already ships a parallel sampler (gated to non-REFPROP sources); the ASan job just never turned it on.

This sets `COOLPROP_SVDSBTL_SAMPLING_THREADS=$(nproc)` for the ASan run.

## Validated under ASan (not just native)

Cold "Phase 2a fluid set" surface build, same binary:

| | threads=1 | threads=8 | speedup |
|---|---|---|---|
| **ASan** | 390s | **126s** | **3.1×** |
| native | 249s | 80s | 3.1× |

The speedup **survives ASan's allocator/shadow-memory contention** (a real risk I checked — it doesn't materialize for all multithreaded workloads under ASan, but it does here). Tests pass; the run reports **0 ASan errors**, so enabling it also exercises the parallel sampler under ASan's heap/UAF instrumentation. Amdahl-capped by the serial SVD decomposition.

REFPROP-sourced surfaces stay serial (the parallel path excludes REFPROP), so this is safe with REFPROP present.

## Context

This is the last of the optional speedups from the ASan-CI investigation (CoolProp-dq9u). The job is already correct and green after the `-O2` build fix (#3129), timeout bump (#3135), and the ECS reference-fluid cache (#3141, ~13× on ECS fluids). This trims the remaining sampling-bound time on the multi-vCPU runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized AddressSanitizer testing workflow to utilize parallel processing for improved test performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->