### PR TITLE
ci(python): fix Windows ARM64 wheels under cibuildwheel 4.0 (native arm runner + disable cross-compile delvewheel)

### DIFF
--- a/.github/workflows/python_buildwheels.yml
+++ b/.github/workflows/python_buildwheels.yml
@@ -170,12 +170,23 @@ jobs:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
       matrix:
-        os: [windows-latest]
         python-version: ${{ fromJSON(needs.set-matrix.outputs.py_versions) }}
         arch: ${{ fromJSON(needs.set-matrix.outputs.windows_archs) }}
     uses: ./.github/workflows/python_cibuildwheel.yml
     with:
-      os: ${{ matrix.os }}
+      # Runner selection for Windows ARM64 (CoolProp-6z0a):
+      #   • CPython ships a native win_arm64 interpreter only for 3.11+, so
+      #     ARM64 on py>=3.11 builds NATIVELY on the windows-11-arm runner.
+      #     Native build means delvewheel (cibuildwheel 4.0's default Windows
+      #     repair) can resolve the ARM64 VC runtime, so the wheel repairs.
+      #   • ARM64 on py3.9/3.10 has no native interpreter; it must cross-compile
+      #     on the x64 windows-latest host, where delvewheel can't find the
+      #     ARM64 msvcp140.dll — so repair is disabled on that leg (see the
+      #     reusable workflow's CIBW_REPAIR_WHEEL_COMMAND_WINDOWS).
+      #   • AMD64/x86 always run on windows-latest with the default repair.
+      # python-version is encoded as 39/310/311/312 (monotonic with the real
+      # version), so `>= 311` correctly means CPython >= 3.11.
+      os: ${{ (matrix.arch == 'ARM64' && matrix.python-version >= 311) && 'windows-11-arm' || 'windows-latest' }}
       python-version: ${{ matrix.python-version }}
       arch: ${{ matrix.arch }}
       TESTPYPI_VERSION: ${{ needs.set-version.outputs.testpypiversion }}

--- a/.github/workflows/python_cibuildwheel.yml
+++ b/.github/workflows/python_cibuildwheel.yml
@@ -77,6 +77,18 @@ jobs:
       with:
         platforms: all
 
+    # cibuildwheel 4.0 makes delvewheel the default Windows repair command, but
+    # the cross-compiled win_arm64 wheels (py3.9/3.10 on the x64 windows-latest
+    # host) can't be repaired there — delvewheel can't find the ARM64
+    # msvcp140.dll and aborts.  Disable repair on that cross leg ONLY, matching
+    # pre-4.0 behavior; native ARM64 (windows-11-arm) and AMD64/x86 keep the
+    # default delvewheel repair.  Setting the var empty = "skip repair";
+    # leaving it unset = cibuildwheel default.  (CoolProp-6z0a)
+    - name: Disable delvewheel repair on cross-compiled Windows ARM64
+      if: ${{ inputs.os == 'windows-latest' && inputs.arch == 'ARM64' }}
+      shell: bash
+      run: echo "CIBW_REPAIR_WHEEL_COMMAND_WINDOWS=" >> "$GITHUB_ENV"
+
     - name: Build and test wheels
       uses: pypa/cibuildwheel@v4.0.0
       env:
@@ -104,7 +116,7 @@ jobs:
         CIBW_ENVIRONMENT_PASS_LINUX: COOLPROP_VERSION_OVERRIDE
         CIBW_BUILD: cp${{ inputs.python-version }}-*
         CIBW_ARCHS_MACOS: ${{ inputs.arch }} # x86_64 arm64 # universal2 is redundant
-        CIBW_ARCHS_WINDOWS: ${{ inputs.arch }} # AMD64 x86 # ARM64 creates problems with msgpack-c
+        CIBW_ARCHS_WINDOWS: ${{ inputs.arch }} # AMD64 x86 ARM64 (ARM64: native on windows-11-arm for py>=3.11, else cross-compiled — see CoolProp-6z0a)
         CIBW_ARCHS_LINUX: ${{ inputs.arch }} # i686 x86_64 aarch64 ppc64le s390x
         # Smoke-test the published v8 wheel: it imports, the nanobind PropsSI works
         # (returns a float for int args), and the State capsule shim loads.


### PR DESCRIPTION
## Problem

The **Python cibuildwheel** workflow has been failing on `master` since #3113 (bump pypa/cibuildwheel 3.4.1 → 4.0.0). Only the **4 Windows ARM64 jobs** (cp39/310/311/312) fail; AMD64/x86/macOS/Linux are all green.

**Root cause** (verified against cibuildwheel's official changelog): 4.0.0 makes `delvewheel repair` the **default** `repair-wheel-command` on Windows — 3.x did *no* Windows repair. The `win_arm64` wheels are cross-compiled on the AMD64 `windows-latest` host, where delvewheel cannot resolve the ARM64 VC runtime:

```
analyzing package-level extension module CoolProp\CoolProp.cp39-win_amd64.pyd
FileNotFoundError: Unable to find library: msvcp140.dll
##[error]cibuildwheel: Command delvewheel repair ... failed with code 1.
```

## Fix

| Leg | Runner | delvewheel |
|---|---|---|
| ARM64 + CPython **3.11 / 3.12** | **`windows-11-arm`** (native) | default repair ✅ |
| ARM64 + CPython **3.9 / 3.10** (no native `win_arm64` interpreter exists) | `windows-latest` (cross-compile) | **disabled** — restores pre-4.0 behavior |
| AMD64 / x86 | `windows-latest` | default repair (unchanged) |

- `python_buildwheels.yml`: the `python_windows` job now derives the reusable-workflow `os` input — `ARM64 && py>=3.11 → windows-11-arm`, else `windows-latest`. (`python-version` is encoded 39/310/311/312, monotonic, so `>= 311` = CPython ≥ 3.11.)
- `python_cibuildwheel.yml`: a guarded step sets `CIBW_REPAIR_WHEEL_COMMAND_WINDOWS=` (empty = skip repair) **only** on the cross-compiled ARM64 leg (`os == windows-latest && arch == ARM64`). Native ARM64 and AMD64/x86 keep the default delvewheel repair.

## Why native for 3.11+ only

CPython ships a native `win_arm64` interpreter only from 3.11. 3.9/3.10 must cross-compile on the x64 host (which is why they did before); they keep doing so, just without the now-default repair that can't work cross-host. These cross-built wheels ship unrepaired exactly as they did under 3.4.1 (and `CIBW_TEST_SKIP` already skips `*-win_arm64` tests).

## Validation

- `actionlint` clean (only pre-existing shellcheck nits on unrelated steps); both workflows parse.
- Routing table simulated for the full matrix; `windows-11-arm` label confirmed against pypa/cibuildwheel's own live CI (`test.yml`).
- `./dev/ci/preflight.sh`: 4 passed / 0 failed / 5 skipped.
- Adversarial review: no blocking findings; the design **fails closed** (a wrong runner label or missing host Python errors loudly — it can never silently ship a broken x64 wheel).

## First-run watch items (both fail-closed)

1. The 3.11/3.12 ARM64 jobs acquire a `windows-11-arm` runner (free for public repos).
2. Host `actions/setup-python@v6` `3.13.x` resolves on the ARM runner.

> Note: the **full** ARM64 matrix runs on push to `master`/tags or on a PR carrying the `full-wheels` label. Add that label here to exercise the ARM64 legs pre-merge.

Fixes the regression introduced by #3113. Tracked as CoolProp-6z0a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized CI/CD pipeline for Windows ARM64 builds based on Python version compatibility
  * Enhanced build process efficiency for cross-compilation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->