### PR TITLE
fix(flash): robustness hardening in the Cubic + Michelsen flash paths

### DIFF
--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -576,9 +576,21 @@ CoolPropDbl CoolProp::AbstractCubicBackend::solver_rho_Tp_global(CoolPropDbl T, 
         // triggers all_critical_points() for many-component mixtures.
         double rho_vap = (rho0 > 0) ? rho0 : rho1;
         double rho_liq = rho2;
-        double g_vap = calc_gibbsmolar_nocache(T, rho_vap);
-        double g_liq = calc_gibbsmolar_nocache(T, rho_liq);
-        rho = (g_liq < g_vap) ? rho_liq : rho_vap;
+        // Guard against a non-physical (<= 0) candidate root: its Gibbs energy is
+        // garbage/NaN, and `g_liq < g_vap` is false for a NaN g_vap, which would
+        // silently select the non-physical root (CoolProp-1tbe.8 finding 3A).
+        bool vap_ok = rho_vap > 0;
+        bool liq_ok = rho_liq > 0;
+        if (vap_ok && liq_ok) {
+            double g_vap = calc_gibbsmolar_nocache(T, rho_vap);
+            double g_liq = calc_gibbsmolar_nocache(T, rho_liq);
+            // Prefer the lower-Gibbs root; if one Gibbs is non-finite, keep the finite one.
+            rho = (ValidNumber(g_liq) && (!ValidNumber(g_vap) || g_liq < g_vap)) ? rho_liq : rho_vap;
+        } else if (vap_ok || liq_ok) {
+            rho = vap_ok ? rho_vap : rho_liq;
+        } else {
+            throw ValueError("solver_rho_Tp_global: no positive density root among the three cubic roots");
+        }
     } else {
         throw ValueError("Obtained neither 1 nor three roots");
     }

--- a/src/Backends/Cubics/CubicBackend.h
+++ b/src/Backends/Cubics/CubicBackend.h
@@ -218,9 +218,22 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
      */
     void rho_Tp_cubic(CoolPropDbl T, CoolPropDbl p, int& Nsolns, double& rho0, double& rho1, double& rho2);
 
-    /// In this class, we are already doing cubic evaluation, just delegate to our function
+    /// In this class, we are already doing cubic evaluation, just delegate to our function.
+    /// solver_rho_Tp(T, p, phase) THROWS when the requested-phase root does not exist, but
+    /// callers of solver_rho_Tp_SRK (e.g. FlashRoutines::PT_flash_mixtures) expect the
+    /// base-class negative-sentinel contract -- they test `rho > 0 && ValidNumber(rho)` and
+    /// are not wrapped in a try/catch.  Honor that contract here so a cubic-mixture
+    /// single-phase PT flash where one branch's root is absent does not throw uncaught from
+    /// update() (CoolProp-1tbe.8 finding 3B).
     CoolPropDbl solver_rho_Tp_SRK(CoolPropDbl T, CoolPropDbl p, phases phase) override {
-        return solver_rho_Tp(T, p, phase);
+        // Catch only the expected "no root" CoolProp error (a ValueError, which
+        // derives from CoolPropBaseError) -- let std::bad_alloc / programming
+        // errors propagate rather than silently degrading them to a -1 sentinel.
+        try {
+            return solver_rho_Tp(T, p, phase);
+        } catch (const CoolPropBaseError&) {
+            return -1;
+        }
     };
     /**
      * /brief Solve for rho = f(T,p)

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -1906,7 +1906,7 @@ void StabilityRoutines::StabilityEvaluationClass::check_stability_michelsen() {
         bool ss_decided = false;
 
         for (int loop = 0; loop < max_ss_loops && !ss_decided; ++loop) {
-            std::array<double, 2> esq_pair;
+            std::array<double, 2> esq_pair = {0, 0};
             std::vector<CoolPropDbl> err(N);
 
             for (int kk = 0; kk < 2 && !ss_decided; ++kk) {
@@ -1992,7 +1992,9 @@ void StabilityRoutines::StabilityEvaluationClass::check_stability_michelsen() {
             // GDEM extrapolation step ([M&M2007] Ch. 12, Sec. 12.6)
             if (esq_pair[0] > 0) {
                 double ratio = std::sqrt(esq_pair[1] / esq_pair[0]);
-                if (ratio < 0 || ratio >= 0.95) ratio = 0.95;
+                // A NaN ratio (non-finite esq) passes both < 0 and >= 0.95, so guard it
+                // explicitly -- otherwise it poisons the GDEM lnK/Y update (CoolProp-1tbe.8 finding 4c).
+                if (!ValidNumber(ratio) || ratio < 0 || ratio >= 0.95) ratio = 0.95;
                 double factor = ratio / (1.0 - ratio);
                 for (std::size_t i = 0; i < N; ++i) {
                     double ln_Y = std::log(std::max(Y[i], 1e-300));
@@ -2534,7 +2536,9 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         // GDEM extrapolation ([M&M2007] Ch. 12, Sec. 12.6)
         if (esq_pair[0] > 0) {
             double ratio = std::sqrt(esq_pair[1] / esq_pair[0]);
-            if (ratio < 0 || ratio >= 0.95) ratio = 0.95;
+            // A NaN ratio (non-finite esq) passes both < 0 and >= 0.95, so guard it
+            // explicitly -- otherwise it poisons the GDEM lnK/Y update (CoolProp-1tbe.8 finding 4c).
+            if (!ValidNumber(ratio) || ratio < 0 || ratio >= 0.95) ratio = 0.95;
             double factor = ratio / (1.0 - ratio);
             for (std::size_t i = 0; i < N; ++i) {
                 lnK[i] += factor * err[i];
@@ -2637,6 +2641,12 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
                     double beta_save = beta;
                     auto x_save = IO.x;
                     auto y_save = IO.y;
+                    // Save the densities too so a rejected trial restores a
+                    // CONSISTENT (beta, x, y, rhomolar_liq, rhomolar_vap); otherwise
+                    // a later !step_ok exit publishes densities from the rejected
+                    // trial composition (CoolProp-1tbe.8 finding 2).
+                    CoolPropDbl rhoL_save = IO.rhomolar_liq;
+                    CoolPropDbl rhoV_save = IO.rhomolar_vap;
                     beta = V_new;
                     IO.x = x_trial;
                     IO.y = y_trial;
@@ -2653,6 +2663,8 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
                         beta = beta_save;
                         IO.x = x_save;
                         IO.y = y_save;
+                        IO.rhomolar_liq = rhoL_save;
+                        IO.rhomolar_vap = rhoV_save;
                         step_scale *= 0.5;
                     }
                 } else {


### PR DESCRIPTION
## Summary

Defense-in-depth fixes from the #3026 flash audit (`CoolProp-1tbe.8`), re-audited against the merged #3140. **Finding 1 (the `unspecify_phase` leak) was already resolved by #3140**, so it's not here. The remaining items are hardening against silent-wrong-answer / uncaught-exception paths — all verified behaviour-preserving (`[cubic]`/`[flash]`/`[mixture]`/`[stability]`/`[michelsen]` all green).

- **3B** — `AbstractCubicBackend::solver_rho_Tp_SRK` delegated to `solver_rho_Tp(phase)`, which *throws* when the requested-phase root is absent, but callers (post-#3140 `PT_flash_mixtures`) expect the base-class negative-sentinel contract and aren't wrapped in try/catch. Honor the contract: catch the expected `CoolPropBaseError` and return `-1`. *(A 25k-flash sweep found no real-mixture trigger — the path is hard to reach — but the contract mismatch is real.)*
- **3A** — `solver_rho_Tp_global`'s 3-root branch could select a non-physical (≤0) density root: its Gibbs energy is NaN, and `g_liq < g_vap` is false for a NaN `g_vap`, silently picking the bad root. Guard root positivity and the NaN comparison.
- **4c** — the GDEM clamp `if (ratio < 0 || ratio >= 0.95)` doesn't catch a NaN `ratio` (it passes both), poisoning the lnK/Y update at the two GDEM sites. Add a `!ValidNumber` guard, and initialize the stability site's `esq_pair` to `{0,0}` (the michelsen site already does).
- **Finding 2 (partial)** — in `solve_michelsen`'s line search, a rejected trial restored `beta/x/y` but left `rhomolar_liq/vap` at the rejected trial values, so a later stalled-search exit could publish densities inconsistent with the restored composition. Save and restore the densities too.

## ⚠️ Bigger finding surfaced — filed as CoolProp-1tbe.22

The **convergence-check** half of Finding 2 is intentionally **not** in this PR. Adding a post-loop "throw if not converged" to `solve_michelsen` made **~13 existing `[flash]`/`[michelsen]` tests fail with `max |Δ(ln f)| ≈ 1–6`** — i.e. the solver is returning two-phase splits whose phase fugacities differ by factors of e¹–e⁶, nowhere near equilibrium, and the #3140 smoke tests accept them (they only check `phase()==twophase` and `Q()>0`, not accuracy). So master silently ships **wrong two-phase compositions** for several mixture PT flashes (e.g. `update(PT_INPUTS, 4e6, 190)`). That's a separate, larger bug needing a maintainer decision (throw vs. fix the solver) — filed under the epic with the diagnostic patch ready. **`.8` findings 4a (stability fail-open) and 4b (hardcoded feed phase) remain** for a follow-up too.

## Verification

- All flash/mixture/stability/michelsen suites pass; the 3A common path is bit-identical to the original, 4c is a no-op for finite in-range ratios, Finding-2 restore only touches the rejected-trial path.
- Adversarial review: all four fixes correct and behaviour-preserving; it flagged the original `catch(...)` as over-broad (fail-open on `bad_alloc`), now **narrowed to `catch (const CoolPropBaseError&)`**.
- preflight: clang-format / build / Catch2 (`[Helmholtz],[REFPROP]`) / semgrep pass. cppcheck + clang-tidy report only **pre-existing** findings in these large flash files (none at the changed lines; both informational/non-gating in CI).

Part of CoolProp-1tbe.8 (findings 3A, 3B, 4c, and the Finding-2 state-restore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced robustness in thermodynamic phase density calculations when multiple physical solutions exist.
  * Improved error handling in vapor-liquid equilibrium computations to gracefully handle edge cases.
  * Fixed state consistency issues in equilibrium calculations by ensuring proper density state restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->