### PR TITLE
[DOCS] Fixed ref links from wrappers page [skip ci]

### DIFF
--- a/Web/coolprop/wrappers/MSYS2/index.rst
+++ b/Web/coolprop/wrappers/MSYS2/index.rst
@@ -1,10 +1,10 @@
-.. _msys2:
+.. _MSYS2:
 
 ***********
 MSYS2 Setup
 ***********
 
-.. image:: https://www.msys2.org/logo.svg
+.. image:: https://www.msys2.org/logo.png
    :alt: MSYS2 Logo
    :width: 75px
    :align: left

--- a/Web/coolprop/wrappers/MathCAD/index.rst
+++ b/Web/coolprop/wrappers/MathCAD/index.rst
@@ -1,4 +1,4 @@
-.. _mathcad:
+.. _Mathcad:
 
 ***************
 Mathcad Wrapper

--- a/Web/coolprop/wrappers/VB.net/index.rst
+++ b/Web/coolprop/wrappers/VB.net/index.rst
@@ -1,4 +1,4 @@
-.. _VBdotnet:
+.. _VBdotNet:
 
 **************
 VB.net Wrapper

--- a/Web/coolprop/wrappers/index.rst
+++ b/Web/coolprop/wrappers/index.rst
@@ -29,7 +29,7 @@ Target                                                  Operating Systems       
 :ref:`Javascript <Javascript>`                          cross-platform               Works in all internet browsers
 :ref:`Labview <Labview>`                                Windows only
 :ref:`Maple <Maple>`                                    linux, OSX, win              CoolProp is included in Maple 2016
-:ref:`Mathcad <MathCAD>`                                Windows only
+:ref:`Mathcad <Mathcad>`                                Windows only
 :ref:`SMath Studio <SMath>`                             linux, OSX, win
 :ref:`Mathematica <Mathematica>`
 :ref:`FORTRAN <FORTRAN>`                                linux, OSX, win
@@ -113,7 +113,7 @@ and explicitly typing "agree" before closing. Then you can use the compiler from
     Octave/index.rst
     Csharp/index.rst
     MATLAB/index.rst
-    MathCAD/index.rst
+    Mathcad/index.rst
     FORTRAN/index.rst
     PHP/index.rst
     EES/index.rst


### PR DESCRIPTION
### Description of the Change

Inconsistent mixed capitalization in docs reference links was causing confusion (both human and machine).  Made refs, links, and directories consistent between:
- wrappers/index.txt
- wrappers/MSYS2/index.txt
- wrappers/Mathcad/index.txt
- wrappers/VBdotNet/index.txt

Some links failing, others throwing Sphinx warnings due to inconsistent mixed case.
 
### Benefits

Reference links all working consistently and warnings gone.

### Possible Drawbacks

None.  No CI needed.

### Verification Process

- [x] Verify wrapper page links on nightly rebuild of devdocs.

### Applicable Issues

none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several wrapper documentation links and section anchors for more consistent navigation.
  * Corrected the displayed branding/casing for the Mathcad and VB.NET wrapper pages.
  * Replaced the MSYS2 logo image with the updated version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->