### PR TITLE
[DOCS] Clear cached dead link on devdocs wrappers page for verification

### DIFF
--- a/Web/coolprop/wrappers/index.rst
+++ b/Web/coolprop/wrappers/index.rst
@@ -6,7 +6,7 @@ Available Wrappers
 
 CoolProp at its core is a C++ library, but it can be of interest to use this code base from other programming environments.  For that reason, wrappers have been constructed for most of the programming languages of technical interest to allow users to seamlessly interface CoolProp and existing codebases.
 
-There are also installer packages available on the :ref:`page on installation packages <Installers>`.
+There are also installer packages available on the :ref:`installation packages page <Installers>`.
 
 Downloads and instructions for each wrapper are included in the page for the wrapper given in the table below.
 
@@ -79,10 +79,10 @@ For python, you should be using `Anaconda/Miniconda <https://www.anaconda.com/do
 
 For the C++ compiler on Windows you have two mainstream options:
 
-* **MSYS2/UCRT64** (a Windows port of GCC and modern version of **MINGW**), most easily obtained via `MSYS2 <https://www.msys2.org/>`_: See :ref:`CoolProp MSYS2 Setup <MSYS2>` guidance.
+* **MSYS2/UCRT64** (a Windows port of GCC and modern version of **MINGW**), most easily obtained via `MSYS2 <https://www.msys2.org/>`_. (See :ref:`CoolProp MSYS2 Setup <MSYS2>` guidance.)
 * **Visual Studio** — install the free Community edition with the "Desktop development with C++" workload.
 
-Most users never need to compile the Python wrapper themselves, since pre-built CoolProp wheels are published on `PyPI <https://pypi.org/project/CoolProp/>`_.  If you do build from source, the old advice about matching a specific Visual Studio version to your Python version no longer applies: since Visual Studio 2015 the C runtime (UCRT) is stable, so any recent Visual Studio works.
+Most users never need to compile the Python wrapper themselves, since pre-built CoolProp wheels are published on `PyPI <https://pypi.org/project/CoolProp/>`_.  If you do build from source, the old advice about matching a specific Visual Studio version to your Python version no longer applies. Since the release of Visual Studio 2015, the C runtime (UCRT) is stable, so any recent Visual Studio works.
 
 Linux
 -----
@@ -90,15 +90,15 @@ On debian based linux distributions (ubuntu, etc.), you can simply do::
 
     sudo apt-get install cmake git g++ p7zip libpython3-dev
 
-although ``git`` is probably already packaged with your operating system; ``g++`` probably isn't.  Python is (probably) included in your distribution, but the headers aren't.  For python, you need the ``six`` package, a ``pip install six`` should do it.
+although ``git`` is probably already packaged with your operating system; ``g++`` probably isn't.  Python is (probably) included in your distribution, but the headers aren't.  For python, you need the ``six`` package; a ``pip install six`` should do it.
 
 OSX
 ---
-OSX should come with a c++ compiler (clang), for git and cmake your best bet is `Homebrew <https://brew.sh/>`_.  With Homebrew installed, you can just do::
+OSX should come with a c++ compiler (clang). For git and cmake your best bet is `Homebrew <https://brew.sh/>`_.  With Homebrew installed, you can just do::
 
     brew install cmake git p7zip
 
-OSX includes a python version, but you should be using `Anaconda/Miniconda <https://www.anaconda.com/download>`_ for your python installation.  Or, you can just install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_, which is sufficient. For python, you need the ``six`` package, a ``pip install six`` should do it.
+OSX includes a python version, but you should be using `Anaconda/Miniconda <https://www.anaconda.com/download>`_ for your python installation.  Alternatively, just install `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_, which is sufficient. For python, you need the ``six`` package, a ``pip install six`` should do it.
 
 If you have never done any command-line compilation before on OSX, chances are that you do not have the utilities needed. Thus you need to first install Xcode: see the description on the page https://guide.macports.org/#installing.xcode . After installing, you need to accept the license by running the following command in the Terminal::
 


### PR DESCRIPTION
### Description of the Change

Dead links (specifically wrappsers -> MSYS2) and warnings were fixed in #3214.  However, the devdocs wrappers page still does not show this specific link after Sphinx conversion to HTML.  After many iterations, combobulation, ruminations, and processing, Claude finally decided that:

>  This is a stale incremental build cache problem: the devdocs build caches the Sphinx .doctrees/ directory across runs. When MSYS2/index.rst was first added (commit 5fcd7be1), wrappers/index.rst was written with the MSYS2 ref unresolved and cached. Subsequent builds don't re-render wrappers/index.rst because its source hasn't changed enough to invalidate the cached doctree.
> **The fix:** make any small change to ``wrappers/index.rst`` in a new commit (or have devdocs add -E to its sphinx-build command to ignore the saved environment). The simplest reliable fix is to touch wrappers/index.rst so Sphinx re-renders it with the now-complete label index.

So, some grammar nits were corrected on the ``coolprop/wrappers/index.rst`` page to hopefully clear the dead link out of the build cache allowing re-rendering and verification on the devdocs that the dead link is actually fixed.  
### Benefits

Should allow verification that dead links from #3214 are actually fixed. 

### Verification Process

- Not skipping the CI's so the page will re-render at https://coolprop.github.io/devdocs/coolprop/wrappers/index.html.
- [x] verify that the page rebuild fixes the dead link to the MSYS2 guidance page.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated wrapper documentation links to better direct readers to the installation packages page.
  * Improved platform-specific setup guidance for Windows, Linux, and macOS.
  * Reorganized compiler and prerequisite instructions into clearer bullet points, including setup notes for MSYS2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->