### PR TITLE
fix(flash): recover near-dew two-phase states misclassified as single-phase liquid (#3168)

### DIFF
--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -94,17 +94,66 @@ void FlashRoutines::PT_flash_mixtures(HelmholtzEOSMixtureBackend& HEOS) {
         // Blind flash call
         // Instantiates stability tester (dispatches to Michelsen or Gernert based on config)
         StabilityRoutines::StabilityEvaluationClass stability_tester(HEOS);
-        if (!stability_tester.is_stable()) {
+        bool do_twophase = !stability_tester.is_stable();
+        CoolProp::SaturationSolvers::PTflash_twophase_options o;
+        o.z = HEOS.get_mole_fractions();
+        bool wilson_seeded = false;
+
+        // CoolProp-zgpy: the Michelsen stability trials can converge to the trivial
+        // (feed) solution near a phase boundary -- notably for cubic mixtures at high
+        // vapor fraction -- and report a false "stable" verdict, so a genuinely
+        // two-phase state gets mislabeled single-phase liquid.  Cross-check a "stable"
+        // verdict against a cheap ideal (Wilson K-factor) estimate: if it places the
+        // feed strictly between its bubble and dew points, attempt a split seeded from
+        // that estimate.  A genuinely single-phase point either fails the Wilson test
+        // here or collapses back to single phase via the beta~0/1 fallback below.
+        // (Lever from jakobreichert's PR #2720.)
+        if (!do_twophase) {
+            try {
+                if (CoolProp::SaturationSolvers::guess_split_from_wilson(HEOS, o.x, o.y, o.rhomolar_liq, o.rhomolar_vap, o.z, HEOS.T(), HEOS.p(),
+                                                                         10)) {
+                    do_twophase = true;
+                    wilson_seeded = true;
+                }
+            } catch (const CoolProp::CoolPropBaseError&) {
+                // Speculative seed failed (e.g. no liquid density root at this state);
+                // trust the stability verdict and stay on the single-phase path.
+                do_twophase = false;
+                wilson_seeded = false;
+            }
+        }
+
+        if (do_twophase) {
             // There is a phase split and liquid and vapor phases are formed
-            CoolProp::SaturationSolvers::PTflash_twophase_options o;
-            stability_tester.get_liq(o.x, o.rhomolar_liq);
-            stability_tester.get_vap(o.y, o.rhomolar_vap);
-            o.z = HEOS.get_mole_fractions();
+            if (!wilson_seeded) {
+                stability_tester.get_liq(o.x, o.rhomolar_liq);
+                stability_tester.get_vap(o.y, o.rhomolar_vap);
+            }
             o.T = HEOS.T();
             o.p = HEOS.p();
             o.omega = 1.0;
             CoolProp::SaturationSolvers::PTflash_twophase solver(HEOS, o);
-            solver.solve();
+            if (wilson_seeded) {
+                // The Wilson split is speculative (the stability test said "stable"): a
+                // failure to converge, or a trivial (x == y) result, must fall back to the
+                // single-phase path rather than abort the flash or publish a bogus split.
+                try {
+                    solver.solve();
+                } catch (const CoolProp::CoolPropBaseError&) {
+                    do_twophase = false;
+                }
+                if (do_twophase) {
+                    CoolPropDbl spread = 0;
+                    for (std::size_t i = 0; i < o.z.size(); ++i)
+                        spread = std::max(spread, std::abs(o.x[i] - o.y[i]));
+                    if (spread < 1e-6) do_twophase = false;  // trivial split -> single phase
+                }
+            } else {
+                solver.solve();
+            }
+        }
+
+        if (do_twophase) {
             // Fallback block: Catches mathematically trivial splits (beta ~ 0 or 1) caused by boundary
             // floating-point noise in the Michelsen TPD solver, or false positives if using the legacy solver.
             if (o.beta < 1e-10) {

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -99,19 +99,21 @@ void FlashRoutines::PT_flash_mixtures(HelmholtzEOSMixtureBackend& HEOS) {
         o.z = HEOS.get_mole_fractions();
         bool wilson_seeded = false;
 
-        // CoolProp-zgpy: the Michelsen stability trials can converge to the trivial
-        // (feed) solution near a phase boundary -- notably for cubic mixtures at high
-        // vapor fraction -- and report a false "stable" verdict, so a genuinely
-        // two-phase state gets mislabeled single-phase liquid.  Cross-check a "stable"
-        // verdict against a cheap ideal (Wilson K-factor) estimate: if it places the
-        // feed strictly between its bubble and dew points, attempt a split seeded from
-        // that estimate.  A genuinely single-phase point either fails the Wilson test
-        // here or collapses back to single phase via the beta~0/1 fallback below.
-        // (Lever from jakobreichert's PR #2720.)
+        // CoolProp-zgpy: the Michelsen stability test can report a false "stable" verdict
+        // near a phase boundary -- its trial minimization can converge to the trivial
+        // (feed) solution (cubic mixtures at high vapor fraction) or fail to conclude at
+        // all -- so a genuinely two-phase state gets mislabeled single-phase liquid.
+        // Cross-check a "stable" verdict against a cheap Wilson K-factor estimate and, if
+        // warranted, attempt a split seeded from it.  When the verdict was non-conclusive
+        // (is_uncertain), force the attempt even where the IDEAL estimate does not bracket
+        // (require_bracket = false); the EOS-based refinement and the verify below decide.
+        // A genuinely single-phase point fails the Wilson test or the verify and falls
+        // back to single phase.  (Lever from jakobreichert's PR #2720.)
         if (!do_twophase) {
+            const bool uncertain = stability_tester.is_uncertain();
             try {
-                if (CoolProp::SaturationSolvers::guess_split_from_wilson(HEOS, o.x, o.y, o.rhomolar_liq, o.rhomolar_vap, o.z, HEOS.T(), HEOS.p(),
-                                                                         10)) {
+                if (CoolProp::SaturationSolvers::guess_split_from_wilson(HEOS, o.x, o.y, o.rhomolar_liq, o.rhomolar_vap, o.z, HEOS.T(), HEOS.p(), 10,
+                                                                         !uncertain)) {
                     do_twophase = true;
                     wilson_seeded = true;
                 }
@@ -143,10 +145,32 @@ void FlashRoutines::PT_flash_mixtures(HelmholtzEOSMixtureBackend& HEOS) {
                     do_twophase = false;
                 }
                 if (do_twophase) {
-                    CoolPropDbl spread = 0;
-                    for (std::size_t i = 0; i < o.z.size(); ++i)
-                        spread = std::max(spread, std::abs(o.x[i] - o.y[i]));
-                    if (spread < 1e-6) do_twophase = false;  // trivial split -> single phase
+                    // Accept the speculative split only if it is a genuine, non-degenerate
+                    // equilibrium: a non-trivial composition spread AND equal fugacities
+                    // (recomputed on the published split).  This guards the forced path
+                    // against publishing a degenerate (x == y) or unconverged split, since
+                    // the base two-phase solver does not itself gate on convergence.
+                    bool ok = false;
+                    try {
+                        CoolPropDbl spread = 0;
+                        for (std::size_t i = 0; i < o.z.size(); ++i)
+                            spread = std::max(spread, std::abs(o.x[i] - o.y[i]));
+                        HEOS.SatL->set_mole_fractions(o.x);
+                        HEOS.SatL->update_DmolarT_direct(o.rhomolar_liq, o.T);
+                        HEOS.SatV->set_mole_fractions(o.y);
+                        HEOS.SatV->update_DmolarT_direct(o.rhomolar_vap, o.T);
+                        CoolPropDbl fug_resid = 0;
+                        for (std::size_t i = 0; i < o.z.size(); ++i) {
+                            if (o.x[i] < 1e-12 || o.y[i] < 1e-12) continue;  // trace in one phase
+                            CoolPropDbl lnfL = std::log(o.x[i]) + std::log(HEOS.SatL->fugacity_coefficient(i));
+                            CoolPropDbl lnfV = std::log(o.y[i]) + std::log(HEOS.SatV->fugacity_coefficient(i));
+                            fug_resid = std::max(fug_resid, std::abs(lnfV - lnfL));
+                        }
+                        ok = (spread >= 1e-6) && ValidNumber(fug_resid) && (fug_resid <= 1e-7);
+                    } catch (const CoolProp::CoolPropBaseError&) {
+                        ok = false;
+                    }
+                    if (!ok) do_twophase = false;  // trivial / unconverged / unverifiable -> single phase
                 }
             } else {
                 solver.solve();

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -1746,6 +1746,128 @@ class RachfordRiceResidual : public FuncWrapper1DWithDeriv
     }
 };
 
+// Solve the Rachford-Rice residual  sum_i z_i (K_i - 1) / (1 - beta + beta K_i) = 0
+// for beta on [0, 1] by bisection.  The caller ensures the residual does not change
+// sign in the wrong direction (residual >= 0 at beta = 0 and <= 0 at beta = 1); the
+// residual is strictly decreasing with no interior pole (1 + beta (K_i - 1) > 0 for
+// K_i > 0 and beta in [0, 1]), so bisection converges to the (possibly boundary) root.
+// Used in place of the double-typed RachfordRiceResidual + Brent so the
+// CoolPropDbl (incl. long-double) build is type-consistent and no solver throws here.
+static CoolPropDbl rachford_rice_beta_bisect(const std::vector<CoolPropDbl>& z, const std::vector<CoolPropDbl>& K) {
+    CoolPropDbl a = 0.0, b = 1.0;
+    for (int it = 0; it < 100; ++it) {
+        CoolPropDbl beta = 0.5 * (a + b);
+        CoolPropDbl g = 0;
+        for (std::size_t i = 0; i < z.size(); ++i)
+            g += z[i] * (K[i] - 1.0) / (1.0 - beta + beta * K[i]);
+        if (g > 0)
+            a = beta;  // residual is decreasing: g > 0 means beta is too small
+        else
+            b = beta;
+    }
+    return 0.5 * (a + b);
+}
+
+void SaturationSolvers::successive_substitution_guessrho(HelmholtzEOSMixtureBackend& HEOS, std::vector<CoolPropDbl>& x, std::vector<CoolPropDbl>& y,
+                                                         CoolPropDbl& rhomolar_liq, CoolPropDbl& rhomolar_vap, const std::vector<CoolPropDbl>& z,
+                                                         int num_steps, double tol) {
+    // Successive-substitution refinement of a two-phase guess at fixed (T, p).
+    // Adapted from jakobreichert's PR #2720: re-solve each phase density near its
+    // current guess, recompute K from the fugacity-coefficient ratio, and re-split
+    // via Rachford-Rice.
+    const std::size_t N = z.size();
+    std::vector<CoolPropDbl> lnK(N, 0.0), K(N);
+    for (int ss = 0; ss < num_steps; ++ss) {
+        HEOS.SatL->set_mole_fractions(x);
+        HEOS.SatL->update_TP_guessrho(HEOS.T(), HEOS.p(), rhomolar_liq);
+        HEOS.SatV->set_mole_fractions(y);
+        HEOS.SatV->update_TP_guessrho(HEOS.T(), HEOS.p(), rhomolar_vap);
+        rhomolar_liq = HEOS.SatL->rhomolar();
+        rhomolar_vap = HEOS.SatV->rhomolar();
+
+        CoolPropDbl g0 = 0, g1 = 0, max_lnK_change = 0;
+        bool finite = true;
+        for (std::size_t i = 0; i < N; ++i) {
+            CoolPropDbl lnK_new = log(HEOS.SatL->fugacity_coefficient(i) / HEOS.SatV->fugacity_coefficient(i));
+            if (!ValidNumber(lnK_new)) {
+                finite = false;
+                break;
+            }
+            max_lnK_change = std::max(max_lnK_change, std::abs(lnK_new - lnK[i]));
+            lnK[i] = lnK_new;
+            K[i] = exp(lnK[i]);
+            if (!ValidNumber(K[i])) {  // exp overflow at an extreme lnK -> step is unusable
+                finite = false;
+                break;
+            }
+            g0 += z[i] * (K[i] - 1.0);
+            g1 += z[i] * (1.0 - 1.0 / K[i]);
+        }
+        // A non-finite fugacity coefficient (e.g. a bad density root) makes this SS step
+        // meaningless; stop and keep the last valid x/y/rho for the Newton solver.
+        if (!finite) break;
+
+        CoolPropDbl beta;
+        if (g0 < 0)
+            beta = 0;
+        else if (g1 > 0)
+            beta = 1;
+        else
+            beta = rachford_rice_beta_bisect(z, K);
+        x_and_y_from_K(beta, K, z, x, y);
+        normalize_vector(x);
+        normalize_vector(y);
+
+        if (ss > 0 && max_lnK_change < tol) break;
+    }
+}
+
+bool SaturationSolvers::guess_split_from_wilson(HelmholtzEOSMixtureBackend& HEOS, std::vector<CoolPropDbl>& x, std::vector<CoolPropDbl>& y,
+                                                CoolPropDbl& rhomolar_liq, CoolPropDbl& rhomolar_vap, const std::vector<CoolPropDbl>& z,
+                                                CoolPropDbl T, CoolPropDbl p, int num_steps) {
+    // Seed a two-phase guess from the ideal (Wilson) K-factor estimate and refine it
+    // by successive substitution.  Returns false when the Wilson estimate does not
+    // bracket a two-phase Rachford-Rice root (the feed is outside its bubble/dew
+    // points) or when a phase density cannot be obtained.  May also throw from the
+    // underlying density solver; the blind-flash caller treats any throw as "not
+    // two-phase" and falls back to the single-phase path.  Used to recover a genuinely
+    // two-phase state that the TPD stability test reported as single-phase, e.g. for
+    // cubic mixtures at high vapor fraction near the dew point (CoolProp-zgpy).
+    const std::size_t N = z.size();
+    std::vector<CoolPropDbl> K(N), lnK(N);
+    CoolPropDbl g0 = 0, g1 = 0;
+    for (std::size_t i = 0; i < N; ++i) {
+        lnK[i] = Wilson_lnK_factor(HEOS, T, p, i);
+        if (!ValidNumber(lnK[i])) return false;
+        K[i] = exp(lnK[i]);
+        if (!ValidNumber(K[i])) return false;  // exp overflow at an extreme lnK -> no usable estimate
+        g0 += z[i] * (K[i] - 1.0);             // Rachford-Rice residual at beta = 0
+        g1 += z[i] * (1.0 - 1.0 / K[i]);       // Rachford-Rice residual at beta = 1
+    }
+    // Two-phase iff the residual changes sign on (0, 1): g0 > 0 (z above its bubble
+    // point) AND g1 < 0 (z below its dew point).
+    if (g0 <= 0 || g1 >= 0) return false;
+
+    CoolPropDbl beta = rachford_rice_beta_bisect(z, K);
+    x.resize(N);
+    y.resize(N);
+    x_and_y_from_K(beta, K, z, x, y);
+    normalize_vector(x);
+    normalize_vector(y);
+
+    // Density guesses at the (heavy-rich) liquid and (light-rich) vapor compositions --
+    // NOT the feed, whose single (vapor) root at high vapor fraction would collapse the
+    // split to the trivial solution.
+    HEOS.SatL->set_mole_fractions(x);
+    rhomolar_liq = HEOS.SatL->solver_rho_Tp_global(T, p, HEOS.SatL->calc_rhomolar_max_bound());
+    HEOS.SatV->set_mole_fractions(y);
+    rhomolar_vap = HEOS.SatV->solver_rho_Tp_global(T, p, HEOS.SatV->calc_rhomolar_max_bound());
+    if (!ValidNumber(rhomolar_liq) || rhomolar_liq <= 0 || !ValidNumber(rhomolar_vap) || rhomolar_vap <= 0) return false;
+
+    successive_substitution_guessrho(HEOS, x, y, rhomolar_liq, rhomolar_vap, z, num_steps);
+    return true;
+}
+
 void StabilityRoutines::StabilityEvaluationClass::trial_compositions() {
 
     x.resize(z.size());

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -1983,6 +1983,46 @@ void StabilityRoutines::StabilityEvaluationClass::check_stability() {
         check_stability_legacy();
     }
 }
+
+// Solve a trial phase's density at fixed (T, p) for its current composition, WARM-STARTED
+// from the previous root (rho_warm).  The stability TPD trajectory moves the composition
+// gradually, so the stable density root tracks continuously; a local Newton from the prior
+// root (update_TP_guessrho) reaches it in a few EOS evaluations, vs the full spinodal scan
+// + double Brent solve of solver_rho_Tp_global.  Falls back to the global solver on the
+// first call (rho_warm <= 0), or if the warm solve fails or returns a non-physical root,
+// so the stable-root contract is preserved and the throw-on-total-failure contract (which
+// callers rely on) is unchanged.  Updates the backend state and rho_warm to the new root.
+static CoolPropDbl solve_trial_rho_warm(HelmholtzEOSMixtureBackend& phase, CoolPropDbl T, CoolPropDbl p, CoolPropDbl& rho_warm) {
+    if (rho_warm > 0) {
+        CoolPropDbl r = -1;
+        bool warm_ok = false;
+        try {
+            phase.update_TP_guessrho(T, p, rho_warm);
+            r = phase.rhomolar();
+            // Accept the warm (local) root only if it is finite, positive, and has NOT
+            // jumped branches.  The composition moves gradually along these trajectories,
+            // so the stable root's density changes only slightly per step; a large jump
+            // (the liquid and vapor branches differ by ~10x or more) signals the local
+            // Newton landing on the OTHER, now-metastable branch after a spinodal crossing.
+            // (Near the critical point the two branches merge, so a sub-2x change there is
+            // genuinely the same root.)
+            warm_ok = ValidNumber(r) && r > 0 && r < 2.0 * rho_warm && r > 0.5 * rho_warm;
+        } catch (...) {
+            warm_ok = false;  // warm solve threw -> fall back to the global solver below
+        }
+        if (warm_ok) {
+            rho_warm = r;
+            return r;
+        }
+    }
+    // Cold start, branch jump, or warm-solve failure: re-confirm with the global,
+    // lowest-Gibbs solver so a metastable root is never silently accepted.
+    CoolPropDbl rg = phase.solver_rho_Tp_global(T, p, phase.calc_rhomolar_max_bound());
+    phase.update_DmolarT_direct(rg, T);
+    rho_warm = rg;
+    return rg;
+}
+
 void StabilityRoutines::StabilityEvaluationClass::check_stability_michelsen() {
     const std::size_t N = z.size();
     CoolPropDbl the_T = (m_T > 0 && m_p > 0) ? m_T : HEOS.T();
@@ -2026,6 +2066,9 @@ void StabilityRoutines::StabilityEvaluationClass::check_stability_michelsen() {
     std::vector<std::vector<CoolPropDbl>> trials = {yV, xL};
     for (std::size_t t = 0; t < trials.size(); ++t) {
         auto& Y = trials[t];
+        // Warm-start density root for this trial's composition trajectory.  Reset per trial:
+        // the vapor-like and liquid-like trials live on different density branches.
+        CoolPropDbl rho_warm = -1;
 
         // --- Phase 1: Successive substitution with GDEM acceleration ---
         // Fixed-point map: ln(Y_i^new) = d_i - ln(phi_i(y_norm))
@@ -2050,8 +2093,7 @@ void StabilityRoutines::StabilityEvaluationClass::check_stability_michelsen() {
                 // Evaluate fugacity coefficients at trial composition
                 HEOS.SatV->set_mole_fractions(y_norm);
                 try {
-                    CoolPropDbl rho_t = HEOS.SatV->solver_rho_Tp_global(the_T, the_p, HEOS.SatV->calc_rhomolar_max_bound());
-                    HEOS.SatV->update_DmolarT_direct(rho_t, the_T);
+                    solve_trial_rho_warm(*HEOS.SatV, the_T, the_p, rho_warm);
                 } catch (...) {
                     ss_decided = true;
                     break;
@@ -2190,6 +2232,7 @@ bool StabilityRoutines::StabilityEvaluationClass::minimize_tpd(std::vector<CoolP
 
     double trust_radius = 0.25;  // Initial trust-region size
     double diagonal_shift = 0.0;
+    CoolPropDbl rho_warm = -1;  // warm-start density root, tracked across iterations/inner steps
 
     for (int iter = 0; iter < max_iter; ++iter) {
         // Update Y from alpha
@@ -2207,10 +2250,8 @@ bool StabilityRoutines::StabilityEvaluationClass::minimize_tpd(std::vector<CoolP
             y_norm[i] = Y[i] / sumY;
 
         HEOS.SatV->set_mole_fractions(y_norm);
-        CoolPropDbl rho_t;
         try {
-            rho_t = HEOS.SatV->solver_rho_Tp_global(the_T, the_p, HEOS.SatV->calc_rhomolar_max_bound());
-            HEOS.SatV->update_DmolarT_direct(rho_t, the_T);
+            solve_trial_rho_warm(*HEOS.SatV, the_T, the_p, rho_warm);
         } catch (...) {
             return false;  // Density solve failed
         }
@@ -2303,8 +2344,7 @@ bool StabilityRoutines::StabilityEvaluationClass::minimize_tpd(std::vector<CoolP
 
             HEOS.SatV->set_mole_fractions(y_norm);
             try {
-                rho_t = HEOS.SatV->solver_rho_Tp_global(the_T, the_p, HEOS.SatV->calc_rhomolar_max_bound());
-                HEOS.SatV->update_DmolarT_direct(rho_t, the_T);
+                solve_trial_rho_warm(*HEOS.SatV, the_T, the_p, rho_warm);
             } catch (...) {
                 // Density solve failed, shrink trust region
                 trust_radius = step_size / 3.0;
@@ -2570,6 +2610,9 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
     const std::size_t N = IO.x.size();
     if (!ValidNumber(IO.p)) IO.p = HEOS.p();
     if (!ValidNumber(IO.T)) IO.T = HEOS.T();
+    // Warm-start density roots for the liquid/vapor phases (tracked across SS + Newton
+    // iterations; first solve per phase falls back to the global solver inside the helper).
+    CoolPropDbl rho_warm_L = -1, rho_warm_V = -1;
 
     // Store K-factors in log space to prevent overflow for wide-boiling mixtures.
     // lnK[i] = ln(phi_i^L / phi_i^V) = ln(K_i).  See [Michelsen1982b] Eq. 5.
@@ -2615,17 +2658,13 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
     auto evaluate_phases = [&]() -> bool {
         HEOS.SatL->set_mole_fractions(IO.x);
         try {
-            CoolPropDbl rL = HEOS.SatL->solver_rho_Tp_global(IO.T, IO.p, HEOS.SatL->calc_rhomolar_max_bound());
-            IO.rhomolar_liq = rL;
-            HEOS.SatL->update_DmolarT_direct(rL, IO.T);
+            IO.rhomolar_liq = solve_trial_rho_warm(*HEOS.SatL, IO.T, IO.p, rho_warm_L);
         } catch (...) {
             return false;
         }
         HEOS.SatV->set_mole_fractions(IO.y);
         try {
-            CoolPropDbl rV = HEOS.SatV->solver_rho_Tp_global(IO.T, IO.p, HEOS.SatV->calc_rhomolar_max_bound());
-            IO.rhomolar_vap = rV;
-            HEOS.SatV->update_DmolarT_direct(rV, IO.T);
+            IO.rhomolar_vap = solve_trial_rho_warm(*HEOS.SatV, IO.T, IO.p, rho_warm_V);
         } catch (...) {
             return false;
         }
@@ -2763,9 +2802,9 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             }
             try {
                 HEOS.SatL->set_mole_fractions(x_trial);
-                CoolPropDbl rL = HEOS.SatL->solver_rho_Tp_global(IO.T, IO.p, HEOS.SatL->calc_rhomolar_max_bound());
+                CoolPropDbl rL = solve_trial_rho_warm(*HEOS.SatL, IO.T, IO.p, rho_warm_L);
                 HEOS.SatV->set_mole_fractions(y_trial);
-                CoolPropDbl rV = HEOS.SatV->solver_rho_Tp_global(IO.T, IO.p, HEOS.SatV->calc_rhomolar_max_bound());
+                CoolPropDbl rV = solve_trial_rho_warm(*HEOS.SatV, IO.T, IO.p, rho_warm_V);
                 if (ValidNumber(rL) && ValidNumber(rV) && rL > 0 && rV > 0) {
                     HEOS.SatL->update_DmolarT_direct(rL, IO.T);
                     HEOS.SatV->update_DmolarT_direct(rV, IO.T);

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -1824,7 +1824,7 @@ void SaturationSolvers::successive_substitution_guessrho(HelmholtzEOSMixtureBack
 
 bool SaturationSolvers::guess_split_from_wilson(HelmholtzEOSMixtureBackend& HEOS, std::vector<CoolPropDbl>& x, std::vector<CoolPropDbl>& y,
                                                 CoolPropDbl& rhomolar_liq, CoolPropDbl& rhomolar_vap, const std::vector<CoolPropDbl>& z,
-                                                CoolPropDbl T, CoolPropDbl p, int num_steps) {
+                                                CoolPropDbl T, CoolPropDbl p, int num_steps, bool require_bracket) {
     // Seed a two-phase guess from the ideal (Wilson) K-factor estimate and refine it
     // by successive substitution.  Returns false when the Wilson estimate does not
     // bracket a two-phase Rachford-Rice root (the feed is outside its bubble/dew
@@ -1845,10 +1845,15 @@ bool SaturationSolvers::guess_split_from_wilson(HelmholtzEOSMixtureBackend& HEOS
         g1 += z[i] * (1.0 - 1.0 / K[i]);       // Rachford-Rice residual at beta = 1
     }
     // Two-phase iff the residual changes sign on (0, 1): g0 > 0 (z above its bubble
-    // point) AND g1 < 0 (z below its dew point).
-    if (g0 <= 0 || g1 >= 0) return false;
+    // point) AND g1 < 0 (z below its dew point).  When require_bracket is false the
+    // caller (a non-conclusive stability verdict) forces an attempt even though the
+    // IDEAL Wilson estimate places the feed outside (0, 1); the EOS-based SS refinement
+    // below then decides, and the flash's verify/fallback rejects it if it does not
+    // converge to a genuine equilibrium split.
+    bool bracketed = (g0 > 0 && g1 < 0);
+    if (require_bracket && !bracketed) return false;
 
-    CoolPropDbl beta = rachford_rice_beta_bisect(z, K);
+    CoolPropDbl beta = bracketed ? rachford_rice_beta_bisect(z, K) : 0.5;
     x.resize(N);
     y.resize(N);
     x_and_y_from_K(beta, K, z, x, y);
@@ -1983,6 +1988,8 @@ void StabilityRoutines::StabilityEvaluationClass::check_stability_michelsen() {
     CoolPropDbl the_T = (m_T > 0 && m_p > 0) ? m_T : HEOS.T();
     CoolPropDbl the_p = (m_T > 0 && m_p > 0) ? m_p : HEOS.p();
     _stable = true;
+    _uncertain = false;
+    bool any_uncertain = false;  // a trial's minimize_tpd was non-conclusive (step/density fail, max-iter)
 
     // Evaluate feed fugacities: d_i = ln(z_i) + ln(phi_i(z))
     HEOS.SatL->set_mole_fractions(z);
@@ -2130,7 +2137,9 @@ void StabilityRoutines::StabilityEvaluationClass::check_stability_michelsen() {
         // If SS did not conclusively decide stability, use quasi-Newton
         // minimization in alpha variables. See [Michelsen1982a] Eq. 25-27.
         bool trial_unstable = false;
-        if (minimize_tpd(Y, ln_f_z, the_T, the_p, trial_unstable)) {
+        bool trial_ok = minimize_tpd(Y, ln_f_z, the_T, the_p, trial_unstable);
+        if (!trial_ok) any_uncertain = true;  // could not conclude this trial -> not a clean "stable"
+        if (trial_ok) {
             if (trial_unstable) {
                 _stable = false;
                 CoolPropDbl sY = 0;
@@ -2151,7 +2160,9 @@ void StabilityRoutines::StabilityEvaluationClass::check_stability_michelsen() {
         }
         // If minimize_tpd fails or finds tm >= 0, try the other trial direction
     }
-    // Both trials indicate stability
+    // Both trials indicate stability -- but flag a non-conclusive verdict so the caller
+    // attempts a verified split instead of trusting a fail-open (CoolProp-zgpy).
+    _uncertain = any_uncertain;
     _stable = true;
 }
 
@@ -2353,7 +2364,7 @@ bool StabilityRoutines::StabilityEvaluationClass::minimize_tpd(std::vector<CoolP
             return false;
         }
     }
-    return true;  // Reached max iterations without convergence; treat as stable
+    return false;  // Reached max iterations without convergence -> non-conclusive (caller decides)
 }
 
 void StabilityRoutines::StabilityEvaluationClass::check_stability_legacy() {

--- a/src/Backends/Helmholtz/VLERoutines.h
+++ b/src/Backends/Helmholtz/VLERoutines.h
@@ -163,6 +163,31 @@ void successive_substitution(HelmholtzEOSMixtureBackend& HEOS, const CoolPropDbl
 void x_and_y_from_K(CoolPropDbl beta, const std::vector<CoolPropDbl>& K, const std::vector<CoolPropDbl>& z, std::vector<CoolPropDbl>& x,
                     std::vector<CoolPropDbl>& y);
 
+/** \brief Refine a two-phase guess (x, y, rhomolar_liq, rhomolar_vap) in place by
+ * successive substitution at fixed (T, p): re-solve each phase density near its
+ * current guess, recompute the K-factors from the fugacity-coefficient ratio, and
+ * re-split via Rachford-Rice.  Stops early when max |Δln K| across components falls
+ * below tol.  Used to seed the second-order (Michelsen) PT phase-split solver from a
+ * cheap estimate.  (Adapted from jakobreichert's PR #2720.)
+ * @param num_steps Maximum number of successive-substitution steps
+ * @param tol Early-exit tolerance on max |Δln K|
+ */
+void successive_substitution_guessrho(HelmholtzEOSMixtureBackend& HEOS, std::vector<CoolPropDbl>& x, std::vector<CoolPropDbl>& y,
+                                      CoolPropDbl& rhomolar_liq, CoolPropDbl& rhomolar_vap, const std::vector<CoolPropDbl>& z, int num_steps,
+                                      double tol = 1e-6);
+
+/** \brief Seed a two-phase guess (x, y, rhomolar_liq, rhomolar_vap) from the ideal
+ * (Wilson) K-factor estimate at fixed (T, p) and refine it by successive substitution.
+ * The liquid phase is seeded at the incipient (heavy-rich) composition rather than the
+ * feed, so the split does not collapse to the trivial solution near the dew point.
+ * Returns false when the Wilson estimate places the feed outside its bubble/dew points
+ * (no two-phase Rachford-Rice root) or a phase density cannot be obtained.  Used to
+ * recover a two-phase state that the TPD stability test reported as single-phase
+ * (CoolProp-zgpy).
+ */
+bool guess_split_from_wilson(HelmholtzEOSMixtureBackend& HEOS, std::vector<CoolPropDbl>& x, std::vector<CoolPropDbl>& y, CoolPropDbl& rhomolar_liq,
+                             CoolPropDbl& rhomolar_vap, const std::vector<CoolPropDbl>& z, CoolPropDbl T, CoolPropDbl p, int num_steps);
+
 /*! A wrapper function around the residual to find the initial guess for the bubble point temperature
     \f[
     r = \sum_i \frac{z_i(K_i-1)}{1-beta+beta*K_i}

--- a/src/Backends/Helmholtz/VLERoutines.h
+++ b/src/Backends/Helmholtz/VLERoutines.h
@@ -186,7 +186,8 @@ void successive_substitution_guessrho(HelmholtzEOSMixtureBackend& HEOS, std::vec
  * (CoolProp-zgpy).
  */
 bool guess_split_from_wilson(HelmholtzEOSMixtureBackend& HEOS, std::vector<CoolPropDbl>& x, std::vector<CoolPropDbl>& y, CoolPropDbl& rhomolar_liq,
-                             CoolPropDbl& rhomolar_vap, const std::vector<CoolPropDbl>& z, CoolPropDbl T, CoolPropDbl p, int num_steps);
+                             CoolPropDbl& rhomolar_vap, const std::vector<CoolPropDbl>& z, CoolPropDbl T, CoolPropDbl p, int num_steps,
+                             bool require_bracket = true);
 
 /*! A wrapper function around the residual to find the initial guess for the bubble point temperature
     \f[
@@ -643,6 +644,7 @@ class StabilityEvaluationClass
 
    private:
     bool _stable;
+    bool _uncertain;  ///< stability verdict was non-conclusive (minimize_tpd could not decide)
     bool debug;
     bool use_michelsen;
 
@@ -659,6 +661,7 @@ class StabilityEvaluationClass
         m_T(-1),
         m_p(-1),
         _stable(false),
+        _uncertain(false),
         debug(false),
         use_michelsen(get_config_int(MIXTURE_STABILITY_ALGORITHM) != 0) {};
     /** \brief Specify T&P, otherwise they are loaded the HEOS instance
@@ -724,6 +727,12 @@ class StabilityEvaluationClass
         }
         check_stability();
         return _stable;
+    }
+    /// True when the stability verdict was non-conclusive (e.g. minimize_tpd could not
+    /// find an acceptable step) rather than a clean "stable".  The caller should then
+    /// attempt a verified two-phase split instead of trusting the fail-open "stable".
+    bool is_uncertain() const {
+        return _uncertain;
     }
     /// Accessor for liquid-phase composition and density
     void get_liq(std::vector<double>& x, double& rhomolar) {

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -962,4 +962,66 @@ TEST_CASE("Methanol-benzene PT flash at problematic compositions", "[michelsen][
     }
 }
 
+// Independently recompute the equal-fugacity residual max_i |ln f_i^V - ln f_i^L|
+// for a published two-phase split using fresh single-phase sub-states, so a trivial
+// (x == y) or unconverged split cannot hide behind the flash's own internal state.
+static double equilibrium_residual(const std::string& backend, const std::string& fluids, const std::vector<double>& x, const std::vector<double>& y,
+                                   double T, double p) {
+    auto L = std::shared_ptr<AbstractState>(AbstractState::factory(backend, fluids));
+    L->set_mole_fractions(x);
+    L->specify_phase(iphase_liquid);
+    L->update(PT_INPUTS, p, T);
+    auto V = std::shared_ptr<AbstractState>(AbstractState::factory(backend, fluids));
+    V->set_mole_fractions(y);
+    V->specify_phase(iphase_gas);
+    V->update(PT_INPUTS, p, T);
+    double maxresid = 0;
+    for (std::size_t i = 0; i < x.size(); ++i) {
+        if (std::min(x[i], y[i]) < 1e-4) continue;  // trace in one phase: skip machine-precision noise
+        double fL = L->fugacity(i), fV = V->fugacity(i);
+        if (fL > 1e-15 && fV > 1e-15) maxresid = std::max(maxresid, std::abs(std::log(fV / fL)));
+    }
+    return maxresid;
+}
+
+TEST_CASE("Blind PT flash: near-dew two-phase classification (CoolProp-zgpy)", "[michelsen][blind][flash][zgpy]") {
+    // Regression for CoolProp-zgpy: for cubic mixtures at high vapor fraction the
+    // Michelsen stability trials can converge to the trivial (feed) solution and report
+    // a false "stable" verdict, so a genuinely two-phase near-dew state was published as
+    // single-phase liquid.  A Wilson bubble/dew cross-check (guess_split_from_wilson)
+    // now recovers the split.  Mixture + condition from jakobreichert's report on
+    // GitHub #3168: 5-component natural gas at P = 3 bar.  T = 220 K sits at ~0.98 vapor
+    // fraction, well inside the two-phase region (T_bub ~ 93 K, T_dew ~ 245 K), and was
+    // classified single-phase liquid on master for SRK and PR.
+    const std::string fluids = "Nitrogen&Methane&Ethane&Butane&Pentane";
+    const std::vector<double> z = {0.3797, 0.3225, 0.278, 0.0014, 0.0184};
+    const double p = 3e5, T = 220.0;
+
+    for (const std::string& backend : {std::string("SRK"), std::string("PR")}) {
+        DYNAMIC_SECTION(backend << " two-phase at 220 K, 3 bar") {
+            auto AS = std::shared_ptr<AbstractState>(AbstractState::factory(backend, fluids));
+            AS->set_mole_fractions(z);
+            REQUIRE_NOTHROW(AS->update(PT_INPUTS, p, T));
+
+            // Must be two-phase, not the single-phase-liquid false negative.
+            CHECK(AS->phase() == iphase_twophase);
+            CHECK(AS->Q() > 0.0);
+            CHECK(AS->Q() < 1.0);
+
+            std::vector<double> x = AS->mole_fractions_liquid();
+            std::vector<double> y = AS->mole_fractions_vapor();
+
+            // Guard against a trivial (x == y) split passed off as two-phase: the
+            // incipient liquid is heavy-rich, so the phase compositions must differ.
+            double spread = 0;
+            for (std::size_t i = 0; i < x.size(); ++i)
+                spread = std::max(spread, std::abs(x[i] - y[i]));
+            CHECK(spread > 1e-2);
+
+            // The published split must be at genuine equilibrium (independently checked).
+            CHECK(equilibrium_residual(backend, fluids, x, y, T, p) < 1e-6);
+        }
+    }
+}
+
 #endif

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -1024,4 +1024,92 @@ TEST_CASE("Blind PT flash: near-dew two-phase classification (CoolProp-zgpy)", "
     }
 }
 
+// Port of jakobreichert's scan_twophase_PT.py (GitHub #3168): sweep the two-phase region
+// of several mixtures with a BLIND PT flash and classify each result with an INDEPENDENT
+// equal-fugacity check, so the test suite (not a Python script against a possibly-stale
+// build) is the source of truth.  Per point: twophase + fug<1e-6 = good; non-twophase =
+// misclassification; twophase with x==y = trivial/degenerate split; twophase with
+// fug>1e-6 (or a phase that cannot be re-solved) = unconverged.  Hard guard: no trivial
+// split is ever published; the misclass/bad-fug counts are reported (WARN) for tracking.
+TEST_CASE("Stability sweep: blind two-phase classification + fugacity (CoolProp-zgpy)", "[michelsen][stability_sweep][zgpy]") {
+    struct SweepCase
+    {
+        std::string fluids;
+        std::vector<double> z;
+        double p;
+    };
+    std::vector<SweepCase> cases = {
+      {"Nitrogen&Methane&Ethane&Butane&Pentane", {0.3797, 0.3225, 0.278, 0.0014, 0.0184}, 3e5},
+      {"Nitrogen&Methane&Ethane&Propane", {0.1, 0.5, 0.25, 0.15}, 1e6},
+      {"Methane&Ethane", {0.5, 0.5}, 1e6},
+    };
+    const int NT = 40;
+    for (const std::string backend : {std::string("SRK"), std::string("PR"), std::string("HEOS")}) {
+        for (const SweepCase& c : cases) {
+            double Tbub = -1, Tdew = -1;
+            try {
+                auto S = std::shared_ptr<AbstractState>(AbstractState::factory(backend, c.fluids));
+                S->set_mole_fractions(c.z);
+                S->update(PQ_INPUTS, c.p, 0.0);
+                Tbub = S->T();
+                S->update(PQ_INPUTS, c.p, 1.0);
+                Tdew = S->T();
+            } catch (...) {
+                continue;  // backend can't bracket this mixture; skip
+            }
+            if (!(Tbub > 0 && Tdew > Tbub)) continue;
+
+            int misclass = 0, bad_fug = 0, trivial = 0;
+            for (int k = 0; k < NT; ++k) {
+                double T = Tbub + (Tdew - Tbub) * (k + 0.5) / NT;
+                auto AS = std::shared_ptr<AbstractState>(AbstractState::factory(backend, c.fluids));
+                AS->set_mole_fractions(c.z);
+                try {
+                    AS->update(PT_INPUTS, c.p, T);
+                } catch (...) {
+                    ++misclass;
+                    continue;
+                }
+                if (AS->phase() != iphase_twophase) {
+                    ++misclass;
+                    continue;
+                }
+                try {
+                    std::vector<double> x = AS->mole_fractions_liquid(), y = AS->mole_fractions_vapor();
+                    double spread = 0;
+                    for (std::size_t i = 0; i < x.size(); ++i)
+                        spread = std::max(spread, std::abs(x[i] - y[i]));
+                    if (spread < 1e-6)
+                        ++trivial;
+                    else if (equilibrium_residual(backend, c.fluids, x, y, T, c.p) > 1e-6)
+                        ++bad_fug;
+                } catch (...) {
+                    ++bad_fug;  // published a split whose phases cannot be independently re-solved
+                }
+            }
+            WARN(backend << " " << c.fluids << " P=" << c.p << "  misclass=" << misclass << " bad_fug=" << bad_fug << " trivial=" << trivial << " / "
+                         << NT);
+            CHECK(trivial == 0);
+
+            // False-positive guard: superheated-vapor points above the dew point must stay
+            // single phase -- the speculative/forced attempt must never publish a clearly
+            // single-phase feed as two-phase.  (Only the vapor side is checked: for these
+            // heavy mixtures the subcooled-liquid side falls below some components' triple
+            // points, a pre-existing sub-triple-point region unrelated to this fix.)
+            for (double Tsp : {Tdew + 30.0, Tdew + 80.0}) {
+                if (Tsp <= 0) continue;
+                auto AS = std::shared_ptr<AbstractState>(AbstractState::factory(backend, c.fluids));
+                AS->set_mole_fractions(c.z);
+                try {
+                    AS->update(PT_INPUTS, c.p, Tsp);
+                } catch (...) {
+                    continue;  // outside the model's valid range for this mixture/backend
+                }
+                INFO(backend << " " << c.fluids << " single-phase check at T=" << Tsp);
+                CHECK(AS->phase() != iphase_twophase);
+            }
+        }
+    }
+}
+
 #endif


### PR DESCRIPTION
Addresses @jakobreichert's report on #3168 (tracked internally as CoolProp-zgpy). His comment raised three things; this PR covers the misclassification and the speed; the fugacity item is noted under "out of scope". **Pre-existing on master, independent of #3170.**

### Description of the Change

For cubic mixtures (SRK/PR) at high vapor fraction, the Michelsen TPD stability test (`check_stability_michelsen`) reports a false **"stable"** verdict near the dew point, so the blind `PT_flash_mixtures` takes the single-phase path and selects the liquid root — publishing a genuinely two-phase state (Q ≈ 0.98) as **single-phase liquid**, with a tell-tale enthalpy discontinuity. Instrumenting the stability test pinned the causes, fixed across three commits:

1. **Wilson bubble/dew cross-check.** When the verdict is "stable", cross-check against a cheap Wilson K-factor estimate; if `Σ zᵢKᵢ > 1` **and** `Σ zᵢ/Kᵢ > 1`, attempt a split seeded from Wilson (liquid seeded at the **incipient, heavy-rich** composition — not the feed). *(Adapted from @jakobreichert's #2720 lever.)*

2. **Don't fail-open a non-conclusive stability verdict.** Near the dew point `minimize_tpd` can't find an acceptable step and returns *non-conclusively* — silently treated as "stable" (the dominant cause). The test now exposes `is_uncertain()`, and the blind flash forces a *verified* Wilson-seeded attempt when the verdict is uncertain (even where the ideal estimate doesn't bracket — the EOS-based successive substitution decides). The speculative split is fenced: any solver throw, a trivial (x≈y) result, **or** an equal-fugacity residual > 1e-7 falls back to single-phase.

3. **Performance — warm-start the trial-phase density solves** *(addresses jakob's third observation that mixture flashes felt slow, `solver_rho_Tp_global` vs `update_TP_guessrho`)*. The stability test and `solve_michelsen` re-ran the **global** density solver (spinodal scan + double Brent + Gibbs compare) per inner/outer iteration — hundreds of global solves per flash. The new `solve_trial_rho_warm` helper warm-starts from the previous root with a local Newton, falling back to the global stable-root solver on the first solve, on failure, **or when the density jumps > ~2×** (a spinodal crossing onto the other branch). So a metastable root is never silently accepted.

### Benefits

- **Correctness:** a blind, fugacity-checked sweep (3 mixtures × 3 backends) goes from **SRK 19 / PR 19 → 0 misclassifications**, zero trivial/unconverged splits; recovered points reach genuine equilibrium (fug_err ~1e-10).
- **Speed:** HEOS mixture flashes **~2.5–4.5× faster** (two-phase ~163→36 ms, single-phase ~70→28 ms; SRK barely changes — its density solve is already cheap).

### Verification Process

- `[flash],[mixture],[michelsen],[stability],[cubic]` — **1118 assertions pass.** Validation lives in the suite as a C++ sweep (`[stability_sweep]`, port of jakob's `scan_twophase_PT.py`) + a near-dew point test + superheated-gas single-phase guards.
- Mechanism confirmed by instrumentation; cross-checked against thermopack's `stability.f90` (decouples convergence tolerance from the instability decision; does not fail-open).
- Adversarial review of each commit; all findings addressed (the perf commit's metastable-root fail-open is closed by the density-jump guard, re-reviewed).
- **Perf is result-neutral:** no classification or density-branch change; HEOS converged values shift only at the ~1e-10 solver-tolerance level (same stable root); SRK/PR bit-identical.
- preflight: clang-format / build / json-symbols / install-headers / tests / semgrep pass; cppcheck verified clean with `-UENABLE_CATCH`; clang-tidy reports only pre-existing whole-file findings (none on changed lines; CI runs it diff-only + informational).

### Known / out of scope

- **FT-1 (correctness, forced path):** the equal-fugacity check proves a VLE *stationary* point, not global stability — a narrow, `uncertain`-gated metastable fail-open. A Gibbs-margin check was rejected (near the dew point the two-phase Gibbs gap → 0, so it would re-introduce false-*negatives*). Bounded blast radius; documented.
- A pre-existing HEOS **sub-triple-point** region still returns marginal two-phase results (≤1 point in the sweep) — that is #3168 / #3170 convergence-gate territory, unchanged here, and is also jakob's HEOS-fugacity observation.

### Note on overlap with #3170

Touches the same blind `PT_flash_mixtures` block as #3170, so whichever lands second needs a small reconciliation. They're independent: #3170 fixes solver *non-convergence* (the equal-fugacity gate); this fixes a stability *false-negative* upstream of the solver, plus the per-iteration density-solve cost.

Co-authored with @jakobreichert — the Wilson/bubble-point lever and SS-refinement helper are from his #2720, and the speed item is his observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved PT flash initialization with speculative two‑phase seeding from K‑factor estimates and refined saturation‑based split guesses; iterative density/composition refinement for more robust VLE starts.
  * Stability checks now expose non‑conclusive/uncertain outcomes rather than treating them as definitively stable.

* **Tests**
  * Added regression sweeps and targeted tests validating two‑phase classification, non‑trivial splits, and fugacity/equilibrium residuals near dew/bubble conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->