### PR TITLE
ci: portable core-count for cmake --build (nproc is empty on macOS → serial builds)

### DIFF
--- a/.github/workflows/library_shared.yml
+++ b/.github/workflows/library_shared.yml
@@ -52,7 +52,16 @@ jobs:
       run: cmake -B build -S . -DCMAKE_BUILD_TYPE:STRING=${{ env.BUILD_TYPE }} -DCOOLPROP_SHARED_LIBRARY:BOOL=ON
 
     - name: Build
-      run: cmake --build build --target install -j $(nproc) --config ${{ env.BUILD_TYPE }}
+      shell: bash
+      # `nproc` is GNU coreutils: absent on macOS (and not a command in
+      # Windows pwsh), so `$(nproc)` silently expands empty here, leaving a
+      # bare `-j` — which goes *serial* on the macOS Unix Makefiles leg
+      # (30+ min vs ~4 min on Linux). Resolve the core count portably and
+      # under bash on all three runners. Mirrors csharp_builder.yml.
+      run: |
+        JOBS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 2)
+        echo "Building with -j$JOBS"
+        cmake --build build --target install -j "$JOBS" --config ${{ env.BUILD_TYPE }}
 
     - name: JSON symbol-leak gate (libCoolProp, Linux/macOS)
       # Fail if nlohmann/valijson/rapidjson symbols leak into libCoolProp's
@@ -81,7 +90,11 @@ jobs:
       
     - name: Build with CMake for 32bit Windows stdcall
       if: startsWith(matrix.os, 'windows')
-      run: cmake --build build_stdc --target install -j $(nproc) --config ${{ env.BUILD_TYPE }}
+      shell: bash
+      run: |
+        JOBS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 2)
+        echo "Building with -j$JOBS"
+        cmake --build build_stdc --target install -j "$JOBS" --config ${{ env.BUILD_TYPE }}
 
     - name: Configure CMake for 32bit Windows cdecl
       if: startsWith(matrix.os, 'windows')
@@ -89,7 +102,11 @@ jobs:
       
     - name: Build with CMake for 32bit Windows cdecl
       if: startsWith(matrix.os, 'windows')
-      run: cmake --build build_cdecl --target install -j $(nproc) --config ${{ env.BUILD_TYPE }}
+      shell: bash
+      run: |
+        JOBS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 2)
+        echo "Building with -j$JOBS"
+        cmake --build build_cdecl --target install -j "$JOBS" --config ${{ env.BUILD_TYPE }}
 
     - name: Configure CMake for 64bit Windows arm64
       if: startsWith(matrix.os, 'windows')
@@ -97,7 +114,11 @@ jobs:
       
     - name: Build with CMake for 64bit Windows arm64
       if: startsWith(matrix.os, 'windows')
-      run: cmake --build build_arm64 --target install -j $(nproc) --config ${{ env.BUILD_TYPE }}
+      shell: bash
+      run: |
+        JOBS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 2)
+        echo "Building with -j$JOBS"
+        cmake --build build_arm64 --target install -j "$JOBS" --config ${{ env.BUILD_TYPE }}
 
 
     # - name: Tar.gz the shared library to maintain case sensitivy and file permissions

--- a/.github/workflows/mathcad_builder.yml
+++ b/.github/workflows/mathcad_builder.yml
@@ -39,8 +39,15 @@ jobs:
       run: cmake -DCOOLPROP_PRIME_MODULE:BOOL=ON -DCOOLPROP_PRIME_ROOT:STRING="${{ github.workspace }}" -B build -S .
 
     - name: Build
-      run: | 
-        cmake --build build --target CoolPropMathcadWrapper -j $(nproc) --config Release
+      # `$(nproc)` is empty in the default Windows pwsh shell (nproc is a
+      # GNU coreutils binary, not a pwsh command), collapsing to a bare `-j`.
+      # Run under Git-Bash and resolve the core count portably. Mirrors
+      # csharp_builder.yml / library_shared.yml.
+      shell: bash
+      run: |
+        JOBS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 2)
+        echo "Building with -j$JOBS"
+        cmake --build build --target CoolPropMathcadWrapper -j "$JOBS" --config Release
         cmake --build build --target install --config Release
 
     - name: Archive artifacts


### PR DESCRIPTION
## Problem

The macOS leg of **Library builds (shared)** runs for **30+ minutes** while the Ubuntu leg finishes the whole job in ~4 min (e.g. [run 27272999913](https://github.com/CoolProp/CoolProp/actions/runs/27272999913/job/80547627071)).

Root cause: the build steps ran

```yaml
cmake --build build --target install -j $(nproc) --config Release
```

under the **default shell**. `nproc` is a GNU coreutils binary — it does **not** exist on macOS, and is not a command in the default Windows `pwsh` shell. So `$(nproc)` expanded to an **empty string**, collapsing the flag to a bare `-j`. With the Unix Makefiles generator that CMake picks on macOS, a bare `-j` runs the underlying `make` with **no parallelism flag at all** → a fully **serial, single-core** build of the whole library.

- **Ubuntu**: `nproc` resolves → real parallelism → ~4 min ✅
- **macOS**: `nproc` empty → bare `-j` → serial → 30+ min ❌
- **Windows** stdcall/cdecl/arm64 steps: same empty-`$(nproc)` in `pwsh`, masked only by MSBuild's default parallelism

## Fix

Resolve the core count portably under `shell: bash` on all runners, matching the existing `csharp_builder.yml` idiom:

```yaml
shell: bash
run: |
  JOBS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 2)
  echo "Building with -j$JOBS"
  cmake --build build --target install -j "$JOBS" --config ${{ env.BUILD_TYPE }}
```

`nproc` (Linux / Git-Bash) → `sysctl -n hw.logicalcpu` (macOS) → `2` floor. The `echo` makes the chosen `-j` visible in logs so a future fallback can't silently regress to a slow build.

Applied to all 4 build steps in `library_shared.yml` and the build step in `mathcad_builder.yml`. Other `$(nproc)` sites (`javascript_builder`, `test_catch2`, `dev_checks` — all ubuntu-only — and the `shell: bash`/Git-Bash Windows steps in `windows_installer`/`csharp_builder`) resolve `nproc` correctly and are left untouched.

## Validation

- Both workflows parse cleanly under a YAML loader
- No bare `$(nproc)` remains in the changed steps
- Adversarial review (per CLAUDE.md): no blocking findings — confirmed `cmake --build` works under Git-Bash for the VS-generator legs (precedent: `windows_installer.yml`), `-A Win32/ARM64` lives on the unchanged configure steps, and the `JOBS=$(…||…||echo 2)` assignment is safe under GHA's `set -eo pipefail`

bd: CoolProp-fzen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build infrastructure parallelism settings for improved reliability and performance across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->