### PR TITLE
fix(HEOS): fugacity_coefficient at Q=0/Q=1 returns sat-state value (GH #3258)

### DIFF
--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -3470,10 +3470,20 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_helmholtzmolar() {
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_fugacity_coefficient(std::size_t i) {
     x_N_dependency_flag xN_flag = XN_DEPENDENT;
     if (isTwoPhase()) {
-        // phi_i = f_i / (x_i * p).  At VLE f_i^L == f_i^V but x_i^L != x_i^V, so
-        // phi_i^L != phi_i^V and no convex combination is physically meaningful for
-        // the overall two-phase state.  Force callers to evaluate on SatL or SatV.
-        throw ValueError(format("fugacity_coefficient is not well-defined in the two-phase region; evaluate on SatL or SatV instead"));
+        // phi_i = f_i / (x_i * p).  For a genuine two-phase state (0 < Q < 1) f_i^L == f_i^V
+        // at VLE but x_i^L != x_i^V, so phi_i^L != phi_i^V and no convex combination is
+        // physically meaningful for the overall state -- throw and force callers to SatL/SatV.
+        // At the dome boundaries Q == 0 (sat liquid) / Q == 1 (sat vapor) the overall
+        // composition equals one saturated phase, so phi_i IS well-defined; dispatch to the
+        // matching sat state, mirroring calc_fugacity (restores pre-#3022 / v7.2 behavior, GH #3258).
+        if (!this->SatL || !this->SatV) throw ValueError(format("The saturation properties are needed for the two-phase properties"));
+        if (std::abs(_Q) < DBL_EPSILON) {
+            return SatL->fugacity_coefficient(i);
+        } else if (std::abs(_Q - 1) < DBL_EPSILON) {
+            return SatV->fugacity_coefficient(i);
+        } else {
+            throw ValueError(format("fugacity_coefficient is not well-defined in the two-phase region; evaluate on SatL or SatV instead"));
+        }
     } else if (isHomogeneousPhase()) {
         return exp(MixtureDerivatives::ln_fugacity_coefficient(*this, i, xN_flag));
     } else {

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5423,8 +5423,10 @@ TEST_CASE("Two-phase chemical_potential mirrors sat-state values; fugacity_coeff
     //   - mu_i^L == mu_i^V at VLE (the equilibrium condition), so the new code
     //     returns the Q-weighted sat-state value, which collapses to either
     //     endpoint up to flash tolerance.
-    //   - phi_i^L != phi_i^V because the phase compositions differ; the new
-    //     code throws to force callers to evaluate on SatL/SatV explicitly.
+    //   - phi_i^L != phi_i^V because the phase compositions differ; in the
+    //     genuine two-phase interior (0 < Q < 1) the code throws to force
+    //     callers to evaluate on SatL/SatV explicitly.  (The dome boundaries
+    //     Q == 0 / Q == 1 are well-defined and covered by the [3258] case below.)
     auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Methane&Ethane&Propane"));
     AS->set_mole_fractions({0.25, 0.25, 0.5});
     AS->update(CoolProp::PQ_INPUTS, 500e3, 0.5);
@@ -5447,11 +5449,47 @@ TEST_CASE("Two-phase chemical_potential mirrors sat-state values; fugacity_coeff
         // overall == Q-weighted combination of sat states (Q=0.5)
         CHECK(std::abs(mu - 0.5 * (muL + muV)) < 1e-9 * std::abs(0.5 * (muL + muV)));
 
-        // fugacity_coefficient throws in two-phase
+        // fugacity_coefficient throws in the genuine two-phase interior (Q = 0.5)
         CHECK_THROWS(AS->fugacity_coefficient(i));
         // but works on the sat states
         CHECK(std::isfinite(satL.fugacity_coefficient(i)));
         CHECK(std::isfinite(satV.fugacity_coefficient(i)));
+    }
+}
+
+TEST_CASE("Two-phase fugacity_coefficient at Q=0/Q=1 returns the sat-state value (GH #3258)", "[mixtures][3258]") {
+    // GH #3258: a low-level routine (Water&Ethanol PQ, Q=0) that worked in v7.2
+    // began throwing in v8.  PR #3022 made calc_fugacity_coefficient throw for ANY
+    // isTwoPhase() state, but at the dome boundaries the overall composition equals
+    // one saturated phase, so phi_i is well-defined and must equal SatL (Q=0) /
+    // SatV (Q=1) -- mirroring calc_fugacity.  Only the interior 0 < Q < 1 throws.
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Water&Ethanol"));
+    AS->set_mole_fractions({0.4, 0.6});
+
+    // Q = 0 (saturated liquid): overall == liquid composition, phi_i == SatL value.
+    AS->update(CoolProp::PQ_INPUTS, 101325, 0);
+    REQUIRE(AS->phase() == CoolProp::iphase_twophase);
+    auto* heosL = dynamic_cast<CoolProp::HelmholtzEOSMixtureBackend*>(AS.get());
+    REQUIRE(heosL != nullptr);
+    auto& satL = heosL->get_SatL();
+    for (std::size_t i = 0; i < 2; ++i) {
+        CAPTURE(i);
+        const double phi = AS->fugacity_coefficient(i);  // must NOT throw
+        CHECK(std::isfinite(phi));
+        CHECK(phi == Catch::Approx(satL.fugacity_coefficient(i)));
+    }
+
+    // Q = 1 (saturated vapor): overall == vapor composition, phi_i == SatV value.
+    AS->update(CoolProp::PQ_INPUTS, 101325, 1);
+    REQUIRE(AS->phase() == CoolProp::iphase_twophase);
+    auto* heosV = dynamic_cast<CoolProp::HelmholtzEOSMixtureBackend*>(AS.get());
+    REQUIRE(heosV != nullptr);
+    auto& satV = heosV->get_SatV();
+    for (std::size_t i = 0; i < 2; ++i) {
+        CAPTURE(i);
+        const double phi = AS->fugacity_coefficient(i);  // must NOT throw
+        CHECK(std::isfinite(phi));
+        CHECK(phi == Catch::Approx(satV.fugacity_coefficient(i)));
     }
 }
 


### PR DESCRIPTION
## Problem

Fixes #3258. A low-level workflow that worked in CoolProp 7.2 began throwing in 8.0:

```julia
handle = AbstractState_factory("HEOS", "Water&Ethanol")
AbstractState_set_fractions(handle, [0.4, 0.6])
AbstractState_update(handle, PQ_INPUTS, 101325, 0)   # saturated liquid, Q=0
AbstractState_get_fugacity_coefficient(handle, 0)
# ERROR: fugacity_coefficient is not well-defined in the two-phase region;
#        evaluate on SatL or SatV instead
```

PR #3022 (a #2345 follow-up) added a guard to `calc_fugacity_coefficient` that throws for **any** `isTwoPhase()` state. The reasoning is correct for a *genuine* two-phase state (`0 < Q < 1`): since φ_i = f_i/(x_i·p) and the phase compositions differ, φ_i^L ≠ φ_i^V and no convex combination is meaningful. But the guard was too broad — `isTwoPhase()` is also true at the dome boundaries `Q = 0` (saturated liquid) and `Q = 1` (saturated vapor), where the overall composition equals one saturated phase and φ_i **is** well-defined. The reporter's `Q = 0` case is exactly such a boundary, and 7.2 returned a valid value there.

Notably the sibling functions `calc_fugacity` and `calc_chemical_potential` (immediately below in the same file) already handle the boundaries correctly, dispatching to `SatL`/`SatV` at `Q ≈ 0` / `Q ≈ 1`. `calc_fugacity_coefficient` was the odd one out.

## Fix

Mirror the `calc_fugacity` `DBL_EPSILON` boundary logic: at `Q ≈ 0` return `SatL->fugacity_coefficient(i)`, at `Q ≈ 1` return `SatV->fugacity_coefficient(i)`, and keep the throw only for the genuine interior `0 < Q < 1`. `SatL`/`SatV` are homogeneous states, so their `fugacity_coefficient(i)` takes the well-defined single-phase path (no recursion). This restores pre-#3022 / v7.2 behavior for the saturated cases while preserving the #3022 safeguard for ambiguous interior states. The vector `fugacity_coefficients()` inherits the fix via its default scalar loop.

## Tests

- New `[3258]` case: `Water&Ethanol` PQ at `Q = 0` and `Q = 1` — asserts a finite value equal (`Catch::Approx`) to the corresponding `SatL`/`SatV` coefficient, and that it no longer throws.
- Existing `[2345-followup]` `Q = 0.5` interior-throw case is unchanged and still passes.
- `[mixtures]`, `[3024]`, `[SBTL]` suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fugacity coefficient handling at two-phase saturation boundaries so values are now returned instead of failing at the edge cases.
  * Continued to flag truly mixed two-phase states as unsupported for this calculation.

* **Tests**
  * Updated coverage to verify exception behavior inside the two-phase region.
  * Added checks for boundary states to ensure results are finite and match the corresponding saturation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->