### PR TITLE
fix(headers): make fluids/Helmholtz.h self-contained (memset needs <cstring>)

### DIFF
--- a/include/CoolProp/fluids/Helmholtz.h
+++ b/include/CoolProp/fluids/Helmholtz.h
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cstring>  // for std::memset, used below -- libstdc++ does not pull it in transitively
 #include <vector>
 #include "CoolProp/detail/tools.h"  // for CoolPropDbl
 //#include "Eigen/Core"
@@ -757,8 +758,8 @@ class BaseHelmholtzContainer
 
    public:
     void clear() {
-        memset(cache.data(), 0, sizeof(cache));
-        memset(is_cached.data(), false, sizeof(is_cached));
+        std::memset(cache.data(), 0, sizeof(cache));
+        std::memset(is_cached.data(), false, sizeof(is_cached));
     };
 
     virtual void empty_the_EOS() = 0;
@@ -879,7 +880,7 @@ class ResidualHelmholtzContainer : public BaseHelmholtzContainer
             cache[i03] = derivs.d3alphar_dtau3;
             cache[i21] = derivs.d3alphar_ddelta2_dtau;
             cache[i12] = derivs.d3alphar_ddelta_dtau2;
-            memset(is_cached.data(), true, sizeof(is_cached));
+            std::memset(is_cached.data(), true, sizeof(is_cached));
         }
         return derivs;
     };
@@ -1447,7 +1448,7 @@ class IdealHelmholtzContainer : public BaseHelmholtzContainer
             cache[i03] = derivs.d3alphar_dtau3 * _prefactor;
             cache[i21] = derivs.d3alphar_ddelta2_dtau * _prefactor;
             cache[i12] = derivs.d3alphar_ddelta_dtau2 * _prefactor;
-            memset(is_cached.data(), true, sizeof(is_cached));
+            std::memset(is_cached.data(), true, sizeof(is_cached));
         }
         return derivs * _prefactor;
     };


### PR DESCRIPTION
## Summary

**Master is currently red on the "Installed-header hygiene gate"** under g++, and so is every open PR (including #3169). Root cause: `include/CoolProp/fluids/Helmholtz.h` calls `memset` (lines 761/762/883/1451) without including `<cstring>`.

- **libc++** (clang) pulls `<cstring>` in transitively, so the header compiled standalone there — which is why local preflight (clang) was green.
- **libstdc++** (the g++ that CI's self-containedness gate uses) does **not**, so the gate fails:
  ```
  FAIL: installed header is not self-contained: CoolProp/fluids/Helmholtz.h
  … 'memset' was not declared in this scope
  ```
- `CoolPropFluid.h` and `IncompressibleFluid.h` both `#include` Helmholtz.h, so the gate reports **6 failures** (3 headers + their 3 flat shims).

This is a **latent gap the #3162 gate exposed** — not introduced by any recent PR (the `memset` calls predate it). It went unnoticed locally because the gate uses CI's compiler (g++) while local preflight uses clang.

## Fix

Add `#include <cstring>` to `Helmholtz.h` and qualify the four calls as `std::memset` (bare `::memset` from `<cstring>` is implementation-defined; `std::memset` is guaranteed by the standard).

## Verification

All **89 installed headers now compile standalone under BOTH g++-15 and clang**:
```
CXX=g++-15 dev/ci/check-installed-headers.sh build_shared   # OK
        dev/ci/check-installed-headers.sh build_shared      # OK (clang)
```

### Follow-up worth considering
The gate's clang-vs-g++ discrepancy means local preflight (clang) can pass while CI (g++) fails. A small `dev/ci/preflight.sh` note — or compiling the headers under both compilers when available — would close that blind spot. (Filed as a thought, not blocking this fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code standards compliance through internal code quality updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->