### PR TITLE
fix(flash): honor imposed phase in mixture PT flash after build_phase_envelope (GH #3243)

### DIFF
--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -22,7 +22,17 @@
 namespace CoolProp {
 
 void FlashRoutines::PT_flash_mixtures(HelmholtzEOSMixtureBackend& HEOS) {
-    if (HEOS.PhaseEnvelope.built && HEOS.PhaseEnvelope.closed) {
+    // Only use the phase envelope to classify the (T, p) point when the caller has
+    // NOT imposed a single homogeneous phase.  A user who called specify_phase(iphase_gas
+    // / iphase_liquid / ...) is explicitly asking for a particular root; the envelope-
+    // guided classifier below decides gas vs. liquid purely from the geometry of the
+    // closest envelope point and would silently override that request (returning e.g. the
+    // metastable liquid root for an imposed vapor state near the dew line — GitHub #3243).
+    // When a single phase is imposed we fall through to the imposed-phase branch, which
+    // solves solver_rho_Tp on the requested root directly.  An imposed iphase_twophase
+    // still benefits from the envelope-guided two-phase seeding, so it is left in.
+    const bool single_phase_imposed = HEOS.imposed_phase_index != iphase_not_imposed && HEOS.imposed_phase_index != iphase_twophase;
+    if (!single_phase_imposed && HEOS.PhaseEnvelope.built && HEOS.PhaseEnvelope.closed) {
         // Use the closed phase envelope to classify the (T, p) point
         try {
             SimpleState closest_state;

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -791,6 +791,59 @@ TEST_CASE("PT flash with built phase envelope", "[michelsen][phase_envelope]") {
     }
 }
 
+TEST_CASE("PT flash: imposed phase honored after build_phase_envelope (GH #3243)", "[michelsen][phase_envelope][3243]") {
+    // Building the phase envelope must NOT poison subsequent
+    // specify_phase(iphase_gas) + update(PT_INPUTS) calls.  Prior to the fix,
+    // PT_flash_mixtures consulted the envelope to classify the (T,p) point and
+    // silently ignored the user's imposed phase, returning the metastable liquid
+    // root (~14000 mol/m^3) for low-T near-dew VAPOR states instead of the vapor
+    // root (~20 mol/m^3).  See GitHub #3243.
+
+    // R404A components (R125/R134A/R143A)
+    const std::vector<double> z = {0.357816784026318, 0.0382639950410712, 0.603919220932611};
+
+    auto make = []() {
+        auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "R125&R134A&R143A"));
+        return AS;
+    };
+
+    // Reference: fresh state, no envelope built, imposed gas phase.
+    auto AS_ref = make();
+    AS_ref->set_mole_fractions(z);
+
+    // Test: build the envelope on this state first, then impose gas + PT.
+    auto AS_env = make();
+    AS_env->set_mole_fractions(z);
+    AS_env->build_phase_envelope("");
+
+    // A grid of single-phase vapor states well below the dew line (low T, low p).
+    struct Pt
+    {
+        double T, p;
+    };
+    const std::vector<Pt> pts = {{206.4, 30980.0}, {180.0, 10000.0}, {200.0, 50000.0}, {240.0, 200000.0}, {300.0, 1.0e6}};
+
+    for (const auto& pt : pts) {
+        CAPTURE(pt.T, pt.p);
+
+        AS_ref->specify_phase(CoolProp::iphase_gas);
+        AS_ref->update(CoolProp::PT_INPUTS, pt.p, pt.T);
+        const double rho_ref = AS_ref->rhomolar();
+        AS_ref->unspecify_phase();
+
+        AS_env->specify_phase(CoolProp::iphase_gas);
+        AS_env->update(CoolProp::PT_INPUTS, pt.p, pt.T);
+        const double rho_env = AS_env->rhomolar();
+        AS_env->unspecify_phase();
+
+        // The imposed-gas density must match the no-envelope reference, and must be
+        // a vapor-like density (near ideal gas), NOT the liquid root.
+        CHECK(rho_env == Catch::Approx(rho_ref).epsilon(1e-6));
+        CHECK(rho_env < 5.0 * pt.p / (8.314472 * pt.T));  // Z > 0.2 -> clearly vapor, not the ~14000 liquid root
+        CHECK(AS_env->phase() == CoolProp::iphase_gas);
+    }
+}
+
 TEST_CASE("PQ/QT flash with built envelope at 0<Q<1 (GH #3192)", "[michelsen][phase_envelope]") {
     // Regression for GH #3192.  With a built phase envelope a mixture PQ/QT flash for a
     // genuine two-phase state (0 < Q < 1) used to route to newton_raphson_twophase, whose


### PR DESCRIPTION
## Summary

Fixes #3243. Calling `build_phase_envelope()` on a HEOS **mixture** `AbstractState` poisoned subsequent `specify_phase(iphase_gas) + update(PT_INPUTS, ...)` calls, returning the **metastable liquid root** instead of the vapor root for low-pressure vapor states near the dew line.

## Root cause

`FlashRoutines::PT_flash_mixtures` consulted a built + closed phase envelope to classify the `(T, p)` point **before** checking whether the caller had imposed a phase. The envelope-guided classifier decides gas-vs-liquid purely from the geometry of the nearest envelope point:

```cpp
phases phase_guess = (T_saved > closest_state.T) ? iphase_gas : iphase_liquid;
```

For a low-`T` near-dew vapor state this picks `iphase_liquid`, silently overriding the user's explicit `specify_phase(iphase_gas)` and returning the liquid root (~14000 mol/m³) instead of the vapor root (~20 mol/m³). A fresh state object, or an explicit density guess via `update_with_guesses`, returned the correct root — hence the report reading as a cache/state-invalidation bug. REFPROP was immune because it never routes through this classifier.

The specific point in the original report is currently masked on `master` (later fixes #3192/#3174 make `is_inside` classify it as two-phase, which collapses to the vapor root by luck), but a grid sweep shows the bug is very much live: **313** corrupted vapor nodes across the low-`T` region for the R404A components.

## Fix

Guard the envelope-guided branch so it runs only when **no single homogeneous phase is imposed**:

```cpp
const bool single_phase_imposed =
  HEOS.imposed_phase_index != iphase_not_imposed && HEOS.imposed_phase_index != iphase_twophase;
if (!single_phase_imposed && HEOS.PhaseEnvelope.built && HEOS.PhaseEnvelope.closed) { ... }
```

- Imposed `iphase_gas` / `iphase_liquid` / `iphase_supercritical*` → falls through to the imposed-phase branch, which solves `solver_rho_Tp` on the requested root directly.
- Imposed `iphase_twophase` → still uses envelope-guided two-phase seeding (unchanged).
- Blind (`iphase_not_imposed`) → condition reduces to the original `built && closed` (unchanged).

After the fix the R404A grid sweep goes from **313 → 0** corrupted nodes.

## Testing

- New regression test `[3243]`: builds the envelope, then checks `specify_phase(iphase_gas)+PT` over a grid of sub-dew vapor states matches the no-envelope reference and returns a vapor-like density. Verified to **fail (9 assertions)** with the source fix reverted, and pass with it.
- No regressions in `[phase_envelope]` (9 cases), `[michelsen]` (52 cases / 1925 assertions), `[flash]` (41 cases), `[mixture]`/`[mixtures]`.
- Adversarial review completed with no blocking findings; it independently reverted the fix, rebuilt, and confirmed the test is a genuine (non-tautological) guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved phase selection so an explicitly requested single-phase state is respected even after the phase envelope has been built.
  * Kept two-phase envelope-based behavior available when a two-phase state is requested.
  * Added regression coverage to confirm imposed vapor-phase results remain consistent with envelope-enabled calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->