### PR TITLE
build+ci: stop shipping detail/msgpack.h + add an installed-header self-containedness gate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -643,9 +643,11 @@ if(COOLPROP_OBJECT_LIBRARY
     # DB headers (*_JSON.h / *_CBOR.h), and detail/json.h + detail/msgpack.h
     # (they pull the un-shipped nlohmann/valijson and msgpack.hpp) plus the
     # CPmsgpack.h shim that forwards to the latter. The shipped fluids/numerics/
-    # superancillary tiers transitively require Eigen and boost on the include
-    # path, and fmt unless NO_FMTLIB is defined; dev/ci/check-installed-headers.sh
-    # compile-checks every shipped header standalone to keep this honest.
+    # superancillary tiers transitively require Eigen on the include path, and
+    # fmt unless NO_FMTLIB is defined (boost is NOT required -- the superancillary
+    # rootfinder is defined out-of-line in src/superancillary.cpp);
+    # dev/ci/check-installed-headers.sh compile-checks every shipped header
+    # standalone (Eigen-only) to keep this honest.
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/CoolProp
             DESTINATION static_library/include FILES_MATCHING PATTERN "*.h"
             REGEX "detail/(json|msgpack)\\.h$" EXCLUDE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -639,13 +639,19 @@ if(COOLPROP_OBJECT_LIBRARY
     # GH #1280: ship the installable C++ header tree so downstream CMake can
     # find_package(CoolProp) and get usable include paths. The flat deprecation
     # shims ship alongside so consumers on the old "X.h" includes keep building
-    # (removed at v9). Generated DB headers (*_JSON.h) are excluded.
+    # (removed at v9). Excluded as internal-only / non-self-contained: generated
+    # DB headers (*_JSON.h / *_CBOR.h), and detail/json.h + detail/msgpack.h
+    # (they pull the un-shipped nlohmann/valijson and msgpack.hpp) plus the
+    # CPmsgpack.h shim that forwards to the latter. The shipped fluids/numerics/
+    # superancillary tiers transitively require Eigen and boost on the include
+    # path, and fmt unless NO_FMTLIB is defined; dev/ci/check-installed-headers.sh
+    # compile-checks every shipped header standalone to keep this honest.
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/CoolProp
             DESTINATION static_library/include FILES_MATCHING PATTERN "*.h"
-            REGEX "detail/json\\.h$" EXCLUDE)
+            REGEX "detail/(json|msgpack)\\.h$" EXCLUDE)
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
             DESTINATION static_library/include FILES_MATCHING PATTERN "*.h"
-            PATTERN "CoolProp" EXCLUDE PATTERN "*_JSON*.h" EXCLUDE PATTERN "*_CBOR*.h" EXCLUDE
+            PATTERN "CoolProp" EXCLUDE PATTERN "*_JSON*.h" EXCLUDE PATTERN "*_CBOR*.h" EXCLUDE PATTERN "CPmsgpack.h" EXCLUDE
             PATTERN "gitrevision.h" EXCLUDE PATTERN "cpversion.h" EXCLUDE)
   elseif(COOLPROP_SHARED_LIBRARY)
     list(APPEND APP_SOURCES
@@ -680,10 +686,10 @@ if(COOLPROP_OBJECT_LIBRARY
     # removed at v9; generated *_JSON.h excluded). See the static branch above.
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/CoolProp
             DESTINATION shared_library/include FILES_MATCHING PATTERN "*.h"
-            REGEX "detail/json\\.h$" EXCLUDE)
+            REGEX "detail/(json|msgpack)\\.h$" EXCLUDE)
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
             DESTINATION shared_library/include FILES_MATCHING PATTERN "*.h"
-            PATTERN "CoolProp" EXCLUDE PATTERN "*_JSON*.h" EXCLUDE PATTERN "*_CBOR*.h" EXCLUDE
+            PATTERN "CoolProp" EXCLUDE PATTERN "*_JSON*.h" EXCLUDE PATTERN "*_CBOR*.h" EXCLUDE PATTERN "CPmsgpack.h" EXCLUDE
             PATTERN "gitrevision.h" EXCLUDE PATTERN "cpversion.h" EXCLUDE)
     set_property(
       TARGET ${LIB_NAME}
@@ -872,10 +878,10 @@ if(COOLPROP_DEBIAN_PACKAGE)
   # <CoolPropLib.h> resolve from /usr/include. Shims removed at v9.
   install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/CoolProp
           DESTINATION "${CMAKE_INSTALL_PREFIX}/usr/include" FILES_MATCHING PATTERN "*.h"
-          REGEX "detail/json\\.h$" EXCLUDE)
+          REGEX "detail/(json|msgpack)\\.h$" EXCLUDE)
   install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
           DESTINATION "${CMAKE_INSTALL_PREFIX}/usr/include" FILES_MATCHING PATTERN "*.h"
-          PATTERN "CoolProp" EXCLUDE PATTERN "*_JSON*.h" EXCLUDE PATTERN "*_CBOR*.h" EXCLUDE
+          PATTERN "CoolProp" EXCLUDE PATTERN "*_JSON*.h" EXCLUDE PATTERN "*_CBOR*.h" EXCLUDE PATTERN "CPmsgpack.h" EXCLUDE
           PATTERN "gitrevision.h" EXCLUDE PATTERN "cpversion.h" EXCLUDE)
 endif()
 

--- a/Web/coolprop/changelog.rst
+++ b/Web/coolprop/changelog.rst
@@ -143,11 +143,12 @@ Highlights:
   ``"CoolProp.h"`` (and friends) to ``"CoolProp/CoolProp.h"``. The install
   rules now ship the full ``include/CoolProp/`` tree (plus the flat shims), so
   a manual include of that directory gives usable include paths out of the box.
-  Transitive dependencies exposed by the public headers: the ``fluids/`` and
-  ``numerics/`` tiers pull in **Eigen** and the ``superancillary/`` tier pulls
-  in **boost** (headers-only), so both must be on your include path if you
-  include those tiers; and ``CoolProp/detail/strings.h`` includes **fmt**
-  unless you compile with ``-DNO_FMTLIB``. (The generated database headers —
+  Transitive dependencies exposed by the public headers: the ``fluids/``,
+  ``numerics/`` and ``superancillary/`` tiers pull in **Eigen**, so Eigen must
+  be on your include path if you include those tiers; and
+  ``CoolProp/detail/strings.h`` includes **fmt** unless you compile with
+  ``-DNO_FMTLIB``. (Boost is *not* required: the superancillary rootfinder is
+  defined out-of-line in the compiled library.) (The generated database headers —
   ``*_JSON.h`` / ``*_CBOR.h`` — and the internal ``detail/json.h`` /
   ``detail/msgpack.h`` are intentionally *not* installed.) See PRs #3074,
   #3075 and #3078 (the #1280 phases), plus #3082

--- a/Web/coolprop/changelog.rst
+++ b/Web/coolprop/changelog.rst
@@ -143,13 +143,14 @@ Highlights:
   ``"CoolProp.h"`` (and friends) to ``"CoolProp/CoolProp.h"``. The install
   rules now ship the full ``include/CoolProp/`` tree (plus the flat shims), so
   a manual include of that directory gives usable include paths out of the box.
-  Two transitive dependencies are exposed by the public headers: the
-  ``fluids/`` and ``numerics/`` tiers pull in **Eigen**, so Eigen must be on
-  your include path if you include those headers; and
-  ``CoolProp/detail/strings.h`` includes **fmt** unless you compile with
-  ``-DNO_FMTLIB``. (The generated database headers — ``*_JSON.h`` /
-  ``*_CBOR.h`` — and the JSON-backed ``detail/json.h`` are intentionally *not*
-  installed.) See PRs #3074, #3075 and #3078 (the #1280 phases), plus #3082
+  Transitive dependencies exposed by the public headers: the ``fluids/`` and
+  ``numerics/`` tiers pull in **Eigen** and the ``superancillary/`` tier pulls
+  in **boost** (headers-only), so both must be on your include path if you
+  include those tiers; and ``CoolProp/detail/strings.h`` includes **fmt**
+  unless you compile with ``-DNO_FMTLIB``. (The generated database headers —
+  ``*_JSON.h`` / ``*_CBOR.h`` — and the internal ``detail/json.h`` /
+  ``detail/msgpack.h`` are intentionally *not* installed.) See PRs #3074,
+  #3075 and #3078 (the #1280 phases), plus #3082
   (the related rapidjson / ``<filesystem>`` public-surface de-leak).
 
 * **Build-system requirements (packagers).** Git submodules have been replaced

--- a/dev/ci/check-installed-headers.sh
+++ b/dev/ci/check-installed-headers.sh
@@ -17,8 +17,9 @@
 # CMake EXCLUDE is specific to json.h and is not over-broad (e.g. wiping the
 # whole detail/ subtree).  Candidates that satisfy this today:
 # detail/configuration_keys.h, detail/strings.h, detail/tools.h,
-# detail/CachedElement.h, detail/filepaths.h, detail/msgpack.h,
+# detail/CachedElement.h, detail/filepaths.h,
 # detail/PlatformDetermination.h, detail/state_capi.h, detail/atomic_write.h.
+# (detail/json.h and detail/msgpack.h are NOT candidates -- both are excluded.)
 # This control does NOT name detail/rapidjson.h (that header was deleted in
 # Phase Final); any of the above is sufficient.
 #
@@ -56,24 +57,73 @@ if [ -z "$DETAIL_OTHER" ]; then
     exit 1
 fi
 
-# Assertion 1: detail/json.h must NOT ship.
-LEAKED="$(find "$PREFIX" -path '*/detail/json.h' || true)"
+# Assertion 1: the internal-only detail/json.h and detail/msgpack.h must NOT
+# ship.  detail/json.h pulls nlohmann/json.hpp + valijson; detail/msgpack.h
+# pulls msgpack.hpp.  None of those third-party headers are installed, so
+# shipping either makes the installed tree non-self-contained for downstream.
+LEAKED="$(find "$PREFIX" \( -path '*/detail/json.h' -o -path '*/detail/msgpack.h' -o -name 'CPmsgpack.h' \) || true)"
 if [ -n "$LEAKED" ]; then
-    echo "FAIL: detail/json.h is shipped in the installed headers (it pulls nlohmann/json.hpp + valijson):" >&2
+    echo "FAIL: an internal-only header (detail/json.h, detail/msgpack.h, or the CPmsgpack.h shim) is shipped in the installed headers:" >&2
     printf '%s\n' "$LEAKED" >&2
     exit 1
 fi
 
-# Assertion 2: no shipped header may #include nlohmann or valijson.
+# Assertion 2: no shipped header may #include nlohmann, valijson or msgpack
+# (the internal-only third-party libraries that are NOT installed).
 # grep -El exits 1 on no match (the PASS case) and 0 on match (the FAIL case).
 # The `|| true` prevents set -e from aborting on the no-match exit code; the
 # actual gate is the `-n` test below, which is fail-closed.
-LEAKING_INCLUDES="$(grep -rEl '#[[:space:]]*include[[:space:]]*[<"]((nlohmann|valijson)/)' \
+LEAKING_INCLUDES="$(grep -rEl '#[[:space:]]*include[[:space:]]*[<"]((nlohmann|valijson)/|msgpack)' \
     "$PREFIX" --include='*.h' --include='*.hpp' || true)"
 if [ -n "$LEAKING_INCLUDES" ]; then
-    echo "FAIL: installed header(s) #include nlohmann/valijson (must stay internal):" >&2
+    echo "FAIL: installed header(s) #include nlohmann/valijson/msgpack (must stay internal):" >&2
     printf '%s\n' "$LEAKING_INCLUDES" >&2
     exit 1
 fi
 
-echo "OK: detail/json.h not installed; no shipped header pulls nlohmann/valijson; detail/ control header present (${NHEADERS} headers from ${BUILD_DIR})"
+# Assertion 3: every installed header must compile STANDALONE.  This catches the
+# general non-self-contained case the grep above cannot -- e.g. a shipped header
+# that #includes a non-installed header by some other path (the old
+# detail/msgpack.h pulling msgpack.hpp slipped past the nlohmann/valijson grep).
+# Compile each installed *.h as its own translation unit.  The installed surface
+# legitimately depends on Eigen + boost (the fluids/numerics/superancillary
+# tiers) and on fmt unless NO_FMTLIB is defined; resolve Eigen/boost from the
+# build's CPM cache and define NO_FMTLIB so fmt is not required.
+CXX_BIN="${CXX:-c++}"
+CACHE="$BUILD_DIR/CMakeCache.txt"
+if [ ! -f "$CACHE" ]; then
+    echo "FAIL: $CACHE not found -- '$BUILD_DIR' is not a configured CMake build dir; cannot resolve Eigen/boost for the self-containedness check." >&2
+    exit 1
+fi
+EIGEN_DIR="$(sed -n 's/^CPM_PACKAGE_Eigen_SOURCE_DIR:INTERNAL=//p' "$CACHE" | head -1)"
+BOOST_DIR="$(sed -n 's/^CPM_PACKAGE_boost_headers_SOURCE_DIR:INTERNAL=//p' "$CACHE" | head -1)"
+if [ -z "$EIGEN_DIR" ] || [ ! -d "$EIGEN_DIR" ] || [ -z "$BOOST_DIR" ] || [ ! -d "$BOOST_DIR" ]; then
+    echo "FAIL: could not resolve Eigen/boost include dirs from $CACHE -- cannot run the self-containedness check (fail-closed)." >&2
+    exit 1
+fi
+INC_ROOT="$(find "$PREFIX" -path '*/include/CoolProp/CoolProp.h' | head -1)"
+INC_ROOT="${INC_ROOT%/CoolProp/CoolProp.h}"
+if [ -z "$INC_ROOT" ] || [ ! -d "$INC_ROOT" ]; then
+    echo "FAIL: could not locate the installed include root (no CoolProp/CoolProp.h) -- cannot validate self-containedness." >&2
+    exit 1
+fi
+SC_LOG=/tmp/installed-headers-selfcontained.log
+: >"$SC_LOG"
+SC_FAIL=0
+while IFS= read -r hdr; do
+    rel="${hdr#"$INC_ROOT"/}"
+    if ! printf '#include "%s"\n' "$rel" | "$CXX_BIN" -std=c++17 -fsyntax-only \
+            -DNO_FMTLIB -DCOOLPROP_NO_DEPRECATED_HEADER_WARNINGS \
+            -I"$INC_ROOT" -I"$EIGEN_DIR" -I"$BOOST_DIR" -x c++ - >>"$SC_LOG" 2>&1; then
+        echo "FAIL: installed header is not self-contained: $rel" >&2
+        SC_FAIL=$((SC_FAIL + 1))
+    fi
+done < <(find "$INC_ROOT" -name '*.h')
+if [ "$SC_FAIL" -ne 0 ]; then
+    echo "FAIL: $SC_FAIL installed header(s) do not compile standalone (see $SC_LOG)." >&2
+    echo "      A shipped header that #includes a non-installed header (internal or third-party)" >&2
+    echo "      is broken for downstream consumers." >&2
+    exit 1
+fi
+
+echo "OK: internal json/msgpack headers not installed; no shipped header pulls nlohmann/valijson/msgpack; all ${NHEADERS} installed headers compile standalone (-DNO_FMTLIB, Eigen+boost on the path) from ${BUILD_DIR}"

--- a/dev/ci/check-installed-headers.sh
+++ b/dev/ci/check-installed-headers.sh
@@ -68,15 +68,15 @@ if [ -n "$LEAKED" ]; then
     exit 1
 fi
 
-# Assertion 2: no shipped header may #include nlohmann, valijson or msgpack
-# (the internal-only third-party libraries that are NOT installed).
+# Assertion 2: no shipped header may #include nlohmann, valijson, msgpack or
+# boost (the internal-only third-party libraries that are NOT installed).
 # grep -El exits 1 on no match (the PASS case) and 0 on match (the FAIL case).
 # The `|| true` prevents set -e from aborting on the no-match exit code; the
 # actual gate is the `-n` test below, which is fail-closed.
-LEAKING_INCLUDES="$(grep -rEl '#[[:space:]]*include[[:space:]]*[<"]((nlohmann|valijson)/|msgpack)' \
+LEAKING_INCLUDES="$(grep -rEl '#[[:space:]]*include[[:space:]]*[<"]((nlohmann|valijson|boost)/|msgpack)' \
     "$PREFIX" --include='*.h' --include='*.hpp' || true)"
 if [ -n "$LEAKING_INCLUDES" ]; then
-    echo "FAIL: installed header(s) #include nlohmann/valijson/msgpack (must stay internal):" >&2
+    echo "FAIL: installed header(s) #include nlohmann/valijson/msgpack/boost (must stay internal):" >&2
     printf '%s\n' "$LEAKING_INCLUDES" >&2
     exit 1
 fi
@@ -86,19 +86,21 @@ fi
 # that #includes a non-installed header by some other path (the old
 # detail/msgpack.h pulling msgpack.hpp slipped past the nlohmann/valijson grep).
 # Compile each installed *.h as its own translation unit.  The installed surface
-# legitimately depends on Eigen + boost (the fluids/numerics/superancillary
-# tiers) and on fmt unless NO_FMTLIB is defined; resolve Eigen/boost from the
-# build's CPM cache and define NO_FMTLIB so fmt is not required.
+# depends only on Eigen (the fluids/numerics/superancillary tiers) and on fmt
+# unless NO_FMTLIB is defined; resolve Eigen from the build's CPM cache and
+# define NO_FMTLIB so fmt is not required.  Boost is deliberately NOT on the
+# path: the superancillary rootfinder routes through an out-of-line helper
+# (src/superancillary.cpp), so a regression that re-introduces a boost include
+# into an installed header fails this compile (and assertion 2 above).
 CXX_BIN="${CXX:-c++}"
 CACHE="$BUILD_DIR/CMakeCache.txt"
 if [ ! -f "$CACHE" ]; then
-    echo "FAIL: $CACHE not found -- '$BUILD_DIR' is not a configured CMake build dir; cannot resolve Eigen/boost for the self-containedness check." >&2
+    echo "FAIL: $CACHE not found -- '$BUILD_DIR' is not a configured CMake build dir; cannot resolve Eigen for the self-containedness check." >&2
     exit 1
 fi
 EIGEN_DIR="$(sed -n 's/^CPM_PACKAGE_Eigen_SOURCE_DIR:INTERNAL=//p' "$CACHE" | head -1)"
-BOOST_DIR="$(sed -n 's/^CPM_PACKAGE_boost_headers_SOURCE_DIR:INTERNAL=//p' "$CACHE" | head -1)"
-if [ -z "$EIGEN_DIR" ] || [ ! -d "$EIGEN_DIR" ] || [ -z "$BOOST_DIR" ] || [ ! -d "$BOOST_DIR" ]; then
-    echo "FAIL: could not resolve Eigen/boost include dirs from $CACHE -- cannot run the self-containedness check (fail-closed)." >&2
+if [ -z "$EIGEN_DIR" ] || [ ! -d "$EIGEN_DIR" ]; then
+    echo "FAIL: could not resolve the Eigen include dir from $CACHE -- cannot run the self-containedness check (fail-closed)." >&2
     exit 1
 fi
 INC_ROOT="$(find "$PREFIX" -path '*/include/CoolProp/CoolProp.h' | head -1)"
@@ -114,7 +116,7 @@ while IFS= read -r hdr; do
     rel="${hdr#"$INC_ROOT"/}"
     if ! printf '#include "%s"\n' "$rel" | "$CXX_BIN" -std=c++17 -fsyntax-only \
             -DNO_FMTLIB -DCOOLPROP_NO_DEPRECATED_HEADER_WARNINGS \
-            -I"$INC_ROOT" -I"$EIGEN_DIR" -I"$BOOST_DIR" -x c++ - >>"$SC_LOG" 2>&1; then
+            -I"$INC_ROOT" -I"$EIGEN_DIR" -x c++ - >>"$SC_LOG" 2>&1; then
         echo "FAIL: installed header is not self-contained: $rel" >&2
         SC_FAIL=$((SC_FAIL + 1))
     fi
@@ -126,4 +128,4 @@ if [ "$SC_FAIL" -ne 0 ]; then
     exit 1
 fi
 
-echo "OK: internal json/msgpack headers not installed; no shipped header pulls nlohmann/valijson/msgpack; all ${NHEADERS} installed headers compile standalone (-DNO_FMTLIB, Eigen+boost on the path) from ${BUILD_DIR}"
+echo "OK: internal json/msgpack headers not installed; no shipped header pulls nlohmann/valijson/msgpack/boost; all ${NHEADERS} installed headers compile standalone (-DNO_FMTLIB, Eigen-only on the path) from ${BUILD_DIR}"

--- a/include/CoolProp/superancillary/superancillary.h
+++ b/include/CoolProp/superancillary/superancillary.h
@@ -40,14 +40,29 @@ Subsequent edits by Ian Bell
 #include <set>
 #include <utility>
 #include <optional>
+#include <functional>
+#include <sstream>
+#include <iomanip>
 #include <Eigen/Dense>
 
-#include "boost/math/tools/toms748_solve.hpp"
+// NOTE: boost (the TOMS 748 rootfinder) is intentionally NOT included here.  Its
+// only uses are routed through detail::toms748 (declared below, defined in
+// src/superancillary.cpp), so this installed public header needs only Eigen on
+// the include path -- not boost -- for downstream consumers (CoolProp-1tbe.14).
 
 namespace CoolProp {
 namespace superancillary {
 
 namespace detail {
+
+/// Bracketing rootfinder (Boost's TOMS 748).  Declared here but DEFINED
+/// out-of-line in src/superancillary.cpp so the boost dependency stays internal
+/// to the compiled CoolProp library -- consumers of this installed header do
+/// not need boost on their include path.  \a f is the residual function and
+/// [\a a, \a b] a bracket with \a fa = f(a), \a fb = f(b); \a bits is the
+/// TOMS 748 bit tolerance and \a max_iter the function-call cap.  Returns the
+/// midpoint of the final bracket.
+double toms748(const std::function<double(double)>& f, double a, double b, double fa, double fb, unsigned int bits, std::size_t max_iter);
 
 // From https://arxiv.org/pdf/1401.5766.pdf (Algorithm #3)
 template <typename Matrix>
@@ -354,7 +369,6 @@ class ChebyshevExpansion
     \return Tuple of value of x and the number of function evaluations required
      */
     auto solve_for_x_count(double y, double a, double b, unsigned int bits, std::size_t max_iter, double boundsytol) const {
-        using namespace boost::math::tools;
         std::size_t counter = 0;
         auto f = [&](double x) {
             counter++;
@@ -368,9 +382,8 @@ class ChebyshevExpansion
         if (std::abs(fb) < boundsytol) {
             return std::make_tuple(b, std::size_t{2});
         }
-        auto max_iter_ = static_cast<boost::math::uintmax_t>(max_iter);
-        auto [l, r] = toms748_solve(f, a, b, fa, fb, eps_tolerance<double>(bits), max_iter_);
-        return std::make_tuple((r + l) / 2.0, counter);
+        double root = detail::toms748(f, a, b, fa, fb, bits, max_iter);
+        return std::make_tuple(root, counter);
     }
 
     /// Return the value of x only for given value of y
@@ -1351,7 +1364,6 @@ class SuperAncillary
             double resid = get_yval(T_, q_fromv1, ch2) - val2;
             return resid;
         };
-        using namespace boost::math::tools;
         double fTmin = f(Tmin), fTmax = f(Tmax);
 
         // First we check if we are converged enough (TOMS748 does not stop based on function value)
@@ -1382,9 +1394,7 @@ class SuperAncillary
         }
         // Neither bound meets the convergence criterion, we need to iterate on temperature
         try {
-            auto max_iter_ = static_cast<boost::math::uintmax_t>(max_iter);
-            auto [l, r] = toms748_solve(f, Tmin, Tmax, fTmin, fTmax, eps_tolerance<double>(bits), max_iter_);
-            T = (r + l) / 2.0;
+            T = detail::toms748(f, Tmin, Tmax, fTmin, fTmax, bits, max_iter);
             return returner();
         } catch (...) {
             fprintf(stderr, "fTmin,fTmax: %g,%g\n", fTmin, fTmax);

--- a/src/superancillary.cpp
+++ b/src/superancillary.cpp
@@ -8,12 +8,35 @@
 
 #include "CoolProp/superancillary/superancillary.h"
 #include "nlohmann/json.hpp"
+#include "boost/math/tools/toms748_solve.hpp"
 
+#include <functional>
 #include <string>
 #include <vector>
 
 namespace CoolProp {
 namespace superancillary {
+
+namespace detail {
+
+// Out-of-line definition of the TOMS 748 bracketing rootfinder declared in the
+// installed header.  Keeping the boost dependency here (rather than in the
+// header) lets downstream consumers compile against superancillary.h with only
+// Eigen on the include path, not boost (CoolProp-1tbe.14).  The callable is
+// type-erased through std::function: this is the inverse (rootfinding) path,
+// NOT the hot eval_sat path, and the std::function is built once per rootfind,
+// so its indirection -- plus a possible one-time small-buffer heap allocation
+// for the larger residual closures (they exceed libc++'s 16-byte SBO) -- is
+// negligible against the tens of Chebyshev evaluations each rootfind performs.
+double toms748(const std::function<double(double)>& f, double a, double b, double fa, double fb, unsigned int bits, std::size_t max_iter) {
+    using namespace boost::math::tools;
+    auto max_iter_ = static_cast<boost::math::uintmax_t>(max_iter);
+    auto [l, r] = toms748_solve(f, a, b, fa, fb, eps_tolerance<double>(bits), max_iter_);
+    return (l + r) / 2.0;
+}
+
+}  // namespace detail
+
 namespace {
 
 template <typename ArrayType>

--- a/src/superancillary.cpp
+++ b/src/superancillary.cpp
@@ -59,10 +59,9 @@ typename SuperAncillary<ArrayType>::LoadedData parse_loaded(const std::string& s
     d.rhocrit_num = j.at("meta").at("rhocrittrue / mol/m^3");
     if (j.contains("check_points")) {
         for (const auto& pt : j.at("check_points")) {
-            d.check_points.push_back({pt.at("T / K").get<double>(), pt.at("p(mp) / Pa").get<double>(),
-                                      pt.at("rho'(mp) / mol/m^3").get<double>(), pt.at("rho''(mp) / mol/m^3").get<double>(),
-                                      pt.at("p(SA)/p(mp)").get<double>(), pt.at("rho'(SA)/rho'(mp)").get<double>(),
-                                      pt.at("rho''(SA)/rho''(mp)").get<double>()});
+            d.check_points.push_back({pt.at("T / K").get<double>(), pt.at("p(mp) / Pa").get<double>(), pt.at("rho'(mp) / mol/m^3").get<double>(),
+                                      pt.at("rho''(mp) / mol/m^3").get<double>(), pt.at("p(SA)/p(mp)").get<double>(),
+                                      pt.at("rho'(SA)/rho'(mp)").get<double>(), pt.at("rho''(SA)/rho''(mp)").get<double>()});
         }
     }
     return d;


### PR DESCRIPTION
## Summary

Make CoolProp's installed C++ header surface genuinely self-contained, and add a CI gate that keeps it that way. Two third-party dependencies were leaking into the public headers; both are now evicted, leaving **Eigen** (+ fmt unless `NO_FMTLIB`) as the only transitive include-path requirement.

### 1. Stop shipping `detail/msgpack.h` (`CoolProp-1tbe.14`)

`detail/msgpack.h` `#include`s the un-installed `msgpack.hpp` and is used only by the internal, non-installed `TabularBackends.h` — exactly the `detail/json.h` case, but only `json.h` was excluded. The shipped header (and the flat `CPmsgpack.h` shim forwarding to it) were broken for downstream. Excluded both from all three install blocks.

### 2. Add a self-containedness gate

`dev/ci/check-installed-headers.sh` only grepped for `nlohmann`/`valijson`, so it couldn't catch the above. Hardened:
- assertion 1 also fails if `detail/msgpack.h` / `CPmsgpack.h` ship;
- assertion 2's forbidden-include grep now covers `msgpack` **and `boost`**;
- **NEW assertion 3** compiles every installed header standalone (`-fsyntax-only -DNO_FMTLIB`, **Eigen-only** on the path), fail-closed — the general check that catches any shipped header pulling a non-installed one.

### 3. Evict the boost requirement from `superancillary.h`

The new gate immediately *revealed* that `superancillary/superancillary.h` required **boost** on the downstream include path (it `#include`d `boost/math/tools/toms748_solve.hpp` for its TOMS 748 rootfinder). Evicted with the same out-of-line pattern `superancillary.cpp` already uses for nlohmann: the two rootfinder call sites now go through a type-erased free function `detail::toms748(...)` declared in the header and **defined in `src/superancillary.cpp`** (where boost is available, compiled into libCoolProp). The header needs only Eigen now. Removing boost also surfaced two latent includes it had been masking (`<sstream>`/`<iomanip>`), now explicit. The rootfinder math is the identical boost call, relocated; rootfinding is the inverse (not the hot eval) path. Consumers that call the rootfinder now link it from libCoolProp (CoolProp's public API is already library-linked).

## Verification

- All **89 installed headers compile standalone with Eigen only** (no boost, no fmt); the gate fails when a needed include is missing.
- Boost eviction: `superancillary.h` compiles standalone Eigen-only; shared lib + Catch runner build/link `detail::toms748`; **6409 `[SBTL]`/`[SVDSBTL]` assertions pass** (rootfinding numerically unchanged).
- Two adversarial reviews (one per commit): **no blocking findings**. The gate is empirically fail-closed; the boost relocation is numerically identical and the linkage is sound. (A review-flagged false "no heap allocation" claim was corrected — the larger residual closures exceed libc++'s 16-byte SBO, so one allocation per rootfind, negligible on the inverse path.)
- Full preflight green except cppcheck, which reports only a **pre-existing** `ChebyshevExpansion() = default` uninitialized-member warning in `superancillary.h:277` (not changed here; cppcheck is informational/non-gating in CI) — zero new findings from this change.
- Corrected the v8 changelog header-reorg note: the installed surface needs Eigen (+ fmt unless `NO_FMTLIB`), **not** boost.

Closes CoolProp-1tbe.14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened packaging to omit generated JSON/CBOR and internal msgpack shims from installed headers.
  * Reduced direct Boost exposure from public headers so most header tiers no longer require Boost headers.

* **Chores / CI checks**
  * Strengthened installation validation: shipped headers must compile standalone and must not leak third‑party includes; explicit checks for json/msgpack/Boost added.

* **Documentation**
  * Updated changelog to clarify public header organization and transitive header dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->