### PR TITLE
feat(mixtures): vector endpoints for per-component fugacity/chemical_potential (#3024)

### DIFF
--- a/include/CoolProp/AbstractState.h
+++ b/include/CoolProp/AbstractState.h
@@ -249,17 +249,58 @@ class AbstractState
     virtual CoolPropDbl calc_fugacity_coefficient(std::size_t i) {
         throw NotImplementedError("calc_fugacity_coefficient is not implemented for this backend");
     };
-    /// Using this backend, calculate the fugacity in Pa
+    /// Number of components used by the default per-component vector getters below.
+    /// Throws if the composition has not been set, so the vector forms fail loudly
+    /// (matching the scalar getters) rather than silently returning an empty vector.
+    std::size_t calc_n_components_for_vector() {
+        const std::size_t N = this->get_mole_fractions().size();
+        if (N == 0) {
+            throw ValueError("Mole fractions must be set before requesting per-component vector properties");
+        }
+        return N;
+    };
+    /// Using this backend, calculate the vector of fugacity coefficients (dimensionless)
+    /// for every component.  The default loops the scalar calc_fugacity_coefficient(i),
+    /// so it inherits that getter's semantics (e.g. a whole-vector throw if any
+    /// component is undefined, as in the two-phase region).  Backends with a faster
+    /// bespoke path (PCSAFT) override this.
     virtual std::vector<CoolPropDbl> calc_fugacity_coefficients() {
-        throw NotImplementedError("calc_fugacity_coefficients is not implemented for this backend");
+        const std::size_t N = calc_n_components_for_vector();
+        std::vector<CoolPropDbl> out(N);
+        for (std::size_t i = 0; i < N; ++i) {
+            out[i] = calc_fugacity_coefficient(i);
+        }
+        return out;
     };
     /// Using this backend, calculate the fugacity in Pa
     virtual CoolPropDbl calc_fugacity(std::size_t i) {
         throw NotImplementedError("calc_fugacity is not implemented for this backend");
     };
+    /// Using this backend, calculate the vector of fugacities in Pa for every
+    /// component.  The default loops the scalar calc_fugacity(i) and inherits its
+    /// semantics (Q-weighted sat-state values in the two-phase region).
+    virtual std::vector<CoolPropDbl> calc_fugacities() {
+        const std::size_t N = calc_n_components_for_vector();
+        std::vector<CoolPropDbl> out(N);
+        for (std::size_t i = 0; i < N; ++i) {
+            out[i] = calc_fugacity(i);
+        }
+        return out;
+    };
     /// Using this backend, calculate the chemical potential in J/mol
     virtual CoolPropDbl calc_chemical_potential(std::size_t i) {
         throw NotImplementedError("calc_chemical_potential is not implemented for this backend");
+    };
+    /// Using this backend, calculate the vector of chemical potentials in J/mol for
+    /// every component.  The default loops the scalar calc_chemical_potential(i) and
+    /// inherits its semantics (Q-weighted sat-state values in the two-phase region).
+    virtual std::vector<CoolPropDbl> calc_chemical_potentials() {
+        const std::size_t N = calc_n_components_for_vector();
+        std::vector<CoolPropDbl> out(N);
+        for (std::size_t i = 0; i < N; ++i) {
+            out[i] = calc_chemical_potential(i);
+        }
+        return out;
     };
     /// Using this backend, calculate the phase identification parameter (PIP)
     virtual CoolPropDbl calc_PIP() {
@@ -1288,8 +1329,12 @@ class AbstractState
     std::vector<double> fugacity_coefficients();
     /// Return the fugacity of the i-th component of the mixture
     double fugacity(std::size_t i);
+    /// Return a vector of the fugacities (in Pa) for all components in the mixture
+    std::vector<double> fugacities();
     /// Return the chemical potential of the i-th component of the mixture
     double chemical_potential(std::size_t i);
+    /// Return a vector of the chemical potentials (in J/mol) for all components in the mixture
+    std::vector<double> chemical_potentials();
     /** \brief Return the fundamental derivative of gas dynamics \f$ \Gamma \f$
      *
      * see also Colonna et al, FPE, 2010

--- a/include/CoolProp/CoolPropLib.h
+++ b/include/CoolProp/CoolPropLib.h
@@ -406,6 +406,56 @@ EXPORT_CODE double CONVENTION AbstractState_get_fugacity(const long handle, cons
 EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long handle, const long i, long* errcode, char* message_buffer,
                                                                      const long buffer_length);
 /**
+     * @brief Return the chemical potential (in J/mol) of the i-th component of the mixture.
+     * @param handle The integer handle for the state class stored in memory
+     * @param i i-th component of the mixture
+     * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+     * @param message_buffer A buffer for the error code
+     * @param buffer_length The length of the buffer for the error code
+     * @return
+     */
+EXPORT_CODE double CONVENTION AbstractState_get_chemical_potential(const long handle, const long i, long* errcode, char* message_buffer,
+                                                                   const long buffer_length);
+/**
+     * @brief Return the fugacities (in Pa) of all components of the mixture in one call.
+     * @param handle The integer handle for the state class stored in memory
+     * @param values The array into which the per-component fugacities are written
+     * @param maxN The length of the buffer for the values
+     * @param N The number of components actually written
+     * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+     * @param message_buffer A buffer for the error code
+     * @param buffer_length The length of the buffer for the error code
+     * @return
+     */
+EXPORT_CODE void CONVENTION AbstractState_get_fugacities(const long handle, double* values, const long maxN, long* N, long* errcode,
+                                                         char* message_buffer, const long buffer_length);
+/**
+     * @brief Return the fugacity coefficients (dimensionless) of all components of the mixture in one call.
+     * @param handle The integer handle for the state class stored in memory
+     * @param values The array into which the per-component fugacity coefficients are written
+     * @param maxN The length of the buffer for the values
+     * @param N The number of components actually written
+     * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+     * @param message_buffer A buffer for the error code
+     * @param buffer_length The length of the buffer for the error code
+     * @return
+     */
+EXPORT_CODE void CONVENTION AbstractState_get_fugacity_coefficients(const long handle, double* values, const long maxN, long* N, long* errcode,
+                                                                    char* message_buffer, const long buffer_length);
+/**
+     * @brief Return the chemical potentials (in J/mol) of all components of the mixture in one call.
+     * @param handle The integer handle for the state class stored in memory
+     * @param values The array into which the per-component chemical potentials are written
+     * @param maxN The length of the buffer for the values
+     * @param N The number of components actually written
+     * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+     * @param message_buffer A buffer for the error code
+     * @param buffer_length The length of the buffer for the error code
+     * @return
+     */
+EXPORT_CODE void CONVENTION AbstractState_get_chemical_potentials(const long handle, double* values, const long maxN, long* N, long* errcode,
+                                                                  char* message_buffer, const long buffer_length);
+/**
      * @brief Update the state of the AbstractState
      * @param handle The integer handle for the state class stored in memory
      * @param input_pair The integer value for the input pair obtained from XXXXXXXXXXXXXXXX

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -940,9 +940,15 @@ double AbstractState::fugacity(std::size_t i) {
     // TODO: Cache the fug. coeff for each component
     return calc_fugacity(i);
 }
+std::vector<double> AbstractState::fugacities() {
+    return calc_fugacities();
+}
 double AbstractState::chemical_potential(std::size_t i) {
     // TODO: Cache the chemical potential for each component
     return calc_chemical_potential(i);
+}
+std::vector<double> AbstractState::chemical_potentials() {
+    return calc_chemical_potentials();
 }
 void AbstractState::build_phase_envelope(const std::string& type) {
     calc_phase_envelope(type);

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -669,12 +669,13 @@ static void copy_component_vector(const std::vector<double>& src, double* values
             values[i] = src[i];
         }
     } else {
-        throw CoolProp::ValueError(format("Length of array [%d] is greater than allocated buffer length [%d]", *N, maxN));
+        throw CoolProp::ValueError(format("Length of array [%ld] is greater than allocated buffer length [%ld]", *N, maxN));
     }
 }
 EXPORT_CODE void CONVENTION AbstractState_get_fugacities(const long handle, double* values, const long maxN, long* N, long* errcode,
                                                          char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    *N = 0;  // so a throw before the copy leaves a well-defined count, not a stale one
     fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
@@ -686,6 +687,7 @@ EXPORT_CODE void CONVENTION AbstractState_get_fugacities(const long handle, doub
 EXPORT_CODE void CONVENTION AbstractState_get_fugacity_coefficients(const long handle, double* values, const long maxN, long* N, long* errcode,
                                                                     char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    *N = 0;  // so a throw before the copy leaves a well-defined count, not a stale one
     fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
@@ -697,6 +699,7 @@ EXPORT_CODE void CONVENTION AbstractState_get_fugacity_coefficients(const long h
 EXPORT_CODE void CONVENTION AbstractState_get_chemical_potentials(const long handle, double* values, const long maxN, long* N, long* errcode,
                                                                   char* message_buffer, const long buffer_length) {
     *errcode = 0;
+    *N = 0;  // so a throw before the copy leaves a well-defined count, not a stale one
     fpu_reset_guard guard;
     try {
         shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -648,6 +648,63 @@ EXPORT_CODE double CONVENTION AbstractState_get_fugacity_coefficient(const long 
     }
     return _HUGE;
 }
+EXPORT_CODE double CONVENTION AbstractState_get_chemical_potential(const long handle, const long i, long* errcode, char* message_buffer,
+                                                                   const long buffer_length) {
+    *errcode = 0;
+    fpu_reset_guard guard;
+    try {
+        shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
+        return AS->chemical_potential(i);
+    } catch (...) {
+        HandleException(errcode, message_buffer, buffer_length);
+    }
+    return _HUGE;
+}
+// Shared helper: copy a vector-returning per-component getter into the caller's buffer
+// using the standard (values, maxN, N) contract shared with AbstractState_get_mole_fractions.
+static void copy_component_vector(const std::vector<double>& src, double* values, const long maxN, long* N) {
+    *N = static_cast<long>(src.size());
+    if (*N <= maxN) {
+        for (long i = 0; i < *N; i++) {
+            values[i] = src[i];
+        }
+    } else {
+        throw CoolProp::ValueError(format("Length of array [%d] is greater than allocated buffer length [%d]", *N, maxN));
+    }
+}
+EXPORT_CODE void CONVENTION AbstractState_get_fugacities(const long handle, double* values, const long maxN, long* N, long* errcode,
+                                                         char* message_buffer, const long buffer_length) {
+    *errcode = 0;
+    fpu_reset_guard guard;
+    try {
+        shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
+        copy_component_vector(AS->fugacities(), values, maxN, N);
+    } catch (...) {
+        HandleException(errcode, message_buffer, buffer_length);
+    }
+}
+EXPORT_CODE void CONVENTION AbstractState_get_fugacity_coefficients(const long handle, double* values, const long maxN, long* N, long* errcode,
+                                                                    char* message_buffer, const long buffer_length) {
+    *errcode = 0;
+    fpu_reset_guard guard;
+    try {
+        shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
+        copy_component_vector(AS->fugacity_coefficients(), values, maxN, N);
+    } catch (...) {
+        HandleException(errcode, message_buffer, buffer_length);
+    }
+}
+EXPORT_CODE void CONVENTION AbstractState_get_chemical_potentials(const long handle, double* values, const long maxN, long* N, long* errcode,
+                                                                  char* message_buffer, const long buffer_length) {
+    *errcode = 0;
+    fpu_reset_guard guard;
+    try {
+        shared_ptr<CoolProp::AbstractState>& AS = handle_manager.get(handle);
+        copy_component_vector(AS->chemical_potentials(), values, maxN, N);
+    } catch (...) {
+        HandleException(errcode, message_buffer, buffer_length);
+    }
+}
 EXPORT_CODE void CONVENTION AbstractState_update(const long handle, const long input_pair, const double value1, const double value2, long* errcode,
                                                  char* message_buffer, const long buffer_length) {
     *errcode = 0;

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5436,6 +5436,61 @@ TEST_CASE("Two-phase chemical_potential mirrors sat-state values; fugacity_coeff
     }
 }
 
+TEST_CASE("Vector per-component mixture getters mirror the scalar getters (#3024)", "[mixtures][3024]") {
+    // The vector-returning fugacities()/fugacity_coefficients()/chemical_potentials()
+    // default-loop the scalar calc_*(i) virtuals, so they must agree element-by-element
+    // with the existing scalar getters and inherit the same two-phase semantics.
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Methane&Ethane&Propane"));
+    const std::vector<double> z{0.25, 0.25, 0.5};
+    AS->set_mole_fractions(z);
+
+    SECTION("single-phase: all three vectors equal the scalar loop") {
+        AS->update(CoolProp::PT_INPUTS, 5e6, 500);  // hot single-phase gas, well above the dome
+        REQUIRE(AS->phase() != CoolProp::iphase_twophase);
+
+        const std::vector<double> f = AS->fugacities();
+        const std::vector<double> phi = AS->fugacity_coefficients();
+        const std::vector<double> mu = AS->chemical_potentials();
+        REQUIRE(f.size() == z.size());
+        REQUIRE(phi.size() == z.size());
+        REQUIRE(mu.size() == z.size());
+        for (std::size_t i = 0; i < z.size(); ++i) {
+            CAPTURE(i);
+            CHECK(f[i] == Catch::Approx(AS->fugacity(i)));
+            CHECK(phi[i] == Catch::Approx(AS->fugacity_coefficient(i)));
+            CHECK(mu[i] == Catch::Approx(AS->chemical_potential(i)));
+        }
+    }
+
+    SECTION("two-phase: fugacities/chemical_potentials finite, fugacity_coefficients throws whole-vector") {
+        AS->update(CoolProp::PQ_INPUTS, 500e3, 0.5);
+        REQUIRE(AS->phase() == CoolProp::iphase_twophase);
+
+        const std::vector<double> f = AS->fugacities();
+        const std::vector<double> mu = AS->chemical_potentials();
+        REQUIRE(f.size() == z.size());
+        REQUIRE(mu.size() == z.size());
+        for (std::size_t i = 0; i < z.size(); ++i) {
+            CAPTURE(i);
+            CHECK(f[i] == Catch::Approx(AS->fugacity(i)));
+            CHECK(mu[i] == Catch::Approx(AS->chemical_potential(i)));
+        }
+        // Whole-vector throw: the scalar fugacity_coefficient(0) throws, so the
+        // default-loop aborts on the first component rather than returning a
+        // partially-filled / NaN-padded vector.
+        CHECK_THROWS(AS->fugacity_coefficients());
+    }
+
+    SECTION("composition not set: vector getters throw rather than returning empty") {
+        auto fresh = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Methane&Ethane&Propane"));
+        // No set_mole_fractions / update: the default-loop must fail loudly so the
+        // misuse path does not silently fail-open with an empty vector.
+        CHECK_THROWS(fresh->fugacities());
+        CHECK_THROWS(fresh->fugacity_coefficients());
+        CHECK_THROWS(fresh->chemical_potentials());
+    }
+}
+
 TEST_CASE("HAPropsSI Twb at high T (T > Tsat) returns the physical root (#2255)", "[HAPropsSI][2255]") {
     // Issue #2255: HAPropsSI('Twb','T',200+273.15,'W',0.2,'P',1000E3)
     // returned 180.7241 C (essentially Tsat at 1 MPa) instead of the

--- a/src/nanobind_interface.cxx
+++ b/src/nanobind_interface.cxx
@@ -824,6 +824,10 @@ void init_CoolProp(nb::module_& m) {
       .def("fugacity_coefficient", &AbstractState::fugacity_coefficient)
       .def("fugacity", &AbstractState::fugacity)
       .def("chemical_potential", &AbstractState::chemical_potential)
+      // Vector forms returning the full per-component arrays in one call (bd CoolProp-eax, #3024)
+      .def("fugacity_coefficients", &AbstractState::fugacity_coefficients)
+      .def("fugacities", &AbstractState::fugacities)
+      .def("chemical_potentials", &AbstractState::chemical_potentials)
       .def("fundamental_derivative_of_gas_dynamics", &AbstractState::fundamental_derivative_of_gas_dynamics)
       .def("PIP", &AbstractState::PIP)
       // bd CoolProp-r9sq.24: out-reference params -> return a (T, rho) tuple.


### PR DESCRIPTION
Closes #3024 (bd `CoolProp-eax`).

Exposes the full per-component property arrays in one call instead of N scalar round-trips through the C interface.

## C++ API (`AbstractState`)
- `calc_fugacities()` / `calc_fugacity_coefficients()` / `calc_chemical_potentials()` base virtuals now **default-loop** the existing scalar `calc_*(i)` getters (the first previously threw `NotImplementedError`; the latter two are new). So every backend gets the vector forms for free, and HEOS inherits the correct two-phase dispatch from #3022:
  - `fugacities` / `chemical_potentials`: Q-weighted SatL/SatV (collapses to the sat-state value at converged VLE).
  - `fugacity_coefficients`: whole-vector throw in two-phase (the scalar throws at component 0, so the loop aborts — no NaN-padded / partial vector).
- PCSAFT keeps its bespoke `calc_fugacity_coefficients()` override.
- New public `fugacities()` / `chemical_potentials()` (`fugacity_coefficients()` already existed).
- A shared `calc_n_components_for_vector()` guard makes the vector forms throw (rather than silently return an empty vector) if the composition has not been set — parity with the scalar getters.

## CoolPropLib C interface
- Filled the scalar gap: `AbstractState_get_chemical_potential`.
- Three vector endpoints mirroring the `AbstractState_get_mole_fractions_satState` `(values, maxN, N)` contract — `AbstractState_get_fugacities`, `_get_fugacity_coefficients`, `_get_chemical_potentials` — via a shared `copy_component_vector` helper with the standard `*N <= maxN` buffer guard (size check before any write).

## Python (nanobind)
- Bound the three plural methods.

## SWIG
- No change required: `%include "CoolProp/AbstractState.h"` + the existing `%template(DoubleVector) std::vector<double>` auto-expose the new public methods (same mechanism that already wrapped `fugacity_coefficients()`).

## Tests
`[mixtures][3024]`:
- single-phase: all three vectors equal the scalar loop element-by-element;
- two-phase (Q=0.5, exercising the convex-combination branch): `fugacities` / `chemical_potentials` finite and Q-weighted, `fugacity_coefficients()` whole-vector throw;
- composition-not-set: all three vector getters throw rather than returning empty.

## Verification
- `[3024]` 26/26 · `[mixtures]` 69/69 · `[pcsaft]` pass.
- `nanobind_interface.cxx` syntax-clean against the real include set (nanobind 2.0.0).
- `preflight.sh`: 6/6 green (clang-format, build, Catch2, semgrep, …). cppcheck + clang-tidy skipped locally — both fail only on **pre-existing** issues in the touched files (cppcheck can't parse the `TEST_CASE_METHOD` macro; clang-tidy findings are all on unchanged lines). CI's clang-tidy is changed-lines-only and CI's cppcheck is informational, so neither is attributable to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added vector-based accessors for mixture fugacity coefficients, fugacities, and chemical potentials.
  * Exposed these per-component results through the C and Python interfaces.
* **Bug Fixes**
  * Improved handling of undefined/two-phase states so vector results match the existing scalar behavior (including clearer failures when component information is unavailable).
* **Tests**
  * Added coverage to confirm vector results match per-component scalar values and that two-phase/undefined-state behaviors are consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->