### PR TITLE
fix(SVDSBTL): lower subcritical table floor to true p_triple; add pmin option (#3189)

### DIFF
--- a/docs/superpowers/specs/2026-05-16-backend-options-string-design.md
+++ b/docs/superpowers/specs/2026-05-16-backend-options-string-design.md
@@ -138,6 +138,10 @@ high-level interfaces.
 ```jsonc
 {
   "schema": 1,
+  "pmin": 611.655,                         // absolute Pa; lower-pressure bound
+                                           // for the PT/PH/PS surfaces.
+                                           // Default = fluid p_triple; must be
+                                           // >= p_triple (no sat boundary below).
   "grid": { "NT": 200, "NR": 800, "rank": 20 },
   "properties": {
     "transport": "auto"                    // auto | on | off

--- a/include/CoolProp/sbtl/SVDSurfaceFactory.h
+++ b/include/CoolProp/sbtl/SVDSurfaceFactory.h
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 
 #include "CoolProp/AbstractState.h"
 #include "CoolProp/sbtl/SVDSurface.h"
@@ -48,17 +49,35 @@ SVDSurface build_surface(::CoolProp::AbstractState& heos, SurfaceSpec spec, cons
 // changes to build_surface() or downstream consumers.
 namespace presets {
 
+// Build-time knobs shared by the subcritical presets and the backend.
+// Bundling them in one struct means a future knob is a new field here
+// (plus where it is parsed and consumed) — NOT a new positional
+// parameter rippling through every preset signature, the dispatcher,
+// and every call site.
+struct PresetOptions
+{
+    std::size_t NT = 200;    // points along the secondary (non-log) axis
+    std::size_t NR = 800;    // points along the primary (log-p) axis
+    std::int32_t rank = 20;  // SVD truncation rank
+    // Absolute-Pa lower-pressure bound for the PT / HmassP / PSmass
+    // surfaces (the backend's `pmin` option).  nullopt -> default
+    // p_triple floor; must be >= p_triple (see
+    // subcritical_pressure_range).  Ignored by the DmassT preset, which
+    // is temperature-indexed and has no pressure floor.
+    std::optional<double> p_min;
+};
+
 // HmassP_INPUTS preset.  (a, b) = (p, h).  Output properties: rho, T, s, u.
-SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT = 200, std::size_t NR = 800, std::int32_t rank = 20);
+SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, const PresetOptions& opts = {});
 
 // PT_INPUTS preset.  (a, b) = (p, T).  Output properties: rho, h, s, u.
-SurfaceSpec pt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT = 200, std::size_t NR = 800, std::int32_t rank = 20);
+SurfaceSpec pt_subcritical(::CoolProp::AbstractState& heos, const PresetOptions& opts = {});
 
 // PSmass_INPUTS preset.  (a, b) = (p, s).  Output properties: rho, T, h, u.
 // Entropy analog of ph_subcritical: s is the secondary axis + query
 // input; the same region geometry (LIQUID/VAPOR/NC/SUPER, IF97 R2/R3/R5
 // split) applies with the build_s_* boundary curves.
-SurfaceSpec ps_subcritical(::CoolProp::AbstractState& heos, std::size_t NT = 200, std::size_t NR = 800, std::int32_t rank = 20);
+SurfaceSpec ps_subcritical(::CoolProp::AbstractState& heos, const PresetOptions& opts = {});
 
 // DmassT_INPUTS preset.  (a, b) = (T, D).  Output properties: p, h, s, u.
 //
@@ -81,7 +100,7 @@ SurfaceSpec ps_subcritical(::CoolProp::AbstractState& heos, std::size_t NT = 200
 // gracefully falls back to a single LIQUID region when no SA is
 // available (REFPROP / IF97 sources, or fluids without a SA in
 // HEOS).
-SurfaceSpec dt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT = 200, std::size_t NR = 800, std::int32_t rank = 20);
+SurfaceSpec dt_subcritical(::CoolProp::AbstractState& heos, const PresetOptions& opts = {});
 
 }  // namespace presets
 

--- a/include/CoolProp/sbtl/SVDSurfaceSerializer.h
+++ b/include/CoolProp/sbtl/SVDSurfaceSerializer.h
@@ -217,7 +217,17 @@ class SVDSurfaceSerializer
     //           the SUPER grid sample positions and U/slopes shift, so
     //           rev-17 caches must rebuild.  Modest-ratio fluids (Water ~3×,
     //           CO2 ~6×) are unchanged in practice (LOG ≈ LINEAR there).
-    static constexpr int kRevision = 18;
+    //   rev 19: CoolProp-naqt / issue #3189.  The subcritical PT / HmassP /
+    //           PSmass presets lower their default p_min from
+    //           ~1.01-1.03·p_triple to the true triple-point pressure
+    //           (heos.p_triple()), so a PT query at p == p_triple() now
+    //           resolves instead of returning NaN.  The log-p primary axis
+    //           span shifts (lower bottom isobar), so the grid sample
+    //           positions and SVD U/slopes change and rev-18 caches must
+    //           rebuild.  (A non-default `pmin` option already produces a
+    //           distinct cache via the opthash; this rev covers the
+    //           all-defaults "{}" case whose opthash is unchanged.)
+    static constexpr int kRevision = 19;
 
     // Pack one surface into a zlib-compressed msgpack blob.
     static std::vector<char> save(const SVDSurface& surface);

--- a/include/CoolProp/sbtl/SatBoundaryFactory.h
+++ b/include/CoolProp/sbtl/SatBoundaryFactory.h
@@ -2,6 +2,7 @@
 #define COOLPROP_SBTL_SAT_BOUNDARY_FACTORY_H
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "CoolProp/AbstractState.h"
@@ -162,10 +163,22 @@ std::unique_ptr<region::CubicSplineCurve> build_s_isotherm_ceiling(::CoolProp::A
 std::vector<double> find_rho_satL_extrema_T(::CoolProp::AbstractState& heos, double T_min, double T_max);
 
 // Convenience: subcritical pressure range for `fluid`.  Returns
-// (p_min, p_max) ≈ (p_triple * 1.01, p_crit * 0.999) so PQ flashes
-// don't fail at the exact boundary.  Driven by the fluid's HEOS
-// AbstractState — needs an instance already constructed by the caller.
-std::pair<double, double> subcritical_pressure_range(::CoolProp::AbstractState& heos);
+// (p_min, p_max) = (p_triple, p_crit * 0.999), where p_triple is the
+// fluid's true triple-point pressure (heos.p_triple(), with a
+// QT-at-Ttriple fallback when that is not finite/positive).  The lowest
+// tabulated isobar therefore sits exactly at p_triple so a PT query at
+// p == p_triple() resolves (RegionAtlas containment is inclusive);
+// PQ(p_triple, 0) converges, so build_T_sat can sample the bottom knot.
+// Driven by the fluid's HEOS AbstractState — needs an instance already
+// constructed by the caller.
+//
+// `p_min_override` (absolute Pa, from the backend's `pmin` option)
+// replaces the p_triple floor when supplied.  It MUST be >= p_triple:
+// below the triple line the liquid-vapour saturation boundary that
+// bounds the subcritical regions does not exist, so a sub-triple floor
+// is rejected with ValueError rather than failing obscurely deep in the
+// boundary-curve sampling.
+std::pair<double, double> subcritical_pressure_range(::CoolProp::AbstractState& heos, std::optional<double> p_min_override = std::nullopt);
 
 // Convenience: supercritical pressure range for `fluid`.  Returns
 // (p_min, p_max) ≈ (p_crit * 1.001, pmax_eos * 0.99) — a thin margin

--- a/include/CoolProp/schemas/SVDSBTLOptions.h
+++ b/include/CoolProp/schemas/SVDSBTLOptions.h
@@ -28,6 +28,11 @@ inline constexpr const char kSVDSBTLOptionsSchemaJson[] = R"JSON({
       "type": "boolean",
       "description": "When true, eagerly build every supported input-pair surface (PT, HmassP, DmassT, PSmass) at construction instead of lazy-loading the secondary pairs on first query. Opt-in complement to the default lazy loading: materializes the whole fluid up front (docs / benchmarking / warm-cache pre-fill) and turns a build/env failure into a loud construction-time error instead of a silent blank later."
     },
+    "pmin": {
+      "type": "number",
+      "exclusiveMinimum": 0,
+      "description": "Lower pressure bound (absolute Pa) for the subcritical PT / HmassP / PSmass surfaces. Defaults to the fluid's triple-point pressure. Must be >= p_triple: the subcritical regions are bounded by the liquid-vapour saturation curve, which does not exist below the triple line. The DmassT surface is temperature-indexed and unaffected."
+    },
     "grid": {
       "type": "object",
       "additionalProperties": false,

--- a/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
+++ b/src/Backends/SVDSBTL/SVDSBTLBackend.cpp
@@ -13,6 +13,7 @@
 #include <exception>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -69,17 +70,12 @@ constexpr std::array<CoolProp::input_pairs, 4> kSupportedPairs = {CoolProp::Hmas
 // and both atlas-miss dome-blend blocks in resolve_point_.
 constexpr double kDomeQTol = 1e-9;
 
-// Resolved grid-shape knobs extracted from the validated options
-// document.  Used both to size the per-input-pair surfaces and to
-// stamp the canonical-options form into the cache filename.
-struct ResolvedGrid
-{
-    std::size_t NT;
-    std::size_t NR;
-    std::int32_t rank;
-};
-
-constexpr ResolvedGrid kDefaultGrid = {200, 800, 20};
+// Build-time preset knobs (grid shape + pmin override) extracted from
+// the validated options document.  This is the shared
+// CoolProp::sbtl::presets::PresetOptions struct, so a new knob is a new
+// field there (plus its resolve line below) — not a new parameter
+// threaded through every preset signature.
+using PresetOptions = CoolProp::sbtl::presets::PresetOptions;
 
 // Polish the patch backend's T after an HmassP_INPUTS update so the
 // returned state is forward-consistent in h(T, p), not just R7-97-
@@ -177,41 +173,51 @@ void polish_patch_state_s_(::CoolProp::AbstractState& s, double p, double s_val)
     }
 }
 
-// Read `grid.NT/NR/rank` out of a validated options document.  Missing
-// keys (and missing `grid` itself) leave the corresponding default in
-// place — the validator has already rejected anything ill-formed.
-ResolvedGrid resolve_grid(const nlohmann::json& opts) {
-    ResolvedGrid g = kDefaultGrid;
+// Read the preset build knobs out of a validated options document:
+// `grid.NT/NR/rank` and the optional `pmin` lower-pressure override.
+// Missing keys leave the struct defaults in place — the validator has
+// already rejected anything ill-formed.  The schema guarantees pmin > 0
+// when present; the >= p_triple check lives in subcritical_pressure_range
+// (it needs the fluid to resolve p_triple).  A future knob = one more
+// field read here, no signature changes downstream.
+PresetOptions resolve_preset_options(const nlohmann::json& opts) {
+    PresetOptions po;
     if (opts.is_object() && opts.contains("grid") && opts.at("grid").is_object()) {
         const auto& grid = opts.at("grid");
-        if (grid.contains("NT")) g.NT = static_cast<std::size_t>(cpjson::get_integer(grid, "NT"));
-        if (grid.contains("NR")) g.NR = static_cast<std::size_t>(cpjson::get_integer(grid, "NR"));
-        if (grid.contains("rank")) g.rank = cpjson::get_integer(grid, "rank");
+        if (grid.contains("NT")) po.NT = static_cast<std::size_t>(cpjson::get_integer(grid, "NT"));
+        if (grid.contains("NR")) po.NR = static_cast<std::size_t>(cpjson::get_integer(grid, "NR"));
+        if (grid.contains("rank")) po.rank = cpjson::get_integer(grid, "rank");
     }
-    return g;
+    if (opts.is_object() && opts.contains("pmin")) {
+        po.p_min = opts.at("pmin").get<double>();
+    }
+    return po;
 }
 
 // Sample-and-build for a given input pair using the matching preset.
-// Grid shape comes from `g` so the caller can drive NT/NR/rank from
-// the options blob.  The source_backend string is threaded into the
-// SurfaceSpec so sample_grid can spawn per-thread AbstractState
-// instances when PARALLEL_SVDSBTL_SAMPLING is on (CoolProp-43h).
+// Build knobs come from `po` so the caller can drive NT/NR/rank and the
+// pmin floor from the options blob.  The source_backend string is
+// threaded into the SurfaceSpec so sample_grid can spawn per-thread
+// AbstractState instances when PARALLEL_SVDSBTL_SAMPLING is on
+// (CoolProp-43h).
 CoolProp::sbtl::SVDSurface build_surface_for_pair_(::CoolProp::AbstractState& source, const std::string& source_backend, CoolProp::input_pairs pair,
-                                                   const ResolvedGrid& g) {
+                                                   const PresetOptions& po) {
     namespace cp_sbtl = CoolProp::sbtl;
     cp_sbtl::SurfaceSpec spec;
     switch (pair) {
         case CoolProp::HmassP_INPUTS:
-            spec = cp_sbtl::presets::ph_subcritical(source, g.NT, g.NR, g.rank);
+            spec = cp_sbtl::presets::ph_subcritical(source, po);
             break;
         case CoolProp::PT_INPUTS:
-            spec = cp_sbtl::presets::pt_subcritical(source, g.NT, g.NR, g.rank);
+            spec = cp_sbtl::presets::pt_subcritical(source, po);
             break;
         case CoolProp::DmassT_INPUTS:
-            spec = cp_sbtl::presets::dt_subcritical(source, g.NT, g.NR, g.rank);
+            // DmassT is temperature-indexed — dt_subcritical ignores
+            // po.p_min (the pressure floor does not apply there).
+            spec = cp_sbtl::presets::dt_subcritical(source, po);
             break;
         case CoolProp::PSmass_INPUTS:
-            spec = cp_sbtl::presets::ps_subcritical(source, g.NT, g.NR, g.rank);
+            spec = cp_sbtl::presets::ps_subcritical(source, po);
             break;
         default:
             throw ValueError("SVDSBTL backend: no preset registered for the requested input pair");
@@ -1005,8 +1011,8 @@ void SVDSBTLBackend::ensure_surface_(CoolProp::input_pairs pair) {
     if (!surface) {
         auto source = source_reference_();
         const nlohmann::json opts = cpjson::parse(options_canonical_.empty() ? "{}" : options_canonical_);
-        const ResolvedGrid grid = resolve_grid(opts);
-        surface = std::make_unique<cp_sbtl::SVDSurface>(build_surface_for_pair_(*source, source_backend_, pair, grid));
+        const PresetOptions preset_opts = resolve_preset_options(opts);
+        surface = std::make_unique<cp_sbtl::SVDSurface>(build_surface_for_pair_(*source, source_backend_, pair, preset_opts));
         try {
             cp_sbtl::SVDSurfaceSerializer::save_to_file(*surface, path);
         } catch (const std::exception&) {  // NOLINT(bugprone-empty-catch)

--- a/src/SBTL/SatBoundaryFactory.cpp
+++ b/src/SBTL/SatBoundaryFactory.cpp
@@ -9,6 +9,8 @@
 #include "boost/math/tools/toms748_solve.hpp"
 
 #include "Backends/Helmholtz/HelmholtzEOSMixtureBackend.h"
+#include "CoolProp/Exceptions.h"
+#include "CoolProp/detail/strings.h"
 #include "CoolProp/region/SuperancillaryBoundaryCurve.h"
 #include "CoolProp/region/SuperancillaryTemperatureBoundaryCurve.h"
 #include "CoolProp/DataStructures.h"
@@ -267,13 +269,45 @@ std::unique_ptr<region::CubicSplineCurve> build_s_isotherm_ceiling(::CoolProp::A
     });
 }
 
-std::pair<double, double> subcritical_pressure_range(::CoolProp::AbstractState& heos) {
+std::pair<double, double> subcritical_pressure_range(::CoolProp::AbstractState& heos, std::optional<double> p_min_override) {
     const double p_crit = heos.p_critical();
-    // Sample HEOS at triple T to get p_triple.  A tiny margin (1%)
-    // helps PQ flashes converge at the boundary.
-    heos.update(::CoolProp::QT_INPUTS, 0.0, heos.Ttriple() * 1.001);
-    const double p_triple = heos.p();
-    return {p_triple * 1.01, 0.999 * p_crit};
+    // True triple-point pressure.  Prefer the fluid's stored p_triple()
+    // (the same value users get back and query against), falling back to
+    // a QT flash at the triple temperature when that is not available
+    // (NaN / non-positive).  The lowest tabulated isobar sits exactly
+    // here so a PT query at p == p_triple() resolves (CoolProp-naqt /
+    // issue #3189): RegionAtlas containment is inclusive and
+    // PQ(p_triple, 0) converges, so build_T_sat can sample the bottom
+    // knot.  The fallback samples at exactly Ttriple (QT there converges
+    // to the true p_triple for every tested fluid); an elevated estimate
+    // would reintroduce the very floor this fix removes.
+    double p_triple = heos.p_triple();
+    if (!std::isfinite(p_triple) || p_triple <= 0.0) {
+        heos.update(::CoolProp::QT_INPUTS, 0.0, heos.Ttriple());
+        p_triple = heos.p();
+    }
+    if (!std::isfinite(p_triple) || p_triple <= 0.0) {
+        throw ValueError("SVDSBTL: unable to resolve a finite, positive triple-point pressure for the subcritical floor.");
+    }
+    double p_min = p_triple;
+    if (p_min_override) {
+        // The subcritical regions are bounded above (in T) by the
+        // liquid-vapour saturation curve, which does not exist below the
+        // triple line.  Reject a non-finite / sub-triple floor loudly
+        // rather than let build_T_sat fail obscurely on a PQ flash below
+        // p_triple, or let a NaN slip past the `< p_triple` test (NaN
+        // compares false) into the axis transform.
+        if (!std::isfinite(*p_min_override) || *p_min_override <= 0.0) {
+            throw ValueError(format("SVDSBTL: pmin (%g Pa) must be a finite, positive pressure.", *p_min_override));
+        }
+        if (*p_min_override < p_triple) {
+            throw ValueError(format("SVDSBTL: pmin (%g Pa) is below the triple-point pressure (%g Pa); the subcritical "
+                                    "surfaces have no saturation boundary below the triple line.",
+                                    *p_min_override, p_triple));
+        }
+        p_min = *p_min_override;
+    }
+    return {p_min, 0.999 * p_crit};
 }
 
 std::pair<double, double> supercritical_pressure_range(::CoolProp::AbstractState& heos) {

--- a/src/SBTL/SurfacePresets.cpp
+++ b/src/SBTL/SurfacePresets.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <optional>
 #include <stdexcept>
 #include <utility>
 
@@ -288,13 +289,17 @@ double solve_T_from_s_toms748(::CoolProp::AbstractState& s, double p, double s_t
 
 }  // namespace
 
-SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std::size_t NR, std::int32_t rank) {
+SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, const PresetOptions& opts) {
+    const std::size_t NT = opts.NT;
+    const std::size_t NR = opts.NR;
+    const std::int32_t rank = opts.rank;
+    const std::optional<double> p_min_override = opts.p_min;
     // Name is historical: this preset now also registers a SUPER
     // region above p_crit so the surface covers the full HEOS
     // (p, h) envelope.  Three regions: LIQUID + VAPOR + SUPER, plus
     // an optional NC_LIQUID/NC_VAPOR pair near pc when source is
     // HEOS/REFPROP (CoolProp-4u9).
-    const auto [p_min, p_max_sub_raw] = subcritical_pressure_range(heos);
+    const auto [p_min, p_max_sub_raw] = subcritical_pressure_range(heos, p_min_override);
     const auto [p_min_sup_raw, p_max_sup] = supercritical_pressure_range(heos);
     const double T_min_eos = std::max(heos.Ttriple(), heos.Tmin());
     const double T_max_eos = heos.Tmax();
@@ -721,14 +726,18 @@ SurfaceSpec ph_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std:
     return spec;
 }
 
-SurfaceSpec ps_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std::size_t NR, std::int32_t rank) {
+SurfaceSpec ps_subcritical(::CoolProp::AbstractState& heos, const PresetOptions& opts) {
+    const std::size_t NT = opts.NT;
+    const std::size_t NR = opts.NR;
+    const std::int32_t rank = opts.rank;
+    const std::optional<double> p_min_override = opts.p_min;
     // Entropy-indexed twin of ph_subcritical.  Identical region
     // geometry — LIQUID + VAPOR + SUPER, optional NC_LIQUID/NC_VAPOR/
     // NC_SUPER near pc, and (for IF97 source) the R2/R3/R5 SUPER split
     // — with the secondary axis being s instead of h.  See
     // ph_subcritical for the full rationale behind each region; the
     // comments here are abbreviated to the entropy-specific points.
-    const auto [p_min, p_max_sub_raw] = subcritical_pressure_range(heos);
+    const auto [p_min, p_max_sub_raw] = subcritical_pressure_range(heos, p_min_override);
     const auto [p_min_sup_raw, p_max_sup] = supercritical_pressure_range(heos);
     const double T_min_eos = std::max(heos.Ttriple(), heos.Tmin());
     const double T_max_eos = heos.Tmax();
@@ -1012,12 +1021,16 @@ std::unique_ptr<region::CubicSplineCurve> pt_T_floor_curve_(::CoolProp::Abstract
 }
 }  // namespace
 
-SurfaceSpec pt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std::size_t NR, std::int32_t rank) {
+SurfaceSpec pt_subcritical(::CoolProp::AbstractState& heos, const PresetOptions& opts) {
+    const std::size_t NT = opts.NT;
+    const std::size_t NR = opts.NR;
+    const std::int32_t rank = opts.rank;
+    const std::optional<double> p_min_override = opts.p_min;
     // Historical name; now covers the full phase diagram via three
     // regions: LIQUID + VAPOR (subcritical) + SUPER (p > p_crit), plus
     // an optional NC_LIQUID/NC_VAPOR pair near pc when source is
     // HEOS/REFPROP (CoolProp-4u9).
-    const auto [p_min, p_max_raw] = subcritical_pressure_range(heos);
+    const auto [p_min, p_max_raw] = subcritical_pressure_range(heos, p_min_override);
     const auto [p_min_sup_raw, p_max_sup] = supercritical_pressure_range(heos);
     const double T_min_eos = std::max(heos.Ttriple(), heos.Tmin());
     const double T_max_eos = heos.Tmax();
@@ -1340,7 +1353,12 @@ std::unique_ptr<region::CubicSplineCurve> build_rho_min_envelope(::CoolProp::Abs
 }
 }  // namespace
 
-SurfaceSpec dt_subcritical(::CoolProp::AbstractState& heos, std::size_t NT, std::size_t NR, std::int32_t rank) {
+SurfaceSpec dt_subcritical(::CoolProp::AbstractState& heos, const PresetOptions& opts) {
+    // DmassT is temperature-indexed, so opts.p_min (the pressure floor)
+    // does not apply here and is intentionally unused.
+    const std::size_t NT = opts.NT;
+    const std::size_t NR = opts.NR;
+    const std::int32_t rank = opts.rank;
     // DT-indexed surface — closes CoolProp-i7j and supersedes the
     // BICUBIC invert_single_phase_y patch attempt at #2892 / #1301.
     //

--- a/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
+++ b/src/Tests/CoolProp-Tests-SBTLAdapter.cpp
@@ -137,7 +137,7 @@ TEST_CASE("SVDSurface PH preset builds + evals against HEOS", "[SBTL][SVDSurface
     // qualitatively (must reproduce HEOS to a few percent on a
     // handful of single-phase probes).  Phase 2a's e2e tool covers
     // production-resolution accuracy.
-    auto spec = cp_sbtl::presets::ph_subcritical(*heos, /*NT=*/40, /*NR=*/80, /*rank=*/10);
+    auto spec = cp_sbtl::presets::ph_subcritical(*heos, {/*NT=*/40, /*NR=*/80, /*rank=*/10});
     REQUIRE(spec.input_pair == ::CoolProp::HmassP_INPUTS);
     // 6 regions: LIQUID, VAPOR, NC_LIQUID, NC_VAPOR, NC_SUPER, SUPER.
     // The NC_* regions are the near-critical sub-regions added in
@@ -202,7 +202,7 @@ TEST_CASE("SVDSurface PH preset builds + evals against HEOS", "[SBTL][SVDSurface
 
 TEST_CASE("SVDSurface PS preset builds + evals against HEOS", "[SBTL][SVDSurface][preset_ps][slow]") {
     auto heos = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("HEOS", "Water"));
-    auto spec = cp_sbtl::presets::ps_subcritical(*heos, /*NT=*/40, /*NR=*/80, /*rank=*/10);
+    auto spec = cp_sbtl::presets::ps_subcritical(*heos, {/*NT=*/40, /*NR=*/80, /*rank=*/10});
     REQUIRE(spec.input_pair == ::CoolProp::PSmass_INPUTS);
     // Same 6-region geometry as the PH preset.
     REQUIRE(spec.regions.size() == 6);
@@ -262,7 +262,7 @@ TEST_CASE("SVDSurface PS preset builds + evals against HEOS", "[SBTL][SVDSurface
 
 TEST_CASE("SVDSurface save/load round-trip is bit-identical", "[SBTL][serializer][slow]") {
     auto heos = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("HEOS", "Water"));
-    auto spec = cp_sbtl::presets::ph_subcritical(*heos, /*NT=*/40, /*NR=*/80, /*rank=*/10);
+    auto spec = cp_sbtl::presets::ph_subcritical(*heos, {/*NT=*/40, /*NR=*/80, /*rank=*/10});
     auto surface_before = cp_sbtl::build_surface(*heos, std::move(spec));
 
     // Save to a byte buffer and load back.
@@ -370,7 +370,7 @@ TEST_CASE("SVDSurface PH preset across multi-fluid set", "[SBTL][SVDSurface][pre
     for (const auto* fluid : {"R134a", "Ammonia", "Methane", "Propane", "CarbonDioxide"}) {
         SECTION(fluid) {
             auto heos = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("HEOS", fluid));
-            auto spec = cp_sbtl::presets::ph_subcritical(*heos, /*NT=*/30, /*NR=*/50, /*rank=*/8);
+            auto spec = cp_sbtl::presets::ph_subcritical(*heos, {/*NT=*/30, /*NR=*/50, /*rank=*/8});
             cp_sbtl::SVDSurface surface = cp_sbtl::build_surface(*heos, std::move(spec));
             REQUIRE(surface.sealed());
             REQUIRE(surface.region_count() == 6);  // CoolProp-4u9: NC_LIQUID + NC_VAPOR + NC_SUPER
@@ -420,7 +420,7 @@ TEST_CASE("SVDSurface PH preset across multi-fluid set", "[SBTL][SVDSurface][pre
 
 TEST_CASE("SVDSurface PT preset water round-trip", "[SBTL][SVDSurface][preset_pt][slow]") {
     auto heos = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("HEOS", "Water"));
-    auto spec = cp_sbtl::presets::pt_subcritical(*heos, /*NT=*/40, /*NR=*/80, /*rank=*/10);
+    auto spec = cp_sbtl::presets::pt_subcritical(*heos, {/*NT=*/40, /*NR=*/80, /*rank=*/10});
     REQUIRE(spec.input_pair == ::CoolProp::PT_INPUTS);
     REQUIRE(spec.regions.size() == 6);  // CoolProp-4u9: NC_LIQUID + NC_VAPOR + NC_SUPER
 
@@ -443,7 +443,7 @@ TEST_CASE("SVDSurface PT preset water round-trip", "[SBTL][SVDSurface][preset_pt
 
 TEST_CASE("SVDSurfaceSerializer file save/load round-trip", "[SBTL][serializer][slow]") {
     auto heos = std::shared_ptr<::CoolProp::AbstractState>(::CoolProp::AbstractState::factory("HEOS", "Water"));
-    auto spec = cp_sbtl::presets::ph_subcritical(*heos, /*NT=*/40, /*NR=*/80, /*rank=*/10);
+    auto spec = cp_sbtl::presets::ph_subcritical(*heos, {/*NT=*/40, /*NR=*/80, /*rank=*/10});
     auto surface = cp_sbtl::build_surface(*heos, std::move(spec));
 
     // Save to a tmp file and load back via the file API.  Use

--- a/src/Tests/CoolProp-Tests-SVDSBTL.cpp
+++ b/src/Tests/CoolProp-Tests-SVDSBTL.cpp
@@ -10,6 +10,7 @@ using Catch::Approx;
 #    include <algorithm>
 #    include <atomic>
 #    include <chrono>
+#    include <cmath>
 #    include <cstdint>
 #    include <filesystem>
 #    include <fstream>
@@ -118,6 +119,74 @@ TEST_CASE("SVDSBTL backend PT lookup matches HEOS within tolerance", "[SVDSBTL][
     // Stored T / p round-trip the user's inputs verbatim.
     REQUIRE(AS->T() == Approx(T).epsilon(1e-12));
     REQUIRE(AS->p() == Approx(p).epsilon(1e-12));
+}
+
+TEST_CASE("SVDSBTL backend resolves PT down to the triple-point pressure (issue #3189)", "[SVDSBTL][pt][low_pressure][issue_3189][slow]") {
+    // Regression for issue #3189 / CoolProp-naqt.  The subcritical PT
+    // surface used to floor its lowest isobar at ~1.01-1.03·p_triple
+    // (subcritical_pressure_range returned p_triple*1.01, and the
+    // p_triple it used was itself a QT sample at Ttriple*1.001, ~1-2%
+    // high).  A low-pressure gas query at p == p_triple() with T well
+    // above the saturation temperature therefore landed below the grid
+    // and returned NaN.  The floor is now the true triple-point pressure
+    // (heos.p_triple()), so p == p_triple() resolves and matches HEOS.
+    const std::vector<std::string> fluids = {"Water", "Nitrogen", "Methane", "Hydrogen"};
+    for (const auto& fluid : fluids) {
+        SECTION(fluid) {
+            auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", fluid));
+            auto heos = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", fluid));
+
+            const double p_tri = AS->p_triple();
+            const double T = 400.0;  // gas: T >> T_sat(p_triple) for all four fluids
+
+            // Exactly at the triple pressure — the boundary that used to fail.
+            AS->update(CoolProp::PT_INPUTS, p_tri, T);
+            heos->update(CoolProp::PT_INPUTS, p_tri, T);
+            INFO(fluid << " at p=p_triple=" << p_tri << " T=" << T);
+            INFO("rho HEOS=" << heos->rhomass() << "  SVDSBTL=" << AS->rhomass());
+            INFO("h   HEOS=" << heos->hmass() << "    SVDSBTL=" << AS->hmass());
+            REQUIRE(std::isfinite(AS->hmass()));
+            REQUIRE(std::isfinite(AS->rhomass()));
+            REQUIRE(AS->rhomass() == Approx(heos->rhomass()).epsilon(5e-3));
+            REQUIRE(AS->hmass() == Approx(heos->hmass()).epsilon(5e-3));
+
+            // A point just inside the floor (1% above p_triple) also resolves.
+            const double p_hi = 1.01 * p_tri;
+            AS->update(CoolProp::PT_INPUTS, p_hi, T);
+            heos->update(CoolProp::PT_INPUTS, p_hi, T);
+            REQUIRE(AS->hmass() == Approx(heos->hmass()).epsilon(5e-3));
+
+            // Strictly below the triple line remains out of the tabulated
+            // domain by design (p_triple is the documented floor): a
+            // property read on an out-of-range point is NaN.
+            AS->update(CoolProp::PT_INPUTS, 0.9 * p_tri, T);
+            REQUIRE_FALSE(std::isfinite(AS->hmass()));
+        }
+    }
+}
+
+TEST_CASE("SVDSBTL pmin option overrides the subcritical lower pressure bound", "[SVDSBTL][pmin][options][slow]") {
+    // The `pmin` option (absolute Pa) raises the PT/PH/PS table floor.
+    // Use Water (p_triple ~= 611 Pa) with a small grid to keep the fresh
+    // surface build cheap — this test exercises geometry, not accuracy.
+    const std::string opts = R"({"pmin": 2000.0, "grid": {"NT": 40, "NR": 80, "rank": 8}})";
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water?" + opts));
+
+    const double T = 400.0;
+    // Below the raised floor (but above p_triple) -> out of range -> NaN.
+    AS->update(CoolProp::PT_INPUTS, 1000.0, T);
+    REQUIRE_FALSE(std::isfinite(AS->hmass()));
+    // Above the floor -> resolves.
+    AS->update(CoolProp::PT_INPUTS, 5000.0, T);
+    REQUIRE(std::isfinite(AS->hmass()));
+}
+
+TEST_CASE("SVDSBTL pmin below the triple pressure is rejected", "[SVDSBTL][pmin][options][reject]") {
+    // A sub-triple pmin has no liquid-vapour saturation boundary to bound
+    // the subcritical regions, so construction (which eagerly builds the
+    // PT surface) throws rather than failing obscurely deep in sampling.
+    const std::string opts = R"({"pmin": 100.0})";  // < Water p_triple (~611 Pa)
+    REQUIRE_THROWS_AS(CoolProp::AbstractState::factory("SVDSBTL&HEOS", "Water?" + opts), CoolProp::ValueError);
 }
 
 TEST_CASE("SVDSBTL backend PH lookup matches HEOS within tolerance", "[SVDSBTL][ph][water][slow]") {


### PR DESCRIPTION
## Summary

Fixes #3189. `SVDSBTL&HEOS` PT queries returned `NaN` for pressures at or just above the triple-point pressure (a low-pressure gas state at `T` well above `T_sat`), even though plain `HEOS` solves them fine.

**Root cause:** `subcritical_pressure_range()` floored the lowest tabulated isobar at `p_triple * 1.01`, and the `p_triple` it used was itself a `QT` sample at `Ttriple * 1.001` (~1–2 % high). The effective floor therefore sat at **~1.02–1.03·p_triple**, so any query at `p ≤ p_triple` landed below the grid → `OutOfRange` → `NaN`.

## Changes

- **Lower the default subcritical floor to the true triple-point pressure** (`heos.p_triple()`, with a `QT`-at-`Ttriple` fallback when that is non-finite/non-positive, and a throw if even that fails). `RegionAtlas` containment is inclusive and `PQ(p_triple, 0)` converges, so `build_T_sat` can sample the bottom knot and a query at `p == p_triple()` now resolves. States strictly **below** the triple line remain out-of-domain by design — the subcritical regions have no liquid–vapour saturation boundary below `p_triple`, so it's the documented floor.
- **New `pmin` option** (absolute Pa) in the SVDSBTL options schema, letting callers raise the floor. A non-finite or sub-triple `pmin` is rejected with a clear `ValueError`. `DmassT` is temperature-indexed and unaffected.
- **Extensibility:** the preset build knobs (grid `NT/NR/rank` + `pmin`) are bundled into a single `CoolProp::sbtl::presets::PresetOptions` struct rather than threaded as positional parameters. A future build-time knob is a new struct field plus its resolve line — not a new parameter rippling through every preset signature, the backend dispatcher, and every call site.
- **Cache revision `18 → 19`**: the log-p axis span shifts, so the all-defaults `{}` surfaces must rebuild (a non-default `pmin` already keys a distinct cache via the opthash).

## Verification

Ran the reporter's exact script against a Python wheel built from this branch. The success/fail boundary moves from **~1.02–1.03·p_triple** to **exactly `p_triple`** for all seven probed fluids:

| Fluid | first success (before) | first success (after) |
|---|---|---|
| Water | 1.0303·p_tri | **1.000·p_tri** |
| Ammonia | 1.0263 | **1.000** |
| Argon | 1.0198 | **1.000** |
| Oxygen | 1.0279 | **1.000** |
| Nitrogen | 1.0218 | **1.000** |
| Hydrogen | 1.0182 | **1.000** |
| Methane | 1.0222 | **1.000** |

- Combined `[SBTL],[SVDSBTL],[SVDComponents],[region]` suite: **118 passed, 8 skipped, 9745 assertions**, including 3 new regression tests (`[issue_3189]`, `[pmin]`). The struct refactor is behavior-preserving (assertion counts identical before/after).
- Rebased onto current `master` (integrates #3190); pre-push preflight gate green.

## Notes

- States below `p_triple` still return `NaN` by design (this is the chosen lower bound, not a fallback to HEOS). The `pmin` option only *raises* the floor; the subcritical surfaces cannot extend below the triple line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an optional `pmin` setting to set the lower absolute pressure bound for SVDSBTL subcritical PT/HmassP/PSmass surfaces (default: fluid triple-point pressure).

* **Bug Fixes**
  * Improved subcritical pressure handling to prefer the true triple-point pressure by default.
  * Added validation to reject `pmin` values below the triple point (temperature-indexed `DmassT` remains unchanged).

* **Documentation**
  * Updated the SVDSBTL options schema/spec to document `pmin`.

* **Compatibility**
  * Bumped SVDSBTL surface cache revision; existing default cached surfaces may require rebuilding.

* **Tests**
  * Added coverage for `pmin` behavior and rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->