### PR TITLE
docs+wrappers: migrate stale include paths off the v9-removal shims

### DIFF
--- a/Web/coolprop/snippets/AbstractState1.cxx
+++ b/Web/coolprop/snippets/AbstractState1.cxx
@@ -1,10 +1,10 @@
-#include "CoolProp.h"
-#include "AbstractState.h"
+#include "CoolProp/CoolProp.h"
+#include "CoolProp/AbstractState.h"
 #include <iostream>
-#include "crossplatform_shared_ptr.h"
+#include <memory>
 using namespace CoolProp;
 int main() {
-    shared_ptr<AbstractState> Water(AbstractState::factory("HEOS", "Water"));
+    std::shared_ptr<AbstractState> Water(AbstractState::factory("HEOS", "Water"));
     Water->update(PQ_INPUTS, 101325, 0);  // SI units
     std::cout << "T: " << Water->T() << " K" << std::endl;
     std::cout << "rho': " << Water->rhomass() << " kg/m^3" << std::endl;

--- a/Web/coolprop/snippets/HighLevelLowLevel.cxx
+++ b/Web/coolprop/snippets/HighLevelLowLevel.cxx
@@ -1,5 +1,5 @@
-#include "CoolPropLib.h"
-#include "CoolPropTools.h"
+#include "CoolProp/CoolPropLib.h"
+#include "CoolProp/detail/tools.h"
 #include <vector>
 #include <time.h>
 

--- a/Web/coolprop/snippets/HighLevelLowLevelMulti.cxx
+++ b/Web/coolprop/snippets/HighLevelLowLevelMulti.cxx
@@ -1,5 +1,5 @@
-#include "CoolPropLib.h"
-#include "CoolPropTools.h"
+#include "CoolProp/CoolPropLib.h"
+#include "CoolProp/detail/tools.h"
 #include <vector>
 #include <time.h>
 

--- a/Web/coolprop/snippets/mixture_derivative_table.cxx
+++ b/Web/coolprop/snippets/mixture_derivative_table.cxx
@@ -1,4 +1,4 @@
-#include "CoolProp.h"
+#include "CoolProp/CoolProp.h"
 #include "Backends/Helmholtz/MixtureDerivatives.h"
 #include <iostream>
 using namespace CoolProp;

--- a/Web/coolprop/snippets/propssi.cxx
+++ b/Web/coolprop/snippets/propssi.cxx
@@ -1,4 +1,4 @@
-#include "CoolProp.h"
+#include "CoolProp/CoolProp.h"
 #include <iostream>
 #include <stdlib.h>
 using namespace CoolProp;

--- a/Web/coolprop/wrappers/SharedLibrary/index.rst
+++ b/Web/coolprop/wrappers/SharedLibrary/index.rst
@@ -199,7 +199,7 @@ Here is another snippet of using the shared library in windows when (for your ap
     // This is to get all the function prototypes from the header
     #define EXPORT_CODE extern "C" __declspec(dllimport)
     #define CONVENTION __stdcall
-    #include "CoolPropLib.h"
+    #include "CoolProp/CoolPropLib.h"
     #undef EXPORT_CODE
     #undef CONVENTION
 
@@ -219,7 +219,7 @@ Based on the discussion on `GitHub <https://github.com/CoolProp/CoolProp/issues/
 
     cat <<EOF > main.cpp
     #include <iostream>
-    #include "CoolPropLib.h"
+    #include "CoolProp/CoolPropLib.h"
     int main(){
         double T{293.15};
         double P{1e5};

--- a/Web/coolprop/wrappers/StaticLibrary/index.rst
+++ b/Web/coolprop/wrappers/StaticLibrary/index.rst
@@ -95,7 +95,7 @@ Usage
 
 For all platforms we start with a simple example file here called main.cpp; the "Hello world" of CoolProp ::
 
-    #include "CoolProp.h"
+    #include "CoolProp/CoolProp.h"
     #include <iostream>
 
     int main()

--- a/wrappers/Lua/coolprop/capi.c
+++ b/wrappers/Lua/coolprop/capi.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <lua.h>
 #include <lauxlib.h>
-#include "../../../include/CoolPropLib.h"
+#include "../../../include/CoolProp/CoolPropLib.h"
 #include "compat.h"
 
 static int lua_coolprop_Props1SI(lua_State* L) {

--- a/wrappers/Python/deprecated_setup.py
+++ b/wrappers/Python/deprecated_setup.py
@@ -439,7 +439,7 @@ if __name__ == '__main__':
         os.path.join(CProot, 'boost_CoolProp'),
         os.path.join(CProot, 'externals', 'incbin'),
         os.path.join(CProot, 'externals', 'nlohmann-json'),
-        os.path.join(CProot, 'externals', 'miniz-3.0.2'),
+        os.path.join(CProot, 'externals', 'miniz-3.1.1'),
         os.path.join(CProot, 'externals', 'msgpack-c', 'include')]
 
     # If the file is run directly without any parameters, clean, build and install
@@ -490,7 +490,7 @@ if __name__ == '__main__':
     here = str(Path('.').parent.absolute())
     
     
-    miniz = ('miniz', {'sources': [str(Path(CProot) / 'externals' / 'miniz-3.0.2' / 'miniz.c')], 'build_temp': here})
+    miniz = ('miniz', {'sources': [str(Path(CProot) / 'externals' / 'miniz-3.1.1' / 'miniz.c')], 'build_temp': here})
     from setuptools.command.build_clib import build_clib
     
     # This class is needed to work around a bug in build_clib that the temporary folder used as the destination for 


### PR DESCRIPTION
## Summary

Cleanup of the include-path stragglers the GH #1280 header reorg left behind (`CoolProp-1tbe.15`).

- **`Web/coolprop/snippets/*.cxx`** — migrate to canonical `CoolProp/` include paths (`CoolProp/CoolProp.h`, `CoolProp/AbstractState.h`, `CoolProp/CoolPropLib.h`, `CoolProp/detail/tools.h`). `AbstractState1.cxx` additionally `#include`d the **deleted** `crossplatform_shared_ptr.h` — a hard compile error for anyone copying the example — replaced with `<memory>` + `std::shared_ptr` (the deleted header was only `using std::shared_ptr`, so this is a faithful replacement). The lone remaining flat include, `Backends/Helmholtz/MixtureDerivatives.h`, is an internal advanced example with no installed public path, so it's left as-is.
- **Inline doc examples** — `StaticLibrary/index.rst` and `SharedLibrary/index.rst` had three `#include "CoolProp.h"` / `"CoolPropLib.h"` literal blocks teaching the deprecated flat shims; migrated to the canonical paths.
- **`wrappers/Lua/coolprop/capi.c`** — the only wrapper #3078 missed; point its relative include at `../../../include/CoolProp/CoolPropLib.h` instead of the deprecated flat shim (kept the relative form: the Lua Makefile falls back to it when `pkg-config CoolProp` is unavailable).
- **`wrappers/Python/deprecated_setup.py`** — the vendored miniz bumped 3.0.2→3.1.1 (#2700); fix the two stale `externals/miniz-3.0.2` paths.

Left as-is (dead/cosmetic, out of include-path scope): the codelite IDE project (wholesale stale after the reorg), the fossilized DEB changelog, the VB.NET AssemblyInfo version stamp.

## Verification

- The migrated `AbstractState1.cxx` + `propssi.cxx` compile standalone against the canonical headers; no doc example references a deleted/flat header.
- Adversarial review: **no blocking findings** — every canonical target verified to exist and match the shim's own forwarding target; the Lua relative path and miniz paths confirmed; `std::shared_ptr` confirmed faithful via the deleted header's history.
- preflight: clang-format / build / Catch2 / cppcheck / semgrep pass. clang-tidy reports pre-existing **doc-snippet** style findings (`std::endl`, magic numbers in the teaching examples) — **none on the changed include lines**; they surfaced only because the fix made the previously-unparseable snippet compile again, and clang-tidy is informational/non-gating in CI.

Closes CoolProp-1tbe.15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated C++ code examples and wrappers to use standardized include paths.
  * Adopted standard C++ library utilities where applicable.

* **Documentation**
  * Updated code examples with standardized include paths.

* **Chores**
  * Updated miniz dependency to version 3.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->