### PR TITLE
fix(HEOS): correct wrong-root PSmass/HSU flash at supercritical pressure

### DIFF
--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -2409,6 +2409,9 @@ void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend& HE
         CoolPropDbl eos0, eos1, rhomolar, rhomolar0, rhomolar1;
         CoolPropDbl Tmin, Tmax;
         bool direct_path_enabled;
+        // Critical pressure, used to gate the warm-density shortcut off for
+        // supercritical-pressure probes — see the note in call().
+        CoolPropDbl p_crit;
 
         solver_resid(HelmholtzEOSMixtureBackend* HEOS, CoolPropDbl p, CoolPropDbl value, parameters other, double Tmin, double Tmax,
                      bool direct_path_enabled)
@@ -2424,7 +2427,8 @@ void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend& HE
             rhomolar1(_HUGE),
             Tmin(Tmin),
             Tmax(Tmax),
-            direct_path_enabled(direct_path_enabled) {
+            direct_path_enabled(direct_path_enabled),
+            p_crit(HEOS->p_critical()) {
             // Specify the state to avoid saturation calls, but only if phase is subcritical
             switch (CoolProp::phases phase = HEOS->phase()) {
                 case iphase_liquid:
@@ -2540,8 +2544,29 @@ void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend& HE
             // to master.  iter < 2 cold iters are amortized; the win is from
             // bypassing the cached inner Householder4 on the warm probes that
             // dominate TOMS748's iteration count.
+            //
+            // EXCEPTION (CoolProp-5sh8): for supercritical pressure (p > p_crit)
+            // the warm carried-rho density Newton is unreliable across the whole
+            // near-critical region, in TWO distinct ways:
+            //   * below T_crit the isotherm p(rho, T) still has a van der Waals
+            //     loop, so the warm Newton (seeded from a neighbouring probe's
+            //     rho) can converge to the spurious low-density root — observed
+            //     for Argon PSmass: T = 127 K returned for a 152 K state;
+            //   * just above T_crit dp/drho -> 0, so the Newton step blows up and
+            //     converges to a garbage density (observed for Oxygen PSmass:
+            //     rho ~ 2600 kg/m3, a negative entropy).
+            // Either way the property evaluated at the bad density is wrong, the
+            // outer residual becomes NON-MONOTONIC in T, and Brent latches onto a
+            // false sign change at the wrong T.  But for p > p_crit the residual
+            // is PHYSICALLY monotone in T (e.g. ds/dT|p = cp/T > 0), so force the
+            // robust cold update(PT_INPUTS) path — whose phase-imposed
+            // solver_rho_Tp (with the #3176 dense-branch TOMS748 fallback)
+            // returns the correct single-phase root — for every supercritical-
+            // pressure probe.  Subcritical p keeps the warm shortcut (single
+            // density branch per imposed phase, no loop).
+            const bool force_robust_density = (p > p_crit);
             const bool want_warm = (iter >= 2 && std::abs(rhomolar1 / rhomolar0 - 1) <= 0.05);
-            if (direct_path_enabled && want_warm) {
+            if (direct_path_enabled && want_warm && !force_robust_density) {
                 try {
                     // WARM: bypass the cached inner solve; reuse the carried
                     // rhomolar (identical to what update_TP_guessrho would seed).
@@ -2590,8 +2615,9 @@ void FlashRoutines::HSU_P_flash_singlephase_Brent(HelmholtzEOSMixtureBackend& HE
                 }
             }
 
-            if (iter < 2 || std::abs(rhomolar1 / rhomolar0 - 1) > 0.05) {
+            if (iter < 2 || std::abs(rhomolar1 / rhomolar0 - 1) > 0.05 || force_robust_density) {
                 // Run the solver with T,P as inputs; but only if the last change in density was greater than a few percent
+                // (or we are in the supercritical-pressure vdW-loop region, where the carried-rho guess can hop branches).
                 HEOS->update(PT_INPUTS, p, T);
             } else {
                 // Run the solver with T,P as inputs; but use the guess value for density from before


### PR DESCRIPTION
## What

Fixes `PSmass_INPUTS` (and `HSU_P_flash` generally) returning a **wrong, non-physical root** at supercritical pressure near the critical point. Closes bd `CoolProp-5sh8`.

Examples (pre-fix):
- **Argon** `PSmass` at p=1.35·pc, s at 152 K → returned **T=127 K, ρ=1142** (a *subcritical* state).
- **Oxygen** `PSmass` at p=1.33·pc → returned **ρ≈2600 kg/m³, negative entropy** (a non-solution).

## Root cause

`HSU_P_flash`'s outer Brent-on-T residual does a per-T inner density solve with a fast **warm carried-ρ Newton** shortcut. For `p > p_crit` that shortcut is unreliable near critical and converges to the wrong density root, making the outer residual **non-monotonic** so Brent latches onto a false root:
- **below Tc**: the isotherm `p(ρ,T)` still has a van der Waals loop → the warm Newton hops to the spurious low-density root (Argon);
- **just above Tc**: `∂p/∂ρ → 0` → the warm Newton step blows up to a garbage density (Oxygen).

## Fix

For `p > p_crit`, `ρ(T,p)` is **single-valued** (the vapor-spinodal max pressure is below pc for all T<Tc, so an isobar above pc crosses the isotherm exactly once, on the dense branch) and the residual is physically monotone in T. So the one-line gate forces the warm shortcut off for supercritical-pressure probes and uses the robust cold `update(PT_INPUTS)` path — whose phase-imposed `solver_rho_Tp` (with #3176's dense-branch TOMS748 fallback) returns the correct root. **Subcritical behaviour is byte-identical** (the warm path's imposed phase already pins the branch). The gate reads the frozen target-pressure member, not the corruptible live `HEOS._p`.

## Validation

- Argon + Oxygen exact cases corrected; a **16-fluid near-critical PSmass sweep → 0 wrong-root cells** (was non-zero).
- `[flash]/[pureflash]/[PXflash]/[PXcdj]/[supercritical]/[critical_points]/[critical_patch]/[melting]/[water_flash]` — 1896 assertions pass.
- `[consistency]` — **24,991 assertions pass**, no regressions.
- Perf: supercritical caloric flashes now ~2× the subcritical warm-path cost (correctness-only region; subcritical hot path untouched).
- Pre-PR adversarial review: no blocking findings.

## Follow-up

This is the right-sized immediate fix. The **general** fix — a phase-bracketed *bounded* secant/Householder density solve (fast high-order step, clamped to a single-root bracket from the superancillary ρL/ρV/psat + melting-line bounds, so it can never hop or overshoot) — is tracked as **CoolProp-uqvr**. That recovers the supercritical perf the gate gives up and retires the whole class.

## Note on preflight

`preflight.sh` flags cppcheck + clang-tidy on `FlashRoutines.cpp`, but these are **pre-existing file-level debt** (the cppcheck `syntaxError` reproduces on master; the clang-tidy findings are outside the changed lines — the nearest is the pre-existing `iter` member declaration). The changed lines are clean. (Same situation #3176 documented.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of density calculations and solver convergence for supercritical and near-critical pressure conditions by applying appropriate computational methods in these regimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->