### PR TITLE
[DOCS] Fix MSYS2 Link Conflicts

### DIFF
--- a/Web/coolprop/wrappers/MSYS2/index.rst
+++ b/Web/coolprop/wrappers/MSYS2/index.rst
@@ -14,7 +14,7 @@ This is not a wrapper in itself, but guidance on using the MSYS2 toolchain to co
 Background
 ==========
 
-Prior versions of CoolProp supported **MINGW** as a Windows port of gcc.  However, the original **MINGW** has been frozen since 2013 and is no longer compatible.  Mingw-x64 (*with 32 and 64-bit compilers*) was forked form MinGW in 2007 to add 64-bit support and coverage of newer Windows APIs absent from the original project.  `MSYS2 <https://www.msys2.org/>`_ followed in the 2010s, building on Mingw-x64 while adding the ``pacman`` package manager and a modernized distribution model. There is also a `VS Code extension <https://code.visualstudio.com/docs/cpp/config-mingw#_prerequisites>`_ facilitating use of **VS Code** as the IDE to run the g++ compiler and GDB debugger.  `MSYS2 <https://www.msys2.org/>`_ is the best place to download this set of GNU compiler tools as well as help on
+Prior versions of CoolProp supported **MINGW** as a Windows port of gcc.  However, the original **MINGW** has been frozen since 2013 and is no longer compatible.  Mingw-x64 (*with 32 and 64-bit compilers*) was forked form MinGW in 2007 to add 64-bit support and coverage of newer Windows APIs absent from the original project.  `MSYS2 <https://www.msys2.org/>`__ followed in the 2010s, building on Mingw-x64 while adding the ``pacman`` package manager and a modernized distribution model. There is also a `VS Code extension <https://code.visualstudio.com/docs/cpp/config-mingw#_prerequisites>`_ facilitating use of **VS Code** as the IDE to run the g++ compiler and GDB debugger.  `MSYS2 <https://www.msys2.org/>`__ is the best place to download this set of GNU compiler tools as well as help on
 
 * Installing and setting up the MSYS2/UCRT64 environment
 * Terminals for command line operations in the UCRT64 environment
@@ -69,7 +69,7 @@ MSYS2 has its own version of cmake that is **UCRT64** aware.  Install it with::
    pacman -S --needed mingw-w64-ucrt-x86_64-cmake
 
 
-**Install UCRT64 Git**::
+**Install UCRT64 Git**
 
 This is practically identical to the standalone "Git for Windows", but it is neatly bundled and pre-configured by the MSYS2 team to seamlessly integrate with your UCRT64 pathing and shell settings.  Install with::
 
@@ -81,7 +81,7 @@ This is practically identical to the standalone "Git for Windows", but it is nea
 
 **Install UCRT64 Ninja**
 
-MSYS2 **Ninja** is a compact, ultra-fast, low-level build system optimized strictly for execution speed. On `MSYS2 <https://www.msys2.org/>`_.  Install it with::
+MSYS2 **Ninja** is a compact, ultra-fast, low-level build system optimized strictly for execution speed. On `MSYS2 <https://www.msys2.org/>`__.  Install it with::
 
     pacman -S --needed mingw-w64-ucrt-x86_64-ninja
 

--- a/Web/coolprop/wrappers/index.rst
+++ b/Web/coolprop/wrappers/index.rst
@@ -80,7 +80,7 @@ For python, you should be using `Anaconda/Miniconda <https://www.anaconda.com/do
 
 For the C++ compiler on Windows you have two mainstream options:
 
-* **MSYS2/UCRT64** (a Windows port of GCC and modern version of **MINGW**), most easily obtained via `MSYS2 <https://www.msys2.org/>`_. (See :ref:`CoolProp MSYS2 Setup <MSYS2>` guidance.)
+* **MSYS2/UCRT64** (a Windows port of GCC and modern version of **MINGW**), most easily obtained via `MSYS2 <https://www.msys2.org/>`_. (See :ref:`CoolProp MSYS2 Setup guidance <MSYS2>`.)
 * **Visual Studio** — install the free Community edition with the "Desktop development with C++" workload.
 
 Most users never need to compile the Python wrapper themselves, since pre-built CoolProp wheels are published on `PyPI <https://pypi.org/project/CoolProp/>`_.  If you do build from source, the old advice about matching a specific Visual Studio version to your Python version no longer applies. Since the release of Visual Studio 2015, the C runtime (UCRT) is stable, so any recent Visual Studio works.


### PR DESCRIPTION
### Description of the Change

Conflicting inline links (single underscore) in ``wrappers/MSYS2/index.rst`` — each creates a named target "msys2". They collide with ``.. _MSYS2:`` at line 1, so docutils strips names from all of them, including the section label itself. Sphinx then sees the ``.. _MSYS2:`` node with names=[] and has no name to register in the std domain.

**The Fix:** change the three `MSYS2 <https://www.msys2.org/>`_ (single _) inline links in `MSYS2/index.rst` to double-underscore `MSYS2 <https://www.msys2.org/>`__ (anonymous), which don't create named targets and don't conflict with ``.. _MSYS2:``.

Also, made tiny innocuous change in ``wrappers/index.rst`` so that it is not incrementally skipped and dead links are cleared from cache.

### Benefits

Attempts to fix dead link between wrappers page and CoolProp MSYS2 Setup Guidance page.

### Verification Process

- [x] Verify live links in devdocs once built by the CI

### Applicable Issues

Finally verify #3214


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved MSYS2 setup docs formatting for clearer rendering.
  * Refined Windows wrapper prerequisites text to better label the MSYS2/UCRT64 setup link.
  * Removed an extra heading marker that was causing an unintended literal block in the setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->