### PR TITLE
fix(deps): pin brace-expansion 1.x to ^1.1.16 to close ReDoS alert (GHSA-3jxr-9vmj-r5cp)

### DIFF
--- a/wrappers/GUI/package-lock.json
+++ b/wrappers/GUI/package-lock.json
@@ -1664,9 +1664,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5164,17 +5164,6 @@
       "license": "ISC",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {

--- a/wrappers/GUI/package.json
+++ b/wrappers/GUI/package.json
@@ -41,6 +41,7 @@
     "vitest": "^4.1.5"
   },
   "overrides": {
-    "protocol-buffers-schema": "3.6.1"
+    "protocol-buffers-schema": "3.6.1",
+    "brace-expansion@1": "^1.1.16"
   }
 }


### PR DESCRIPTION
Closes Dependabot alert #17 (high): `brace-expansion < 1.1.16` is vulnerable to DoS via exponential-time expansion of consecutive non-expanding `{}` groups ([GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp)).

## The dependency

It's dev-only and fully transitive:

```
license-checker -> glob@3 -> minimatch@3 -> brace-expansion@1.1.14
```

`minimatch` already requests `^1.1.7`, so 1.1.16 satisfies the existing range. An `overrides` entry is enough to move it — no need to promote `brace-expansion` to a direct dependency.

## Why the override is scoped

```json
"overrides": {
  "protocol-buffers-schema": "3.6.1",
  "brace-expansion@1": "^1.1.16"
}
```

The first draft of this used a bare `"brace-expansion": "1.1.16"`. That form applies to **every** edge regardless of major, and pre-PR review caught the consequence. Reproduced directly: in a tree containing `minimatch@9` (which declares `brace-expansion: ^2.0.1`), the bare override silently resolves it to **1.1.16** — a cross-major downgrade, with no `ERESOLVE`, no warning, and nothing in CI that would catch it. Latent today (the tree has exactly one consumer), but it would fire the moment any devDependency bump pulls `minimatch@9`/`glob@10`.

Scoping to `brace-expansion@1` resolves both lines correctly — verified with a mixed tree:

| path | bare override | scoped override |
|---|---|---|
| `minimatch@9` (wants `^2.0.1`) | `1.1.16` ❌ | `2.1.2` ✅ |
| `glob@7` (wants `^1.1.7`) | `1.1.16` ✅ | `1.1.16` (nested) ✅ |

Using a `^` range rather than an exact pin also lets future 1.x security patches land via a lockfile-only Dependabot bump, which an exact pin in `package.json` would block.

## Verification

- `npm ci` clean (503 packages)
- `npm audit` — 0 vulnerabilities (was 1 high)
- `npm ls brace-expansion --all` — exactly one node in the tree, at 1.1.16
- `license-checker` run **directly**: exit 0 over 277 packages
- `vitest` — 21/21
- `./dev/ci/preflight.sh` — 4 passed / 0 failed / 5 skipped

license-checker was checked standalone rather than via `npm test`, because `scripts/generate-licenses.mjs:121` catches any failure from it, leaves the npm section empty, and still exits 0. A green `npm test` would not have proven that path works. Filed separately as a fail-open in the notices generator.

The unrelated `source-map@0.6.1` removal in the lockfile is pre-existing drift — regenerating the untouched committed lockfile with npm 11.6 drops that optional/peer-only entry too.

## Not addressed here

Dependabot alert #7 (`glib < 0.20.0`, [GHSA-wrw7-89jp-8q8g](https://github.com/advisories/GHSA-wrw7-89jp-8q8g)) is **not actionable**. `tauri` 2.x pins `gtk ^0.18`, which pins `glib ^0.18` — still true in the latest 2.11.5, not just our locked 2.11.1 — and `cargo update -p glib --precise 0.20.0` fails on that constraint. There is no 0.18.x backport (the advisory patches at 0.20.0; glib is now at 0.22.8), so it's blocked on Tauri migrating the gtk-rs stack upstream.

Practical exposure is low: Linux-only code path, the issue is an unsoundness in `glib::VariantStrIter`, and the GUI's Rust sources never reference `glib` or `Variant`. Deliberately left open so it resurfaces when Tauri moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package resolution to use a compatible version of a transitive dependency.
  * Preserved the existing package override configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->