### PR TITLE
fix(backends): clear cppcheck uninitMemberVar warnings across core backends

### DIFF
--- a/include/CoolProp/CoolPropFluid.h
+++ b/include/CoolProp/CoolPropFluid.h
@@ -34,7 +34,7 @@ struct BibTeXKeysStruct
 
 struct EnvironmentalFactorsStruct
 {
-    double GWP20, GWP100, GWP500, ODP, HH, PH, FH;
+    double GWP20 = _HUGE, GWP100 = _HUGE, GWP500 = _HUGE, ODP = _HUGE, HH = _HUGE, PH = _HUGE, FH = _HUGE;
     std::string ASHRAE34;
 };
 struct CriticalRegionSplines
@@ -276,13 +276,13 @@ struct ViscosityInitialDensityVariables
 struct ViscosityModifiedBatschinskiHildebrandData
 {
     std::vector<CoolPropDbl> a, d1, d2, t1, t2, f, g, h, p, q, gamma, l;
-    CoolPropDbl T_reduce, rhomolar_reduce;
+    CoolPropDbl T_reduce = _HUGE, rhomolar_reduce = _HUGE;
 };
 struct ViscosityFrictionTheoryData
 {
     std::vector<CoolPropDbl> Aa, Aaa, Aaaa, Ar, Arr, Adrdr, Arrr, Ai, Aii, AdrAdr;
-    int Na, Naa, Naaa, Nr, Nrr, Nrrr, Nii;
-    CoolPropDbl c1, c2, T_reduce, rhomolar_reduce;
+    int Na = 0, Naa = 0, Naaa = 0, Nr = 0, Nrr = 0, Nrrr = 0, Nii = 0;
+    CoolPropDbl c1 = _HUGE, c2 = _HUGE, T_reduce = _HUGE, rhomolar_reduce = _HUGE;
 };
 struct ViscosityHigherOrderVariables
 {
@@ -308,7 +308,7 @@ struct ViscosityHigherOrderVariables
 struct ViscosityRhoSrVariables
 {
     std::vector<double> c_liq, c_vap;
-    double C, x_crossover, rhosr_critical;
+    double C = _HUGE, x_crossover = _HUGE, rhosr_critical = _HUGE;
 };
 struct ViscosityECSVariables
 {

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -412,10 +412,10 @@ void CoolProp::AbstractCubicBackend::rho_Tp_cubic(CoolPropDbl T, CoolPropDbl p, 
 class SaturationResidual : public CoolProp::FuncWrapper1D
 {
    public:
-    CoolProp::AbstractCubicBackend* ACB;
-    CoolProp::input_pairs inputs;
-    double imposed_variable;
-    double deltaL, deltaV;
+    CoolProp::AbstractCubicBackend* ACB = nullptr;
+    CoolProp::input_pairs inputs = CoolProp::INPUT_PAIR_INVALID;
+    double imposed_variable = _HUGE;
+    double deltaL = _HUGE, deltaV = _HUGE;
 
     SaturationResidual() = default;
     SaturationResidual(CoolProp::AbstractCubicBackend* ACB, CoolProp::input_pairs inputs, double imposed_variable)

--- a/src/Backends/Cubics/CubicsLibrary.h
+++ b/src/Backends/Cubics/CubicsLibrary.h
@@ -13,14 +13,14 @@ namespace CubicLibrary {
 
 struct CubicsValues
 {
-    double Tc,         ///< Critical temperature (K)
-      pc,              ///< Critical pressure (Pa)
-      molemass,        ///< Molar mass (kg/mol)
-      acentric,        ///< Acentric factor (-)
-      rhomolarc;       ///< Critical density (mol/m3) (initialized to an invalid negative number)
-    std::string name,  // name of fluid
-      CAS,             // CAS reference number of fluid
-      BibTeX;          // BibTex key(s) for the values
+    double Tc = _HUGE,   ///< Critical temperature (K)
+      pc = _HUGE,        ///< Critical pressure (Pa)
+      molemass = _HUGE,  ///< Molar mass (kg/mol)
+      acentric = _HUGE,  ///< Acentric factor (-)
+      rhomolarc;         ///< Critical density (mol/m3) (initialized to an invalid negative number)
+    std::string name,    // name of fluid
+      CAS,               // CAS reference number of fluid
+      BibTeX;            // BibTex key(s) for the values
     std::vector<std::string> aliases;
     std::string alpha_type;            ///< The type of alpha function
     std::vector<double> alpha_coeffs;  ///< The vector of coefficients for the alpha function

--- a/src/Backends/Cubics/UNIFAC.h
+++ b/src/Backends/Cubics/UNIFAC.h
@@ -23,10 +23,10 @@ class UNIFACMixture
 
     CoolProp::CachedElement _T;  ///< The cached temperature
 
-    std::size_t N;  ///< Number of components
+    std::size_t N = 0;  ///< Number of components
 
-    double m_T;  ///< The temperature in K
-    double T_r;  ///< Reducing temperature
+    double m_T = _HUGE;  ///< The temperature in K
+    double T_r;          ///< Reducing temperature
 
     std::map<std::pair<std::size_t, std::size_t>, double> Psi_;  /// < temporary storage for Psi
 

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -4185,6 +4185,7 @@ class L0CurveTracer : public FuncWrapper1DWithDeriv
         delta(delta0),
         tau(tau0),
         M1_last(_HUGE),
+        theta_last(_HUGE),
         R_delta_tracer(0.1),
         R_tau_tracer(0.1),
         N_critical_points(0),

--- a/src/Backends/Helmholtz/VLERoutines.h
+++ b/src/Backends/Helmholtz/VLERoutines.h
@@ -486,14 +486,14 @@ struct newton_raphson_saturation_options
 class newton_raphson_saturation
 {
    public:
-    newton_raphson_saturation_options::imposed_variable_options imposed_variable;
+    newton_raphson_saturation_options::imposed_variable_options imposed_variable = newton_raphson_saturation_options::NO_VARIABLE_IMPOSED;
     CoolPropDbl error_rms, rhomolar_liq, rhomolar_vap, T, p, min_rel_change;
-    std::size_t N;
-    bool logging;
-    bool bubble_point;
-    int Nsteps;
+    std::size_t N = 0;
+    bool logging = false;
+    bool bubble_point = false;
+    int Nsteps = 0;
     Eigen::MatrixXd J;
-    HelmholtzEOSMixtureBackend* HEOS;
+    HelmholtzEOSMixtureBackend* HEOS = nullptr;
     CoolPropDbl dTsat_dPsat, dPsat_dTsat;
     std::vector<CoolPropDbl> K, x, y;
     Eigen::VectorXd r, err_rel;
@@ -567,9 +567,9 @@ struct PTflash_twophase_options
 class PTflash_twophase
 {
    public:
-    double error_rms;
-    bool logging;
-    int Nsteps;
+    double error_rms = _HUGE;
+    bool logging = false;
+    int Nsteps = 0;
     Eigen::MatrixXd J;
     Eigen::VectorXd r, err_rel;
     HelmholtzEOSMixtureBackend& HEOS;

--- a/src/Backends/Helmholtz/VLERoutines.h
+++ b/src/Backends/Helmholtz/VLERoutines.h
@@ -487,14 +487,14 @@ class newton_raphson_saturation
 {
    public:
     newton_raphson_saturation_options::imposed_variable_options imposed_variable = newton_raphson_saturation_options::NO_VARIABLE_IMPOSED;
-    CoolPropDbl error_rms, rhomolar_liq, rhomolar_vap, T, p, min_rel_change;
+    CoolPropDbl error_rms = _HUGE, rhomolar_liq = _HUGE, rhomolar_vap = _HUGE, T = _HUGE, p = _HUGE, min_rel_change = _HUGE;
     std::size_t N = 0;
     bool logging = false;
     bool bubble_point = false;
     int Nsteps = 0;
     Eigen::MatrixXd J;
     HelmholtzEOSMixtureBackend* HEOS = nullptr;
-    CoolPropDbl dTsat_dPsat, dPsat_dTsat;
+    CoolPropDbl dTsat_dPsat = _HUGE, dPsat_dTsat = _HUGE;
     std::vector<CoolPropDbl> K, x, y;
     Eigen::VectorXd r, err_rel;
     std::vector<SuccessiveSubstitutionStep> step_logger;


### PR DESCRIPTION
## Summary

A `cppcheck --enable=warning` sweep over **all C/C++ changed since `v7.2.0`** (247 files, same invocation as `dev/ci/preflight.sh`) surfaced **30 `uninitMemberVar` warnings**. This clears the **core-library** ones by giving each flagged member a default member initializer (NSDMI), or — for `L0CurveTracer::theta_last` — extending the existing constructor init-list.

Every change is **behavior-neutral**: the default only takes effect on a read-before-write path, which was undefined behavior before. Two of them (`EnvironmentalFactorsStruct`, `PTflash_twophase::error_rms`) additionally retire a *latent* uninitialized-read: the new deterministic value (`_HUGE`) is rejected by the existing `ValidNumber`/`<0` guards or yields the correct keep-iterating semantics, where prior garbage could have slipped through.

Default convention: `_HUGE` for physical-quantity doubles (codebase idiom), `0`/`false`/`nullptr`/enum-sentinel otherwise.

### Structs touched
`ViscosityModifiedBatschinskiHildebrandData`, `ViscosityFrictionTheoryData`, `ViscosityRhoSrVariables`, `EnvironmentalFactorsStruct`, `CubicsValues`, `UNIFACMixture`, `SaturationResidual`, `newton_raphson_saturation`, `PTflash_twophase`, `L0CurveTracer`.

### Deliberately out of scope
- **`superancillary.h` `ChebyshevExpansion::m_xmin/m_xmax`** — fixed on #3162, which already reworks that header.
- **`IncompressibleBackend::fluid`** — cppcheck false positive (both flagged constructors `throw` before the member is read).
- **Non-shipping dev tools** (`dev/fitter/Fitter.cpp` self-assign) and **legacy wrappers** (EES buffer/return-value, Modelica copy-ctor) — left as-is; not built in CI.

## Validation

- **cppcheck core `uninitMemberVar`: 30 → 0.**
- Build links clean; `[Helmholtz]`, `[REFPROP]`, `[cubic]`, `[critical_points]` tests pass (470 assertions, 0 failures).
- clang-format clean on all six files.
- Adversarial review (per CLAUDE.md) returned no blocking findings; it verified behavior-neutrality on every post-constructor read path and confirmed `_HUGE` scope + enum sentinels.

> Note: `dev/ci/preflight.sh`'s clang-tidy step runs **whole-file** and flags pre-existing debt in these large legacy backends (make-shared, static_cast downcast, implicit-bool on lines this diff never touches). There are **zero** clang-tidy findings on this diff's changed lines; CI's clang-tidy is diff-only + informational and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization of environmental property data to avoid uninitialized values (GWP, ODP, etc.).
  * Enhanced stability and reliability of viscosity and transport calculations via default initialization of numeric parameters.
  * Increased robustness of cubic and Helmholtz backend solvers and mixture models by initializing solver and cache state members.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->