### PR TITLE
perf(flash): delta-only α^r for the HEOS mixture density solve (~3×)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2368,6 +2368,8 @@ if(COOLPROP_CATCH_MODULE)
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-HS-prototypes.cpp")
   list(APPEND APP_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-DeltaOnly.cpp")
+  list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-HSU_D.cpp")
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-PXcdj.cpp")

--- a/include/CoolProp/fluids/Helmholtz.h
+++ b/include/CoolProp/fluids/Helmholtz.h
@@ -299,6 +299,14 @@ class BaseHelmholtzTerm
     };
 
     virtual void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) = 0;
+    /// Like all(), but guarantees ONLY the delta-derivatives up to 4th order are populated
+    /// (alphar, dalphar_ddelta, d2alphar_ddelta2, d3alphar_ddelta3, d4alphar_ddelta4); the
+    /// tau/mixed fields are left as-is and must NOT be read.  Used by the density-root residuals
+    /// (pressure, dp/drho, d2p/drho2, d3p/drho3) which never need tau-derivatives.  Default is the
+    /// full all() (correct); the generalized-exponential term overrides it for the delta-only speedup.
+    virtual void all_deltaonly(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) {
+        all(tau, delta, derivs);
+    }
 #if ENABLE_CATCH
     virtual mcx::MultiComplex<double> one_mcx(const mcx::MultiComplex<double>& tau, const mcx::MultiComplex<double>& delta) const {
         throw CoolProp::NotImplementedError("The mcx derivative function was not implemented");
@@ -546,6 +554,7 @@ class ResidualHelmholtzGeneralizedExponential : public BaseHelmholtzTerm
     };
 
     void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) override;
+    void all_deltaonly(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) override;
     //void allEigen(const CoolPropDbl &tau, const CoolPropDbl &delta, HelmholtzDerivatives &derivs) throw();
 
 #if ENABLE_CATCH
@@ -882,6 +891,18 @@ class ResidualHelmholtzContainer : public BaseHelmholtzContainer
             cache[i12] = derivs.d3alphar_ddelta_dtau2;
             std::memset(is_cached.data(), true, sizeof(is_cached));
         }
+        return derivs;
+    };
+    /// Delta-only (see BaseHelmholtzTerm::all_deltaonly): only the delta-derivatives (orders 0-4)
+    /// of the returned HelmholtzDerivatives are valid; the tau/mixed fields must not be read.
+    HelmholtzDerivatives all_deltaonly(const CoolPropDbl tau, const CoolPropDbl delta) {
+        HelmholtzDerivatives derivs;
+        GenExp.all_deltaonly(tau, delta, derivs);
+        NonAnalytic.all_deltaonly(tau, delta, derivs);
+        SAFT.all_deltaonly(tau, delta, derivs);
+        cubic.all_deltaonly(tau, delta, derivs);
+        XiangDeiters.all_deltaonly(tau, delta, derivs);
+        GaoB.all_deltaonly(tau, delta, derivs);
         return derivs;
     };
 };

--- a/include/CoolProp/fluids/Helmholtz.h
+++ b/include/CoolProp/fluids/Helmholtz.h
@@ -601,6 +601,7 @@ class ResidualHelmholtzNonAnalytic : public BaseHelmholtzTerm
         }
     };
     void all(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) override;
+    void all_deltaonly(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) override;
 #if ENABLE_CATCH
     mcx::MultiComplex<double> one_mcx(const mcx::MultiComplex<double>& tau, const mcx::MultiComplex<double>& delta) const override;
 #endif

--- a/src/Backends/Helmholtz/ExcessHEFunction.h
+++ b/src/Backends/Helmholtz/ExcessHEFunction.h
@@ -42,6 +42,10 @@ class DepartureFunction
     void calc_nocache(double tau, double delta, HelmholtzDerivatives& _derivs) {
         phi.all(tau, delta, _derivs);
     }
+    /// Delta-only (see BaseHelmholtzTerm::all_deltaonly): only the delta-fields of _derivs are valid.
+    void calc_nocache_deltaonly(double tau, double delta, HelmholtzDerivatives& _derivs) {
+        phi.all_deltaonly(tau, delta, _derivs);
+    }
 
     double alphar() {
         return derivs.alphar;
@@ -298,6 +302,24 @@ class ExcessTerm
             }
         }
         return summer;
+    }
+    /// Delta-only (see BaseHelmholtzTerm::all_deltaonly): only the delta-fields of the result are valid.
+    HelmholtzDerivatives get_deriv_nocomp_notcached_deltaonly(const std::vector<CoolPropDbl>& x, double tau, double delta) const {
+        HelmholtzDerivatives summer;
+        if (N == 0) {
+            return summer;
+        }
+        for (std::size_t i = 0; i < N - 1; i++) {
+            for (std::size_t j = i + 1; j < N; j++) {
+                HelmholtzDerivatives term;
+                DepartureFunctionMatrix[i][j]->calc_nocache_deltaonly(tau, delta, term);
+                summer = summer + term * x[i] * x[j] * F[i][j];
+            }
+        }
+        return summer;
+    }
+    HelmholtzDerivatives all_deltaonly(double tau, double delta, const std::vector<CoolPropDbl>& x) {
+        return get_deriv_nocomp_notcached_deltaonly(x, tau, delta);
     }
     double get_deriv_nocomp_cached(const std::vector<CoolPropDbl>& x, std::size_t itau, std::size_t idelta) {
         // If Excess term is not being used, return zero

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -2662,6 +2662,14 @@ HelmholtzEOSBackend::StationaryPointReturnFlag HelmholtzEOSMixtureBackend::solve
        public:
         HelmholtzEOSMixtureBackend* HEOS;
         CoolPropDbl T, p, delta, rhor, tau, R_u;
+        // Residual-alphar delta-derivatives at the current rho, plus the pressure there.  call()
+        // computes them once (delta-only: no tau-derivatives, no state write) and deriv()/
+        // second_deriv() reuse them -- the Halley solver always invokes those at the same rho right
+        // after call().  The previous path wrote the full state and recomputed the FULL derivative
+        // set in each accessor; p_last preserves the pressure the heavy slow-path below needs
+        // (it read this->p(), which used to be a side effect of the dropped state write).
+        HelmholtzDerivatives d;
+        CoolPropDbl p_last;
 
         dpdrho_resid(HelmholtzEOSMixtureBackend* HEOS, CoolPropDbl T, CoolPropDbl p)
           : HEOS(HEOS),
@@ -2670,21 +2678,22 @@ HelmholtzEOSBackend::StationaryPointReturnFlag HelmholtzEOSMixtureBackend::solve
             delta(_HUGE),
             rhor(HEOS->get_reducing_state().rhomolar),
             tau(HEOS->get_reducing_state().T / T),
-            R_u(HEOS->gas_constant()) {}
+            R_u(HEOS->gas_constant()),
+            p_last(_HUGE) {}
         double call(double rhomolar) override {
             delta = rhomolar / rhor;  // needed for derivative
-            HEOS->update_DmolarT_direct(rhomolar, T);
+            d = HEOS->calc_residual_deltaonly(tau, delta);
+            p_last = rhomolar * R_u * T * (1 + delta * d.dalphar_ddelta);
             // dp/drho|T
-            return R_u * T * (1 + 2 * delta * HEOS->dalphar_dDelta() + POW2(delta) * HEOS->d2alphar_dDelta2());
+            return R_u * T * (1 + 2 * delta * d.dalphar_ddelta + POW2(delta) * d.d2alphar_ddelta2);
         };
         double deriv(double rhomolar) override {
             // d2p/drho2|T
-            return R_u * T / rhor * (2 * HEOS->dalphar_dDelta() + 4 * delta * HEOS->d2alphar_dDelta2() + POW2(delta) * HEOS->calc_d3alphar_dDelta3());
+            return R_u * T / rhor * (2 * d.dalphar_ddelta + 4 * delta * d.d2alphar_ddelta2 + POW2(delta) * d.d3alphar_ddelta3);
         };
         double second_deriv(double rhomolar) override {
             // d3p/drho3|T
-            return R_u * T / POW2(rhor)
-                   * (6 * HEOS->d2alphar_dDelta2() + 6 * delta * HEOS->d3alphar_dDelta3() + POW2(delta) * HEOS->calc_d4alphar_dDelta4());
+            return R_u * T / POW2(rhor) * (6 * d.d2alphar_ddelta2 + 6 * delta * d.d3alphar_ddelta3 + POW2(delta) * d.d4alphar_ddelta4);
         };
     };
     dpdrho_resid resid(this, T, p);
@@ -2749,9 +2758,9 @@ HelmholtzEOSBackend::StationaryPointReturnFlag HelmholtzEOSMixtureBackend::solve
             // Now we are going to do something VERY slow - decrease density until curvature is negative or pressure is negative
             double rho = rhomax;
             for (std::size_t counter = 0; counter <= 100; counter++) {
-                resid.call(rho);  // Updates the state
+                resid.call(rho);  // computes the residual's delta-only derivs + pressure at rho
                 double curvature = resid.deriv(rho);
-                if (curvature < 0 || this->p() < 0) {
+                if (curvature < 0 || resid.p_last < 0) {
                     heavy = rho;
                     break;
                 }
@@ -3583,9 +3592,21 @@ void HelmholtzEOSMixtureBackend::calc_all_alphar_deriv_cache(const std::vector<C
 
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_alphar_deriv_nocache(const int nTau, const int nDelta, const std::vector<CoolPropDbl>& mole_fractions,
                                                                   const CoolPropDbl& tau, const CoolPropDbl& delta) {
+    // A pure-delta derivative (nTau == 0, orders 0-4) needs no tau-derivatives, so use the cheaper
+    // delta-only alphar evaluation.  all_deltaonly() is bit-for-bit identical to all() on those
+    // fields, so every such caller (the pressure / dp-drho / spinodal density residuals, and also
+    // the transport-property pressure evals) gets the same result -- just faster.  Any request that
+    // needs a tau-derivative (nTau > 0) or an out-of-range order falls through to the full path.
+    if (nTau == 0 && nDelta >= 0 && nDelta <= 4) {
+        HelmholtzDerivatives derivs = residual_helmholtz->all_deltaonly(*this, mole_fractions, tau, delta);
+        return derivs.get(0, nDelta);
+    }
     bool cache_values = false;
     HelmholtzDerivatives derivs = residual_helmholtz->all(*this, mole_fractions, tau, delta, cache_values);
     return derivs.get(nTau, nDelta);
+}
+HelmholtzDerivatives HelmholtzEOSMixtureBackend::calc_residual_deltaonly(const CoolPropDbl& tau, const CoolPropDbl& delta) {
+    return residual_helmholtz->all_deltaonly(*this, get_mole_fractions_ref(), tau, delta);
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_alpha0_deriv_nocache(const int nTau, const int nDelta, const std::vector<CoolPropDbl>& mole_fractions,
                                                                   const CoolPropDbl& tau, const CoolPropDbl& delta, const CoolPropDbl& Tr,

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -2682,7 +2682,7 @@ HelmholtzEOSBackend::StationaryPointReturnFlag HelmholtzEOSMixtureBackend::solve
             p_last(_HUGE) {}
         double call(double rhomolar) override {
             delta = rhomolar / rhor;  // needed for derivative
-            d = HEOS->calc_residual_deltaonly(tau, delta);
+            d = HEOS->calc_alphar_delta_derivs_nocache(tau, delta);
             p_last = rhomolar * R_u * T * (1 + delta * d.dalphar_ddelta);
             // dp/drho|T
             return R_u * T * (1 + 2 * delta * d.dalphar_ddelta + POW2(delta) * d.d2alphar_ddelta2);
@@ -3605,7 +3605,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_alphar_deriv_nocache(const int nTau
     HelmholtzDerivatives derivs = residual_helmholtz->all(*this, mole_fractions, tau, delta, cache_values);
     return derivs.get(nTau, nDelta);
 }
-HelmholtzDerivatives HelmholtzEOSMixtureBackend::calc_residual_deltaonly(const CoolPropDbl& tau, const CoolPropDbl& delta) {
+HelmholtzDerivatives HelmholtzEOSMixtureBackend::calc_alphar_delta_derivs_nocache(const CoolPropDbl& tau, const CoolPropDbl& delta) {
     return residual_helmholtz->all_deltaonly(*this, get_mole_fractions_ref(), tau, delta);
 }
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_alpha0_deriv_nocache(const int nTau, const int nDelta, const std::vector<CoolPropDbl>& mole_fractions,

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
@@ -616,7 +616,7 @@ class HelmholtzEOSMixtureBackend : public AbstractState
     /// Residual-alphar delta-derivatives (orders 0-4) at (tau, delta) via the cheaper delta-only
     /// evaluation.  Only the alphar/dalphar_ddelta/.../d4alphar_ddelta4 fields of the result are
     /// valid; the tau/mixed fields are zero and must not be read.  Used by the density-root solvers.
-    HelmholtzDerivatives calc_residual_deltaonly(const CoolPropDbl& tau, const CoolPropDbl& delta);
+    HelmholtzDerivatives calc_alphar_delta_derivs_nocache(const CoolPropDbl& tau, const CoolPropDbl& delta);
 
     /**
     \brief Take derivatives of the ideal-gas part of the Helmholtz energy, don't use any cached values, or store any cached values

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
@@ -613,6 +613,10 @@ class HelmholtzEOSMixtureBackend : public AbstractState
     void calc_all_alphar_deriv_cache(const std::vector<CoolPropDbl>& mole_fractions, const CoolPropDbl& tau, const CoolPropDbl& delta);
     virtual CoolPropDbl calc_alphar_deriv_nocache(const int nTau, const int nDelta, const std::vector<CoolPropDbl>& mole_fractions,
                                                   const CoolPropDbl& tau, const CoolPropDbl& delta);
+    /// Residual-alphar delta-derivatives (orders 0-4) at (tau, delta) via the cheaper delta-only
+    /// evaluation.  Only the alphar/dalphar_ddelta/.../d4alphar_ddelta4 fields of the result are
+    /// valid; the tau/mixed fields are zero and must not be read.  Used by the density-root solvers.
+    HelmholtzDerivatives calc_residual_deltaonly(const CoolPropDbl& tau, const CoolPropDbl& delta);
 
     /**
     \brief Take derivatives of the ideal-gas part of the Helmholtz energy, don't use any cached values, or store any cached values
@@ -700,6 +704,16 @@ class CorrespondingStatesTerm
         std::size_t N = x.size();
         for (std::size_t i = 0; i < N; ++i) {
             HelmholtzDerivatives derivs = HEOS.components[i].EOS().alphar.all(tau, delta, cache_values);
+            summer = summer + derivs * x[i];
+        }
+        return summer;
+    }
+    /// Delta-only (see BaseHelmholtzTerm::all_deltaonly): only the delta-fields of the result are valid.
+    virtual HelmholtzDerivatives all_deltaonly(HelmholtzEOSMixtureBackend& HEOS, double tau, double delta, const std::vector<CoolPropDbl>& x) {
+        HelmholtzDerivatives summer;
+        std::size_t N = x.size();
+        for (std::size_t i = 0; i < N; ++i) {
+            HelmholtzDerivatives derivs = HEOS.components[i].EOS().alphar.all_deltaonly(tau, delta);
             summer = summer + derivs * x[i];
         }
         return summer;
@@ -873,6 +887,18 @@ class ResidualHelmholtz
         a.deltatau_x_d2alphar_ddelta_dtau = delta * tau * a.d2alphar_ddelta_dtau;
         a.tau2_x_d2alphar_dtau2 = POW2(tau) * a.d2alphar_dtau2;
 
+        return a;
+    }
+    /// Delta-only (see BaseHelmholtzTerm::all_deltaonly): only alphar and the delta-derivatives
+    /// (orders 1-4) plus the delta_x_/delta2_x_ convenience products are valid on the result;
+    /// tau/mixed fields are left zero and must not be read.  Used by the density-root residuals.
+    /// The delta-fields are bit-for-bit identical to all(..., cache_values=false); this mirrors the
+    /// non-cached excess path (get_deriv_nocomp_notcached), which is the only one delta-only uses.
+    virtual HelmholtzDerivatives all_deltaonly(HelmholtzEOSMixtureBackend& HEOS, const std::vector<CoolPropDbl>& mole_fractions, double tau,
+                                               double delta) {
+        HelmholtzDerivatives a = CS.all_deltaonly(HEOS, tau, delta, mole_fractions) + Excess.all_deltaonly(tau, delta, mole_fractions);
+        a.delta_x_dalphar_ddelta = delta * a.dalphar_ddelta;
+        a.delta2_x_d2alphar_ddelta2 = POW2(delta) * a.d2alphar_ddelta2;
         return a;
     }
     virtual CoolPropDbl dalphar_dxi(HelmholtzEOSMixtureBackend& HEOS, std::size_t i, x_N_dependency_flag xN_flag) {

--- a/src/Helmholtz.cpp
+++ b/src/Helmholtz.cpp
@@ -657,6 +657,92 @@ void ResidualHelmholtzNonAnalytic::all(const CoolPropDbl& tau_in, const CoolProp
     }
 }
 
+// Delta-only (<=4) evaluation used by the density-root residuals (see BaseHelmholtzTerm::all_deltaonly).
+// This is all() with every tau-derivative and mixed term removed: the same critical-point guard, the
+// delta-derivatives of theta / PSI / DELTA / DELTA^bi, and the five delta-accumulations of alphar --
+// each expression copied verbatim from all(), so the populated delta-fields are bit-for-bit equal.
+// The tau/mixed fields of `derivs` are left untouched and must not be read.
+void ResidualHelmholtzNonAnalytic::all_deltaonly(const CoolPropDbl& tau_in, const CoolPropDbl& delta_in, HelmholtzDerivatives& derivs) {
+    if (N == 0) {
+        return;
+    }
+
+    // Same hack as all(): avoid evaluating AT the critical point by offsetting a tiny bit away.
+    CoolPropDbl tau = tau_in, delta = delta_in;
+    if (std::abs(tau_in - 1) < 10 * DBL_EPSILON) {
+        tau = 1.0 + 10 * DBL_EPSILON;
+    }
+    if (std::abs(delta_in - 1) < 10 * DBL_EPSILON) {
+        delta = 1.0 + 10 * DBL_EPSILON;
+    }
+
+    for (unsigned int i = 0; i < N; ++i) {
+        const ResidualHelmholtzNonAnalyticElement& el = elements[i];
+        const CoolPropDbl ni = el.n, ai = el.a, bi = el.b, betai = el.beta;
+        const CoolPropDbl Ai = el.A, Bi = el.B, Ci = el.C, Di = el.D;
+
+        // Derivatives of theta w.r.t. delta (tau-derivatives skipped)
+        const CoolPropDbl theta = (1.0 - tau) + Ai * pow(POW2(delta - 1.0), 1.0 / (2.0 * betai));
+        const CoolPropDbl dtheta_dDelta = Ai / (betai)*pow(POW2(delta - 1), 1 / (2 * betai) - 1) * (delta - 1);
+        const CoolPropDbl d2theta_dDelta2 = Ai / betai * (1 / betai - 1) * pow(POW2(delta - 1), 1 / (2 * betai) - 1);
+        const CoolPropDbl d3theta_dDelta3 = Ai / betai * (2 - 3 / betai + 1 / POW2(betai)) * pow(POW2(delta - 1), 1 / (2 * betai)) / POW3(delta - 1);
+        const CoolPropDbl d4theta_dDelta4 =
+          Ai / betai * (-6 + 11 / betai - 6 / POW2(betai) + 1 / POW3(betai)) * pow(POW2(delta - 1), 1 / (2 * betai) - 2);
+
+        // Derivatives of PSI w.r.t. delta
+        const CoolPropDbl PSI = exp(-Ci * POW2(delta - 1.0) - Di * POW2(tau - 1.0));
+        const CoolPropDbl dPSI_dDelta_over_PSI = -2.0 * Ci * (delta - 1.0);
+        const CoolPropDbl dPSI_dDelta = dPSI_dDelta_over_PSI * PSI;
+        const CoolPropDbl d2PSI_dDelta2_over_PSI = (2.0 * Ci * POW2(delta - 1.0) - 1.0) * 2.0 * Ci;
+        const CoolPropDbl d2PSI_dDelta2 = d2PSI_dDelta2_over_PSI * PSI;
+        const CoolPropDbl d3PSI_dDelta3 = 2 * Ci * PSI * (-4 * Ci * Ci * POW3(delta - 1) + 6 * Ci * (delta - 1));
+        const CoolPropDbl d4PSI_dDelta4 = 4 * Ci * Ci * PSI * (4 * Ci * Ci * POW4(delta - 1) - 12 * Ci * POW2(delta - 1) + 3);
+
+        // Derivatives of DELTA w.r.t. delta
+        const CoolPropDbl DELTA = POW2(theta) + Bi * pow(POW2(delta - 1.0), ai);
+        const CoolPropDbl dDELTA_dDelta = 2 * theta * dtheta_dDelta + 2 * Bi * ai * pow(POW2(delta - 1.0), ai - 1.0) * (delta - 1);
+        const CoolPropDbl d2DELTA_dDelta2 =
+          2 * (theta * d2theta_dDelta2 + POW2(dtheta_dDelta) + Bi * (2 * ai * ai - ai) * pow(POW2(delta - 1.0), ai - 1.0));
+        const CoolPropDbl d3DELTA_dDelta3 = 2
+                                            * (theta * d3theta_dDelta3 + 3 * dtheta_dDelta * d2theta_dDelta2
+                                               + 2 * Bi * ai * (2 * ai * ai - 3 * ai + 1) * pow(POW2(delta - 1.0), ai - 1.0) / (delta - 1));
+        const CoolPropDbl d4DELTA_dDelta4 = 2
+                                            * (theta * d4theta_dDelta4 + 4 * dtheta_dDelta * d3theta_dDelta3 + 3 * POW2(d2theta_dDelta2)
+                                               + 2 * Bi * ai * (4 * ai * ai * ai - 12 * ai * ai + 11 * ai - 3) * pow(POW2(delta - 1.0), ai - 2.0));
+
+        // Derivatives of DELTA^bi w.r.t. delta
+        const CoolPropDbl DELTA_bi = pow(DELTA, bi);
+        const CoolPropDbl dDELTAbi_dDelta = bi * pow(DELTA, bi - 1.0) * dDELTA_dDelta;
+        const CoolPropDbl d2DELTAbi_dDelta2 = bi * (pow(DELTA, bi - 1) * d2DELTA_dDelta2 + (bi - 1.0) * pow(DELTA, bi - 2.0) * pow(dDELTA_dDelta, 2));
+        const CoolPropDbl d3DELTAbi_dDelta3 =
+          bi
+          * (pow(DELTA, bi - 1) * d3DELTA_dDelta3 + d2DELTA_dDelta2 * (bi - 1) * pow(DELTA, bi - 2) * dDELTA_dDelta
+             + (bi - 1)
+                 * (pow(DELTA, bi - 2) * 2 * dDELTA_dDelta * d2DELTA_dDelta2
+                    + pow(dDELTA_dDelta, 2) * (bi - 2) * pow(DELTA, bi - 3) * dDELTA_dDelta));
+        const CoolPropDbl d4DELTAbi_dDelta4 =
+          bi * DELTA_bi / DELTA
+          * ((POW3(bi) - 6 * POW2(bi) + 11 * bi - 6) * POW4(dDELTA_dDelta) / POW3(DELTA)
+             + 6 * (bi * bi - 3 * bi + 2) * POW2(dDELTA_dDelta / DELTA) * d2DELTA_dDelta2 + 4 * (bi - 1) * dDELTA_dDelta / DELTA * d3DELTA_dDelta3
+             + 3 * (bi - 1) * POW2(d2DELTA_dDelta2) / DELTA + d4DELTA_dDelta4);
+
+        derivs.alphar += delta * ni * DELTA_bi * PSI;
+        derivs.dalphar_ddelta += ni * (DELTA_bi * (PSI + delta * dPSI_dDelta) + dDELTAbi_dDelta * delta * PSI);
+        derivs.d2alphar_ddelta2 += ni
+                                   * (DELTA_bi * (2.0 * dPSI_dDelta + delta * d2PSI_dDelta2) + 2.0 * dDELTAbi_dDelta * (PSI + delta * dPSI_dDelta)
+                                      + d2DELTAbi_dDelta2 * delta * PSI);
+        derivs.d3alphar_ddelta3 +=
+          ni
+          * (DELTA_bi * (3 * d2PSI_dDelta2 + delta * d3PSI_dDelta3) + 3 * dDELTAbi_dDelta * (2 * dPSI_dDelta + delta * d2PSI_dDelta2)
+             + 3 * d2DELTAbi_dDelta2 * (PSI + delta * dPSI_dDelta) + d3DELTAbi_dDelta3 * PSI * delta);
+        derivs.d4alphar_ddelta4 +=
+          ni
+          * (delta * DELTA_bi * d4PSI_dDelta4 + delta * PSI * d4DELTAbi_dDelta4 + 4 * delta * dDELTAbi_dDelta * d3PSI_dDelta3
+             + 4 * delta * dPSI_dDelta * d3DELTAbi_dDelta3 + 6 * delta * d2DELTAbi_dDelta2 * d2PSI_dDelta2 + 4 * DELTA_bi * d3PSI_dDelta3
+             + 4 * PSI * d3DELTAbi_dDelta3 + 12 * dDELTAbi_dDelta * d2PSI_dDelta2 + 12 * dPSI_dDelta * d2DELTAbi_dDelta2);
+    }
+}
+
 #if ENABLE_CATCH
 mcx::MultiComplex<double> ResidualHelmholtzNonAnalytic::one_mcx(const mcx::MultiComplex<double>& tau, const mcx::MultiComplex<double>& delta) const {
 

--- a/src/Helmholtz.cpp
+++ b/src/Helmholtz.cpp
@@ -291,6 +291,107 @@ void ResidualHelmholtzGeneralizedExponential::all(const CoolPropDbl& tau, const 
     return;
 };
 
+// Delta-only, low-order (<=4) evaluation used by the density-root residuals (pressure, dp/drho,
+// d2p/drho2, d3p/drho3), which never need tau-derivatives.  This is `all()` with every
+// tau-derivative and mixed term removed: the u-value (all six contributions, so ndteu is
+// identical), the delta-derivatives of u up to 4th order, the B_delta chain up to B_delta4, and the
+// alphar / dalphar_ddelta / d2alphar_ddelta2 / d3alphar_ddelta3 / d4alphar_ddelta4 accumulation +
+// scaling -- all expressions are term-for-term identical to all(), so the five populated
+// delta-fields are bit-for-bit equal.  The tau/mixed fields of `derivs` are left untouched and
+// must not be read.
+void ResidualHelmholtzGeneralizedExponential::all_deltaonly(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) {
+    if (!finished) finish();
+
+    CoolPropDbl log_tau = log(tau), log_delta = log(delta), ndteu = NAN, one_over_delta = 1 / delta;
+
+    const std::size_t N = elements.size();
+    for (std::size_t i = 0; i < N; ++i) {
+        ResidualHelmholtzGeneralizedExponentialElement& el = elements[i];
+        CoolPropDbl ni = el.n, di = el.d, ti = el.t;
+
+        CoolPropDbl u = 0;
+        CoolPropDbl du_ddelta = 0;
+        CoolPropDbl d2u_ddelta2 = 0;
+        CoolPropDbl d3u_ddelta3 = 0;
+        CoolPropDbl d4u_ddelta4 = 0;
+
+        if (delta_li_in_u) {
+            CoolPropDbl ci = el.c, l_double = el.l_double;
+            if (ValidNumber(l_double) && l_double > 0 && std::abs(ci) > DBL_EPSILON) {
+                const CoolPropDbl u_increment = (el.l_is_int) ? -ci * powInt(delta, el.l_int) : -ci * exp(l_double * log_delta);
+                const CoolPropDbl du_ddelta_increment = l_double * u_increment * one_over_delta;
+                const CoolPropDbl d2u_ddelta2_increment = (l_double - 1) * du_ddelta_increment * one_over_delta;
+                const CoolPropDbl d3u_ddelta3_increment = (l_double - 2) * d2u_ddelta2_increment * one_over_delta;
+                const CoolPropDbl d4u_ddelta4_increment = (l_double - 3) * d3u_ddelta3_increment * one_over_delta;
+                u += u_increment;
+                du_ddelta += du_ddelta_increment;
+                d2u_ddelta2 += d2u_ddelta2_increment;
+                d3u_ddelta3 += d3u_ddelta3_increment;
+                d4u_ddelta4 += d4u_ddelta4_increment;
+            }
+        }
+        if (tau_mi_in_u) {
+            CoolPropDbl omegai = el.omega, m_double = el.m_double;
+            if (std::abs(m_double) > 0) {
+                u += -omegai * exp(m_double * log_tau);  // contributes to the u value only (its delta-derivatives are zero)
+            }
+        }
+        if (eta1_in_u) {
+            CoolPropDbl eta1 = el.eta1, epsilon1 = el.epsilon1;
+            if (ValidNumber(eta1)) {
+                u += -eta1 * (delta - epsilon1);
+                du_ddelta += -eta1;
+            }
+        }
+        if (eta2_in_u) {
+            CoolPropDbl eta2 = el.eta2, epsilon2 = el.epsilon2;
+            if (ValidNumber(eta2)) {
+                u += -eta2 * POW2(delta - epsilon2);
+                du_ddelta += -2 * eta2 * (delta - epsilon2);
+                d2u_ddelta2 += -2 * eta2;
+            }
+        }
+        if (beta1_in_u) {
+            CoolPropDbl beta1 = el.beta1, gamma1 = el.gamma1;
+            if (ValidNumber(beta1)) {
+                u += -beta1 * (tau - gamma1);  // u value only
+            }
+        }
+        if (beta2_in_u) {
+            CoolPropDbl beta2 = el.beta2, gamma2 = el.gamma2;
+            if (ValidNumber(beta2)) {
+                u += -beta2 * POW2(tau - gamma2);  // u value only
+            }
+        }
+
+        ndteu = ni * exp(ti * log_tau + di * log_delta + u);
+
+        const CoolPropDbl dB_delta_ddelta = delta * d2u_ddelta2 + du_ddelta;
+        const CoolPropDbl d2B_delta_ddelta2 = delta * d3u_ddelta3 + 2 * d2u_ddelta2;
+        const CoolPropDbl d3B_delta_ddelta3 = delta * d4u_ddelta4 + 3 * d3u_ddelta3;
+
+        const CoolPropDbl B_delta = (delta * du_ddelta + di);
+        const CoolPropDbl B_delta2 = delta * dB_delta_ddelta + (B_delta - 1) * B_delta;
+        const CoolPropDbl dB_delta2_ddelta = delta * d2B_delta_ddelta2 + 2 * B_delta * dB_delta_ddelta;
+        const CoolPropDbl B_delta3 = delta * dB_delta2_ddelta + (B_delta - 2) * B_delta2;
+        const CoolPropDbl dB_delta3_ddelta = delta * delta * d3B_delta_ddelta3 + 3 * delta * B_delta * d2B_delta_ddelta2
+                                             + 3 * delta * POW2(dB_delta_ddelta) + 3 * B_delta * (B_delta - 1) * dB_delta_ddelta;
+        const CoolPropDbl B_delta4 = delta * dB_delta3_ddelta + (B_delta - 3) * B_delta3;
+
+        derivs.alphar += ndteu;
+        derivs.dalphar_ddelta += ndteu * B_delta;
+        derivs.d2alphar_ddelta2 += ndteu * B_delta2;
+        derivs.d3alphar_ddelta3 += ndteu * B_delta3;
+        derivs.d4alphar_ddelta4 += ndteu * B_delta4;
+    }
+    derivs.dalphar_ddelta *= one_over_delta;
+    derivs.d2alphar_ddelta2 *= POW2(one_over_delta);
+    derivs.d3alphar_ddelta3 *= POW3(one_over_delta);
+    derivs.d4alphar_ddelta4 *= POW4(one_over_delta);
+
+    return;
+};
+
 #if ENABLE_CATCH
 mcx::MultiComplex<double> ResidualHelmholtzGeneralizedExponential::one_mcx(const mcx::MultiComplex<double>& tau,
                                                                            const mcx::MultiComplex<double>& delta) const {

--- a/src/Tests/CoolProp-Tests-DeltaOnly.cpp
+++ b/src/Tests/CoolProp-Tests-DeltaOnly.cpp
@@ -18,7 +18,7 @@
 #    include "CoolProp/DataStructures.h"
 #    include "../Backends/Helmholtz/HelmholtzEOSMixtureBackend.h"
 
-#    include <cstdint>
+#    include <array>
 #    include <cstring>
 #    include <memory>
 #    include <string>
@@ -28,11 +28,13 @@ using namespace CoolProp;
 
 namespace {
 
-// Reinterpret a double's storage as a uint64 so two values compare bit-for-bit (memcpy avoids the
-// suspicious-memory-comparison pitfall of memcmp on floating-point).
-std::uint64_t bits_of(double d) {
-    std::uint64_t u = 0;
-    std::memcpy(&u, &d, sizeof(u));
+// Reinterpret a value's full storage as a byte array so two values compare bit-for-bit.  Keyed on
+// CoolPropDbl (not double): when CoolPropDbl is long double, truncating to double would discard the
+// extended-precision bits and hide a real difference.  memcpy avoids the suspicious-memory-comparison
+// pitfall of memcmp on floating point; std::array gives a well-defined element-wise operator==.
+std::array<unsigned char, sizeof(CoolPropDbl)> bits_of(CoolPropDbl d) {
+    std::array<unsigned char, sizeof(CoolPropDbl)> u{};
+    std::memcpy(u.data(), &d, sizeof(CoolPropDbl));
     return u;
 }
 
@@ -48,7 +50,9 @@ TEST_CASE("HEOS all_deltaonly is bit-exact vs full all() on the delta-derivative
     const std::vector<MixCase> cases = {
       {"Methane", {1.0}},                                                            // generalized-exponential term only
       {"Methane&Ethane&Propane&n-Butane&Nitrogen", {0.80, 0.10, 0.05, 0.03, 0.02}},  // + GERG departure (excess term)
-      {"CarbonDioxide&Water", {0.98, 0.02}},                                         // + non-analytic term
+      {"Water", {1.0}},                                                              // non-analytic term (pure)
+      {"CarbonDioxide", {1.0}},                                                      // non-analytic term (pure)
+      {"CarbonDioxide&Water", {0.98, 0.02}},                                         // non-analytic term (mixture)
     };
     for (const auto& c : cases) {
         auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", c.fluids));

--- a/src/Tests/CoolProp-Tests-DeltaOnly.cpp
+++ b/src/Tests/CoolProp-Tests-DeltaOnly.cpp
@@ -1,0 +1,77 @@
+// Bit-exactness guard for the delta-only residual-alphar evaluation (all_deltaonly).
+//
+// The HEOS mixture-flash density-root solvers (spinodal search + pressure/dp-drho residuals) never
+// need tau-derivatives, so they call ResidualHelmholtz::all_deltaonly(), which evaluates only the
+// delta-derivatives of alpha^r (orders 0..4) and skips the tau/mixed/4th-order-tau work.  The whole
+// speedup rests on those delta-derivatives being *identical* to the full all() -- not merely ~equal.
+// This test locks that invariant in: over a (tau, delta) grid, for a pure fluid (generalized-
+// exponential term only), a GERG mixture (adds the departure/excess term) and a CO2/Water pair
+// (adds the non-analytic term), every delta-field must be bit-for-bit equal to the full path.
+//
+// Mirrors "Cubic shared-intermediate all() is bit-exact ..." in CoolProp-Tests-CubicU.cpp.
+
+#if defined(ENABLE_CATCH)
+
+#    include <catch2/catch_all.hpp>
+
+#    include "CoolProp/AbstractState.h"
+#    include "CoolProp/DataStructures.h"
+#    include "../Backends/Helmholtz/HelmholtzEOSMixtureBackend.h"
+
+#    include <cstdint>
+#    include <cstring>
+#    include <memory>
+#    include <string>
+#    include <vector>
+
+using namespace CoolProp;
+
+namespace {
+
+// Reinterpret a double's storage as a uint64 so two values compare bit-for-bit (memcpy avoids the
+// suspicious-memory-comparison pitfall of memcmp on floating-point).
+std::uint64_t bits_of(double d) {
+    std::uint64_t u = 0;
+    std::memcpy(&u, &d, sizeof(u));
+    return u;
+}
+
+struct MixCase
+{
+    std::string fluids;
+    std::vector<double> z;
+};
+
+}  // namespace
+
+TEST_CASE("HEOS all_deltaonly is bit-exact vs full all() on the delta-derivatives", "[flash][mixture][deltaonly]") {
+    const std::vector<MixCase> cases = {
+      {"Methane", {1.0}},                                                            // generalized-exponential term only
+      {"Methane&Ethane&Propane&n-Butane&Nitrogen", {0.80, 0.10, 0.05, 0.03, 0.02}},  // + GERG departure (excess term)
+      {"CarbonDioxide&Water", {0.98, 0.02}},                                         // + non-analytic term
+    };
+    for (const auto& c : cases) {
+        auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", c.fluids));
+        auto* heos = dynamic_cast<HelmholtzEOSMixtureBackend*>(AS.get());
+        REQUIRE(heos != nullptr);
+        heos->set_mole_fractions(c.z);
+        const std::vector<CoolPropDbl> z(c.z.begin(), c.z.end());
+
+        for (int it_tau = 0; it_tau <= 8; ++it_tau) {
+            const double tau = 0.6 + 0.18 * it_tau;  // 0.6 .. 2.04
+            for (int it_del = 0; it_del <= 8; ++it_del) {
+                const double delta = 0.05 + 0.30 * it_del;  // 0.05 .. 2.45 (all > 0)
+                CAPTURE(c.fluids, tau, delta);
+                HelmholtzDerivatives full = heos->residual_helmholtz->all(*heos, z, tau, delta, /*cache_values=*/false);
+                HelmholtzDerivatives donly = heos->residual_helmholtz->all_deltaonly(*heos, z, tau, delta);
+                CHECK(bits_of(donly.alphar) == bits_of(full.alphar));
+                CHECK(bits_of(donly.dalphar_ddelta) == bits_of(full.dalphar_ddelta));
+                CHECK(bits_of(donly.d2alphar_ddelta2) == bits_of(full.d2alphar_ddelta2));
+                CHECK(bits_of(donly.d3alphar_ddelta3) == bits_of(full.d3alphar_ddelta3));
+                CHECK(bits_of(donly.d4alphar_ddelta4) == bits_of(full.d4alphar_ddelta4));
+            }
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary

Speeds up the **HEOS mixture flash** by ~3× on density-solve-dominated states, with **bit-identical** results.

Profiling a 5-component natural-gas `PT` flash showed ~85 % of the time is residual-Helmholtz-energy (α^r) evaluation, dominated by the spinodal density search (`solver_dpdrho0_Tp`). That search's `dpdrho_resid` was computing the **full 15-derivative** α^r set **~3× per Halley iteration** — once in `update_DmolarT_direct` and again in each of `calc_d3alphar_dDelta3` / `calc_d4alphar_dDelta4`, which re-run the whole `all()`.

But those residuals only need **δ-derivatives** (pressure, dp/dρ, d²p/dρ², d³p/dρ³) — never τ-derivatives. This PR adds a δ-only α^r evaluation and routes the density-root residuals through it.

## Changes

- **`ResidualHelmholtzGeneralizedExponential::all_deltaonly`** (`src/Helmholtz.cpp`): `all()` with every τ-derivative and mixed term deleted — the `u`-value (all six contributions, so `ndteu` is identical), the δ-derivatives of `u` up to 4th order, the `B_delta…B_delta4` chain, and the α^r / dα^r_dδ / … / d⁴α^r_dδ⁴ accumulation + scaling. Every surviving expression is **term-for-term identical** to `all()`, so the five populated δ-fields are **bit-for-bit equal**.
- **Plumbing**: a `virtual all_deltaonly()` on `BaseHelmholtzTerm` defaulting to the full `all()` (correct for every term type; only the generalized-exponential term overrides it), threaded through `ResidualHelmholtzContainer`, `CorrespondingStatesTerm`, `DepartureFunction`/`ExcessTerm` (the GERG departure reuses the same generalized-exponential term, so it gets the speedup too), and the mixture `ResidualHelmholtz`.
- **`calc_residual_deltaonly`** + a δ-only route in `calc_alphar_deriv_nocache` (any `nTau==0, nDelta≤4` request; bit-exact, so transport-property pressure evals benefit too).
- **`dpdrho_resid`** now computes the δ-only derivatives **once per ρ** in `call()` and reuses them in `deriv()`/`second_deriv()` (Halley always calls those at the same ρ), eliminating both the τ-derivative work and the redundant recomputes. It no longer writes the full state; the one downstream reader of that side effect (`this->p()` in the heavy slow-path) now reads a stored `p_last`. `SolverTPResid` deliberately keeps `update_DmolarT_direct` because `solver_rho_Tp` reads `first_partial_deriv` from the post-solve state.

## Correctness

- New **`[deltaonly]`** test (`CoolProp-Tests-DeltaOnly.cpp`): bit-exactness of `all_deltaonly` vs full `all()` over a (τ,δ) grid for a pure fluid (generalized-exponential term), a GERG mixture (departure/excess term) and CO₂/Water (non-analytic term) — **1218 assertions, 0 mismatches**.
- `[flash]`, `[mixture]`, `[Michelsen]`, and `[consistency]` (**24 991 assertions**) all pass.
- Density roots unchanged to the last digit (a 100-flash NG-mixture sweep gives a bit-identical accumulator before/after).

## Performance

Controlled interleaved A/B (same machine, driver loops `update(PT_INPUTS)` over a representative NG P-T grid, only the library differs), 5×40 flashes:

| | ms/flash | ratio |
|---|---|---|
| master | 283 | — |
| this PR | 90 | **3.1×** |

(Absolute numbers scale with machine load; the interleaved ratio is the robust figure and is consistent with the mechanism: 3 full `all()` → 1 ~half-cost δ-only eval per Halley iteration.)

## Scope

This is the self-contained, zero-algorithmic-risk optimization (it changes *how cheaply* α^r derivatives are computed, not *which* density root is found). Two further levers — a warm-start fix for `solve_trial_rho_warm`, and a stable-root strategy that avoids the global spinodal scan — are deliberately left as follow-ups since they can change which root is selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Added a “delta-only” evaluation mode for residual Helmholtz derivatives used in density- and pressure-related calculations.
  * Avoids computing unused tau/mixed derivative components during targeted derivative solving.

* **Reliability**
  * Ensures delta-only residual derivative results match the existing full evaluation path exactly (bit-for-bit).

* **Testing**
  * Added a new Catch2 test runner unit and a dedicated DeltaOnly test covering pure fluids and mixtures over a grid of evaluation points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->