### PR TITLE
fix(core): make debug_level + error/warning string globals thread-safe (CoolProp-4qf)

### DIFF
--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -37,6 +37,7 @@
 #include <cstdio>
 #include <string>
 #include <locale>
+#include <atomic>
 #include "CoolProp/detail/tools.h"
 #include "CoolProp/numerics/Solvers.h"
 #include "CoolProp/numerics/MatrixMath.h"
@@ -56,9 +57,17 @@
 
 namespace CoolProp {
 
-static int debug_level = 0;
-static std::string error_string;
-static std::string warning_string;
+// debug_level is written via set_debug_level and read from 30+ hot-path sites;
+// make it atomic so those concurrent accesses are not a data race (bd CoolProp-4qf).
+static std::atomic<int> debug_level{0};
+// error_string / warning_string are written from any exception handler and
+// read-then-cleared by get_global_param_string("errstring"/"warnstring"). As
+// shared globals that was a data race on std::string (UB) that also lost or
+// double-observed messages when threads raced. Make them thread_local so each
+// thread captures and drains its own message -- this matches per-thread
+// exception semantics and the State capsule shim's existing thread_local error.
+static thread_local std::string error_string;
+static thread_local std::string warning_string;
 
 void set_debug_level(int level) {
     debug_level = level;


### PR DESCRIPTION
## What

Three file-scope globals in `src/CoolProp.cpp` were read/written across threads without synchronization (bd CoolProp-4qf):

| Global | Problem | Fix |
|---|---|---|
| `debug_level` | written by `set_debug_level`, read at 30+ hot-path sites via `get_debug_level` | `std::atomic<int>` |
| `error_string` / `warning_string` | written from any exception handler; `get_global_param_string("errstring"/"warnstring")` does a non-atomic **read-then-clear** → data race on `std::string` (UB) + lost/double-observed messages | `thread_local` |

`thread_local` gives each thread its own message — matching per-thread exception semantics and the State capsule shim's existing `thread_local` error string. `deriv_counter` (the third item in the original report) was **already** `std::atomic` from the earlier thread-safety audit, so it's untouched.

No API change; single-thread behavior is identical.

## Validation

- `[get_global_param_string]` test passes (16 assertions — directly exercises the errstring/warnstring read-then-clear).
- Fast Catch2 suite green: **321 passed / 26 REFPROP-skipped, 0 failed, 118,420 assertions**.
- Adversarial review: no blocking findings — confirmed internal linkage preserved, the atomic load/store conversions are valid (every read goes through `get_debug_level`), and **every error-string set/read pair is same-thread** (the SVD-factory and HumidAir worker-thread paths use their own result/flag channels, not the global error string). Also noted: under `__EMSCRIPTEN__`, `thread_local` is `#define`d empty → degrades to plain `static`, correct for the single-threaded WASM target.

## Preflight note

Preflight shows 2 failures, both **pre-existing and unrelated to this 3-line change** (and informational on CI):
- **cppcheck** "syntax error" — cppcheck can't parse the embedded Catch2 `TEST_CASE` macro; reports the *same* error on the unmodified master file (line shifts 703→712 only because this adds 9 lines).
- **clang-tidy** — findings at lines 132/211/286/302, none of them touched here (nodiscard / implicit-bool / unscoped-enum / uninit-record), pre-existing in the file.

clang-format, build, tests, semgrep, and the json-symbol/header-hygiene gates all pass.

bd CoolProp-4qf

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal stability and reliability in multi-threaded environments through thread-safe state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->