### PR TITLE
Update docs and CMakeLists.txt to use MSYS2/UCRT64 for Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,23 @@ if(MSVC
   add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
 endif()
 
+if(MINGW)
+  if (DEFINED ENV{MSYSTEM})
+    message(STATUS "MSYS2 $ENV{MSYSTEM} environment detected")
+    if ("$ENV{MSYSTEM}" STREQUAL "MINGW64")
+      message(STATUS "MINGW64 environment detected. Ming-w64 is being phased out in favor of MSYS2 UCRT64, but it is still supported for now.")
+      message(STATUS "To compile with MSYS2 UCRT64, run CMake from within the MSYS2 UCRT64 shell.")
+    endif()
+    if ("$ENV{MSYSTEM}" STREQUAL "MSYS")
+      message(STATUS "MSYS environment detected. The MSYS environment is not recommended for building CoolProp.")
+      message(FATAL_ERROR "To compile with MSYS2 UCRT64, run CMake from within the MSYS2 UCRT64 shell.")
+    endif()
+  else()
+      message(STATUS "Original MINGW Detected. MinGW is deprecated in favor of MSYS2 UCRT64.")
+      message(FATAL_ERROR "To compile with MSYS2 UCRT64, run CMake from within the MSYS2 UCRT64 shell.")
+  endif()
+endif()
+
 if(COOLPROP_RELEASE AND COOLPROP_DEBUG)
   message(FATAL_ERROR "You can only make a release OR and debug build.")
 endif()
@@ -261,6 +278,16 @@ elseif(COOLPROP_DEBUG)
   #  ELSE ()
   #    SET(CMAKE_BUILD_TYPE Release)
   #  ENDIF()
+endif()
+
+# Ensure MSYS2/UCRT outputs are grouped by build type - emmulates MSVC behavior
+if(MINGW AND DEFINED ENV{MSYSTEM})
+  if("${CMAKE_BUILD_TYPE}" STREQUAL "")
+    set(CMAKE_BUILD_TYPE Release)
+  endif()
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}")
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}")
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}")
 endif()
 
 if(COOLPROP_MSVC_STATIC)
@@ -448,7 +475,8 @@ endmacro()
 #        Calculate if 32 or 64        #
 #######################################
 
-if(WIN32)
+## If WIN32 (but NOT MINGW where bitness is determined from SIZEOF_VOID_P)
+if(WIN32 AND NOT MINGW)
   if(CMAKE_CL_64)
     set(BITNESS "64")
   else()
@@ -469,19 +497,19 @@ if(MSVC AND (FORCE_BITNESS_32 OR FORCE_BITNESS_64))
   )
   message(
     STATUS
+      "Pass '-G \"Visual Studio 17 2022\" -A x64' to CMake to make a 64bit binary using VS2017 or later."
+  )
+  message(
+    STATUS
+      "Pass '-G \"Visual Studio 17 2022\" -A win32' to CMake to make a 32bit binary using VS2017 or later."
+  )
+  message(
+    STATUS
       "Pass '-G \"Visual Studio 10 2010 Win64\"' to CMake to make a 64bit binary using VS2010."
   )
   message(
     STATUS
       "Pass '-G \"Visual Studio 10 2010\"' to CMake to make a 32bit binary using VS2010."
-  )
-  message(
-    STATUS
-      "Pass '-G \"Visual Studio 9 2008 Win64\"' to CMake to make a 64bit binary using VS2008."
-  )
-  message(
-    STATUS
-      "Pass '-G \"Visual Studio 9 2008\"' to CMake to make a 32bit binary using VS2008."
   )
   message(FATAL_ERROR "Fix that and try again...")
 endif()
@@ -666,8 +694,8 @@ if(COOLPROP_OBJECT_LIBRARY
     # Embed Windows VERSIONINFO so CoolProp.dll's Properties dialog shows
     # FileVersion/ProductVersion fields (#2391). The .rc is configured from
     # COOLPROP_VERSION_{MAJOR,MINOR,PATCH} above and added to the source
-    # list only on MSVC, where rc.exe is available.
-    if(MSVC)
+    # list only on MSVC and MSYS2 (MinGW), where rc.exe (or MSYS2 windres) is available.
+    if(MSVC OR MINGW)
       configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/dev/CoolProp.rc.in"
         "${CMAKE_CURRENT_BINARY_DIR}/CoolProp.rc"
@@ -732,6 +760,23 @@ if(COOLPROP_OBJECT_LIBRARY
         DESTINATION ${OUTPUT_FOLDER}
 	  )
     endif()
+
+    # MSYS2(MINGW) specific stuff
+    if(MINGW AND DEFINED ENV{MSYSTEM})
+      # Add postfix for debugging (same as MSVC)
+      set_property(TARGET ${LIB_NAME} PROPERTY DEBUG_POSTFIX d)
+      set_property(TARGET ${LIB_NAME} PROPERTY RELEASE_POSTFIX)
+      # No lib prefix for the shared library (same as MSVC)
+      set_property(TARGET ${LIB_NAME} PROPERTY PREFIX "")
+      set_target_properties(${LIB_NAME} PROPERTIES IMPORT_PREFIX "" IMPORT_SUFFIX ".a")
+      # Statically link all MINGW libraries and make the file truly portable
+      # See (https://stackoverflow.com/questions/13768515/how-to-do-static-linking-of-libwinpthread-1-dll-in-mingw)
+      # NOTE: use MSYS2/UCRT64 ntldd to check dependencies, MSYS2 & cygwin ldd will give false ucrt64 dependencies
+      target_link_options(${LIB_NAME} PRIVATE -static-libgcc -static-libstdc++)
+      target_link_libraries(${LIB_NAME} PRIVATE -Wl,-Bstatic -lwinpthread -Wl,-Bdynamic)  #scopes only winpthreads
+      # Note that Windows system DLLs (ucrt, kernel32, etc.) remain dynamically linked.
+    endif()
+
     # For Linux
     if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
       set_property(TARGET ${LIB_NAME} PROPERTY VERSION ${COOLPROP_VERSION})
@@ -826,7 +871,11 @@ if(COOLPROP_OBJECT_LIBRARY
   message(STATUS "COOLPROP_STATIC_LIBRARY: ${COOLPROP_STATIC_LIBRARY}")
   message(STATUS "COOLPROP_SHARED_LIBRARY: ${COOLPROP_SHARED_LIBRARY}")
   message(STATUS "COOLPROP_OBJECT_LIBRARY: ${COOLPROP_OBJECT_LIBRARY}")
-  message(STATUS "CONVENTION: ${CONVENTION}")
+  if(("${CONVENTION}" STREQUAL "NULL") OR ("${CONVENTION}" STREQUAL ""))
+     message(STATUS "CONVENTION: Not Set")
+  else()
+     message(STATUS "CONVENTION: ${CONVENTION}")
+  endif()
   message(STATUS "COOLPROP_LIBRARY_HEADER: ${COOLPROP_LIBRARY_HEADER}")
   message(STATUS "COOLPROP_LIBRARY_SOURCE: ${COOLPROP_LIBRARY_SOURCE}")
   #
@@ -2042,7 +2091,6 @@ if(COOLPROP_MATHEMATICA_MODULE)
 
   if(MSVC)
     modify_msvc_flags("/MT")
-
     # Note that the default is not used if ${COOLPROP_MSVC_REL} or ${COOLPROP_MSVC_DBG} is set
   endif()
 
@@ -2060,14 +2108,56 @@ if(COOLPROP_MATHEMATICA_MODULE)
   )
   message(STATUS "Mathematica_USERBASE_DIR=${Mathematica_USERBASE_DIR}")
 
+  # Build a fresh source list: core CoolProp sources WITHOUT CoolPropLib.cpp.
+  set(MATHEMATICA_SOURCES ${APP_SOURCES})
+  list(REMOVE_ITEM MATHEMATICA_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/CoolPropLib.cpp")
   list(
-    APPEND APP_SOURCES
+    APPEND MATHEMATICA_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/wrappers/Mathematica/CoolPropMathematica.cpp")
   list(APPEND APP_INCLUDE_DIRS "${Mathematica_WolframLibrary_INCLUDE_DIR}")
   include_directories(${APP_INCLUDE_DIRS})
-  add_library(CoolProp SHARED ${APP_SOURCES})
+  add_library(CoolProp SHARED ${MATHEMATICA_SOURCES})
   add_dependencies(CoolProp generate_headers)
   coolprop_hide_json_symbols(CoolProp)
+  if(MINGW AND DEFINED ENV{MSYSTEM})
+    # Add postfix for debugging (same as MSVC)
+    set_property(TARGET ${app_name} PROPERTY PREFIX "")
+    set_target_properties(${app_name} PROPERTIES IMPORT_PREFIX "" IMPORT_SUFFIX ".a")
+    # COFF section-number overflow fix: HelmholtzEOSMixtureBackend.cpp emits
+    # 33K+ COMDAT sections (one per template instantiation from Eigen/fmt/etc).
+    # Standard COFF stores section numbers as a signed 16-bit integer (max 32767);
+    # sections numbered above that get a negative SectionNumber in symbol-table
+    # entries, making vtable symbols appear undefined to the linker.
+    # -O1 inlines enough small template functions at call sites to keep the
+    # per-TU section count below 32767 without requiring assembler bigobj support.
+    # (Release builds already pass -O2/-O3 via CMAKE_BUILD_TYPE, so this only
+    # matters for Debug/unoptimized builds.)
+    if(NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "Debug")
+      target_compile_options(${app_name} PRIVATE -O1)
+    endif()
+    # Statically link all MINGW libraries and make the file truly Windows portable
+    # See (https://stackoverflow.com/questions/13768515/how-to-do-static-linking-of-libwinpthread-1-dll-in-mingw)
+    # NOTE: use MSYS2/UCRT64 ntldd to check dependencies, MSYS2 & cygwin ldd will give false ucrt64 dependencies
+    # Use -static-libgcc/-static-libstdc++ embed the GCC/C++ runtimes; -Bstatic/-Bdynamic scopes only winpthread
+    target_link_options(${app_name} PRIVATE -static-libgcc -static-libstdc++)
+    # Use -Bstatic/-Bdynamic scopes only winpthread so that Windows system DLLs (ucrt, kernel32, etc.) remain dynamically linked.
+    target_link_libraries(${app_name} PRIVATE -Wl,-Bstatic -lwinpthread -Wl,-Bdynamic)
+  endif()
+
+  # Set the bitness
+  if(NOT MSVC)
+    if(NOT "${BITNESS}" STREQUAL "NATIVE")
+      message(STATUS "Setting bitness flag -m${BITNESS}")
+      set_property(
+        TARGET ${app_name}
+        APPEND_STRING
+        PROPERTY COMPILE_FLAGS " -m${BITNESS}")
+      set_property(
+        TARGET ${app_name}
+        APPEND_STRING
+        PROPERTY LINK_FLAGS " -m${BITNESS}")
+    endif()
+  endif()
 
   if(MSVC)
     add_custom_command(

--- a/Web/coolprop/wrappers/Installers/index.rst
+++ b/Web/coolprop/wrappers/Installers/index.rst
@@ -23,6 +23,17 @@ Microsoft Excel
 
 The add-in for Microsoft Excel can also be installed from this package and it automatically determines which of the two available add-ins is needed.  There is ``CoolProp.xla`` for Microsoft Office versions prior to version 2007 and ``CoolProp.xlam`` for more recent Office installations. The add-ins are installed into the user's add-in directory and they are activated by default.  Please note that the Excel add-in includes the installation of some of the shared libraries.  Upon installation, an example file is placed on the user's desktop.  This file demonstrates some of the features of the Excel wrapper and can be moved or deleted freely, it will not be removed by the uninstaller. Have a look at the dedicated :ref:`page <Excel>` for more information.
 
+.. note::
+   If the CoolProp functions in the calculation cells display ``=Name?`` you may have to "dirty" the cell equations (i.e., re-enter them) to get the functions to work.  The easiest and fastest way to do this for an entire worksheet is to:
+
+   1. Press ``Ctrl + A`` to select the entire worksheet.
+   2. Press ``Ctrl + H`` to open the Find and Replace dialog box.
+   3. Type an equals sign (``=``) into the **Find what** field.
+   4. Type an equals sign (``=``) into the **Replace with** field.
+   5. Click **Replace All**.
+
+   This effectively replaces the ``=`` sign in the formulas with itself so that Excel thinks this is a new formula. This should properly evaluate all cells containing CoolProp functions.
+
 Engineering Equation Solver
 ===========================
 

--- a/Web/coolprop/wrappers/MSYS2/index.rst
+++ b/Web/coolprop/wrappers/MSYS2/index.rst
@@ -1,0 +1,117 @@
+.. _msys2:
+
+***********
+MSYS2 Setup
+***********
+
+.. image:: https://www.msys2.org/logo.svg
+   :alt: MSYS2 Logo
+   :width: 75px
+   :align: left
+
+This is not a wrapper in itself, but guidance on using the MSYS2 toolchain to compile libraries and wrappers on Windows.
+
+Background
+==========
+
+Prior versions of CoolProp supported **MINGW** as a Windows port of gcc.  However, the original **MINGW** has been frozen since 2013 and is no longer compatible.  Mingw-x64 (*with 32 and 64-bit compilers*) was forked form MinGW in 2007 to add 64-bit support and coverage of newer Windows APIs absent from the original project.  `MSYS2 <https://www.msys2.org/>`_ followed in the 2010s, building on Mingw-x64 while adding the ``pacman`` package manager and a modernized distribution model. There is also a `VS Code extension <https://code.visualstudio.com/docs/cpp/config-mingw#_prerequisites>`_ facilitating use of **VS Code** as the IDE to run the g++ compiler and GDB debugger.  `MSYS2 <https://www.msys2.org/>`_ is the best place to download this set of GNU compiler tools as well as help on
+
+* Installing and setting up the MSYS2/UCRT64 environment
+* Terminals for command line operations in the UCRT64 environment
+* Compilers and toolchains, including the most recent gcc version
+* A UCRT64 specific version of CMake and other compiler tools
+* Ninja CMake generator for auto-selection of toolchain based on current terminal environment
+
+
+Installation
+============
+
+Install **MSYS2** from `MSYS2.org <https://www.msys2.org/>`_.
+
+* Requires 64-bit Windows 10 (1809+) or newer.  Support for Windows 8.1 was dropped in February, 2026.
+* Install to ``C:\msys64``` only.  This will make life much easier!
+* When given a choice, choose the **UCRT64** environment!
+
+  * The **UCRT** C standard library is newer and also used by MS Visual Studio by default.  It has better compatibility with MSVC, both at build and runtime, and is for modern C++ development.
+  * The **MSYS** environment uses the cygwin C Library and is really only for package management.
+  * There is a **MINGW64** environment, but it is being phased out of **MSYS2**.
+  * The **CLANG64** or **CLANGARM64** environments can be used (especially if compiling on ARM architecture), but have not been tested with CoolProp (*yet*).
+
+In addition to installation, read through the `MSYS2 Documentation <https://www.msys2.org/docs/what-is-msys2/>`_.  There is a lot of information there that will help with environment and tools setup.
+
+Adding Compiler and Tools
+=========================
+
+Instead of MinGW or Ming-w64, install the **UCRT64** compiler toolchain::
+
+    pacman -S --needed base_devel mingw-w64-ucrt-x86_64-toolchain
+
+This will install:
+
+* g++
+* gcc
+* ld
+* standard C++ libraries
+* modern Windows CRT (UCRT) libraries
+
+.. note::
+   **MinGW** is no longer supported and **Ming-w64** is being phased out of MSYS2 in favor of **UCRT64**.
+
+Tools Needed for the CoolProp Build Process
+======================================================
+
+Other than the compilers, there are a few additional tools that will be needed.  These can be installed separately with the pacman package manager, or all at once by listing them all on the packman package list.
+
+**Install UCRT64 CMake**
+
+MSYS2 has its own version of cmake that is **UCRT64** aware.  Install it with::
+
+   pacman -S --needed mingw-w64-ucrt-x86_64-cmake
+
+
+**Install UCRT64 Git**::
+
+This is practically identical to the standalone "Git for Windows", but it is neatly bundled and pre-configured by the MSYS2 team to seamlessly integrate with your UCRT64 pathing and shell settings.  Install with::
+
+    pacman -S --needed mingw-w64-ucrt-x86_64-git
+
+.. note::
+   MSYS2 has its own **git** package primarily because standard Windows programs and Unix/Linux programs handle file paths, lines endings, and system processes fundamentally differently.
+
+
+**Install UCRT64 Ninja**
+
+MSYS2 **Ninja** is a compact, ultra-fast, low-level build system optimized strictly for execution speed. On `MSYS2 <https://www.msys2.org/>`_.  Install it with::
+
+    pacman -S --needed mingw-w64-ucrt-x86_64-ninja
+
+
+.. note::
+   Ninja is actually the default backend for the MSYS2 version of CMake. If you do not pass a -G flag to CMake, it automatically looks for a Ninja installation.
+
+Verify the Installation
+=======================
+
+Open an ``MSYS2/MSYS2 UCRT64`` terminal from the Windows start menu and type::
+
+  which gcc g++ cmake git
+
+all found paths should be in ``/ucrt64/bin/``. This means they are all in the ``UCRT64`` environment path.
+
+Keeping MSYS2 Up-to-Date
+========================
+
+MSYS2 uses a global update process, rather than a package update, in order to ensure resolution of package dependencies.  Periodically, the MSYS2 environment should be updated with the command::
+
+  pacman -Syu
+
+UCRT64 Shell Environment
+========================
+
+**Always, always, always** build CoolProp in a ``UCRT64`` terminal (see `MSYS2 Terminals <https://www.msys2.org/docs/terminals/>`_ on setting this up).  Inside a UCRT64 Shell, the normal Windows environment variable and paths are completely replaced with a UCRT64 environment.  This means that running git, cmake, or g++ will use the MSYS2 UCRT64 versions of these codes instead of the Windows native or Cygwin versions if they are installed on the machine.
+
+Pro-Tip:
+========
+
+1. If using VS Code as your IDE/Text Editor, add the `MSYS2 recommended json <https://www.msys2.org/docs/terminals/>`_ so that the ``MSYS2 UCRT64`` profile is available when launching a terminal window.
+2. Add the path to VS Code to your .bashrc file so that it is available within a UCRT64 Shell and can be launched by typing ``code`` at the shell prompt.

--- a/Web/coolprop/wrappers/Mathematica/index.rst
+++ b/Web/coolprop/wrappers/Mathematica/index.rst
@@ -48,25 +48,31 @@ You need to just slightly modify the building procedure
     # Make a build folder
     mkdir build && cd build
 
-2. Pick a toolchain (A or B)
+2. Pick a toolchain (A or B):
 
-    A: Building using Visual Studio::
-
-        # Build the makefile using CMake
-        cmake .. -DCOOLPROP_MATHEMATICA_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -G "Visual Studio 17 2022" -A x64"
-
-.. note::
-    If you have a different version of Visual Studio installed, replace the generator name in the ``-G`` argument.  Note that the DLL must be 64-bit by using the ``-A x64`` option at the end.  Prior to VS 2017, this "bitness" was embedded in the ``-G`` argument using the format **-G "Visual Studio 14 2015 Win64"** and will not use the ``-A`` option.
-
-    B: Building using MinGW::
+    A: Create the Build system using **Visual Studio**::
 
         # Build the makefile using CMake
-        cmake .. -DCOOLPROP_MATHEMATICA_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -G "MinGW Makefiles"
+        cmake .. -DCOOLPROP_MATHEMATICA_MODULE=ON -G "Visual Studio 17 2022" -A x64
 
-3. Actually do the build::
+    .. note::
+        If you have a different version of Visual Studio installed, replace the generator name in the ``-G`` argument.  Note that the DLL must be 64-bit by using the ``-A x64`` option at the end.  Prior to VS 2017, this "bitness" was embedded in the ``-G`` argument using the format **-G "Visual Studio 14 2015 Win64"** and will not use the ``-A`` option.
 
-    # Make the shared library
-    cmake --build . --config Release
+    B: Create the Build system using **MSYS2 UCRT64** (MinGW) from within a ``UCRT64`` shell terminal::
+
+        # From with a UCRT64 window, build the makefile using CMake
+        cmake -G Ninja -DCOOLPROP_MATHEMATICA_MODULE=ON -DCOOLPROP_RELEASE=ON ..
+
+3. Actually do the build
+
+    Under both toolchains::
+
+        # Make the shared library
+        cmake --build . --config Release
+
+    .. note::
+        Alternatively, if using MSYS2 UCRT64, you can simply issue the comman: ``ninja``
+
 
 Install and Verify
 ==================
@@ -80,6 +86,6 @@ There is a small example file ``example.nb`` in the CoolProp repository under ``
 
 Future Work
 ===========
-As of Wolfram Mathematica 14.0, the Wolfram Language has the ability to make API calls *directly to the CoolProp shared library*.  This can be done from a Wolfram Language ``paclet`` that obviates the need for compiling a C++ wrapper and can be handled solely through Mathematica's **Paclet Manager**.  This means that the wrapper can be built with automation scripts by any user for any version of Mathematica greater than v14.0.
+As of Wolfram Mathematica 14.0, the Wolfram Language has the ability to make API calls *directly to the CoolProp shared library*.  This can be done from a Wolfram Language ``package``/``paclet`` that obviates the need for compiling a C++ wrapper and can be handled solely through Mathematica's **Paclet Manager**.  This means that the wrapper can be built with automation scripts by any user for any version of Mathematica greater than v14.0.
 
 We welcome any Wolfram Language users to take this on and contribute to the CoolProp project.

--- a/Web/coolprop/wrappers/SharedLibrary/index.rst
+++ b/Web/coolprop/wrappers/SharedLibrary/index.rst
@@ -36,16 +36,13 @@ On windows, the greatest amount of complexity is experienced.
 
 Your compiler options are:
 
-* MinGW (a windows port of GCC)
+* `MSYS2 <https://www.msys2.org/>`_ UCRT64 (formerly MinGW, a windows port of GCC)
 * Visual Studio, multiple versions can be installed in parallel
 
-By default, cmake will use your most up to date version of visual studio it finds.
+By default, cmake will use your most up to date version of MS Visual Studio it finds.
 
 .. warning::
-    An old MinGW GCC may have problems building the latest version of CoolProp.  Use a
-    recent MinGW-w64 toolchain (for instance via `MSYS2 <https://www.msys2.org/>`_) or the
-    `TDM-GCC distribution <https://jmeubank.github.io/tdm-gcc/>`_, both of which ship a
-    modern GCC.
+    The old MinGW GCC may have problems building the latest version of CoolProp.  Use a more recent toolchain (for instance via `MSYS2 <https://www.msys2.org/>`_) that ships a modern GCC.
 
 Your calling convention options are:
 
@@ -54,6 +51,9 @@ Your calling convention options are:
 * 64-bit (``-DCOOLPROP_SHARED_LIBRARY=ON``)
 
 You can select the compiler in the call to cmake below.
+
+.. note::
+   If using `MSYS2/UCRT64 <https://www.msys2.org/>`_, perform these steps in a UCRT64 terminal.  If using Visual Studio, you can use a command window (cmd) or a PowerShell terminal.
 
 1. Check out sources and go into the build directory::
 
@@ -64,45 +64,62 @@ You can select the compiler in the call to cmake below.
     # Make a build folder
     mkdir build && cd build
 
-2. Generate the build file.  Here is where it gets complicated.
+2. Generate the build file.  Here is where it gets a little complicated.
 
-    A. If you use MinGW, these are your options:
+   A. If you use `MSYS2/UCRT64 <https://www.msys2.org/>`_, these are your options:
 
-    For 64-bit DLL::
+      For 64-bit DLL (default)::
 
-        cmake .. -DCOOLPROP_SHARED_LIBRARY=ON -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release
+        cmake .. -DCOOLPROP_SHARED_LIBRARY=ON -G "Ninja" -DCMAKE_BUILD_TYPE=Release
 
-    For 32-bit __stdcall DLL::
+      For 32-bit __stdcall DLL::
 
-        cmake .. -DCOOLPROP_SHARED_LIBRARY=ON -DCOOLPROP_STDCALL_LIBRARY=ON -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release
+        cmake .. -DCOOLPROP_SHARED_LIBRARY=ON -DCOOLPROP_STDCALL_LIBRARY=ON -G "Ninja" -DCMAKE_BUILD_TYPE=Release
 
-    For 32-bit __cdecl DLL::
+      For 32-bit __cdecl DLL::
 
-        cmake .. -DCOOLPROP_SHARED_LIBRARY=ON -DCOOLPROP_CDECL_LIBRARY=ON -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release
-        
-    You can cross-compile by forcing a non-native bitness by using the additional flags ``-DFORCE_BITNESS_32=ON`` and ``-DFORCE_BITNESS_64=ON``.
+        cmake .. -DCOOLPROP_SHARED_LIBRARY=ON -DCOOLPROP_CDECL_LIBRARY=ON -G "Ninja" -DCMAKE_BUILD_TYPE=Release
 
-    B. If you use Visual Studio, you will need to replace the visual studio version with the version that you are using.  Running the command ``cmake`` at the command prompt will tell you what generators are supported
+      You can cross-compile by forcing a non-native bitness by using the additional flags ``-DFORCE_BITNESS_32=ON`` and ``-DFORCE_BITNESS_64=ON``.
 
-    For 64-bit DLL (Watch out for the 64-bit flag with Win64)::
+   .. note::
+      The commands above should be executed *within* an **MSYS2/UCRT64** environment window (see `MSYS2 <https://www.msys2.org/>`_ for setup).  This window will remove windows system paths to native Windows tools and, instead, rely on the UCRT64 toolchain and your ``.bashrc`` file. **UCRT64** versions of ``gcc``, ``CMake`` and ``Ninja`` should be installed as part of this tool chain using the ``pacman`` package manager.  The ``Ninja`` generator simplifies the process by choosing the MingW, Ming-w64, or ucrt64 gcc/g++ compiler, depending on the environment window in which the commands are executed.
 
-        cmake .. -DCOOLPROP_SHARED_LIBRARY=ON -G "Visual Studio 10 2010 Win64"
+   B. If using Visual Studio, replace the Visual Studio version with the version that you are using (see Note below).  Running the command ``cmake`` at the command prompt will tell you which generators are supported
 
-    For 32-bit __stdcall DLL::
+      For 64-bit DLL (Watch out for the 64-bit flag with Win64)::
 
-        cmake .. -DCOOLPROP_SHARED_LIBRARY=ON -DCOOLPROP_STDCALL_LIBRARY=ON -G "Visual Studio 10 2010"
+        cmake .. -DCOOLPROP_SHARED_LIBRARY=ON -G "Visual Studio 17 2022" -A x64
 
-    For 32-bit __cdecl DLL::
+      For 32-bit __stdcall DLL::
 
-        cmake .. -DCOOLPROP_SHARED_LIBRARY=ON -DCOOLPROP_CDECL_LIBRARY=ON -G "Visual Studio 10 2010"
-        
-    Since you already selected the bitness via the Visual Studio version, passing an additional flag to force a certain bitness will cause a n error and make the process terminate prematurely. 
+        cmake .. -DCOOLPROP_SHARED_LIBRARY=ON -DCOOLPROP_STDCALL_LIBRARY=ON -G "Visual Studio 17 2022" -A x64
+
+      For 32-bit __cdecl DLL::
+
+        cmake .. -DCOOLPROP_SHARED_LIBRARY=ON -DCOOLPROP_CDECL_LIBRARY=ON -G "Visual Studio 17 2022" -A x64
+
+   .. note::
+      With Visual Studio 2019 or later, the bitness is no longer embedded in the ``-G`` parameter, but specified with an additional ``-A`` parameter followed by either ``Win32`` or ``x64``.  As of Visual Studio 2017, 64-bit is the default.
+
+      Example: for 64-bit,
+
+        -G "Visual Studio 17 2022" -A x64
+
+      or for 32-bit,
+
+        -G "Visual Studio 17 2022" -A Win32
+
+
+   Since the bitness for Visual Studio is already specified with the ``-A`` switch (*or embedded in the ``-G`` string for older VS versions*), passing an additional flag to force a certain bitness will cause an error and the process will terminate.
 
 3. Do the build::
 
     cmake --build . --config Release
 
-If you are using MinGW, you can leave off the ``--config Release``, the default build configuration is release
+   .. note::
+      Alternatively, if using MSYS2 UCRT64, you can simply issue the comman: ``ninja``
+|
 
 Linux & OSX
 -----------
@@ -142,7 +159,7 @@ For 64-bit compilation::
 On Linux, installation could be done by::
 
     # Change "32" to match your system bitness
-    sudo cp libCoolProp.so /usr/local/lib/libCoolProp.so.32.:version: 
+    sudo cp libCoolProp.so /usr/local/lib/libCoolProp.so.32.:version:
     pushd /usr/local/lib
     sudo ln -sf libCoolProp.so.32.:version: libCoolProp.so.5
     sudo ln -sf libCoolProp.so.5 libCoolProp.so
@@ -193,7 +210,7 @@ Here is a small example for calling the shared library from C on windows, as con
             printf("Could not load CoolProp DLL.");
         }
     }
-    
+
 Here is another snippet of using the shared library in windows when (for your application), you MUST use a Visual Studio 32-bit stdcall dll of CoolProp for compatibility with other tools::
 
     // This is to get all the function prototypes from the header
@@ -211,7 +228,7 @@ Here is another snippet of using the shared library in windows when (for your ap
         return 1;
     }
 
-    
+
 Linux
 -----
 

--- a/Web/coolprop/wrappers/StaticLibrary/index.rst
+++ b/Web/coolprop/wrappers/StaticLibrary/index.rst
@@ -69,25 +69,25 @@ You can build the static library using::
     cmake .. -DCOOLPROP_STATIC_LIBRARY=ON
     # Make the static library
     cmake --build .
-    
+
 .. note::
 
-    If you use mingw port of gcc on windows, you should add the generator name to the first call of cmake so that it reads something like::
-    
-        cmake .. -G "MinGW Makefiles" -DCOOLPROP_STATIC_LIBRARY=ON
-        
+    If you use the modern mingw (MSYS2/UCRT) port of gcc on windows, you should run from within the UCRT64 environment and add the generator name to the first call of cmake so that it reads something like::
+
+        cmake .. -G "Ninja" -DCOOLPROP_STATIC_LIBRARY=ON -DCOOLPROP_RELEASE=ON
+
 .. note::
 
     If you use Microsoft Visual Studio, you should tell cmake what exact version of visual studio you would like it to use, by doing something like::
-    
-        cmake .. -G "Visual Studio 12 2013 Win64" -DCOOLPROP_STATIC_LIBRARY=ON
-        
-    which is a 64-bit build for Microsoft Visual Studio 2013 (even express version) for instance.  You can get the full list of supported generators on your machine by doing `cmake --help`.
-    
+
+        cmake .. -G "Visual Studio 17 2022" -A x64 -DCOOLPROP_STATIC_LIBRARY=ON
+
+    which is a 64-bit build for Microsoft Visual Studio 2022 (even express version) for instance.  You can get the full list of supported generators on your machine by doing `cmake --help`.
+
 .. note::
-    
+
     If you use gcc with libstdc++ (like on ubuntu) and want to build the debug library, you should add the proper cxx flags to link to the correct debug libstdc++ librariries::
-    
+
         cmake .. -DCOOLPROP_DEBUG=ON -DCMAKE_CXX_FLAGS_DEBUG='-g -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC'
 
 Usage
@@ -114,17 +114,17 @@ On linux and OSX, you can use the compiled static library in your application by
 This will result in an executable which can be run by the user.
 
 .. warning::
-    
+
     In gcc and mingw ports of gcc, make sure that the `-lCoolProp` is the last argument in the line, otherwise you will certainly get linking errors.  See also: https://www.mingw.org/wiki/specify_the_libraries_for_the_linker_to_use .
-    
+
 Windows
 ^^^^^^^
 
-On windows the two main compiler families are Visual Studio and MINGW+GCC.
+On windows the two main compiler families are Visual Studio and MSYS2(UCRT64)+gcc.
 
-**Mingw+gcc**: If you use mingw, follow the instructions like for linux and OSX, and leave off the ``-ldl`` argument to the compilation.
+**MSYS2(UCRT64)+gcc**: If you use MSYS2(UCRT64) (*formerly MINGW*), follow the instructions like for linux and OSX, and leave off the ``-ldl`` argument to the compilation.
 
-**Visual Studio**: 
+**Visual Studio**:
 
 a) Generate the static library following the command line instructions above, ensuring that you have selected the proper visual studio version as well as ``Win64`` in your generator if you would like a 64-bit static library
 b) Create a new empty project in visual studio, change to 64-bit (x64) build type if you would like

--- a/Web/coolprop/wrappers/index.rst
+++ b/Web/coolprop/wrappers/index.rst
@@ -23,7 +23,7 @@ Target                                                  Operating Systems       
 :ref:`Java <Java>`                                      linux, OSX, win              Wrapper is SWIG based
 :ref:`R <R>`                                            linux, OSX, win              Wrapper is SWIG based
 :ref:`Scilab <Scilab>`                                  linux, OSX, win              Wrapper is SWIG based (experimental)
-:ref:`Julia <Julia>`                                    linux, OSX, win              
+:ref:`Julia <Julia>`                                    linux, OSX, win
 `Modelica <https://github.com/modelica/ExternalMedia>`_ linux, OSX, win
 :ref:`PHP <PHP>`                                        linux, OSX, win              Mostly used on linux
 :ref:`Javascript <Javascript>`                          cross-platform               Works in all internet browsers
@@ -37,8 +37,8 @@ Target                                                  Operating Systems       
 :ref:`Microsoft Excel <Excel>`                          Windows only                 Included in the Windows :ref:`installer <Installers>`
 :ref:`LibreOffice <LibreOffice>`                        Windows, linux
 :ref:`Delphi & Lazarus <Delphi>`                        linux, OSX, win
-:ref:`iOS (iPhone) <ios>`                       
-:ref:`Android <Android>`                       
+:ref:`iOS (iPhone) <ios>`
+:ref:`Android <Android>`
 ======================================================= ===========================  =====================================================
 
 .. _wrapper_common_prereqs:
@@ -59,7 +59,7 @@ Windows
 On Windows, download the newest binary installer for CMake from `CMake downloads <https://www.cmake.org/cmake/resources/software.html>`_.  Run the installer.  Check that at the command prompt you can do something like::
 
     C:\Users\XXXX>cmake -version
-    cmake version 2.8.12.2
+    cmake version 4.3.2
 
 For git, your best bet is the installer from https://git-scm.com/download/win.  Check that at the command prompt you can do something like::
 
@@ -70,7 +70,7 @@ For 7-zip, download the installer from https://www.7-zip.org/ .  Check that at t
 
     C:\Users\XXXX>7z
 
-    7-Zip [64] 9.20  Copyright (c) 1999-2010 Igor Pavlov  2010-11-18
+    7-Zip [64] 26.00  Copyright (c) 1999-2010 Igor Pavlov  2010-11-18
 
     Usage: 7z <command> [<switches>...] <archive_name> [<file_names>...]
            [<@listfiles...>]
@@ -79,7 +79,7 @@ For python, you should be using `Anaconda/Miniconda <https://www.anaconda.com/do
 
 For the C++ compiler on Windows you have two mainstream options:
 
-* **MinGW-w64** (a Windows port of GCC), most easily obtained via `MSYS2 <https://www.msys2.org/>`_: after installing it, run ``pacman -S mingw-w64-x86_64-gcc`` and add the ``mingw64\bin`` directory to your PATH.  Install to a path without spaces.
+* **MSYS2/UCRT64** (a Windows port of GCC and modern version of **MINGW**), most easily obtained via `MSYS2 <https://www.msys2.org/>`_: See :ref:`CoolProp MSYS2 Setup <MSYS2>` guidance.
 * **Visual Studio** — install the free Community edition with the "Desktop development with C++" workload.
 
 Most users never need to compile the Python wrapper themselves, since pre-built CoolProp wheels are published on `PyPI <https://pypi.org/project/CoolProp/>`_.  If you do build from source, the old advice about matching a specific Visual Studio version to your Python version no longer applies: since Visual Studio 2015 the C runtime (UCRT) is stable, so any recent Visual Studio works.
@@ -97,7 +97,7 @@ OSX
 OSX should come with a c++ compiler (clang), for git and cmake your best bet is `Homebrew <https://brew.sh/>`_.  With Homebrew installed, you can just do::
 
     brew install cmake git p7zip
-    
+
 OSX includes a python version, but you should be using `Anaconda/Miniconda <https://www.anaconda.com/download>`_ for your python installation.  Or, you can just install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_, which is sufficient. For python, you need the ``six`` package, a ``pip install six`` should do it.
 
 If you have never done any command-line compilation before on OSX, chances are that you do not have the utilities needed. Thus you need to first install Xcode: see the description on the page https://guide.macports.org/#installing.xcode . After installing, you need to accept the license by running the following command in the Terminal::
@@ -135,3 +135,4 @@ and explicitly typing "agree" before closing. Then you can use the compiler from
     VB.net/index.rst
     R/index.rst
     Installers/index.rst
+    MSYS2/index.rst


### PR DESCRIPTION
### Description of the Change

This is a focused MSYS2/UCRT64 enablement patch - including detection, output layout, linking and documentation.  Provides guidance on using MSYS2/UCRT64 as a replacement to MINGW and Ming-w64.  Here's a summary of the changes to ``CMakeLists.txt``:

1. **MinGW environment detection & gating** (lines ~251–266)
A new block checks MINGW + $ENV{MSYSTEM}. It warns if MINGW64 is detected (being phased out), and hard-errors if the bare MSYS or original MinGW environments are used, directing users to UCRT64.

2. **MSYS2 output directory grouping** (lines ~283–288)
When building under MSYS2, CMAKE_RUNTIME/LIBRARY/ARCHIVE_OUTPUT_DIRECTORY are set to include the build type subfolder, mimicking MSVC's per-config output layout.

3. **Bitness detection fix for MINGW** (line ~475)
The WIN32 bitness check is changed to WIN32 AND NOT MINGW so that MinGW builds use CMAKE_SIZEOF_VOID_P (the generic path) instead of CMAKE_CL_64 (MSVC-only).  Note that even under MSYS2/UCRT64 builds the MINGW environment variable is valid and set in CMake.

4. **Updated VS generator hint messages** (lines ~497–513)
The MSVC bitness-forcing error messages now reference VS 2017/2022 (-A x64/-A win32) instead of the old VS 2008/2010 generator strings.

5. **MSYS2 windres support for shared library** (line ~694)
The .rc VERSIONINFO embed (for the DLL's file/product version properties) now also applies to MSYS2 builds, where ``windres`` is available to incorporate version info.

6. **MSYS2-specific shared library settings** (lines ~757–775)
New block for the COOLPROP_SHARED_LIBRARY target under MSYS2: removes the lib prefix, sets import suffix to .a, and statically links GCC/C++ runtimes + winpthread so the output DLL is portable without MSYS2 runtime dependencies.

7. **Convention status message fix** (lines ~868–874)
The CONVENTION status message now guards against printing an empty string, showing "Not Set" instead.

8. **Mathematica module overhaul** (lines ~2088–2160)
Ensures proper linking without CoolPropLib as the Mathematica wrapper provides the exported functions.  Also fixes an issue using Debug ON caused by large CoolProp files that exceed COFF 32767 byte section limits without any optimization.  Also sets bitness flag for non-MSVC builds (i.g., MSYS2). 

Web Docs are updated to direct users to MSYS2/UCRT64 builds using the MSYS2 Ninja generator for CMake.  An MSYS2 Guidance page is provided as well as updates to the following ``.rst`` files:
- **Installers** (discovered an Excel issue and workaround when CoolProp functions are not recognized)
- **Mathematica** (Building with MSYS2/UCRT or VS options)
- **SharedLibrary** (Building with MSYS2/UCRT or VS options)
    - Per Code Rabbit: removed reference to TDM-GCC, which is also an older toolchain and not UCRT compliant.
    - Per Code Rabbit: updated VS examples to supported VS version generators.
- **StaticLibrary** (Building with MSYS2/UCRT or VS options)

### Benefits

Using MSYS2/UCRT64 is more robust and compatible with MSVC, using the Microsoft UCRT std C libraries.  Docs and CMake messages provide clearer guidance on building with MSYS2/UCRT64 with easy setup and package management in an encapsulated UCRT64 shell environment.

Provides an alternative to Visual Studio to create Windows CoolProp binaries. (Although at this point VS Community is more streamlined, generates smaller portable libraries, and is freely available to open-source developers, students, and individuals.)

### Possible Drawbacks

- MSYS2/UCRT binaries can be twice as large as VS/MSVC binaries because of static linking of MSYS2 libs
- The Octave docs still point to the original MingW (not my bailiwick)
- The Fortran docs still point to Ming-w64, rather than MSYS2/UCRT (for another day)

### Verification Process

- [x] Verified compilation of Shared Library per new docs and tested by calling from the Excel wrapper.
- [x] Verified Shared Library does not contain any MSYS2/UCRT64 dependencies using ``ntldd`` 
- [x] Verified Shared Library contains embedded VERSIONINFO details, even when compiled with MSYS2/UCRT64
- [x] Verified compilation of Static Library per new docs.
- [x] Verified compilation of Mathematica wrapper per new docs and verified usage in Mathematica 14.3.
- [x] Verified previous steps still work with VS and there are no regressions when using VS/MSVC


### Applicable Issues

Closes #3208 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Windows MSYS2/MinGW build compatibility and support, including shared-library and Mathematica wrapper build/linking behavior

* **Documentation**
  * Added guide for setting up the MSYS2 UCRT64 build environment on Windows
  * Updated Windows build instructions across wrapper modules (Shared/Static/Mathematica/MSYS2)
  * Added Excel worksheet formula troubleshooting guidance for `=Name?` cells
<!-- end of auto-generated comment: release notes by coderabbit.ai -->