### PR TITLE
fix(ci): force binary numpy in Linux cibuildwheel test env

### DIFF
--- a/.github/workflows/python_cibuildwheel.yml
+++ b/.github/workflows/python_cibuildwheel.yml
@@ -115,7 +115,18 @@ jobs:
         CIBW_BEFORE_BUILD_LINUX: >
           pip install ninja &&
           git config --global --add safe.directory "*"
-        CIBW_ENVIRONMENT_LINUX: COOLPROP_CMAKE=default,NATIVE CPM_SOURCE_CACHE=/root/.cache/CPM PIP_RETRIES=10 PIP_TIMEOUT=60 PIP_DEFAULT_TIMEOUT=60 COOLPROP_NANOBIND=ON
+        # PIP_ONLY_BINARY=numpy: numpy stopped shipping manylinux2014 (glibc 2.17)
+        # wheels after 2.2.6, so the test-install inside the manylinux2014
+        # container was compiling numpy from its sdist; numpy 2.5's meson build
+        # hard-requires GCC >= 10.3 and the container has devtoolset-10 (10.2.1),
+        # which broke the cp312 Linux jobs.  Forcing binary-only makes pip
+        # backtrack to the newest numpy WITH a manylinux2014 wheel (2.2.6 for
+        # cp312; wheels exist for cp39-cp313 on x86_64 and aarch64).  numpy is a
+        # runtime dep only, not a build requirement, so this cannot affect the
+        # wheel build itself.  NOTE: a future cp314 Linux job has NO
+        # manylinux2014 numpy wheel at all -- migrating the images to
+        # manylinux_2_28 is the real fix (bd CoolProp-rcrj).
+        CIBW_ENVIRONMENT_LINUX: COOLPROP_CMAKE=default,NATIVE CPM_SOURCE_CACHE=/root/.cache/CPM PIP_RETRIES=10 PIP_TIMEOUT=60 PIP_DEFAULT_TIMEOUT=60 COOLPROP_NANOBIND=ON PIP_ONLY_BINARY=numpy
         CIBW_ENVIRONMENT_WINDOWS: COOLPROP_NANOBIND=ON PIP_RETRIES=10 PIP_TIMEOUT=60 PIP_DEFAULT_TIMEOUT=60
         # Linux wheels build inside the manylinux container, which does not
         # inherit host env vars; forward the resolved version through so the
@@ -127,7 +138,9 @@ jobs:
         CIBW_ARCHS_LINUX: ${{ inputs.arch }} # i686 x86_64 aarch64 ppc64le s390x
         # Smoke-test the published v8 wheel: it imports, the nanobind PropsSI works
         # (returns a float for int args), and the State capsule shim loads.
-        CIBW_TEST_COMMAND: python -c "import CoolProp; from CoolProp.CoolProp import PropsSI; from CoolProp.State import State; assert '?' not in CoolProp.__gitrevision__; assert isinstance(PropsSI('T','P',101325,'Q',0,'Water'), float)"
+        # import numpy guards the PIP_ONLY_BINARY backtrack above: a numpy wheel
+        # that installs but cannot import should fail the job.
+        CIBW_TEST_COMMAND: python -c "import numpy; import CoolProp; from CoolProp.CoolProp import PropsSI; from CoolProp.State import State; assert '?' not in CoolProp.__gitrevision__; assert isinstance(PropsSI('T','P',101325,'Q',0,'Water'), float)"
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
         CIBW_MANYLINUX_I686_IMAGE: manylinux2014
         CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014


### PR DESCRIPTION
## Problem

The `python_ubuntu`/`python_ubuntu_arm` **cp312** jobs started failing on master ([run 28743739465](https://github.com/CoolProp/CoolProp/actions/runs/28743739465)) at cibuildwheel's test-install step:

```
Downloading numpy-2.5.1.tar.gz (20.8 MB)
../meson.build:25:4: ERROR: Problem encountered: NumPy requires GCC >= 10.3
```

Causal chain:
1. The test step runs `pip install <coolprop wheel>` **inside the manylinux2014 container** (CentOS 7, glibc 2.17, devtoolset-10 = GCC 10.2.1), pulling the wheel's `numpy>=1.20` dependency.
2. numpy stopped publishing manylinux2014 (glibc 2.17) wheels after **2.2.6** — everything since is `manylinux_2_28`-only — so pip has been silently falling back to the numpy **sdist** and compiling it from source in every Linux test step for months (the passing cp311 job in the same run compiled `numpy-2.4.6.tar.gz`, ~2 min).
3. numpy 2.5 (`requires-python >=3.12`, released 2026-06-21) added a hard meson requirement of GCC >= 10.3. The container has 10.2.1 → only the cp312 Linux jobs fail; 3.9–3.11 resolve older numpy that still compiles, and Windows/macOS get real wheels.

## Fix (stopgap)

Add `PIP_ONLY_BINARY=numpy` to `CIBW_ENVIRONMENT_LINUX`: pip refuses numpy sdists and backtracks to the newest numpy **with** a manylinux2014 wheel (2.2.6 for cp312; verified on PyPI for cp39–cp313, x86_64 + aarch64). numpy is a runtime dep only (not in `build-system.requires`), so the wheel build is unaffected — and every Linux test step stops compiling numpy from source.

Also adds `import numpy` to `CIBW_TEST_COMMAND` so a numpy wheel that installs but can't import fails the job (previously the smoke test never touched numpy).

## Real fix (tracked, not this PR)

Migrate the Linux images to `manylinux_2_28` — tracked in **bd CoolProp-rcrj**. That raises the glibc floor of published wheels from 2.17 to 2.28 (a user-facing decision), and must land before any cp314 Linux wheels (no manylinux2014 numpy wheel supports 3.14 at all).

## Verification

- `./dev/ci/preflight.sh`: 4 passed / 0 failed (workflow-only change; C++ gates skipped by path selection)
- Adversarial review subagent: no blocking findings; flagged trade-offs addressed (numpy import guard) or noted in CoolProp-rcrj (cibuildwheel `environment`-applies-to-tests semantics)
- YAML parses; embedded `python -c` program passes `ast.parse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux wheel build reliability by ensuring `numpy` installs as a prebuilt binary in the manylinux environment.
  * Added an explicit import check for `numpy` during wheel tests, helping catch broken installations earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->