### PR TITLE
fix(REFPROP): close off-by-one strcpy buffer overflows in fixed-buffer length guards

### DIFF
--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -636,7 +636,12 @@ std::string REFPROPMixtureBackend::get_binary_interaction_string(const std::stri
     // Get the current state
     GETKTVdll(&icomp, &jcomp, hmodij.data(), fij, hfmix.data(), hfij.data(), hbinp.data(), hmxrul.data(), 3, 255, 255, 255, 255);
 
-    std::string shmodij(hmodij.data());
+    // hmodij is a fixed 3-character REFPROP (FORTRAN) field with no NUL
+    // terminator; read exactly the field width (constructing from a C-string
+    // over-reads past the 3-byte buffer, CWE-126) and trim the trailing space
+    // padding that FORTRAN uses.
+    std::string shmodij(hmodij.data(), hmodij.size());
+    shmodij.erase(shmodij.find_last_not_of(' ') + 1);
     //if (shmodij.find("KW") == 0 || shmodij.find("GE") == 0)  // Starts with KW or GE
     //{
     if (parameter == "model") {

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -399,10 +399,13 @@ void REFPROPMixtureBackend::set_REFPROP_fluids(const std::vector<std::string>& f
         std::array<char, 255> hmx_bnc{};
         const std::string HMX_path = get_REFPROP_HMX_BNC_path();
         const char* _HMX_path = HMX_path.c_str();
-        if (strlen(_HMX_path) > refpropcharlength) {
-            throw ValueError(format("Full HMX path (%s) is too long; max length is 255 characters", _HMX_path));
+        // The copy writes strlen+1 bytes (incl. the NUL), so the safe maximum is
+        // one less than the buffer; reject at >= to avoid a 1-byte overflow.
+        if (strlen(_HMX_path) >= refpropcharlength) {
+            throw ValueError(
+              format("Full HMX path (%s) is too long; max length is %d characters", _HMX_path, static_cast<int>(refpropcharlength) - 1));
         }
-        strcpy(hmx_bnc.data(), _HMX_path);
+        memcpy(hmx_bnc.data(), _HMX_path, strlen(_HMX_path) + 1);  // +1 for the NUL; length checked above
 
         if (get_config_bool(REFPROP_USE_GERG)) {
             int iflag = 1,  // Tell REFPROP to use GERG04; 0 unsets GERG usage
@@ -424,10 +427,11 @@ void REFPROPMixtureBackend::set_REFPROP_fluids(const std::vector<std::string>& f
 
             std::string path_to_MIX_file = join_path(get_REFPROP_mixtures_path_prefix(), components_joined_raw);
             const char* _components_joined_raw = path_to_MIX_file.c_str();
-            if (strlen(_components_joined_raw) > 255) {
+            // The copy appends a NUL, so the safe maximum is sizeof(mix)-1.
+            if (strlen(_components_joined_raw) >= sizeof(mix)) {
                 throw ValueError(format("components (%s) is too long", components_joined_raw.c_str()));
             }
-            strcpy(mix, _components_joined_raw);
+            memcpy(mix, _components_joined_raw, strlen(_components_joined_raw) + 1);  // +1 for the NUL; length checked above
 
             SETMIXdll(mix, hmx_bnc.data(), reference_state, &N, component_string.data(), &(x[0]), &ierr, herr.data(), 255, 255, 3, 10000, 255);
             if (static_cast<int>(ierr) <= 0) {
@@ -481,10 +485,12 @@ void REFPROPMixtureBackend::set_REFPROP_fluids(const std::vector<std::string>& f
 
             // Copy over the list of components
             const char* _components_joined = components_joined.c_str();
-            if (strlen(_components_joined) > 10000) {
+            // The safe maximum is component_string.size()-1; the space-padding
+            // loop below fills the remainder, so no NUL terminator is needed.
+            if (strlen(_components_joined) >= component_string.size()) {
                 throw ValueError(format("components_joined (%s) is too long", _components_joined));
             }
-            strcpy(component_string.data(), _components_joined);
+            memcpy(component_string.data(), _components_joined, strlen(_components_joined));
             // Pad the fluid string all the way to 10k characters with spaces to deal with string parsing bug in REFPROP in SETUPdll
             for (int i = static_cast<int>(components_joined.size()); i < 10000; ++i) {
                 component_string[i] = ' ';
@@ -670,11 +676,15 @@ void REFPROPMixtureBackend::set_binary_interaction_string(const std::size_t i, c
     GETKTVdll(&icomp, &jcomp, hmodij.data(), fij, hfmix.data(), hfij.data(), hbinp.data(), hmxrul.data(), 3, 255, 255, 255, 255);
 
     if (parameter == "model") {
-        if (value.length() > 4) {
-            throw ValueError(format("Model parameter (%s) is longer than 4 characters.", value));
-        } else {
-            strcpy(hmodij.data(), value.c_str());
+        // hmodij is a fixed 3-character REFPROP (FORTRAN) field with no room for a
+        // NUL terminator, so strcpy is unsafe here: reject anything longer than the
+        // field and copy without a NUL, space-padding the remainder per FORTRAN
+        // fixed-width string convention.
+        if (value.length() > hmodij.size()) {
+            throw ValueError(format("Model parameter (%s) is longer than %d characters.", value.c_str(), static_cast<int>(hmodij.size())));
         }
+        hmodij.fill(' ');
+        memcpy(hmodij.data(), value.data(), value.length());
     } else {
         throw ValueError(format("I don't know what to do with your parameter [%s]", parameter.c_str()));
     }

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -6531,6 +6531,20 @@ TEST_CASE("REFPROP set_binary_interaction_string model param is length-guarded (
         } catch (const CoolProp::ValueError&) { /* REFPROP may reject the code; acceptable */
         }
     }());
+
+    // The getter reads the same fixed 3-char field; constructing a std::string
+    // from hmodij as a C-string over-reads past the 3-byte buffer (CWE-126), so
+    // it must read exactly the field width and trim the FORTRAN space padding.
+    // Exercise the read path (ASAN guards the over-read); CAS: Methane=74-82-8,
+    // Ethane=74-84-0. The CAS lookup is REFPROP-version dependent, so tolerate
+    // a ValueError but require a within-field-width result when it succeeds.
+    CHECK_NOTHROW([&] {
+        try {
+            std::string m = RP->get_binary_interaction_string("74-82-8", "74-84-0", "model");
+            CHECK(m.size() <= 3);
+        } catch (const CoolProp::ValueError&) { /* CAS lookup version-dependent; acceptable */
+        }
+    }());
 }
 
 TEST_CASE("REFPROP cross-check: sat-state fugacity_coefficient agrees with HEOS for Methane/Ethane/Propane", "[REFPROPsat][2345-followup]") {

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -6505,6 +6505,34 @@ TEST_CASE("REFPROP saturation derivs work for a mixture", "[REFPROPsat]") {
     CHECK_THROWS(RP->first_two_phase_deriv_splined(iDmolar, iHmolar, iP, 0.5));
 }
 
+TEST_CASE("REFPROP set_binary_interaction_string model param is length-guarded (CoolProp-tw7t)", "[REFPROP][refprop][binary_interaction]") {
+    Skip_if_No_REFPROP();
+    std::shared_ptr<AbstractState> RP(AbstractState::factory("REFPROP", "Methane&Ethane"));
+    RP->set_mole_fractions({0.6, 0.4});
+
+    // hmodij is a 3-character REFPROP (FORTRAN) field. An over-long model value
+    // must be rejected by the length guard, NOT strcpy'd into the 3-byte buffer
+    // (which overflowed the stack by 1-2 bytes — CoolProp-tw7t). The length-4
+    // case is the precise regression: the old guard `value.length() > 4` let it
+    // through and overflowed; ASAN only flags it with a boundary-length input,
+    // which no prior test supplied.
+    CHECK_THROWS_AS(RP->set_binary_interaction_string(0, 1, "model", "ABCD"), CoolProp::ValueError);     // 4 chars
+    CHECK_THROWS_AS(RP->set_binary_interaction_string(0, 1, "model", "TOOLONG"), CoolProp::ValueError);  // 7 chars
+    // An unknown parameter must also fail cleanly rather than silently no-op.
+    CHECK_THROWS_AS(RP->set_binary_interaction_string(0, 1, "bogus", "x"), CoolProp::ValueError);
+
+    // A valid-length (<=3 char) model exercises the bounded copy: it must not
+    // overflow hmodij[3]. Whether REFPROP accepts the specific code is version-
+    // dependent, so we only require the call does not corrupt the stack (ASAN
+    // would abort the binary if it did).
+    CHECK_NOTHROW([&] {
+        try {
+            RP->set_binary_interaction_string(0, 1, "model", "KW0");
+        } catch (const CoolProp::ValueError&) { /* REFPROP may reject the code; acceptable */
+        }
+    }());
+}
+
 TEST_CASE("REFPROP cross-check: sat-state fugacity_coefficient agrees with HEOS for Methane/Ethane/Propane", "[REFPROPsat][2345-followup]") {
     Skip_if_No_REFPROP();
     const std::vector<double> z = {0.25, 0.25, 0.5};


### PR DESCRIPTION
## Summary

Closes four real stack buffer overflows (CWE-787) in `REFPROPMixtureBackend.cpp`, surfaced by the v8 clang-tidy audit (`CoolProp-erne`) and confirmed by code review. Each length guard used `>` against the **exact** buffer size, ignoring the NUL that `strcpy` appends (safe max is size−1):

| Site | Buffer | Old guard | Overflow |
|------|--------|-----------|----------|
| HMX path | `hmx_bnc[255]` | `strlen > refpropcharlength` (=255) | 255-char path → 256 B |
| predefined mix | `mix[255]` | `strlen > 255` | 255-char name → 256 B |
| component string | `component_string[10000]` | `strlen > 10000` | 10000-char → 10001 B |
| model code | `hmodij[3]` | `value.length() > 4` | 3–4 char model → +1–2 B |

## Why ASAN never caught these
REFPROP **is** built and run under the ASAN CI job, but the overflow only fires at *boundary-length* inputs (255/10000-char strings, or a 3–4 char model code) — which no existing test supplied. A runtime sanitizer can't see an overflow on a path it never executes with triggering data; this is the static-analysis-finds-what-ASAN-misses case.

## Fix
- **Guards** now reject at `>= buffer size`, so the NUL always fits.
- **Copies** converted from `strcpy` to bounded `memcpy` (defense-in-depth — cannot overflow even if a guard later regresses; also clears the `clang-analyzer-security.insecureAPI.strcpy` findings).
- **`hmodij`** is a 3-char REFPROP/FORTRAN field with no room for a NUL → space-padded `memcpy` instead of `strcpy`, guard at `> size`. Also fixes the error path that passed a `std::string` straight to `format("%s")`.

## Test
Adds a `[refprop]` Catch test driving the model path to the boundary. It is **red before** the fix (a length-4 model value silently overflowed `hmodij[3]` with no throw) and **green after** — exactly the boundary case that should have been covered. Verified locally against the real REFPROP10 library.

## Validation
- New test: 4/4 assertions pass.
- Regression: `[REFPROPsat]` (48 assertions) and `[REFPROP]` (1099 assertions) green — normal SETUP/mixture loading unaffected.
- clang-format clean (pinned 18.1.8); changed lines are cppcheck- and clang-tidy-clean. Two adversarial reviews (guards + the memcpy delta) returned no blocking findings.

Refs CoolProp-tw7t, CoolProp-erne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety when handling REFPROP mixture component paths and binary interaction strings, ensuring fixed-width fields cannot be overrun.
  * Strengthened validation for the binary interaction `"model"` parameter by consistently rejecting values longer than the allowed field size and properly handling fixed-width formatting.

* **Tests**
  * Added a regression test covering overlong `"model"` values, invalid parameter names, and basic verification of reading the `"model"` interaction field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->