### PR TITLE
Add VERSIONINFO to Mathcad and Mathematica wrappers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -992,6 +992,16 @@ if(COOLPROP_PRIME_MODULE)
   list(APPEND APP_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/CoolPropLib.cpp")
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/wrappers/MathCAD/CoolPropMathcad.cpp")
+  # Embed Windows VERSIONINFO so CoolPropPrimeWrapper.dll's Properties dialog shows
+  # FileVersion/ProductVersion fields (#2391). The .rc is configured from
+  # COOLPROP_VERSION_{MAJOR,MINOR,PATCH} above and added to the source list.
+  # NOTE: Only here if WIN32, where rc.exe (or MSYS2 windres) is available.
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/wrappers/MathCAD/CoolProp.rc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/CoolProp.rc"
+    @ONLY)
+  list(APPEND APP_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/CoolProp.rc")
+  # Source list complete, add all to library
   add_library(CoolPropMathcadWrapper SHARED ${APP_SOURCES})
   coolprop_hide_json_symbols(CoolPropMathcadWrapper)
   include_directories("${COOLPROP_PRIME_ROOT}/Custom Functions")
@@ -2116,6 +2126,20 @@ if(COOLPROP_MATHEMATICA_MODULE)
     "${CMAKE_CURRENT_SOURCE_DIR}/wrappers/Mathematica/CoolPropMathematica.cpp")
   list(APPEND APP_INCLUDE_DIRS "${Mathematica_WolframLibrary_INCLUDE_DIR}")
   include_directories(${APP_INCLUDE_DIRS})
+  
+  # Embed Windows VERSIONINFO so CoolPropPrimeWrapper.dll's Properties dialog shows
+  # FileVersion/ProductVersion fields (#2391). The .rc is configured from
+  # COOLPROP_VERSION_{MAJOR,MINOR,PATCH} above and added to the source list.
+  # NOTE: Only here if WIN32, where rc.exe (or MSYS2 windres) is available.
+  if(MSVC OR MINGW)
+    configure_file(
+      "${CMAKE_CURRENT_SOURCE_DIR}/wrappers/Mathematica/CoolProp.rc.in"
+      "${CMAKE_CURRENT_BINARY_DIR}/CoolProp.rc"
+      @ONLY)
+    list(APPEND MATHEMATICA_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/CoolProp.rc")
+  endif()
+  # Source list complete, add all to library
+
   add_library(CoolProp SHARED ${MATHEMATICA_SOURCES})
   add_dependencies(CoolProp generate_headers)
   coolprop_hide_json_symbols(CoolProp)

--- a/wrappers/MathCAD/CoolProp.rc.in
+++ b/wrappers/MathCAD/CoolProp.rc.in
@@ -1,0 +1,36 @@
+// Windows version-info resource for the CoolProp Mathcad Add-in DLL.
+// Configured by CMake from COOLPROP_VERSION_{MAJOR,MINOR,PATCH}.
+// The numeric VERSION fields require integer literals (commas, not dots),
+// so the trailing -dev/-rc revision suffix is dropped — it lives only in
+// the StringFileInfo "ProductVersion" string for human readers.
+
+#include <winver.h>
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION    @COOLPROP_VERSION_MAJOR@,@COOLPROP_VERSION_MINOR@,@COOLPROP_VERSION_PATCH@,0
+ PRODUCTVERSION @COOLPROP_VERSION_MAJOR@,@COOLPROP_VERSION_MINOR@,@COOLPROP_VERSION_PATCH@,0
+ FILEFLAGSMASK  VS_FFI_FILEFLAGSMASK
+ FILEFLAGS      0x0L
+ FILEOS         VOS_NT_WINDOWS32
+ FILETYPE       VFT_DLL
+ FILESUBTYPE    VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName",      "CoolProp project"
+            VALUE "FileDescription",  "CoolProp thermodynamic properties library"
+            VALUE "FileVersion",      "@COOLPROP_VERSION@"
+            VALUE "InternalName",     "CoolProp"
+            VALUE "LegalCopyright",   "MIT License"
+            VALUE "OriginalFilename", "CoolPropMathcadWrapper.dll"
+            VALUE "ProductName",      "CoolProp Mathcad Prime Add-in"
+            VALUE "ProductVersion",   "@COOLPROP_VERSION@"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 0x04B0
+    END
+END

--- a/wrappers/Mathematica/CoolProp.rc.in
+++ b/wrappers/Mathematica/CoolProp.rc.in
@@ -1,0 +1,36 @@
+// Windows version-info resource for the CoolProp Wolfram-Mathematica Add-in DLL.
+// Configured by CMake from COOLPROP_VERSION_{MAJOR,MINOR,PATCH}.
+// The numeric VERSION fields require integer literals (commas, not dots),
+// so the trailing -dev/-rc revision suffix is dropped — it lives only in
+// the StringFileInfo "ProductVersion" string for human readers.
+
+#include <winver.h>
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION    @COOLPROP_VERSION_MAJOR@,@COOLPROP_VERSION_MINOR@,@COOLPROP_VERSION_PATCH@,0
+ PRODUCTVERSION @COOLPROP_VERSION_MAJOR@,@COOLPROP_VERSION_MINOR@,@COOLPROP_VERSION_PATCH@,0
+ FILEFLAGSMASK  VS_FFI_FILEFLAGSMASK
+ FILEFLAGS      0x0L
+ FILEOS         VOS_NT_WINDOWS32
+ FILETYPE       VFT_DLL
+ FILESUBTYPE    VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName",      "CoolProp project"
+            VALUE "FileDescription",  "CoolProp thermodynamic properties library"
+            VALUE "FileVersion",      "@COOLPROP_VERSION@"
+            VALUE "InternalName",     "CoolProp"
+            VALUE "LegalCopyright",   "MIT License"
+            VALUE "OriginalFilename", "CoolProp.dll"
+            VALUE "ProductName",      "CoolProp Wolfram Add-in"
+            VALUE "ProductVersion",   "@COOLPROP_VERSION@"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 0x04B0
+    END
+END


### PR DESCRIPTION
### Description of the Change

Emulating #2863 for SharedLibrary builds, add VERSIONINFO information on Windows DLLs for the Mathcad and Mathematica wrappers.

This PR adds a standard Windows VERSIONINFO resource template at wrappers/[MathCAD|Mathematica]/CoolProp.rc.in, configured by CMake from the existing COOLPROP_VERSION_{MAJOR,MINOR,PATCH} variables. The .rc is added to the SHARED library's source list only on MSVC (where rc.exe is available) and MSYS2(MINGW) (where windres.exe is available); other platforms are unaffected (Mathcad wrapper can only be built with MSVC).

After the change, right-click on CoolProp.dll → Properties → Details shows:

<img width="304" height="382" alt="image" src="https://github.com/user-attachments/assets/cb206b2d-a0e0-418a-b421-97428c301be3" /><img width="304" height="382" alt="image" src="https://github.com/user-attachments/assets/e11e2376-b758-424c-b416-aabcc3ce3aee" />

Numeric FILEVERSION/PRODUCTVERSION fields require integer literals so the trailing -dev/-rc revision suffix is dropped from those; it remains visible in the ProductVersion string for human readers.

### Benefits

The shipped DLLs had an empty Product Version / File Version field in the Windows Properties dialog, making it impossible to tell which build a user has on disk and triggering Edge SmartScreen warnings on download.

### Possible Drawbacks

none.

### Verification Process

- [x] CMake configure succeeds locally on MSVC and MSYS2 (Mathematica only)
- [x] Substitution into the .rc template produces valid VERSIONINFO syntax with the configured version numbers
- [ ] Verify on Windows CI that `rc.exe` accepts the configured file and that the resulting Mathcad DLL shows the new fields in Properties → Details (Mathematica not built in CI)

### Applicable Issues

none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows build configuration for Mathcad and Mathematica add-ins to embed version information metadata in compiled DLL files for proper identification and compatibility checking on Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->