### PR TITLE
feat(python): default the build to nanobind for v8 + ship PDSim CoolProp.pxd

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -287,6 +287,27 @@ jobs:
           done
           test "$ran" -gt 0 || { echo "::error::no Python interpreter could run a nanobind wheel"; exit 1; }
 
+      - name: PDSim cimport contract (compile + run against the abi3 wheel)
+        shell: bash
+        run: |
+          set -euo pipefail
+          # PDSim consumes CoolProp's cdef State / AbstractState / constants
+          # surface via `cimport` (dev/pdsim_cimport_contract/SURFACE.md), incl.
+          # `from CoolProp.CoolProp cimport State`.  Compile + run the frozen
+          # contract against the installed v8 wheel so a drift in that surface
+          # fails CI here rather than silently breaking PDSim's next build
+          # (CoolProp-1tbe.6).  Fail-closed: a missing wheel is a hard error.
+          WHL=$(ls dist/coolprop-*-cp312-abi3-*.whl 2>/dev/null || true)
+          if [ -z "$WHL" ]; then
+            echo "::error::no cp312-abi3 wheel found for the PDSim cimport contract"
+            exit 1
+          fi
+          uv venv --python 3.12 .venv-pdsim
+          source .venv-pdsim/bin/activate
+          uv pip install "cython>=3.1" setuptools numpy "$WHL"
+          python dev/pdsim_cimport_contract/run_contract.py
+          deactivate
+
   clang-tidy:
     name: clang-tidy (diff-only, informational)
     # Runs clang-tidy on lines changed in the PR via clang-tidy-diff.py and

--- a/dev/pdsim_cimport_contract/pdsim_surface.pyx
+++ b/dev/pdsim_cimport_contract/pdsim_surface.pyx
@@ -28,6 +28,7 @@ Keep this list in sync with SURFACE.md.  Anything added here should be a
 deliberate, reviewed widening of the contract.
 """
 from CoolProp.State cimport State                   # the cdef class (CoolProp.State path)
+from CoolProp.CoolProp cimport State as StateViaCoolProp  # PDSim core/state_flooded path
 cimport CoolProp.constants_header as constants      # enum module (constants.iXxx)
 from CoolProp.constants_header cimport parameters   # enum used as a C type
 
@@ -120,3 +121,14 @@ cpdef double hot_loop(object Fluid, double T, double rho, int n):
         S.update_Trho(T + 0.001 * i, rho)
         acc += S.get_p() + S.get_h() + S.pAS.keyed_output(constants.iSmass)
     return acc
+
+
+cpdef double exercise_state_flooded_path(object Fluid, double T, double rho):
+    """Exercise the `from CoolProp.CoolProp cimport State` path that PDSim's
+    core/state_flooded uses (SURFACE.md), distinct from the CoolProp.State
+    path above.  Statically typing the local as ``StateViaCoolProp`` forces
+    Cython to resolve the cdef class through CoolProp.CoolProp at compile
+    time; constructing + reading a value proves it is the same working class
+    at runtime.  CoolProp-1tbe.6."""
+    cdef StateViaCoolProp S = StateViaCoolProp(Fluid, {'T': T, 'D': rho})
+    return S.get_p()

--- a/dev/pdsim_cimport_contract/run_contract.py
+++ b/dev/pdsim_cimport_contract/run_contract.py
@@ -87,6 +87,11 @@ def check():
     if not isinstance(rf["phase"], int):
         fails.append(f"Phase() did not return an int: {rf['phase']!r}")
 
+    # the `from CoolProp.CoolProp cimport State` path (PDSim core/state_flooded)
+    # must resolve to the same working cdef class as CoolProp.State
+    p_via_cc = pdsim_surface.exercise_state_flooded_path(FLUID, T, RHO)
+    expect("State via CoolProp.CoolProp cimport [kPa]", p_via_cc, SI("P") / 1000.0)
+
     # hot loop (PDSim's inner pattern) just has to run and produce a finite sum
     acc = pdsim_surface.hot_loop(FLUID, T, RHO, 1000)
     if not (math.isfinite(acc) and acc != 0.0):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,11 @@ authors = [
 ]
 description = "Open-source thermodynamic and transport properties database"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "MIT"}
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -112,7 +111,7 @@ wheel.py-api = "cp312"
 
 [tool.cibuildwheel]
 # Build for multiple Python versions (CPython only)
-build = "cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
+build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
 
 # Skip musllinux for now
 skip = "*-musllinux_*"

--- a/wrappers/Python/CMakeLists.txt
+++ b/wrappers/Python/CMakeLists.txt
@@ -27,20 +27,22 @@ find_package(Cython REQUIRED)
 
 # Opt-in: build the nanobind core + the capsule `State` shim instead of the
 # legacy Cython interface, reusing this same harness (constants generation,
-# package assembly, install rules, scikit-build wheel).  Default OFF -> the
-# shipped (legacy Cython) wheel is completely unchanged.  When ON, the nanobind
-# core (CoolProp.<abi3>.so) replaces the legacy Cython CoolProp module and the
-# link-free State capsule shim is built as CoolProp.State.
+# package assembly, install rules, scikit-build wheel).  Default ON for v8 ->
+# the nanobind core (CoolProp.<abi3>.so) is the shipped CoolProp module and the
+# link-free State capsule shim is built as CoolProp.State.  Building the
+# retired legacy Cython wrapper is now an explicit opt-OUT via
+# `-DCOOLPROP_NANOBIND=OFF`.  Flipping the default ON is what makes a plain
+# `pip install` from the sdist (no env var) build the v8 nanobind interface
+# rather than silently falling back to the legacy Cython one (CoolProp-1tbe.4).
 #
-# A `COOLPROP_NANOBIND=ON` *environment* build flips this on via a
-# scikit-build-core override (pyproject.toml) that injects
-# cmake.define.COOLPROP_NANOBIND=ON; the same env var (on Py>=3.12) also turns
-# on the abi3 wheel tag.  Both signals flow through ONE scikit-build-core
-# override block, so they cannot diverge.  `-DCOOLPROP_NANOBIND=ON` directly
-# (or via cmake.define) still works for nanobind selection; abi3-ness of the
-# Cython sidecars follows scikit-build-core's own SKBUILD_SABI_VERSION below, so
-# a define-only build simply yields a valid per-version nanobind wheel.
-option(COOLPROP_NANOBIND "Build the nanobind-based CoolProp package (core + State capsule shim)" OFF)
+# CI's `COOLPROP_NANOBIND=ON` environment signal still flows through the
+# scikit-build-core overrides in pyproject.toml: on Py>=3.12 the same env var
+# also turns on the abi3 wheel tag (the override cannot see -D defines, so the
+# env var remains the canonical signal for the abi3 publish matrix).  With the
+# default now ON, the env-var *selection* override is redundant but harmless; a
+# define-only / env-less build (e.g. an sdist `pip install`) simply yields a
+# valid per-version nanobind wheel, abi3-ness following SKBUILD_SABI_VERSION.
+option(COOLPROP_NANOBIND "Build the nanobind-based CoolProp package (core + State capsule shim)" ON)
 
 # Set root directory
 set(ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
@@ -415,6 +417,10 @@ install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/_nanobind/__init__.py"
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/_nanobind/__init__.pxd"
     DESTINATION CoolProp)
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/_nanobind/State.pxd"
+    DESTINATION CoolProp)
+# Re-export pxd so `from CoolProp.CoolProp cimport State` (PDSim
+# core/state_flooded) resolves to the CoolProp.State cdef class.
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/_nanobind/CoolProp.pxd"
     DESTINATION CoolProp)
 install(FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/CoolProp/constants.py"

--- a/wrappers/Python/_nanobind/CoolProp.pxd
+++ b/wrappers/Python/_nanobind/CoolProp.pxd
@@ -1,0 +1,12 @@
+# Re-export the cdef `State` class on the `CoolProp.CoolProp` cimport path.
+#
+# PDSim's core/state_flooded does `from CoolProp.CoolProp cimport State` (see
+# dev/pdsim_cimport_contract/SURFACE.md).  In the legacy Cython package the
+# `State` cdef class lived in the CoolProp.CoolProp module itself; in v8 the
+# nanobind core IS CoolProp.CoolProp (a compiled extension with no cimportable
+# cdef classes) and `State` is the frozen capsule shim in CoolProp.State.  This
+# .pxd bridges the two: re-exporting `State` here lets the documented
+# `from CoolProp.CoolProp cimport State` resolve to the same cdef class as
+# `from CoolProp.State cimport State`, at both Cython compile time and runtime
+# (the type object is sourced from the CoolProp.State module).  CoolProp-1tbe.6.
+from CoolProp.State cimport State


### PR DESCRIPTION
## Summary

Two v8 packaging gaps from the pre-release audit.

### `.4` — sdist/default build now produces the nanobind interface

The `COOLPROP_NANOBIND` CMake option gated whether the wrapper builds the v8 nanobind interface or the retired legacy Cython one, defaulting **OFF**, and only CI set the `COOLPROP_NANOBIND=ON` env var. So a plain `pip install coolprop` from the **sdist** (musllinux/Alpine, ppc64le, `--no-binary`, or any platform without a wheel) silently built the **legacy** interface labeled `8.0.0` — different exception types, vector semantics, and the removed `Props`/`HAProps` still present.

Flipping the option default **ON** makes every build path (sdist, pip, raw cmake) build nanobind; legacy is now explicit opt-OUT via `-DCOOLPROP_NANOBIND=OFF`. The CI env-var overrides still drive the abi3 publish matrix unchanged (verified: a `-DCOOLPROP_NANOBIND=OFF` build is never mis-tagged abi3, since the abi3 `py-api` override keys on the env var). Also bumps `requires-python` 3.8 → 3.9 (a 3.8 user would have fallen straight into the sdist-legacy path) and drops `cp38` from the cibuildwheel set.

### `.6` — PDSim `from CoolProp.CoolProp cimport State` now resolves

Ships a `CoolProp/CoolProp.pxd` that re-exports the `State` cdef class, so the cimport PDSim's `core/state_flooded` makes (documented in `SURFACE.md`) resolves in the nanobind package. The legacy package defined `State` in the `CoolProp.CoolProp` module; in v8 the nanobind core *is* `CoolProp.CoolProp` (no cimportable cdef classes) and `State` is the `CoolProp.State` capsule shim, so the `.pxd` bridges both paths to the same class. The cimport contract now exercises that path (it previously tested only `from CoolProp.State cimport State`, missing the surface its own `SURFACE.md` documents) and is wired into CI as a **fail-closed** gate in the `nanobind-wheels` job.

## Verification

A fresh `pip install .` with **no env var** builds the nanobind interface (no legacy `Props`; PropsSI correct; `CoolProp.pxd` shipped) → `coolprop-…-cp312-cp312-…whl`. The PDSim cimport contract compiles + runs against that wheel, including the new `CoolProp.CoolProp` `State` path (matches PropsSI under the kPa/kJ convention). Adversarial review: no blocking findings.

## ⚠️ Merge-ordering dependency

Flipping the default switches the **docs build** (`pip wheel .`, no env var) to nanobind too. This should land **after** the SuperAncillary bindings (#3155, CoolProp-1tbe.5) — otherwise the SuperAncillary docs notebook degrades to a traceback page. The review confirmed #3155 is the only docs dependency.

The nanobind/Cython build-system pins and the `Development Status :: Beta` classifier remain for CoolProp-1tbe.13.

Fixes CoolProp-1tbe.4, CoolProp-1tbe.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised minimum Python requirement to 3.9 and updated wheel build matrix to cover Python 3.9–3.14.
  * Made nanobind the default packaging approach and ensured nanobind re-exports the State cimport surface for compatibility.

* **Tests**
  * Added a CI contract check that compiles and runs a runtime cimport compatibility validation against the abi3 wheel, failing CI on mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->