### PR TITLE
docs(v8): concise tabular TOC entry, contributors list, smaller superancillary plots

### DIFF
--- a/Web/coolprop/changelog.rst
+++ b/Web/coolprop/changelog.rst
@@ -160,6 +160,9 @@ Highlights:
   dependencies unless ``CPM_SOURCE_CACHE`` points at a populated cache. The
   minimum CMake is now **3.14** and a **C++17** compiler is required.
 
+Contributors to this release (everyone with a merged PR since 7.2.0):
+`ibell <https://github.com/ibell>`_, `henningjp <https://github.com/henningjp>`_, `andr1976 <https://github.com/andr1976>`_, `fwitte <https://github.com/fwitte>`_, `volkan-a <https://github.com/volkan-a>`_, `tobias-loew <https://github.com/tobias-loew>`_, `thorade <https://github.com/thorade>`_, `portyanikhin <https://github.com/portyanikhin>`_, `luzechao <https://github.com/luzechao>`_, `jakobreichert <https://github.com/jakobreichert>`_, `HaSchneider <https://github.com/HaSchneider>`_, `friederikeboehm <https://github.com/friederikeboehm>`_
+
 Issues closed:
 
 * `#2254 <https://github.com/CoolProp/CoolProp/issues/2254>`_ : CSharp wrapper folder missing from download location since version 6.4.2

--- a/Web/index.rst
+++ b/Web/index.rst
@@ -15,8 +15,7 @@ CoolProp is a C++ library that implements:
 * :ref:`Pure and pseudo-pure fluid equations of state and transport properties <list_of_fluids>` for |num_pure_fluids| components
 * :ref:`Mixture properties using high-accuracy Helmholtz energy formulations <mixtures>`
 * :ref:`Correlations of properties of incompressible fluids and brines <Pure>`
-* :ref:`Computationally efficient tabular interpolation <tabular_interpolation>`
-* :ref:`Sub-microsecond SVD-compressed tabular evaluation for water (IAPWS-G13-15 conformant) and multi-fluid HEOS-backed presets <SVDSBTL>`
+* Computationally efficient tabular interpolation with :ref:`SVD+SBTL <SVDSBTL>` or :ref:`bicubic/TTSE <tabular_interpolation>`
 * :ref:`Highest accuracy psychrometric routines <Humid-Air>`
 * :ref:`User-friendly interface around the full capabilities of NIST REFPROP <REFPROP>`
 * :ref:`Fast IAPWS-IF97 (Industrial Formulation) for Water/Steam <IF97>`

--- a/Web/scripts/CPWeb/SphinxTools.py
+++ b/Web/scripts/CPWeb/SphinxTools.py
@@ -67,6 +67,7 @@ The following figure shows the accuracy of the superancillary functions relative
     You can download the script that generated the following figure here: :download:`(link to script)<Superancillaryplots/{fluid:s}.py>`, right-click the link and then save as... or the equivalent in your browser.  You can also download this figure :download:`as a PDF<Superancillaryplots/{fluid:s}.pdf>`.
 
 .. image:: Superancillaryplots/{fluid:s}.png
+    :width: 400px
 
 """
 


### PR DESCRIPTION
Three small documentation tweaks ahead of the v8 release.

## Changes

**1. `Web/index.rst` — concise tabular TOC entry**
Collapsed the two separate tabular bullets into one, with each method linked:
> Computationally efficient tabular interpolation with :ref:`SVD+SBTL <SVDSBTL>` or :ref:`bicubic/TTSE <tabular_interpolation>`

**2. `Web/coolprop/changelog.rst` — contributors list**
Added a "Contributors to this release" line to the 8.0.0 entry, one GitHub-profile link per handle. The list is **every author with a PR merged since v7.2.0** (the range 8.0.0 covers), pulled from the GitHub API, bots excluded — 12 contributors. Matches the historical `Contributors to this release:` convention used in older changelog entries.

**3. `Web/scripts/CPWeb/SphinxTools.py` — smaller superancillary plots**
The per-fluid superancillary deviation figure was emitted with a bare `.. image::` (no size cap), so the tall 3.5×7in @300dpi PNG rendered full-size. Added `:width: 400px` to scale it down (aspect ratio preserved, no PNG regeneration needed).

## Verification
- Both `:ref:` targets (`SVDSBTL`, `tabular_interpolation`) confirmed to exist and be singly-defined.
- Contributor hyperlinks are well-formed RST embedded URIs; handles verified against GitHub API merged-PR data.
- `:width:` option indentation confirmed to parse as a directive option (no `.format()` brace breakage).
- `./dev/ci/preflight.sh` (via pre-push hook): 4 passed / 5 skipped (docs-only).
- Adversarial review subagent: no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a contributors section to the CoolProp 8.0.0 changelog.
  * Updated the “What is CoolProp?” overview with refreshed wording around tabular interpolation methods.
  * Adjusted image sizing on generated fluid pages for cleaner display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->