### PR TITLE
fix(python): unmask State shim errors + make mixture copy() work (#3151)

### DIFF
--- a/dev/state_capsule/test_capsule.py
+++ b/dev/state_capsule/test_capsule.py
@@ -151,6 +151,52 @@ def main():
     if not (math.isfinite(acc) and acc != 0.0):
         fails.append(f"hot_loop acc {acc}")
 
+    # --- mixtures (GH #3151) -------------------------------------------------
+    # HEOS has no (T, D) flash for mixtures (DHSU_T_flash does not support
+    # mixtures yet), so a bare (T, D) mixture construction must raise that REAL
+    # error -- not the bogus "'str' object has no attribute 'decode'" that the
+    # broken _raise_if_error used to mask it with.
+    MIX = "HEOS::R32[0.7]&R125[0.3]"
+    try:
+        State.State(MIX, {"T": 300.0, "D": 30.0})
+        fails.append("mixture (T,D) without phase unexpectedly succeeded")
+    except ValueError as e:
+        msg = str(e)
+        if "decode" in msg or "AttributeError" in msg:
+            fails.append(f"mixture error still masked by decode bug: {msg}")
+        elif "mixtures" not in msg:
+            fails.append(f"mixture (T,D) raised an unexpected error: {msg}")
+    except Exception as e:  # not even a ValueError -> the mask is back
+        fails.append(f"mixture (T,D) raised {type(e).__name__}, not a clear ValueError: {e}")
+
+    # With a phase hint the (T, D) update is a direct evaluation and works; the
+    # composition must be honoured (fractions forwarded to the backend).
+    Smix = State.State(MIX, {"T": 300.0, "D": 30.0}, phase="gas")
+    if not math.isclose(Smix.get_T(), 300.0, rel_tol=1e-12):
+        fails.append(f"mixture get_T {Smix.get_T()}")
+    if not math.isclose(Smix.get_rho(), 30.0, rel_tol=1e-12):
+        fails.append(f"mixture get_rho {Smix.get_rho()}")
+    if sorted(n.lower() for n in Smix.pAS.fluid_names()) != ["r125", "r32"]:
+        fails.append(f"mixture fluid_names {Smix.pAS.fluid_names()}")
+
+    # copy() must forward the composition AND reproduce the phase (PDSim's
+    # guess_outlet_temp path) -- bit-for-bit the same state as the source.
+    Cmix = Smix.copy()
+    for name, a, b in (("T", Smix.get_T(), Cmix.get_T()),
+                       ("p", Smix.get_p(), Cmix.get_p()),
+                       ("rho", Smix.get_rho(), Cmix.get_rho()),
+                       ("h", Smix.get_h(), Cmix.get_h()),
+                       ("s", Smix.get_s(), Cmix.get_s())):
+        if not math.isclose(a, b, rel_tol=1e-12):
+            fails.append(f"mixture copy() {name}: source {a:.12g} != copy {b:.12g}")
+    # the copy must have lifted the imposed phase: a later update on a different
+    # (supported) input pair auto-detects, i.e. does not crash with a stale phase.
+    try:
+        Cmix.update({"P": Cmix.get_p(), "T": Cmix.get_T() + 20.0})
+        _ = Cmix.get_h()  # lazy calc under the (now auto-detected) phase
+    except Exception as e:
+        fails.append(f"mixture copy() left an imposed phase (later update failed): {e}")
+
     # cimport-level: PDSim's `cdef State` + cdef method/.pAS calls compile & run
     import cimport_check   # noqa: E402
     cc = cimport_check.check("Water", 320.0, 1000.0)

--- a/include/CoolProp/detail/state_capi.h
+++ b/include/CoolProp/detail/state_capi.h
@@ -45,6 +45,13 @@ extern "C"
         // Impose a phase (a `phases` enum value) on the handle, so the shim's
         // ``State(..., phase=...)`` can force the gas/liquid root like legacy.
         void (*specify_phase)(void* handle, long phase);
+        // Lift a previously-imposed phase so the backend resumes auto-detecting it.
+        // (specify_phase(iphase_not_imposed) is NOT a substitute: it also clobbers
+        // the cached _phase, breaking lazy property evaluation.)  copy() uses this
+        // to reproduce a mixture state under an imposed phase, then restore
+        // auto-detect on the returned handle.  Appended last to keep field offsets
+        // stable.
+        void (*unspecify_phase)(void* handle);
     } CoolProp_StateCAPI;
 
 #ifdef __cplusplus

--- a/src/nanobind_interface.cxx
+++ b/src/nanobind_interface.cxx
@@ -239,8 +239,23 @@ void capi_specify_phase(void* h, long phase) {
         capi_set_error(nullptr);
     }
 }
+void capi_unspecify_phase(void* h) {
+    if (h == nullptr) {
+        capi_set_error("unspecify_phase: null handle");
+        return;
+    }
+    try {
+        (*static_cast<_CAPI_SP*>(h))->unspecify_phase();
+        g_capi_error.clear();
+    } catch (const std::exception& e) {
+        capi_set_error(e.what());
+    } catch (...) {
+        capi_set_error(nullptr);
+    }
+}
 const CoolProp_StateCAPI g_state_capi = {
-  capi_make, capi_destroy, capi_update, capi_keyed_output, capi_first_partial_deriv, capi_last_error, capi_set_mole_fractions, capi_specify_phase};
+  capi_make,          capi_destroy,        capi_update, capi_keyed_output, capi_first_partial_deriv, capi_last_error, capi_set_mole_fractions,
+  capi_specify_phase, capi_unspecify_phase};
 }  // namespace
 
 void init_CoolProp(nb::module_& m) {

--- a/wrappers/Python/_nanobind/State.pxd
+++ b/wrappers/Python/_nanobind/State.pxd
@@ -20,6 +20,7 @@ cdef class _AbstractStateView:
 cdef class State:
     cdef void* handle
     cdef object _fluids
+    cdef object _fractions   # parsed mixture mole fractions (None for pure), for copy()
     cdef readonly _AbstractStateView pAS
     cdef readonly double T_, p_, rho_
     cdef readonly bytes Fluid, phase

--- a/wrappers/Python/_nanobind/State.pyx
+++ b/wrappers/Python/_nanobind/State.pyx
@@ -32,6 +32,7 @@ cdef extern from "CoolProp/detail/state_capi.h":
         const char* (*last_error)()
         void (*set_mole_fractions)(void*, const double*, long)
         void (*specify_phase)(void*, long)
+        void (*unspecify_phase)(void*)
 
 import CoolProp as _CP  # the nanobind core: exports `_capi` + the int-convertible enums
 if not hasattr(_CP, "_capi"):
@@ -61,6 +62,19 @@ cdef long _iP_critical = int(_CP.iP_critical)
 cdef long _iP_triple = int(_CP.iP_triple)
 cdef long _iphase_gas = int(_CP.iphase_gas)
 cdef long _iphase_liquid = int(_CP.iphase_liquid)
+# Determinate single-phase indices.  Imposing one of these on a handle makes a
+# mixture (T, D) update a direct evaluation (no flash needed) -- which is how
+# copy() reproduces a state without the unsupported mixture DHSU_T_flash.
+# twophase / critical_point / unknown / not_imposed are deliberately excluded:
+# a mixture (T, D) with one of those imposed has no supported direct path, so
+# copy() must NOT impose it (it would route into an unsupported mixture flash
+# branch and risk a silently-wrong result) -- it falls back to a plain update
+# that raises the clear core error instead.
+cdef frozenset _SINGLE_PHASE = frozenset((
+    int(_CP.iphase_liquid), int(_CP.iphase_supercritical),
+    int(_CP.iphase_supercritical_gas), int(_CP.iphase_supercritical_liquid),
+    int(_CP.iphase_gas),
+))
 cdef long _DmassT = int(_CP.DmassT_INPUTS)
 cdef long _HmassP = int(_CP.HmassP_INPUTS)
 
@@ -81,7 +95,14 @@ cdef inline void _raise_if_error() except *:
     # (PDSim's ODE solver catches these and rejects the step -- like the old State).
     cdef const char* e = _C.last_error()
     if e is not NULL:
-        raise ValueError("CoolProp: " + e.decode("utf-8", "replace"))
+        # Cast to ``bytes`` first, THEN decode.  This module is cythonised with
+        # ``c_string_type=unicode`` (see wrappers/Python/CMakeLists.txt), under
+        # which a bare ``char*`` auto-coerces to ``str`` -- so ``e.decode(...)``
+        # would run ``.decode`` on a ``str`` and raise ``'str' object has no
+        # attribute 'decode'``, masking the *real* CoolProp error (GH #3151).
+        # ``<bytes>e`` forces the C-string -> bytes conversion regardless of the
+        # directive, so ``.decode`` always sees ``bytes``.
+        raise ValueError("CoolProp: " + (<bytes>e).decode("utf-8", "replace"))
 
 
 cdef inline double _keyed_output(void* handle, long key) except *:
@@ -117,6 +138,12 @@ cdef inline void _set_mole_fractions(void* handle, list fracs) except *:
 cdef inline void _specify_phase(void* handle, long phase) except *:
     # Impose a phase (a phases enum value) on the handle.
     _C.specify_phase(handle, phase)
+    _raise_if_error()
+
+
+cdef inline void _unspecify_phase(void* handle) except *:
+    # Lift a previously-imposed phase so the backend resumes auto-detecting it.
+    _C.unspecify_phase(handle)
     _raise_if_error()
 
 
@@ -244,6 +271,12 @@ cdef class State:
             raise ValueError("State: could not create AbstractState for " + _fl)
         if set_fractions:
             _set_mole_fractions(self.handle, fracs)
+            self._fractions = fracs
+        else:
+            # Plain name or bare ``&``-joined mixture: no bracket fractions to
+            # carry.  ``None`` (not ``[]``) so ``copy()`` can tell "no composition
+            # to forward" from "an explicit empty list".
+            self._fractions = None
         self._fluids = _fl
         self.Fluid = _fl.encode()
         if self.pAS is None:
@@ -293,8 +326,37 @@ cdef class State:
         self._refresh()
 
     cpdef State copy(self):
-        """Return an independent ``State`` for the same fluid at this (T, rho)."""
-        return State(self._fluids, {'T': self.T_, 'D': self.rho_})
+        """Return an independent ``State`` for the same fluid at this (T, rho).
+
+        For a mixture the constituent mole fractions are forwarded (``self._fluids``
+        is the bracket-stripped name, so a plain ``State(self._fluids, ...)`` would
+        drop the composition and fail with "Mole fractions must be set"), and the
+        source state's phase is imposed for the (T, rho) update.  HEOS mixtures have
+        no (T, D) flash -- ``DHSU_T_flash does not support mixtures (yet)`` -- so
+        without the imposed phase the copy of a perfectly valid mixture state would
+        fail there (this is PDSim's ``guess_outlet_temp`` path, GH #3151).  The
+        imposition is then lifted (``unspecify_phase``) so the returned State
+        auto-detects phase on any later update, exactly like a freshly built one.
+
+        Only a determinate single-phase source (gas/liquid/supercritical*) gets
+        its phase imposed; a two-phase (or otherwise indeterminate) mixture has no
+        supported direct (T, D) path, so the copy falls through to a plain update
+        that raises the clear core error rather than a silently-wrong result.
+        """
+        cdef State s = State(self._fluids, None)
+        cdef long ph
+        if self._fractions is not None:
+            _set_mole_fractions(s.handle, self._fractions)
+            ph = <long>_keyed_output(self.handle, _iPhase)   # this state's phase
+            if ph in _SINGLE_PHASE:
+                _specify_phase(s.handle, ph)                 # skip the missing flash
+                s.update({'T': self.T_, 'D': self.rho_})
+                _unspecify_phase(s.handle)                   # back to auto-detect
+                return s
+        # Pure fluid, or a mixture with no supported direct (T, D) path: plain
+        # update (correct for pure; clear core error for such a mixture).
+        s.update({'T': self.T_, 'D': self.rho_})
+        return s
 
     cpdef double Props(self, long key) except *:
         """Raw keyed output for CoolProp parameter ``key`` [SI]."""


### PR DESCRIPTION
Fixes #3151.

The v8 nanobind `CoolProp.State` compat shim (the frozen `cimport` surface for PDSim) failed on HEOS mixtures for two independent reasons. Both are reproduced against the test.pypi beta (`7.2.1.dev20260610124924`) and fixed here.

## Defect 1 — every error on the mixture path was masked

`_raise_if_error` did `e.decode(...)` on a `const char*`. The shim is cythonised with `--directive c_string_type=unicode` (`wrappers/Python/CMakeLists.txt`), under which a bare `char*` auto-coerces to a Python `str` — so `.decode()` ran on a `str` and raised `AttributeError: 'str' object has no attribute 'decode'`, hiding the real CoolProp error.

Fix: cast to `<bytes>` before decoding, so the true message surfaces regardless of the directive.

## Defect 2 — `copy()` broke on mixtures

`State.copy()` reconstructed from `self._fluids` (the **bracket-stripped** name), so it dropped the mixture mole fractions (`Mole fractions must be set`), and it never reproduced the source phase — so copying a perfectly valid HEOS mixture state hit the core's `DHSU_T_flash does not support mixtures (yet)` (HEOS has no `(T,D)` flash for mixtures). This is the path PDSim's `guess_outlet_temp` exercises.

Fix: `copy()` now forwards the parsed fractions and, for a **determinate single-phase** source (gas/liquid/supercritical\*), imposes that phase so the `(T,D)` update is a direct evaluation, then lifts the imposition so the returned `State` auto-detects phase on any later update. Two-phase / indeterminate mixtures fall through to a plain update that raises the clear core error rather than routing into an unsupported mixture flash branch (avoids any silent-wrong-number path).

Lifting the imposition requires a real `unspecify_phase`: `specify_phase(iphase_not_imposed)` also clobbers the backend's cached `_phase` (breaking lazy property evaluation — `phase is invalid in calc_hmolar`). A new `unspecify_phase` entry is **appended** to the `State` C-ABI capsule (existing field offsets unchanged).

## Scope note

Arbitrary `(T,D)` mixture **construction** without a phase is a longstanding **core** limitation — legacy CoolProp fails identically. It is out of scope here; after Defect 1 it now raises that same clear error instead of the bogus `AttributeError`.

## Verification

- Rebuilt the nanobind wheel; pure-fluid parity (Water/CO2) + a new mixture block in `dev/state_capsule/test_capsule.py` pass.
- Gas **and** liquid mixture `copy()` are bit-exact to the source and restore phase auto-detect on later updates.
- Frozen `cimport` contract (`cimport_check.pyx`) still compiles & runs against the new `.pxd`.
- `./dev/ci/preflight.sh`: 8 passed / 0 failed / 1 skipped (clang-format, CatchTestRunner build, Catch2 `[!slow][!benchmark]`, cppcheck, clang-tidy, semgrep, json-symbols, install-headers).
- Pre-PR adversarial review: no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to lift previously imposed phases on state objects, enabling auto-detection on subsequent updates.
  * Enhanced state copying to properly preserve mixture composition and phase handling.

* **Bug Fixes**
  * Improved error message decoding for state operations.

* **Tests**
  * Added tests for mixture state phase management and state copying behavior, including auto-detection after phase updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->