### PR TITLE
fix(IF97): correct copy-paste error message in two-phase conductivity path

### DIFF
--- a/src/Backends/IF97/IF97Backend.h
+++ b/src/Backends/IF97/IF97Backend.h
@@ -393,7 +393,7 @@ class IF97Backend : public AbstractState
                             throw NotImplementedError(format("Viscosity not valid in two phase region"));
                             break;
                         case iconductivity:
-                            throw NotImplementedError(format("Viscosity not valid in two phase region"));
+                            throw NotImplementedError(format("Conductivity not valid in two phase region"));
                             break;
                         case isurface_tension:
                             return IF97::sigma97(_T);


### PR DESCRIPTION
## Summary
In `IF97Backend.h`, the `iconductivity` case in the two-phase region threw `NotImplementedError("Viscosity not valid in two phase region")` — copy-pasted verbatim from the `iviscosity` case directly above. A user calling for thermal conductivity in the two-phase region got a misleading "Viscosity" error. Now says "Conductivity".

Found during the v8 clang-tidy audit (`CoolProp-erne`, `bugprone-branch-clone`).

## Validation
- Builds clean; `[IF97]` tests pass (77 assertions, 5 cases).
- Pure error-message string change — no logic/control-flow impact. Adversarial review confirmed the `iviscosity` case above is untouched and no other case in the switch has a mismatched name.

Refs CoolProp-erne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the error message shown when conductivity is requested in the two-phase region, so it now accurately reports that conductivity is not valid there.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->