### PR TITLE
Do not evaluate melting line below ptrip

### DIFF
--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -1712,8 +1712,12 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
         switch (other) {
             case iT: {
                 // Check for the presence of the melting line (skipped when the caller has
-                // opted out of property-limit checks, mirroring the subcritical path below)
-                if (has_melting_line() && !get_config_bool(DONT_CHECK_PROPERTY_LIMITS)) {
+                // opted out of property-limit checks, mirroring the subcritical path below).
+                // Also skip when _p is below the lower bound of the melting-line fit
+                // (i.e. below the triple-point pressure); the fit is undefined there and
+                // the fluid must be gas or gas+solid, never liquid.
+                if (has_melting_line() && !get_config_bool(DONT_CHECK_PROPERTY_LIMITS)
+                    && _p > calc_melting_line(iP_min, -1, -1)) {
                     double Tm = melting_line(iT, iP, _p);
                     if (_T < Tm - 0.001) {
                         throw ValueError(format("For now, we don't support T [%g K] below Tmelt(p) [%g K]", _T, Tm));
@@ -1789,7 +1793,8 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
 
                 if (other == iT) {
                     if (value < Tsat - 100 * DBL_EPSILON) {
-                        if (has_melting_line() && !get_config_bool(DONT_CHECK_PROPERTY_LIMITS)) {
+                        if (has_melting_line() && !get_config_bool(DONT_CHECK_PROPERTY_LIMITS)
+                            && _p > calc_melting_line(iP_min, -1, -1)) {
                             double Tm = melting_line(iT, iP, _p);
                             if (_T < Tm - 0.001) {
                                 throw ValueError(format("For now, we don't support T [%g K] below Tmelt(p) [%g K]", _T, Tm));
@@ -1859,7 +1864,7 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
         switch (other) {
             case iT: {
 
-                if (has_melting_line()) {
+                if (has_melting_line() && _p > calc_melting_line(iP_min, -1, -1)) {
                     double Tm = melting_line(iT, iP, _p);
                     if (get_config_bool(DONT_CHECK_PROPERTY_LIMITS)) {
                         _phase = iphase_liquid;
@@ -2176,7 +2181,8 @@ void HelmholtzEOSMixtureBackend::T_phase_determination_pure_or_pseudopure(int ot
 
     // Check for the presence of the melting line (skipped when the caller has opted out
     // of property-limit checks, mirroring p_phase_determination_pure_or_pseudopure)
-    if (other == iP && has_melting_line() && !get_config_bool(DONT_CHECK_PROPERTY_LIMITS)) {
+    if (other == iP && has_melting_line() && !get_config_bool(DONT_CHECK_PROPERTY_LIMITS)
+        && value > calc_melting_line(iP_min, -1, -1)) {
         double Tm = melting_line(iT, iP, value);
         if (_T < Tm - 0.001) {
             throw ValueError(format("For now, we don't support T [%g K] below Tmelt(p) [%g K]", _T, Tm));

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -1716,8 +1716,7 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
                 // Also skip when _p is below the lower bound of the melting-line fit
                 // (i.e. below the triple-point pressure); the fit is undefined there and
                 // the fluid must be gas or gas+solid, never liquid.
-                if (has_melting_line() && !get_config_bool(DONT_CHECK_PROPERTY_LIMITS)
-                    && _p > calc_melting_line(iP_min, -1, -1)) {
+                if (has_melting_line() && !get_config_bool(DONT_CHECK_PROPERTY_LIMITS) && _p > calc_melting_line(iP_min, -1, -1)) {
                     double Tm = melting_line(iT, iP, _p);
                     if (_T < Tm - 0.001) {
                         throw ValueError(format("For now, we don't support T [%g K] below Tmelt(p) [%g K]", _T, Tm));
@@ -1793,8 +1792,7 @@ void HelmholtzEOSMixtureBackend::p_phase_determination_pure_or_pseudopure(int ot
 
                 if (other == iT) {
                     if (value < Tsat - 100 * DBL_EPSILON) {
-                        if (has_melting_line() && !get_config_bool(DONT_CHECK_PROPERTY_LIMITS)
-                            && _p > calc_melting_line(iP_min, -1, -1)) {
+                        if (has_melting_line() && !get_config_bool(DONT_CHECK_PROPERTY_LIMITS) && _p > calc_melting_line(iP_min, -1, -1)) {
                             double Tm = melting_line(iT, iP, _p);
                             if (_T < Tm - 0.001) {
                                 throw ValueError(format("For now, we don't support T [%g K] below Tmelt(p) [%g K]", _T, Tm));
@@ -2181,8 +2179,7 @@ void HelmholtzEOSMixtureBackend::T_phase_determination_pure_or_pseudopure(int ot
 
     // Check for the presence of the melting line (skipped when the caller has opted out
     // of property-limit checks, mirroring p_phase_determination_pure_or_pseudopure)
-    if (other == iP && has_melting_line() && !get_config_bool(DONT_CHECK_PROPERTY_LIMITS)
-        && value > calc_melting_line(iP_min, -1, -1)) {
+    if (other == iP && has_melting_line() && !get_config_bool(DONT_CHECK_PROPERTY_LIMITS) && value > calc_melting_line(iP_min, -1, -1)) {
         double Tm = melting_line(iT, iP, value);
         if (_T < Tm - 0.001) {
             throw ValueError(format("For now, we don't support T [%g K] below Tmelt(p) [%g K]", _T, Tm));

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4126,6 +4126,42 @@ TEST_CASE_METHOD(PropertyLimitsFixture, "Below-melting PT guard honors DONT_CHEC
     }
 }
 
+TEST_CASE("PT update below melting-line pmin succeeds without specify_phase for all HEOS fluids", "[melting]") {
+    // Before the fix in HelmholtzEOSMixtureBackend.cpp, the phase-determination
+    // paths called melting_line(iT, iP, p) unconditionally for any fluid with a
+    // melting-line fit, including when p was below pmin (the triple-point pressure).
+    // The evaluator threw an out-of-bounds error in that case, breaking any call
+    // that omits specify_phase when the pressure is below the fit's lower bound --
+    // for example Argon in an air mixture where the partial pressure (~941 Pa) is
+    // far below Argon's pmin (~69 688 Pa).
+    using namespace CoolProp;
+    const std::vector<std::string> all_fluids = strsplit(get_global_param_string("fluids_list"), ',');
+    for (const auto& name : all_fluids) {
+        std::shared_ptr<AbstractState> AS;
+        try {
+            AS.reset(AbstractState::factory("HEOS", name));
+        } catch (...) {
+            continue;
+        }
+        if (!AS->has_melting_line()) continue;
+
+        const double pmin = AS->melting_line(iP_min, -1, -1);
+        // Just below the lower bound of the melting-line fit
+        const double p_test = 0.99 * pmin;
+        // Well above the triple point temperature -- unambiguously gas at p < ptriple
+        const double T_test = AS->Ttriple() * 1.1;
+
+        SECTION(name) {
+            CAPTURE(pmin);
+            CAPTURE(p_test);
+            CAPTURE(T_test);
+            CHECK_NOTHROW(AS->update(PT_INPUTS, p_test, T_test));
+            CHECK(ValidNumber(AS->rhomolar()));
+            CHECK(AS->rhomolar() > 0);
+        }
+    }
+}
+
 TEST_CASE("HeavyWater (D2O) melting line matches Herrig et al. check values", "[melting]") {
     // Melting-pressure equations Eqs. (4)-(7) of Herrig, Thol, Harvey, Lemmon,
     // "A Reference Equation of State for Heavy Water," J. Phys. Chem. Ref. Data


### PR DESCRIPTION
Resolve #3158 

This PR implements a guard for fluids with melting line to only evaluate the melting line if the pressure is above the minimum pressure of the polynomial. Tests are added for all fluids with melting line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened melting-line checks during phase determination so constraints are only applied above the melting-line's valid lower pressure bound, improving robustness of phase classification near the melting-line.

* **Tests**
  * Added regression test to verify PT updates just below the melting-line lower bound succeed and produce finite, positive density values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->