### PR TITLE
fix(HEOS): flash-consistency robustness — TOMS748 density/flash fallbacks + REFPROP max-density grid bound

### DIFF
--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -339,7 +339,53 @@ void FlashRoutines::DP_flash(HelmholtzEOSMixtureBackend& HEOS) {
             }
             // Then, do the solver using the full EOS
             solver_DP_resid resid(&HEOS, HEOS.rhomolar(), HEOS.p());
-            Halley(resid, T0, 1e-10, 100);
+            bool dp_ok = false;
+            try {
+                Halley(resid, T0, 1e-10, 100);
+                // Halley is unbounded: from a poor PR/ancillary seed at extreme (rho, p)
+                // it can diverge to a nonphysical (negative / out-of-range) temperature, or
+                // stall at a range-valid point that does not satisfy the residual.  Accept
+                // only a finite, positive, in-range root that actually converged (re-checking
+                // the normalized pressure residual, which also leaves the state consistent).
+                if (ValidNumber(HEOS._T) && HEOS._T > 0 && HEOS._T <= 1.5 * HEOS.Tmax() && std::abs(resid.call(HEOS._T)) < 1e-7) {
+                    dp_ok = true;
+                }
+            } catch (...) {
+                dp_ok = false;  // Halley threw (non-convergence); the bracketed fallback below handles it.
+            }
+            if (!dp_ok) {
+                // p(T, rho) is monotonic in T at fixed rho, so bracket on the EOS
+                // temperature range and solve with TOMS748 (asymptotically optimal,
+                // matching the other P+X legs in this file).  Use the residual's
+                // captured (rho, p): the failed Halley above may have left _p corrupted.
+                const CoolPropDbl Tlo = HEOS.Tmin(), Thi = 1.5 * HEOS.Tmax();
+                CoolPropDbl flo = NAN, fhi = NAN;
+                try {
+                    flo = resid.call(Tlo);
+                    fhi = resid.call(Thi);
+                } catch (...) {
+                    // Endpoint EOS evaluation threw; force the NaN guard below to treat it as "no bracket".
+                    flo = fhi = NAN;
+                }
+                if (ValidNumber(flo) && ValidNumber(fhi) && flo * fhi < 0) {
+                    try {
+                        boost::math::uintmax_t max_iter = 100;
+                        auto f = [&resid](const double T) { return resid.call(T); };
+                        auto [l, r] = toms748_solve(f, static_cast<double>(Tlo), static_cast<double>(Thi), static_cast<double>(flo),
+                                                    static_cast<double>(fhi), boost::math::tools::eps_tolerance<double>(30), max_iter);
+                        // Re-evaluate at the bracket midpoint so HEOS is left at the converged state.
+                        resid.call(0.5 * (l + r));
+                    } catch (...) {
+                        // An interior EOS evaluation threw inside the bracket; degrade to a clean
+                        // ValueError rather than letting a non-ValueError exception escape the flash.
+                        throw ValueError(format("DP_flash TOMS748 fallback failed for rho=%Lg mol/m^3, p=%Lg Pa",
+                                                static_cast<CoolPropDbl>(resid.rhomolar), static_cast<CoolPropDbl>(resid.p)));
+                    }
+                } else {
+                    throw ValueError(format("DP_flash could not bracket T for rho=%Lg mol/m^3, p=%Lg Pa (Halley diverged)",
+                                            static_cast<CoolPropDbl>(resid.rhomolar), static_cast<CoolPropDbl>(resid.p)));
+                }
+            }
             HEOS._Q = -1;
             // Update the state for conditions where the state was guessed
             HEOS.recalculate_singlephase_phase();
@@ -2184,7 +2230,15 @@ void FlashRoutines::HSU_D_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
                         y_lo = HEOS.calc_pressure_nocache(T_lo, HEOS._rhomolar);
                         break;
                 }
-                if (!ValidNumber(y_lo) || value < y_lo) {
+                // Floor tolerance: the consistency grid lands points exactly ON the
+                // melting line, where `value` (from the forward path) and `y_lo`
+                // (recomputed here via calc_*_nocache) differ only at ULP level.  A
+                // strict `value < y_lo` then rejects a valid melting-line state on
+                // last-bit noise.  Allow a small relative slack so boundary states pass
+                // (consistent with the conservative-floor intent noted above) while
+                // states genuinely below the melting line are still rejected.
+                const CoolPropDbl floor_tol = 1e-8 * std::abs(y_lo) + 1e-10;
+                if (!ValidNumber(y_lo) || value < y_lo - floor_tol) {
                     // Colder than the coldest liquid attainable at this density:
                     // genuinely below the melting line (solid / out of range).
                     throw ValueError(format("D+X below melting line [other=%d]: %g < %g at Tmelt_min %g K", other, value, y_lo, T_lo));
@@ -3995,7 +4049,54 @@ void FlashRoutines::HS_flash(HelmholtzEOSMixtureBackend& HEOS) {
     if (rmin * rmax > 0 && std::abs(rmax) < std::abs(rmin)) {
         throw CoolProp::ValueError(format("HS inputs correspond to temperature above maximum temperature of EOS [%g K]", HEOS.Tmax()));
     }
-    Brent(resid, Tmin, Tmax, DBL_EPSILON, 1e-10, 100);
+    // The residual h(SmolarT(s, T)) - h_target is frequently NON-MONOTONIC: the inner
+    // SmolarT solve degrades (or returns a wildly different branch) at high T for
+    // low-entropy cold-liquid inputs, so f(Tmin) and f(Tmax) often share a sign while
+    // the true root sits just above Tmin -- a plain Brent(Tmin, Tmax) then reports
+    // "do not bracket".  Scan upward from Tmin for the FIRST sign change and solve that
+    // sub-interval with TOMS748, skipping temperatures where the inner solve throws and
+    // never reaching the pathological high-T region.
+    bool hs_solved = false;
+    if (ValidNumber(rmin)) {
+        const int Nscan = 50;
+        double T_prev = Tmin, f_prev = rmin;
+        int i_prev = 0;  // grid index of the last VALID sample (Tmin is index 0)
+        for (int i = 1; i <= Nscan; ++i) {
+            const double Tt = Tmin + (Tmax - Tmin) * static_cast<double>(i) / Nscan;
+            double ft = NAN;
+            try {
+                ft = resid.call(Tt);
+            } catch (...) {
+                continue;  // inner SmolarT solve failed at this T; skip and keep scanning
+            }
+            if (!ValidNumber(ft)) {
+                continue;
+            }
+            // Only bracket between ADJACENT valid samples (i == i_prev + 1).  If a sample was
+            // skipped in between, the interval (T_prev, Tt) spans temperatures where the inner
+            // solve throws, so TOMS748's interior probes there would escape -- don't bracket
+            // across that gap; advance and look for a clean adjacent sign change instead.
+            if (i == i_prev + 1 && f_prev * ft <= 0) {
+                try {
+                    boost::math::uintmax_t max_iter = 100;
+                    auto f = [&resid](const double T) { return resid.call(T); };
+                    auto [l, r] = toms748_solve(f, T_prev, Tt, f_prev, ft, boost::math::tools::eps_tolerance<double>(30), max_iter);
+                    resid.call(0.5 * (l + r));  // leave HEOS at the converged state
+                    hs_solved = true;
+                    break;
+                } catch (...) {  // NOLINT(bugprone-empty-catch) -- intentional: keep scanning, then fall to Brent
+                }
+            }
+            T_prev = Tt;
+            f_prev = ft;
+            i_prev = i;
+        }
+    }
+    if (!hs_solved) {
+        // No interior sign change found by the scan; fall back to the original assumption
+        // that [Tmin, Tmax] brackets the root.
+        Brent(resid, Tmin, Tmax, DBL_EPSILON, 1e-10, 100);
+    }
 }
 
 #if defined(ENABLE_CATCH)

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -29,6 +29,7 @@
 #include "Backends/Cubics/GeneralizedCubic.h"
 #include "CoolProp/numerics/Solvers.h"
 #include "CoolProp/numerics/MatrixMath.h"
+#include "boost/math/tools/toms748_solve.hpp"
 #include "VLERoutines.h"
 #include "FlashRoutines.h"
 #include "TransportRoutines.h"
@@ -2958,11 +2959,71 @@ CoolPropDbl HelmholtzEOSMixtureBackend::solver_rho_Tp(CoolPropDbl T, CoolPropDbl
                 }
                 return rhomolar;
             } catch (...) {
-                double rhomolar = Brent(resid, rhoLancval * 0.99, rhoLtripleancval * 1.1, DBL_EPSILON, 1e-8, 100);
-                if (!ValidNumber(rhomolar)) {
-                    throw ValueError();
+                try {
+                    double rhomolar = Brent(resid, rhoLancval * 0.99, rhoLtripleancval * 1.1, DBL_EPSILON, 1e-8, 100);
+                    if (!ValidNumber(rhomolar)) {
+                        throw ValueError();
+                    }
+                    return rhomolar;
+                } catch (...) {
+                    // Robust dense-branch TOMS748 fallback (CoolProp-r1w7, critical-region
+                    // "p is not a valid number").  Near the critical isotherm the ancillary-
+                    // anchored brackets above start near rho_c -- inside the van der Waals loop,
+                    // where p(rho) is non-monotonic and Brent can return a non-finite density
+                    // (-> NaN pressure, caught only by post_update).  Build a monotonic bracket
+                    // on the STABLE dense branch by walking the upper bound up until it brackets
+                    // p_target, then the lower bound down until p < p_target, and TOMS748-solve.
+                    // The walk does NOT require a spinodal, so it is also correct for EOS whose
+                    // isotherms are monotonic (no van der Waals loop, e.g. some nitrogen models).
+                    // limits.rhomax is unreliable (0/unset for some fluids, e.g. R21), so anchor
+                    // the upper bound on the reducing density and bump it up until it brackets p.
+                    const double pTarget = p;
+                    // Whole-fallback guard: every calc_pressure_nocache probe below (the bracket
+                    // walk, the fa/fb endpoint evals, and the TOMS748 interior probes) is wrapped
+                    // so a non-finite/throwing EOS evaluation degrades to the ValueError at the
+                    // end rather than escaping solver_rho_Tp as an unexpected exception type.
+                    double rhoMolarFallback = NAN;
+                    try {
+                        double rhoHi = 5 * rhomolar_reducing();
+                        for (int i = 0; i < 60 && calc_pressure_nocache(T, rhoHi) < pTarget; ++i) {
+                            rhoHi *= 1.5;
+                        }
+                        double rhoLo = rhoHi;
+                        bool bracketed = false;
+                        for (int i = 0; i < 400; ++i) {
+                            rhoLo /= 1.05;
+                            if (rhoLo <= 1e-10) {
+                                break;
+                            }
+                            if (calc_pressure_nocache(T, rhoLo) < pTarget) {
+                                bracketed = true;
+                                break;
+                            }
+                        }
+                        if (bracketed) {
+                            auto f = [this, T, pTarget](double rho) { return this->calc_pressure_nocache(T, rho) - pTarget; };
+                            double fa = f(rhoLo), fb = f(rhoHi);
+                            if (ValidNumber(fa) && ValidNumber(fb) && fa * fb < 0) {
+                                boost::math::uintmax_t max_iter = 100;
+                                auto bracket =
+                                  boost::math::tools::toms748_solve(f, rhoLo, rhoHi, fa, fb, boost::math::tools::eps_tolerance<double>(48), max_iter);
+                                const double rho = 0.5 * (bracket.first + bracket.second);
+                                if (ValidNumber(rho) && rho > 0) {
+                                    rhoMolarFallback = rho;
+                                }
+                            }
+                        }
+                    } catch (...) {  // NOLINT(bugprone-empty-catch) -- an EOS evaluation in the fallback threw; degrade to the ValueError below
+                    }
+                    if (ValidNumber(rhoMolarFallback) && rhoMolarFallback > 0) {
+                        // Restore the live state at the converged density: the failed Brent attempts
+                        // above left _p corrupted (NaN) via update_DmolarT_direct, and the bracketing
+                        // above used calc_pressure_nocache (no state write).
+                        update_DmolarT_direct(rhoMolarFallback, T);
+                        return rhoMolarFallback;
+                    }
+                    throw ValueError(format("solver_rho_Tp could not find a supercritical_liquid density for T=%Lg, p=%Lg", T, pTarget));
                 }
-                return rhomolar;
             }
         }
     }

--- a/wrappers/Python/CoolProp/Plots/ConsistencyPlots.py
+++ b/wrappers/Python/CoolProp/Plots/ConsistencyPlots.py
@@ -332,6 +332,37 @@ class ConsistencyAxis(object):
             p_min = self.state.keyed_output(CP.iP_min) * 1.01
             p_max = self.state.keyed_output(CP.iP_max)
 
+        # Maximum-density (REFPROP Dmax) domain bound for fluids without a melting line:
+        # the densest validated fluid state is the triple-point saturated liquid, so colder
+        # states at a given pressure would be a compressed solid / unvalidated extrapolation.
+        # Precompute that density (and a spare state to map it to a per-isobar temperature
+        # floor below).  Fluids with a melting line are bounded by the melting-line floor
+        # instead, so this is skipped for them.
+        rho_max_1phase = None
+        pc_1phase = None
+        state_rhomax = None
+        # The maximum-density (REFPROP Dmax = triple-point liquid density) bound is a
+        # pure-fluid concept.  Pseudo-pure blends (Air, R404A, ...) have a saturation glide,
+        # so QT Q=0 is not a clean maximum density and the floor mis-bounds the grid; skip
+        # them (the density solver already improves them) and apply the bound to pure fluids.
+        is_pure_fluid = False
+        try:
+            from CoolProp.CoolProp import get_fluid_param_string
+            is_pure_fluid = (get_fluid_param_string(self.fluid, "pure") == "true")
+        except Exception:
+            is_pure_fluid = False
+        if self.T_limits_1phase is None and is_pure_fluid and not self.state.has_melting_line():
+            try:
+                state_rhomax = CP.AbstractState(self.backend, self.fluid)
+                state_rhomax.update(CP.QT_INPUTS, 0, self.state.keyed_output(CP.iT_triple))
+                rho_max_1phase = state_rhomax.rhomolar()
+                pc_1phase = self.state.keyed_output(CP.iP_critical)
+            except Exception as E:
+                # Could not establish the maximum-density bound; disable it (the grid then
+                # behaves as before this feature) but report why rather than silently swallowing.
+                rho_max_1phase = None
+                myprint(1, 'Dmax precompute:', self.fluid, E)
+
         for p in np.logspace(np.log10(p_min), np.log10(p_max), self.Np_1phase):
 
             if self.T_limits_1phase is None:
@@ -350,7 +381,34 @@ class ConsistencyAxis(object):
                         myprint(1, 'MeltingLine:', E)
                 else:
                     T0 = Tmin + 1.1
-                Tvec = np.linspace(T0, self.state.keyed_output(CP.iT_max), self.NT_1phase)
+                Tmax_1phase = self.state.keyed_output(CP.iT_max)
+                if (not self.state.has_melting_line() and rho_max_1phase is not None
+                        and pc_1phase is not None and p >= pc_1phase):
+                    # At supercritical pressure, floor T where rho(p, T) reaches the maximum
+                    # (triple-point liquid) density (REFPROP's default Dmax); colder states
+                    # are denser than any validated fluid (compressed solid / unvalidated
+                    # extrapolation).  Restricted to p >= pc on purpose: there is no
+                    # saturation curve to collide with (at subcritical p the rho=rho_L,triple
+                    # contour hugs the dome, where the forward PT flash fails), and the dense
+                    # subcritical region is already handled robustly by the density solver.
+                    # Density falls monotonically with T at fixed p, so if even the hottest
+                    # point on the isobar is already denser than the maximum, the whole isobar
+                    # is out of the validated domain and is skipped.
+                    try:
+                        state_rhomax.update(CP.PT_INPUTS, p, Tmax_1phase)
+                        if state_rhomax.rhomolar() > rho_max_1phase:
+                            continue
+                        state_rhomax.update(CP.DmolarP_INPUTS, rho_max_1phase, p)
+                        if state_rhomax.T() > T0:
+                            T0 = state_rhomax.T()
+                    except Exception as E:
+                        # Could not establish the Dmax floor on this isobar; test it from the
+                        # default floor (the pre-bound behaviour) rather than skipping it -- the
+                        # solver handles the dense region -- but report why.
+                        myprint(1, 'Dmax floor (p=%g):' % p, self.fluid, E)
+                if T0 >= Tmax_1phase:
+                    continue
+                Tvec = np.linspace(T0, Tmax_1phase, self.NT_1phase)
             else:
                 # Use the provided limits for T
                 Tvec = np.linspace(self.T_limits_1phase[0], self.T_limits_1phase[1], self.NT_1phase)


### PR DESCRIPTION
## Summary

Robustness fixes for HEOS single-phase flash solvers that eliminate large buckets of `ConsistencyReport` failures, plus a REFPROP-style max-density bound in the consistency-plot grid. Two commits:

1. **`solver_rho_Tp` supercritical_liquid TOMS748 fallback + grid bound** (`CoolProp-kf78`)
   - Near the critical isotherm the `iphase_supercritical_liquid` Brent bracket spanned the van der Waals loop and returned NaN ("p is not a valid number") in a thin band around Tc. Adds a TOMS748 dense-branch fallback (upper bound anchored on `rhomolar_reducing()` since `EOS().limits.rhomax` is 0/unset for some fluids; live state restored at the converged density).
   - `ConsistencyPlots.py`: a REFPROP-style maximum-density floor (triple-point liquid density) applied to the single-phase grid **for pure fluids at supercritical pressure only** — excludes the unvalidated compressed-solid/extrapolation region rather than testing it.

2. **DP / HS / D+X flash robustness** (`CoolProp-r1w7.1`, `CoolProp-vmp`)
   - **DP_flash**: unbounded Halley diverged to negative/out-of-range T at extreme (ρ,p) ("temperature of −926 K below minimum 0 K"). Now accepts Halley only on a converged, in-range root and otherwise falls back to a bracketed TOMS748 solve over `[Tmin, 1.5·Tmax]`.
   - **HS_flash legacy path**: the `h(SmolarT(s,T)) − h_target` residual is non-monotonic (the inner SmolarT solve degrades at high T), so endpoint-only `Brent(Tmin,Tmax)` reported "do not bracket" while the root sat just above Tmin. Now scans upward for the first sign change between *adjacent* valid samples and solves with TOMS748 (Brent fallback if none found).
   - **D+X melting-line floor**: strict `value < y_lo` rejected on-melting-line states on last-bit noise (e.g. `−810.862 < −810.862`); added a small relative tolerance.

All new TOMS748 brackets wrap interior/endpoint EOS evaluations so a throw degrades to a clean `ValueError` (or the Brent fallback) rather than escaping the flash.

## Impact (full 136-fluid `ConsistencyFigure`, 40×40, drift-free vs the branch base)

| | failures |
|---|---|
| base (this PR's master ancestor) | 2193 |
| after this PR | **893** |

**−1300 (−59%), zero regressions** — verified both vs the base and incrementally per change. Fully cleared (→0): R21, MDM, Isohexane, n-Octane, n-Nonane, n-Decane, R152A, R22, Nitrogen, Neon, Hydrogen, CarbonMonoxide, Fluorine, Oxygen, Krypton, Isopentane, … (18 fluids); R123 117→1, Helium 109→26.

Remaining buckets are out of scope (separate beads): mixture/pseudo-pure two-phase (R407C, R404A), near-vacuum dome-corner P+energy (PropyleneGlycol, MD3M, MethylLinolenate), Air near-critical D+X.

## Validation
- Production Catch2 suites pass: `[flash]/[pureflash]/[PXflash]/[PXcdj]/[PDflash]/[critical_patch]/[critical_points]/[melting]/[water_flash]/[supercritical]` (1893 assertions) and `[consistency]` (24,991 assertions).
- Adversarial review + a second re-review of the hardening: the original 3 blocking findings (unguarded TOMS748 interior-throw) are resolved; no new issues.
- Branch is based on a recent `master` ancestor (`38997b8b5`); rebase before merge if desired.

> Note: a local `preflight.sh` run flags cppcheck + clang-tidy, but those are **pre-existing file-level debt** in the touched files (the cppcheck `syntaxError` reproduces identically on `master`; the clang-tidy findings are outside the changed lines). The changed lines are clang-tidy-clean (intentional swallow-catches use `// NOLINT(bugprone-empty-catch)` per the repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust single-phase temperature solves with safer fallbacks and clearer failure reporting for convergence issues.
  * Improved density solving for supercritical-liquid states using a more reliable root-finding fallback.
  * Consistency-plot sampling now avoids unphysically dense conditions for pure fluids and better skips invalid isobars near phase boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->