### PR TITLE
fix(HEOS): supercritical fast path for D+{H,S,U} back-flashes (clears Air near-critical D+X failures)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2215,6 +2215,8 @@ if(COOLPROP_CATCH_MODULE)
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-AirMelting.cpp")
   list(APPEND APP_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-AirCritical.cpp")
+  list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-Michelsen.cpp"
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-FPUGuard.cpp")
   list(APPEND APP_SOURCES

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -1908,6 +1908,73 @@ void FlashRoutines::HSU_D_flash(HelmholtzEOSMixtureBackend& HEOS, parameters oth
 
         CoolPropFluid& component = HEOS.components[0];
 
+        // Supercritical single-phase fast path.  The region logic below is anchored on the
+        // triple-point states (unset for pseudo-pure fluids like Air, where they default to
+        // -1) and on saturation_D_pure, which is numerically unstable near rho_c.  Together
+        // these route Air's near-critical supercritical D+X back-flashes to a branch whose
+        // Ttriple-anchored temperature bracket spans the two-phase dome, producing
+        // "p is not a valid number".  But if the caloric input lies above its value on the
+        // critical isotherm at this density, the solution temperature is above Tc, so the
+        // state is unambiguously single-phase and needs no saturation: h, s and u all
+        // increase with T at fixed rho, so bracket the residual directly on [Tc, 1.5*Tmax]
+        // and solve with TOMS748.  Any failure falls through to the legacy region logic.
+        if (other == iHmolar || other == iSmolar || other == iUmolar) {
+            const double rho_in = HEOS._rhomolar;
+            const double value_in = (other == iHmolar) ? HEOS._hmolar : ((other == iSmolar) ? HEOS._smolar : HEOS._umolar);
+            bool fast_ok = false;
+            try {
+                const double Tc_ = HEOS.T_critical();
+                const double Tb = HEOS.Tmax() * 1.5;
+                // Restrict to rho < 2*rho_c.  The Air D+X failures sit at rho/rho_c ~ 0.8-1.005,
+                // so the bound must reach just past rho_c, but it must stay well below the dense-
+                // liquid extrapolation (rho >> rho_c, e.g. ~3*rho_c) where the critical-isotherm
+                // probe X(Tc, rho) is unreliable/non-monotonic and could mis-fire onto a spurious
+                // root.  In [rho_c, 2*rho_c] a subcritical state still has value < X(Tc, rho) (X is
+                // monotonic in T there), so the probe only fires for genuinely supercritical states.
+                if (rho_in > 0 && rho_in < 2.0 * HEOS.rhomolar_critical()) {
+                    const double X_Tc = (other == iHmolar)   ? HEOS.calc_hmolar_nocache(Tc_, rho_in)
+                                        : (other == iSmolar) ? HEOS.calc_smolar_nocache(Tc_, rho_in)
+                                                             : HEOS.calc_umolar_nocache(Tc_, rho_in);
+                    if (ValidNumber(X_Tc) && ValidNumber(value_in) && value_in > X_Tc) {
+                        solver_resid resid(&HEOS, rho_in, value_in, other, Tc_, Tb);
+                        const double fa = resid.call(Tc_), fb = resid.call(Tb);
+                        if (ValidNumber(fa) && ValidNumber(fb) && fa * fb < 0) {
+                            boost::math::uintmax_t max_iter = 100;
+                            auto f = [&resid](double T) { return resid.call(T); };
+                            auto [l, r] = toms748_solve(f, Tc_, Tb, fa, fb, boost::math::tools::eps_tolerance<double>(44), max_iter);
+                            HEOS.update_DmolarT_direct(rho_in, 0.5 * (l + r));
+                            // Accept only a state that reproduces the caloric input (and rho, which
+                            // update_DmolarT_direct restored by construction); otherwise fall through.
+                            const double xout = HEOS.keyed_output(other);
+                            if (ValidNumber(xout) && std::abs(xout - value_in) <= 1e-6 * std::abs(value_in) + 1e-3) {
+                                HEOS._p = HEOS.calc_pressure_nocache(HEOS.T(), HEOS.rhomolar());
+                                HEOS._Q = 10000;
+                                HEOS.unspecify_phase();
+                                HEOS.recalculate_singlephase_phase();
+                                fast_ok = true;
+                            }
+                        }
+                    }
+                }
+            } catch (...) {  // NOLINT(bugprone-empty-catch) -- fall through to the legacy region logic below
+            }
+            if (fast_ok) {
+                return;
+            }
+            // The probes above (solver_resid::call -> update_DmolarT_direct -> clear()) overwrite
+            // the cached caloric inputs; restore the originals so the legacy path below solves for
+            // the correct target instead of a corrupted one.
+            HEOS._rhomolar = rho_in;
+            if (other == iHmolar) {
+                HEOS._hmolar = value_in;
+            } else if (other == iSmolar) {
+                HEOS._smolar = value_in;
+            } else {
+                HEOS._umolar = value_in;
+            }
+            HEOS.unspecify_phase();
+        }
+
         shared_ptr<HelmholtzEOSMixtureBackend> Sat;
         CoolPropDbl rhoLtriple = component.triple_liquid.rhomolar;
         CoolPropDbl rhoVtriple = component.triple_vapor.rhomolar;

--- a/src/Tests/CoolProp-Tests-AirCritical.cpp
+++ b/src/Tests/CoolProp-Tests-AirCritical.cpp
@@ -1,0 +1,113 @@
+// Dense round-trip consistency coverage of Air's critical region.
+//
+// Air is modelled as a PSEUDO-PURE fluid, so its property surfaces are not
+// perfectly continuous near the critical point (the underlying mixture has a
+// temperature glide that the pseudo-pure approximation collapses).  That makes
+// the flash routines fragile in this region; in particular the D+{H,S,U}
+// back-flashes (HSU_D_flash) used to throw "p is not a valid number" at
+// near-critical density because pseudo-pure fluids cannot take the
+// is_pure()-gated superancillary happy path and fall onto the legacy
+// saturation_D_pure path, which is unstable near rho_c.
+//
+// This harness sweeps a dense (T, p) grid spanning the critical region
+// (T/Tc in [0.96, 2.0], p/pc in [0.5, 5.0]) and, for every single-phase grid
+// point, requires that each of the seven non-trivial back-flashes recovers the
+// forward (T, rho).  Grid points that land in the two-phase dome are skipped:
+// PT inputs there are genuinely unsupported for a pseudo-pure fluid.
+//
+// Built into CatchTestRunner when COOLPROP_CATCH_MODULE=ON.  Run via
+//   ./build_catch/CatchTestRunner "[air_critical]"
+
+#include "CoolProp/AbstractState.h"
+#include "CoolProp/CoolProp.h"
+#include "CoolProp/DataStructures.h"
+
+#if defined(ENABLE_CATCH)
+#    include <catch2/catch_all.hpp>
+
+#    include <memory>
+#    include <cmath>
+#    include <cstdio>
+#    include <array>
+
+TEST_CASE("Air critical-region round-trip consistency (pseudo-pure)", "[air_critical][HSU_D]") {
+    using namespace CoolProp;
+
+    auto fwd = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", "Air"));
+    auto rt = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", "Air"));
+
+    const double Tc = fwd->T_critical();
+    const double pc = fwd->p_critical();
+
+    // Round-trip tolerance.  The critical region is ill-conditioned (dp/drho -> 0
+    // near rho_c), so a small relative slack is used; the production solvers stay
+    // well inside it everywhere on this grid.
+    const double tol = 2e-4;
+
+    const int NT = 60, NP = 40;
+    std::size_t single_phase = 0, two_phase_skipped = 0;
+
+    for (int i = 0; i < NT; ++i) {
+        const double T = (0.96 + (2.0 - 0.96) * i / (NT - 1)) * Tc;
+        for (int j = 0; j < NP; ++j) {
+            const double p = (0.5 + (5.0 - 0.5) * j / (NP - 1)) * pc;
+
+            // Forward PT defines the reference single-phase state.  A throw here
+            // means the point fell in/at the two-phase dome (PT not supported for
+            // a pseudo-pure fluid) -- not a back-flash defect -- so skip it.
+            try {
+                fwd->update(PT_INPUTS, p, T);
+            } catch (...) {
+                ++two_phase_skipped;
+                continue;
+            }
+            const double rho = fwd->rhomolar();
+            const double h = fwd->hmolar();
+            const double s = fwd->smolar();
+            const double u = fwd->umolar();
+            if (!ValidNumber(rho) || !ValidNumber(h) || !ValidNumber(s) || !ValidNumber(u)) {
+                continue;
+            }
+            ++single_phase;
+
+            // Each back-flash must recover the forward (T, rho).
+            struct Case
+            {
+                const char* name;
+                input_pairs pair;
+                double v1, v2;
+            };
+            const std::array<Case, 7> cases = {{
+              {"DmolarHmolar", DmolarHmolar_INPUTS, rho, h},
+              {"DmolarSmolar", DmolarSmolar_INPUTS, rho, s},
+              {"DmolarUmolar", DmolarUmolar_INPUTS, rho, u},
+              {"HmolarP", HmolarP_INPUTS, h, p},
+              {"PSmolar", PSmolar_INPUTS, p, s},
+              {"PUmolar", PUmolar_INPUTS, p, u},
+              {"DmolarP", DmolarP_INPUTS, rho, p},
+            }};
+            for (const auto& c : cases) {
+                CAPTURE(c.name, T, p, T / Tc, p / pc, rho);
+                bool threw = false;
+                try {
+                    rt->update(c.pair, c.v1, c.v2);
+                } catch (const std::exception& e) {
+                    threw = true;
+                    FAIL_CHECK("back-flash threw: " << e.what());
+                }
+                if (threw) {
+                    continue;
+                }
+                CHECK(rt->T() == Catch::Approx(T).epsilon(tol));
+                CHECK(rt->rhomolar() == Catch::Approx(rho).epsilon(tol));
+            }
+        }
+    }
+
+    std::printf("[air_critical] Air: %zu single-phase points round-tripped (x7 back-flashes), %zu two-phase PT points skipped\n", single_phase,
+                two_phase_skipped);
+    // Guard against the grid silently collapsing (e.g. forward PT failing wholesale).
+    CHECK(single_phase > 2000);
+}
+
+#endif  // ENABLE_CATCH


### PR DESCRIPTION
## Summary

`HSU_D_flash` (the D+{H,S,U} flash) routes **pseudo-pure** fluids' near-critical-density D+X back-flashes through the legacy "sad path", whose region logic is anchored on the **triple-point states** (unset for pseudo-pure fluids → default `-1`) and on `saturation_D_pure`, which is numerically **unstable near ρc**. For **Air**, `DmolarHmolar`/`DmolarSmolar`/`DmolarUmolar` at ρ/ρc ≈ 0.8–1.0 and T/Tc up to ~15 therefore throw **"p is not a valid number"**. The modern superancillary "happy path" that avoids this is gated on `is_pure()`, so pseudo-pure fluids can't use it.

This adds a **supercritical single-phase fast path** at the top of the legacy path: when the caloric input lies above its value on the critical isotherm at this density, the solution temperature is above Tc, so the state is unambiguously single-phase and needs no saturation. h, s and u all increase with T at fixed ρ, so the residual is bracketed directly on `[Tc, 1.5·Tmax]` and solved with TOMS748.

**Guards:**
- Restricted to **ρ < 2·ρc** — the Air failures sit at ρ/ρc ≤ 1.005, while staying clear of the dense-liquid extrapolation (ρ ≫ ρc) where the critical-isotherm probe is unreliable and could mis-fire.
- Commits only a state that **reproduces the caloric input** (else falls through).
- **Restores the cached inputs** that the probes overwrite (`update_DmolarT_direct` → `clear()`), so a fall-through hands the legacy path the original target.
- The TOMS748 call is inside a `try`; an interior EOS throw degrades to fall-through, never escaping `HSU_D_flash`.

## Impact

Clears the **108 Air D+X** consistency failures (Air's entire `Dmolar{Hmolar,Smolar,Umolar}` bucket). On the full 136-fluid `ConsistencyFigure` sweep, **only Air changes** — **zero new regressions**.

- Standalone on this base: **Air 135 → 27** (full sweep 2193 → 2085); the remaining 27 Air `PT`/`DmolarP` failures are a separate bucket addressed by the companion consistency PR #3176.
- On a branch combining this with #3176, **Air → 0** (full sweep 903 → 795, only Air changes).

## Validation
- Production Catch2: `[flash]`, `[PXcdj]`, `[PDflash]`, `[critical_patch]` pass; `[consistency]` 24,991 assertions; `[HSU_D]` 56,935 assertions pass.
- Adversarial review (built + a round-trip harness over Air/Water/CO₂/Nitrogen/Methane, supercritical + subcritical-liquid, ~1300 back-flashes): **0 wrong-T, 0 throws**; confirmed the ρ<2ρc bound is safe and state is fully restored on every fall-through.

> Note: a local `preflight.sh` flags cppcheck + clang-tidy, but those are **pre-existing file-level debt** in `FlashRoutines.cpp` (the cppcheck `syntaxError` reproduces on master; no clang-tidy finding falls in the changed lines). The added `catch(...)` uses the repo's `// NOLINT(bugprone-empty-catch)` idiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an accelerated supercritical single‑phase fast path that detects genuine supercritical states, computes temperature/brackets solutions, and accepts validated single‑phase results—improving performance and robustness for certain thermodynamic evaluations.

* **Tests**
  * Added a critical‑region round‑trip consistency test for pseudo‑pure air to validate forward/back flash accuracy across the critical region.

* **Chores**
  * Registered the new test with the test runner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->