### PR TITLE
docs(release): document the signed Desktop GUI (Tauri) release flow + bump GUI version to 8.0.0

### DIFF
--- a/.github/workflows/gui_builder.yml
+++ b/.github/workflows/gui_builder.yml
@@ -414,6 +414,12 @@ jobs:
           signing-policy-slug: ${{ vars.SIGNPATH_POLICY_SLUG || 'test-signing' }}
           github-artifact-id: ${{ steps.signpath_upload.outputs.artifact-id }}
           wait-for-completion: true
+          # The release-signing policy requires a manual approval (1 approver),
+          # so the submitted request sits Pending until a human approves it in
+          # the SignPath dashboard. The action's default wait is 600s (10 min),
+          # a tight scramble on release day. Give the approver an hour — a real
+          # approval was observed taking ~41 min in validation.
+          wait-for-completion-timeout-in-seconds: 3600
           output-artifact-directory: signpath-signed
 
       - name: Overlay signed Windows installers onto bundle

--- a/Web/develop/release.rst
+++ b/Web/develop/release.rst
@@ -62,3 +62,82 @@ the CoolProp library.
       ``X.Y.Z.dev<timestamp>`` nightlies that CI publishes to TestPyPI.
 
 That's all folks.
+
+*****************************
+Desktop GUI release (Tauri)
+*****************************
+
+The cross-platform desktop GUI (``wrappers/GUI``, a Tauri + React app) is
+**released on its own ``gui-vX.X.X`` tag** by the ``gui_builder.yml``
+workflow — independently of the library's ``vX.X.X`` tag and the
+SourceForge/PyPI flow above. A ``gui-v*`` tag builds all three platforms,
+code-signs them, and creates a single **draft** GitHub Release with the
+installers plus the ``latest.json`` auto-updater manifest attached.
+
+Signing is engaged on every ``gui-v*`` tag (and on any build whose HEAD
+commit message contains the ``[gui-sign]`` marker). macOS is signed +
+notarized; Windows is signed through SignPath. **Routine pushes build
+unsigned** and send no signing email.
+
+**Preconditions (verify before tagging — all fail *open* to an
+unsigned-but-functional build, so check them explicitly):**
+
+* **GUI version**: the bundle is stamped from the **committed** version in
+  ``wrappers/GUI/package.json`` / ``src-tauri/tauri.conf.json`` /
+  ``src-tauri/Cargo.toml`` (plus their lockfiles). A build-time sync
+  (``scripts/generate-licenses.mjs``, run via ``beforeBuildCommand``) derives
+  the version from ``CMakeLists.txt`` and rewrites these files — but Tauri
+  reads ``tauri.conf.json`` *before* that sync runs, so the sync does **not**
+  fix the in-flight bundle; the committed value is what lands on the
+  ``.dmg`` / ``.msi`` / ``.deb``. So bump the four version fields (run
+  ``npm run build:licenses`` in ``wrappers/GUI`` after bumping
+  ``CMakeLists.txt``, or edit them directly) **and commit them** before
+  tagging. Use plain semver (e.g. ``8.0.0``); a CMake ``REVISION`` qualifier
+  like ``b1`` is not valid for Cargo/npm and is dropped by the sync.
+* **Apple agreements current**: notarization returns HTTP 403 *"a required
+  agreement is missing or has expired"* if either the **Apple Developer
+  Program License Agreement** (developer.apple.com/account, accepted by the
+  Account Holder) or the **App Store Connect → Business** agreement has
+  lapsed. Clear any pending banner first.
+* **Apple secrets present**: ``APPLE_CERTIFICATE`` /
+  ``APPLE_CERTIFICATE_PASSWORD`` / ``APPLE_SIGNING_IDENTITY`` /
+  ``APPLE_TEAM_ID`` and the App Store Connect API-key trio
+  (``APPLE_API_ISSUER`` / ``APPLE_API_KEY`` / ``APPLE_API_KEY_BASE64``).
+* **Auto-updater secrets present**: ``TAURI_SIGNING_PRIVATE_KEY`` (+
+  password) — without them the release ships but in-app updates won't
+  verify.
+* **Windows / SignPath**: the repo variable ``SIGNPATH_POLICY_SLUG`` must be
+  ``release-signing`` (it defaults to the untrusted ``test-signing`` cert,
+  which does **not** clear SmartScreen), the org secret
+  ``SIGNPATH_API_TOKEN`` must be set, and the ``CI builds`` submitter must
+  be on the ``release-signing`` policy's submitters list.
+
+**Cutting the release:**
+
+#. Push the tag: ``git tag gui-vX.X.X && git push origin gui-vX.X.X``.
+#. **Approve the Windows signing request.** The ``release-signing`` policy
+   requires a manual approval (1 approver). When the Windows job reaches the
+   SignPath step it submits the request and **blocks Pending approval** —
+   approve it in the SignPath dashboard
+   (``coolprop`` → ``release-signing``) within the action's
+   ``wait-for-completion-timeout-in-seconds`` (currently 3600 s / 1 h) or
+   the job times out and fails. (A real approval in validation took ~41 min,
+   so don't trim this much.)
+#. Let all three platform builds finish. The release job's ``latest.json``
+   step is **all-or-nothing** — a single failed/unsigned platform aborts the
+   whole release, so a macOS notarization or Windows approval failure means
+   *no* release is produced.
+#. The ``Overlay signed Windows installers onto bundle`` step prints each
+   Windows installer's Authenticode ``Status`` — confirm ``Valid`` (the
+   release cert), not ``UnknownError`` (the test cert) or ``NotSigned``.
+#. Edit the **draft** release body (testers only see what's there) and
+   publish. Publishing is what arms the in-app auto-updater
+   (``releases/latest/download/latest.json``), so don't publish a build you
+   don't want pushed to existing users.
+
+.. note::
+
+   The draft's "prerelease" flag is auto-set only for tags containing
+   ``-alpha`` / ``-beta`` / ``-rc``. A PEP 440-style ``gui-v8.0.0b1`` is
+   **not** matched — tick *Set as a pre-release* by hand before publishing a
+   beta.

--- a/wrappers/GUI/package-lock.json
+++ b/wrappers/GUI/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coolprop-gui",
-  "version": "7.2.1",
+  "version": "8.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coolprop-gui",
-      "version": "7.2.1",
+      "version": "8.0.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-process": "^2",

--- a/wrappers/GUI/package.json
+++ b/wrappers/GUI/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coolprop-gui",
   "private": true,
-  "version": "7.2.1",
+  "version": "8.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/wrappers/GUI/src-tauri/Cargo.lock
+++ b/wrappers/GUI/src-tauri/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "coolprop-gui"
-version = "7.2.1"
+version = "8.0.0"
 dependencies = [
  "cmake",
  "once_cell",

--- a/wrappers/GUI/src-tauri/Cargo.toml
+++ b/wrappers/GUI/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coolprop-gui"
-version = "7.2.1"
+version = "8.0.0"
 edition = "2021"
 
 [lib]

--- a/wrappers/GUI/src-tauri/tauri.conf.json
+++ b/wrappers/GUI/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CoolProp",
-  "version": "7.2.1",
+  "version": "8.0.0",
   "identifier": "org.coolprop.gui",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Documents the **signed Desktop GUI (Tauri) release rail** that `Web/develop/release.rst` predated, and brings the GUI's own version in line with the library (8.0.0). Comes out of an end-to-end validation that got Windows + macOS GUI signing working for the first time (tracked in `CoolProp-crw8`).

### `release.rst` — new "Desktop GUI release (Tauri)" section
The GUI ships on its own `gui-v*` tag (separate from the library `vX.X.X` tag / SourceForge-PyPI flow). The section documents:
- Signing preconditions, all of which **fail open** to an unsigned build: Apple Developer + App Store Connect Business agreements current; `APPLE_*`, `TAURI_SIGNING_*`, and SignPath secrets/variables present; `SIGNPATH_POLICY_SLUG=release-signing`; `CI builds` on the policy's submitters list.
- The **manual SignPath approval** step (`release-signing` requires 1 approval) and its wait window.
- The all-or-nothing `latest.json` behavior (one failed platform aborts the whole release).
- The Authenticode `Valid` check (in the `Overlay signed Windows installers onto bundle` step).
- The `b1`-isn't-`-beta` prerelease-flag gotcha for draft releases.
- A precise GUI-version note: the **committed** manifest values are what get stamped onto the bundle (the build-time `CMakeLists.txt` sync runs *after* Tauri reads the version, so it doesn't fix the in-flight bundle).

### `gui_builder.yml` — approval timeout 600s → 3600s
The `release-signing` approval gate makes the signing action wait for a human. A real approval in validation took **~41 min**, so the 10-min default is too tight; raised to 1 h.

### GUI version 7.2.1 → 8.0.0
The Tauri GUI carries its own committed version and had lagged at 7.2.1, so every signed bundle was stamped `CoolProp_7.2.1`. Bumped all six version self-references (`package.json`, `tauri.conf.json`, `Cargo.toml`, plus the `Cargo.lock` / `package-lock.json` lockfile entries so `--locked` / `npm ci` stay consistent) to plain semver `8.0.0`.

## Validation
Windows release-signing proven end-to-end (run on a throwaway branch): both installers verify Authenticode `Status=Valid`, signer *SignPath Foundation*; macOS builds + notarizes. No code paths changed — docs + workflow timeout value + version strings only. Preflight: 4 passed / 0 failed / 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop GUI releases now follow a dedicated release flow with separate versioned tags, signed builds, draft release creation, and updater manifest publishing.
  * Windows signing approvals now allow a longer wait time during release runs.

* **Documentation**
  * Expanded the release checklist with clear pre-release checks and step-by-step instructions for publishing GUI releases.

* **Chores**
  * Bumped the desktop GUI version to `8.0.0` across release configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->