### PR TITLE
fix(core): mutex-guard error/warning globals; restore cross-thread errstring retrieval (#3211)

### DIFF
--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -38,6 +38,8 @@
 #include <string>
 #include <locale>
 #include <atomic>
+#include <mutex>
+#include <thread>
 #include "CoolProp/detail/tools.h"
 #include "CoolProp/numerics/Solvers.h"
 #include "CoolProp/numerics/MatrixMath.h"
@@ -61,13 +63,26 @@ namespace CoolProp {
 // make it atomic so those concurrent accesses are not a data race (bd CoolProp-4qf).
 static std::atomic<int> debug_level{0};
 // error_string / warning_string are written from any exception handler and
-// read-then-cleared by get_global_param_string("errstring"/"warnstring"). As
-// shared globals that was a data race on std::string (UB) that also lost or
-// double-observed messages when threads raced. Make them thread_local so each
-// thread captures and drains its own message -- this matches per-thread
-// exception semantics and the State capsule shim's existing thread_local error.
-static thread_local std::string error_string;
-static thread_local std::string warning_string;
+// read-then-cleared by get_global_param_string("errstring"/"warnstring").
+//
+// These form a process-global "outbox": the public contract is that one call
+// (e.g. PropsSI) writes the message and a SEPARATE later call drains it.
+// Thread-pooled hosts (Mathcad Prime, COM/Excel) dispatch those two calls on
+// DIFFERENT threads, so the slot must be shared across threads.  CoolProp-4qf
+// (PR #3146) made these thread_local to fix the data race, but that gave every
+// thread its own outbox and silently broke cross-thread retrieval (#3211).
+//
+// The race that #3146 targeted was the non-atomic read-then-clear of a shared
+// std::string (UB).  Restore the single shared slot and guard every access with
+// message_mutex so the read-then-clear is atomic -- this kills the UB without
+// breaking the cross-thread retrieval the wrappers rely on.  The lock is taken
+// only on the error path and on explicit errstring/warnstring drains, never on
+// the PropsSI success hot path.  (Two threads racing UNRELATED failures still
+// clobber one another last-writer-wins -- inherent to a single global slot and
+// the pre-#3146 behaviour -- but no longer UB.)
+static std::string error_string;
+static std::string warning_string;
+static std::mutex message_mutex;
 
 void set_debug_level(int level) {
     debug_level = level;
@@ -81,9 +96,11 @@ int get_debug_level() {
 #include "cpversion.h"    // Contents are like "char version [] = "2.5";"
 
 void set_warning_string(const std::string& warning) {
+    std::scoped_lock lock(message_mutex);
     warning_string = warning;
 }
 void set_error_string(const std::string& error) {
+    std::scoped_lock lock(message_mutex);
     error_string = error;
 }
 
@@ -1028,10 +1045,12 @@ std::string get_global_param_string(const std::string& ParamName) {
     } else if (ParamName == "gitrevision") {
         return gitrevision;
     } else if (ParamName == "errstring") {
+        std::scoped_lock lock(message_mutex);
         std::string temp = error_string;
         error_string = "";
         return temp;
     } else if (ParamName == "warnstring") {
+        std::scoped_lock lock(message_mutex);
         std::string temp = warning_string;
         warning_string = "";
         return temp;
@@ -1075,6 +1094,41 @@ TEST_CASE("Check inputs to get_global_param_string", "[get_global_param_string]"
         };
     }
     CHECK_THROWS(CoolProp::get_global_param_string(""));
+};
+
+// Regression test for #3211: the error/warning "outbox" is a process-global slot
+// whose contract is that one call sets the message and a SEPARATE later call
+// drains it.  Thread-pooled hosts (Mathcad Prime, COM/Excel) make those two
+// calls land on DIFFERENT threads.  PR #3146 made the slot thread_local, which
+// gave each thread its own outbox and silently broke this cross-thread handoff.
+// Set the message on one thread and require it to be readable from another.
+TEST_CASE("errstring/warnstring survive cross-thread retrieval", "[get_global_param_string],[3211]") {
+    // Drain any residual message so we observe only what this test writes.
+    CoolProp::get_global_param_string("errstring");
+    CoolProp::get_global_param_string("warnstring");
+
+    const std::string emsg = "cross-thread error payload #3211";
+    const std::string wmsg = "cross-thread warning payload #3211";
+
+    // Writer thread A stashes the messages...
+    std::thread([&] {
+        CoolProp::set_error_string(emsg);
+        CoolProp::set_warning_string(wmsg);
+    }).join();
+
+    // ...reader thread B must see them (would be blank if the slot were thread_local).
+    std::string got_err, got_warn;
+    std::thread([&] {
+        got_err = CoolProp::get_global_param_string("errstring");
+        got_warn = CoolProp::get_global_param_string("warnstring");
+    }).join();
+
+    CHECK(got_err == emsg);
+    CHECK(got_warn == wmsg);
+
+    // The read-then-clear must have drained the slot (on any thread).
+    CHECK(CoolProp::get_global_param_string("errstring").empty());
+    CHECK(CoolProp::get_global_param_string("warnstring").empty());
 };
 #endif
 std::string get_fluid_param_string(const std::string& FluidName, const std::string& ParamName) {


### PR DESCRIPTION
## What

Fixes #3211 — a regression in 8.0.0b1 where the Mathcad wrapper (and any thread-pooled host: COM/Excel) gets a **blank** `errstring` back from `get_global_param_string("errstring")` after a failed `PropsSI`.

## Root cause

PR #3146 (CoolProp-4qf) made `error_string` / `warning_string` in `src/CoolProp.cpp` `thread_local` to fix a real data race: the non-atomic **read-then-clear** of a shared `std::string` in `get_global_param_string` was UB.

But these globals are a process-global **"outbox"**: the public contract is that one call (`PropsSI`) writes the message and a **separate later call** drains it via `get_global_param_string("errstring")`. Thread-pooled hosts dispatch those two calls on **different threads**. `thread_local` gave every thread its own outbox, so the retrieval read an empty per-thread slot → blank "No error". The #3146 review verified "every set/read pair is same-thread" *within CoolProp's internals* — but the API contract is itself cross-call/cross-thread, which is what broke.

## Fix

Restore a single process-global slot for both messages and guard **every** access — `set_error_string`, `set_warning_string`, and the `errstring`/`warnstring` read-then-clear branches of `get_global_param_string` — with a shared `std::mutex` (`std::scoped_lock`, matching the existing `ASLib_mutex` pattern in `CoolPropLib.cpp`).

This **kills the UB that #3146 targeted** without breaking cross-thread retrieval. The lock is taken only on the error path and on explicit drains — **never** on the `PropsSI` success hot path.

Residual, documented and unchanged from pre-#3146 behavior: two threads racing *unrelated* failures still clobber one another (last-writer-wins on a single global slot) — but it is no longer UB.

## Test

New regression test `[3211]` sets the message on one thread and requires it readable from another. Verified it **fails under `thread_local`** (blank — the exact reported symptom) and **passes** with the mutex-guarded global.

## Validation

- `[3211]` regression test passes; fails as expected when reverted to `thread_local`.
- Fast suite (`[!slow][!benchmark]`) green via preflight.
- clang-format clean; the only new lint (`modernize-use-scoped-lock`) addressed by using `std::scoped_lock`. Remaining preflight cppcheck/clang-tidy findings are **pre-existing** in this file (TEST_CASE macro parse; nodiscard/implicit-bool/unscoped-enum/uninit-record at lines 149/228/303/319), unrelated to this 3-line change — same set #3146 documented.
- Adversarial review: no blocking findings (no unguarded access remains, non-recursive lock with deadlock-free scopes, no static-init hazard, no WASM regression — `std::mutex` is already a hard dependency via `CoolPropLib.cpp`, no `noexcept` violation, no hot-path cost).

## Follow-up

Filed bd CoolProp-z8wk for the principled long-term fix: an error-returning `PropsSI` variant mirroring the C ABI buffer pattern, to retire the global error slot and migrate wrappers off it. Not a 8.0.0 blocker.

bd CoolProp-z1up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Restored proper cross-thread retrieval of error and warning messages.

* **Tests**
  * Added regression test for message retrieval across threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->