### PR TITLE
fix(flash): harden two-phase density solves in VLERoutines (overflow guard + density rollback)

### DIFF
--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -1778,6 +1778,10 @@ void SaturationSolvers::successive_substitution_guessrho(HelmholtzEOSMixtureBack
     const std::size_t N = z.size();
     std::vector<CoolPropDbl> lnK(N, 0.0), K(N);
     for (int ss = 0; ss < num_steps; ++ss) {
+        // Preserve the current (last-good) densities so a bad density root this step can be
+        // rolled back: update_TP_guessrho overwrites rhomolar_liq/vap before the finite check
+        // below, and on !finite the caller's Newton solver must still receive a valid seed.
+        const CoolPropDbl rho_liq_prev = rhomolar_liq, rho_vap_prev = rhomolar_vap;
         HEOS.SatL->set_mole_fractions(x);
         HEOS.SatL->update_TP_guessrho(HEOS.T(), HEOS.p(), rhomolar_liq);
         HEOS.SatV->set_mole_fractions(y);
@@ -1804,8 +1808,13 @@ void SaturationSolvers::successive_substitution_guessrho(HelmholtzEOSMixtureBack
             g1 += z[i] * (1.0 - 1.0 / K[i]);
         }
         // A non-finite fugacity coefficient (e.g. a bad density root) makes this SS step
-        // meaningless; stop and keep the last valid x/y/rho for the Newton solver.
-        if (!finite) break;
+        // meaningless; restore the last-good densities (x/y are not yet updated this step) and
+        // stop, so the Newton solver receives the last valid x/y/rho.
+        if (!finite) {
+            rhomolar_liq = rho_liq_prev;
+            rhomolar_vap = rho_vap_prev;
+            break;
+        }
 
         CoolPropDbl beta;
         if (g0 < 0)
@@ -2629,9 +2638,15 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         for (int rr_iter = 0; rr_iter < 50; ++rr_iter) {
             CoolPropDbl r = 0, dr = 0;
             for (std::size_t i = 0; i < N; ++i) {
-                double Ki = std::exp(lnK[i]);
-                double term = Ki - 1.0;
-                double denom = 1.0 + beta * term;
+                // Clamp lnK before exp() so a wide-boiling step (lnK grows unbounded via the
+                // GDEM acceleration that feeds this solve) cannot overflow Ki -- nor term*term /
+                // denom*denom below -- to +inf and poison r/dr with NaN.  At the clamp Ki
+                // dominates, so term/denom -> 1/beta and term^2/denom^2 -> 1/beta^2, i.e. the
+                // exact Ki->inf asymptotic limits; 350 keeps term*term (~exp(2*lnK)) in range.
+                // CoolPropDbl (not double) matches lnK's storage type.
+                CoolPropDbl Ki = std::exp(std::min(lnK[i], static_cast<CoolPropDbl>(350.0)));
+                CoolPropDbl term = Ki - 1.0;
+                CoolPropDbl denom = 1.0 + beta * term;
                 r += IO.z[i] * term / denom;
                 dr -= IO.z[i] * term * term / (denom * denom);
             }
@@ -2646,7 +2661,9 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             beta = beta_new;
         }
         for (std::size_t i = 0; i < N; ++i) {
-            double Ki = std::exp(lnK[i]);
+            // Same clamp as the residual loop: keeps a heavy component's Ki finite so x_i -> 0
+            // and y_i -> z_i/beta (the correct Ki->inf limits) instead of inf/NaN.
+            CoolPropDbl Ki = std::exp(std::min(lnK[i], static_cast<CoolPropDbl>(350.0)));
             IO.x[i] = IO.z[i] / (1.0 + beta * (Ki - 1.0));
             IO.y[i] = Ki * IO.x[i];
         }


### PR DESCRIPTION
Two latent robustness fixes in the mixture two-phase flash path, both pre-existing on `master` and surfaced during review of #3170 (the merge commit's diff re-exposed this code to the bot reviewer). Neither is a reproduced failure; both are defensive and behavior-neutral on current paths.

### 1. Rachford-Rice overflow guard (fixes #3186)

`solve_rachford_rice` (inside `PTflash_twophase::solve_michelsen`, originally from #3026) materialized `Ki = exp(lnK[i])` as `double`. `lnK` is updated **unbounded** by the GDEM acceleration step that feeds this solve, so for `lnK > ~709` the `exp()` overflows to `+inf` — and `term*term` / `denom*denom` overflow even earlier (`lnK > ~354`) — yielding `r`/`dr = NaN`, which the bisection guards (`if (r > 0)`, `abs(r) < 1e-11`) do not cleanly reject (a `NaN` can propagate into `beta`).

**Fix:** clamp `lnK` to `350` before `exp()`. At that bound `Ki` dominates, so `term/denom → 1/β` and `term²/denom² → 1/β²` — the exact `Ki → ∞` asymptotic limits — with every intermediate finite. The intermediates are also changed `double → CoolPropDbl` to match `lnK`'s storage type (a no-op in the default build; meaningful only in opt-in long-double builds, where it also keeps the `std::min` clamp type-correct). A log-space rewrite was rejected: RR's residual `Σ zᵢ(Kᵢ−1)/(1+β(Kᵢ−1))` is a sum of rational functions of `Kᵢ` with no log-sum-exp form.

### 2. Density rollback in `successive_substitution_guessrho` (from #3174)

The SS loop overwrites `rhomolar_liq`/`rhomolar_vap` at the top of each iteration (via `update_TP_guessrho`) **before** the `finite` check. On a `!finite` break (bad density root), the just-computed invalid densities stayed committed — contradicting the comment "keep the last valid x/y/rho for the Newton solver."

**Fix:** save the densities at the top of the iteration and restore them on the `!finite` break, so the caller's Newton solver receives the last known-good seed. Low impact: the only consumer (the Wilson-seeded path in `PT_flash_mixtures`) is already fenced by a try/catch + equal-fugacity verify, so a bad seed could not have produced a wrong answer — but a good seed is strictly better.

### Scope note

The clamp deliberately targets **unbounded growth → `+inf`** (a legitimate wide-boiling / GDEM-overshoot situation with a well-defined `Ki → ∞` limit). A `NaN`-valued `lnK` (from genuinely broken upstream fugacity) is intentionally **not** absorbed — `std::min(NaN, 350)` returns `NaN`, so a divergent result still propagates to the downstream `evaluate_phases()` throw and the `PT_flash_mixtures` verify/fallback, rather than being silently fabricated into a finite-but-bogus value. Masking it would be the more dangerous choice.

### Verification

- Build clean; `[flash],[mixture],[michelsen],[stability],[cubic]` + `[zgpy]` + `[stability_sweep]` pass.
- Behavior-neutral on all current paths (both fixes only alter pathological / over-range cases the tests don't hit) — no result changes.
- Adversarial review; preflight (clang-format / build / json-symbols / install-headers / tests / semgrep pass; cppcheck/clang-tidy informational only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced stability of vapor-liquid equilibrium calculations by preserving valid density estimates when intermediate iterations fail.
  * Prevented numerical overflow in equilibrium constant calculations that could produce invalid or corrupted results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->