### PR TITLE
docs: add SignPath code-signing sponsor attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ It was originally developed by Ian Bell, at the time a post-doc at the Universit
 * [Contributions](https://github.com/CoolProp/CoolProp/blob/master/.github/CONTRIBUTING.md) to this project are welcomed and encouraged! If you wish to [contribute](https://github.com/CoolProp/CoolProp/blob/master/.github/CONTRIBUTING.md) bug fixes, patches, or new features, wrappers, or material properties, please submit a Pull Request with your code.
 
 * If you are new to Git and Github, please see the [CoolProp Wiki](https://github.com/CoolProp/CoolProp/wiki) for guidance on becoming a contributor to the project.
+
+## Sponsors
+
+Free code signing on Windows provided by [SignPath.io](https://about.signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).

--- a/wrappers/GUI/src/App.css
+++ b/wrappers/GUI/src/App.css
@@ -294,6 +294,17 @@ button.primary:disabled {
   overflow: auto;
 }
 
+.about-sponsors {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid #e0e0e0;
+}
+
+.about-sponsors-title {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
 .about-notices summary {
   cursor: pointer;
   font-weight: 500;

--- a/wrappers/GUI/src/components/AboutModal.tsx
+++ b/wrappers/GUI/src/components/AboutModal.tsx
@@ -37,6 +37,25 @@ export default function AboutModal({ onClose }: Props) {
             </a>
           </p>
 
+          <div className="about-sponsors">
+            <div className="about-sponsors-title">Sponsors</div>
+            <p>
+              Free code signing on Windows provided by{" "}
+              <a
+                href="https://about.signpath.io/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                SignPath.io
+              </a>
+              , certificate by{" "}
+              <a href="https://signpath.org/" target="_blank" rel="noreferrer">
+                SignPath Foundation
+              </a>
+              .
+            </p>
+          </div>
+
           <details className="about-notices">
             <summary>Third-party notices</summary>
             <pre className="about-notices-pre">{NOTICES}</pre>


### PR DESCRIPTION
Adds the required [SignPath](https://signpath.org/) OSS-program attribution for the free Windows code-signing certificate.

## Changes
- **README.md** — new `## Sponsors` section.
- **wrappers/GUI/src/components/AboutModal.tsx** — "Sponsors" block in the desktop GUI About modal, with links to SignPath.io and SignPath Foundation (matching the existing external-link pattern: `target="_blank" rel="noreferrer"`).
- **wrappers/GUI/src/App.css** — styling for the new sponsors block.

Attribution text:

> Free code signing on Windows provided by [SignPath.io](https://about.signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).

Docs/GUI-only; no C/C++ changes. CI skipped via `[skip ci]` in the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a Sponsors section in the About modal, featuring supporters of free code signing capabilities on Windows with direct links to provider information.

* **Documentation**
  * Added a Sponsors section to the README acknowledging organizations providing code signing support to the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->