### PR TITLE
ci(wheels): add build target for Pyodide wasm32 wheels

### DIFF
--- a/.github/workflows/python_buildwheels.yml
+++ b/.github/workflows/python_buildwheels.yml
@@ -214,9 +214,24 @@ jobs:
       arch: ${{ matrix.arch }}
       TESTPYPI_VERSION: ${{ needs.set-version.outputs.testpypiversion }}
 
+  python_pyodide:
+    needs: [set-version, set-matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [313,314]
+        arch: [wasm32]
+    uses: ./.github/workflows/python_cibuildwheel.yml
+    with:
+      os: ubuntu-latest
+      python-version: ${{ matrix.python-version }}
+      arch: ${{ matrix.arch }}
+      platform: pyodide
+      TESTPYPI_VERSION: ${{ needs.set-version.outputs.testpypiversion }}
+
   merge_wheels:
    runs-on: ubuntu-latest
-   needs: [python_source, python_ubuntu, python_ubuntu_arm, python_windows, python_macos]
+   needs: [python_source, python_ubuntu, python_ubuntu_arm, python_windows, python_macos, python_pyodide]
    steps:
      - name: Merge Artifacts
        uses: actions/upload-artifact/merge@v7

--- a/.github/workflows/python_cibuildwheel.yml
+++ b/.github/workflows/python_cibuildwheel.yml
@@ -15,6 +15,10 @@ on:
       TESTPYPI_VERSION:
         required: true 
         type: string
+      platform:
+        required: false
+        type: string
+        default: auto
 
 jobs:
 
@@ -122,6 +126,9 @@ jobs:
         # manylinux_2_28 is the real fix (bd CoolProp-rcrj).
         CIBW_ENVIRONMENT_LINUX: COOLPROP_CMAKE=default,NATIVE CPM_SOURCE_CACHE=/root/.cache/CPM PIP_RETRIES=10 PIP_TIMEOUT=60 PIP_DEFAULT_TIMEOUT=60 COOLPROP_NANOBIND=ON PIP_ONLY_BINARY=numpy
         CIBW_ENVIRONMENT_WINDOWS: COOLPROP_NANOBIND=ON PIP_RETRIES=10 PIP_TIMEOUT=60 PIP_DEFAULT_TIMEOUT=60
+        # Platform and archs for Pyodide target
+        CIBW_PLATFORM: ${{ inputs.platform }}
+        CIBW_ARCHS_PYODIDE: ${{ inputs.arch }}
         # Linux wheels build inside the manylinux container, which does not
         # inherit host env vars; forward the resolved version through so the
         # version provider sees it. macOS/Windows build on the host directly.

--- a/Web/coolprop/wrappers/Python/index.rst
+++ b/Web/coolprop/wrappers/Python/index.rst
@@ -368,7 +368,7 @@ packages from `PyPI <https://pypi.org/>`_ as part of the implementation of
 CoolProp 8.0.1, CoolProp WebAssembly wheels are provided on PyPI. However, for versions 
 of Pyodide that bundle CoolProp, the version of CoolProp needs to be specified as 
 ``>=8.0.1`` in the ``micropip`` call to get the latest CoolProp version since Pyodide 
-will use its bundled version first, if available (CoolProp 7.2.0 with Pyodide 314.02, 
+will use its bundled version first, if available (CoolProp 7.2.0 with Pyodide 314.0.2, 
 for example). Future versions of Pyodide will stop including CoolProp as part of the PEP 783 
 rollout making it no longer necessary to specify the CoolProp version to get the latest version.
 

--- a/Web/coolprop/wrappers/Python/index.rst
+++ b/Web/coolprop/wrappers/Python/index.rst
@@ -299,6 +299,78 @@ given message only once and then ignore further instances.
 
 See `Python >>> Module Warnings <https://docs.python.org/3/library/warnings.html#module-warnings>`_ for more information on using `filterwarnings()`
 
+.. _python_wasm_demo:
+
+Running CoolProp in the Browser Using Pyodide
+=============================================
+
+The `Pyodide project <https://pyodide.org/en/stable/>`_  
+is a Python interpreter compiled to WebAssembly that includes many
+of the scientific Python packages, including NumPy, SciPy, and CoolProp.
+WebAssembly makes these packages available in the web browser environment, enabling the 
+deployment of static websites that can perform Python calculations.
+
+Minimal CoolProp Pyodide example
+--------------------------------
+
+The following example shows a minimal web page that calls a CoolProp function using 
+Pyodide. See the `Pyodide documentation page <https://pyodide.org/en/stable/usage/index.html>`_ 
+for further details on the usage of Pyodide.
+
+.. code-block:: html
+
+    <!doctype html>
+    <html>
+      <head>
+          <!-- Load Pyodide from Pyodide's official CDN-->
+          <script src="https://cdn.jsdelivr.net/pyodide/v314.0.2/full/pyodide.js"></script>
+      </head>
+      <body>
+        <script type="text/javascript">
+          async function main() {
+            // Load Pyodide (the loadPyodide function is provided by the script tag above)
+            let pyodide = await loadPyodide();
+            
+            // Load micropip so that PyPI wheels can be installed
+            await pyodide.loadPackage("micropip");
+            const micropip = pyodide.pyimport("micropip");
+
+            // Use micropip to install the latest CoolProp
+            await micropip.install("CoolProp>=8.0.1");
+            
+            // Run the Python code, the expression on the last line is returned to javascript
+            results = pyodide.runPython(`
+                import CoolProp
+                import CoolProp.CoolProp as CP
+
+                version = CoolProp.__version__
+                temp = CP.PropsSI('T', 'P', 101325, 'Q', 0, 'Water')
+
+                (version, temp)
+            `);
+
+            // Popup an alert with the results
+            alert(`CoolProp.__version__=${results[0]}\nThe boiling point of water at 1 atm = ${results[1]} K`);
+          }
+          main();
+        </script>
+      </body>
+    </html>
+
+Getting the latest CoolProp version in Pyodide
+----------------------------------------------
+
+Historically, the Pyodide project has bundled CoolProp as part of the Pyodide distribution 
+(beginning with Pyodide 0.24.0). This locked the CoolProp version to the version
+bundled with Pyodide. Versions of Pyodide 0.28.x and later are able to load compiled Python 
+packages from `PyPI <https://pypi.org/>`_ as part of the implementation of 
+`PEP 783 <https://peps.python.org/pep-0783/>`_. Starting with 
+CoolProp 8.0.1, CoolProp WebAssembly wheels are provided on PyPI. However, for versions 
+of Pyodide that bundle CoolProp, the version of CoolProp needs to be specified as 
+``>=8.0.1`` in the ``micropip`` call to get the latest CoolProp version since Pyodide 
+will use its bundled version first, if available (CoolProp 7.2.0 with Pyodide 314.02, 
+for example). Future versions of Pyodide will stop including CoolProp as part of the PEP 783 
+rollout making it no longer necessary to specify the CoolProp version to get the latest version.
 
 Module Documentation
 ====================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Development Status :: 5 - Production/Stable",
     "Environment :: Other Environment",
+    "Environment :: WebAssembly :: Emscripten",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
@@ -124,8 +125,8 @@ build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
 skip = "*-musllinux_*"
 
 # Test command
-test-command = "python -c \"import CoolProp; print(CoolProp.__version__); CoolProp.CoolProp.PropsSI('T', 'P', 101325, 'Q', 0, 'Water')\""
-test-requires = ["numpy"]
+test-command = "pytest {project}/wrappers/Python/pytest/smoke_test.py"
+test-requires = ["numpy", "pytest"]
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
@@ -138,9 +139,18 @@ archs = ["x86_64", "aarch64"]
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]
 
+[tool.cibuildwheel.pyodide]
+build-frontend = {name = "build", args = ["--exports", "whole_archive"]}
+
+[tool.cibuildwheel.pyodide.environment]
+CFLAGS = "-fwasm-exceptions -DCOOLPROP_NO_INCBIN"
+CXXFLAGS = "-fwasm-exceptions -DCOOLPROP_NO_INCBIN"
+LDFLAGS = "-fwasm-exceptions"
+
 [dependency-groups]
 dev = [
     "matplotlib>=3.7.5",
     "pandas>=2.0.3",
+    "pytest>=8.4.2",
     "scipy>=1.10.1",
 ]

--- a/wrappers/Python/pytest/smoke_test.py
+++ b/wrappers/Python/pytest/smoke_test.py
@@ -1,0 +1,34 @@
+"""
+CI Smoke Test Suite for CoolProp Wheel Verification.
+
+Validates that compiled C++ extensions (nanobind) load successfully, executes 
+basic thermodynamic property lookups (PropsSI), and verifies core exception 
+handling. 
+
+Designed to run under both native desktop wheels and WebAssembly (Pyodide) 
+runtimes with minimal external dependencies.
+
+Usage:
+    pytest wrappers/Python/pytest/test_smoke.py
+"""
+import pytest
+from CoolProp.CoolProp import PropsSI, PhaseSI
+from CoolProp.HumidAirProp import HAPropsSI
+
+
+def test_simple_propssi():
+    assert round(PropsSI("T", "P", 101325, "Q", 0, "Water"), 3) == 373.124
+
+    with pytest.raises(ValueError):
+        PropsSI("T", "P", 101325, "Q", 0, "Walter")
+
+
+def test_simple_phasesi():
+    assert PhaseSI("P", 101325, "Q", 0, "Water") == "twophase"
+
+
+def test_simple_HAPropsSI():
+    assert round(HAPropsSI("H", "T", 298.15, "P", 101325, "R", 0.5), 3) == 50423.450
+
+    with pytest.raises(ValueError):
+        HAPropsSI("H", "T", 298.15, "P", -101325, "R", 0.5)


### PR DESCRIPTION
Creates wasm32 wheels and adds exception testing to all wheel builds

### Requirements

* Fill out this template to the extent possible so that this PR can be reviewed in a timely manner.
* Replace the bracketed text below with your own.
* All new code requires tests to ensure against regressions.

### Description of the Change

This PR adds Pyodide wasm32 wheel targets to the cibuildwheel configuration. This is needed since, after the implementation of [PEP 783](https://peps.python.org/pep-0783/), the building of Pyodide wheels will move out of the Pyodide project and will now be hosted on [PyPI directly](https://blog.pyodide.org/posts/314-release/#pep-783-is-accepted-what-does-it-mean). You've already done the heavy lifting since CoolProp already uses cibuildwheel 4.1.0, which has native Pyodide wheel support. I just had to add the wasm32 targets.

Additionally, I added exception testing to the cibuildwheel configuration, since exception handling is one of the tricky things to get right with the Pyodide builds. The test is based on the current [Pyodide project test](https://github.com/pyodide/pyodide-recipes/blob/main/packages/coolprop/test_coolprop.py) for CoolProp.

### Benefits

Pyodide users will always have access to the latest CoolProp version. Currently, the Pyodide version of CoolProp is at [v7.2](https://github.com/pyodide/pyodide-recipes/blob/main/packages/coolprop/meta.yaml) and can only be updated by a pull request to the [pyodide-recipes repo](https://github.com/pyodide/pyodide-recipes) and by waiting for the next release of Pyodide. And even when it's updated, older versions of the Pyodide runtime won't be able use the new version. In short, with this update, the Pyodide users of CoolProp will have an experience more like other Python users where they'll be able to use the most recent version of CoolProp that's compatible with their Pyodide runtime at the same time as other Python users.

### Possible Drawbacks

Two more GitHub actions runners are triggered to build the two new wasm32 wheels. Even though CoolProp is using the stable ABI through nanobind, the way emscripten works, a pyodide wasm32 wheel for each minor version of Python is required.

### Verification Process

I tested the generated wasm32 wheels locally in the browser to make sure they work. The cp313 wheel works with Pyodide v0.28.x and v0.29.x and the cp314 wheels work with Pyodide v314.x.x.

To check for regressions with the other Python wheels I made sure the full Python tests worked locally and in CI. The test added specifically for the wheels (`smoke_test.py` to test for normal operation and exceptions) works both locally and in GitHub actions and for all of the wheels, not just for the wasm32 wheels.

### Applicable Issues

I couldn't find any issues that this closes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pyodide/WebAssembly wheel builds for Python 3.13 and 3.14.
  * Updated packaging/CI support to enable Pyodide platform and architecture selection.
* **Tests**
  * Added a Pyodide-compatible Python smoke test covering basic computations, phase classification, and error handling.
* **Documentation**
  * Added a browser guide with a minimal Pyodide example, including notes on loading the latest CoolProp version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->