### PR TITLE
fix(SVDSBTL): classify exact bubble/dew-line caloric inputs as two-phase (#3190)

### DIFF
--- a/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
+++ b/include/CoolProp/Backends/SVDSBTL/SVDSBTLBackend.h
@@ -375,6 +375,22 @@ class SVDSBTLBackend : public AbstractState
     [[nodiscard]] double sat_T_from_p_(double p);
     [[nodiscard]] double sat_eval_(double T, char what, int side);
 
+    // Near-dome reclassification guard for a single-phase atlas hit
+    // (issue #3190).  The atlas LIQUID/VAPOR regions' dome-side boundary
+    // is an interpolated saturation curve that can disagree with the
+    // authoritative sat endpoints by its fit error (~1 J/kg), so a point
+    // sitting on the true bubble/dew line resolves single-phase instead
+    // of two-phase.  When the resolved point is within a thin eta band of
+    // a region edge, this re-tests it against the same saturation
+    // provider the forward PQ flash uses.  `what` is 'H' (HmassP/HmolarP)
+    // or 'S' (PSmass/PSmolar); `value_mass` is the mass-basis h or s.
+    // Uses ONLY the fast sat provider (SA -> surrogate): if no provider
+    // is available it returns false (leaving `pt` untouched) so the
+    // single-phase hot path never pays for an expensive source-PQ flash.
+    // Returns true and rewrites `pt` to a DomeBlend iff the point is
+    // genuinely inside the dome (yL <= y <= yV, boundary inclusive).
+    [[nodiscard]] bool try_fast_dome_reclassify_(PointEvaluation& pt, char what, double p_val, double value_mass);
+
     std::string fluid_name_;
     std::string source_backend_;               // "HEOS" / "REFPROP" / "IF97"
     std::vector<CoolPropDbl> mole_fractions_;  // always {1.0}

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -60,6 +60,15 @@ namespace {
 constexpr std::array<CoolProp::input_pairs, 4> kSupportedPairs = {CoolProp::HmassP_INPUTS, CoolProp::PT_INPUTS, CoolProp::DmassT_INPUTS,
                                                                   CoolProp::PSmass_INPUTS};
 
+// Quality tolerance for the #3190 dome-edge guards.  A Q=0/1 round-trip
+// (y_mass = y_sat/M forward, y_mol = y_mass*M back) is not bit-exact, so an
+// input sitting on the saturation boundary can land a few ULP outside
+// [yL, yV].  Accepting within this band (and clamping Q to [0, 1]) keeps the
+// round-trip two-phase; matches the +/-1e-9 Q band HEOS p_phase_determination
+// uses at the dome edge.  Shared by try_fast_dome_reclassify_ (atlas-hit path)
+// and both atlas-miss dome-blend blocks in resolve_point_.
+constexpr double kDomeQTol = 1e-9;
+
 // Resolved grid-shape knobs extracted from the validated options
 // document.  Used both to size the per-input-pair surfaces and to
 // stamp the canonical-options form into the cache filename.
@@ -1034,11 +1043,9 @@ bool SVDSBTLBackend::try_fast_dome_reclassify_(PointEvaluation& pt, char what, d
     const double Q = (y_mol - yL) / (yV - yL);
     // Boundary inclusive, with a small tolerance band so a round-trip
     // input that lands a few ULP outside [yL, yV] (h(p, Q=0) re-flashed
-    // is yL +/- rounding) still classifies two-phase.  Mirrors the
-    // +/-1e-9 Q band HEOS's own p_phase_determination uses at the dome
-    // edge.  Outside the band the point is genuinely single-phase.
-    constexpr double kQtol = 1e-9;
-    if (Q < -kQtol || Q > 1.0 + kQtol) {
+    // is yL +/- rounding) still classifies two-phase.  Outside the band
+    // the point is genuinely single-phase.  See kDomeQTol.
+    if (Q < -kDomeQTol || Q > 1.0 + kDomeQTol) {
         return false;
     }
     pt.kind = PointEvaluation::Kind::DomeBlend;
@@ -1463,14 +1470,21 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
             } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
             }
         }
-        if (sat_resolved) {
+        if (sat_resolved && hV_mol > hL_mol) {
             const double h_mol = h_mass * M;
-            if (hL_mol <= h_mol && h_mol <= hV_mol) {
+            const double Qd = (h_mol - hL_mol) / (hV_mol - hL_mol);
+            // Tolerance + clamp (issue #3190): a Q=0/1 round-trip can land a
+            // ULP outside [hL, hV] -- the forward h_mass = hV/M then back
+            // h_mol = h_mass*M re-scaling is not bit-exact -- which a strict
+            // containment check would drop to OutOfRange (reported Q=-inf).
+            // Accept within kDomeQTol of the dome and clamp Q onto [0, 1].
+            // Mirrors try_fast_dome_reclassify_ on the atlas-hit path.
+            if (Qd >= -kDomeQTol && Qd <= 1.0 + kDomeQTol) {
                 pt.kind = PointEvaluation::Kind::DomeBlend;
                 pt.status = CoolProp::fast_evaluate_ok;
                 pt.T = T_sat;
                 pt.T_sat = T_sat;
-                pt.Q = (h_mol - hL_mol) / (hV_mol - hL_mol);
+                pt.Q = std::min(1.0, std::max(0.0, Qd));
                 pt.hL_mol = hL_mol;
                 pt.hV_mol = hV_mol;
                 pt.rhoL_mol = rhoL_mol_seed;
@@ -1523,14 +1537,19 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
             } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)
             }
         }
-        if (sat_resolved) {
+        if (sat_resolved && sV_mol > sL_mol) {
             const double s_mol = s_mass * M;
-            if (sL_mol <= s_mol && s_mol <= sV_mol) {
+            const double Qd = (s_mol - sL_mol) / (sV_mol - sL_mol);
+            // Tolerance + clamp (issue #3190): entropy twin of the HmassP
+            // atlas-miss block above -- a Q=0/1 round-trip can land a ULP
+            // outside [sL, sV] and a strict check would drop it to
+            // OutOfRange (reported Q=-inf).  Accept within kDomeQTol, clamp [0,1].
+            if (Qd >= -kDomeQTol && Qd <= 1.0 + kDomeQTol) {
                 pt.kind = PointEvaluation::Kind::DomeBlend;
                 pt.status = CoolProp::fast_evaluate_ok;
                 pt.T = T_sat;
                 pt.T_sat = T_sat;
-                pt.Q = (s_mol - sL_mol) / (sV_mol - sL_mol);
+                pt.Q = std::min(1.0, std::max(0.0, Qd));
                 pt.sL_mol = sL_mol;
                 pt.sV_mol = sV_mol;
                 pt.rhoL_mol = rhoL_mol_seed;

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -1009,6 +1009,58 @@ void SVDSBTLBackend::ensure_surface_(CoolProp::input_pairs pair) {
     surfaces_[static_cast<int>(pair)] = std::move(surface);
 }
 
+// Near-dome reclassification guard (issue #3190).  See header for the
+// full rationale.  Fast-only: never falls back to source-PQ, so the
+// single-phase hot path stays cheap.  Leaves `pt` untouched on a false
+// return (the caller then accepts the atlas single-phase classification).
+bool SVDSBTLBackend::try_fast_dome_reclassify_(PointEvaluation& pt, char what, double p_val, double value_mass) {
+    double T_sat = std::numeric_limits<double>::quiet_NaN();
+    double yL = std::numeric_limits<double>::quiet_NaN();
+    double yV = std::numeric_limits<double>::quiet_NaN();
+    try {
+        T_sat = sat_T_from_p_(p_val);
+        if (!std::isfinite(T_sat)) {
+            return false;
+        }
+        yL = sat_eval_(T_sat, what, 0);
+        yV = sat_eval_(T_sat, what, 1);
+    } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch) — mirrors the atlas-miss dome blend
+        return false;
+    }
+    if (!std::isfinite(yL) || !std::isfinite(yV) || !(yV > yL)) {
+        return false;
+    }
+    const double y_mol = value_mass * calc_molar_mass();
+    const double Q = (y_mol - yL) / (yV - yL);
+    // Boundary inclusive, with a small tolerance band so a round-trip
+    // input that lands a few ULP outside [yL, yV] (h(p, Q=0) re-flashed
+    // is yL +/- rounding) still classifies two-phase.  Mirrors the
+    // +/-1e-9 Q band HEOS's own p_phase_determination uses at the dome
+    // edge.  Outside the band the point is genuinely single-phase.
+    constexpr double kQtol = 1e-9;
+    if (Q < -kQtol || Q > 1.0 + kQtol) {
+        return false;
+    }
+    pt.kind = PointEvaluation::Kind::DomeBlend;
+    pt.status = CoolProp::fast_evaluate_ok;
+    pt.T = T_sat;
+    pt.T_sat = T_sat;
+    // Clamp sub-tolerance noise onto [0, 1] so the saturated endpoint
+    // reports exactly Q=0 / Q=1 and the lever rule returns rhoL / rhoV.
+    pt.Q = std::min(1.0, std::max(0.0, Q));
+    // Stash the endpoints we already computed so the DomeBlend caloric
+    // arms don't re-evaluate them; the opposite-property and rho
+    // endpoints stay lazy (ensure_dome_*_endpoints_).
+    if (what == 'H') {
+        pt.hL_mol = yL;
+        pt.hV_mol = yV;
+    } else {  // 'S'
+        pt.sL_mol = yL;
+        pt.sV_mol = yV;
+    }
+    return true;
+}
+
 // resolve_point_: the shared kernel called by both update() and
 // fast_evaluate().  Maps (input_pair, v1, v2) to a PointEvaluation
 // without mutating any backend state.  The same routing logic — input-
@@ -1334,6 +1386,36 @@ SVDSBTLBackend::PointEvaluation SVDSBTLBackend::resolve_point_(CoolProp::input_p
     // (for PT or genuinely OOB HmassP).
     pt.resolved = surface->resolve(a, b);
     if (pt.resolved.region_idx >= 0) {
+        // Near-dome guard (issue #3190).  The atlas single-phase regions'
+        // dome-side boundary is an interpolated sat curve whose fit error
+        // makes it overshoot the true bubble/dew line, so a caloric input
+        // sitting exactly on the saturation boundary resolves single-phase
+        // (Q = -1) instead of two-phase.  resolve() returns the secondary-
+        // axis (h / s) normalised coordinate eta in svd_x; the misclassified
+        // band hugs a region edge (eta -> 1 on the LIQUID dome side, eta ->
+        // 0 on the VAPOR dome side), spanning only ~1e-6 in eta.  When eta
+        // is within a thin band of either edge, re-test against the
+        // authoritative sat provider (the same one the forward PQ flash
+        // uses) so the round-trip is consistent.  kDomeEtaBand must comfortably
+        // exceed the boundary-curve fit error in eta units; 1e-2 leaves a
+        // ~1000x margin while still sparing >98% of single-phase queries
+        // the sat lookup.  The check itself only reclassifies points that
+        // are genuinely in the dome, so the wider band only costs the
+        // occasional wasted (correct) sat eval at a non-dome region edge.
+        constexpr double kDomeEtaBand = 1e-2;
+        const double eta = pt.resolved.svd_x;
+        const bool near_edge = std::isfinite(eta) && (eta < kDomeEtaBand || eta > 1.0 - kDomeEtaBand);
+        if (near_edge) {
+            if (input_pair == CoolProp::HmassP_INPUTS || input_pair == CoolProp::HmolarP_INPUTS) {
+                if (try_fast_dome_reclassify_(pt, 'H', *pt.p, *pt.h_mass)) {
+                    return pt;
+                }
+            } else if (input_pair == CoolProp::PSmass_INPUTS || input_pair == CoolProp::PSmolar_INPUTS) {
+                if (try_fast_dome_reclassify_(pt, 'S', *pt.p, *pt.s_mass)) {
+                    return pt;
+                }
+            }
+        }
         pt.kind = PointEvaluation::Kind::SinglePhase;
         pt.status = CoolProp::fast_evaluate_ok;
         return pt;

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -272,6 +272,51 @@ TEST_CASE("SVDSBTL backend HmassP_INPUTS dome-hit routes to two-phase blend", "[
     }
 }
 
+TEST_CASE("SVDSBTL backend HmassP_INPUTS on the bubble/dew line stays two-phase (issue #3190)",
+          "[SVDSBTL][twophase][hp_dome][regression][issue_3190][water][slow]") {
+    // Round-trip h(p, Q) -> (p, h) on the saturation boundary itself.
+    // The atlas single-phase regions' dome-side boundary is an
+    // interpolated sat curve that overshoots the true bubble/dew line by
+    // its fit error, so a point sitting EXACTLY on the boundary used to
+    // resolve single-phase (Q=-1, iphase_not_imposed).  The near-dome
+    // eta guard must reclassify it as two-phase with Q == Q_in.
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
+
+    const double p_tri = AS->p_triple();
+    const double p_crit = AS->p_critical();
+    for (const double Q_in : {0.0, 1.0}) {
+        for (int i = 1; i <= 12; ++i) {
+            const double p = p_tri + (p_crit - p_tri) * (static_cast<double>(i) / 13.0);
+            AS->update(CoolProp::PQ_INPUTS, p, Q_in);
+            const double h = AS->hmass();
+            AS->update(CoolProp::HmassP_INPUTS, h, p);
+            INFO("Q_in=" << Q_in << "  p=" << p << "  h=" << h << "  -> phase=" << AS->phase() << "  Q=" << AS->Q());
+            REQUIRE(AS->phase() == CoolProp::iphase_twophase);
+            REQUIRE(AS->Q() == Approx(Q_in).margin(1e-6));
+        }
+    }
+}
+
+TEST_CASE("SVDSBTL backend PSmass_INPUTS on the bubble/dew line stays two-phase (issue #3190)",
+          "[SVDSBTL][twophase][ps_dome][regression][issue_3190][water][slow]") {
+    // Entropy twin of the HmassP bubble/dew-line round-trip above.
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
+
+    const double p_tri = AS->p_triple();
+    const double p_crit = AS->p_critical();
+    for (const double Q_in : {0.0, 1.0}) {
+        for (int i = 1; i <= 12; ++i) {
+            const double p = p_tri + (p_crit - p_tri) * (static_cast<double>(i) / 13.0);
+            AS->update(CoolProp::PQ_INPUTS, p, Q_in);
+            const double s = AS->smass();
+            AS->update(CoolProp::PSmass_INPUTS, p, s);
+            INFO("Q_in=" << Q_in << "  p=" << p << "  s=" << s << "  -> phase=" << AS->phase() << "  Q=" << AS->Q());
+            REQUIRE(AS->phase() == CoolProp::iphase_twophase);
+            REQUIRE(AS->Q() == Approx(Q_in).margin(1e-6));
+        }
+    }
+}
+
 TEST_CASE("SVDSBTL backend PS lookup matches HEOS within tolerance", "[SVDSBTL][ps][water][slow]") {
     auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
     auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -1361,9 +1361,7 @@ TEST_CASE("SVDSBTLBackend uses surrogate when source has no SuperAncillary", "[S
 // supported input-pair surface at construction instead of lazy-loading
 // the secondary pairs (DmassT / PSmass) on first query.
 TEST_CASE("SVDSBTL prebuild option eagerly builds all surfaces", "[SBTL][SVDSBTL][prebuild][slow]") {
-    auto contains = [](const std::vector<CoolProp::input_pairs>& v, CoolProp::input_pairs p) {
-        return std::find(v.begin(), v.end(), p) != v.end();
-    };
+    auto contains = [](const std::vector<CoolProp::input_pairs>& v, CoolProp::input_pairs p) { return std::find(v.begin(), v.end(), p) != v.end(); };
     // Small grid keeps the four dense SVD builds fast for a unit test.
     const char* small_grid = R"({"grid":{"NT":40,"NR":80,"rank":10}})";
     const char* small_grid_prebuild = R"({"prebuild":true,"grid":{"NT":40,"NR":80,"rank":10}})";
@@ -1371,8 +1369,7 @@ TEST_CASE("SVDSBTL prebuild option eagerly builds all surfaces", "[SBTL][SVDSBTL
     // Default (lazy): only the eager pairs PT + HmassP are registered at
     // construction; DmassT / PSmass are absent until first queried.
     {
-        auto AS = std::shared_ptr<CoolProp::AbstractState>(
-          CoolProp::AbstractState::factory("SVDSBTL&HEOS", std::string("Water?") + small_grid));
+        auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", std::string("Water?") + small_grid));
         auto* be = dynamic_cast<CoolProp::SVDSBTLBackend*>(AS.get());
         REQUIRE(be != nullptr);
         const auto pairs = be->registered_input_pairs();
@@ -1383,8 +1380,8 @@ TEST_CASE("SVDSBTL prebuild option eagerly builds all surfaces", "[SBTL][SVDSBTL
     }
     // prebuild=true: all four supported pairs are registered eagerly.
     {
-        auto AS = std::shared_ptr<CoolProp::AbstractState>(
-          CoolProp::AbstractState::factory("SVDSBTL&HEOS", std::string("Water?") + small_grid_prebuild));
+        auto AS =
+          std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", std::string("Water?") + small_grid_prebuild));
         auto* be = dynamic_cast<CoolProp::SVDSBTLBackend*>(AS.get());
         REQUIRE(be != nullptr);
         const auto pairs = be->registered_input_pairs();
@@ -1399,9 +1396,7 @@ TEST_CASE("SVDSBTL&IF97 prebuild skips the unbuildable DmassT surface", "[SBTL][
     if (!source_backend_available("IF97", "Water")) {
         SKIP("IF97 backend not available; skipping SVDSBTL&IF97 prebuild test");
     }
-    auto contains = [](const std::vector<CoolProp::input_pairs>& v, CoolProp::input_pairs p) {
-        return std::find(v.begin(), v.end(), p) != v.end();
-    };
+    auto contains = [](const std::vector<CoolProp::input_pairs>& v, CoolProp::input_pairs p) { return std::find(v.begin(), v.end(), p) != v.end(); };
     // DmassT can't be sampled on a (D,T) grid from IF97 (all-NaN matrix),
     // so prebuild builds PT + HmassP + PSmass but leaves DmassT out rather
     // than throwing at construction.
@@ -1454,7 +1449,7 @@ TEST_CASE("SVDSBTL prebuild shares the surface cache with a plain instance", "[S
     heos->update(CoolProp::PT_INPUTS, 5.0e5, 400.0);
     plain->update(CoolProp::PSmass_INPUTS, 5.0e5, heos->smass());
     REQUIRE(plain->rhomass() == Approx(heos->rhomass()).epsilon(1e-1));  // coarse grid; just confirms it resolved
-    REQUIRE(count_ps_files() == 1);  // shared, not a second opthash
+    REQUIRE(count_ps_files() == 1);                                      // shared, not a second opthash
 
     CoolProp::set_config_string(ALTERNATIVE_SVDTABLES_DIRECTORY, saved);
     fs::remove_all(tmpdir, ec);

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -317,6 +317,45 @@ TEST_CASE("SVDSBTL backend PSmass_INPUTS on the bubble/dew line stays two-phase 
     }
 }
 
+TEST_CASE("SVDSBTL backend bubble/dew-line round-trip across fluids (issue #3190, atlas-miss path)",
+          "[SVDSBTL][twophase][regression][issue_3190][multi_fluid][slow]") {
+    // Multi-fluid guard for the atlas-MISS branch of the #3190 fix.  The
+    // Water-only cases above exercise the atlas-hit near-dome guard; these
+    // non-water fluids surfaced low-p dew-line points that go through the
+    // atlas-miss dome blend, where a Q=0/1 round-trip lands a ULP outside
+    // [yL, yV] (the y_mass = yV/M then y_mol = y_mass*M re-scaling is not
+    // bit-exact) and a strict containment check dropped them to OutOfRange
+    // (reported Q=-inf).  Sweep p in [p_triple, p_critical] and require the
+    // re-flash stays two-phase with Q == Q_in for both HmassP and PSmass.
+    for (const char* fluid : {"n-Propane", "R245fa"}) {
+        auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", fluid));
+        const double p_tri = AS->p_triple();
+        const double p_crit = AS->p_critical();
+        // Sweep stops short of p_crit (max i/N = 0.975): as p -> p_crit the
+        // dome (yV - yL) collapses and the lever-rule Q noise grows, which is
+        // the critical patch's domain, not this dome-blend round-trip's.
+        const int N = 40;
+        for (const double Q_in : {0.0, 1.0}) {
+            for (int i = 1; i < N; ++i) {
+                const double p = p_tri + (p_crit - p_tri) * (static_cast<double>(i) / static_cast<double>(N));
+                AS->update(CoolProp::PQ_INPUTS, p, Q_in);
+                const double h = AS->hmass();
+                AS->update(CoolProp::HmassP_INPUTS, h, p);
+                INFO(fluid << " HmassP Q_in=" << Q_in << " p/pc=" << (p / p_crit) << " -> phase=" << AS->phase() << " Q=" << AS->Q());
+                REQUIRE(AS->phase() == CoolProp::iphase_twophase);
+                REQUIRE(AS->Q() == Approx(Q_in).margin(1e-6));
+
+                AS->update(CoolProp::PQ_INPUTS, p, Q_in);
+                const double s = AS->smass();
+                AS->update(CoolProp::PSmass_INPUTS, p, s);
+                INFO(fluid << " PSmass Q_in=" << Q_in << " p/pc=" << (p / p_crit) << " -> phase=" << AS->phase() << " Q=" << AS->Q());
+                REQUIRE(AS->phase() == CoolProp::iphase_twophase);
+                REQUIRE(AS->Q() == Approx(Q_in).margin(1e-6));
+            }
+        }
+    }
+}
+
 TEST_CASE("SVDSBTL backend PS lookup matches HEOS within tolerance", "[SVDSBTL][ps][water][slow]") {
     auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water"));
     auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water"));


### PR DESCRIPTION
## Problem (#3190)

Round-tripping `h(p, Q=0|1) → (p, h)` on `SVDSBTL&HEOS` (and the entropy twin `PSmass`) returned `iphase_not_imposed` / `Q = -1` instead of two-phase for ~all subcritical pressures. Reproduced on Water: **49/50** points failed for both `Q=0` and `Q=1`. Pure `HEOS` is unaffected (returns two-phase, `Q≈0`).

The forward `h`/`s` are exact (`hL_sbtl − hL_heos = −4.7e-10` J/kg). The bug is purely in **back-flash classification**: the atlas single-phase LIQUID/VAPOR regions' dome-side boundary is an *interpolated* saturation curve baked in at surface-construction time, and its fit error makes it overshoot the true bubble/dew line by ~`ΔQ 1e-6`. A caloric input sitting exactly on the saturation line therefore resolves into a single-phase region instead of the dome. (This is why `Q=0.0001` / `0.9999` worked but `Q=0` / `1` didn't.)

## Fix

In `resolve_point_`, when the atlas resolves a single-phase H/S point whose secondary-axis normalized coordinate `η` (`resolved.svd_x`) is within a thin band (`1e-2`) of a region edge, re-test against the **authoritative** fast saturation provider — the same one the forward PQ flash uses — via the new `try_fast_dome_reclassify_` helper. It reclassifies to a two-phase `DomeBlend` when `yL ≤ y ≤ yV`, with a `±1e-9` Q tolerance band (matching HEOS `p_phase_determination`'s own dome-edge handling) and Q clamped to `[0, 1]`. Covers `HmassP` / `HmolarP` / `PSmass` / `PSmolar`.

The `η` gate keeps the single-phase hot path effectively free: the saturation lookup (SA → surrogate, **never** the expensive source-PQ flash) runs only inside the thin near-dome band and short-circuits cheaply at supercritical `p` (NaN `T_sat`). Away from the dome — i.e. essentially all single-phase queries — the guard is two float comparisons. Measured marginal cost when it does run is ~170 ns; for context single-phase `HmassP` is ~430 ns on SVDSBTL vs ~97 µs on HEOS.

## Tests

- Two new regression cases (`[issue_3190]`) covering the bubble- and dew-line round-trip for both `HmassP` and `PSmass` — 96 assertions.
- Full `[SBTL]` umbrella: 5455 assertions pass.
- `./dev/ci/preflight.sh`: all 8 gates green (clang-format, build, tests, cppcheck, clang-tidy, semgrep, json-symbol/header hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SVDSBTL classification for points extremely close to the saturation dome boundaries, preventing near-dome points from being misidentified as single-phase; these now resolve as two-phase (including boundary cases).
  * Adjusted dome-blend handling to use a tolerance-based `Q` evaluation, with safer clamping to avoid precision-related out-of-range behavior.

* **Tests**
  * Added SVDSBTL regression coverage for water bubble/dew line boundary cases to verify `HmassP` and `PSmass` inputs return two-phase results with the expected `Q` value (including an additional multi-fluid sweep).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->