### PR TITLE
fix(python): validate vectorized HAPropsSI elements + guard null State capsule handle

### DIFF
--- a/src/nanobind_interface.cxx
+++ b/src/nanobind_interface.cxx
@@ -161,6 +161,10 @@ void capi_destroy(void* h) {
     }
 }
 void capi_update(void* h, long input_pair, double v1, double v2) {
+    if (h == nullptr) {
+        capi_set_error("update: null handle");
+        return;
+    }
     try {
         (*static_cast<_CAPI_SP*>(h))->update(static_cast<CoolProp::input_pairs>(input_pair), v1, v2);
         g_capi_error.clear();
@@ -171,6 +175,10 @@ void capi_update(void* h, long input_pair, double v1, double v2) {
     }
 }
 double capi_keyed_output(void* h, long key) {
+    if (h == nullptr) {
+        capi_set_error("keyed_output: null handle");
+        return NAN;
+    }
     try {
         double v = (*static_cast<_CAPI_SP*>(h))->keyed_output(static_cast<CoolProp::parameters>(key));
         g_capi_error.clear();
@@ -184,6 +192,10 @@ double capi_keyed_output(void* h, long key) {
     }
 }
 double capi_first_partial_deriv(void* h, long Of, long Wrt, long Constant) {
+    if (h == nullptr) {
+        capi_set_error("first_partial_deriv: null handle");
+        return NAN;
+    }
     try {
         double v = (*static_cast<_CAPI_SP*>(h))
                      ->first_partial_deriv(static_cast<CoolProp::parameters>(Of), static_cast<CoolProp::parameters>(Wrt),
@@ -1111,9 +1123,13 @@ void init_CoolProp(nb::module_& m) {
               std::vector<double> out(n);
               for (std::size_t i = 0; i < n; ++i) {
                   out[i] = HumidAir::HAPropsSI(Output, N1, v1[i], N2, v2[i], N3, v3[i]);
+                  // Legacy HAPropsSI raised ValueError on the FIRST non-finite result for
+                  // vector inputs too (HumidAirProp.pyx), not just the all-scalar case --
+                  // validate every element so a NaN/inf cannot pass silently through an
+                  // array/list result (CoolProp-1tbe.11).
+                  _raise_if_invalid(out[i]);
               }
               if (!any_seq) {
-                  _raise_if_invalid(out[0]);
                   return nb::float_(out[0]);
               }
               if (any_ndarray) {

--- a/wrappers/Python/pytest/test_parity.py
+++ b/wrappers/Python/pytest/test_parity.py
@@ -175,6 +175,15 @@ class TestHAPropsSI:
         with pytest.raises(ValueError):
             HAPropsSI("T", "P", 101325.0, "R", 2.0, "B", 290.0)  # R out of range
 
+    def test_bad_element_in_array_raises_valueerror(self):
+        # Legacy HAPropsSI raised on the first non-finite element of a vector
+        # input; the nanobind array path must not pass NaN/inf through silently
+        # (CoolProp-1tbe.11).  Second element (R=5.0) is unphysical.
+        with pytest.raises(ValueError):
+            HAPropsSI("H", "T", [298.15, 300.0], "P", 101325.0, "R", [0.5, 5.0])
+        with pytest.raises(ValueError):
+            HAPropsSI("H", "T", [298.15, 300.0], "P", 101325.0, "R", np.array([0.5, 5.0]))
+
 
 # --------------------------------------------------------------------------- #
 # r9sq.23 -- enum completeness

--- a/wrappers/Python/pytest/test_state_shim.py
+++ b/wrappers/Python/pytest/test_state_shim.py
@@ -141,3 +141,19 @@ class TestMiscParity:
         S = State("Water", {"T": 300.0, "D": 1000.0})
         with pytest.raises(ValueError):
             S.Props(-1)
+
+
+class TestNullHandleGuard:
+    # State('none') is the legacy no-op construction (used internally by
+    # get_Tsat/copy); it leaves the underlying handle NULL.  Calling a property
+    # method on it must raise a clean ValueError, not segfault by dereferencing
+    # the null handle in the C-ABI capsule (CoolProp-1tbe.11).
+    def test_keyed_output_on_none_state_raises(self):
+        S = State("none")
+        with pytest.raises(ValueError):
+            S.get_T()
+
+    def test_update_on_none_state_raises(self):
+        S = State("none")
+        with pytest.raises(ValueError):
+            S.update_Trho(300.0, 1000.0)


### PR DESCRIPTION
## Summary

Two v8 nanobind-interface gaps from the pre-release audit (CoolProp-1tbe.11).

### Vectorized `HAPropsSI` passed NaN through arrays

The vectorized path only validated the all-scalar case, so a non-finite result in a **list/ndarray** input passed through silently as NaN/inf. The legacy `HumidAirProp.pyx` raised `ValueError` on the **first** non-finite element for vector inputs too. Fix: move the finiteness check into the per-element loop so list and ndarray results match that contract (scalar/list/ndarray return shapes all preserved; empty input still returns empty).

### `State` C-ABI capsule null-handle segfault

`capi_set_mole_fractions` / `specify_phase` / `unspecify_phase` null-check the handle, but `capi_update` / `capi_keyed_output` / `capi_first_partial_deriv` dereferenced it unguarded. `State('none')` (the legacy no-op construction) leaves the handle `NULL`, so a subsequent `get_T()`/`update()` **segfaulted**. Added the same null guard to the three; the Cython wrappers already call `_raise_if_error()`, so this now surfaces a clean `ValueError`.

## Verification

Built a nanobind 3.12 package and confirmed:
- `HAPropsSI("H","T",[298.15,300.0],"P",101325.0,"R",[0.5,5.0])` (and the `np.array` form) now raise `ValueError` (previously returned an array with a silent NaN).
- `State('none').get_T()` and `.update_Trho(...)` raise `ValueError("CoolProp: …: null handle")` instead of crashing — no segfault.
- New regression tests in `test_parity.py` (bad array element) and `test_state_shim.py` (`TestNullHandleGuard`); full pytest suite **147 passed / 10 skipped**.

Adversarial review: no blocking findings (full 9-entry capi table audited — no other unguarded deref; HAPropsSI loop matches the legacy first-non-finite contract). preflight: clang-format / build / Catch2 / cppcheck / clang-tidy / semgrep all pass.

Fixes CoolProp-1tbe.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added defensive null-handle checks to state operations, returning proper error messages instead of crashing
  * Fixed vectorized operations to validate all array elements, preventing silent NaN/inf propagation in results
  * Improved validation of invalid input values in arrays and lists

* **Tests**
  * Added regression tests for null handle error handling and invalid input array element detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->