### PR TITLE
ci+build: close the abi3 wheel-test fail-open + pin the build toolchain

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -254,7 +254,9 @@ jobs:
           # 3.9-3.11 use their own per-version wheel; 3.12/3.13/3.14 all install the
           # single cp312-abi3 wheel (the crux of abi3 -- it must work on each).
           ran=0
+          ran_abi3=0   # legs that ran the cp312-abi3 wheel (3.12/3.13/3.14)
           for PY in 3.9 3.10 3.11 3.12 3.13 3.14; do
+            is_abi3=0
             case "$PY" in
               3.9 | 3.10 | 3.11)
                 tag="cp${PY/./}"
@@ -262,6 +264,7 @@ jobs:
                 ;;
               *)
                 WHL=$(ls dist/coolprop-*-cp312-abi3-*.whl 2>/dev/null || true)
+                is_abi3=1
                 ;;
             esac
             if [ -z "$WHL" ]; then
@@ -271,21 +274,29 @@ jobs:
             echo "::group::pytest on Python $PY ($(basename "$WHL"))"
             uv venv --python "$PY" ".venv-$PY"
             source ".venv-$PY/bin/activate"
-            # Guard the runtime-dep install: a brand-new interpreter may transiently
+            # Install the TEST DEPS first: a brand-new interpreter may transiently
             # lack pytest/numpy cp wheels (a toolchain gap, not a regression) -- warn
-            # and skip that leg. The `ran` counter still fails the job if NO leg ran.
-            if ! uv pip install pytest numpy "$WHL"; then
-              echo "::warning::runtime deps unavailable on Python $PY; skipping this leg"
+            # and skip that leg. But the CoolProp wheel ITSELF failing to install is a
+            # real defect, so install it SEPARATELY (below) under `set -e` -- a broken
+            # or mis-built wheel must fail the job, not warn-and-skip (CoolProp-1tbe.12).
+            if ! uv pip install pytest numpy; then
+              echo "::warning::test deps (pytest/numpy) unavailable on Python $PY; skipping this leg"
               deactivate; echo "::endgroup::"; continue
             fi
+            uv pip install "$WHL"   # broken/incompatible wheel -> hard fail via set -e
             uv pip install mypy || echo "::warning::mypy unavailable on $PY; test_stub mypy check will skip"
             python -c "import sys; print('Python', sys.version.split()[0])"
             pytest wrappers/Python/pytest -q
             ran=$((ran + 1))
+            if [ "$is_abi3" -eq 1 ]; then ran_abi3=$((ran_abi3 + 1)); fi
             deactivate
             echo "::endgroup::"
           done
           test "$ran" -gt 0 || { echo "::error::no Python interpreter could run a nanobind wheel"; exit 1; }
+          # The cp312-abi3 wheel is the v8 crux (one wheel for 3.12/3.13/3.14); it must
+          # actually be exercised on at least one of them, else a broken abi3 wheel
+          # could green the job on the 3.9-3.11 per-version legs alone (CoolProp-1tbe.12).
+          test "$ran_abi3" -gt 0 || { echo "::error::the cp312-abi3 wheel ran on NO interpreter (3.12/3.13/3.14) -- it is the v8 crux and must be tested"; exit 1; }
 
       - name: PDSim cimport contract (compile + run against the abi3 wheel)
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,14 @@
 [build-system]
 # nanobind is required for the v8 core (built whenever COOLPROP_NANOBIND=ON,
 # which is now the default for the published wheels -- bd CoolProp-r9sq.6).
-requires = ["scikit-build-core>=0.10", "cython>=0.29", "nanobind>=2.0"]
+# nanobind is PINNED to match the stub drift gate (.github/workflows/dev_checks.yml
+# installs nanobind==2.12.0): isolated builds (publish cibuildwheel, sdist
+# pip install) resolve build-system.requires, so an unpinned `>=2.0` could build
+# the published wheel with a newer nanobind than the gate validated, drifting the
+# generated bindings/stub. Bump this and the gate version together (CoolProp-1tbe.13).
+# Cython >= 3.1 is required for the limited-API (Py_LIMITED_API) State/_constants
+# sidecars that make the single cp312-abi3 wheel.
+requires = ["scikit-build-core>=0.10", "cython>=3.1", "nanobind==2.12.0"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -22,7 +29,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Environment :: Other Environment",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
## Summary

### `.12` — abi3 wheel test was fail-open

The `nanobind-wheels` pytest step warn-and-skipped a leg whenever `uv pip install pytest numpy "$WHL"` failed, lumping a **broken CoolProp wheel** in with a transient pytest/numpy toolchain gap. With the final guard only requiring `ran > 0`, all three cp312-abi3 legs (3.12/3.13/3.14) could skip on a broken abi3 wheel while the 3.9–3.11 per-version legs alone greened the job — so the abi3 wheel, the **v8 crux**, went untested.

Fix:
- Install the test deps (`pytest numpy`) first — a real toolchain gap still warns and skips.
- Install the CoolProp wheel **separately** under `set -euo pipefail` so a broken/mis-built wheel **hard-fails**.
- Track `ran_abi3` and require `ran_abi3 > 0` so the abi3 wheel must actually be exercised on at least one of 3.12/3.13/3.14.

### `.13` (remainder) — pin the isolated-build toolchain

`build-system.requires` was `cython>=0.29`, `nanobind>=2.0`. Isolated builds (publish cibuildwheel, sdist `pip install`) resolve those to **latest** — so a published wheel could be built with a newer nanobind than the stub drift gate validated, drifting the generated bindings/stub. Pin `nanobind==2.12.0` (matching the gate; bump together) and `cython>=3.1` (required for the limited-API sidecars). Also bump the trove classifier `4 - Beta` → `5 - Production/Stable`. (`requires-python>=3.9` + the cp38 drop already landed in #3156.)

## Verification

- Confirmed the broken-wheel path now hard-fails under `set -e` (the wheel install is a bare command, not in an `if !`/`||` list) and the `if [ "$is_abi3" … ]` counter does not trip `set -e`.
- An **isolated** `pip install .` (which resolves `build-system.requires`, unlike `--no-build-isolation`) builds a working nanobind wheel with the pinned `cython>=3.1` + `nanobind==2.12.0` (PropsSI correct, no legacy `Props`).
- `pyproject.toml` parses as TOML; `dev_checks.yml` parses as YAML.
- Adversarial review: no blocking findings; the `set -e`+`&&` foot-gun was verified safe (and converted to an explicit `if` for clarity). Flagged trade-offs: `ran_abi3>0` has a tiny self-correcting false-fail surface; the exact nanobind pin is an intentional maintenance coupling with the gate.

Fixes CoolProp-1tbe.12; closes the remainder of CoolProp-1tbe.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project status to Production/Stable
  * Pinned build dependency version for consistency
  * Enhanced CI wheel validation to fail on broken packages
  * Improved test skip handling for unavailable dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->