### PR TITLE
feat(SVDSBTL): opt-in `prebuild` to materialize all input-pair surfaces

### DIFF
--- a/Web/coolprop/SVDSBTL.rst
+++ b/Web/coolprop/SVDSBTL.rst
@@ -467,9 +467,22 @@ Configuration keys
 Backend options JSON (``factory("SVDSBTL&HEOS", "Water",
 '{"grid": {"NT": 200, "NR": 800, "rank": 20}}')``) lets per-instance
 overrides tune the SVD grid and rank; see :doc:`BackendOptions`.  Any
-non-default options change the table's ``OptHash`` and therefore its
-cache filename, so multiple grid sizes for the same fluid coexist
-peacefully on disk.
+content-affecting option (grid, rank, transport) changes the table's
+``OptHash`` and therefore its cache filename, so multiple grid sizes for
+the same fluid coexist peacefully on disk.
+
+``{"prebuild": true}`` is an opt-in flag that eagerly builds **every**
+supported input-pair surface (PT, HmassP, DmassT, PSmass) at construction
+instead of lazy-loading the secondary pairs (DmassT / PSmass) on first
+query.  Use it to materialize a whole fluid up front — docs rendering,
+benchmarking, warm-cache pre-fill — or to turn a build / environment
+failure into a loud construction-time error rather than a silent NaN on a
+later query.  Because ``prebuild`` only changes *when* surfaces are built,
+not their content, it is stripped from the ``OptHash``: a
+``{"prebuild": true}`` instance shares its serialized surfaces with plain
+``SVDSBTL&HEOS`` queries (and with an IF97 source it builds PT / HmassP /
+PSmass but skips DmassT, which can't be sampled on a ``(D, T)`` grid from
+IF97).
 
 .. _SVDSBTL-decision-guide:
 

--- a/Web/coolprop/SVDSBTLValidation.ipynb
+++ b/Web/coolprop/SVDSBTLValidation.ipynb
@@ -313,6 +313,30 @@
    "id": "cell-005",
    "metadata": {},
    "source": [
+    "### Environment preflight\n",
+    "\n",
+    "Before the parallel grid below, eagerly materialize **all four** input-pair surfaces for a single fluid via the SVDSBTL `prebuild` option. This fails **loudly here** if the CoolProp build / kernel environment can't produce them (e.g. a stale wheel without `PSmass` support) — rather than letting every PS / DT panel downstream render as a silent blank. `prebuild` strips itself from the cache key, so these surfaces are shared with the plain `SVDSBTL&HEOS` constructions the panels use.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-006",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# prebuild=true builds PT + HmassP + DmassT + PSmass for Water in a single\n",
+    "# construction; a build / env failure raises here and fails the docs build,\n",
+    "# which is the intended loud signal (vs. a quietly blank panel).\n",
+    "CP.AbstractState('SVDSBTL&HEOS', 'Water?{\"prebuild\": true}')\n",
+    "print('preflight OK: all SVDSBTL input-pair surfaces build for Water')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-007",
+   "metadata": {},
+   "source": [
     "### Grid computation\n",
     "\n",
     "Each `(fluid, input_pair)` pair is an independent unit of work, so we compute all of them concurrently via `joblib` (process-based workers; `n_jobs=min(len(FLUIDS)*len(INPUT_PAIRS), cpu_count)`). Most of the wall-clock here is the one-time SVDSBTL surface build (a dense SVD at production resolution), not the per-point lookups; surfaces are cached and reused on subsequent builds.\n"
@@ -321,7 +345,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cell-006",
+   "id": "cell-008",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -342,7 +366,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cell-007",
+   "id": "cell-009",
    "metadata": {},
    "source": [
     "## Water"
@@ -350,28 +374,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cell-008",
-   "metadata": {},
-   "source": [
-    "### PT"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-009",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_from_grid('Water', 'PT', GRIDS[('Water', 'PT')])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "cell-010",
    "metadata": {},
    "source": [
-    "### HP"
+    "### PT"
    ]
   },
   {
@@ -381,7 +387,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('Water', 'HP', GRIDS[('Water', 'HP')])"
+    "plot_from_grid('Water', 'PT', GRIDS[('Water', 'PT')])"
    ]
   },
   {
@@ -389,7 +395,7 @@
    "id": "cell-012",
    "metadata": {},
    "source": [
-    "### DT"
+    "### HP"
    ]
   },
   {
@@ -399,7 +405,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('Water', 'DT', GRIDS[('Water', 'DT')])"
+    "plot_from_grid('Water', 'HP', GRIDS[('Water', 'HP')])"
    ]
   },
   {
@@ -407,7 +413,7 @@
    "id": "cell-014",
    "metadata": {},
    "source": [
-    "### PS"
+    "### DT"
    ]
   },
   {
@@ -417,7 +423,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('Water', 'PS', GRIDS[('Water', 'PS')])"
+    "plot_from_grid('Water', 'DT', GRIDS[('Water', 'DT')])"
    ]
   },
   {
@@ -425,25 +431,25 @@
    "id": "cell-016",
    "metadata": {},
    "source": [
-    "## Argon"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-017",
-   "metadata": {},
-   "source": [
-    "### PT"
+    "### PS"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cell-018",
+   "id": "cell-017",
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('Argon', 'PT', GRIDS[('Argon', 'PT')])"
+    "plot_from_grid('Water', 'PS', GRIDS[('Water', 'PS')])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-018",
+   "metadata": {},
+   "source": [
+    "## Argon"
    ]
   },
   {
@@ -451,7 +457,7 @@
    "id": "cell-019",
    "metadata": {},
    "source": [
-    "### HP"
+    "### PT"
    ]
   },
   {
@@ -461,7 +467,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('Argon', 'HP', GRIDS[('Argon', 'HP')])"
+    "plot_from_grid('Argon', 'PT', GRIDS[('Argon', 'PT')])"
    ]
   },
   {
@@ -469,7 +475,7 @@
    "id": "cell-021",
    "metadata": {},
    "source": [
-    "### DT"
+    "### HP"
    ]
   },
   {
@@ -479,7 +485,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('Argon', 'DT', GRIDS[('Argon', 'DT')])"
+    "plot_from_grid('Argon', 'HP', GRIDS[('Argon', 'HP')])"
    ]
   },
   {
@@ -487,7 +493,7 @@
    "id": "cell-023",
    "metadata": {},
    "source": [
-    "### PS"
+    "### DT"
    ]
   },
   {
@@ -497,7 +503,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('Argon', 'PS', GRIDS[('Argon', 'PS')])"
+    "plot_from_grid('Argon', 'DT', GRIDS[('Argon', 'DT')])"
    ]
   },
   {
@@ -505,25 +511,25 @@
    "id": "cell-025",
    "metadata": {},
    "source": [
-    "## Hydrogen"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-026",
-   "metadata": {},
-   "source": [
-    "### PT"
+    "### PS"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cell-027",
+   "id": "cell-026",
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('Hydrogen', 'PT', GRIDS[('Hydrogen', 'PT')])"
+    "plot_from_grid('Argon', 'PS', GRIDS[('Argon', 'PS')])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-027",
+   "metadata": {},
+   "source": [
+    "## Hydrogen"
    ]
   },
   {
@@ -531,7 +537,7 @@
    "id": "cell-028",
    "metadata": {},
    "source": [
-    "### HP"
+    "### PT"
    ]
   },
   {
@@ -541,7 +547,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('Hydrogen', 'HP', GRIDS[('Hydrogen', 'HP')])"
+    "plot_from_grid('Hydrogen', 'PT', GRIDS[('Hydrogen', 'PT')])"
    ]
   },
   {
@@ -549,7 +555,7 @@
    "id": "cell-030",
    "metadata": {},
    "source": [
-    "### DT"
+    "### HP"
    ]
   },
   {
@@ -559,7 +565,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('Hydrogen', 'DT', GRIDS[('Hydrogen', 'DT')])"
+    "plot_from_grid('Hydrogen', 'HP', GRIDS[('Hydrogen', 'HP')])"
    ]
   },
   {
@@ -567,7 +573,7 @@
    "id": "cell-032",
    "metadata": {},
    "source": [
-    "### PS"
+    "### DT"
    ]
   },
   {
@@ -577,7 +583,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('Hydrogen', 'PS', GRIDS[('Hydrogen', 'PS')])"
+    "plot_from_grid('Hydrogen', 'DT', GRIDS[('Hydrogen', 'DT')])"
    ]
   },
   {
@@ -585,25 +591,25 @@
    "id": "cell-034",
    "metadata": {},
    "source": [
-    "## R1234yf"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-035",
-   "metadata": {},
-   "source": [
-    "### PT"
+    "### PS"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cell-036",
+   "id": "cell-035",
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('R1234yf', 'PT', GRIDS[('R1234yf', 'PT')])"
+    "plot_from_grid('Hydrogen', 'PS', GRIDS[('Hydrogen', 'PS')])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-036",
+   "metadata": {},
+   "source": [
+    "## R1234yf"
    ]
   },
   {
@@ -611,7 +617,7 @@
    "id": "cell-037",
    "metadata": {},
    "source": [
-    "### HP"
+    "### PT"
    ]
   },
   {
@@ -621,7 +627,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('R1234yf', 'HP', GRIDS[('R1234yf', 'HP')])"
+    "plot_from_grid('R1234yf', 'PT', GRIDS[('R1234yf', 'PT')])"
    ]
   },
   {
@@ -629,7 +635,7 @@
    "id": "cell-039",
    "metadata": {},
    "source": [
-    "### DT"
+    "### HP"
    ]
   },
   {
@@ -639,7 +645,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('R1234yf', 'DT', GRIDS[('R1234yf', 'DT')])"
+    "plot_from_grid('R1234yf', 'HP', GRIDS[('R1234yf', 'HP')])"
    ]
   },
   {
@@ -647,7 +653,7 @@
    "id": "cell-041",
    "metadata": {},
    "source": [
-    "### PS"
+    "### DT"
    ]
   },
   {
@@ -657,7 +663,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('R1234yf', 'PS', GRIDS[('R1234yf', 'PS')])"
+    "plot_from_grid('R1234yf', 'DT', GRIDS[('R1234yf', 'DT')])"
    ]
   },
   {
@@ -665,25 +671,25 @@
    "id": "cell-043",
    "metadata": {},
    "source": [
-    "## R245fa"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-044",
-   "metadata": {},
-   "source": [
-    "### PT"
+    "### PS"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cell-045",
+   "id": "cell-044",
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('R245fa', 'PT', GRIDS[('R245fa', 'PT')])"
+    "plot_from_grid('R1234yf', 'PS', GRIDS[('R1234yf', 'PS')])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-045",
+   "metadata": {},
+   "source": [
+    "## R245fa"
    ]
   },
   {
@@ -691,7 +697,7 @@
    "id": "cell-046",
    "metadata": {},
    "source": [
-    "### HP"
+    "### PT"
    ]
   },
   {
@@ -701,7 +707,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('R245fa', 'HP', GRIDS[('R245fa', 'HP')])"
+    "plot_from_grid('R245fa', 'PT', GRIDS[('R245fa', 'PT')])"
    ]
   },
   {
@@ -709,7 +715,7 @@
    "id": "cell-048",
    "metadata": {},
    "source": [
-    "### DT"
+    "### HP"
    ]
   },
   {
@@ -719,7 +725,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('R245fa', 'DT', GRIDS[('R245fa', 'DT')])"
+    "plot_from_grid('R245fa', 'HP', GRIDS[('R245fa', 'HP')])"
    ]
   },
   {
@@ -727,7 +733,7 @@
    "id": "cell-050",
    "metadata": {},
    "source": [
-    "### PS"
+    "### DT"
    ]
   },
   {
@@ -737,7 +743,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('R245fa', 'PS', GRIDS[('R245fa', 'PS')])"
+    "plot_from_grid('R245fa', 'DT', GRIDS[('R245fa', 'DT')])"
    ]
   },
   {
@@ -745,25 +751,25 @@
    "id": "cell-052",
    "metadata": {},
    "source": [
-    "## D6"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-053",
-   "metadata": {},
-   "source": [
-    "### PT"
+    "### PS"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cell-054",
+   "id": "cell-053",
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('D6', 'PT', GRIDS[('D6', 'PT')])"
+    "plot_from_grid('R245fa', 'PS', GRIDS[('R245fa', 'PS')])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-054",
+   "metadata": {},
+   "source": [
+    "## D6"
    ]
   },
   {
@@ -771,7 +777,7 @@
    "id": "cell-055",
    "metadata": {},
    "source": [
-    "### HP"
+    "### PT"
    ]
   },
   {
@@ -781,7 +787,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('D6', 'HP', GRIDS[('D6', 'HP')])"
+    "plot_from_grid('D6', 'PT', GRIDS[('D6', 'PT')])"
    ]
   },
   {
@@ -789,7 +795,7 @@
    "id": "cell-057",
    "metadata": {},
    "source": [
-    "### DT"
+    "### HP"
    ]
   },
   {
@@ -799,7 +805,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('D6', 'DT', GRIDS[('D6', 'DT')])"
+    "plot_from_grid('D6', 'HP', GRIDS[('D6', 'HP')])"
    ]
   },
   {
@@ -807,7 +813,7 @@
    "id": "cell-059",
    "metadata": {},
    "source": [
-    "### PS"
+    "### DT"
    ]
   },
   {
@@ -817,7 +823,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('D6', 'PS', GRIDS[('D6', 'PS')])"
+    "plot_from_grid('D6', 'DT', GRIDS[('D6', 'DT')])"
    ]
   },
   {
@@ -825,25 +831,25 @@
    "id": "cell-061",
    "metadata": {},
    "source": [
-    "## CO2"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-062",
-   "metadata": {},
-   "source": [
-    "### PT"
+    "### PS"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cell-063",
+   "id": "cell-062",
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('CO2', 'PT', GRIDS[('CO2', 'PT')])"
+    "plot_from_grid('D6', 'PS', GRIDS[('D6', 'PS')])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-063",
+   "metadata": {},
+   "source": [
+    "## CO2"
    ]
   },
   {
@@ -851,7 +857,7 @@
    "id": "cell-064",
    "metadata": {},
    "source": [
-    "### HP"
+    "### PT"
    ]
   },
   {
@@ -861,7 +867,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('CO2', 'HP', GRIDS[('CO2', 'HP')])"
+    "plot_from_grid('CO2', 'PT', GRIDS[('CO2', 'PT')])"
    ]
   },
   {
@@ -869,7 +875,7 @@
    "id": "cell-066",
    "metadata": {},
    "source": [
-    "### DT"
+    "### HP"
    ]
   },
   {
@@ -879,7 +885,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('CO2', 'DT', GRIDS[('CO2', 'DT')])"
+    "plot_from_grid('CO2', 'HP', GRIDS[('CO2', 'HP')])"
    ]
   },
   {
@@ -887,7 +893,7 @@
    "id": "cell-068",
    "metadata": {},
    "source": [
-    "### PS"
+    "### DT"
    ]
   },
   {
@@ -897,7 +903,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('CO2', 'PS', GRIDS[('CO2', 'PS')])"
+    "plot_from_grid('CO2', 'DT', GRIDS[('CO2', 'DT')])"
    ]
   },
   {
@@ -905,25 +911,25 @@
    "id": "cell-070",
    "metadata": {},
    "source": [
-    "## Helium"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-071",
-   "metadata": {},
-   "source": [
-    "### PT"
+    "### PS"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cell-072",
+   "id": "cell-071",
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('Helium', 'PT', GRIDS[('Helium', 'PT')])"
+    "plot_from_grid('CO2', 'PS', GRIDS[('CO2', 'PS')])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-072",
+   "metadata": {},
+   "source": [
+    "## Helium"
    ]
   },
   {
@@ -931,7 +937,7 @@
    "id": "cell-073",
    "metadata": {},
    "source": [
-    "### HP"
+    "### PT"
    ]
   },
   {
@@ -941,7 +947,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('Helium', 'HP', GRIDS[('Helium', 'HP')])"
+    "plot_from_grid('Helium', 'PT', GRIDS[('Helium', 'PT')])"
    ]
   },
   {
@@ -949,7 +955,7 @@
    "id": "cell-075",
    "metadata": {},
    "source": [
-    "### DT"
+    "### HP"
    ]
   },
   {
@@ -959,7 +965,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('Helium', 'DT', GRIDS[('Helium', 'DT')])"
+    "plot_from_grid('Helium', 'HP', GRIDS[('Helium', 'HP')])"
    ]
   },
   {
@@ -967,7 +973,7 @@
    "id": "cell-077",
    "metadata": {},
    "source": [
-    "### PS"
+    "### DT"
    ]
   },
   {
@@ -977,12 +983,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_from_grid('Helium', 'PS', GRIDS[('Helium', 'PS')])"
+    "plot_from_grid('Helium', 'DT', GRIDS[('Helium', 'DT')])"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "cell-079",
+   "metadata": {},
+   "source": [
+    "### PS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-080",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_from_grid('Helium', 'PS', GRIDS[('Helium', 'PS')])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-081",
    "metadata": {},
    "source": [
     "## Notes\n",

--- a/Web/coolprop/_gen/gen_SVDSBTLValidation.py
+++ b/Web/coolprop/_gen/gen_SVDSBTLValidation.py
@@ -335,6 +335,23 @@ nb.cells = [
         "    return fig\n"
     ),
     _md(
+        "### Environment preflight\n\n"
+        "Before the parallel grid below, eagerly materialize **all four** input-pair "
+        "surfaces for a single fluid via the SVDSBTL `prebuild` option. This fails "
+        "**loudly here** if the CoolProp build / kernel environment can't produce them "
+        "(e.g. a stale wheel without `PSmass` support) — rather than letting every PS / DT "
+        "panel downstream render as a silent blank. `prebuild` strips itself from the "
+        "cache key, so these surfaces are shared with the plain `SVDSBTL&HEOS` "
+        "constructions the panels use.\n"
+    ),
+    _code(
+        "# prebuild=true builds PT + HmassP + DmassT + PSmass for Water in a single\n"
+        "# construction; a build / env failure raises here and fails the docs build,\n"
+        "# which is the intended loud signal (vs. a quietly blank panel).\n"
+        "CP.AbstractState('SVDSBTL&HEOS', 'Water?{\"prebuild\": true}')\n"
+        "print('preflight OK: all SVDSBTL input-pair surfaces build for Water')\n"
+    ),
+    _md(
         "### Grid computation\n\n"
         "Each `(fluid, input_pair)` pair is an independent unit of work, so we compute "
         "all of them concurrently via `joblib` "

--- a/include/CoolProp/schemas/SVDSBTLOptions.h
+++ b/include/CoolProp/schemas/SVDSBTLOptions.h
@@ -24,6 +24,10 @@ inline constexpr const char kSVDSBTLOptionsSchemaJson[] = R"JSON({
       "const": 1,
       "description": "Schema version. Bump when the layout below changes."
     },
+    "prebuild": {
+      "type": "boolean",
+      "description": "When true, eagerly build every supported input-pair surface (PT, HmassP, DmassT, PSmass) at construction instead of lazy-loading the secondary pairs on first query. Opt-in complement to the default lazy loading: materializes the whole fluid up front (docs / benchmarking / warm-cache pre-fill) and turns a build/env failure into a loud construction-time error instead of a silent blank later."
+    },
     "grid": {
       "type": "object",
       "additionalProperties": false,

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -289,6 +289,29 @@ SVDSBTLBackend::SVDSBTLBackend(const std::string& fluid_name,      // NOLINT(mod
     if (source_backend_ == "IF97" && fluid_name != "Water") {
         throw ValueError(format("SVDSBTL&IF97 is Water-only; got fluid '%s'", fluid_name.c_str()));
     }
+    // Opt-in `prebuild`: materialize every supported surface at
+    // construction instead of lazy-loading the secondary pairs.  Off by
+    // default (lazy); turned on for docs / benchmarking / warm-cache
+    // pre-fill, where building up front also turns a build/env failure
+    // into a loud construction-time throw instead of a silent blank on
+    // the first query.  (CoolProp-rhb5)
+    bool prebuild = false;
+    {
+        nlohmann::json opts = cpjson::parse(options_canonical_.empty() ? "{}" : options_canonical_);
+        if (opts.is_object() && opts.contains("prebuild")) {
+            prebuild = cpjson::get_bool(opts, "prebuild");
+            // prebuild is build-eagerness only — it changes neither surface
+            // nor critpatch content.  Strip it from the canonical options
+            // so the cache opthash (and the critpatch sidecar key) are
+            // identical to a default no-prebuild instance: a
+            // {"prebuild":true} build therefore shares its serialized
+            // surfaces with plain SVDSBTL&<source> queries (and vice
+            // versa), rather than caching a redundant copy under a
+            // different opthash.
+            opts.erase("prebuild");
+            options_canonical_ = to_canonical_json_str(opts.dump());
+        }
+    }
     for (const auto pair : kSupportedPairs) {
         // DmassT/DmolarT share the DmassT_INPUTS surface, built lazily on
         // the first density-input query (see update()/fast_evaluate()).
@@ -303,7 +326,15 @@ SVDSBTLBackend::SVDSBTLBackend(const std::string& fluid_name,      // NOLINT(mod
         // HmassP/PT-only consumers should not pay the heavy ps_subcritical
         // dense SVD up front.  Built on the first (p, s) query in
         // update()/fast_evaluate().
-        if (pair == ::CoolProp::DmassT_INPUTS || pair == ::CoolProp::PSmass_INPUTS) {
+        //
+        // `prebuild` overrides reason (a) — the caller has asked for the
+        // whole fluid — but NOT reason (b): a DmassT surface still can't
+        // be sampled from an IF97 source, so it stays skipped for IF97
+        // even under prebuild (PT/HmassP/PSmass build fine for IF97).
+        if (!prebuild && (pair == ::CoolProp::DmassT_INPUTS || pair == ::CoolProp::PSmass_INPUTS)) {
+            continue;
+        }
+        if (pair == ::CoolProp::DmassT_INPUTS && source_backend_ == "IF97") {
             continue;
         }
         ensure_surface_(pair);

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -1312,6 +1312,109 @@ TEST_CASE("SVDSBTLBackend uses surrogate when source has no SuperAncillary", "[S
     REQUIRE(rp_be->sat_surrogate_consulted());
 }
 
+// CoolProp-rhb5: the opt-in `prebuild` option materializes every
+// supported input-pair surface at construction instead of lazy-loading
+// the secondary pairs (DmassT / PSmass) on first query.
+TEST_CASE("SVDSBTL prebuild option eagerly builds all surfaces", "[SBTL][SVDSBTL][prebuild][slow]") {
+    auto contains = [](const std::vector<CoolProp::input_pairs>& v, CoolProp::input_pairs p) {
+        return std::find(v.begin(), v.end(), p) != v.end();
+    };
+    // Small grid keeps the four dense SVD builds fast for a unit test.
+    const char* small_grid = R"({"grid":{"NT":40,"NR":80,"rank":10}})";
+    const char* small_grid_prebuild = R"({"prebuild":true,"grid":{"NT":40,"NR":80,"rank":10}})";
+
+    // Default (lazy): only the eager pairs PT + HmassP are registered at
+    // construction; DmassT / PSmass are absent until first queried.
+    {
+        auto AS = std::shared_ptr<CoolProp::AbstractState>(
+          CoolProp::AbstractState::factory("SVDSBTL&HEOS", std::string("Water?") + small_grid));
+        auto* be = dynamic_cast<CoolProp::SVDSBTLBackend*>(AS.get());
+        REQUIRE(be != nullptr);
+        const auto pairs = be->registered_input_pairs();
+        REQUIRE(contains(pairs, CoolProp::PT_INPUTS));
+        REQUIRE(contains(pairs, CoolProp::HmassP_INPUTS));
+        REQUIRE_FALSE(contains(pairs, CoolProp::DmassT_INPUTS));
+        REQUIRE_FALSE(contains(pairs, CoolProp::PSmass_INPUTS));
+    }
+    // prebuild=true: all four supported pairs are registered eagerly.
+    {
+        auto AS = std::shared_ptr<CoolProp::AbstractState>(
+          CoolProp::AbstractState::factory("SVDSBTL&HEOS", std::string("Water?") + small_grid_prebuild));
+        auto* be = dynamic_cast<CoolProp::SVDSBTLBackend*>(AS.get());
+        REQUIRE(be != nullptr);
+        const auto pairs = be->registered_input_pairs();
+        REQUIRE(contains(pairs, CoolProp::PT_INPUTS));
+        REQUIRE(contains(pairs, CoolProp::HmassP_INPUTS));
+        REQUIRE(contains(pairs, CoolProp::DmassT_INPUTS));
+        REQUIRE(contains(pairs, CoolProp::PSmass_INPUTS));
+    }
+}
+
+TEST_CASE("SVDSBTL&IF97 prebuild skips the unbuildable DmassT surface", "[SBTL][SVDSBTL][prebuild][if97][slow]") {
+    if (!source_backend_available("IF97", "Water")) {
+        SKIP("IF97 backend not available; skipping SVDSBTL&IF97 prebuild test");
+    }
+    auto contains = [](const std::vector<CoolProp::input_pairs>& v, CoolProp::input_pairs p) {
+        return std::find(v.begin(), v.end(), p) != v.end();
+    };
+    // DmassT can't be sampled on a (D,T) grid from IF97 (all-NaN matrix),
+    // so prebuild builds PT + HmassP + PSmass but leaves DmassT out rather
+    // than throwing at construction.
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(
+      CoolProp::AbstractState::factory("SVDSBTL&IF97", std::string(R"(Water?{"prebuild":true,"grid":{"NT":40,"NR":80,"rank":10}})")));
+    auto* be = dynamic_cast<CoolProp::SVDSBTLBackend*>(AS.get());
+    REQUIRE(be != nullptr);
+    const auto pairs = be->registered_input_pairs();
+    REQUIRE(contains(pairs, CoolProp::PT_INPUTS));
+    REQUIRE(contains(pairs, CoolProp::HmassP_INPUTS));
+    REQUIRE(contains(pairs, CoolProp::PSmass_INPUTS));
+    REQUIRE_FALSE(contains(pairs, CoolProp::DmassT_INPUTS));
+}
+
+// prebuild must NOT change the cache key: a {"prebuild":true} build has
+// to share its serialized surfaces with a plain no-prebuild instance (the
+// opthash is stripped of the build-eagerness flag).  Otherwise the docs
+// pre-warm would cache under a different opthash than the panels load.
+TEST_CASE("SVDSBTL prebuild shares the surface cache with a plain instance", "[SBTL][SVDSBTL][prebuild][cache][slow]") {
+    namespace fs = std::filesystem;
+    const std::string saved = CoolProp::get_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY);
+    const fs::path tmpdir = fs::temp_directory_path() / ("coolprop_svdtables_prebuild_" + std::to_string(CoolProp::tests::test_pid()));
+    std::error_code ec;
+    fs::remove_all(tmpdir, ec);
+    CoolProp::set_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY, tmpdir.string());
+
+    auto count_ps_files = [&]() {
+        int n = 0;
+        for (const auto& e : fs::directory_iterator(tmpdir, ec)) {
+            const auto name = e.path().filename().string();
+            if (name.find("PSmass_INPUTS") != std::string::npos && name.find(".svd.bin.z") != std::string::npos) ++n;
+        }
+        return n;
+    };
+
+    // critical_patch off so we don't pay the bbox-calibration loop; small
+    // grid so the four builds are a few seconds.
+    const char* prebuild_opts = R"({"prebuild":true,"critical_patch":{"mode":"off"},"grid":{"NT":40,"NR":80,"rank":10}})";
+    const char* plain_opts = R"({"critical_patch":{"mode":"off"},"grid":{"NT":40,"NR":80,"rank":10}})";
+
+    // Prebuild instance: writes one PSmass surface to the tmpdir.
+    { auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", std::string("Water?") + prebuild_opts)); }
+    REQUIRE(count_ps_files() == 1);
+
+    // Plain instance (same grid, NO prebuild): a PS query must LOAD the
+    // already-cached surface — the opthash strip means it looks for the
+    // same file, so no second PSmass cache file appears.
+    auto plain = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", std::string("Water?") + plain_opts));
+    auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));
+    heos->update(CoolProp::PT_INPUTS, 5.0e5, 400.0);
+    plain->update(CoolProp::PSmass_INPUTS, 5.0e5, heos->smass());
+    REQUIRE(plain->rhomass() == Approx(heos->rhomass()).epsilon(1e-1));  // coarse grid; just confirms it resolved
+    REQUIRE(count_ps_files() == 1);  // shared, not a second opthash
+
+    CoolProp::set_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY, saved);
+    fs::remove_all(tmpdir, ec);
+}
+
 // CoolProp-4u9: the tiny p-strip immediately around pc (sub: p ∈
 // [(1−1e-10)·pc, pc]; super: p ∈ [pc, (1+1e-10)·pc]) sits outside
 // the NC sub-regions (which stop at (1−1e-10)·pc on the sub-side


### PR DESCRIPTION
## What

Adds a `{"prebuild": true}` SVDSBTL backend option that eagerly builds **every** supported input-pair surface (PT, HmassP, DmassT, PSmass) at construction, instead of lazy-loading the secondary pairs (DmassT/PSmass) on first query. The opt-in complement to the default lazy loading. Closes bd `CoolProp-rhb5`.

> **Stacked on #3178** (PS input support) — it needs `PSmass` in `kSupportedPairs`. Base this PR's review on the diff vs `ihb/svdsbtl-ps-inputs`; merge after #3178.

## Why

- **Materialize a whole fluid up front** — docs rendering, benchmarking, warm-cache pre-fill.
- **Loud failure instead of silent blank** — building at construction turns a build/environment failure into a construction-time throw, rather than a silent NaN on a later query. This is the exact failure mode that hid a stale-kernel-env from the validation notebook (PS/DT panels rendered blank with no error marker).

## Design

- `prebuild` changes only *when* surfaces are built, not their content, so it's **stripped from the cache opthash** — a `{"prebuild":true}` build shares its serialized surfaces with plain `SVDSBTL&<source>` queries (verified by a cache-sharing regression test). `to_canonical_json_str` is idempotent/order-independent, so the stripped canonical form is byte-identical to a no-prebuild instance's.
- For an **IF97** source, `DmassT` can't be sampled on a `(D,T)` grid (all-NaN), so it stays skipped even under prebuild (PT/HmassP/PSmass build fine).

## Changes

- **schema** (`SVDSBTLOptions.h`): new top-level `prebuild` boolean.
- **constructor**: parse + strip `prebuild`; drive the eager-build loop off the flag.
- **tests**: HEOS builds all 4; IF97 skips DmassT; cache-sharing (prebuild + plain ⇒ one `PSmass` cache file).
- **docs**: validation-notebook "environment preflight" cell that prebuilds Water and fails loudly if surfaces can't build; `SVDSBTL.rst` option docs.

## Verification

- `./dev/ci/preflight.sh`: **8 passed / 0 failed / 1 skipped**.
- New `[prebuild]` tests pass (3 cases).
- Verified in Python: `'Water?{"prebuild": true}'` constructs, and a plain instance reuses the prebuilt cache (opthash strip holds end-to-end).
- Pre-PR adversarial review: no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)