### PR TITLE
ci: tag-vs-version gate for PyPI publishing + bump to 8.0.0b1

### DIFF
--- a/.github/workflows/python_buildwheels.yml
+++ b/.github/workflows/python_buildwheels.yml
@@ -104,7 +104,14 @@ jobs:
       run: |
         set -euo pipefail
         if [[ "$GITHUB_REF" == *"refs/tags"* ]]; then
-          COOLPROP_VERSION_OVERRIDE=$(python dev/extract_version.py --pypi)
+          # Gate (CoolProp-1tbe.3): the published REAL-PyPI version is derived
+          # from CMakeLists.txt, NOT the tag name. Assert the tag matches the
+          # CMakeLists version and is not a .dev release before publishing
+          # (else e.g. a v8.0.0b1 tag on an unbumped 7.2.1dev tree would publish
+          # 7.2.1.dev0). --current pins the published version to CMakeLists (no
+          # auto-increment), so tag == CMakeLists == published.
+          python dev/ci/check_tag_version.py "$GITHUB_REF"
+          COOLPROP_VERSION_OVERRIDE=$(python dev/extract_version.py --pypi --current)
         else
           COOLPROP_VERSION_OVERRIDE=$(python dev/extract_version.py --version "${{ needs.set-version.outputs.testpypiversion }}")
         fi

--- a/.github/workflows/python_cibuildwheel.yml
+++ b/.github/workflows/python_cibuildwheel.yml
@@ -46,7 +46,14 @@ jobs:
       run: |
         set -euo pipefail
         if [[ "$GITHUB_REF" == *"refs/tags"* ]]; then
-          COOLPROP_VERSION_OVERRIDE=$(python dev/extract_version.py --pypi)
+          # Gate (CoolProp-1tbe.3): the published REAL-PyPI version is derived
+          # from CMakeLists.txt, NOT the tag name. Assert the tag matches the
+          # CMakeLists version and is not a .dev release before publishing
+          # (else e.g. a v8.0.0b1 tag on an unbumped 7.2.1dev tree would publish
+          # 7.2.1.dev0). --current pins the published version to CMakeLists (no
+          # auto-increment), so tag == CMakeLists == published.
+          python dev/ci/check_tag_version.py "$GITHUB_REF"
+          COOLPROP_VERSION_OVERRIDE=$(python dev/extract_version.py --pypi --current)
         else
           COOLPROP_VERSION_OVERRIDE=$(python dev/extract_version.py --version "${{ inputs.TESTPYPI_VERSION }}")
         fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,10 +219,15 @@ set(app_name ${project_name})
 project(${project_name})
 
 # Project version
-set(COOLPROP_VERSION_MAJOR 7)
-set(COOLPROP_VERSION_MINOR 2)
-set(COOLPROP_VERSION_PATCH 1)
-set(COOLPROP_VERSION_REVISION dev)
+# REVISION is concatenated onto the patch and PEP 440-normalized by the version
+# tooling (dev/extract_version.py, dev/coolprop_version_provider.py): "b1" ->
+# 8.0.0b1 (a beta pre-release), "dev" -> 8.0.0.dev0, "" -> 8.0.0 (final).
+# The dev_checks tag gate (dev/ci/check_tag_version.py) requires a v* tag to
+# match this version, so bump here before tagging a release/beta.
+set(COOLPROP_VERSION_MAJOR 8)
+set(COOLPROP_VERSION_MINOR 0)
+set(COOLPROP_VERSION_PATCH 0)
+set(COOLPROP_VERSION_REVISION b1)
 set(COOLPROP_VERSION
     "${COOLPROP_VERSION_MAJOR}.${COOLPROP_VERSION_MINOR}.${COOLPROP_VERSION_PATCH}${COOLPROP_VERSION_REVISION}"
 )

--- a/dev/ci/check_tag_version.py
+++ b/dev/ci/check_tag_version.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Assert a ``v*`` tag matches the CMakeLists version and is publishable to PyPI.
+
+On a tagged release the wheels publish to **real PyPI** with a version derived
+from ``CMakeLists.txt`` (via ``dev/extract_version.py``), NOT from the tag name.
+So nothing currently couples the tag to the published version: tagging e.g.
+``v8.0.0b1`` while ``CMakeLists.txt`` still says ``7.2.1dev`` would silently
+publish ``7.2.1.dev0`` to real PyPI (the #2988 class of bug -- CoolProp-1tbe.3).
+
+This gate, run on the tag path before the ``--pypi`` version is computed,
+enforces two things:
+
+  1. the tag's PEP 440 version equals the CMakeLists version (so ``v8.0.0b1``
+     requires ``COOLPROP_VERSION_* = 8.0.0b1``); and
+  2. that version is NOT a developmental (``.dev``) release -- a ``dev`` revision
+     must never reach real PyPI.  Final, beta (``b1``) and rc (``rc1``) markers
+     are all allowed, so a ``v8.0.0b1`` beta tag passes.
+
+Usage:
+    check_tag_version.py <git-ref-or-tag>     # e.g. refs/tags/v8.0.0b1
+
+Exit 0 if the tag is consistent and publishable; non-zero with a GitHub-Actions
+``::error::`` annotation otherwise.
+"""
+import re
+import sys
+from pathlib import Path
+
+from packaging import version
+
+CMAKELISTS = Path(__file__).resolve().parents[2] / "CMakeLists.txt"
+
+
+def cmake_version() -> str:
+    """Build the version string from CMakeLists.txt the same way the build does.
+
+    Mirrors dev/extract_version.py / dev/coolprop_version_provider.py: REVISION
+    may be unquoted (``dev`` / ``b1``) or a quoted string (``""`` on a final
+    release); both are accepted, and it is concatenated directly onto the patch
+    (so ``8.0.0`` + ``b1`` -> ``8.0.0b1``, which packaging normalizes to a beta).
+    """
+    text = CMAKELISTS.read_text(encoding="utf-8")
+
+    def grab(key: str, pat: str) -> str:
+        m = re.search(rf'set\(COOLPROP_VERSION_{key}\s+"?{pat}"?\)', text)
+        if m is None:
+            raise RuntimeError(f"could not parse COOLPROP_VERSION_{key} from {CMAKELISTS}")
+        return m.group(1)
+
+    major = grab("MAJOR", r"(\d+)")
+    minor = grab("MINOR", r"(\d+)")
+    patch = grab("PATCH", r"(\d+)")
+    rev = grab("REVISION", r"(\w*)")
+    return f"{major}.{minor}.{patch}{rev}"
+
+
+def main(ref: str) -> int:
+    tag = ref.rsplit("/", 1)[-1]  # refs/tags/v8.0.0b1 -> v8.0.0b1
+    if tag[:1].lower() == "v":
+        tag = tag[1:]
+
+    try:
+        tag_v = version.Version(tag)
+    except version.InvalidVersion as e:
+        print(f"::error::tag '{tag}' is not a PEP 440 version: {e}", file=sys.stderr)
+        return 1
+
+    cmake_str = cmake_version()
+    try:
+        cmake_v = version.Version(cmake_str)
+    except version.InvalidVersion as e:
+        print(f"::error::CMakeLists version '{cmake_str}' is not a PEP 440 version: {e}", file=sys.stderr)
+        return 1
+
+    if tag_v != cmake_v:
+        print(
+            f"::error::tag version {tag_v} does not match CMakeLists.txt version {cmake_v}. "
+            f"Bump COOLPROP_VERSION_MAJOR/MINOR/PATCH/REVISION to match the tag before tagging "
+            f"(the published PyPI version comes from CMakeLists.txt, not the tag).",
+            file=sys.stderr,
+        )
+        return 1
+
+    if cmake_v.is_devrelease:
+        print(
+            f"::error::refusing to publish a developmental version ({cmake_v}) to real PyPI. "
+            f"Set COOLPROP_VERSION_REVISION to a release marker (empty), or a beta/rc (e.g. b1, rc1), not 'dev'.",
+            file=sys.stderr,
+        )
+        return 1
+
+    kind = "pre-release" if cmake_v.is_prerelease else "final release"
+    print(f"OK: tag {tag_v} matches CMakeLists.txt {cmake_v} ({kind}); publishable to PyPI.")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: check_tag_version.py <git-ref-or-tag>", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))


### PR DESCRIPTION
## Summary

Closes the last v8-prep P1 (`CoolProp-1tbe.3`): wheels publish to **real PyPI** on a `v*` tag with the version derived from `CMakeLists.txt` (not the tag name), so nothing currently stops a mis-versioned publish — tagging `v8.0.0b1` on an unbumped `7.2.1dev` tree would silently push `7.2.1.dev0` to PyPI. The team isn't ready for `8.0.0` final but wants to be able to cut a **beta**, with TestPyPI dev numbering kept intact.

Two independent commits:

### 1. `ci:` tag-vs-version gate (safe to merge anytime)
- New `dev/ci/check_tag_version.py`, run on the tag path of **both** publish workflows (`python_buildwheels.yml`, `python_cibuildwheel.yml`) before the `--pypi` version is computed. Fail-closed, it asserts:
  1. the tag's PEP 440 version **==** the CMakeLists version (`v8.0.0b1` requires `COOLPROP_VERSION_* = 8.0.0b1`); and
  2. that version is **not** a `.dev` release — final / beta (`b1`) / rc (`rc1`) are allowed, so a beta tag passes but a dev tree can't reach PyPI.
- Pins the tag path to `extract_version.py --pypi --current` so the published version is the CMakeLists version verbatim (no auto-increment), giving a deterministic **tag == CMakeLists == published** chain (`twine --skip-existing` covers a re-publish).

### 2. `chore(version):` bump to `8.0.0b1` (merge when cutting the beta)
- `COOLPROP_VERSION_*` → `8 / 0 / 0 / b1`, yielding `8.0.0b1` on a tag→PyPI, `8.0.0.dev<ts>` on branch→TestPyPI, `CoolProp.__version__`/`cpversion.h` = `8.0.0b1`, SONAME → `libCoolProp.so.8`. Kept as its own commit so it can be merged independently of the gate.

## TestPyPI numbering (the explicit requirement) — unaffected

A beta tag publishes to **real PyPI only** (`TWINE_REPOSITORY=pypi` on tags). The TestPyPI version is `base_version.dev<ts>`, and `base_version` **strips** the `b1`, so nightlies stay `8.0.0.dev<ts>` — timestamp-monotonic, collision-free, and PEP 440-sorting *below* `8.0.0b1 < 8.0.0`. The beta can't shadow the dev line; the dev line can't shadow the beta.

## Verification

- `check_tag_version.py` passes `v8.0.0b1`/`v8.0.0-b1` against the bumped tree and fails a mismatched tag, a `.dev` tree, and a non-PEP-440 tag (all exit non-zero under `set -euo pipefail`).
- `--current` traced: first publish → `8.0.0b1`; re-publish → keeps `b1` (skip-existing). Confirmed not a regression (the tag path never used auto-increment for finals).
- Build compiles with `8.0.0b1` in `cpversion.h`; Catch2 tests pass.
- Adversarial review: **no blocking findings** — gate fail-closed on every path, no ungated PyPI publish path, bump side effects clean (SOVERSION, `.rc`, installer all handle the non-numeric suffix).

## To cut the beta
Merge this, then tag `v8.0.0b1`. The gate verifies the tag matches `CMakeLists`, and `--current` publishes exactly `8.0.0b1` to PyPI.

Closes CoolProp-1tbe.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 8.0.0-b1 (beta 1)
  * Enhanced CI/CD validation to ensure version consistency between build tags and release metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->