### PR TITLE
fix(fluids): add melting lines for OrthoHydrogen and the deuterium isotopes

### DIFF
--- a/CoolPropBibTeXLibrary.bib
+++ b/CoolPropBibTeXLibrary.bib
@@ -695,6 +695,18 @@
   Timestamp                = {2013.04.08}
 }
 
+@Article{Diatschenko-PRB-1985,
+  Title                    = {{Melting curves of molecular hydrogen and molecular deuterium under high pressures between 20 and 373 K}},
+  Author                   = {V. Diatschenko and C. W. Chu and D. H. Liebenberg and D. A. Young and M. Ross and R. L. Mills},
+  Journal                  = {Physical Review B},
+  Year                     = {1985},
+  Number                   = {1},
+  Pages                    = {381-389},
+  Volume                   = {32},
+
+  Doi                      = {10.1103/PhysRevB.32.381}
+}
+
 @Article{Datchi-PRB-2000,
   Title                    = {{Extended and accurate determination of the melting curves of argon, helium, ice (H$_2$O) and hydrogen (H$_2$)}},
   Author                   = {Fr{\'e}d{\'e}ric Datchi and Paul Loubeyre and Ren{\'e} LeToullec},

--- a/dev/fluids/Deuterium.json
+++ b/dev/fluids/Deuterium.json
@@ -44,6 +44,21 @@
       "max_abs_error_units": "J/mol",
       "type": "rational_polynomial"
     },
+    "melting_line": {
+      "BibTeX": "Diatschenko-PRB-1985",
+      "T_m": 18.724,
+      "parts": [
+        {
+          "T_0": 1,
+          "T_max": 175,
+          "T_min": 19.72,
+          "a": 366000.0,
+          "c": 1.677,
+          "p_0": -53944000.0
+        }
+      ],
+      "type": "Simon"
+    },
     "pS": {
       "T_r": 38.34,
       "Tmax": 38.33999999999991,

--- a/dev/fluids/OrthoDeuterium.json
+++ b/dev/fluids/OrthoDeuterium.json
@@ -44,6 +44,21 @@
       "max_abs_error_units": "J/mol",
       "type": "rational_polynomial"
     },
+    "melting_line": {
+      "BibTeX": "Diatschenko-PRB-1985",
+      "T_m": 18.724,
+      "parts": [
+        {
+          "T_0": 1,
+          "T_max": 175,
+          "T_min": 19.72,
+          "a": 366000.0,
+          "c": 1.677,
+          "p_0": -53944000.0
+        }
+      ],
+      "type": "Simon"
+    },
     "pS": {
       "T_r": 38.34,
       "Tmax": 38.33999999999991,

--- a/dev/fluids/OrthoHydrogen.json
+++ b/dev/fluids/OrthoHydrogen.json
@@ -44,6 +44,21 @@
       "max_abs_error_units": "J/mol",
       "type": "rational_polynomial"
     },
+    "melting_line": {
+      "BibTeX": "Datchi-PRB-2000",
+      "T_m": 14.009985,
+      "parts": [
+        {
+          "T_0": 1,
+          "T_max": 700,
+          "T_min": 13.957,
+          "a": 231000.0,
+          "c": 1.7627,
+          "p_0": -236200.0
+        }
+      ],
+      "type": "Simon"
+    },
     "pS": {
       "T_r": 33.22,
       "Tmax": 33.219999999999914,

--- a/dev/fluids/ParaDeuterium.json
+++ b/dev/fluids/ParaDeuterium.json
@@ -44,6 +44,21 @@
       "max_abs_error_units": "J/mol",
       "type": "rational_polynomial"
     },
+    "melting_line": {
+      "BibTeX": "Diatschenko-PRB-1985",
+      "T_m": 18.724,
+      "parts": [
+        {
+          "T_0": 1,
+          "T_max": 175,
+          "T_min": 19.72,
+          "a": 366000.0,
+          "c": 1.677,
+          "p_0": -53944000.0
+        }
+      ],
+      "type": "Simon"
+    },
     "pS": {
       "T_r": 38.34,
       "Tmax": 38.33999999999991,

--- a/src/Tests/CoolProp-Tests-PXFlash.cpp
+++ b/src/Tests/CoolProp-Tests-PXFlash.cpp
@@ -105,4 +105,64 @@ TEST_CASE("P+X single-phase round-trips (PH/PS/PU)", "[PXflash]") {
     }
 }
 
+// ---------------------------------------------------------------------------
+// High-pressure quantum-fluid P+X reliability (bd CoolProp-r1w7.1).
+//
+// At p >> psat_max (hundreds of MPa) with T just above Tc, the HSU_P flash's
+// T-search bracket straddles Tc.  Without a melting line the search floor is
+// the bare EOS triple temperature, so trial T < Tc probe the cold solid-region
+// isotherm (a van der Waals loop pinned near p~0); solver_rho_Tp cannot find the
+// high-density root there and threw "Inputs in Brent [...] do not bracket the
+// root", aborting the flash before it could reach the valid T > Tc solution.
+// This was the largest exception bucket in the HEOS consistency report and is
+// perfectly correlated with a missing melting line (Hydrogen / ParaHydrogen,
+// which HAVE one, do not fail; OrthoHydrogen and the Deuterium isotopes, which
+// did not, failed ~684-702 times each).  The fix gives these fluids a melting
+// line so the flash floors its T-search at Tmelt(p), above the loop.  Points are
+// taken from the per-fluid consistency CSVs.
+// ---------------------------------------------------------------------------
+TEST_CASE("P+X high-pressure quantum-fluid reliability (was failing)", "[PXflash]") {
+    struct Case
+    {
+        const char* fluid;
+        double T;  // K  (> Tc, but the flash's T-search dips below Tc)
+        double p;  // Pa (>> psat_max)
+    };
+    // Genuine fluid states (T > Tmelt(p)) at p >> psat_max that failed in the
+    // consistency report.  Lower-T grid points at the same pressure are below the
+    // melting line (solid) and are correctly rejected, not solved.  Adding the
+    // melting line (Datchi-2000 for H2; Diatschenko-1985 for the D2 isotopes)
+    // floors the HSU_P T-search at Tmelt(p) so these no longer fail.
+    const Case c =
+      GENERATE(Case{"OrthoHydrogen", 90.86892307692308, 404007839.5225975}, Case{"Deuterium", 79.32923076923078, 448875035.8934926},
+               Case{"OrthoDeuterium", 79.32923076923078, 448875035.8934926}, Case{"ParaDeuterium", 79.32923076923078, 448875035.8934926});
+    CAPTURE(c.fluid, c.T, c.p);
+
+    auto ref = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", c.fluid));
+    auto wrk = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", c.fluid));
+
+    REQUIRE_NOTHROW(ref->update(CoolProp::PT_INPUTS, c.p, c.T));
+    const double h = ref->hmolar();
+    const double s = ref->smolar();
+    const double u = ref->umolar();
+    const double rho = ref->rhomolar();
+    REQUIRE(std::isfinite(rho));
+
+    SECTION("PH") {
+        REQUIRE_NOTHROW(wrk->update(CoolProp::HmolarP_INPUTS, h, c.p));
+        CHECK(wrk->T() == Catch::Approx(c.T).epsilon(1e-5));
+        CHECK(wrk->rhomolar() == Catch::Approx(rho).epsilon(1e-5));
+    }
+    SECTION("PS") {
+        REQUIRE_NOTHROW(wrk->update(CoolProp::PSmolar_INPUTS, c.p, s));
+        CHECK(wrk->T() == Catch::Approx(c.T).epsilon(1e-5));
+        CHECK(wrk->rhomolar() == Catch::Approx(rho).epsilon(1e-5));
+    }
+    SECTION("PU") {
+        REQUIRE_NOTHROW(wrk->update(CoolProp::PUmolar_INPUTS, c.p, u));
+        CHECK(wrk->T() == Catch::Approx(c.T).epsilon(1e-5));
+        CHECK(wrk->rhomolar() == Catch::Approx(rho).epsilon(1e-5));
+    }
+}
+
 #endif  // ENABLE_CATCH


### PR DESCRIPTION
## Summary

The HEOS flash-consistency report ([devdocs](https://coolprop.github.io/devdocs/fluid_properties/ConsistencyReport.html), 2026-06-10) showed ~3,700 `P+{H,S,U}` single-phase flash failures across **OrthoHydrogen, Deuterium, OrthoDeuterium, and ParaDeuterium**, all of the form `Inputs in Brent [...] do not bracket the root`.

**Root cause:** these four fluids lacked a melting line. `HSU_P_flash` floors its temperature search at `Tmelt(p)` when a melting line exists (`FlashRoutines.cpp:2828`); without one it falls back to the bare EOS triple temperature and the T-search dips below Tc into the cold solid-region van der Waals-loop isotherm, where the inner density solve cannot reach the (high-density) root and throws. The smoking gun is a clean natural experiment across the isotope family:

| Fluid | Melting line | PHSU failures |
|---|---|---|
| Hydrogen | ✅ | **0** |
| ParaHydrogen | ✅ | **0** |
| OrthoHydrogen | ❌ → ✅ | 702 → 0 |
| Deuterium / Ortho / Para | ❌ → ✅ | 684 each → 0 |

## Change

Add the melting line (data only — `solver_rho_Tp` is untouched):

- **OrthoHydrogen**: Datchi-PRB-2000 Simon curve, copied verbatim from `Hydrogen.json`. Orthohydrogen is normal hydrogen's dominant spin isomer, so the melting curve is identical.
- **Deuterium / OrthoDeuterium / ParaDeuterium**: Diatschenko-PRB-1985 D₂ fit `P[kbar] = -0.5431 + 3.66e-3·T^1.677` (valid to 19 kbar), converted to CoolProp's Simon form `p = p_0 + a·((T/T_0)^c - 1)` with `T_0=1`: **a=366000, c=1.677, p_0=-53944000**. `T_min=19.72 K` puts the lower bound on the positive-pressure branch (pmin ≈ the D₂ triple pressure), matching the existing convention (cf. ParaHydrogen).
- New BibTeX entry `Diatschenko-PRB-1985`.

The H₂ coefficients from the same paper reproduce CoolProp's existing Datchi H₂ curve to 0.4% at 100–150 K, confirming the form/units; D₂ Tmelt(449 MPa)=74.4 K > H₂ 73.7 K (correct isotope effect).

Solid-region grid points (`T < Tmelt(p)`) are now correctly **rejected**; genuine fluid points **solve**.

## Validation

- `[PXflash]` extended with genuine-fluid points for all four fluids — pass.
- `[melting]` 387 assertions, `[flash]`/`[pureflash]`/`[supercritical]`/`[water_flash]`/`[critical_patch]` 1724 assertions (50 cases), `[consistency]` 24991 assertions — all pass.

## Scope

This closes the hydrogen/deuterium-isotope sub-bucket. Other PHSU contributors (Air, Neon, n-Decane, PropyleneGlycol) reach that bucket via different root causes and are tracked separately under the epic.

bd CoolProp-r1w7.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored reliable high-pressure thermodynamic calculations for quantum fluids (Deuterium, OrthoHydrogen, OrthoDeuterium, ParaDeuterium) by adding melting-line data support, resolving prior failures at extreme conditions.

* **Tests**
  * Added regression tests verifying high-pressure thermodynamic round-trips for the affected quantum fluids.

* **Chores**
  * Added a bibliographic reference entry used by the new data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->