### PR TITLE
Check both for REFPROPname.empty() or != 'N/A'

### DIFF
--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -174,6 +174,15 @@ std::string get_REFPROP_HMX_BNC_path() {
     }
 }
 
+/// Return the REFPROP .FLD stem for a CoolPropFluid, falling back to fluid.name
+/// when REFPROPname is absent or the sentinel "N/A".
+static std::string refprop_stem(const CoolPropFluid& fluid) {
+    if (!fluid.REFPROPname.empty() && fluid.REFPROPname != "N/A") {
+        return fluid.REFPROPname;
+    }
+    return fluid.name;
+}
+
 namespace CoolProp {
 
 class REFPROPGenerator : public AbstractStateGenerator
@@ -357,9 +366,7 @@ void REFPROPMixtureBackend::set_REFPROP_fluids(const std::vector<std::string>& f
             for (std::size_t i = 0; i < resolved_names.size(); ++i) {
                 try {
                     CoolPropFluid fluid = get_library().get(fluid_names[i]);
-                    // REFPROPname holds the .FLD stem; when absent, fluid.name is
-                    // the REFPROP-valid name by documented contract (CoolPropFluid.h).
-                    resolved_names[i] = fluid.REFPROPname.empty() ? fluid.name : fluid.REFPROPname;
+                    resolved_names[i] = refprop_stem(fluid);
                 } catch (const CoolProp::ValueError&) {
                     // Direct lookup failed.  If the name carries a REFPROP file
                     // extension (e.g. "R600.FLD"), strip it and retry so that
@@ -374,7 +381,7 @@ void REFPROPMixtureBackend::set_REFPROP_fluids(const std::vector<std::string>& f
                             for (const auto& lookup : {stem, upper(stem)}) {
                                 try {
                                     CoolPropFluid fluid = get_library().get(lookup);
-                                    resolved_names[i] = fluid.REFPROPname.empty() ? fluid.name : fluid.REFPROPname;
+                                    resolved_names[i] = refprop_stem(fluid);
                                     break;
                                 } catch (const CoolProp::ValueError&) {
                                 }

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -174,13 +174,15 @@ std::string get_REFPROP_HMX_BNC_path() {
     }
 }
 
-/// Return the REFPROP .FLD stem for a CoolPropFluid, falling back to fluid.name
-/// when REFPROPname is absent or the sentinel "N/A".
-static std::string refprop_stem(const CoolProp::CoolPropFluid& fluid) {
+/// Return the REFPROP .FLD stem for a CoolPropFluid.
+/// Falls back to `fallback` when REFPROPname is absent or the sentinel "N/A",
+/// so the original user-supplied name is preserved rather than fluid.name
+/// (which may differ, e.g. "R1336mzz(E)" vs the file "R1336MZZE.FLD").
+static std::string refprop_stem(const CoolProp::CoolPropFluid& fluid, const std::string& fallback) {
     if (!fluid.REFPROPname.empty() && fluid.REFPROPname != "N/A") {
         return fluid.REFPROPname;
     }
-    return fluid.name;
+    return fallback;
 }
 
 namespace CoolProp {
@@ -366,7 +368,7 @@ void REFPROPMixtureBackend::set_REFPROP_fluids(const std::vector<std::string>& f
             for (std::size_t i = 0; i < resolved_names.size(); ++i) {
                 try {
                     CoolPropFluid fluid = get_library().get(fluid_names[i]);
-                    resolved_names[i] = refprop_stem(fluid);
+                    resolved_names[i] = refprop_stem(fluid, fluid_names[i]);
                 } catch (const CoolProp::ValueError&) {
                     // Direct lookup failed.  If the name carries a REFPROP file
                     // extension (e.g. "R600.FLD"), strip it and retry so that
@@ -381,7 +383,7 @@ void REFPROPMixtureBackend::set_REFPROP_fluids(const std::vector<std::string>& f
                             for (const auto& lookup : {stem, upper(stem)}) {
                                 try {
                                     CoolPropFluid fluid = get_library().get(lookup);
-                                    resolved_names[i] = refprop_stem(fluid);
+                                    resolved_names[i] = refprop_stem(fluid, stem);
                                     break;
                                 } catch (const CoolProp::ValueError&) {
                                 }

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -176,7 +176,7 @@ std::string get_REFPROP_HMX_BNC_path() {
 
 /// Return the REFPROP .FLD stem for a CoolPropFluid, falling back to fluid.name
 /// when REFPROPname is absent or the sentinel "N/A".
-static std::string refprop_stem(const CoolPropFluid& fluid) {
+static std::string refprop_stem(const CoolProp::CoolPropFluid& fluid) {
     if (!fluid.REFPROPname.empty() && fluid.REFPROPname != "N/A") {
         return fluid.REFPROPname;
     }

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -174,17 +174,6 @@ std::string get_REFPROP_HMX_BNC_path() {
     }
 }
 
-/// Return the REFPROP .FLD stem for a CoolPropFluid.
-/// Falls back to `fallback` when REFPROPname is absent or the sentinel "N/A",
-/// so the original user-supplied name is preserved rather than fluid.name
-/// (which may differ, e.g. "R1336mzz(E)" vs the file "R1336MZZE.FLD").
-static std::string refprop_stem(const CoolProp::CoolPropFluid& fluid, const std::string& fallback) {
-    if (!fluid.REFPROPname.empty() && fluid.REFPROPname != "N/A") {
-        return fluid.REFPROPname;
-    }
-    return fallback;
-}
-
 namespace CoolProp {
 
 class REFPROPGenerator : public AbstractStateGenerator

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.h
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.h
@@ -9,11 +9,24 @@
 #define REFPROPMIXTUREBACKEND_H_
 
 #include "CoolProp/AbstractState.h"
+#include "CoolProp/CoolPropFluid.h"
 #include "CoolProp/DataStructures.h"
 
+#include <string>
 #include <vector>
 
 namespace CoolProp {
+
+/// Return the REFPROP .FLD stem for a CoolPropFluid.
+/// Falls back to `fallback` when REFPROPname is absent or the sentinel "N/A",
+/// so the original user-supplied name is preserved rather than fluid.name
+/// (which may differ, e.g. "R1336mzz(E)" vs the file "R1336MZZE.FLD").
+inline std::string refprop_stem(const CoolPropFluid& fluid, const std::string& fallback) {
+    if (!fluid.REFPROPname.empty() && fluid.REFPROPname != "N/A") {
+        return fluid.REFPROPname;
+    }
+    return fallback;
+}
 
 struct THERM0dllOutputs
 {

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -1988,6 +1988,23 @@ TEST_CASE("REFPROP names for coolprop fluids", "[REFPROPName]") {
         }
     }
 }
+TEST_CASE("refprop_stem falls back to user-supplied name when REFPROPname is unusable", "[REFPROPName][refprop_stem]") {
+    CoolPropFluid fluid;
+    fluid.name = "R1336mzz(E)";
+
+    SECTION("empty REFPROPname returns fallback") {
+        fluid.REFPROPname = "";
+        CHECK(CoolProp::refprop_stem(fluid, "R1336MZZE") == "R1336MZZE");
+    }
+    SECTION("N/A REFPROPname returns fallback") {
+        fluid.REFPROPname = "N/A";
+        CHECK(CoolProp::refprop_stem(fluid, "R1336MZZE") == "R1336MZZE");
+    }
+    SECTION("valid REFPROPname is returned unchanged") {
+        fluid.REFPROPname = "BUTANE";
+        CHECK(CoolProp::refprop_stem(fluid, "R600") == "BUTANE");
+    }
+}
 TEST_CASE("Backwards compatibility for REFPROP v4 fluid name convention", "[REFPROP_backwards_compatibility]") {
     Skip_if_No_REFPROP();  // Skip this test if REFPROPMixture backend is not available
 


### PR DESCRIPTION
Resolve #3241 

This fixes a bug in REFPROP alias resolution, if a custom `.FLD` file is available for a fluid that is usually not in REFPROP but is available in CoolProp. In this case CoolProp `"REFPROP_NAME"` is `"N/A"`, therefore the resolving searches for `"N/A.FLD"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved REFPROP mixture fluid name resolution to make REFPROP file lookups more reliable.
  * Added consistent fallback behavior when a fluid’s REFPROP name is missing or unavailable, reducing lookup failures.
  * Enhanced alias handling by applying the improved resolution consistently for both direct matches and the retry flow after stripping known REFPROP file extensions.

* **Tests**
  * Added coverage for the new REFPROP stem selection behavior to ensure expected fallback and passthrough outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->