### PR TITLE
fix(flash): mixture PT flash returns spurious middle-branch root for subcooled liquid (#3283)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2374,6 +2374,8 @@ if(COOLPROP_CATCH_MODULE)
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-PXFlash.cpp")
   list(APPEND APP_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-PTFlashMiddleRoot.cpp")
+  list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-CubicAlpha.cpp")
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-CubicU.cpp")

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -126,9 +126,18 @@ void FlashRoutines::PT_flash_mixtures(HelmholtzEOSMixtureBackend& HEOS) {
             double rho_srk_liq = HEOS.solver_rho_Tp_SRK(T_saved, p_saved, iphase_liquid);
             bool gas_ok = rho_srk_gas > 0 && ValidNumber(rho_srk_gas);
             bool liq_ok = rho_srk_liq > 0 && ValidNumber(rho_srk_liq);
+            // solver_rho_Tp_SRK returns the SAME single root for both phase requests when the SRK
+            // cubic has only one real root (a single-phase state).  Only Gibbs-compare two HEOS
+            // branches when the SRK roots are genuinely DISTINCT (a real vapor+liquid pair).
+            // Otherwise the "gas" HEOS solve is seeded from a liquid-like SRK density and, on a
+            // pathological multiparameter mixture isotherm, can converge to a spurious middle root
+            // whose unphysical Gibbs energy is lower than the true liquid root's, so the Gibbs test
+            // selects it (GH #3283: Methane/Ethane/Propane subcooled liquid at 20 bar returning a
+            // bogus rho~6751 "gas" root at knife-edge temperatures 223.15/212.5/235 K).
+            bool srk_distinct = gas_ok && liq_ok && std::abs(rho_srk_gas - rho_srk_liq) > 1e-3 * std::max(rho_srk_gas, rho_srk_liq);
 
-            if (gas_ok && liq_ok) {
-                // Both SRK roots valid — solve both HEOS roots, pick lower Gibbs
+            if (srk_distinct) {
+                // Both SRK roots valid and distinct — solve both HEOS roots, pick lower Gibbs
                 double rho_gas = -1, rho_liq = -1;
                 HEOS.specify_phase(iphase_gas);
                 try {
@@ -152,9 +161,13 @@ void FlashRoutines::PT_flash_mixtures(HelmholtzEOSMixtureBackend& HEOS) {
                     throw ValueError("Unable to obtain either HEOS density root in PT_flash_mixtures");
                 }
             } else {
-                // Only one SRK root valid (or neither) — solve that branch,
-                // fall back to the other if HEOS throws.
-                phases primary = gas_ok ? iphase_gas : (liq_ok ? iphase_liquid : iphase_gas);
+                // A single SRK root (both requests returned the same value), or only one/none
+                // valid => a single phase.  Solve the branch whose density class matches the SRK
+                // seed (dense => liquid, else gas); this seeds solver_rho_Tp on the correct side
+                // and avoids converging to the spurious middle root.  Fall back to the other
+                // branch if HEOS throws.
+                double rho_srk = liq_ok ? rho_srk_liq : rho_srk_gas;
+                phases primary = (gas_ok || liq_ok) ? ((rho_srk > HEOS.rhomolar_reducing()) ? iphase_liquid : iphase_gas) : iphase_gas;
                 phases fallback = (primary == iphase_gas) ? iphase_liquid : iphase_gas;
                 HEOS.specify_phase(primary);
                 try {

--- a/src/Tests/CoolProp-Tests-PTFlashMiddleRoot.cpp
+++ b/src/Tests/CoolProp-Tests-PTFlashMiddleRoot.cpp
@@ -1,0 +1,64 @@
+// Focused regression test for the blind (no-envelope) mixture PT flash returning a
+// spurious middle-branch density root (GitHub #3283).
+//
+// Runs in the default suite (tag [PTflash], NOT [.]-hidden).  Run explicitly:
+//   ./CatchTestRunner "[PTflash]"
+//
+// Background (#3283): for Methane&Ethane&Propane at z=[0.05,0.90,0.05], p=2.0 MPa the
+// state is subcooled single-phase LIQUID (bubble p ~ 8.98 bar << 20 bar).  At scattered
+// "knife-edge" temperatures the flash returned a spurious rho ~ 6751 mol/m^3 classified
+// as gas (h ~ -666 kJ/mol) instead of the liquid root (rho ~ 16400, h ~ +3 kJ/mol).
+//
+// Root cause: in FlashRoutines::PT_flash_mixtures the SRK pre-screen has a single real
+// root at these conditions (solver_rho_Tp_SRK returns the same value for both phase
+// requests), but solve_single_phase treated gas_ok && liq_ok as "two roots", solved a
+// spurious gas HEOS branch seeded from the liquid-like SRK density (converging onto a
+// secondary loop of the GERG isotherm), and the Gibbs-minimising selection picked that
+// artifact root because its unphysical Gibbs energy was lower than the true liquid's.
+// The fix only Gibbs-compares when the SRK roots are genuinely distinct.
+
+#if defined(ENABLE_CATCH)
+
+#    include <catch2/catch_all.hpp>
+
+#    include <memory>
+#    include <string>
+#    include <vector>
+
+#    include "CoolProp/AbstractState.h"
+#    include "CoolProp/DataStructures.h"
+
+TEST_CASE("Mixture PT flash selects the liquid root for subcooled liquid (was #3283)", "[PTflash]") {
+    // p = 2.0 MPa >> bubble pressure (~0.9 MPa) at all these T -> single-phase liquid.
+    // Includes the reported knife-edge temperatures (223.15, 212.5, 235 K) that failed,
+    // plus their passing neighbours as controls.
+    const double T = GENERATE(212.5, 222.5, 223.15, 225.0, 235.0, 248.15, 193.15);
+    CAPTURE(T);
+    const double p = 2.0e6;
+
+    // Reference: the correct liquid root, obtained by explicitly imposing the liquid phase.
+    auto ref = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Methane&Ethane&Propane"));
+    ref->set_mole_fractions({0.05, 0.90, 0.05});
+    ref->specify_phase(CoolProp::iphase_liquid);
+    ref->update(CoolProp::PT_INPUTS, p, T);
+    const double rho_liquid = ref->rhomolar();
+
+    // Sanity on the reference: a real ethane-rich liquid near these T is ~15000-18000 mol/m^3.
+    REQUIRE(rho_liquid > 14000.0);
+    REQUIRE(rho_liquid < 19000.0);
+
+    // The blind flash (no phase imposed, fresh state) must land on the same liquid root,
+    // not the spurious middle-branch root (~6751 mol/m^3).
+    auto wrk = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Methane&Ethane&Propane"));
+    wrk->set_mole_fractions({0.05, 0.90, 0.05});
+    wrk->update(CoolProp::PT_INPUTS, p, T);
+
+    // Loose epsilon: this compares two different code paths (blind SRK-seeded solve vs the
+    // imposed-liquid reference); the spurious root is ~4x away, so 1e-4 guards it with headroom.
+    CHECK(wrk->rhomolar() == Catch::Approx(rho_liquid).epsilon(1e-4));
+    CHECK(wrk->phase() == CoolProp::iphase_liquid);
+    // Guard the specific failure signature: the spurious root sat well below the liquid branch.
+    CHECK(wrk->rhomolar() > 13000.0);
+}
+
+#endif


### PR DESCRIPTION
## Summary

Fixes a wrong-root bug in the blind (no-envelope) HEOS **PT flash** for mixtures: at scattered "knife-edge" temperatures it returned a **spurious middle-branch density root** for a subcooled-liquid state.

Closes #3283.

Reproduction (Methane&Ethane&Propane, z=[0.05, 0.90, 0.05], p = 2.0 MPa):

```python
import CoolProp.CoolProp as CP
AS = CP.AbstractState("HEOS", "Methane&Ethane&Propane")
AS.set_mole_fractions([0.05, 0.90, 0.05])
AS.update(CP.PT_INPUTS, 2.0e6, 223.15)
print(AS.phase(), AS.rhomolar(), AS.hmolar()/1000)   # before: gas, 6750.9, -666.2   (WRONG)
                                                      # after:  liquid, 16357.5, +3.20
```

At 20 bar the bubble pressure is ≈ 8.98 bar, so the state is subcooled single-phase **liquid** (ρ ≈ 16 400). Before the fix, 223.15/212.5/235 K returned a bogus ρ ≈ 6751 "gas" root (h ≈ −666 kJ/mol); neighbouring 222.5/225 K were fine — the fingerprint of a density-solver root-selection problem.

## Root cause

In `FlashRoutines::PT_flash_mixtures` → `solve_single_phase`: at these conditions the SRK pre-screen has a **single** real root, and `solver_rho_Tp_SRK` returns that same value for **both** the gas and liquid phase requests. The code treated `gas_ok && liq_ok` as "two roots exist" and solved **both** HEOS branches. The gas branch, seeded from the liquid-like SRK density, converged onto a **secondary loop** of the GERG mixture isotherm at ρ ≈ 6751 — a mechanically-stable (dp/dρ > 0) but thermodynamically-artifact root whose computed Gibbs energy (≈ −19039 J/mol) is *lower* than the true liquid's (≈ −1044), so the Gibbs-minimising selection picked it. Knife-edge in T because that spurious loop only yields a convergeable root at scattered temperatures.

## Fix

Only run the two-branch Gibbs comparison when the SRK roots are **genuinely distinct** (`|ρ_srk_gas − ρ_srk_liq| > 1e-3·max(...)`, a real vapour+liquid pair). A single SRK root ⇒ single phase ⇒ solve only the branch whose density class matches the SRK seed (`ρ_srk > ρ_reducing` → liquid, else gas), with fallback to the other branch on throw. The `srk_distinct` two-branch block is unchanged from before.

Note: this also slightly changes the single-valid-root selection to classify by density (dense → liquid) rather than always preferring the "ok" phase — an improvement that matches the root's density class; the fallback-on-throw still protects a misclassified state.

## Relationship to #3171

Distinct. #3171 is a Michelsen stability **false-positive** (whose wrong-answer symptom is already handled by #3170's fallback); there the stability test is wrong. Here the stability test correctly reports **stable** — the bug is one layer downstream, in the single-phase root selection. Verified empirically: my fix does not change the #3171 case (still correct liquid) and does not alter the stability verdict.

## Validation

New regression test `[PTflash]` (`CoolProp-Tests-PTFlashMiddleRoot.cpp`) covers the reported knife-edge temperatures + passing-neighbour controls, comparing the blind flash against the imposed-liquid reference root. It **fails on unmodified master** (8/35 assertions) and **passes with the fix**. No regressions: `[mixture]` (24), `[flash]` (2097) and `[consistency]` (24991) assertions all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pressure–temperature flash calculations for certain subcooled mixtures.
  - Prevented selection of an incorrect intermediate-density root.
  - Improved liquid-phase density selection when multiple candidate solutions are available.
  - Increased reliability of liquid-state results in challenging mixture conditions.

- **Tests**
  - Added regression coverage for methane, ethane, and propane mixtures across affected temperature conditions.
  - Verified correct liquid-phase identification and density results.
  - Expanded automated test builds to include the new regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->