### PR TITLE
perf(docs): parallelize Consistency plots, -j auto Sphinx, ccache wrapper builds

### DIFF
--- a/.github/workflows/docs_docker-run.yml
+++ b/.github/workflows/docs_docker-run.yml
@@ -39,6 +39,18 @@ jobs:
       # host-side actions/cache step sees the same files.
       COOLPROP_ALTERNATIVE_SVDTABLES_DIRECTORY: ${{ github.workspace }}/.svdtables-cache
 
+      # Compiler cache for the wrapper-example builds (LinuxRun.py).  Each
+      # COOLPROP_*_MODULE build recompiles the CoolProp core from scratch, so
+      # the core is built once per wrapper language.  Persisting the dir on the
+      # workspace lets actions/cache carry hits across runs, so an unchanged
+      # core source (docs-only changes, the cron on a quiet master, re-runs) is
+      # a full hit next time.  (Within a single run the four modules don't share
+      # core objects yet -- the Octave/Java/R blocks add header dirs via global
+      # include_directories(), which lands on the core compiles; scoping those
+      # to the swig target would unlock that, tracked separately.)  Same
+      # bind-mounted-workspace reasoning as the SVD dir above.
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+
     container:
       image: ghcr.io/coolprop/coolprop_docs_02_builder:dev
       # options: --user 1001 --group 1001
@@ -94,6 +106,22 @@ jobs:
         path: .svdtables-cache
         key: svd-tables-${{ hashFiles('dev/fluids/*.json', 'src/SBTL/**', 'src/Backends/SVDSBTL/**', 'src/Region/**', 'include/CoolProp/sbtl/**', 'Web/coolprop/_gen/gen_SVDSBTLValidation.py') }}
 
+    # Persist the ccache dir (CCACHE_DIR, set at job level) across runs so the
+    # wrapper-example builds also reuse the CoolProp core compiled by previous
+    # runs, not just within a single run.  ccache is content-addressed and
+    # self-managed (bounded by its own max-size), so a rolling per-SHA key with
+    # a restore-keys fallback is the right pattern: always seed from the most
+    # recent prior cache, then save a fresh snapshot.  A stale object is never a
+    # correctness risk — ccache keys on the preprocessed source + compiler args,
+    # so any real change is a natural miss.
+    - uses: actions/cache@v5
+      if: ${{ !env.ACT }}
+      with:
+        path: .ccache
+        key: docs-ccache-${{ github.sha }}
+        restore-keys: |
+          docs-ccache-
+
     - name: Schedule calculations
       id: schedule_calculation
       shell: bash
@@ -143,6 +171,18 @@ jobs:
         python -c "import CoolProp; print(CoolProp.__gitrevision__)"
         python -c "import CoolProp; print(CoolProp.__file__)"
         
+    - name: Install ccache (runtime escape hatch until the docs image rebuilds)
+      shell: bash
+      run: |
+        source activate docs
+        # ccache is baked into docs_01_base.Dockerfile, but PR builds run on the
+        # already-published image (not rebuilt for PRs), so install it here until
+        # the next image rebuild on master — same escape hatch as the pip
+        # packages in the wheel step.  Skips cleanly once the image already
+        # carries it; a genuine install failure still fails the step (not masked).
+        command -v ccache >/dev/null || conda install -y -c conda-forge ccache
+        ccache --version
+
     - name: Build homepage and create graphs
       # Use a single argument with "True" or "1" to trigger a full rebuild
       working-directory: ./Web/scripts/

--- a/.github/workflows/docs_docker-run.yml
+++ b/.github/workflows/docs_docker-run.yml
@@ -111,10 +111,18 @@ jobs:
     # runs, not just within a single run.  ccache is content-addressed and
     # self-managed (bounded by its own max-size), so a rolling per-SHA key with
     # a restore-keys fallback is the right pattern: always seed from the most
-    # recent prior cache, then save a fresh snapshot.  A stale object is never a
-    # correctness risk — ccache keys on the preprocessed source + compiler args,
-    # so any real change is a natural miss.
-    - uses: actions/cache@v5
+    # recent prior cache.  A stale object is never a correctness risk — ccache
+    # keys on the preprocessed source + compiler args, so any real change is a
+    # natural miss.
+    #
+    # Restore on every event, but SAVE only on trusted (non-PR) events: the
+    # later steps compile + execute native artifacts out of this cache, so an
+    # untrusted PR must never populate a store a trusted push/schedule run could
+    # later restore.  (GitHub's cache scope already isolates PR-created caches
+    # from default-branch runs; this is defense-in-depth and also keeps PR churn
+    # from evicting the mainline cache.)  Hence the cache/restore + conditional
+    # cache/save split instead of the combined actions/cache action.
+    - uses: actions/cache/restore@v5
       if: ${{ !env.ACT }}
       with:
         path: .ccache
@@ -191,7 +199,23 @@ jobs:
         source activate docs
         echo "Calling: python -u __init__.py ${{ env.COOLPROP_EXPENSIVE }}"
         python -u __init__.py ${{ env.COOLPROP_EXPENSIVE }}
-        
+
+    # Save the ccache populated by the wrapper-example builds above — but only
+    # on a trusted event and only if the build SUCCEEDED.  An explicit `if:`
+    # drops the implicit success() check, so success() must be restated or the
+    # save would fire after a failed/partial build and persist a bad snapshot
+    # that a later run restores.  The event allowlist (push — incl. tags —,
+    # schedule, workflow_dispatch; all require write access) is used instead of
+    # `!= 'pull_request'` so a future pull_request_target trigger can't slip
+    # through and poison the trusted cache.  Placed right after the homepage
+    # build (the only ccache writer) so a later doxygen/sphinx failure doesn't
+    # discard a cache from an otherwise-good wrapper build.
+    - uses: actions/cache/save@v5
+      if: ${{ success() && !env.ACT && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+      with:
+        path: .ccache
+        key: docs-ccache-${{ github.sha }}
+
     - name: Build documentation with Doxygen
       shell: bash
       run: |

--- a/Web/Makefile
+++ b/Web/Makefile
@@ -40,13 +40,13 @@ clean:
 	@echo "Removing existing _build directory."
 	$(REMOVE_BUILD)
 
-html: 
-	$(SPHINXBUILD) -j3 -T -b html $(ALLSPHINXOPTS) _build/html
+html:
+	$(SPHINXBUILD) -j auto -T -b html $(ALLSPHINXOPTS) _build/html
 	@echo
 	@echo "Build finished. The HTML pages are in _build/html."
 
-html_release: 
-	$(SPHINXBUILD) -j3 -T -b html -t Release $(ALLSPHINXOPTS)  _build/html
+html_release:
+	$(SPHINXBUILD) -j auto -T -b html -t Release $(ALLSPHINXOPTS)  _build/html
 	@echo
 	@echo "Build finished. The HTML pages are in _build/html."
     

--- a/Web/scripts/fluid_properties.Consistency.py
+++ b/Web/scripts/fluid_properties.Consistency.py
@@ -120,6 +120,29 @@ def build_one_fluid(fluid):
         failure = str(exc)
         print('BUILD FAILED for', fluid, ':', failure)
     finally:
+        if failure is not None:
+            # Drop stale per-fluid data artifacts on failure. These dirs are
+            # restored from cache, so a prior SUCCESSFUL run may have left a
+            # <fluid>-summary.csv (which the consolidated report aggregates
+            # unconditionally below) and a <fluid>-consistency.csv (whose
+            # presence, with the png, marks the fluid "cached" so the next run
+            # skips it). Leaving them would make this build report stale success
+            # for a fluid that actually failed, and mask the failure on reruns.
+            # Removing them excludes the fluid from this run's aggregation and
+            # forces a clean regeneration next run; build_failures still records
+            # it for the report's failure list.
+            for stale in (fluid + '-summary.csv', fluid + '-consistency.csv'):
+                stale_path = os.path.join(plots_path, stale)
+                try:
+                    if os.path.exists(stale_path):
+                        os.remove(stale_path)
+                except OSError as exc:
+                    # Best effort: failing to delete a stale artifact must not
+                    # escape this finally (it would surface via ex.map and abort
+                    # every other fluid). A leftover stale file is the lesser
+                    # evil and is logged.
+                    print('WARN: could not remove stale %s: %s' % (stale_path, exc))
+
         # Guarantee the per-fluid HEOS report fragment exists. The fluid page
         # includes it unconditionally, so a crash before the subprocess wrote it
         # (or a partial cache) must not leave a dangling `.. include::`.

--- a/Web/scripts/fluid_properties.Consistency.py
+++ b/Web/scripts/fluid_properties.Consistency.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os.path
+import concurrent.futures
 import CoolProp
 import pandas
 import subprocess
@@ -76,48 +77,89 @@ def regenerate_fragment_from_csv(fluid):
     summary.to_csv(os.path.join(plots_path, fluid + '-summary.csv'), index=False)
 
 
+def build_one_fluid(fluid):
+    """Generate (or cheaply regenerate from cache) the consistency artifacts for
+    one fluid and guarantee its include fragments exist.  Returns
+    ``(fluid, failure_msg_or_None)``.
+
+    Runs in a worker thread; the expensive rendering is an isolated subprocess,
+    so concurrent calls scale across cores without GIL contention.  Any
+    exception is captured into the failure message rather than raised — one
+    bad fluid must never abort the whole loop (the stub fragment written in the
+    ``finally`` keeps the fluid page's ``.. include::`` from dangling, exactly
+    as the old serial fall-through did)."""
+    failure = None
+    try:
+        png_path = os.path.join(plots_path, fluid + '.png')
+        csv_path = os.path.join(plots_path, fluid + '-consistency.csv')
+
+        if os.path.exists(png_path) and not force and os.path.exists(csv_path):
+            print('fluid:', fluid, '- cached; regenerating fragment from CSV')
+            regenerate_fragment_from_csv(fluid)
+        else:
+            print('fluid:', fluid, '- generating (backend=%s)' % backend)
+            csv_relpath = subdir + '/' + fluid + '-consistency.csv'
+            intro_rst = refprop_intro(fluid) if backend == 'REFPROP' else ''
+            file_string = template.format(backend=backend, fluid=fluid,
+                                          csv_relpath=csv_relpath, intro_rst=intro_rst, dpi=dpi)
+            file_path = os.path.join(plots_path, fluid + '.py')
+            with open(file_path, 'w') as fp:
+                fp.write(file_string)
+            # Capture output and emit it as one contiguous block so concurrent
+            # fluids' logs don't interleave line-by-line.
+            proc = subprocess.run([sys.executable, '-u', fluid + '.py'], cwd=plots_path,
+                                  stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                  universal_newlines=True)
+            if proc.stdout:
+                sys.stdout.write('----- %s -----\n%s\n' % (fluid, proc.stdout.rstrip('\n')))
+                sys.stdout.flush()
+            if proc.returncode != 0:
+                failure = 'exit code %d' % proc.returncode
+                print('BUILD FAILED for', fluid, ':', failure)
+    except Exception as exc:  # noqa: BLE001 — a single fluid must not kill the build
+        failure = str(exc)
+        print('BUILD FAILED for', fluid, ':', failure)
+    finally:
+        # Guarantee the per-fluid HEOS report fragment exists. The fluid page
+        # includes it unconditionally, so a crash before the subprocess wrote it
+        # (or a partial cache) must not leave a dangling `.. include::`.
+        report_frag = os.path.join(plots_path, fluid + '-report.rst')
+        if not os.path.exists(report_frag):
+            rpt.write_stub_fragment(report_frag,
+                                    'Consistency data could not be generated for this fluid in this build.')
+
+        # During the default (HEOS) build, ensure a REFPROP stub fragment exists so
+        # the fluid page's REFPROP include never points at a missing file.
+        if backend == 'HEOS':
+            refprop_frag = os.path.join(refprop_path, fluid + '-report.rst')
+            if not os.path.exists(refprop_frag):
+                rpt.write_stub_fragment(refprop_frag,
+                                        'REFPROP consistency plots were not generated in this build.')
+
+    return fluid, failure
+
+
+# Render fluids concurrently: each is an isolated, single-threaded subprocess, so
+# a worker per core saturates the (4-core) CI builder instead of running 136
+# fluids strictly serially.  Worker count is overridable via
+# COOLPROP_CONSISTENCY_JOBS; default to the core count.  Each worker only ever
+# touches files named for its own fluid, so there are no shared-file races.
+fluids = list(CoolProp.__fluids__)
+jobs_env = os.environ.get('COOLPROP_CONSISTENCY_JOBS')
+try:
+    max_workers = int(jobs_env) if jobs_env else (os.cpu_count() or 1)
+except ValueError:
+    max_workers = os.cpu_count() or 1
+max_workers = max(1, min(max_workers, len(fluids)))
+print('Building consistency plots for %d fluids with %d worker(s)' % (len(fluids), max_workers))
+
 build_failures = []
-
-for fluid in CoolProp.__fluids__:
-    png_path = os.path.join(plots_path, fluid + '.png')
-    csv_path = os.path.join(plots_path, fluid + '-consistency.csv')
-
-    if os.path.exists(png_path) and not force and os.path.exists(csv_path):
-        print('fluid:', fluid, '- cached; regenerating fragment from CSV')
-        regenerate_fragment_from_csv(fluid)
-    else:
-        print('fluid:', fluid, '- generating (backend=%s)' % backend)
-        csv_relpath = subdir + '/' + fluid + '-consistency.csv'
-        intro_rst = refprop_intro(fluid) if backend == 'REFPROP' else ''
-        file_string = template.format(backend=backend, fluid=fluid,
-                                      csv_relpath=csv_relpath, intro_rst=intro_rst, dpi=dpi)
-        file_path = os.path.join(plots_path, fluid + '.py')
-        with open(file_path, 'w') as fp:
-            fp.write(file_string)
-        try:
-            subprocess.check_call([sys.executable, '-u', fluid + '.py'], cwd=plots_path,
-                                  stdout=sys.stdout, stderr=sys.stderr)
-        except subprocess.CalledProcessError as exc:
-            print('BUILD FAILED for', fluid, ':', exc)
-            build_failures.append((fluid, str(exc)))
-            # fall through: a stub fragment is written below so the fluid-page
-            # include never dangles and the whole Sphinx build does not break.
-
-    # Guarantee the per-fluid HEOS report fragment exists. The fluid page includes
-    # it unconditionally, so a crash before the subprocess wrote it (or a partial
-    # cache) must not leave a dangling `.. include::`.
-    report_frag = os.path.join(plots_path, fluid + '-report.rst')
-    if not os.path.exists(report_frag):
-        rpt.write_stub_fragment(report_frag,
-                                'Consistency data could not be generated for this fluid in this build.')
-
-    # During the default (HEOS) build, ensure a REFPROP stub fragment exists so the
-    # fluid page's REFPROP include never points at a missing file.
-    if backend == 'HEOS':
-        refprop_frag = os.path.join(refprop_path, fluid + '-report.rst')
-        if not os.path.exists(refprop_frag):
-            rpt.write_stub_fragment(refprop_frag,
-                                    'REFPROP consistency plots were not generated in this build.')
+with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as ex:
+    # map() preserves input order, so build_failures stays deterministic (fluid
+    # order) for the consolidated report.
+    for fluid, failure in ex.map(build_one_fluid, fluids):
+        if failure is not None:
+            build_failures.append((fluid, failure))
 
 # Aggregate per-fluid summaries into the consolidated report page.
 summaries = []

--- a/dev/docker/docs_01_base.Dockerfile
+++ b/dev/docker/docs_01_base.Dockerfile
@@ -21,6 +21,7 @@ FROM continuumio/miniconda3
 RUN apt-get -y -m update && \
     apt-get install -y \
         g++ make cmake ninja-build swig doxygen p7zip-full \
+        ccache \
         mono-mcs \
         octave liboctave-dev \
         r-base-dev \

--- a/dev/scripts/examples/LinuxRun.py
+++ b/dev/scripts/examples/LinuxRun.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-import subprocess, os
+import subprocess, os, sys
 from example_generator import *
 import shutil
 import codecs
@@ -25,6 +25,24 @@ def copyfiles(lang, ext):
 
 if __name__ == '__main__':
 
+    # Each COOLPROP_*_MODULE build below recompiles the entire CoolProp core
+    # from scratch, so the core is compiled once per wrapper language (4x per
+    # run).  A compiler cache avoids redoing that work when the core source is
+    # unchanged.  This helps most ACROSS runs (docs-only changes, the daily/
+    # weekly cron on an unchanged master, re-runs): a later build of the same
+    # module is then a full cache hit.  It does NOT share core objects between
+    # the four modules within a single run -- the Octave/Java/R cmake blocks add
+    # their header dirs via global include_directories(), so those -I flags land
+    # on the core .cpp compile lines and make each module's core objects
+    # distinct.  Scoping those includes to the swig target would unlock within-
+    # run sharing (tracked separately).  Empty string => no-op when ccache isn't
+    # installed, so local runs without it behave exactly as before.
+    CCACHE = (' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache'
+              if shutil.which('ccache') else '')
+    if CCACHE:
+        # Zero the stats so the ccache -s at the end reads as a per-run hit rate.
+        subprocess.call('ccache -z', shell=True)
+
     # C++
     #kwargs = dict(stdout = sys.stdout, stderr = sys.stderr, shell = True)
     #subprocess.check_call('cmake ../../../.. -DCOOLPROP_MY_MAIN=Example.cpp -DCMAKE_VERBOSE_MAKEFILE=ON', **kwargs)
@@ -42,7 +60,7 @@ if __name__ == '__main__':
     O = Octave()
     O.write('Octave/Example.m', O.parse())
     kwargs = dict(stdout=sys.stdout, stderr=sys.stderr, shell=True, cwd='Octave')
-    subprocess.check_call('cmake ../../../.. -G Ninja -DCOOLPROP_OCTAVE_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON', **kwargs)
+    subprocess.check_call('cmake ../../../.. -G Ninja -DCOOLPROP_OCTAVE_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON' + CCACHE, **kwargs)
     subprocess.check_call('cmake --build .', **kwargs)
     with codecs.open('Octave/Example.out', 'w', encoding='utf-8') as fp:
        tee_call(r'octave Example.m', fp, shell=True, cwd='Octave')
@@ -52,7 +70,7 @@ if __name__ == '__main__':
     J = Java()
     J.write('Java/Example.java', J.parse())
     kwargs = dict(stdout=sys.stdout, stderr=sys.stderr, shell=True, cwd='Java')
-    subprocess.check_call('cmake ../../../.. -G Ninja -DCOOLPROP_JAVA_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON', **kwargs)
+    subprocess.check_call('cmake ../../../.. -G Ninja -DCOOLPROP_JAVA_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON' + CCACHE, **kwargs)
     subprocess.check_call('cmake --build .', **kwargs)
     subprocess.check_call(r'javac *.java', **kwargs)
     with codecs.open('Java/Example.out', 'w', encoding='utf-8') as fp:
@@ -63,7 +81,7 @@ if __name__ == '__main__':
     C = Csharp()
     C.write('Csharp/Example.cs', C.parse())
     kwargs = dict(stdout=sys.stdout, stderr=sys.stderr, shell=True, cwd='Csharp')
-    subprocess.check_call('cmake ../../../.. -G Ninja -DCOOLPROP_CSHARP_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON', **kwargs)
+    subprocess.check_call('cmake ../../../.. -G Ninja -DCOOLPROP_CSHARP_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON' + CCACHE, **kwargs)
     subprocess.check_call('cmake --build .', **kwargs)
     subprocess.check_call(r'mcs -out:Example *.cs', **kwargs)
     with codecs.open('Csharp/Example.out', 'w', encoding='utf-8') as fp:
@@ -74,11 +92,16 @@ if __name__ == '__main__':
     RR = R()
     RR.write('R/Example.R', RR.parse())
     kwargs = dict(stdout=sys.stdout, stderr=sys.stderr, shell=True, cwd='R')
-    subprocess.check_call('cmake ../../../.. -G Ninja -DCOOLPROP_R_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON -DR_BIN=/usr/bin', **kwargs)
+    subprocess.check_call('cmake ../../../.. -G Ninja -DCOOLPROP_R_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON -DR_BIN=/usr/bin' + CCACHE, **kwargs)
     subprocess.check_call('cmake --build .', **kwargs)
     with codecs.open('R/Example.out', 'w', encoding='utf-8') as fp:
         tee_call(r'DYLD_LIBRARY_PATH=/opt/refprop Rscript Example.R', fp, shell=True, cwd='R')
     copyfiles('R', 'R')
+
+    if CCACHE:
+        # Surface the hit rate in the CI log so a regression (e.g. a flag that
+        # silently busts the cache across modules) is visible.
+        subprocess.call('ccache -s', shell=True)
     #
     #if not os.path.exists('MATLAB'): os.mkdir('MATLAB')
     #M = MATLAB()

--- a/dev/scripts/examples/OSXRun.py
+++ b/dev/scripts/examples/OSXRun.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-import subprocess, os
+import subprocess, os, sys
 from example_generator import *
 import shutil
 import codecs
@@ -25,6 +25,24 @@ def copyfiles(lang, ext):
 
 if __name__ == '__main__':
 
+    # Each COOLPROP_*_MODULE build below recompiles the entire CoolProp core
+    # from scratch, so the core is compiled once per wrapper language (4x per
+    # run).  A compiler cache avoids redoing that work when the core source is
+    # unchanged.  This helps most ACROSS runs (docs-only changes, the daily/
+    # weekly cron on an unchanged master, re-runs): a later build of the same
+    # module is then a full cache hit.  It does NOT share core objects between
+    # the four modules within a single run -- the Octave/Java/R cmake blocks add
+    # their header dirs via global include_directories(), so those -I flags land
+    # on the core .cpp compile lines and make each module's core objects
+    # distinct.  Scoping those includes to the swig target would unlock within-
+    # run sharing (tracked separately).  Empty string => no-op when ccache isn't
+    # installed, so local runs without it behave exactly as before.
+    CCACHE = (' -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache'
+              if shutil.which('ccache') else '')
+    if CCACHE:
+        # Zero the stats so the ccache -s at the end reads as a per-run hit rate.
+        subprocess.call('ccache -z', shell=True)
+
     # C++
     #kwargs = dict(stdout = sys.stdout, stderr = sys.stderr, shell = True)
     #subprocess.check_call('cmake ../../../.. -DCOOLPROP_MY_MAIN=Example.cpp -DCMAKE_VERBOSE_MAKEFILE=ON', **kwargs)
@@ -42,7 +60,7 @@ if __name__ == '__main__':
     O = Octave()
     O.write('Octave/Example.m', O.parse())
     kwargs = dict(stdout=sys.stdout, stderr=sys.stderr, shell=True, cwd='Octave')
-    subprocess.check_call('cmake ../../../.. -DCOOLPROP_OCTAVE_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON', **kwargs)
+    subprocess.check_call('cmake ../../../.. -DCOOLPROP_OCTAVE_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON' + CCACHE, **kwargs)
     subprocess.check_call('cmake --build .', **kwargs)
     with codecs.open('Octave/Example.out', 'w', encoding='utf-8') as fp:
         tee_call(r'octave Example.m', fp, shell=True, cwd='Octave')
@@ -61,7 +79,7 @@ if __name__ == '__main__':
         raise
         
     kwargs = dict(stdout=sys.stdout, stderr=sys.stderr, shell=True, cwd='Java')
-    subprocess.check_call('cmake ../../../.. -DCOOLPROP_JAVA_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON', **kwargs)
+    subprocess.check_call('cmake ../../../.. -DCOOLPROP_JAVA_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON' + CCACHE, **kwargs)
     subprocess.check_call('cmake --build .', **kwargs)
     subprocess.check_call(r'javac *.java', **kwargs)
     with codecs.open('Java/Example.out', 'w', encoding='utf-8') as fp:
@@ -72,7 +90,7 @@ if __name__ == '__main__':
     C = Csharp()
     C.write('Csharp/Example.cs', C.parse())
     kwargs = dict(stdout=sys.stdout, stderr=sys.stderr, shell=True, cwd='Csharp')
-    subprocess.check_call('cmake ../../../.. -DCOOLPROP_CSHARP_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON', **kwargs)
+    subprocess.check_call('cmake ../../../.. -DCOOLPROP_CSHARP_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON' + CCACHE, **kwargs)
     subprocess.check_call('cmake --build .', **kwargs)
     subprocess.check_call(r'mcs -out:Example *.cs', **kwargs)
     with codecs.open('Csharp/Example.out', 'w', encoding='utf-8') as fp:
@@ -83,11 +101,16 @@ if __name__ == '__main__':
     RR = R()
     RR.write('R/Example.R', RR.parse())
     kwargs = dict(stdout=sys.stdout, stderr=sys.stderr, shell=True, cwd='R')
-    subprocess.check_call('cmake ../../../.. -DCOOLPROP_R_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON -DR_BIN=/opt/homebrew/bin', **kwargs)
+    subprocess.check_call('cmake ../../../.. -DCOOLPROP_R_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON -DR_BIN=/opt/homebrew/bin' + CCACHE, **kwargs)
     subprocess.check_call('cmake --build .', **kwargs)
     with codecs.open('R/Example.out', 'w', encoding='utf-8') as fp:
         tee_call(r'DYLD_LIBRARY_PATH=/opt/refprop Rscript Example.R', fp, shell=True, cwd='R')
     copyfiles('R', 'R')
+
+    if CCACHE:
+        # Surface the hit rate in the log so a regression (e.g. a flag that
+        # silently busts the cache across modules) is visible.
+        subprocess.call('ccache -s', shell=True)
 
     #if not os.path.exists('MATLAB'): os.mkdir('MATLAB')
     #M = MATLAB()


### PR DESCRIPTION
## Why

The docs build had several serial CPU-bound bottlenecks on the 4-core CI builder. This addresses the highest-leverage, lowest-risk ones.

## What

- **`Web/scripts/fluid_properties.Consistency.py`** — the 136-fluid consistency-plot loop now runs in a bounded `ThreadPoolExecutor` (`COOLPROP_CONSISTENCY_JOBS`, default `os.cpu_count()`). The heavy work was already an isolated subprocess per fluid, so threads give true parallelism without pickling. Refactored into `build_one_fluid()` with `try/except/finally` so one bad fluid can never abort the build (the stub include fragment is still written), subprocess output is emitted as a per-fluid block to keep concurrent logs readable, and `build_failures` order is preserved via `ex.map` for a deterministic consolidated report.
- **`Web/Makefile`** — `html` / `html_release`: `-j3` → `-j auto` (use the 4th core).
- **`dev/scripts/examples/LinuxRun.py` / `OSXRun.py`** — pass `ccache` as the compiler launcher to each wrapper-example configure (Octave/Java/Csharp/R), gated on `shutil.which('ccache')` so it's a **no-op where ccache isn't installed**. Each `COOLPROP_*_MODULE` build recompiles the CoolProp core, so ccache skips that work when the core source is unchanged across runs (docs-only changes, cron on a quiet master, re-runs). Also adds a per-run `ccache -s` hit-rate readout.
- **`dev/docker/docs_01_base.Dockerfile`** — `ccache` added to the apt install (durable).
- **`.github/workflows/docs_docker-run.yml`** — `CCACHE_DIR` on the cacheable workspace, an `actions/cache` step (rolling per-SHA key + `docs-ccache-` restore-keys), and a runtime `conda install` escape hatch until the image rebuild lands.

## Scope / follow-up

Within-run core-object sharing across the four wrapper modules is **not** achieved here — the Octave/Java/R cmake blocks add module-specific headers via global `include_directories()`, which lands on the core compiles and makes each module's core objects distinct. So ccache helps across-run (unchanged source), not within a source-changed run. Unlocking the within-run 4→1 needs an object-library refactor of the shared wrapper cmake blocks (touches shipped wrappers, needs cross-platform verification) and is tracked separately (`bd CoolProp-fe64`).

Note (by design): a filesystem failure in `Consistency.py`'s `finally` stub-write (disk full / permission) will abort the run — same as the prior serial code; a single fluid's *rendering* failure does not.

## Verification

- `./dev/ci/preflight.sh`: **4 passed / 0 failed / 5 skipped** (skips justified — no C/C++ or fluid-JSON in the diff; build + Catch2 `[!slow][!benchmark]` + JSON-symbol + installed-header gates all passed).
- Pre-PR adversarial review: no blocking findings (verified fail-closed gates, no shared-file write races across worker threads, comments don't overstate behavior).
- `Consistency.py` smoke-tested locally on a 3-fluid subset: cold generation and cached no-op paths both green; all per-fluid artifacts + consolidated report produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Infrastructure**
  * Use automatic parallelism for documentation builds (replaces fixed thread counts).
  * Add compiler caching (ccache) for CI and local builds, with on-demand install and per-run cache stats.
  * CI now seeds/restores ccache and conditionally saves trusted caches to avoid polluted restores.
  * Documentation artifact generation made parallel and resilient: per-item failures no longer abort overall build; stub outputs ensured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->