### PR TITLE
ci(coderabbit): stop flagging identifier naming/casing conventions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,14 @@
+# CodeRabbit configuration
+# Schema: https://docs.coderabbit.ai/reference/configuration
+language: en-US
+
+reviews:
+  # Project-wide guidance for the reviewer.
+  path_instructions:
+    - path: "**"
+      instructions: >
+        Do not comment on identifier naming conventions or casing style.
+        In particular, never suggest renaming identifiers to camelCase, and
+        do not flag snake_case, PascalCase, or other casing as an issue.
+        Naming style is a deliberate project choice and is out of scope for
+        review.


### PR DESCRIPTION
## What

Adds a repo-root `.coderabbit.yaml` so the CodeRabbit reviewer stops commenting on identifier naming conventions — in particular it will no longer suggest renaming identifiers to camelCase.

## How

A single `reviews.path_instructions` entry scoped to all files (`**`) instructs the reviewer that naming/casing is a deliberate project choice and out of scope for review.

## Notes

- Scoped deliberately to naming only. An earlier draft also set `profile: chill`, but that globally weakens *all* review categories, which wasn't the goal, so it was dropped.
- CodeRabbit loads `.coderabbit.yaml` from a PR's **base branch**, so this takes effect on new PRs once merged to `master`.
- `path_instructions` is advisory guidance to the reviewer (soft suppression), not a hard filter — an occasional naming comment could still slip through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review configuration settings.

---

*Note: This is an internal configuration change with no user-visible impact.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->