### PR TITLE
fix(flash): mixture PQ/QT two-phase flash with a built phase envelope — crash + non-convergence (#3192)

### DIFF
--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -955,10 +955,17 @@ void FlashRoutines::QT_flash(HelmholtzEOSMixtureBackend& HEOS) {
         // successive-substitution + newton_raphson_saturation path, which is robust to ~1e-9%.
         bool solved_with_envelope = false;
         if (HEOS.PhaseEnvelope.built) {
+            // PT_Q_flash_mixtures mutates HEOS._T/_p while seeding its solve.  Save the caller's
+            // inputs and restore them on failure so the blind fallback runs from the original
+            // state.  (The blind QT path only reads the imposed HEOS._T, which the seed preserves,
+            // so this is defensive; it keeps the contract explicit if either side changes.)
+            const CoolPropDbl T_in = HEOS._T, p_in = HEOS._p;
             try {
                 PT_Q_flash_mixtures(HEOS, iT, HEOS._T);
                 solved_with_envelope = true;
             } catch (...) {
+                HEOS._T = T_in;
+                HEOS._p = p_in;
                 solved_with_envelope = false;  // fall back to the blind solver below
             }
         }
@@ -1236,10 +1243,15 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend& HEOS) {
         // QT_flash above (GH #3192).
         bool solved_with_envelope = false;
         if (HEOS.PhaseEnvelope.built) {
+            // Save/restore the caller's inputs around the envelope solve (see QT_flash): the blind
+            // PQ fallback reads the imposed HEOS._p (preserved by the seed), so this is defensive.
+            const CoolPropDbl T_in = HEOS._T, p_in = HEOS._p;
             try {
                 PT_Q_flash_mixtures(HEOS, iP, HEOS._p);
                 solved_with_envelope = true;
             } catch (...) {
+                HEOS._T = T_in;
+                HEOS._p = p_in;
                 solved_with_envelope = false;  // fall back to the blind solver below
             }
         }

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -948,7 +948,13 @@ void FlashRoutines::QT_flash(HelmholtzEOSMixtureBackend& HEOS) {
         // Load the outputs
         HEOS._phase = iphase_twophase;
     } else {
-        if (HEOS.PhaseEnvelope.built) {
+        // The envelope-guided fast path (PT_Q_flash_mixtures) is only reliable for the dew-
+        // and bubble-point lookups (Q==0 / Q==1), which use newton_raphson_saturation.  For a
+        // genuine two-phase split (0 < Q < 1) it routes to newton_raphson_twophase, which is
+        // both crash-prone and ~1% inaccurate (GH #3192); fall through to the blind
+        // successive-substitution + newton_raphson_saturation path (converges to ~1e-9%).
+        const bool dew_or_bubble = std::abs(HEOS._Q) < 100 * DBL_EPSILON || std::abs(HEOS._Q - 1) < 100 * DBL_EPSILON;
+        if (HEOS.PhaseEnvelope.built && dew_or_bubble) {
             PT_Q_flash_mixtures(HEOS, iT, HEOS._T);
         } else {
             // Set some input options
@@ -1219,7 +1225,10 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend& HEOS) {
             HEOS._T = HEOS.SatL->T();
         }
     } else {
-        if (HEOS.PhaseEnvelope.built) {
+        // Only use the envelope fast path for dew/bubble points (Q==0 / Q==1); route genuine
+        // two-phase states (0 < Q < 1) to the blind branch.  See QT_flash above (GH #3192).
+        const bool dew_or_bubble = std::abs(HEOS._Q) < 100 * DBL_EPSILON || std::abs(HEOS._Q - 1) < 100 * DBL_EPSILON;
+        if (HEOS.PhaseEnvelope.built && dew_or_bubble) {
             PT_Q_flash_mixtures(HEOS, iP, HEOS._p);
         } else {
 

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -1419,6 +1419,14 @@ void FlashRoutines::PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend& HEOS, parame
 
     PhaseEnvelopeData& env = HEOS.PhaseEnvelope;
 
+    // The CubicInterp guesses below use a 4-point stencil [i-1 .. i+2], so the envelope must
+    // hold at least 4 points for the index clamps to keep that stencil in range.  A
+    // successfully built envelope always has many more, but guard defensively: too few points
+    // -> throw, so the caller's try/catch falls back to the blind solver (GH #3192).
+    if (env.T.size() < 4) {
+        throw ValueError(format("Phase envelope has too few points (%d) for envelope-guided flash", static_cast<int>(env.T.size())));
+    }
+
     enum quality_options
     {
         SATURATED_LIQUID,
@@ -1453,16 +1461,12 @@ void FlashRoutines::PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend& HEOS, parame
 
             std::size_t& imax = solutions[0];
 
-            // Shift the solution if needed to ensure that imax+2 and imax-1 are both in range
-            if (imax + 2 >= env.T.size()) {
-                imax--;
-            } else if (imax == 0) {
-                imax++;
-            }
-            // Here imax+2 or imax-1 is still possibly out of range:
-            // 1. If imax initially is 1, and env.T.size() <= 3, then imax will become 0.
-            // 2. If imax initially is 0, and env.T.size() <= 2, then imax will become MAX_UINT.
-            // 3. If imax+2 initially is more than env.T.size(), then single decrement will not bring it to range
+            // Clamp imax so the 4-point CubicInterp stencil [imax-1 .. imax+2] stays within
+            // [0, env.T.size()-1].  env.T.size() >= 4 is guaranteed above, so size-3 >= 1 and
+            // the two clamps are consistent (ported from PR #2720, GH #3192).  The previous
+            // imax--/imax++ shift could still leave an index out of range for short envelopes.
+            imax = std::min(imax, env.T.size() - 3);  // ensures imax+2 <= env.T.size()-1
+            imax = std::max(imax, std::size_t(1));    // ensures imax-1 >= 0
 
             SaturationSolvers::newton_raphson_saturation NR;
             SaturationSolvers::newton_raphson_saturation_options IO;
@@ -1535,6 +1539,17 @@ void FlashRoutines::PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend& HEOS, parame
         }
         std::size_t iliq = liquid_solutions[0], ivap = vapor_solutions[0];
 
+        // Clamp ivap and iliq so the 4-point CubicInterp stencil [i-1 .. i+2] below stays
+        // within [0, env.T.size()-1].  Without this an envelope intersection at index 0 or
+        // near the end indexes out of bounds (size_t underflow on i-1) -> UB, which the
+        // try/catch fallback cannot trap.  env.T.size() >= 4 is guaranteed above, so
+        // size-3 >= 1 and the min/max clamps are consistent (ported from PR #2720, GH #3192).
+        const std::size_t Nenv = env.T.size();
+        ivap = std::min(ivap, Nenv - 3);
+        iliq = std::min(iliq, Nenv - 3);
+        ivap = std::max(ivap, std::size_t(1));
+        iliq = std::max(iliq, std::size_t(1));
+
         SaturationSolvers::newton_raphson_twophase NR;
         SaturationSolvers::newton_raphson_twophase_options IO;
         IO.beta = HEOS._Q;
@@ -1599,6 +1614,17 @@ void FlashRoutines::PT_Q_flash_mixtures(HelmholtzEOSMixtureBackend& HEOS, parame
         }
         IO.x[IO.x.size() - 1] = 1 - std::accumulate(IO.x.begin(), IO.x.end() - 1, 0.0);
         IO.y[IO.y.size() - 1] = 1 - std::accumulate(IO.y.begin(), IO.y.end() - 1, 0.0);
+
+        // Refine the envelope-interpolated composition/density guess with a few bounded
+        // successive-substitution steps before the Newton solve.  SS updates x,y via
+        // x_and_y_from_K + normalize, so they stay inside the simplex by construction and the
+        // (damped) Newton-Raphson gets a feasible, fugacity-consistent start, improving
+        // robustness and the round-trip accuracy (ported from PR #2720, GH #3192).  SS runs at
+        // fixed (T,p), so seed both from the interpolated guess; T (or p) is then refined by NR.
+        HEOS._T = IO.T;
+        HEOS._p = IO.p;
+        SaturationSolvers::successive_substitution_guessrho(HEOS, IO.x, IO.y, IO.rhomolar_liq, IO.rhomolar_vap, IO.z, 5);
+
         NR.call(HEOS, IO);
     }
 }

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -948,15 +948,21 @@ void FlashRoutines::QT_flash(HelmholtzEOSMixtureBackend& HEOS) {
         // Load the outputs
         HEOS._phase = iphase_twophase;
     } else {
-        // The envelope-guided fast path (PT_Q_flash_mixtures) is only reliable for the dew-
-        // and bubble-point lookups (Q==0 / Q==1), which use newton_raphson_saturation.  For a
-        // genuine two-phase split (0 < Q < 1) it routes to newton_raphson_twophase, which is
-        // both crash-prone and ~1% inaccurate (GH #3192); fall through to the blind
-        // successive-substitution + newton_raphson_saturation path (converges to ~1e-9%).
-        const bool dew_or_bubble = std::abs(HEOS._Q) < 100 * DBL_EPSILON || std::abs(HEOS._Q - 1) < 100 * DBL_EPSILON;
-        if (HEOS.PhaseEnvelope.built && dew_or_bubble) {
-            PT_Q_flash_mixtures(HEOS, iT, HEOS._T);
-        } else {
+        // With a phase envelope available, try the envelope-guided fast path: it warm-starts
+        // the dew/bubble and two-phase solves from the envelope.  The two-phase solver now
+        // damps its Newton step and reports non-convergence rather than returning a stale
+        // guess (GH #3192); as a safety net, any failure falls back to the blind
+        // successive-substitution + newton_raphson_saturation path, which is robust to ~1e-9%.
+        bool solved_with_envelope = false;
+        if (HEOS.PhaseEnvelope.built) {
+            try {
+                PT_Q_flash_mixtures(HEOS, iT, HEOS._T);
+                solved_with_envelope = true;
+            } catch (...) {
+                solved_with_envelope = false;  // fall back to the blind solver below
+            }
+        }
+        if (!solved_with_envelope) {
             // Set some input options
             SaturationSolvers::mixture_VLE_IO options;
             options.sstype = SaturationSolvers::imposed_T;
@@ -1225,12 +1231,19 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend& HEOS) {
             HEOS._T = HEOS.SatL->T();
         }
     } else {
-        // Only use the envelope fast path for dew/bubble points (Q==0 / Q==1); route genuine
-        // two-phase states (0 < Q < 1) to the blind branch.  See QT_flash above (GH #3192).
-        const bool dew_or_bubble = std::abs(HEOS._Q) < 100 * DBL_EPSILON || std::abs(HEOS._Q - 1) < 100 * DBL_EPSILON;
-        if (HEOS.PhaseEnvelope.built && dew_or_bubble) {
-            PT_Q_flash_mixtures(HEOS, iP, HEOS._p);
-        } else {
+        // Try the envelope-guided fast path when an envelope is available; on any failure fall
+        // back to the blind successive-substitution + newton_raphson_saturation path.  See
+        // QT_flash above (GH #3192).
+        bool solved_with_envelope = false;
+        if (HEOS.PhaseEnvelope.built) {
+            try {
+                PT_Q_flash_mixtures(HEOS, iP, HEOS._p);
+                solved_with_envelope = true;
+            } catch (...) {
+                solved_with_envelope = false;  // fall back to the blind solver below
+            }
+        }
+        if (!solved_with_envelope) {
 
             // Set some input options
             SaturationSolvers::mixture_VLE_IO io;

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -1630,8 +1630,15 @@ void SaturationSolvers::newton_raphson_twophase::call(HelmholtzEOSMixtureBackend
         // inside (0,1), backed off by step_safety so it stays strictly interior.
         double tau = 1.0;
         const double step_safety = 0.8;
+        // The dependent mole fractions x[N-1] = 1 - sum(x[0..N-2]) and y[N-1] likewise change by
+        // minus the sum of the independent steps; accumulate those so the dependent component is
+        // bounded to (0,1) too (otherwise it can still overshoot for N>=3 and reintroduce the
+        // non-finite fugacity path this damping is meant to prevent).
+        double dx_last = 0.0, dy_last = 0.0;
         for (std::size_t i = 0; i < N - 1; ++i) {
             const double dx = v[i], dy = v[i + (N - 1)];
+            dx_last -= dx;
+            dy_last -= dy;
             if (x[i] + dx <= 0.0) {
                 tau = std::min(tau, step_safety * (-x[i] / dx));
             } else if (x[i] + dx >= 1.0) {
@@ -1642,6 +1649,18 @@ void SaturationSolvers::newton_raphson_twophase::call(HelmholtzEOSMixtureBackend
             } else if (y[i] + dy >= 1.0) {
                 tau = std::min(tau, step_safety * ((1.0 - y[i]) / dy));
             }
+        }
+        // Bound the dependent (Nth) mole fraction with the same rule.
+        const double x_last = x[N - 1], y_last = y[N - 1];
+        if (x_last + dx_last <= 0.0) {
+            tau = std::min(tau, step_safety * (-x_last / dx_last));
+        } else if (x_last + dx_last >= 1.0) {
+            tau = std::min(tau, step_safety * ((1.0 - x_last) / dx_last));
+        }
+        if (y_last + dy_last <= 0.0) {
+            tau = std::min(tau, step_safety * (-y_last / dy_last));
+        } else if (y_last + dy_last >= 1.0) {
+            tau = std::min(tau, step_safety * ((1.0 - y_last) / dy_last));
         }
 
         for (unsigned int i = 0; i < N - 1; ++i) {

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -1611,42 +1611,75 @@ void SaturationSolvers::newton_raphson_twophase::call(HelmholtzEOSMixtureBackend
         // Build the Jacobian and residual vectors
         build_arrays();
 
+        // A previous step may have left the composition/density infeasible, making the
+        // fugacity (hence the residual) non-finite.  Fail loudly so the caller falls back
+        // to the blind solver, rather than letting "NaN > tol == false" silently exit the
+        // loop and return a stale, unconverged state (GH #3192 follow-up).
+        if (!ValidNumber(error_rms)) {
+            throw ValueError("newton_raphson_twophase::call produced a non-finite residual");
+        }
+
         // Solve for the step; v is the step with the contents
         // [delta(x_0), delta(x_1), ..., delta(x_{N-2}), delta(spec)]
-
-        // Uncomment to see Jacobian and residual at every step
-        // std::cout << vec_to_string(J, "%0.12Lg") << std::endl;
-        // std::cout << vec_to_string(negative_r, "%0.12Lg") << std::endl;
-
         Eigen::VectorXd v = J.colPivHouseholderQr().solve(-r);
 
+        // Damp the Newton step so neither phase composition leaves the open interval (0,1).
+        // An undamped step routinely overshoots (x_i < 0 or y_i > 1); the next fugacity
+        // evaluation then returns NaN and the solve diverges (GH #3192 follow-up).  tau is
+        // the largest fraction of the full step that keeps every stepped mole fraction
+        // inside (0,1), backed off by step_safety so it stays strictly interior.
+        double tau = 1.0;
+        const double step_safety = 0.8;
+        for (std::size_t i = 0; i < N - 1; ++i) {
+            const double dx = v[i], dy = v[i + (N - 1)];
+            if (x[i] + dx <= 0.0) {
+                tau = std::min(tau, step_safety * (-x[i] / dx));
+            } else if (x[i] + dx >= 1.0) {
+                tau = std::min(tau, step_safety * ((1.0 - x[i]) / dx));
+            }
+            if (y[i] + dy <= 0.0) {
+                tau = std::min(tau, step_safety * (-y[i] / dy));
+            } else if (y[i] + dy >= 1.0) {
+                tau = std::min(tau, step_safety * ((1.0 - y[i]) / dy));
+            }
+        }
+
         for (unsigned int i = 0; i < N - 1; ++i) {
-            err_rel[i] = v[i] / x[i];
-            x[i] += v[i];
-            err_rel[i + (N - 1)] = v[i + (N - 1)] / y[i];
-            y[i] += v[i + (N - 1)];
+            err_rel[i] = tau * v[i] / x[i];
+            x[i] += tau * v[i];
+            err_rel[i + (N - 1)] = tau * v[i + (N - 1)] / y[i];
+            y[i] += tau * v[i + (N - 1)];
         }
         x[N - 1] = 1 - std::accumulate(x.begin(), x.end() - 1, 0.0);
         y[N - 1] = 1 - std::accumulate(y.begin(), y.end() - 1, 0.0);
 
         if (imposed_variable == newton_raphson_twophase_options::P_IMPOSED) {
-            T += v[2 * N - 2];
-            err_rel[2 * N - 2] = v[2 * N - 2] / T;
+            T += tau * v[2 * N - 2];
+            err_rel[2 * N - 2] = tau * v[2 * N - 2] / T;
         } else if (imposed_variable == newton_raphson_twophase_options::T_IMPOSED) {
-            p += v[2 * N - 2];
-            err_rel[2 * N - 2] = v[2 * N - 2] / p;
+            p += tau * v[2 * N - 2];
+            err_rel[2 * N - 2] = tau * v[2 * N - 2] / p;
         } else {
             throw ValueError("invalid imposed_variable");
         }
-        //std::cout << format("\t%Lg ", this->error_rms) << T << " " << rhomolar_liq << " " << rhomolar_vap << " v " << vec_to_string(v, "%0.10Lg")  << " x " << vec_to_string(x, "%0.10Lg") << " r " << vec_to_string(r, "%0.10Lg") << std::endl;
 
-        min_rel_change = err_rel.cwiseAbs().minCoeff();
+        // Stop only when the LARGEST relative change is small (maxCoeff, not minCoeff: a
+        // single near-stationary variable must not terminate the iteration prematurely).
+        min_rel_change = err_rel.cwiseAbs().maxCoeff();
         iter++;
 
         if (iter == IO.Nstep_max) {
-            throw ValueError(format("newton_raphson_saturation::call reached max number of iterations [%d]", IO.Nstep_max));
+            throw ValueError(format("newton_raphson_twophase::call reached max number of iterations [%d]", IO.Nstep_max));
         }
     } while (this->error_rms > 1e-9 && min_rel_change > 1000 * DBL_EPSILON && iter < IO.Nstep_max);
+
+    // Refresh the residual at the final iterate (this also leaves SatL/SatV holding the
+    // converged state) and require genuine convergence; otherwise signal failure so the
+    // caller can fall back to the blind solver instead of returning the last guess.
+    build_arrays();
+    if (!ValidNumber(error_rms) || error_rms > 1e-7) {
+        throw ValueError(format("newton_raphson_twophase::call did not converge (error_rms = %g)", static_cast<double>(error_rms)));
+    }
 
     IO.Nsteps = iter;
     IO.p = p;
@@ -1664,6 +1697,13 @@ void SaturationSolvers::newton_raphson_twophase::call(HelmholtzEOSMixtureBackend
 void SaturationSolvers::newton_raphson_twophase::build_arrays() {
     // References to the classes for concision
     HelmholtzEOSMixtureBackend &rSatL = *(HEOS->SatL.get()), &rSatV = *(HEOS->SatV.get());
+
+    // Zero the Jacobian first: the beta-constraint rows (k = N .. 2N-2) below only write the
+    // two mole-fraction columns the constraint depends on; the imposed-variable (T/p) column,
+    // and for N>=3 the off-diagonal mole-fraction columns, are left untouched and their true
+    // value is 0.  Eigen::resize() does not zero storage, so without this those entries are
+    // uninitialized memory feeding the Newton solve (GH #3192 follow-up).
+    J.setZero();
 
     // Step 0:
     // -------

--- a/src/Backends/Helmholtz/VLERoutines.h
+++ b/src/Backends/Helmholtz/VLERoutines.h
@@ -398,7 +398,10 @@ class newton_raphson_twophase
     bool logging;
     int Nsteps;
     Eigen::MatrixXd J;
-    Eigen::Vector2d r, err_rel;
+    // r and err_rel hold 2N-1 residuals/relative-errors (see class docstring), so they MUST
+    // be dynamically sized.  They were Eigen::Vector2d (fixed size 2), which overflowed for
+    // every mixture (N>=2 -> 2N-1>=3) and hard-crashed via out-of-bounds writes (GH #3192).
+    Eigen::VectorXd r, err_rel;
     std::vector<CoolPropDbl> K, x, y, z;
     std::vector<SuccessiveSubstitutionStep> step_logger;
 

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -753,6 +753,66 @@ TEST_CASE("PT flash with built phase envelope", "[michelsen][phase_envelope]") {
     }
 }
 
+TEST_CASE("PQ/QT flash with built envelope at 0<Q<1 (GH #3192)", "[michelsen][phase_envelope]") {
+    // Regression for GH #3192.  With a built phase envelope a mixture PQ/QT flash for a
+    // genuine two-phase state (0 < Q < 1) used to route to newton_raphson_twophase, whose
+    // residual vectors r/err_rel were Eigen::Vector2d (fixed size 2) but need 2N-1 (>=3)
+    // entries -> out-of-bounds write -> HARD CRASH (process abort, not a C++ exception, so it
+    // cannot be caught — pre-fix this test binary terminates here).  These states are now
+    // routed to the accurate blind branch (newton_raphson_saturation), which must (a) not
+    // crash and (b) match the blind (no-envelope) flash closely.
+    std::vector<double> z = {0.5, 0.5};
+
+    auto make_pe = [&]() {
+        auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", "Methane&Ethane"));
+        AS->set_mole_fractions(z);
+        AS->build_phase_envelope("");
+        return AS;
+    };
+    auto make_blind = [&]() {
+        auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", "Methane&Ethane"));
+        AS->set_mole_fractions(z);
+        return AS;
+    };
+
+    SECTION("PQ flash, P=1e5, Q=0.5 (exact reporter repro)") {
+        auto AS = make_pe();
+        auto ref = make_blind();
+        // Guard: the fix is only exercised if the envelope is actually built; otherwise the
+        // dispatch already falls through to the blind branch and the test is vacuous.
+        REQUIRE(AS->get_phase_envelope_data().built);
+        CHECK_NOTHROW(AS->update(PQ_INPUTS, 1e5, 0.5));
+        ref->update(PQ_INPUTS, 1e5, 0.5);
+        CHECK(AS->phase() == iphase_twophase);
+        CHECK(std::isfinite(AS->T()));
+        CHECK(AS->T() == Catch::Approx(ref->T()).epsilon(1e-6));
+        CHECK(AS->rhomolar() == Catch::Approx(ref->rhomolar()).epsilon(1e-6));
+    }
+
+    SECTION("QT flash, Q=0.5, T=180 K") {
+        auto AS = make_pe();
+        auto ref = make_blind();
+        REQUIRE(AS->get_phase_envelope_data().built);
+        CHECK_NOTHROW(AS->update(QT_INPUTS, 0.5, 180.0));
+        ref->update(QT_INPUTS, 0.5, 180.0);
+        CHECK(AS->phase() == iphase_twophase);
+        CHECK(AS->p() == Catch::Approx(ref->p()).epsilon(1e-6));
+        CHECK(AS->rhomolar() == Catch::Approx(ref->rhomolar()).epsilon(1e-6));
+    }
+
+    SECTION("Dew/bubble (Q==0, Q==1) still use the envelope fast path and stay accurate") {
+        auto AS = make_pe();
+        auto ref = make_blind();
+        REQUIRE(AS->get_phase_envelope_data().built);
+        CHECK_NOTHROW(AS->update(PQ_INPUTS, 1e5, 1.0));  // dew point
+        ref->update(PQ_INPUTS, 1e5, 1.0);
+        CHECK(AS->T() == Catch::Approx(ref->T()).epsilon(1e-6));
+        CHECK_NOTHROW(AS->update(PQ_INPUTS, 1e5, 0.0));  // bubble point
+        ref->update(PQ_INPUTS, 1e5, 0.0);
+        CHECK(AS->T() == Catch::Approx(ref->T()).epsilon(1e-6));
+    }
+}
+
 // ============================================================================
 // Phase-envelope-guided PT flash tests
 //

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -758,9 +758,10 @@ TEST_CASE("PQ/QT flash with built envelope at 0<Q<1 (GH #3192)", "[michelsen][ph
     // genuine two-phase state (0 < Q < 1) used to route to newton_raphson_twophase, whose
     // residual vectors r/err_rel were Eigen::Vector2d (fixed size 2) but need 2N-1 (>=3)
     // entries -> out-of-bounds write -> HARD CRASH (process abort, not a C++ exception, so it
-    // cannot be caught — pre-fix this test binary terminates here).  These states are now
-    // routed to the accurate blind branch (newton_raphson_saturation), which must (a) not
-    // crash and (b) match the blind (no-envelope) flash closely.
+    // cannot be caught — pre-fix this test binary terminates here).  The two-phase solver is
+    // now hardened (step damping + non-finite/convergence guards), so the envelope fast path
+    // is used and must (a) not crash and (b) match the blind (no-envelope) flash closely; any
+    // solver failure falls back to the blind path.
     std::vector<double> z = {0.5, 0.5};
 
     auto make_pe = [&]() {
@@ -811,6 +812,39 @@ TEST_CASE("PQ/QT flash with built envelope at 0<Q<1 (GH #3192)", "[michelsen][ph
         ref->update(PQ_INPUTS, 1e5, 0.0);
         CHECK(AS->T() == Catch::Approx(ref->T()).epsilon(1e-6));
     }
+
+    SECTION("pq -> pt -> q roundtrip recovers the imposed quality") {
+        // The reporter's accuracy metric: a two-phase PQ flash followed by a PT flash at the
+        // recovered T must return the original quality.  Before the rework the envelope branch
+        // returned its unconverged interpolation guess and the roundtrip was off by ~0.4%.
+        auto AS = make_pe();
+        REQUIRE(AS->get_phase_envelope_data().built);
+        AS->update(PQ_INPUTS, 1e5, 0.5);
+        const double T_2ph = AS->T();
+        auto rt = make_blind();
+        rt->update(PT_INPUTS, 1e5, T_2ph);
+        CHECK(rt->Q() == Catch::Approx(0.5).epsilon(1e-4));
+    }
+}
+
+TEST_CASE("PQ flash with built envelope, ternary two-phase (GH #3192, N>=3)", "[michelsen][phase_envelope]") {
+    // Locks in N>=3.  The Newton-step damping bounds only the N-1 independent mole fractions,
+    // so for ternary+ mixtures the dependent component's feasibility leans on the
+    // throw -> blind-fallback safety net.  A ternary two-phase PQ flash must still converge and
+    // match the blind solver (verified during review to ~1e-9 across 0.5-4 MPa).
+    std::vector<double> z = {0.4, 0.35, 0.25};
+    auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", "Methane&Ethane&Propane"));
+    AS->set_mole_fractions(z);
+    AS->build_phase_envelope("");
+    auto ref = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", "Methane&Ethane&Propane"));
+    ref->set_mole_fractions(z);
+
+    CHECK_NOTHROW(AS->update(PQ_INPUTS, 1e6, 0.5));
+    ref->update(PQ_INPUTS, 1e6, 0.5);
+    CHECK(AS->phase() == iphase_twophase);
+    CHECK(std::isfinite(AS->T()));
+    CHECK(AS->T() == Catch::Approx(ref->T()).epsilon(1e-5));
+    CHECK(AS->rhomolar() == Catch::Approx(ref->rhomolar()).epsilon(1e-5));
 }
 
 // ============================================================================

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -828,14 +828,16 @@ TEST_CASE("PQ/QT flash with built envelope at 0<Q<1 (GH #3192)", "[michelsen][ph
 }
 
 TEST_CASE("PQ flash with built envelope, ternary two-phase (GH #3192, N>=3)", "[michelsen][phase_envelope]") {
-    // Locks in N>=3.  The Newton-step damping bounds only the N-1 independent mole fractions,
-    // so for ternary+ mixtures the dependent component's feasibility leans on the
-    // throw -> blind-fallback safety net.  A ternary two-phase PQ flash must still converge and
-    // match the blind solver (verified during review to ~1e-9 across 0.5-4 MPa).
+    // Locks in N>=3.  The Newton-step damping bounds the dependent mole fraction x[N-1]=1-sum as
+    // well as the N-1 independent ones, so a ternary two-phase PQ flash must converge through the
+    // envelope path and match the blind solver (verified during review to ~1e-9 across 0.5-4 MPa).
     std::vector<double> z = {0.4, 0.35, 0.25};
     auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", "Methane&Ethane&Propane"));
     AS->set_mole_fractions(z);
     AS->build_phase_envelope("");
+    // Guard against vacuous coverage: if the envelope did not build, the dispatch would silently
+    // use the blind path and this test would no longer exercise the envelope-guided solver.
+    REQUIRE(AS->get_phase_envelope_data().built);
     auto ref = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", "Methane&Ethane&Propane"));
     ref->set_mole_fractions(z);
 


### PR DESCRIPTION
## Description

Fixes #3192 (reported by @jakobreichert). With a phase envelope built (`PhaseEnvelope.built == true`), a mixture **PQ/QT flash for a genuine two-phase state (0 < Q < 1)** routed through `FlashRoutines::PT_Q_flash_mixtures → SaturationSolvers::newton_raphson_twophase` and:

1. **Hard-crashed** — `r`/`err_rel` were `Eigen::Vector2d` (fixed size 2) but the solver has `2N-1 ≥ 3` unknowns; `build_arrays` wrote `r[i+N]` out of bounds → UB (no C++ exception, the process just exits). This was masked when `build_phase_envelope()` exited early (`built == false`), since PQ then silently used the blind branch.
2. **Did not converge even after the crash fix** — the undamped Newton step drove mole fractions outside (0,1), the fugacity went non-finite, `error_rms` became NaN, and `while (error_rms > 1e-9 ...)` silently exited on the NaN, returning the raw envelope-interpolation guess (~0.4–1% off, matching the reporter's round-trip error).

## The fix (3 commits)

1. `Eigen::Vector2d → Eigen::VectorXd` for `r`/`err_rel` (the crash fix @jakobreichert identified in the issue).
2. Harden `newton_raphson_twophase`: damp the Newton step to keep both phase compositions strictly inside (0,1); throw on a non-finite residual instead of silently exiting on NaN; `J.setZero()` (the β-constraint rows left the imposed-variable column — and, for N≥3, off-diagonal columns — uninitialized); switch the relative-change stop from `minCoeff` to `maxCoeff`; re-evaluate and require genuine convergence at the end. Re-enable the envelope fast path in `QT_flash`/`PQ_flash`, wrapped in `try/catch` → blind-solver fallback (mirrors the `PT_flash_mixtures` pattern).
3. Adopt two improvements from @jakobreichert's #2720: `std::min`/`std::max` index clamps (+ a `size ≥ 4` precondition) on `imax`/`ivap`/`iliq` in `PT_Q_flash_mixtures` — fixing a separate latent out-of-bounds read the `try/catch` cannot trap — and a short bounded successive-substitution warm-start before the Newton solve, reusing the `successive_substitution_guessrho` that already landed on master via #3168/#3174.

## Credit

- **@jakobreichert** reported #3192, identified the `Vector2d → VectorXd` fix, and authored #2720, from which the index clamps and the SS warm-start are adapted (co-author trailer on the relevant commit).
- This is **complementary to #2720**, not a replacement: #2720's robust two-phase engine (`successive_substitution_guessrho → PTflash_twophase`/`solve_michelsen`) is **PT-only** (β is an output), so it cannot solve the β-imposed PQ/QT problem (where T or p is the unknown); that path needs the hardened `newton_raphson_twophase`.

## Tests

New `[michelsen][phase_envelope]` cases: PQ/QT two-phase + dew/bubble vs the blind flash, a `pq → pt → q` round-trip recovering the imposed quality, and a ternary (N≥3) case. Verified across PR/SRK/HEOS at N = 2,3,4 — envelope results match the blind flash and the round-trip recovers Q. Suites green: `[phase_envelope]`, `[michelsen]`, `[flash]`, `[mixture(s)]`, `[PDflash]`.

## Notes

- Scope is **correctness**, not speed: a clean envelope-vs-blind benchmark shows the imposed-Q envelope path is ~parity-to-slower than blind (it has no stability step to skip, unlike the PT path), so the value here is that the path no longer crashes / returns wrong results when an envelope is built.
- Local preflight's `cppcheck`/`clang-tidy` run whole-file and flag only **pre-existing** debt in the touched files (e.g. `enum quality_options`, a `TEST_CASE` macro false-positive, `duplInheritedMember` in an untouched header) — none on the changed lines; the diff-only CI lint is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stability and accuracy of phase-envelope-guided two-phase flash calculations for both `PT`, `PQ`, and `QT` workflows.
  * Added safer fallback behavior when envelope interpolation is not applicable, and improved handling near bubble/dew endpoints.
  * Strengthened Newton-based two-phase convergence by rejecting non-finite residuals, applying damped updates, and ensuring genuine convergence before returning results.

* **Tests**
  * Added regression coverage for `PQ`/`QT` flashes using built phase envelopes for binary and ternary methane/ethane/propane mixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->