### PR TITLE
fix(docs): build Java example with -package org.coolprop; guard empty-package CMake paths (#3245 follow-up)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1785,14 +1785,19 @@ if(COOLPROP_JAVA_MODULE)
   set_target_properties(CoolProp PROPERTIES OUTPUT_NAME "CoolPropJava")
   coolprop_hide_json_symbols(CoolProp)
 
-  # Relocate SWIG-generated Java files into the package directory (cross-platform)
-  add_custom_command(
-      TARGET CoolProp
-      POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -D SRC_DIR="${CMAKE_CURRENT_BINARY_DIR}"
-                               -D DST_DIR="${CMAKE_CURRENT_BINARY_DIR}/${JAVA_PACKAGE_DIR}"
-                               -P "${CMAKE_CURRENT_SOURCE_DIR}/dev/cmake/relocate_java.cmake"
-  )
+  # Relocate SWIG-generated Java files into the package directory (cross-platform).
+  # Only when a -package was requested via COOLPROP_SWIG_OPTIONS: without one the
+  # generated sources belong in the default package (flat in the binary dir) and
+  # relocating would run with DST_DIR == SRC_DIR.
+  if(NOT JAVA_PACKAGE_DIR STREQUAL "")
+    add_custom_command(
+        TARGET CoolProp
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -D SRC_DIR="${CMAKE_CURRENT_BINARY_DIR}"
+                                 -D DST_DIR="${CMAKE_CURRENT_BINARY_DIR}/${JAVA_PACKAGE_DIR}"
+                                 -P "${CMAKE_CURRENT_SOURCE_DIR}/dev/cmake/relocate_java.cmake"
+    )
+  endif()
 
   if(WIN32)
     set_target_properties(CoolProp PROPERTIES PREFIX "")
@@ -1810,11 +1815,20 @@ if(COOLPROP_JAVA_MODULE)
 
   add_dependencies(${app_name} generate_headers generate_examples)
 
+  # With a package, the .java sources live under the package directory after
+  # relocation; without one they are flat in the binary dir (the pre-package
+  # behavior, where an empty JAVA_PACKAGE_DIR would otherwise make the glob
+  # the literal filesystem root "/*.java" and archive nothing)
+  if(NOT JAVA_PACKAGE_DIR STREQUAL "")
+    set(JAVA_ARCHIVE_GLOB "${JAVA_PACKAGE_DIR}/*.java")
+  else()
+    set(JAVA_ARCHIVE_GLOB "${CMAKE_CURRENT_BINARY_DIR}/*.java" "-x!Example.java")
+  endif()
   add_custom_command(
     TARGET CoolProp
     POST_BUILD
     COMMAND 7z a "${CMAKE_CURRENT_BINARY_DIR}/platform-independent.7z"
-            "${JAVA_PACKAGE_DIR}/*.java"
+            ${JAVA_ARCHIVE_GLOB}
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
   #add_custom_command(TARGET CoolProp
   #                   POST_BUILD
@@ -1822,11 +1836,30 @@ if(COOLPROP_JAVA_MODULE)
   #                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/dev/scripts/examples")
   #
   # Install all the generated java files
-  get_filename_component(JAVA_PACKAGE_TOP "${JAVA_PACKAGE_DIR}" DIRECTORY)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Example.java"
           DESTINATION ${CMAKE_INSTALL_PREFIX}/Java)
-  install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${JAVA_PACKAGE_TOP}"
-      DESTINATION Java/platform-independent)
+  if(NOT JAVA_PACKAGE_DIR STREQUAL "")
+    # Install the package tree rooted at its FIRST path component so the full
+    # package layout is preserved under platform-independent/.  The parent-of-
+    # leaf form (get_filename_component ... DIRECTORY) is empty for a single-
+    # segment package -- which would install the entire binary dir -- and drops
+    # the top-level directory for packages more than two segments deep.
+    string(REGEX REPLACE "/.*" "" JAVA_PACKAGE_TOP "${JAVA_PACKAGE_DIR}")
+    if(JAVA_PACKAGE_TOP STREQUAL "")
+      # e.g. '-package .coolprop': an empty top component would make the
+      # DIRECTORY rule below install the entire binary dir
+      message(FATAL_ERROR "Invalid -package value in COOLPROP_SWIG_OPTIONS: '${JAVA_PACKAGE}'")
+    endif()
+    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${JAVA_PACKAGE_TOP}"
+        DESTINATION Java/platform-independent)
+  else()
+    # No package: flat default-package sources.  An empty JAVA_PACKAGE_TOP in
+    # the DIRECTORY form above would install the entire binary dir.
+    install(
+      CODE "file( GLOB _GeneratedJavaSources \"${CMAKE_CURRENT_BINARY_DIR}/*.java\" )"
+      CODE "file( INSTALL \${_GeneratedJavaSources} DESTINATION ${CMAKE_INSTALL_PREFIX}/Java/platform-independent )"
+    )
+  endif()
 
 
   install(

--- a/dev/scripts/examples/LinuxRun.py
+++ b/dev/scripts/examples/LinuxRun.py
@@ -70,7 +70,9 @@ if __name__ == '__main__':
     J = Java()
     J.write('Java/Example.java', J.parse())
     kwargs = dict(stdout=sys.stdout, stderr=sys.stderr, shell=True, cwd='Java')
-    subprocess.check_call('cmake ../../../.. -G Ninja -DCOOLPROP_JAVA_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON' + CCACHE, **kwargs)
+    # The generated Example.java imports org.coolprop, so the wrapper must be
+    # built with the same SWIG package the official java_builder workflow uses
+    subprocess.check_call('cmake ../../../.. -G Ninja -DCOOLPROP_JAVA_MODULE=ON -DCOOLPROP_SWIG_OPTIONS="-package org.coolprop" -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON' + CCACHE, **kwargs)
     subprocess.check_call('cmake --build .', **kwargs)
     subprocess.check_call(r'javac *.java', **kwargs)
     with codecs.open('Java/Example.out', 'w', encoding='utf-8') as fp:

--- a/dev/scripts/examples/OSXRun.py
+++ b/dev/scripts/examples/OSXRun.py
@@ -79,7 +79,9 @@ if __name__ == '__main__':
         raise
         
     kwargs = dict(stdout=sys.stdout, stderr=sys.stderr, shell=True, cwd='Java')
-    subprocess.check_call('cmake ../../../.. -DCOOLPROP_JAVA_MODULE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON' + CCACHE, **kwargs)
+    # The generated Example.java imports org.coolprop, so the wrapper must be
+    # built with the same SWIG package the official java_builder workflow uses
+    subprocess.check_call('cmake ../../../.. -DCOOLPROP_JAVA_MODULE=ON -DCOOLPROP_SWIG_OPTIONS="-package org.coolprop" -DCMAKE_VERBOSE_MAKEFILE=ON -DCOOLPROP_NO_EXAMPLES=ON' + CCACHE, **kwargs)
     subprocess.check_call('cmake --build .', **kwargs)
     subprocess.check_call(r'javac *.java', **kwargs)
     with codecs.open('Java/Example.out', 'w', encoding='utf-8') as fp:


### PR DESCRIPTION
## Problem

Docs CI fails on master since 5ad9628da (#3245, JNI Java wrappers) — nightly master runs and every PR (docs builds run on the merge ref) die in the `Build homepage and create graphs` step:

```
Example.java:1: error: package org.coolprop does not exist
```

## Root cause

#3245 made `example_generator.py` unconditionally emit `import org.coolprop.*;` in the generated `Example.java`, but the docs example pipeline (`dev/scripts/examples/LinuxRun.py` / `OSXRun.py`) configures the Java wrapper **without** `COOLPROP_SWIG_OPTIONS`, so SWIG generates default-package classes and `javac` cannot resolve the import.

The same empty-package configuration also broke three CMake steps from #3245, all visible in the failing logs: the 7z POST_BUILD glob degenerates to the literal filesystem root `/*.java` (archives 0 files), `relocate_java.cmake` runs with `DST_DIR == SRC_DIR`, and `install(DIRECTORY "${BINARY_DIR}/${JAVA_PACKAGE_TOP}")` with an empty top would install the entire binary directory.

## Fix

- **`LinuxRun.py` / `OSXRun.py`**: pass `-DCOOLPROP_SWIG_OPTIONS="-package org.coolprop"` so the docs example builds with the same package as the official `java_builder.yml` workflow.
- **`CMakeLists.txt`**: guard the package-dependent steps so builds *without* a `-package` option keep the pre-#3245 flat behavior (relocate skipped, flat 7z glob with `-x!Example.java`, pre-#3245 GLOB install). Additionally, the packaged install now roots at the **first** path component of the package (`org.coolprop` → identical layout as before; single-segment `coolprop` no longer installs the whole binary dir; 3+-segment packages no longer silently drop their top directory), and a malformed package that would still yield an empty top (e.g. `.coolprop`) is a configure-time `FATAL_ERROR`. `java_builder.yml` always passes the package flag and its behavior is provably unchanged (`JAVA_PACKAGE_TOP='org'` both before and after).

## Verification (local, macOS, real JDK)

- Pre-fix reproduction: flat default-package sources + the exact CI `javac` error.
- Post-fix packaged build: sources relocated to `org/coolprop/`, `javac *.java` compiles, `java Example` runs the full example via JNI (info banner + fluid list), 7z archive contains the 40 packaged sources; install lands at `Java/platform-independent/org/coolprop/*.java`.
- Flat no-package build: sources stay flat, 7z archives 40 files (was 0), install is the flat pre-#3245 layout, no build internals leak.
- Single-segment `-package coolprop`: installs `platform-independent/coolprop/`, not the binary dir; `-package .coolprop` fails loud at configure.
- Preflight: 4 passed / 0 failed / 5 skipped (no C++ changes). Adversarial review + delta re-review: one blocking finding (the single-segment install) — fixed and re-verified; residual edge closed with the configure-time guard.

## Follow-ups filed (pre-existing #3245 regressions, out of scope here)

- **CoolProp-qrn3**: the unified Java release artifact ships without wrapper sources (`install(FILES platform-independent.7z)` dropped by #3245 + fail-open `|| true` copy in the `java_builder.yml` merge step).
- **CoolProp-jrvp**: `Web/coolprop/wrappers/Java/index.rst` still documents the flat no-package build whose own `Javatestbuild` ctest now fails for the same import reason.

Closes bd issue CoolProp-7c3b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Java wrapper packaging and installation when no SWIG package is specified.
  * Prevented unintended relocation or installation of unrelated build files.
  * Added validation for invalid Java package paths.

* **Build Improvements**
  * Example Java builds on Linux and macOS now use the standard `org.coolprop` package consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->