### PR TITLE
fix(fluids): add the air melting line (Lemmon et al. 2000)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2198,6 +2198,8 @@ if(COOLPROP_CATCH_MODULE)
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-PXFlash.cpp")
   list(APPEND APP_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-AirMelting.cpp")
+  list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-Michelsen.cpp"
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-FPUGuard.cpp")
   list(APPEND APP_SOURCES

--- a/dev/fluids/Air.json
+++ b/dev/fluids/Air.json
@@ -44,6 +44,21 @@
       "max_abs_error_units": "J/mol",
       "type": "rational_polynomial"
     },
+    "melting_line": {
+      "BibTeX": "Lemmon-JPCRD-2000",
+      "T_m": -1,
+      "parts": [
+        {
+          "T_0": 59.75,
+          "T_max": 265,
+          "T_min": 59.75,
+          "a": 186844210.7644081,
+          "c": 1.78963,
+          "p_0": 5264.1810687705665
+        }
+      ],
+      "type": "Simon"
+    },
     "pL": {
       "T_r": 132.6312,
       "Tmax": 132.6312,

--- a/src/Tests/CoolProp-Tests-AirMelting.cpp
+++ b/src/Tests/CoolProp-Tests-AirMelting.cpp
@@ -1,0 +1,53 @@
+// Tests for the air (pseudo-pure) melting line (bd CoolProp-r1w7 Tier 3).
+//
+// Air lacked a melting line, so its high-pressure P+{H,S,U} consistency points
+// failed ("Inputs in Brent [...] do not bracket the root"): the HSU_P flash
+// floored its T-search at the EOS triple temperature and probed the cold dense
+// region.  The melting line of Lemmon et al. (2000) -- the same paper as air's
+// EOS, ported from REFPROP's AIR.PPF -- is added so the flash floors the search
+// at Tmelt(p).  Run explicitly:  ./CatchTestRunner "[melting]"
+
+#if defined(ENABLE_CATCH)
+
+#    include <catch2/catch_all.hpp>
+
+#    include <memory>
+
+#    include "CoolProp/AbstractState.h"
+#    include "CoolProp/DataStructures.h"
+
+// Check values pinning the air melting line (Simon form, reproduces REFPROP's
+// Lemmon-2000 curve to <0.02%).  T(p) obtained by inverting the fitted curve.
+TEST_CASE("Air melting line check values (Lemmon-2000)", "[melting]") {
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Air"));
+    CHECK(AS->melting_line(CoolProp::iT, CoolProp::iP, 1.0e8) == Catch::Approx(75.920).epsilon(1e-4));
+    CHECK(AS->melting_line(CoolProp::iT, CoolProp::iP, 1.0e9) == Catch::Approx(167.875).epsilon(1e-4));
+}
+
+// Regression: a genuine fluid state (T > Tmelt(p)) at p ~ 1 GPa that previously
+// failed the P+{H,S,U} flash now round-trips, because the melting line floors
+// the HSU_P T-search above the cold dense region.
+TEST_CASE("Air high-pressure P+X reliability (was failing)", "[melting]") {
+    const double T = 210.01538461538462;  // K  (> Tmelt(1.035 GPa) ~ 170 K)
+    const double p = 1035411979.2369467;  // Pa
+    auto ref = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Air"));
+    auto wrk = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Air"));
+    REQUIRE_NOTHROW(ref->update(CoolProp::PT_INPUTS, p, T));
+    const double h = ref->hmolar(), s = ref->smolar(), u = ref->umolar(), rho = ref->rhomolar();
+
+    SECTION("PH") {
+        REQUIRE_NOTHROW(wrk->update(CoolProp::HmolarP_INPUTS, h, p));
+        CHECK(wrk->T() == Catch::Approx(T).epsilon(1e-5));
+        CHECK(wrk->rhomolar() == Catch::Approx(rho).epsilon(1e-5));
+    }
+    SECTION("PS") {
+        REQUIRE_NOTHROW(wrk->update(CoolProp::PSmolar_INPUTS, p, s));
+        CHECK(wrk->T() == Catch::Approx(T).epsilon(1e-5));
+    }
+    SECTION("PU") {
+        REQUIRE_NOTHROW(wrk->update(CoolProp::PUmolar_INPUTS, p, u));
+        CHECK(wrk->T() == Catch::Approx(T).epsilon(1e-5));
+    }
+}
+
+#endif  // ENABLE_CATCH


### PR DESCRIPTION
## Summary

Air (pseudo-pure) had no melting line, so its high-pressure `P+{H,S,U}` consistency points failed with `Inputs in Brent [...] do not bracket the root` (~392 failures): the HSU_P flash floored its T-search at the EOS triple temperature (59.75 K) and probed the cold dense isotherms up to the EOS pmax (2000 MPa).

This adds air's melting line from **Lemmon et al. (2000)** — the same paper as air's EOS, which already contains the curve (it simply was never ported into CoolProp). It's taken from REFPROP's `AIR.PPF` (ML1 model) and expressed in CoolProp's `Simon` form:

```
p = p_0 + a·((T/T_0)^c − 1),  T_0 = 59.75 K,  p_0 = 5264.18 Pa,  a = 1.86844e8,  c = 1.78963
```

- Reproduces REFPROP's `MELTTdll` air melting curve to **<0.02%**.
- Anchored at the triple point (`p_0` = air's triple pressure), so `p_min` == the triple pressure — no out-of-bounds band.
- `T_max = 265 K` ⇒ the curve reaches the EOS pmax (2000 MPa, at ~236 K) with margin.

With the melting line present, the HSU_P T-search floors at `Tmelt(p)` and the high-pressure states resolve.

## Validation

- New `[melting]` tests: air melting check-values (75.920 K @ 0.1 GPa, 167.875 K @ 1 GPa) + a genuine-fluid `P+{H,S,U}` round-trip regression at **210 K / 1.035 GPa** (above `Tmelt`≈170 K).
- `[melting]`, `[flash]`, `[consistency]` all pass; preflight green; adversarial review clean.

## Scope

Data + tests only (Air fluid file, one new test file). No solver/guard code; no other fluids. `Lemmon-JPCRD-2000` is already in the bibliography (air's EOS source), so no new citation.

This is the first of the Tier-3 fixes for the HEOS flash-consistency epic (`CoolProp-r1w7`); companion melting-line PRs: #3164 (Neon), and #3159 (Argon/Fluorine guard, by @fwitte).

bd CoolProp-r1w7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added melting line thermodynamic data for Air, enabling calculations at phase transition conditions.

* **Tests**
  * Introduced validation tests for Air's melting line properties across pressure ranges.
  * Added regression tests ensuring high-pressure Air state calculations maintain accuracy through round-trip conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->