### PR TITLE
fix(EES): harden COOLPROP_EES — buffer overflows, OOB read, crash-on-fopen, format UB + cleanup

### DIFF
--- a/wrappers/EES/main.cpp
+++ b/wrappers/EES/main.cpp
@@ -55,6 +55,16 @@ struct EesParamRec
 
 using namespace CoolProp;
 
+// EES always passes `fluid` as a fixed 256-char buffer (see the header comment
+// at the top of this file).  Route every write to it through this helper so a
+// long fluid/input string or error/warning message is truncated to fit instead
+// of overrunning the buffer; the result is always NUL-terminated.
+static void set_fluid(char* fluid, const std::string& message) {
+    const std::size_t n = std::min(message.size(), static_cast<std::size_t>(255));
+    message.copy(fluid, n);
+    fluid[n] = '\0';
+}
+
 // Tell C++ to use the "C" style calling conventions rather than the C++ mangled names
 extern "C"
 {
@@ -70,7 +80,7 @@ extern "C"
         std::vector<std::string> fluid_split;
 
         if (mode == -1) {
-            strcpy(fluid, "T = PropsSI('T','P',101325,'Q',0,'Water')");
+            set_fluid(fluid, "T = PropsSI('T','P',101325,'Q',0,'Water')");
             return 0;
         }
 
@@ -78,7 +88,7 @@ extern "C"
         fluid_split = strsplit(fluid_string, '~');
         if (fluid_split.size() != 5) {
             sprintf(err_str, "fluid[%s] length[%d] not 5 elements long", fluid_string.c_str(), fluid_split.size());
-            strcpy(fluid, err_str);
+            set_fluid(fluid, err_str);
             if (EES_DEBUG) {
                 FILE* fp;
                 fp = fopen("log.txt", "a+");
@@ -115,7 +125,7 @@ extern "C"
 
         if (NInputs < 2) {
             sprintf(err_str, "Number of inputs [%d] < 2", NInputs);
-            strcpy(fluid, err_str);
+            set_fluid(fluid, err_str);
             return 0;
         }
 
@@ -167,11 +177,11 @@ extern "C"
                 }
             } else {
                 if (In1str.size() != 1) {
-                    strcpy(fluid, format("Input #1 [%s] can only be 1 character long for coolprop()", In1str.c_str()).c_str());
+                    set_fluid(fluid, format("Input #1 [%s] can only be 1 character long for coolprop()", In1str.c_str()));
                     return 0;
                 }
                 if (In2str.size() != 1) {
-                    strcpy(fluid, format("Input #2 [%s] can only be 1 character long for coolprop()", In2str.c_str()).c_str());
+                    set_fluid(fluid, format("Input #2 [%s] can only be 1 character long for coolprop()", In2str.c_str()));
                     return 0;
                 }
                 // Mole fractions are not given
@@ -187,7 +197,7 @@ extern "C"
                 fprintf(fp, "Error: %s \n", err_str.c_str());
                 fclose(fp);
             }
-            strcpy(fluid, err_str.c_str());
+            set_fluid(fluid, err_str);
 
             return 0.0;
         }
@@ -201,7 +211,7 @@ extern "C"
                 fprintf(fp, "Error: %s \n", err_str.c_str());
                 fclose(fp);
             }
-            strcpy(fluid, err_str.c_str());
+            set_fluid(fluid, err_str);
             return 0.0;
         } else {
             // Check if there was a warning
@@ -214,7 +224,7 @@ extern "C"
                     fclose(fp);
                 }
                 // There was a warning, write it back
-                strcpy(fluid, warn_string.c_str());
+                set_fluid(fluid, warn_string);
             }
             if (EES_DEBUG) {
                 FILE* fp;

--- a/wrappers/EES/main.cpp
+++ b/wrappers/EES/main.cpp
@@ -136,9 +136,12 @@ extern "C"
         }
 
         if (EES_DEBUG) {
-            // This redirects standard output to log_stdout.txt
-            freopen("log_stdout.txt", "w", stdout);
-            ::set_debug_level(100000);  // Maximum debugging
+            // This redirects standard output to log_stdout.txt; only crank up
+            // the debug output if the redirect succeeded, so we don't spew to a
+            // broken stdout when the log file can't be opened.
+            if (freopen("log_stdout.txt", "w", stdout) != NULL) {
+                ::set_debug_level(100000);  // Maximum debugging
+            }
         }
 
         try {
@@ -163,11 +166,13 @@ extern "C"
                     out = PropsSI(Outstr, In1str, In1, In2str, In2, Fluidstr);
                 }
             } else {
-                if (In1str.size() != 0) {
+                if (In1str.size() != 1) {
                     strcpy(fluid, format("Input #1 [%s] can only be 1 character long for coolprop()", In1str.c_str()).c_str());
+                    return 0;
                 }
-                if (In2str.size() != 0) {
+                if (In2str.size() != 1) {
                     strcpy(fluid, format("Input #2 [%s] can only be 1 character long for coolprop()", In2str.c_str()).c_str());
+                    return 0;
                 }
                 // Mole fractions are not given
                 out = Props(Outstr.c_str(), In1str[0], In1, In2str[0], In2, Fluidstr.c_str());

--- a/wrappers/EES/main.cpp
+++ b/wrappers/EES/main.cpp
@@ -61,7 +61,7 @@ extern "C"
     __declspec(dllexport) double COOLPROP_EES(char fluid[256], int mode, struct EesParamRec* input_rec) {
         double In1 = _HUGE, In2 = _HUGE, out;  // Two inputs, one output
         int NInputs;                           // Ninputs is the number of inputs
-        char NInputs_string[3], err_str[1000];
+        char err_str[1000];
         std::string fluid_string = fluid;
 
         std::vector<double> z;
@@ -114,8 +114,8 @@ extern "C"
         };
 
         if (NInputs < 2) {
-            sprintf(NInputs_string, "Number of inputs [%d] < 2", NInputs);
-            strcpy(fluid, NInputs_string);
+            sprintf(err_str, "Number of inputs [%d] < 2", NInputs);
+            strcpy(fluid, err_str);
             return 0;
         }
 

--- a/wrappers/EES/main.cpp
+++ b/wrappers/EES/main.cpp
@@ -38,7 +38,6 @@
 #include <algorithm>
 #include <string>
 #include <stdio.h>
-#include <string.h>
 #include <vector>
 #include "CoolProp/CoolProp.h"
 #include "CoolProp/CoolPropLib.h"
@@ -65,18 +64,28 @@ static void set_fluid(char* fluid, const std::string& message) {
     fluid[n] = '\0';
 }
 
+// Append a line to the EES debug log, skipping silently if the file can't be
+// opened.  Debug logging must never crash or abort the EES call, so the fopen
+// result is always checked before use.
+static void log_debug(const std::string& line) {
+    FILE* fp = fopen("log.txt", "a+");
+    if (fp != nullptr) {
+        fputs(line.c_str(), fp);
+        fclose(fp);
+    }
+}
+
 // Tell C++ to use the "C" style calling conventions rather than the C++ mangled names
 extern "C"
 {
     __declspec(dllexport) double COOLPROP_EES(char fluid[256], int mode, struct EesParamRec* input_rec) {
-        double In1 = _HUGE, In2 = _HUGE, out;  // Two inputs, one output
-        int NInputs;                           // Ninputs is the number of inputs
-        char err_str[1000];
+        double In1 = _HUGE, In2 = _HUGE, out = _HUGE;  // Two inputs, one output
+        int NInputs = 0;                               // Ninputs is the number of inputs
         std::string fluid_string = fluid;
 
         std::vector<double> z;
 
-        std::string ErrorMsg, Outstr, In1str, In2str, Fluidstr, Units;
+        std::string Outstr, In1str, In2str, Fluidstr, Units;
         std::vector<std::string> fluid_split;
 
         if (mode == -1) {
@@ -87,14 +96,10 @@ extern "C"
         // Split the string that is passed in at the '~' delimiter that was used to join it
         fluid_split = strsplit(fluid_string, '~');
         if (fluid_split.size() != 5) {
-            sprintf(err_str, "fluid[%s] length[%d] not 5 elements long", fluid_string.c_str(), fluid_split.size());
-            set_fluid(fluid, err_str);
+            const std::string msg = format("fluid[%s] length[%d] not 5 elements long", fluid_string.c_str(), static_cast<int>(fluid_split.size()));
+            set_fluid(fluid, msg);
             if (EES_DEBUG) {
-                FILE* fp;
-                fp = fopen("log.txt", "a+");
-                fprintf(fp, "%s %s %g %s %g %s\n", Outstr.c_str(), In1str.c_str(), In1, In2str.c_str(), In2, Fluidstr.c_str());
-                fprintf(fp, "%s\n", err_str);
-                fclose(fp);
+                log_debug(format("%s %s %g %s %g %s\n%s\n", Outstr.c_str(), In1str.c_str(), In1, In2str.c_str(), In2, Fluidstr.c_str(), msg.c_str()));
             }
             return 0;
         } else {
@@ -105,17 +110,17 @@ extern "C"
             Units = upper(fluid_split[4]);
         }
 
-        if (Fluidstr.find("$DEBUG") != std::string::npos) {
+        const std::size_t debug_pos = Fluidstr.find("$DEBUG");
+        if (debug_pos != std::string::npos) {
             EES_DEBUG = true;
-            Fluidstr = Fluidstr.substr(0, Fluidstr.find("$DEBUG"));
+            Fluidstr.resize(debug_pos);
         } else {
             EES_DEBUG = false;
         }
 
         // Check the number of inputs
-        NInputs = 0;
         EesParamRec* aninput_rec = input_rec;
-        while (aninput_rec != 0) {
+        while (aninput_rec != nullptr) {
             if (NInputs >= 2) {
                 z.push_back(aninput_rec->value);
             }
@@ -124,8 +129,7 @@ extern "C"
         };
 
         if (NInputs < 2) {
-            sprintf(err_str, "Number of inputs [%d] < 2", NInputs);
-            set_fluid(fluid, err_str);
+            set_fluid(fluid, format("Number of inputs [%d] < 2", NInputs));
             return 0;
         }
 
@@ -139,28 +143,26 @@ extern "C"
         //This block can be used to debug the code by writing output or intermediate values to a text file
 
         if (EES_DEBUG) {
-            FILE* fp;
-            fp = fopen("log.txt", "a+");
-            fprintf(fp, "Inputs: %s %s %g %s %g %s %s\n", Outstr.c_str(), In1str.c_str(), In1, In2str.c_str(), In2, Fluidstr.c_str(), Units.c_str());
-            fclose(fp);
+            log_debug(
+              format("Inputs: %s %s %g %s %g %s %s\n", Outstr.c_str(), In1str.c_str(), In1, In2str.c_str(), In2, Fluidstr.c_str(), Units.c_str()));
         }
 
         if (EES_DEBUG) {
             // This redirects standard output to log_stdout.txt; only crank up
             // the debug output if the redirect succeeded, so we don't spew to a
             // broken stdout when the log file can't be opened.
-            if (freopen("log_stdout.txt", "w", stdout) != NULL) {
+            if (freopen("log_stdout.txt", "w", stdout) != nullptr) {
                 ::set_debug_level(100000);  // Maximum debugging
             }
         }
 
         try {
-            if (!Units.compare("SI")) {
-                if (z.size() > 0) {
-                    std::string backend, fluid;
-                    extract_backend(Fluidstr, backend, fluid);
+            if (Units == "SI") {
+                if (!z.empty()) {
+                    std::string backend, fluid_only;
+                    extract_backend(Fluidstr, backend, fluid_only);
                     // Vectorize the inputs
-                    std::vector<std::string> fluids = strsplit(fluid, '&');
+                    std::vector<std::string> fluids = strsplit(fluid_only, '&');
                     std::vector<std::string> outputs(1, Outstr);
                     std::vector<double> val1(1, In1);
                     std::vector<double> val2(1, In2);
@@ -188,49 +190,37 @@ extern "C"
                 out = Props(Outstr.c_str(), In1str[0], In1, In2str[0], In2, Fluidstr.c_str());
             }
         } catch (...) {
-            std::string err_str = format("Uncaught error: \"%s\",\"%s\",%g,\"%s\",%g,\"%s\"\n", Outstr.c_str(), In1str.c_str(), In1, In2str.c_str(),
-                                         In2, Fluidstr.c_str());
+            std::string error_message = format("Uncaught error: \"%s\",\"%s\",%g,\"%s\",%g,\"%s\"\n", Outstr.c_str(), In1str.c_str(), In1,
+                                               In2str.c_str(), In2, Fluidstr.c_str());
             // There was an error
             if (EES_DEBUG) {
-                FILE* fp;
-                fp = fopen("log.txt", "a+");
-                fprintf(fp, "Error: %s \n", err_str.c_str());
-                fclose(fp);
+                log_debug(format("Error: %s \n", error_message.c_str()));
             }
-            set_fluid(fluid, err_str);
+            set_fluid(fluid, error_message);
 
             return 0.0;
         }
 
         if (!ValidNumber(out)) {
-            std::string err_str = CoolProp::get_global_param_string("errstring");
+            std::string error_message = CoolProp::get_global_param_string("errstring");
             // There was an error
             if (EES_DEBUG) {
-                FILE* fp;
-                fp = fopen("log.txt", "a+");
-                fprintf(fp, "Error: %s \n", err_str.c_str());
-                fclose(fp);
+                log_debug(format("Error: %s \n", error_message.c_str()));
             }
-            set_fluid(fluid, err_str);
+            set_fluid(fluid, error_message);
             return 0.0;
         } else {
             // Check if there was a warning
             std::string warn_string = CoolProp::get_global_param_string("warnstring");
             if (!warn_string.empty()) {
                 if (EES_DEBUG) {
-                    FILE* fp;
-                    fp = fopen("log.txt", "a+");
-                    fprintf(fp, "Warning: %s \n", warn_string.c_str());
-                    fclose(fp);
+                    log_debug(format("Warning: %s \n", warn_string.c_str()));
                 }
                 // There was a warning, write it back
                 set_fluid(fluid, warn_string);
             }
             if (EES_DEBUG) {
-                FILE* fp;
-                fp = fopen("log.txt", "a+");
-                fprintf(fp, "Output: %g\n", out);
-                fclose(fp);
+                log_debug(format("Output: %g\n", out));
             }
             return out;
         }


### PR DESCRIPTION
## Summary

A full audit and hardening pass over the EES wrapper (`wrappers/EES/main.cpp`). This wrapper **ships in the Windows installer** — compiled to `COOLPROP_EES.dlf` (32-bit) by `COOLPROP_WINDOWS_PACKAGE_EES` and packaged via the `ExcelAddinInstaller` Inno script under the user-selectable `EesUserLib` task, so these reach end users. It is **32-bit-Windows/MSVC-only** and **not** in the normal PR build matrix (which is why the issues accumulated unnoticed); verification is via `cppcheck` + adversarial review, not compilation.

After this PR, `cppcheck --enable=all --inconclusive` on the file is clean.

## Fixes (by commit)

**1. Stack buffer overflow** — the `<2 inputs` path did `sprintf(..., NInputs)` into `char NInputs_string[3]` (3 bytes) → stack smash on every call with fewer than two inputs.

**2. Out-of-bounds read + unchecked freopen** — the legacy `Props()` branch read `In1str[0]`/`In2str[0]` after guards testing `size() != 0` that never returned (so a valid 1-char key wrote a spurious error and an empty key indexed `[0]` out of bounds); tightened to `size() != 1` + early return. And `freopen(stdout)`'s result was ignored before cranking debug logging; now gated on success.

**3. Unbounded `fluid` writes** — every error/warning path `strcpy`'d into the fixed 256-char `fluid` buffer, several copying user-derived content (input fields, whole-input echo, errstring/warnstring globals) → overflow past 255 chars. All writes now go through a `set_fluid()` helper that truncates to 255 and always NUL-terminates.

**4. Remaining sweep**
- **Crash on `fopen` failure** — 6 debug-log sites did `fopen("log.txt")` then `fprintf(fp,…)` with no null check → NULL-deref crash if the file can't be opened. Centralized in a `log_debug()` helper that checks the handle.
- **Format UB** — `"%d"` was formatting a `size_t`; cast to `int`.
- Dropped the `char err_str[1000]` scratch buffer and both `sprintf`s; messages are now built with CoolProp's `format()` (the file's existing idiom).
- Removed dead `ErrorMsg`; initialized `out`/`NInputs`; computed `find("$DEBUG")` once with `resize()` instead of a double-find + self-`substr`.
- Renamed shadowing locals (`fluid`→`fluid_only`, `err_str`→`error_message`); modernized `0`/`NULL`→`nullptr`, `size()>0`→`!empty()`, `!compare("SI")`→`== "SI"`; dropped the now-unused `<string.h>`.

## Validation

- `cppcheck --enable=all --inconclusive` on `wrappers/EES/main.cpp`: **clean**; clang-format clean.
- Each of the 4 commits passed an adversarial review (per CLAUDE.md). The final review verified every `log_debug`/`format` replacement is output-identical, all 6 fopen sites consolidated, format specifiers all match, and the renames/control-flow changes are behavior-preserving.
- Windows/MSVC-only module → not buildable on the CI runners; `__declspec(dllexport)` and the C-stdio in `log_debug` are intentional and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation tightened for SI unit inputs: each must be a single character; invalid inputs return a clear explanatory message.
  * Error and warning text now reliably fit a fixed-size buffer with safe truncation and termination, preventing corruption or overflow across various failure paths.

* **Chores**
  * Debug logging only enables when log output can be opened; debug marker detection/removal now occurs before parsing for more predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->