### PR TITLE
perf(VTPR): cache T-only UNIFAC tables + densify group arrays (~6-7x for multicomponent flash)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2378,6 +2378,8 @@ if(COOLPROP_CATCH_MODULE)
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-CubicU.cpp")
   list(APPEND APP_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-VTPRMixture.cpp")
+  list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-NeonMelting.cpp")
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-AirMelting.cpp")

--- a/src/Backends/Cubics/UNIFAC.cpp
+++ b/src/Backends/Cubics/UNIFAC.cpp
@@ -1,5 +1,7 @@
 #include "UNIFAC.h"
 
+#include <algorithm>
+
 void UNIFAC::UNIFACMixture::set_interaction_parameters() {
     for (const auto& isgi : unique_groups) {
         for (const auto& jsgi : unique_groups) {
@@ -61,9 +63,10 @@ void UNIFAC::UNIFACMixture::set_mole_fractions(const std::vector<double>& z) {
     if (this->N != z.size()) {
         throw CoolProp::ValueError("Size of molar fraction do not match number of components.");
     }
-    // Composition changed -> the cached mixture group residual ln(Gamma) (m_lnGammag), which depends
-    // on the group surface fractions m_thetag computed below, is now stale.
-    m_lnGammag_valid = false;
+    // Composition changed -> the temperature-keyed group-table cache (whose mixture group residual
+    // depends on the group surface fractions m_thetag computed below) is now stale.
+    m_T_cache.clear();
+    m_tables_valid = false;
 
     m_Xg.assign(m_G, 0.0);
     m_thetag.assign(m_G, 0.0);
@@ -133,90 +136,107 @@ double UNIFAC::UNIFACMixture::theta_pure(std::size_t i, std::size_t sgi) const {
 }
 
 void UNIFAC::UNIFACMixture::set_temperature(const double T) {
-    this->m_T = T;
-
     if (this->mole_fractions.empty()) {
         throw CoolProp::ValueError("mole fractions must be set before calling set_temperature");
     }
 
-    // The Psi interaction table and the pure-component reference ln(Gamma) computed in this block
-    // depend ONLY on temperature.  A flash holds T fixed across all of its density-solve iterations
-    // and its O(N^2) composition-derivative (fugacity-Jacobian) evaluations, so recomputing them on
-    // every call -- each rebuild dominated by std::map<pair,...> lookups -- made VTPR scale
-    // catastrophically with the number of components.  Recompute them only when T actually changes;
-    // the exact `==` means "recompute whenever T differs at all", so results are unchanged.
-    if (!(static_cast<bool>(_T) && static_cast<double>(_T) == T && !Psi_.empty())) {
-        // Compute the dense Psi table once for the different calls (row-major, [gk*m_G + gm]).
-        Psi_.assign(m_G * m_G, 0.0);
-        for (std::size_t gk = 0; gk < m_G; ++gk) {
-            for (std::size_t gm = 0; gm < m_G; ++gm) {
-                Psi_[gk * m_G + gm] = Psi(m_groups[gk], m_groups[gm]);
-            }
-        }
+    // Fast path: the working tables already hold this T at the current composition.
+    if (m_tables_valid && m_T == T) {
+        return;
+    }
+    m_T = T;
 
-        for (std::size_t i = 0; i < this->mole_fractions.size(); ++i) {
-            const UNIFACLibrary::Component& c = components[i];
-            const std::vector<double>& theta_i = pure_data[i].theta;
-            for (std::size_t k = 0; k < c.groups.size(); ++k) {
-                double Q = c.groups[k].group.Q_k;
-                std::size_t gk = m_gidx[c.groups[k].group.sgi];
-                double sum1 = 0;
-                for (const auto& group : c.groups) {
-                    std::size_t gm = m_gidx[group.group.sgi];
-                    sum1 += theta_i[gm] * Psi_[gm * m_G + gk];
-                }
-                // sum1 > 0: c.groups is the set of groups present in component i, theta_pure
-                // returns the (positive) surface-area fraction of each, and Psi = exp(-a/T) > 0.
-                // cppcheck cannot prove this symbolically.
-                // cppcheck-suppress invalidFunctionArg
-                double s = 1 - log(sum1);
-                for (std::size_t m = 0; m < c.groups.size(); ++m) {
-                    std::size_t gm = m_gidx[c.groups[m].group.sgi];
-                    double sum2 = 0;
-                    for (const auto& group : c.groups) {
-                        std::size_t gn = m_gidx[group.group.sgi];
-                        sum2 += theta_i[gn] * Psi_[gn * m_G + gm];
-                    }
-                    s -= theta_i[gm] * Psi_[gk * m_G + gm] / sum2;
-                }
-                pure_data[i].lnGamma[gk] = Q * s;
-                //printf("ln(Gamma)^(%d)_{%d}: %g\n", static_cast<int>(i + 1), m_groups[gk], Q*s);
-            }
+    // Cache hit: restore the fully-computed tables for this T (at the current composition).  The
+    // finite-difference tau-derivatives in ln_gamma_R evaluate at perturbed temperatures that repeat
+    // across the per-component loop and across density iterations, so this restore (a few small
+    // vector copies) replaces a full Psi + pure + group-residual rebuild.
+    auto it = m_T_cache.find(T);
+    if (it != m_T_cache.end()) {
+        const GroupTables& t = it->second;
+        Psi_ = t.Psi;
+        for (std::size_t i = 0; i < N; ++i) {
+            std::copy(t.pure_lnGamma.begin() + i * m_G, t.pure_lnGamma.begin() + (i + 1) * m_G, pure_data[i].lnGamma.begin());
         }
-        _T = T;  // mark the T-only tables (Psi + pure references) valid for this T
+        m_lnGammag = t.lnGammag;
+        m_tables_valid = true;
+        return;
     }
 
-    // The mixture group residual ln(Gamma) below depends on composition (m_thetag, set by
-    // set_mole_fractions) as well as on T.  gE_R_RT evaluates ln_gamma_R for every component at the
-    // SAME (T, composition) -- and set_temperature is invoked from each -- so without this guard the
-    // O(G^3) block below was rebuilt N times per gE evaluation.  Recompute it only when the
-    // composition has changed (m_lnGammag_valid) or the temperature differs from the last build.
-    if (!(m_lnGammag_valid && m_lnGammag_T == m_T)) {
-        m_lnGammag.assign(m_G, 0.0);
+    // Miss: compute the dense Psi table (row-major, [gk*m_G + gm]), the pure-component reference
+    // ln(Gamma), and the mixture group residual ln(Gamma), then store them keyed by T.
+    Psi_.assign(m_G * m_G, 0.0);
+    for (std::size_t gk = 0; gk < m_G; ++gk) {
+        for (std::size_t gm = 0; gm < m_G; ++gm) {
+            Psi_[gk * m_G + gm] = Psi(m_groups[gk], m_groups[gm]);
+        }
+    }
 
-        for (std::size_t gk = 0; gk < m_G; ++gk) {
+    for (std::size_t i = 0; i < this->mole_fractions.size(); ++i) {
+        const UNIFACLibrary::Component& c = components[i];
+        const std::vector<double>& theta_i = pure_data[i].theta;
+        for (std::size_t k = 0; k < c.groups.size(); ++k) {
+            double Q = c.groups[k].group.Q_k;
+            std::size_t gk = m_gidx[c.groups[k].group.sgi];
             double sum1 = 0;
-            for (std::size_t gm = 0; gm < m_G; ++gm) {
-                sum1 += m_thetag[gm] * Psi_[gm * m_G + gk];
+            for (const auto& group : c.groups) {
+                std::size_t gm = m_gidx[group.group.sgi];
+                sum1 += theta_i[gm] * Psi_[gm * m_G + gk];
             }
-            // sum1 > 0: m_thetag are the (positive) group surface fractions and Psi = exp(-a/T) > 0,
-            // so the sum over the (non-empty) group set is strictly positive.  cppcheck cannot prove
-            // this symbolically.
+            // sum1 > 0: c.groups is the set of groups present in component i, theta_pure
+            // returns the (positive) surface-area fraction of each, and Psi = exp(-a/T) > 0.
+            // cppcheck cannot prove this symbolically.
             // cppcheck-suppress invalidFunctionArg
             double s = 1 - log(sum1);
-            for (std::size_t gm = 0; gm < m_G; ++gm) {
-                double sum3 = 0;
-                for (std::size_t gn = 0; gn < m_G; ++gn) {
-                    sum3 += m_thetag[gn] * Psi_[gn * m_G + gm];
+            for (std::size_t m = 0; m < c.groups.size(); ++m) {
+                std::size_t gm = m_gidx[c.groups[m].group.sgi];
+                double sum2 = 0;
+                for (const auto& group : c.groups) {
+                    std::size_t gn = m_gidx[group.group.sgi];
+                    sum2 += theta_i[gn] * Psi_[gn * m_G + gm];
                 }
-                s -= m_thetag[gm] * Psi_[gk * m_G + gm] / sum3;
+                s -= theta_i[gm] * Psi_[gk * m_G + gm] / sum2;
             }
-            m_lnGammag[gk] = m_Q[gk] * s;
-            //printf("log(Gamma)_{%d}: %g\n", m_groups[gk], m_Q[gk]*s);
+            pure_data[i].lnGamma[gk] = Q * s;
+            //printf("ln(Gamma)^(%d)_{%d}: %g\n", static_cast<int>(i + 1), m_groups[gk], Q*s);
         }
-        m_lnGammag_valid = true;
-        m_lnGammag_T = m_T;
     }
+
+    m_lnGammag.assign(m_G, 0.0);
+    for (std::size_t gk = 0; gk < m_G; ++gk) {
+        double sum1 = 0;
+        for (std::size_t gm = 0; gm < m_G; ++gm) {
+            sum1 += m_thetag[gm] * Psi_[gm * m_G + gk];
+        }
+        // sum1 > 0: m_thetag are the (positive) group surface fractions and Psi = exp(-a/T) > 0,
+        // so the sum over the (non-empty) group set is strictly positive.  cppcheck cannot prove
+        // this symbolically.
+        // cppcheck-suppress invalidFunctionArg
+        double s = 1 - log(sum1);
+        for (std::size_t gm = 0; gm < m_G; ++gm) {
+            double sum3 = 0;
+            for (std::size_t gn = 0; gn < m_G; ++gn) {
+                sum3 += m_thetag[gn] * Psi_[gn * m_G + gm];
+            }
+            s -= m_thetag[gm] * Psi_[gk * m_G + gm] / sum3;
+        }
+        m_lnGammag[gk] = m_Q[gk] * s;
+        //printf("log(Gamma)_{%d}: %g\n", m_groups[gk], m_Q[gk]*s);
+    }
+    m_tables_valid = true;
+
+    // Store a snapshot for this T (at the current composition).  The cap bounds memory if a caller
+    // sweeps many distinct temperatures at fixed composition (e.g. a temperature-search flash).
+    if (m_T_cache.size() >= m_T_cache_cap) {
+        m_T_cache.clear();
+    }
+    GroupTables t;
+    t.Psi = Psi_;
+    t.pure_lnGamma.resize(N * m_G);
+    for (std::size_t i = 0; i < N; ++i) {
+        std::copy(pure_data[i].lnGamma.begin(), pure_data[i].lnGamma.end(), t.pure_lnGamma.begin() + i * m_G);
+    }
+    t.lnGammag = m_lnGammag;
+    m_T_cache.emplace(T, std::move(t));
 }
 double UNIFAC::UNIFACMixture::ln_gamma_R(const double tau, std::size_t i, std::size_t itau) {
     if (itau == 0) {
@@ -294,6 +314,10 @@ void UNIFAC::UNIFACMixture::set_components(const std::string& identifier_type, c
 
 /// Calculate the parameters X and theta for the pure components, which does not depend on temperature nor molar fraction
 void UNIFAC::UNIFACMixture::set_pure_data() {
+    // The group set / Q values are changing, so every cached temperature table is stale.
+    m_T_cache.clear();
+    m_tables_valid = false;
+
     pure_data.clear();
     unique_groups.clear();
     m_gidx.clear();

--- a/src/Backends/Cubics/UNIFAC.cpp
+++ b/src/Backends/Cubics/UNIFAC.cpp
@@ -140,7 +140,12 @@ void UNIFAC::UNIFACMixture::set_temperature(const double T) {
         throw CoolProp::ValueError("mole fractions must be set before calling set_temperature");
     }
 
-    // Fast path: the working tables already hold this T at the current composition.
+    // Fast path: the working tables already hold this T at the current composition.  The exact
+    // floating-point comparison is intentional: T is a cache key, not a physical tolerance -- the
+    // caller re-passes the identical T value (T_r/tau at fixed tau) across a flash, and the perturbed
+    // temperatures of the finite-difference tau-derivatives are likewise exact repeats.  A tolerance
+    // would wrongly return tables computed at a *different* temperature.  (Same rationale for the
+    // std::map<double, ...> lookup below.)
     if (m_tables_valid && m_T == T) {
         return;
     }
@@ -367,6 +372,14 @@ void UNIFAC::UNIFACMixture::set_pure_data() {
             cd.theta[g] /= summerxq;
         }
         pure_data.push_back(cd);
+    }
+
+    // If a composition was already set (e.g. set_Q_k called after set_mole_fractions), the mixture
+    // group surface fractions m_Xg/m_thetag depend on the group layout and Q that just changed, so
+    // refresh them from the stored composition.  (When called from set_components the composition is
+    // not yet set, so this is skipped.)
+    if (!mole_fractions.empty() && mole_fractions.size() == N) {
+        set_mole_fractions(std::vector<double>(mole_fractions));
     }
 }
 

--- a/src/Backends/Cubics/UNIFAC.cpp
+++ b/src/Backends/Cubics/UNIFAC.cpp
@@ -61,40 +61,42 @@ void UNIFAC::UNIFACMixture::set_mole_fractions(const std::vector<double>& z) {
     if (this->N != z.size()) {
         throw CoolProp::ValueError("Size of molar fraction do not match number of components.");
     }
+    // Composition changed -> the cached mixture group residual ln(Gamma) (m_lnGammag), which depends
+    // on the group surface fractions m_thetag computed below, is now stale.
+    m_lnGammag_valid = false;
 
-    std::map<std::size_t, double>&Xg = m_Xg, &thetag = m_thetag;
-    Xg.clear();
-    thetag.clear();
+    m_Xg.assign(m_G, 0.0);
+    m_thetag.assign(m_G, 0.0);
 
     // Iterate over the fluids
     double X_summer = 0;
     for (std::size_t i = 0; i < this->mole_fractions.size(); ++i) {
         X_summer += this->mole_fractions[i] * pure_data[i].group_count;
     }
-    /// Calculations for each group in the total mixture
-    for (const auto& sgi : unique_groups) {
+    /// Calculations for each group in the total mixture (ascending compact-group order == ascending sgi)
+    for (std::size_t g = 0; g < m_G; ++g) {
         double X = 0;
         // Iterate over the fluids
         for (std::size_t i = 0; i < this->mole_fractions.size(); ++i) {
-            X += this->mole_fractions[i] * group_count(i, sgi);
+            X += this->mole_fractions[i] * m_group_count[i][g];
         }
-        Xg.emplace(sgi, X);
+        m_Xg[g] = X;
     }
     /// Now come back through and divide by the sum(z_i*count) for this fluid
-    for (auto& [key, val] : Xg) {
-        val /= X_summer;
-        //printf("X_{%d}: %g\n", key, val);
+    for (std::size_t g = 0; g < m_G; ++g) {
+        m_Xg[g] /= X_summer;
+        //printf("X_{%d}: %g\n", m_groups[g], m_Xg[g]);
     }
     double theta_summer = 0;
-    for (const auto& sgi : unique_groups) {
-        double cont = Xg.find(sgi)->second * m_Q.find(sgi)->second;
+    for (std::size_t g = 0; g < m_G; ++g) {
+        double cont = m_Xg[g] * m_Q[g];
         theta_summer += cont;
-        thetag.emplace(sgi, cont);
+        m_thetag[g] = cont;
     }
     /// Now come back through and divide by the sum(X*Q) for this fluid
-    for (auto& [key, val] : thetag) {
-        val /= theta_summer;
-        //printf("theta_{%d}: %g\n", key, val);
+    for (std::size_t g = 0; g < m_G; ++g) {
+        m_thetag[g] /= theta_summer;
+        //printf("theta_{%d}: %g\n", m_groups[g], m_thetag[g]);
     }
 }
 
@@ -119,96 +121,113 @@ double UNIFAC::UNIFACMixture::Psi(std::size_t sgi1, std::size_t sgi2) const {
 }
 
 std::size_t UNIFAC::UNIFACMixture::group_count(std::size_t i, std::size_t sgi) const {
-    const UNIFACLibrary::Component& c = components[i];
-    for (const auto& cg : c.groups) {
-        if (cg.group.sgi == sgi) {
-            return cg.count;
-        }
+    auto it = m_gidx.find(sgi);
+    if (it == m_gidx.end()) {
+        return 0;
     }
-    return 0;
+    return static_cast<std::size_t>(m_group_count[i][it->second]);
 }
 
 double UNIFAC::UNIFACMixture::theta_pure(std::size_t i, std::size_t sgi) const {
-    return pure_data[i].theta.find(sgi)->second;
+    return pure_data[i].theta[m_gidx.find(sgi)->second];
 }
 
 void UNIFAC::UNIFACMixture::set_temperature(const double T) {
-    //    // Check whether you are using exactly the same temperature as last time
-    //    if (static_cast<bool>(_T) && std::abs(static_cast<double>(_T) - T) < 1e-15 {
-    //        //
-    //        return;
-    //    }
     this->m_T = T;
 
     if (this->mole_fractions.empty()) {
         throw CoolProp::ValueError("mole fractions must be set before calling set_temperature");
     }
 
-    // Compute Psi once for the different calls
-    for (const auto& k : unique_groups) {
-        for (const auto& m : unique_groups) {
-            Psi_[std::pair<std::size_t, std::size_t>(k, m)] = Psi(k, m);
+    // The Psi interaction table and the pure-component reference ln(Gamma) computed in this block
+    // depend ONLY on temperature.  A flash holds T fixed across all of its density-solve iterations
+    // and its O(N^2) composition-derivative (fugacity-Jacobian) evaluations, so recomputing them on
+    // every call -- each rebuild dominated by std::map<pair,...> lookups -- made VTPR scale
+    // catastrophically with the number of components.  Recompute them only when T actually changes;
+    // the exact `==` means "recompute whenever T differs at all", so results are unchanged.
+    if (!(static_cast<bool>(_T) && static_cast<double>(_T) == T && !Psi_.empty())) {
+        // Compute the dense Psi table once for the different calls (row-major, [gk*m_G + gm]).
+        Psi_.assign(m_G * m_G, 0.0);
+        for (std::size_t gk = 0; gk < m_G; ++gk) {
+            for (std::size_t gm = 0; gm < m_G; ++gm) {
+                Psi_[gk * m_G + gm] = Psi(m_groups[gk], m_groups[gm]);
+            }
         }
+
+        for (std::size_t i = 0; i < this->mole_fractions.size(); ++i) {
+            const UNIFACLibrary::Component& c = components[i];
+            const std::vector<double>& theta_i = pure_data[i].theta;
+            for (std::size_t k = 0; k < c.groups.size(); ++k) {
+                double Q = c.groups[k].group.Q_k;
+                std::size_t gk = m_gidx[c.groups[k].group.sgi];
+                double sum1 = 0;
+                for (const auto& group : c.groups) {
+                    std::size_t gm = m_gidx[group.group.sgi];
+                    sum1 += theta_i[gm] * Psi_[gm * m_G + gk];
+                }
+                // sum1 > 0: c.groups is the set of groups present in component i, theta_pure
+                // returns the (positive) surface-area fraction of each, and Psi = exp(-a/T) > 0.
+                // cppcheck cannot prove this symbolically.
+                // cppcheck-suppress invalidFunctionArg
+                double s = 1 - log(sum1);
+                for (std::size_t m = 0; m < c.groups.size(); ++m) {
+                    std::size_t gm = m_gidx[c.groups[m].group.sgi];
+                    double sum2 = 0;
+                    for (const auto& group : c.groups) {
+                        std::size_t gn = m_gidx[group.group.sgi];
+                        sum2 += theta_i[gn] * Psi_[gn * m_G + gm];
+                    }
+                    s -= theta_i[gm] * Psi_[gk * m_G + gm] / sum2;
+                }
+                pure_data[i].lnGamma[gk] = Q * s;
+                //printf("ln(Gamma)^(%d)_{%d}: %g\n", static_cast<int>(i + 1), m_groups[gk], Q*s);
+            }
+        }
+        _T = T;  // mark the T-only tables (Psi + pure references) valid for this T
     }
 
-    for (std::size_t i = 0; i < this->mole_fractions.size(); ++i) {
-        const UNIFACLibrary::Component& c = components[i];
-        for (std::size_t k = 0; k < c.groups.size(); ++k) {
-            double Q = c.groups[k].group.Q_k;
-            int sgik = c.groups[k].group.sgi;
+    // The mixture group residual ln(Gamma) below depends on composition (m_thetag, set by
+    // set_mole_fractions) as well as on T.  gE_R_RT evaluates ln_gamma_R for every component at the
+    // SAME (T, composition) -- and set_temperature is invoked from each -- so without this guard the
+    // O(G^3) block below was rebuilt N times per gE evaluation.  Recompute it only when the
+    // composition has changed (m_lnGammag_valid) or the temperature differs from the last build.
+    if (!(m_lnGammag_valid && m_lnGammag_T == m_T)) {
+        m_lnGammag.assign(m_G, 0.0);
+
+        for (std::size_t gk = 0; gk < m_G; ++gk) {
             double sum1 = 0;
-            for (const auto& group : c.groups) {
-                int sgim = group.group.sgi;
-                sum1 += theta_pure(i, sgim) * Psi_.find(std::pair<std::size_t, std::size_t>(sgim, sgik))->second;
+            for (std::size_t gm = 0; gm < m_G; ++gm) {
+                sum1 += m_thetag[gm] * Psi_[gm * m_G + gk];
             }
-            // sum1 > 0: c.groups is the set of groups present in component i, theta_pure
-            // returns the (positive) surface-area fraction of each, and Psi = exp(-a/T) > 0.
-            // cppcheck cannot prove this symbolically.
+            // sum1 > 0: m_thetag are the (positive) group surface fractions and Psi = exp(-a/T) > 0,
+            // so the sum over the (non-empty) group set is strictly positive.  cppcheck cannot prove
+            // this symbolically.
             // cppcheck-suppress invalidFunctionArg
             double s = 1 - log(sum1);
-            for (std::size_t m = 0; m < c.groups.size(); ++m) {
-                int sgim = c.groups[m].group.sgi;
-                double sum2 = 0;
-                for (const auto& group : c.groups) {
-                    int sgin = group.group.sgi;
-                    sum2 += theta_pure(i, sgin) * Psi_.find(std::pair<std::size_t, std::size_t>(sgin, sgim))->second;
+            for (std::size_t gm = 0; gm < m_G; ++gm) {
+                double sum3 = 0;
+                for (std::size_t gn = 0; gn < m_G; ++gn) {
+                    sum3 += m_thetag[gn] * Psi_[gn * m_G + gm];
                 }
-                s -= theta_pure(i, sgim) * Psi_.find(std::pair<std::size_t, std::size_t>(sgik, sgim))->second / sum2;
+                s -= m_thetag[gm] * Psi_[gk * m_G + gm] / sum3;
             }
-            pure_data[i].lnGamma[sgik] = Q * s;
-            //printf("ln(Gamma)^(%d)_{%d}: %g\n", static_cast<int>(i + 1), sgik, Q*s);
+            m_lnGammag[gk] = m_Q[gk] * s;
+            //printf("log(Gamma)_{%d}: %g\n", m_groups[gk], m_Q[gk]*s);
         }
+        m_lnGammag_valid = true;
+        m_lnGammag_T = m_T;
     }
-
-    std::map<std::size_t, double>&thetag = m_thetag, &lnGammag = m_lnGammag;
-    lnGammag.clear();
-
-    for (const auto& ksgi : unique_groups) {
-        double sum1 = 0;
-        for (const auto& msgi : unique_groups) {
-            sum1 += thetag.find(msgi)->second * Psi_.find(std::pair<std::size_t, std::size_t>(msgi, ksgi))->second;
-        }
-        double s = 1 - log(sum1);
-        for (const auto& msgi : unique_groups) {
-            double sum3 = 0;
-            for (const auto& nsgi : unique_groups) {
-                sum3 += thetag.find(nsgi)->second * Psi_.find(std::pair<std::size_t, std::size_t>(nsgi, msgi))->second;
-            }
-            s -= thetag.find(msgi)->second * Psi_.find(std::pair<std::size_t, std::size_t>(ksgi, msgi))->second / sum3;
-        }
-        lnGammag.emplace(ksgi, m_Q.find(ksgi)->second * s);
-        //printf("log(Gamma)_{%d}: %g\n", itk->sgi, itk->Q_k*s);
-    }
-    _T = m_T;
 }
 double UNIFAC::UNIFACMixture::ln_gamma_R(const double tau, std::size_t i, std::size_t itau) {
     if (itau == 0) {
         set_temperature(T_r / tau);
         double summer = 0;
-        for (const auto& sgi : unique_groups) {
-            std::size_t count = group_count(i, sgi);
+        const std::vector<int>& gc_i = m_group_count[i];
+        const std::vector<double>& lnGamma_i = pure_data[i].lnGamma;
+        for (std::size_t g = 0; g < m_G; ++g) {
+            int count = gc_i[g];
             if (count > 0) {
-                summer += count * (m_lnGammag.find(sgi)->second - pure_data[i].lnGamma.find(sgi)->second);
+                summer += count * (m_lnGammag[g] - lnGamma_i[g]);
             }
         }
         //printf("log(gamma)_{%d}: %g\n", i+1, summer);
@@ -277,31 +296,51 @@ void UNIFAC::UNIFACMixture::set_components(const std::string& identifier_type, c
 void UNIFAC::UNIFACMixture::set_pure_data() {
     pure_data.clear();
     unique_groups.clear();
-    m_Q.clear();
+    m_gidx.clear();
+    m_groups.clear();
+
+    // Pass 1: collect the unique subgroups across all components.  std::set keeps them ascending,
+    // which fixes the compact-group ordering so that summation order matches the previous
+    // std::map-based implementation (results stay bit-for-bit identical).
+    for (std::size_t i = 0; i < N; ++i) {
+        for (const auto& cg : components[i].groups) {
+            unique_groups.insert(cg.group.sgi);
+        }
+    }
+    m_G = unique_groups.size();
+    m_groups.assign(unique_groups.begin(), unique_groups.end());
+    for (std::size_t g = 0; g < m_G; ++g) {
+        m_gidx[m_groups[g]] = g;
+    }
+
+    // Pass 2: build the dense per-group Q, per-component group counts, and per-component X / theta.
+    m_Q.assign(m_G, 0.0);
+    m_lnGammag.assign(m_G, 0.0);
+    m_group_count.assign(N, std::vector<int>(m_G, 0));
     for (std::size_t i = 0; i < N; ++i) {
         const UNIFACLibrary::Component& c = components[i];
         ComponentData cd;
-        double summerxq = 0;
+        cd.X.assign(m_G, 0.0);
+        cd.theta.assign(m_G, 0.0);
+        cd.lnGamma.assign(m_G, 0.0);
         cd.group_count = 0;
+        double summerxq = 0;
         for (const auto& cg : c.groups) {
+            std::size_t g = m_gidx[cg.group.sgi];
             auto x = static_cast<double>(cg.count);
             auto theta = static_cast<double>(cg.count * cg.group.Q_k);
-            cd.X.emplace(cg.group.sgi, x);
-            cd.theta.emplace(cg.group.sgi, theta);
+            cd.X[g] = x;
+            cd.theta[g] = theta;
             cd.group_count += cg.count;
+            m_group_count[i][g] = cg.count;
             summerxq += x * cg.group.Q_k;
-            unique_groups.insert(cg.group.sgi);
-            m_Q.emplace(cg.group.sgi, cg.group.Q_k);
+            m_Q[g] = cg.group.Q_k;  // Q_k is a property of the subgroup, identical across components
         }
-        /// Now come back through and divide by the total # groups for this fluid
-        for (auto& [key, val] : cd.X) {
-            val /= cd.group_count;
-            //printf("X^(%d)_{%d}: %g\n", static_cast<int>(i + 1), static_cast<int>(key), val);
-        }
-        /// Now come back through and divide by the sum(X*Q) for this fluid
-        for (auto& [key, val] : cd.theta) {
-            val /= summerxq;
-            //printf("theta^(%d)_{%d}: %g\n", static_cast<int>(i+1), static_cast<int>(key), val);
+        /// Now come back through and divide by the total # groups / the sum(X*Q) for this fluid.
+        /// Entries for groups absent from this component stay zero (0 / c = 0) and are never read.
+        for (std::size_t g = 0; g < m_G; ++g) {
+            cd.X[g] /= cd.group_count;
+            cd.theta[g] /= summerxq;
         }
         pure_data.push_back(cd);
     }

--- a/src/Backends/Cubics/UNIFAC.h
+++ b/src/Backends/Cubics/UNIFAC.h
@@ -2,15 +2,19 @@
 #define UNIFAC_H_
 
 #include <map>
+#include <set>
+#include <vector>
 
 #include "UNIFACLibrary.h"
 #include "CoolProp/detail/CachedElement.h"
 #include "CoolProp/Exceptions.h"
 
-/// Structure containing data for the pure fluid in the mixture
+/// Structure containing data for the pure fluid in the mixture.
+/// X/theta/lnGamma are dense vectors indexed by the mixture's compact group index
+/// (see UNIFACMixture::m_groups); entries for groups absent from this component are zero.
 struct ComponentData
 {
-    std::map<std::size_t, double> X, theta, lnGamma;
+    std::vector<double> X, theta, lnGamma;
     int group_count;  ///< The total number of groups in the pure fluid
 };
 
@@ -28,12 +32,29 @@ class UNIFACMixture
     double m_T = _HUGE;  ///< The temperature in K
     double T_r;          ///< Reducing temperature
 
-    std::map<std::pair<std::size_t, std::size_t>, double> Psi_;  /// < temporary storage for Psi
+    // Group-indexed quantities are stored in DENSE arrays indexed by a compact group index
+    // (0..m_G-1), built once in set_pure_data from the sorted set of unique subgroups.  This
+    // replaces the std::map<...> lookups that dominated the hot UNIFAC evaluation loops.  The
+    // compact index preserves the ascending-sgi ordering of the original std::map iteration, so
+    // summation order -- and therefore results -- are bit-for-bit unchanged.
+    std::size_t m_G = 0;                        ///< Number of unique subgroups in the mixture
+    std::vector<std::size_t> m_groups;          ///< Compact index -> subgroup index (sgi), ascending
+    std::map<std::size_t, std::size_t> m_gidx;  ///< sgi -> compact group index (cold-path lookups only)
 
-    std::map<std::size_t, double> m_Xg,  ///< Map from sgi to mole fraction of group in the mixture
-      m_thetag,                          ///< Map from sgi to theta for the group in the mixture
-      m_lnGammag,                        ///< Map from sgi to ln(Gamma) for the group in the mixture
-      m_Q;                               ///< Map from sgi to Q for the sgi
+    std::vector<double> Psi_;  ///< Dense m_G x m_G Psi table, row-major: Psi_[gi*m_G + gj]
+
+    std::vector<double> m_Xg,  ///< Compact-group-indexed mole fraction of group in the mixture
+      m_thetag,                ///< Compact-group-indexed theta for the group in the mixture
+      m_lnGammag,              ///< Compact-group-indexed ln(Gamma) for the group in the mixture
+      m_Q;                     ///< Compact-group-indexed Q for the group
+
+    std::vector<std::vector<int>> m_group_count;  ///< [component][compact group index] -> group count
+
+    /// Validity of the cached mixture group residual ln(Gamma) (m_lnGammag).  It depends on both T
+    /// and composition, so it is invalidated whenever the composition changes (set_mole_fractions)
+    /// and recomputed by set_temperature only when the temperature it was computed at differs.
+    bool m_lnGammag_valid = false;
+    double m_lnGammag_T = _HUGE;  ///< Temperature at which m_lnGammag was last computed
 
     /// A map from (i, j) indices for subgroup, subgroup indices to the interaction parameters for this pair
     std::map<std::pair<int, int>, UNIFACLibrary::InteractionParameters> interaction;

--- a/src/Backends/Cubics/UNIFAC.h
+++ b/src/Backends/Cubics/UNIFAC.h
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "UNIFACLibrary.h"
-#include "CoolProp/detail/CachedElement.h"
 #include "CoolProp/Exceptions.h"
 
 /// Structure containing data for the pure fluid in the mixture.
@@ -24,8 +23,6 @@ class UNIFACMixture
    private:
     /// A const reference to the library of group and interaction parameters
     const UNIFACLibrary::UNIFACParameterLibrary& library;
-
-    CoolProp::CachedElement _T;  ///< The cached temperature
 
     std::size_t N = 0;  ///< Number of components
 
@@ -50,11 +47,23 @@ class UNIFACMixture
 
     std::vector<std::vector<int>> m_group_count;  ///< [component][compact group index] -> group count
 
-    /// Validity of the cached mixture group residual ln(Gamma) (m_lnGammag).  It depends on both T
-    /// and composition, so it is invalidated whenever the composition changes (set_mole_fractions)
-    /// and recomputed by set_temperature only when the temperature it was computed at differs.
-    bool m_lnGammag_valid = false;
-    double m_lnGammag_T = _HUGE;  ///< Temperature at which m_lnGammag was last computed
+    /// Temperature-keyed cache of the fully-computed group tables (dense Psi, per-component pure
+    /// reference ln(Gamma), and the mixture group residual ln(Gamma)) at the current composition.
+    /// The finite-difference tau-derivatives in ln_gamma_R evaluate at perturbed temperatures
+    /// (tau +/- dtau) that repeat across the per-component loop and across density iterations at
+    /// fixed (T, composition); keying by T (rather than a single slot) lets those repeats hit the
+    /// cache instead of rebuilding the tables.  All entries depend on the composition, so the cache
+    /// is cleared whenever the composition changes (set_mole_fractions) -- which, because the flash
+    /// Jacobian is analytical (not composition-perturbed), happens only per trial phase.
+    struct GroupTables
+    {
+        std::vector<double> Psi;           ///< dense m_G x m_G
+        std::vector<double> pure_lnGamma;  ///< N x m_G, flattened [i*m_G + g]
+        std::vector<double> lnGammag;      ///< m_G
+    };
+    std::map<double, GroupTables> m_T_cache;           ///< T -> tables (at the current composition)
+    bool m_tables_valid = false;                       ///< do the working tables hold the current (m_T, composition)?
+    static constexpr std::size_t m_T_cache_cap = 256;  ///< safety bound on distinct cached temperatures
 
     /// A map from (i, j) indices for subgroup, subgroup indices to the interaction parameters for this pair
     std::map<std::pair<int, int>, UNIFACLibrary::InteractionParameters> interaction;
@@ -72,7 +81,7 @@ class UNIFACMixture
     std::vector<ComponentData> pure_data;
 
    public:
-    UNIFACMixture(const UNIFACLibrary::UNIFACParameterLibrary& library, const double T_r) : library(library), T_r(T_r) {};
+    UNIFACMixture(const UNIFACLibrary::UNIFACParameterLibrary& library, const double T_r) : library(library), T_r(T_r){};
 
     /** \brief Set all the interaction parameters between groups */
     void set_interaction_parameters();

--- a/src/Tests/CoolProp-Tests-VTPRMixture.cpp
+++ b/src/Tests/CoolProp-Tests-VTPRMixture.cpp
@@ -1,0 +1,117 @@
+// VTPR (Volume-Translated Peng-Robinson, group-contribution) MIXTURE tests.
+//
+// CoolProp ships the VTPR machinery but not the UNIFAC parameters, so these tests embed a minimal
+// UNIFAC dataset (methanol + water: their two subgroups, R_k/Q_k, the CH3OH<->H2O interaction, and
+// the group decompositions), write it to a temporary directory, point VTPR_UNIFAC_PATH at it, and
+// run a mixture flash.  This is the first mixture-level coverage for the VTPR backend and guards the
+// UNIFAC evaluation path (the caching + dense-array work in UNIFAC.cpp): the asserted bubble
+// pressure is a regression value that changes if the UNIFAC group-activity math changes.
+
+#if defined(ENABLE_CATCH)
+
+#    include <catch2/catch_all.hpp>
+
+#    include "CoolProp/AbstractState.h"
+#    include "CoolProp/Configuration.h"
+#    include "CoolProp/DataStructures.h"
+
+#    include <filesystem>
+#    include <fstream>
+#    include <memory>
+#    include <string>
+#    include <vector>
+
+using namespace CoolProp;
+
+namespace {
+
+const char* const GROUP_DATA = R"([
+ {"sgi": 15, "mgi": 6, "R_k": 0.0, "Q_k": 0.8779, "maingroup_name": "CH3OH", "subgroup_name": "CH3OH"},
+ {"sgi": 16, "mgi": 7, "R_k": 0.0, "Q_k": 1.5576, "maingroup_name": "H2O",   "subgroup_name": "H2O"}
+])";
+
+const char* const INTERACTION_DATA = R"([
+ {"mgi1": 6, "mgi2": 7, "a_ij": -387.4, "b_ij": 1.9621, "c_ij": -0.0034336,
+  "a_ji": -168.82, "b_ji": 0.6674, "c_ji": 0.0041881}
+])";
+
+const char* const DECOMP_DATA = R"([
+ {"name": "Methanol", "registry_number": "67-56-1", "inchikey": "OKKJLVBELUTLKV-UHFFFAOYSA-N", "userid": "",
+  "Tc": 512.5, "pc": 8084000.0, "acentric": 0.5658, "molemass": 0.03204216,
+  "groups": [{"count": 1, "sgi": 15}], "alpha": {"type": "Twu", "c": [0.6755, 0.9141, 1.7586]}},
+ {"name": "Water", "registry_number": "7732-18-5", "inchikey": "XLYOFNOQVPJJNP-UHFFFAOYSA-N", "userid": "",
+  "Tc": 647.1, "pc": 22064000.0, "acentric": 0.3449, "molemass": 0.018015268,
+  "groups": [{"count": 1, "sgi": 16}], "alpha": {"type": "Twu", "c": [0.3865, 0.872, 1.9693]}}
+])";
+
+// Writes the minimal UNIFAC dataset to a fresh temp directory and returns its (slash-terminated) path.
+std::string write_unifac_dataset() {
+    std::filesystem::path dir = std::filesystem::temp_directory_path() / "coolprop_vtpr_test_unifac";
+    std::filesystem::create_directories(dir);
+    auto put = [&](const char* fname, const char* body) {
+        std::ofstream f((dir / fname).string(), std::ios::binary | std::ios::trunc);
+        f << body;
+    };
+    put("group_data.json", GROUP_DATA);
+    put("interaction_parameters.json", INTERACTION_DATA);
+    put("decompositions.json", DECOMP_DATA);
+    std::string p = dir.string();
+    if (!p.empty() && p.back() != '/' && p.back() != '\\') p += '/';
+    return p;
+}
+
+// Restores VTPR config keys to their prior values on scope exit, so the test does not leak state.
+struct VTPRConfigGuard
+{
+    std::string old_path = get_config_string(VTPR_UNIFAC_PATH);
+    bool old_reload = get_config_bool(VTPR_ALWAYS_RELOAD_LIBRARY);
+    VTPRConfigGuard() = default;
+    VTPRConfigGuard(const VTPRConfigGuard&) = delete;
+    VTPRConfigGuard& operator=(const VTPRConfigGuard&) = delete;
+    VTPRConfigGuard(VTPRConfigGuard&&) = delete;
+    VTPRConfigGuard& operator=(VTPRConfigGuard&&) = delete;
+    ~VTPRConfigGuard() {
+        set_config_string(VTPR_UNIFAC_PATH, old_path);
+        set_config_bool(VTPR_ALWAYS_RELOAD_LIBRARY, old_reload);
+    }
+};
+
+}  // namespace
+
+TEST_CASE("VTPR methanol-water mixture flash", "[VTPR][cubic][mixture]") {
+    VTPRConfigGuard guard;
+    set_config_string(VTPR_UNIFAC_PATH, write_unifac_dataset());
+    set_config_bool(VTPR_ALWAYS_RELOAD_LIBRARY, true);  // force our test dataset to load
+
+    SECTION("bubble pressure regression at 313.15 K, x_MeOH = 0.5") {
+        auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("VTPR", "Methanol&Water"));
+        AS->set_mole_fractions({0.5, 0.5});
+        AS->update(QT_INPUTS, 0.0, 313.15);  // bubble point
+        // Regression value from the UNIFAC group-activity evaluation (VTPR, this dataset).
+        CHECK(AS->p() == Catch::Approx(24669.872).epsilon(1e-4));
+        // The incipient vapour is methanol-rich (positive deviation from Raoult's law).
+        CHECK(AS->mole_fractions_vapor()[0] == Catch::Approx(0.822922).epsilon(1e-4));
+    }
+
+    SECTION("blind PT flash inside the two-phase region returns two phases") {
+        auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("VTPR", "Methanol&Water"));
+        AS->set_mole_fractions({0.5, 0.5});
+        AS->update(PT_INPUTS, 20000.0, 313.15);  // ~20 kPa is between dew and bubble here
+        CHECK(AS->phase() == iphase_twophase);
+        CHECK(AS->Q() > 0.0);
+        CHECK(AS->Q() < 1.0);
+    }
+
+    SECTION("pure-endpoint bubble pressures bracket the mixture") {
+        // Water is the heavy end, methanol the light end; the mixture bubble P sits between them.
+        auto W = std::shared_ptr<AbstractState>(AbstractState::factory("VTPR", "Water"));
+        W->update(QT_INPUTS, 0.0, 313.15);
+        auto M = std::shared_ptr<AbstractState>(AbstractState::factory("VTPR", "Methanol"));
+        M->update(QT_INPUTS, 0.0, 313.15);
+        CHECK(W->p() < M->p());
+        CHECK(W->p() == Catch::Approx(7453.9).epsilon(1e-3));
+        CHECK(M->p() == Catch::Approx(36061.0).epsilon(1e-3));
+    }
+}
+
+#endif

--- a/src/Tests/CoolProp-Tests-VTPRMixture.cpp
+++ b/src/Tests/CoolProp-Tests-VTPRMixture.cpp
@@ -60,11 +60,14 @@ std::string write_unifac_dataset() {
     return p;
 }
 
-// Restores VTPR config keys to their prior values on scope exit, so the test does not leak state.
+// Restores VTPR config on scope exit so the test does not leak state.  The VTPR UNIFAC library is a
+// process-global that this test overwrites with its minimal dataset; restoring only the config keys
+// would leave that dataset resident, so a later VTPR test could pick it up.  We therefore restore the
+// path but FORCE reload-on-next-use (rather than restoring the old flag), so any subsequent VTPR
+// construction reloads from its own path instead of reusing this test's library.
 struct VTPRConfigGuard
 {
     std::string old_path = get_config_string(VTPR_UNIFAC_PATH);
-    bool old_reload = get_config_bool(VTPR_ALWAYS_RELOAD_LIBRARY);
     VTPRConfigGuard() = default;
     VTPRConfigGuard(const VTPRConfigGuard&) = delete;
     VTPRConfigGuard& operator=(const VTPRConfigGuard&) = delete;
@@ -72,7 +75,7 @@ struct VTPRConfigGuard
     VTPRConfigGuard& operator=(VTPRConfigGuard&&) = delete;
     ~VTPRConfigGuard() {
         set_config_string(VTPR_UNIFAC_PATH, old_path);
-        set_config_bool(VTPR_ALWAYS_RELOAD_LIBRARY, old_reload);
+        set_config_bool(VTPR_ALWAYS_RELOAD_LIBRARY, true);
     }
 };
 


### PR DESCRIPTION
## Summary

Fixes the catastrophic slowdown of **VTPR mixture flashes** with component count (issue #3275). A 6-component natural-gas two-phase PT flash went from **~2.7 s to ~0.43 s** (~6×); a single-phase flash from ~0.5 s to ~0.07 s (~7×). Results are **bit-for-bit identical** — this is pure memoization + a data-structure change, no math change.

## Root cause

Profiling showed ~84 % of the flash in `UNIFAC::UNIFACMixture::set_temperature`, which rebuilt the entire temperature-dependent UNIFAC table on **every call** using `std::map<pair,double>` lookups, and was invoked O(N²) times per flash iteration through the fugacity-composition-derivative Jacobian. The temperature-cache guard was present but commented out.

## Changes

1. **Cache the T-only tables** (Ψ interaction table + pure-component reference ln Γ). A flash holds T fixed across its density-solve iterations and its O(N²) composition-derivative evaluations, so these are recomputed only when T changes (re-enabled the guard).

2. **Cache the mixture group residual ln Γ (`m_lnGammag`) on (T, composition).** `gE_R_RT` evaluates `ln_gamma_R` for every component at the *same* (T, composition), invoking `set_temperature` from each, so this O(G³) block was rebuilt N× per gE evaluation. It is invalidated whenever the composition changes — `set_mole_fractions` is the **sole writer** of the group surface fractions it depends on, so the cache is invalidated exactly when its input changes. This is safe across a phase split: every liquid/vapour trial composition routes through `set_mole_fractions`, and `SatL`/`SatV` are separate instances with independent caches.

3. **Replace the `std::map` group structures with dense arrays** indexed by a compact group index built once in `set_pure_data`. The compact index preserves the ascending-sgi ordering of the previous `std::map` iteration, so summation order — and therefore results — are unchanged.

## Results

| 6-component NG single flash | before | after |
|---|---|---|
| single-phase gas | ~502 ms | ~72 ms |
| two-phase | ~2665 ms | ~426 ms |

VTPR/HEOS ratio at N=6 drops from ~57× to ~5×, and VTPR is now *faster* than HEOS for N ≤ 3. Total instruction count 3.24 B → 760 M.

## Correctness / tests

- **Bit-identical** verified before/after on methanol-water (bubble P 24669.872 Pa exact) and a 6-component NG mixture (bubble/dew match exactly at every T) — the NG case exercises asymmetric Ψ and many group pairs, ruling out an index transposition.
- Adds the **first VTPR mixture test** (`CoolProp-Tests-VTPRMixture.cpp`, `[VTPR][cubic][mixture]`). CoolProp bundles no UNIFAC parameters, so it embeds a minimal methanol-water UNIFAC dataset, writes it to a temp dir, and loads it via `VTPR_UNIFAC_PATH`; the asserted bubble pressure is a regression value guarding the group-activity math. Config is restored on scope exit.
- `[cubic]` (3694 assertions) passes; preflight green (clang-format, build, tests, cppcheck, clang-tidy, semgrep).

## Remaining (separate follow-up)

The dominant remaining cost is the **finite-difference temperature derivatives** in `ln_gamma_R` (`itau > 0`), which evaluate at perturbed T (`tau ± dtau`) and so miss the T-cache. Replacing them with **analytical τ-derivatives** of ln Γ would remove it and is a distinct piece of work.

Closes #3275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced UNIFAC mixture calculations with more efficient dense data structures and compact-group indexing.
  - Improved responsiveness to composition/temperature changes using updated caching and table-validity handling.

- **Testing**
  - Added a new VTPR methanol–water integration test (bubble-point regression and blind PT flash), using an embedded/local UNIFAC dataset.
  - Expanded the Catch2 test runner build to include an additional UNIFAC-related test translation unit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Update: added temperature-keyed cache for the finite-difference τ-derivative path (commit c9e5bab9)

The finite-difference temperature derivatives in `ln_gamma_R` (`itau>0`, needed by the const-P fugacity Jacobian) evaluate the group tables at perturbed temperatures (`tau ± dtau`). Those repeat across the per-component loop and the density-solve iterations at fixed (T, composition), but the single-slot cache thrashed on every perturbation. Replaced it with a **temperature-keyed cache** of the fully-computed group tables — a hit restores them with a few small vector copies instead of a rebuild. Cleared on composition/group change (and, since the Jacobian is analytical, composition changes only per trial phase, so the perturbed-T tables are reused across the whole density solve). A size cap bounds memory.

Still **bit-for-bit identical** (methanol-water and 6-component NG bubble/dew match exactly). Adds ~1.3× on top of the previous work → **~8× cumulative** vs the original (6-component NG two-phase flash ~2.7 s → ~0.33 s).

The remaining follow-up is now genuinely just the **analytical τ-derivatives** (an accuracy improvement over the finite differences, which would also remove the perturbed-T evaluations entirely) — a distinct, non-bit-identical piece of work.
