### PR TITLE
fix(cubics): correct PR/SRK entropy value — restore Tc/Tr chain-rule scaling on ideal-gas alpha0 derivatives (#3287)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2378,6 +2378,8 @@ if(COOLPROP_CATCH_MODULE)
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-CubicU.cpp")
   list(APPEND APP_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-CubicEntropy.cpp")
+  list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-NeonMelting.cpp")
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-AirMelting.cpp")

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -3717,6 +3717,11 @@ HelmholtzDerivatives HelmholtzEOSMixtureBackend::calc_all_alpha0_derivs_nocache(
         a.d3alphar_ddelta_dtau2 *= fT * fT * fD;
         a.d3alphar_ddelta2_dtau *= fT * fD * fD;
         a.d3alphar_ddelta3 *= fD * fD * fD;
+        a.d4alphar_dtau4 *= fT * fT * fT * fT;
+        a.d4alphar_ddelta_dtau3 *= fT * fT * fT * fD;
+        a.d4alphar_ddelta2_dtau2 *= fT * fT * fD * fD;
+        a.d4alphar_ddelta3_dtau *= fT * fD * fD * fD;
+        a.d4alphar_ddelta4 *= fD * fD * fD * fD;
         return a;
     } else {
         HelmholtzDerivatives ders;

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -3699,7 +3699,25 @@ HelmholtzDerivatives HelmholtzEOSMixtureBackend::calc_all_alpha0_derivs_nocache(
         // Cache the reducing temperature in some terms that need it (GERG-2004 models)
         E.alpha0.set_Tred(Tc);
         double taustar = Tc / Tr * tau, deltastar = rhor / rhomolarc * delta;
-        return E.alpha0.all(taustar, deltastar, false);
+        HelmholtzDerivatives a = E.alpha0.all(taustar, deltastar, false);
+        // all() returns derivatives w.r.t. taustar=Tc/T and deltastar=rho/rhoc, but the caller
+        // needs them w.r.t. tau=Tr/T and delta=rho/rhor.  Apply the same chain-rule scaling as
+        // calc_alpha0_deriv_nocache (val *= pow(rhor/rhomolarc, nDelta); val /= pow(Tr/Tc, nTau))
+        // and the mixture branch below.  For multiparameter EOS Tc/Tr == 1 and rhoc/rhor == 1, so
+        // these are no-ops; only cubics (where Tr != Tc) were affected -- see GH #3287, where the
+        // missing tau factor made cubic Smolar/Smass values too steep in T.  The value (alphar)
+        // carries zero derivative order, so it is intentionally left unscaled.
+        const double fT = Tc / Tr, fD = rhor / rhomolarc;
+        a.dalphar_dtau *= fT;
+        a.dalphar_ddelta *= fD;
+        a.d2alphar_dtau2 *= fT * fT;
+        a.d2alphar_ddelta_dtau *= fT * fD;
+        a.d2alphar_ddelta2 *= fD * fD;
+        a.d3alphar_dtau3 *= fT * fT * fT;
+        a.d3alphar_ddelta_dtau2 *= fT * fT * fD;
+        a.d3alphar_ddelta2_dtau *= fT * fD * fD;
+        a.d3alphar_ddelta3 *= fD * fD * fD;
+        return a;
     } else {
         HelmholtzDerivatives ders;
 

--- a/src/Tests/CoolProp-Tests-CubicEntropy.cpp
+++ b/src/Tests/CoolProp-Tests-CubicEntropy.cpp
@@ -1,0 +1,78 @@
+// Regression guard for GH #3287: the cubic (PR/SRK) entropy *value* must be
+// self-consistent with CoolProp's own analytic derivatives.
+//
+// Root cause of #3287: HelmholtzEOSMixtureBackend::calc_all_alpha0_derivs_nocache
+// (added in PR #2625) returned the ideal-gas alpha0 derivatives from
+// E.alpha0.all(taustar, ...) WITHOUT the chain-rule scaling (Tc/Tr for tau
+// derivatives, rhor/rhomolarc for delta derivatives) that the old
+// calc_alpha0_deriv_nocache and the mixture branch both apply.  calc_smolar()
+// consumed the unscaled da0/dtau, so cubic Smolar/Smass VALUES were too steep in
+// T (~1.5x methane .. ~3x water), while Hmolar and d(Smolar)/d(T)|P stayed
+// correct.  HEOS is unaffected because Tc/Tr == 1 there.
+//
+// Two internal self-consistency checks (no external reference data, so these are
+// independent of the entropy reference state):
+//   1. Smass(T2) - Smass(T1) == integral of the analytic d(Smass)/d(T)|P
+//   2. T * (dS/dT|P of the value) == Cpmass  (from T*(dS/dT)_P = (dH/dT)_P = Cp)
+
+#if defined(ENABLE_CATCH)
+
+#    include <catch2/catch_all.hpp>
+
+#    include "CoolProp.h"
+
+#    include <string>
+#    include <vector>
+
+namespace {
+
+// Trapezoid integral of the ANALYTIC derivative d(Smass)/d(T)|P over [T1, T2].
+double integ_dSdT(const std::string& fluid, double P, double T1, double T2, int n = 2000) {
+    const double h = (T2 - T1) / n;
+    double s = 0;
+    for (int i = 0; i <= n; ++i) {
+        const double w = (i == 0 || i == n) ? 0.5 : 1.0;
+        s += w * CoolProp::PropsSI("d(Smass)/d(T)|P", "T", T1 + i * h, "P", P, fluid);
+    }
+    return h * s;
+}
+
+}  // namespace
+
+TEST_CASE("Cubic entropy value is self-consistent with its own derivative (GH #3287)", "[cubic][entropy][3287]") {
+    // Single-phase, superheated, well away from saturation for each fluid.
+    struct Case
+    {
+        std::string fluid;
+        double P, T1, T2;
+    };
+    const std::vector<Case> cases = {
+      {"Water", 1e5, 450.0, 550.0},
+      {"Methane", 1e6, 200.0, 300.0},
+      {"Ammonia", 1e5, 300.0, 400.0},
+    };
+
+    for (const std::string& be : {std::string("PR"), std::string("SRK")}) {
+        for (const Case& c : cases) {
+            const std::string f = be + "::" + c.fluid;
+            CAPTURE(f, c.P, c.T1, c.T2);
+
+            // Check 1: value increment integrates to the analytic derivative.
+            const double dS_value = CoolProp::PropsSI("Smass", "T", c.T2, "P", c.P, f) - CoolProp::PropsSI("Smass", "T", c.T1, "P", c.P, f);
+            const double dS_integral = integ_dSdT(f, c.P, c.T1, c.T2);
+            // 0.2 % of the analytic increment covers trapezoid truncation with room to spare;
+            // the #3287 defect made these differ by 50 %..200 %.
+            CHECK(dS_value == Catch::Approx(dS_integral).epsilon(2e-3));
+
+            // Check 2: T*(dS/dT)_P from a central difference of the VALUE equals Cp.
+            const double Tm = 0.5 * (c.T1 + c.T2);
+            const double dT = 0.5;
+            const double dSdT =
+              (CoolProp::PropsSI("Smass", "T", Tm + dT, "P", c.P, f) - CoolProp::PropsSI("Smass", "T", Tm - dT, "P", c.P, f)) / (2 * dT);
+            const double cp = CoolProp::PropsSI("Cpmass", "T", Tm, "P", c.P, f);
+            CHECK(Tm * dSdT == Catch::Approx(cp).epsilon(2e-3));
+        }
+    }
+}
+
+#endif  // ENABLE_CATCH


### PR DESCRIPTION
## Summary

Fixes #3287. On the cubic backends (`PR::`/`SRK::`), `PropsSI("Smolar"/"Smass", …)` returned entropy **values** that were too steep in temperature (~1.5× for methane … ~3× for water), inconsistent with the backend's own analytic `d(Smolar)/d(T)|P` and with `Cpmolar`. Enthalpy and the analytic entropy derivative were already correct; `HEOS` was unaffected.

## Root cause

`HelmholtzEOSMixtureBackend::calc_all_alpha0_derivs_nocache` (added in #2625, the 7.1.0→7.2.0 window the issue bisected to) returned the ideal-gas α⁰ derivatives from

```cpp
return E.alpha0.all(taustar, deltastar, false);   // derivatives w.r.t. taustar/deltastar
```

**without** the chain-rule scaling back to `tau=Tr/T` / `delta=rho/rhor`. The pre-existing `calc_alpha0_deriv_nocache` applies it (`val *= pow(rhor/rhomolarc, nDelta); val /= pow(Tr/Tc, nTau)`), and so does this function's own *mixture* branch (`T_ci/Tr * pure.dalphar_dtau`) — only the pure-fluid branch omitted it.

`calc_smolar` is the sole property whose **value** consumes `da0_dTau` (and `a0`) directly:

```
s/R = τ·(da0_dTau + dar_dTau) − a0 − ar
```

- The α⁰ **value** (`.alphar`, derivative order 0) needs factor 1 → `a0` was correct.
- `da0_dTau` was returned as `∂α⁰/∂taustar`, a factor `Tc/Tr` too small (647× for water). The `τ·da0_dTau` term then failed to cancel the `−a0` term's temperature variation, so the entropy value grew ~3× too fast.

Enthalpy (uses the cached, correctly-scaled `dalpha0_dTau()`) and `d(Smolar)/d(T)|P` (cached derivatives) stayed correct. For multiparameter EOS `Tc/Tr == 1`, so `HEOS` never saw the bug.

## Fix

Apply the same per-order chain-rule scaling in the pure-fluid branch (`fT = Tc/Tr` per τ-order, `fD = rhor/rhomolarc` per δ-order), leaving the value unscaled. For multiparameter EOS both factors are 1, so `HEOS` output is bit-for-bit unchanged.

The batched accessor's other callers (`FlashRoutines.cpp` HS-flash helpers, an HS-prototype test) are raw consumers that were subject to the same defect for cubics; they are fixed, not double-corrected, by this change.

## Test

New `src/Tests/CoolProp-Tests-CubicEntropy.cpp` (tag `[3287]`) asserts, for `PR`/`SRK` × {Water, Methane, Ammonia} at single-phase superheated/supercritical points:

1. `Smass(T2) − Smass(T1)` equals the trapezoid integral of the analytic `d(Smass)/d(T)|P`.
2. `T·(dS/dT)|P` (central difference of the value) equals `Cpmass`.

Both cross two independent code paths (value vs. cached derivative), so they cannot false-pass on a shared bug. Verified 12/12 assertions **fail** without the fix and **pass** with it; the full `[cubic]` suite (3698 assertions) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of thermodynamic derivative calculations used by cubic and mixture backends, improving agreement between entropy values, entropy temperature derivatives, and heat capacity-related results.

* **Tests**
  * Added a Catch2 regression test covering entropy self-consistency for water, methane, and ammonia using Peng–Robinson and Soave–Redlich–Kwong models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->