### PR TITLE
Add methods for setting Tcrit and pcrit constants in cubic backend.

### DIFF
--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -806,6 +806,18 @@ void CoolProp::AbstractCubicBackend::set_fluid_parameter_double(const size_t i, 
             auto* ACB = static_cast<AbstractCubicBackend*>(state.get());
             ACB->set_fluid_parameter_double(i, parameter, value);
         }
+    } else if (parameter == "Tcrit" || parameter == "Tc") {
+        get_cubic()->set_Tci(i, value);
+        for (auto& state : linked_states) {
+            auto* ACB = static_cast<AbstractCubicBackend*>(state.get());
+            ACB->set_fluid_parameter_double(i, parameter, value);
+        }
+    } else if (parameter == "pcrit" || parameter == "pc") {
+        get_cubic()->set_pci(i, value);
+        for (auto& state : linked_states) {
+            auto* ACB = static_cast<AbstractCubicBackend*>(state.get());
+            ACB->set_fluid_parameter_double(i, parameter, value);
+        }
     } else {
         throw ValueError(format("I don't know what to do with parameter [%s]", parameter.c_str()));
     }
@@ -820,6 +832,10 @@ double CoolProp::AbstractCubicBackend::get_fluid_parameter_double(const size_t i
         return get_cubic()->get_cm();
     } else if (parameter == "Q" || parameter == "Qk" || parameter == "Q_k") {
         return get_cubic()->get_Q_k(i);
+    } else if (parameter == "Tcrit" || parameter == "Tc") {
+        return get_cubic()->get_Tc()[i];
+    } else if (parameter == "pcrit" || parameter == "pc") {
+        return get_cubic()->get_pc()[i];
     } else {
         throw ValueError(format("I don't know what to do with parameter [%s]", parameter.c_str()));
     }

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -796,30 +796,18 @@ void CoolProp::AbstractCubicBackend::set_fluid_parameter_double(const size_t i, 
     // Set the volume translation parrameter, currently applied to the whole fluid, not to components.
     if (parameter == "c" || parameter == "cm" || parameter == "c_m") {
         get_cubic()->set_cm(value);
-        for (auto& state : linked_states) {
-            auto* ACB = static_cast<AbstractCubicBackend*>(state.get());
-            ACB->set_fluid_parameter_double(i, parameter, value);
-        }
     } else if (parameter == "Q" || parameter == "Qk" || parameter == "Q_k") {
         get_cubic()->set_Q_k(i, value);
-        for (auto& state : linked_states) {
-            auto* ACB = static_cast<AbstractCubicBackend*>(state.get());
-            ACB->set_fluid_parameter_double(i, parameter, value);
-        }
     } else if (parameter == "Tcrit" || parameter == "Tc") {
         get_cubic()->set_Tci(i, value);
-        for (auto& state : linked_states) {
-            auto* ACB = static_cast<AbstractCubicBackend*>(state.get());
-            ACB->set_fluid_parameter_double(i, parameter, value);
-        }
     } else if (parameter == "pcrit" || parameter == "pc") {
         get_cubic()->set_pci(i, value);
-        for (auto& state : linked_states) {
-            auto* ACB = static_cast<AbstractCubicBackend*>(state.get());
-            ACB->set_fluid_parameter_double(i, parameter, value);
-        }
     } else {
         throw ValueError(format("I don't know what to do with parameter [%s]", parameter.c_str()));
+    }
+    for (auto& state : linked_states) {
+        auto* ACB = static_cast<AbstractCubicBackend*>(state.get());
+        ACB->set_fluid_parameter_double(i, parameter, value);
     }
 }
 double CoolProp::AbstractCubicBackend::get_fluid_parameter_double(const size_t i, const std::string& parameter) {

--- a/src/Backends/Cubics/GeneralizedCubic.cpp
+++ b/src/Backends/Cubics/GeneralizedCubic.cpp
@@ -280,12 +280,18 @@ double AbstractCubic::bm_term(const std::vector<double>& x) {
     // m_b0_ii_cache[i] holds exactly the value b0_ii(i) returns.
     if (m_b0_ii_cache.size() != static_cast<std::size_t>(N)) {
         m_b0_ii_cache.resize(N);
+        m_b0_ii_cache_valid.assign(N, 0);
         for (int i = 0; i < N; ++i) {
             m_b0_ii_cache[i] = b0_ii(i);
+            m_b0_ii_cache_valid[i] = 1;
         }
     }
     double summer = 0;
     for (int i = N - 1; i >= 0; --i) {
+        if (!m_b0_ii_cache_valid[i]) {
+            m_b0_ii_cache[i] = b0_ii(i);
+            m_b0_ii_cache_valid[i] = 1;
+        }
         summer += x[i] * m_b0_ii_cache[i];
     }
     return summer;

--- a/src/Backends/Cubics/GeneralizedCubic.h
+++ b/src/Backends/Cubics/GeneralizedCubic.h
@@ -137,6 +137,7 @@ class AbstractCubic
     /// construction), so they are computed once on first use; bm_term() reads them instead of
     /// re-evaluating the R_u*Tc/pc division on every call.
     mutable std::vector<double> m_b0_ii_cache;
+    mutable std::vector<char> m_b0_ii_cache_valid;
     void _ensure_aii_cache(double tau) const {
         bool stale = (std::memcmp(&tau, &m_tau_cache, sizeof(double)) != 0) || (m_alpha_versions_cache.size() != alpha.size());
         if (!stale) {
@@ -268,8 +269,10 @@ class AbstractCubic
         // Refresh both in the existing alpha function so its parameters stay consistent.
         alpha[i]->set_a0(a0_ii(i));
         alpha[i]->set_Tr_over_Tci(T_r / Tc[i]);
-        // b0_ii depends on Tc[i]/pc[i]; clear the lazy cache so it is recomputed.
-        m_b0_ii_cache.clear();
+        // b0_ii depends on Tc[i]/pc[i]; mark the affected entry as stale.
+        if (i < m_b0_ii_cache.size()) {
+            m_b0_ii_cache_valid[i] = 0;
+        }
         m_tau_cache = std::numeric_limits<double>::quiet_NaN();  // invalidate aii cache
     }
     /**
@@ -282,8 +285,10 @@ class AbstractCubic
         pc[i] = pci;
         // a0_ii depends on Tc[i]^2/pc[i]; refresh it in the existing alpha function.
         alpha[i]->set_a0(a0_ii(i));
-        // b0_ii depends on Tc[i]/pc[i]; clear the lazy cache so it is recomputed.
-        m_b0_ii_cache.clear();
+        // b0_ii depends on Tc[i]/pc[i]; mark the affected entry as stale.
+        if (i < m_b0_ii_cache.size()) {
+            m_b0_ii_cache_valid[i] = 0;
+        }
         m_tau_cache = std::numeric_limits<double>::quiet_NaN();  // invalidate aii cache
     }
     /// Set the three Mathias-Copeman constants in one shot for the component i of a mixture

--- a/src/Backends/Cubics/GeneralizedCubic.h
+++ b/src/Backends/Cubics/GeneralizedCubic.h
@@ -55,6 +55,11 @@ class AbstractCubicAlphaFunction
         this->sqrt_Tr_Tci = sqrt(Tr_over_Tci);
         ++m_version;
     };
+    /// Update the leading constant a0 that scales the alpha function (e.g., after a change to Tc or pc)
+    void set_a0(double a0_new) {
+        this->a0 = a0_new;
+        ++m_version;
+    };
     /// Monotonically increasing counter bumped whenever this alpha function's parameters change;
     /// callers that cache term() values (e.g., AbstractCubic::_ensure_aii_cache) can compare this
     /// against a previously-recorded value to detect stale cache entries.
@@ -250,6 +255,37 @@ class AbstractCubic
         return rho_r;
     }
 
+    /**
+     * \brief Set the critical temperature of the i-th component [K]
+     *
+     * Updates Tc[i], refreshes the alpha function's a0 and Tr/Tci ratio, and
+     * invalidates the b0 and aii caches so that all subsequent evaluations pick
+     * up the new value consistently.
+     */
+    void set_Tci(std::size_t i, double Tci) {
+        Tc[i] = Tci;
+        // a0_ii depends on Tc[i]^2/pc[i], and Tr_over_Tci = T_r/Tc[i].
+        // Refresh both in the existing alpha function so its parameters stay consistent.
+        alpha[i]->set_a0(a0_ii(i));
+        alpha[i]->set_Tr_over_Tci(T_r / Tc[i]);
+        // b0_ii depends on Tc[i]/pc[i]; clear the lazy cache so it is recomputed.
+        m_b0_ii_cache.clear();
+        m_tau_cache = std::numeric_limits<double>::quiet_NaN();  // invalidate aii cache
+    }
+    /**
+     * \brief Set the critical pressure of the i-th component [Pa]
+     *
+     * Updates pc[i], refreshes the alpha function's a0, and invalidates the b0
+     * cache so that all subsequent evaluations pick up the new value consistently.
+     */
+    void set_pci(std::size_t i, double pci) {
+        pc[i] = pci;
+        // a0_ii depends on Tc[i]^2/pc[i]; refresh it in the existing alpha function.
+        alpha[i]->set_a0(a0_ii(i));
+        // b0_ii depends on Tc[i]/pc[i]; clear the lazy cache so it is recomputed.
+        m_b0_ii_cache.clear();
+        m_tau_cache = std::numeric_limits<double>::quiet_NaN();  // invalidate aii cache
+    }
     /// Set the three Mathias-Copeman constants in one shot for the component i of a mixture
     void set_C_MC(std::size_t i, double c1, double c2, double c3) {
         alpha[i] = std::make_shared<MathiasCopemanAlphaFunction>(a0_ii(i), c1, c2, c3, T_r / Tc[i]);

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4408,6 +4408,72 @@ TEST_CASE("Cubic pure-fluid DmolarT/DmassT round-trip vs PT", "[cubic_DmolarT][2
 }
 
 // ============================================================================
+// Tests for set_fluid_parameter_double("Tcrit"/"pcrit") on cubic backends
+// ============================================================================
+
+TEST_CASE("Cubic set/get Tc and pc via set_fluid_parameter_double", "[cubic_Tcpc]") {
+    // Use PR backend with propane as a representative pure fluid
+    std::shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("PR", "Propane"));
+    auto& ACB = *dynamic_cast<AbstractCubicBackend*>(AS.get());
+
+    const double Tc_orig = ACB.get_fluid_parameter_double(0, "Tcrit");
+    const double pc_orig = ACB.get_fluid_parameter_double(0, "pcrit");
+
+    SECTION("get_fluid_parameter_double returns original Tc and pc") {
+        CHECK(Tc_orig > 0.0);
+        CHECK(pc_orig > 0.0);
+    }
+
+    SECTION("set and get Tc via 'Tcrit' key round-trips correctly") {
+        const double Tc_new = Tc_orig + 5.0;
+        AS->set_fluid_parameter_double(0, "Tcrit", Tc_new);
+        CHECK(ACB.get_fluid_parameter_double(0, "Tcrit") == Catch::Approx(Tc_new).epsilon(1e-12));
+        // Restore
+        AS->set_fluid_parameter_double(0, "Tcrit", Tc_orig);
+    }
+
+    SECTION("set and get pc via 'pcrit' key round-trips correctly") {
+        const double pc_new = pc_orig * 1.02;
+        AS->set_fluid_parameter_double(0, "pcrit", pc_new);
+        CHECK(ACB.get_fluid_parameter_double(0, "pcrit") == Catch::Approx(pc_new).epsilon(1e-12));
+        // Restore
+        AS->set_fluid_parameter_double(0, "pcrit", pc_orig);
+    }
+
+    SECTION("set Tc via 'Tc' alias also works") {
+        const double Tc_new = Tc_orig - 3.0;
+        AS->set_fluid_parameter_double(0, "Tc", Tc_new);
+        CHECK(ACB.get_fluid_parameter_double(0, "Tc") == Catch::Approx(Tc_new).epsilon(1e-12));
+    }
+
+    SECTION("set pc via 'pc' alias also works") {
+        const double pc_new = pc_orig * 0.98;
+        AS->set_fluid_parameter_double(0, "pc", pc_new);
+        CHECK(ACB.get_fluid_parameter_double(0, "pc") == Catch::Approx(pc_new).epsilon(1e-12));
+    }
+
+    SECTION("Twu alpha function: shifting Tc changes saturation pressure") {
+        // Use generic Twu parameters (L, M, N) – these are not from any specific
+        // source; the purpose is only to verify that the Tc change propagates
+        // through the alpha function.
+        const double L = 0.3, M = 0.8, N = 2.0;
+        AS->set_cubic_alpha_C(0, "Twu", L, M, N);
+
+        const double T_test = 300.0;
+        AS->update(QT_INPUTS, 0.0, T_test);
+        const double p_default = AS->p();
+
+        // Shift Tc by +10 K and verify that the saturation pressure changes
+        const double Tc_shifted = Tc_orig + 10.0;
+        AS->set_fluid_parameter_double(0, "Tcrit", Tc_shifted);
+        AS->update(QT_INPUTS, 0.0, T_test);
+        const double p_shifted = AS->p();
+
+        CHECK(std::abs(p_shifted - p_default) / p_default > 1e-4);
+    }
+}
+
+// ============================================================================
 // Lemmon-Akasaka 2022 R-1234yf EOS check values (Table 7)
 // Lemmon & Akasaka, Int. J. Thermophys. 43:119 (2022), DOI 10.1007/s10765-022-03015-y
 // Table 7: density in mol/dm^3, pressure in MPa, cv/cp in J/(mol K), w in m/s

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4414,7 +4414,9 @@ TEST_CASE("Cubic pure-fluid DmolarT/DmassT round-trip vs PT", "[cubic_DmolarT][2
 TEST_CASE("Cubic set/get Tc and pc via set_fluid_parameter_double", "[cubic_Tcpc]") {
     // Use PR backend with propane as a representative pure fluid
     std::shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("PR", "Propane"));
-    auto& ACB = *dynamic_cast<AbstractCubicBackend*>(AS.get());
+    AbstractCubicBackend* raw = dynamic_cast<AbstractCubicBackend*>(AS.get());
+    REQUIRE(raw != nullptr);
+    auto& ACB = *raw;
 
     const double Tc_orig = ACB.get_fluid_parameter_double(0, "Tcrit");
     const double pc_orig = ACB.get_fluid_parameter_double(0, "pcrit");


### PR DESCRIPTION
### Description of the Change

This change introduces the methods set_Tci and set_pci to AbstractCubic. Each setter updates the stored Tc[i]/pc[i], then immediately refreshes the alpha function's a0 (which depends on Tc²/pc) and Tr/Tci ratio, and invalidates both the b0_ii cache and the aii tau-cache so all subsequent evaluations are consistent. 
The methods set_fluid_parameter_double() and get_fluid_parameter_double() are extended with keys "Tcrit" and "pcrit".


### Benefits

Critical constants can be manipulated at runtime, which was not possible before. This is necessary for consistency when using an alpha function, whose parameters were fitted with different Tcrit and pcrit than the default values in CoolProp.


### Verification Process

A Catch2 test is added, which verifies that the constants are set correctly and propagate through the alpha function.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-component cubic critical temperature/pressure support, including `Tcrit/Tc` and `pcrit/pc` aliases.
  * Critical-property updates now apply to all linked states and keep dependent calculations consistent.

* **Bug Fixes**
  * Fixed missing handling for critical-parameter aliases that could return “unknown parameter”.
  * Improved component-level caching so critical constant changes correctly invalidate and refresh affected results.

* **Tests**
  * Added cubic regression coverage for critical value round-tripping and saturation-pressure sensitivity after changing `Tcrit`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->