### PR TITLE
ci(wheels): drop dead QEMU setup step (Linux builds native on ARM runner)

### DIFF
--- a/.github/workflows/python_cibuildwheel.yml
+++ b/.github/workflows/python_cibuildwheel.yml
@@ -78,12 +78,6 @@ jobs:
           cpm-${{ runner.os }}-${{ inputs.arch }}-
           cpm-${{ runner.os }}-
 
-    - name: Set up QEMU
-      if: ${{ runner.os == 'Linux' }}
-      uses: docker/setup-qemu-action@v4.1.0
-      with:
-        platforms: all
-
     # cibuildwheel 4.0 makes delvewheel the default Windows repair command, but
     # the cross-compiled win_arm64 wheels (py3.9/3.10 on the x64 windows-latest
     # host) can't be repaired there — delvewheel can't find the ARM64


### PR DESCRIPTION
## What

Removes the `Set up QEMU` step (`docker/setup-qemu-action`) from the reusable `python_cibuildwheel.yml`.

## Why

Linux wheels no longer emulate. Each Linux leg builds only its runner's native arch:

- `python_ubuntu` → `ubuntu-latest`, `CIBW_ARCHS_LINUX=x86_64`
- `python_ubuntu_arm` → **`ubuntu-24.04-arm`** (native ARM runner), `CIBW_ARCHS_LINUX=aarch64`

The manylinux containers run at the host's native arch, so the QEMU binfmt handlers this step registered were never exercised. `setup-qemu-action` is referenced nowhere else in the repo, so this is the only instance.

Closes Dependabot **#3253** (the `setup-qemu-action` 4.1.0 → 4.2.0 bump) as no-longer-applicable — the action it bumps is being removed.

## Safety / caveat

Verified via matrix trace that no Linux leg ever requests a non-native arch (the `os`↔arch pairing is hardcoded in `set-matrix`, not computed). If the Linux matrix ever gains a genuinely cross-arch target — `ppc64le`/`s390x`, or aarch64 on an x86 runner — this step must be **restored first**, since cibuildwheel does not self-register binfmt. (`i686`-in-`x86_64`-container is the exception; it needs no QEMU.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the Linux wheel build workflow by removing an extra setup step. This should make builds leaner while keeping the release process otherwise unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->