### PR TITLE
fix(beads): bootstrap bd in ephemeral containers via a single hardened SessionStart hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,15 @@
       {
         "hooks": [
           {
+            "command": "sh dev/ci/bootstrap-beads.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      },
+      {
+        "hooks": [
+          {
             "command": "bd prime",
             "type": "command"
           }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,17 +15,9 @@
       {
         "hooks": [
           {
-            "command": "sh dev/ci/bootstrap-beads.sh",
-            "type": "command"
-          }
-        ],
-        "matcher": ""
-      },
-      {
-        "hooks": [
-          {
-            "command": "bd prime",
-            "type": "command"
+            "command": "sh \"${CLAUDE_PROJECT_DIR}/dev/ci/bootstrap-beads.sh\"",
+            "type": "command",
+            "timeout": 600
           }
         ],
         "matcher": ""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,23 @@ bd close <id>         # Complete work
 - If push fails, resolve and retry until it succeeds
 <!-- END BEADS INTEGRATION -->
 
+### `bd` in ephemeral (Claude Code web/CI) containers
+
+Fresh containers have no `bd` binary and no Dolt DB (the DB dir
+`.beads/embeddeddolt/` is gitignored). `dev/ci/bootstrap-beads.sh` — wired
+as the first `SessionStart` hook in `.claude/settings.json`, ahead of the
+beads-managed `bd prime` — installs `bd` via `go install` (the `curl|bash`
+installer's GitHub-release download is blocked by the agent proxy; the Go
+module proxy is allowed) and rehydrates the DB from the committed
+`.beads/issues.jsonl`. It is idempotent and non-fatal. First cold start
+takes ~2 min (Go toolchain fetch + build); warm containers skip both steps.
+To persist newly filed issues, append their `bd export --include-memories`
+lines to `.beads/issues.jsonl` and commit — do **not** overwrite the file
+wholesale (bd 1.1.0 re-serializes the `dependencies` field on unrelated
+issues, and a plain `bd export` drops the persisted memories). `bd dolt
+push` in the session-completion steps above is a no-op here — there is no
+Dolt remote in web containers; committing `issues.jsonl` is the sync.
+
 
 ## Build & Test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,11 +61,15 @@ GitHub-release download is blocked by the agent proxy; the Go module proxy is
 allowed), rehydrates the DB from the committed `.beads/issues.jsonl`, and
 finally runs `bd prime` itself once both are ready.
 
-It only bootstraps in recognized ephemeral environments (`CI=true` or
-`CLAUDE_CODE_REMOTE=true`) — a developer workstation with `go` on `PATH` is
-left alone rather than getting an unprompted `go install` / toolchain fetch.
-Set `BEADS_BOOTSTRAP_FORCE=1` to opt in anywhere else (e.g. to exercise the
-script locally). It is idempotent — hydration is checked with a `bd count`
+It only bootstraps when explicitly opted in with `BEADS_BOOTSTRAP=1` — set once
+in an environment's persistent config, not auto-detected from `CI`/
+`CLAUDE_CODE_REMOTE`, since the cold-start install+hydrate can take a couple of
+minutes and that cost should be a deliberate per-environment choice, not
+sprung on every session in every ephemeral container. Without it, the hook
+only primes an already-installed `bd` (near-zero cost) and exits — never
+installs, never hydrates; a developer workstation with `go` on `PATH` is
+naturally left alone unless someone sets the variable there too. It is
+idempotent — hydration is checked with a `bd count`
 health probe rather than directory presence, so a partial or failed import is
 retried next session instead of latching "done" forever — and non-fatal: any
 failure warns on stderr and the session continues without bd. An `flock(1)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,10 +68,15 @@ Set `BEADS_BOOTSTRAP_FORCE=1` to opt in anywhere else (e.g. to exercise the
 script locally). It is idempotent — hydration is checked with a `bd count`
 health probe rather than directory presence, so a partial or failed import is
 retried next session instead of latching "done" forever — and non-fatal: any
-failure warns on stderr and the session continues without bd. A single-shot
-mkdir lock (with dead-PID stealing, not a busy-wait) guards the hydration
-critical section against two SessionStart hooks racing in the same container.
-On a tree that was clean beforehand, it also restores the few tracked files
+failure warns on stderr and the session continues without bd. An `flock(1)`
+lock (not a busy-wait) guards the hydration critical section against two
+SessionStart hooks racing in the same container; a session that loses the
+race skips hydration *and* `bd prime` entirely for that run rather than
+risk reading the DB mid-rebuild, and retries from scratch next session.
+flock's kernel-level exclusivity is what makes the acquire itself atomic
+and self-releasing on any exit (including SIGKILL, which no trap can
+catch) — no separate staleness/steal logic needed. On a tree that was
+clean beforehand, it also restores the few tracked files
 (`.beads/config.yaml`, `.beads/.gitignore`, `.gitignore`) that `bd init
 --stealth` still normalizes even in stealth mode, via a trap on EXIT/INT/TERM
 so a *signal-interrupted* hook doesn't leave those files dirty; it never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,13 +52,30 @@ bd close <id>         # Complete work
 ### `bd` in ephemeral (Claude Code web/CI) containers
 
 Fresh containers have no `bd` binary and no Dolt DB (the DB dir
-`.beads/embeddeddolt/` is gitignored). `dev/ci/bootstrap-beads.sh` — wired
-as the first `SessionStart` hook in `.claude/settings.json`, ahead of the
-beads-managed `bd prime` — installs `bd` via `go install` (the `curl|bash`
-installer's GitHub-release download is blocked by the agent proxy; the Go
-module proxy is allowed) and rehydrates the DB from the committed
-`.beads/issues.jsonl`. It is idempotent and non-fatal. First cold start
-takes ~2 min (Go toolchain fetch + build); warm containers skip both steps.
+`.beads/embeddeddolt/` is gitignored). `dev/ci/bootstrap-beads.sh` is the
+**only** `SessionStart` hook for beads (`.claude/settings.json`) — Claude Code
+runs same-event hooks concurrently rather than in array order, so a separate
+`bd prime` hook would race a `bd` this script hasn't finished installing yet.
+The script installs `bd` via `go install` (the `curl|bash` installer's
+GitHub-release download is blocked by the agent proxy; the Go module proxy is
+allowed), rehydrates the DB from the committed `.beads/issues.jsonl`, and
+finally runs `bd prime` itself once both are ready.
+
+It only bootstraps in recognized ephemeral environments (`CI=true` or
+`CLAUDE_CODE_REMOTE=true`) — a developer workstation with `go` on `PATH` is
+left alone rather than getting an unprompted `go install` / toolchain fetch.
+Set `BEADS_BOOTSTRAP_FORCE=1` to opt in anywhere else (e.g. to exercise the
+script locally). It is idempotent — hydration is checked with a `bd count`
+health probe rather than directory presence, so a partial or failed import is
+retried next session instead of latching "done" forever — and non-fatal: any
+failure warns on stderr and the session continues without bd. On a tree that
+was clean beforehand, it also restores the few tracked files
+(`.beads/config.yaml`, `.beads/.gitignore`, `.gitignore`) that `bd init
+--stealth` still normalizes even in stealth mode, via a trap so an
+interrupted hook doesn't leave those files dirty; it never touches a tree
+that already had pending edits to them. First cold start takes ~2-3 min (Go
+toolchain fetch + build); warm containers skip both install and hydration.
+
 To persist newly filed issues, append their `bd export --include-memories`
 lines to `.beads/issues.jsonl` and commit — do **not** overwrite the file
 wholesale (bd 1.1.0 re-serializes the `dependencies` field on unrelated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,13 +68,20 @@ Set `BEADS_BOOTSTRAP_FORCE=1` to opt in anywhere else (e.g. to exercise the
 script locally). It is idempotent — hydration is checked with a `bd count`
 health probe rather than directory presence, so a partial or failed import is
 retried next session instead of latching "done" forever — and non-fatal: any
-failure warns on stderr and the session continues without bd. On a tree that
-was clean beforehand, it also restores the few tracked files
+failure warns on stderr and the session continues without bd. A single-shot
+mkdir lock (with dead-PID stealing, not a busy-wait) guards the hydration
+critical section against two SessionStart hooks racing in the same container.
+On a tree that was clean beforehand, it also restores the few tracked files
 (`.beads/config.yaml`, `.beads/.gitignore`, `.gitignore`) that `bd init
---stealth` still normalizes even in stealth mode, via a trap so an
-interrupted hook doesn't leave those files dirty; it never touches a tree
-that already had pending edits to them. First cold start takes ~2-3 min (Go
-toolchain fetch + build); warm containers skip both install and hydration.
+--stealth` still normalizes even in stealth mode, via a trap on EXIT/INT/TERM
+so a *signal-interrupted* hook doesn't leave those files dirty; it never
+touches a tree that already had pending edits to them. No trap survives
+SIGKILL or a hard container teardown, though — a hydration killed that way
+can still leave those three files modified, and since the next session reads
+"already dirty" as a developer's in-progress edit, it won't auto-restore them
+either; `git checkout -- .beads/config.yaml .beads/.gitignore .gitignore`
+clears it manually. First cold start takes ~2-3 min (Go toolchain fetch +
+build); warm containers skip both install and hydration.
 
 To persist newly filed issues, append their `bd export --include-memories`
 lines to `.beads/issues.jsonl` and commit — do **not** overwrite the file

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -83,9 +83,10 @@ CLAUDE.md's "`bd` in ephemeral (Claude Code web/CI) containers" section for
 the full story (gating, idempotency, and why it's the only `SessionStart`
 hook for beads).
 
-It only runs in recognized ephemeral environments (`CI=true` or
-`CLAUDE_CODE_REMOTE=true`); set `BEADS_BOOTSTRAP_FORCE=1` to exercise it on a
-workstation.
+It's opt-in: the install+hydrate steps only run when `BEADS_BOOTSTRAP=1` is
+set in an environment's persistent config (the cold-start cost is a
+per-environment choice, not auto-detected from `CI`/`CLAUDE_CODE_REMOTE`).
+Without it, the hook just primes an already-installed `bd`, if any.
 
 ---
 

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -70,6 +70,25 @@ get caught locally.
 
 ---
 
+## bootstrap-beads.sh — bd in ephemeral containers
+
+`dev/ci/bootstrap-beads.sh` is the `SessionStart` hook (see
+`.claude/settings.json`) that makes `bd` (the beads issue tracker) usable in
+Claude Code web/CI containers, which start from a fresh clone with no `bd`
+binary and no Dolt database. It installs `bd` via `go install` (the
+`curl|bash` installer's GitHub-release download is blocked by the agent
+proxy; the Go module proxy is allowed), rehydrates the embedded DB from the
+committed `.beads/issues.jsonl`, and then runs `bd prime` itself — see
+CLAUDE.md's "`bd` in ephemeral (Claude Code web/CI) containers" section for
+the full story (gating, idempotency, and why it's the only `SessionStart`
+hook for beads).
+
+It only runs in recognized ephemeral environments (`CI=true` or
+`CLAUDE_CODE_REMOTE=true`); set `BEADS_BOOTSTRAP_FORCE=1` to exercise it on a
+workstation.
+
+---
+
 ## clang-format
 
 `.clang-format` at repo root is the source of truth for formatting rules.

--- a/dev/ci/bootstrap-beads.sh
+++ b/dev/ci/bootstrap-beads.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env sh
+#
+# bootstrap-beads.sh — make `bd` (beads) usable in ephemeral containers.
+#
+# Claude Code web/CI containers start from a fresh clone, where:
+#   * the `bd` binary is not installed, and the upstream `curl | bash`
+#     installer downloads a prebuilt binary from GitHub Releases — which the
+#     agent proxy blocks (403 on api.github.com / release asset hosts); but
+#   * `go install` through the allowlisted module proxy (proxy.golang.org)
+#     works, and beads embeds its Dolt engine, so no separate `dolt` binary
+#     is needed; and
+#   * the embedded DB dir (.beads/embeddeddolt/) is gitignored and therefore
+#     absent — it must be rehydrated from the committed .beads/issues.jsonl,
+#     which is the source of truth.
+#
+# This script is registered as the FIRST SessionStart hook (see
+# .claude/settings.json) so it runs before the beads-managed
+# `bd prime --hook-json` hook, which then finds an installed bd and a
+# populated database.
+#
+# It is idempotent and strictly non-fatal: a warm container already has bd on
+# PATH and the DB in place (both steps no-op), and any failure logs a warning
+# and exits 0 so a beads hiccup never blocks the session — the git hooks are
+# already guarded the same way.
+
+set -u
+
+BD_VERSION="v1.1.0"  # pinned: a future release must not silently wedge cold start
+
+# bd installs to $GOPATH/bin; make sure that's on PATH for this session.
+if command -v go >/dev/null 2>&1; then
+    _gobin="$(go env GOPATH 2>/dev/null)/bin"
+    case ":${PATH}:" in
+        *":${_gobin}:"*) ;;
+        *) PATH="${_gobin}:${PATH}"; export PATH ;;
+    esac
+fi
+
+# 1. Install bd if missing.
+if ! command -v bd >/dev/null 2>&1; then
+    if command -v go >/dev/null 2>&1; then
+        echo "beads-bootstrap: installing bd ${BD_VERSION} via 'go install'..." >&2
+        # GOTOOLCHAIN=auto lets go fetch the newer toolchain beads' go.mod
+        # requires (via the allowlisted module proxy) when the base toolchain
+        # is older.
+        if ! GOTOOLCHAIN=auto GOFLAGS=-mod=mod go install \
+            "github.com/steveyegge/beads/cmd/bd@${BD_VERSION}" >&2 2>&1; then
+            echo "beads-bootstrap: 'go install bd' failed — bd commands unavailable this session." >&2
+        fi
+    else
+        echo "beads-bootstrap: 'go' not found — cannot install bd." >&2
+    fi
+fi
+command -v bd >/dev/null 2>&1 || exit 0
+
+# 2. Hydrate the embedded Dolt DB from the committed JSONL if it isn't there.
+#    Presence of the gitignored DB dir is the reliable "already hydrated" test
+#    (bd's own commands exit 0 even when no DB exists, so exit codes can't be
+#    used here).
+if [ ! -d .beads/embeddeddolt ]; then
+    # Record whether the tree already had changes, so the post-init restore
+    # below only runs on a clean fresh container and never touches a
+    # developer's in-progress edits to these config files.
+    _bd_pre_dirty="$(git status --porcelain -- .beads/config.yaml .beads/.gitignore .gitignore 2>/dev/null)"
+    echo "beads-bootstrap: hydrating beads DB from .beads/issues.jsonl..." >&2
+    # --stealth keeps beads files out of git (via .git/info/exclude), so init
+    #   makes NO commits and rewrites NO tracked files — critical in a hook,
+    #   which must never dirty the tree or auto-commit;
+    # --from-jsonl imports the committed .beads/issues.jsonl in the same step;
+    # --non-interactive / --quiet for the non-TTY container.
+    if ! bd init --stealth --non-interactive --quiet --from-jsonl >/dev/null 2>&1; then
+        echo "beads-bootstrap: 'bd init --from-jsonl' failed — beads DB unavailable this session." >&2
+    fi
+    # --stealth avoids commits and the CLAUDE.md/AGENTS.md/settings rewrites,
+    # but bd init still normalizes a few tracked config files
+    # (.beads/config.yaml, .beads/.gitignore, .gitignore). Restore them so a
+    # fresh container's tree stays clean; the gitignored embedded DB is kept
+    # and remains usable (config.yaml holds only commented defaults). Guarded
+    # so it only runs when the pre-hook tree was clean (fresh container), never
+    # clobbering real in-progress edits.
+    if [ -z "$_bd_pre_dirty" ]; then
+        git checkout -- .beads/config.yaml .beads/.gitignore .gitignore 2>/dev/null || true
+    fi
+fi
+
+exit 0

--- a/dev/ci/bootstrap-beads.sh
+++ b/dev/ci/bootstrap-beads.sh
@@ -91,7 +91,7 @@ if command -v go >/dev/null 2>&1; then
         *":${_gobin}:"*) ;;
         *) PATH="${_gobin}:${PATH}"; export PATH ;;
     esac
-    hash -r 2>/dev/null || echo "beads-bootstrap: 'hash -r' failed — a stale command lookup cache could mask the freshly-installed bd." >&2
+    hash -r || echo "beads-bootstrap: 'hash -r' failed — a stale command lookup cache could mask the freshly-installed bd." >&2
 fi
 
 # 1. Install bd if missing.
@@ -105,7 +105,7 @@ if ! command -v bd >/dev/null 2>&1; then
             "github.com/steveyegge/beads/cmd/bd@${BD_VERSION}" >&2; then
             echo "beads-bootstrap: 'go install bd' failed — bd commands unavailable this session." >&2
         fi
-        hash -r 2>/dev/null || echo "beads-bootstrap: 'hash -r' failed — a stale command lookup cache could mask the freshly-installed bd." >&2
+        hash -r || echo "beads-bootstrap: 'hash -r' failed — a stale command lookup cache could mask the freshly-installed bd." >&2
     else
         echo "beads-bootstrap: 'go' not found — cannot install bd." >&2
     fi
@@ -132,14 +132,20 @@ if command -v bd >/dev/null 2>&1; then
     # the acquire itself is atomic (no TOCTOU window to race), and a holder
     # that dies for any reason — including SIGKILL, which no trap can catch
     # — has its lock released automatically when its file descriptors close,
-    # so there's no separate staleness/steal logic to get subtly wrong. If
-    # flock isn't on PATH (unlikely — it ships with util-linux — but not
-    # guaranteed on every minimal image), proceed unlocked rather than fail:
-    # same exposure as before this lock existed, not a new one.
+    # so there's no separate staleness/steal logic to get subtly wrong.
+    #
+    # Fail CLOSED, not open, if the lock itself can't be obtained (flock
+    # missing, or the lock file can't be opened): the entire point of this
+    # function is to guarantee exclusivity, so "couldn't tell" must be
+    # treated the same as "someone else has it" — skip this session and let
+    # the next session's `bd count` probe retry from scratch, rather than
+    # silently racing an unprotected rm -rf/bd init. flock ships with
+    # util-linux and is present on the Ubuntu-based containers this targets,
+    # so this fallback is defensive, not the expected path.
     _beads_bootstrap_acquire_lock() {
         if ! command -v flock >/dev/null 2>&1; then
-            echo "beads-bootstrap: 'flock' not found — hydration will proceed without a concurrency lock." >&2
-            return 0
+            echo "beads-bootstrap: 'flock' not found — cannot safely coordinate hydration." >&2
+            return 1
         fi
         # No `2>/dev/null` here: a bare `exec` (no command) applies its
         # redirects to the CURRENT shell persistently, not just to this one
@@ -149,8 +155,8 @@ if command -v bd >/dev/null 2>&1; then
         # warn explicitly too so "lock open failed" isn't indistinguishable
         # from "lock acquired" in the caller.
         if ! exec 9>"$_bd_lockfile"; then
-            echo "beads-bootstrap: could not open $_bd_lockfile for locking — hydration will proceed without a concurrency lock." >&2
-            return 0
+            echo "beads-bootstrap: could not open $_bd_lockfile for locking." >&2
+            return 1
         fi
         # fd 9 stays open (and inherited by bd/go/git children) for the rest
         # of this process's life — that's what makes the flock self-release
@@ -205,14 +211,18 @@ if command -v bd >/dev/null 2>&1; then
             # and the kernel drops it when this process's descriptors close,
             # on any exit path including SIGKILL.
         else
-            # Another process holds the lock and is actively hydrating (or
-            # tearing down and rebuilding) .beads/embeddeddolt right now.
-            # Don't call `bd prime` here — it can read mid-rebuild state, or
-            # itself write to the DB (see the comment above `rm -rf
-            # .beads/embeddeddolt`) — race the concurrent hydration. Skip
-            # priming this session entirely; the next session's `bd count`
-            # probe re-evaluates from scratch.
-            echo "beads-bootstrap: another bootstrap appears to be in progress (lock held) — skipping this session; it will retry next session." >&2
+            # Either another process holds the lock and is actively
+            # hydrating (or tearing down and rebuilding) .beads/embeddeddolt
+            # right now, or the lock itself couldn't be obtained (see the
+            # specific warning already logged inside
+            # _beads_bootstrap_acquire_lock) — both cases mean we can't
+            # safely touch the DB this run. Don't call `bd prime` either —
+            # it can read mid-rebuild state, or itself write to the DB (see
+            # the comment above `rm -rf .beads/embeddeddolt`) — race a
+            # concurrent hydration we can't see. Skip priming this session
+            # entirely; the next session's `bd count` probe re-evaluates
+            # from scratch.
+            echo "beads-bootstrap: could not acquire the hydration lock — skipping this session; it will retry next session." >&2
             exit 0
         fi
     fi

--- a/dev/ci/bootstrap-beads.sh
+++ b/dev/ci/bootstrap-beads.sh
@@ -13,27 +13,79 @@
 #     absent — it must be rehydrated from the committed .beads/issues.jsonl,
 #     which is the source of truth.
 #
-# This script is registered as the FIRST SessionStart hook (see
-# .claude/settings.json) so it runs before the beads-managed
-# `bd prime --hook-json` hook, which then finds an installed bd and a
-# populated database.
+# This is the ONLY SessionStart hook for beads (see .claude/settings.json).
+# Claude Code runs all hooks for one event concurrently — array position does
+# not sequence them — so a separate `bd prime` hook would race a `bd` this
+# script hasn't finished installing yet. Instead this script runs `bd prime`
+# itself as its last step, once bd and the DB are ready.
 #
-# It is idempotent and strictly non-fatal: a warm container already has bd on
-# PATH and the DB in place (both steps no-op), and any failure logs a warning
-# and exits 0 so a beads hiccup never blocks the session — the git hooks are
-# already guarded the same way.
+# Restricted to recognized ephemeral containers (CI=true or CLAUDE_CODE_REMOTE
+# set): a developer workstation with `go` on PATH must never get an
+# unprompted `go install` / toolchain fetch and multi-minute session stall.
+# Set BEADS_BOOTSTRAP_FORCE=1 to opt in anywhere else (e.g. to exercise this
+# script locally).
+#
+# It is idempotent (hydration is checked with a `bd count` health probe, not
+# directory presence, so a partial/failed import is retried next session
+# rather than latching "done" forever) and strictly non-fatal: a warm
+# container already has bd on PATH and the DB in place (both steps no-op),
+# and any failure logs a warning and lets the session continue without bd —
+# the git hooks are already guarded the same way.
 
 set -u
 
 BD_VERSION="v1.1.0"  # pinned: a future release must not silently wedge cold start
 
+cd "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || exit 0
+
+# Container gate: only bootstrap in recognized ephemeral environments, unless
+# explicitly opted in. Elsewhere, just prime an already-installed bd (if any)
+# and get out of the way.
+if [ -z "${BEADS_BOOTSTRAP_FORCE:-}" ] \
+    && [ "${CI:-}" != "true" ] \
+    && [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+    command -v bd >/dev/null 2>&1 && bd prime
+    exit 0
+fi
+
+# Tracks whether we've started an import this run, and whether the tree was
+# clean beforehand — read by the trap below so an interrupted or completed
+# hydration never leaves the tree dirty (bd init normalizes a few tracked
+# config files even under --stealth; see step 2). Default pre_dirty=1 (i.e.
+# "don't restore") so a trap firing before either variable is computed can
+# never touch the tree.
+_bd_did_init=0
+_bd_pre_dirty=1
+
+_beads_bootstrap_cleanup() {
+    [ "$_bd_did_init" = 1 ] || return 0
+    [ "$_bd_pre_dirty" = 0 ] || return 0
+    for _f in .beads/config.yaml .beads/.gitignore .gitignore; do
+        git ls-files --error-unmatch "$_f" >/dev/null 2>&1 && git checkout -- "$_f" 2>/dev/null
+    done
+}
+trap '_beads_bootstrap_cleanup' EXIT
+# A trap alone does not terminate the shell on INT/TERM (dash keeps running
+# past the signal once it's caught) — exit explicitly after cleanup so an
+# external kill (e.g. a hook timeout) still takes effect promptly. This also
+# re-fires the EXIT trap above, which is a harmless no-op the second time.
+trap '_beads_bootstrap_cleanup; exit 130' INT
+trap '_beads_bootstrap_cleanup; exit 143' TERM
+
 # bd installs to $GOPATH/bin; make sure that's on PATH for this session.
 if command -v go >/dev/null 2>&1; then
     _gobin="$(go env GOPATH 2>/dev/null)/bin"
+    # On Windows/Git Bash, `go env GOPATH` prints a Windows path
+    # (C:\Users\...\go); a bare PATH-membership test never matches it, and
+    # prepending it verbatim would split on the drive-letter colon.
+    if command -v cygpath >/dev/null 2>&1; then
+        _gobin="$(cygpath -u "$_gobin")"
+    fi
     case ":${PATH}:" in
         *":${_gobin}:"*) ;;
         *) PATH="${_gobin}:${PATH}"; export PATH ;;
     esac
+    hash -r 2>/dev/null || true
 fi
 
 # 1. Install bd if missing.
@@ -44,43 +96,69 @@ if ! command -v bd >/dev/null 2>&1; then
         # requires (via the allowlisted module proxy) when the base toolchain
         # is older.
         if ! GOTOOLCHAIN=auto GOFLAGS=-mod=mod go install \
-            "github.com/steveyegge/beads/cmd/bd@${BD_VERSION}" >&2 2>&1; then
+            "github.com/steveyegge/beads/cmd/bd@${BD_VERSION}" >&2; then
             echo "beads-bootstrap: 'go install bd' failed — bd commands unavailable this session." >&2
         fi
+        hash -r 2>/dev/null || true
     else
         echo "beads-bootstrap: 'go' not found — cannot install bd." >&2
     fi
 fi
-command -v bd >/dev/null 2>&1 || exit 0
 
-# 2. Hydrate the embedded Dolt DB from the committed JSONL if it isn't there.
-#    Presence of the gitignored DB dir is the reliable "already hydrated" test
-#    (bd's own commands exit 0 even when no DB exists, so exit codes can't be
-#    used here).
-if [ ! -d .beads/embeddeddolt ]; then
-    # Record whether the tree already had changes, so the post-init restore
-    # below only runs on a clean fresh container and never touches a
-    # developer's in-progress edits to these config files.
-    _bd_pre_dirty="$(git status --porcelain -- .beads/config.yaml .beads/.gitignore .gitignore 2>/dev/null)"
-    echo "beads-bootstrap: hydrating beads DB from .beads/issues.jsonl..." >&2
-    # --stealth keeps beads files out of git (via .git/info/exclude), so init
-    #   makes NO commits and rewrites NO tracked files — critical in a hook,
-    #   which must never dirty the tree or auto-commit;
-    # --from-jsonl imports the committed .beads/issues.jsonl in the same step;
-    # --non-interactive / --quiet for the non-TTY container.
-    if ! bd init --stealth --non-interactive --quiet --from-jsonl >/dev/null 2>&1; then
-        echo "beads-bootstrap: 'bd init --from-jsonl' failed — beads DB unavailable this session." >&2
+if command -v bd >/dev/null 2>&1; then
+    # 2. Hydrate the embedded Dolt DB from the committed JSONL if needed.
+    #    "already hydrated" is checked with a health probe (bd count), not
+    #    directory presence: bd init creates .beads/embeddeddolt/ *before*
+    #    importing, so a partial/failed import would otherwise leave a
+    #    directory that latches "hydrated" forever. `bd count` also exits
+    #    non-zero when no DB exists at all, so a single probe covers both
+    #    "never initialized" and "initialized but empty".
+    _bd_hydrated() {
+        _n="$(bd count --quiet 2>/dev/null)" || return 1
+        [ -n "$_n" ] && [ "$_n" -gt 0 ] 2>/dev/null
+    }
+
+    if [ -f .beads/issues.jsonl ] && ! _bd_hydrated; then
+        _bd_did_init=1
+        # Record whether the tree already had changes, so the restore below
+        # (via the trap) only runs on a clean fresh container and never
+        # touches a developer's in-progress edits to these config files.
+        # Checked separately from emptiness: a `git status` that itself
+        # errors (index lock contention, git missing, cwd outside a repo)
+        # must not be read as "clean".
+        if _bd_dirty_out="$(git status --porcelain -- .beads/config.yaml .beads/.gitignore .gitignore 2>&1)"; then
+            [ -z "$_bd_dirty_out" ] && _bd_pre_dirty=0
+        fi
+
+        echo "beads-bootstrap: hydrating beads DB from .beads/issues.jsonl..." >&2
+        # Our own health probe just said "not hydrated", so nothing of value
+        # is lost by clearing whatever's here first. This matters because
+        # step 3's `bd prime` lazily creates an empty Dolt DB as a side
+        # effect whenever none exists (confirmed by testing, not documented
+        # behavior) — so a prior failed/skipped attempt in this same
+        # container can leave an empty DB behind, and `bd init --from-jsonl`
+        # refuses to run against ANY existing DB ("already initialized")
+        # without this.
+        rm -rf .beads/embeddeddolt
+        # --stealth keeps beads files out of git (via .git/info/exclude), so
+        #   init makes NO commits — critical in a hook, which must never
+        #   auto-commit;
+        # --from-jsonl imports the committed .beads/issues.jsonl in the same
+        #   step;
+        # --non-interactive / --quiet for the non-TTY container.
+        if ! bd init --stealth --non-interactive --quiet --from-jsonl >/dev/null; then
+            echo "beads-bootstrap: 'bd init --from-jsonl' failed — beads DB unavailable this session." >&2
+            rm -rf .beads/embeddeddolt
+        elif ! _bd_hydrated; then
+            echo "beads-bootstrap: bd init reported success but the DB has no issues — treating as a failed hydration so it retries next session." >&2
+            rm -rf .beads/embeddeddolt
+        fi
+        # The tracked-file restore itself happens in the EXIT trap above, so
+        # it also fires on an interrupted hook, not just a clean finish.
     fi
-    # --stealth avoids commits and the CLAUDE.md/AGENTS.md/settings rewrites,
-    # but bd init still normalizes a few tracked config files
-    # (.beads/config.yaml, .beads/.gitignore, .gitignore). Restore them so a
-    # fresh container's tree stays clean; the gitignored embedded DB is kept
-    # and remains usable (config.yaml holds only commented defaults). Guarded
-    # so it only runs when the pre-hook tree was clean (fresh container), never
-    # clobbering real in-progress edits.
-    if [ -z "$_bd_pre_dirty" ]; then
-        git checkout -- .beads/config.yaml .beads/.gitignore .gitignore 2>/dev/null || true
-    fi
+
+    # 3. Hand off to the beads-managed workflow-context hook.
+    bd prime
 fi
 
 exit 0

--- a/dev/ci/bootstrap-beads.sh
+++ b/dev/ci/bootstrap-beads.sh
@@ -19,11 +19,14 @@
 # script hasn't finished installing yet. Instead this script runs `bd prime`
 # itself as its last step, once bd and the DB are ready.
 #
-# Restricted to recognized ephemeral containers (CI=true or CLAUDE_CODE_REMOTE
-# set): a developer workstation with `go` on PATH must never get an
-# unprompted `go install` / toolchain fetch and multi-minute session stall.
-# Set BEADS_BOOTSTRAP_FORCE=1 to opt in anywhere else (e.g. to exercise this
-# script locally).
+# Opt-in via BEADS_BOOTSTRAP=1, not auto-detected from CI/CLAUDE_CODE_REMOTE:
+# the cold-start install+hydrate can take a couple of minutes, a cost that
+# should be a deliberate choice for an environment, not a surprise sprung on
+# every session in every ephemeral container. Set it once in the persistent
+# env config for an environment that actually wants beads tracking; every
+# session there then gets bd automatically, cold start included. Without it,
+# this script only primes an already-installed bd (near-zero cost) and gets
+# out of the way — never installs, never hydrates.
 #
 # It is idempotent (hydration is checked with a `bd count` health probe, not
 # directory presence, so a partial/failed import is retried next session
@@ -38,12 +41,10 @@ BD_VERSION="v1.1.0"  # pinned: a future release must not silently wedge cold sta
 
 cd "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || exit 0
 
-# Container gate: only bootstrap in recognized ephemeral environments, unless
-# explicitly opted in. Elsewhere, just prime an already-installed bd (if any)
-# and get out of the way.
-if [ "${BEADS_BOOTSTRAP_FORCE:-}" != "1" ] \
-    && [ "${CI:-}" != "true" ] \
-    && [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+# Opt-in gate: only bootstrap when explicitly enabled for this environment.
+# Elsewhere, just prime an already-installed bd (if any) and get out of the
+# way — no install, no hydration, no cold-start cost.
+if [ "${BEADS_BOOTSTRAP:-}" != "1" ]; then
     if command -v bd >/dev/null 2>&1; then
         bd prime || echo "beads-bootstrap: 'bd prime' failed (exit $?)." >&2
     fi

--- a/dev/ci/bootstrap-beads.sh
+++ b/dev/ci/bootstrap-beads.sh
@@ -41,10 +41,12 @@ cd "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || exit 0
 # Container gate: only bootstrap in recognized ephemeral environments, unless
 # explicitly opted in. Elsewhere, just prime an already-installed bd (if any)
 # and get out of the way.
-if [ -z "${BEADS_BOOTSTRAP_FORCE:-}" ] \
+if [ "${BEADS_BOOTSTRAP_FORCE:-}" != "1" ] \
     && [ "${CI:-}" != "true" ] \
     && [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
-    command -v bd >/dev/null 2>&1 && bd prime
+    if command -v bd >/dev/null 2>&1; then
+        bd prime || echo "beads-bootstrap: 'bd prime' failed (exit $?)." >&2
+    fi
     exit 0
 fi
 
@@ -56,11 +58,9 @@ fi
 # never touch the tree.
 _bd_did_init=0
 _bd_pre_dirty=1
-_bd_lockdir=".beads/.bootstrap.lock"
-_bd_lock_held=0
+_bd_lockfile=".beads/.bootstrap.lock"
 
 _beads_bootstrap_cleanup() {
-    [ "$_bd_lock_held" = 1 ] && rm -rf "$_bd_lockdir" 2>/dev/null
     [ "$_bd_did_init" = 1 ] || return 0
     [ "$_bd_pre_dirty" = 0 ] || return 0
     for _f in .beads/config.yaml .beads/.gitignore .gitignore; do
@@ -90,7 +90,7 @@ if command -v go >/dev/null 2>&1; then
         *":${_gobin}:"*) ;;
         *) PATH="${_gobin}:${PATH}"; export PATH ;;
     esac
-    hash -r 2>/dev/null || true
+    hash -r 2>/dev/null || echo "beads-bootstrap: 'hash -r' failed — a stale command lookup cache could mask the freshly-installed bd." >&2
 fi
 
 # 1. Install bd if missing.
@@ -104,7 +104,7 @@ if ! command -v bd >/dev/null 2>&1; then
             "github.com/steveyegge/beads/cmd/bd@${BD_VERSION}" >&2; then
             echo "beads-bootstrap: 'go install bd' failed — bd commands unavailable this session." >&2
         fi
-        hash -r 2>/dev/null || true
+        hash -r 2>/dev/null || echo "beads-bootstrap: 'hash -r' failed — a stale command lookup cache could mask the freshly-installed bd." >&2
     else
         echo "beads-bootstrap: 'go' not found — cannot install bd." >&2
     fi
@@ -126,27 +126,37 @@ if command -v bd >/dev/null 2>&1; then
     # Single-shot mutex around the hydration critical section below: two
     # SessionStart hooks racing in the same container (e.g. two sessions
     # attached to one environment) would otherwise both see "not hydrated"
-    # and both rm -rf/reinit .beads/embeddeddolt concurrently. No retry loop
-    # — if the lock is held by a live process we just skip hydration this
-    # run (self-heals next session via the same `bd count` probe); if the
-    # holder's PID is dead (e.g. it was SIGKILLed before it could release —
-    # no trap catches that), steal the lock instead of wedging forever.
+    # and both rm -rf/reinit .beads/embeddeddolt concurrently. Use flock(1)
+    # rather than a hand-rolled mkdir+pid-file scheme: the kernel guarantees
+    # the acquire itself is atomic (no TOCTOU window to race), and a holder
+    # that dies for any reason — including SIGKILL, which no trap can catch
+    # — has its lock released automatically when its file descriptors close,
+    # so there's no separate staleness/steal logic to get subtly wrong. If
+    # flock isn't on PATH (unlikely — it ships with util-linux — but not
+    # guaranteed on every minimal image), proceed unlocked rather than fail:
+    # same exposure as before this lock existed, not a new one.
     _beads_bootstrap_acquire_lock() {
-        if mkdir "$_bd_lockdir" 2>/dev/null; then
-            echo "$$" >"$_bd_lockdir/pid" 2>/dev/null
-            _bd_lock_held=1
+        if ! command -v flock >/dev/null 2>&1; then
+            echo "beads-bootstrap: 'flock' not found — hydration will proceed without a concurrency lock." >&2
             return 0
         fi
-        _lock_pid="$(cat "$_bd_lockdir/pid" 2>/dev/null)"
-        if [ -n "$_lock_pid" ] && ! kill -0 "$_lock_pid" 2>/dev/null; then
-            rm -rf "$_bd_lockdir" 2>/dev/null
-            if mkdir "$_bd_lockdir" 2>/dev/null; then
-                echo "$$" >"$_bd_lockdir/pid" 2>/dev/null
-                _bd_lock_held=1
-                return 0
-            fi
+        # No `2>/dev/null` here: a bare `exec` (no command) applies its
+        # redirects to the CURRENT shell persistently, not just to this one
+        # statement — `2>/dev/null` on it would silently swallow every
+        # later stderr warning for the rest of the script's life, not just
+        # a failure of this one open. Let a genuine open failure print, and
+        # warn explicitly too so "lock open failed" isn't indistinguishable
+        # from "lock acquired" in the caller.
+        if ! exec 9>"$_bd_lockfile"; then
+            echo "beads-bootstrap: could not open $_bd_lockfile for locking — hydration will proceed without a concurrency lock." >&2
+            return 0
         fi
-        return 1
+        # fd 9 stays open (and inherited by bd/go/git children) for the rest
+        # of this process's life — that's what makes the flock self-release
+        # on any exit. Safe today because bd's embedded Dolt engine runs
+        # in-process per invocation rather than forking a long-lived
+        # daemon (per the header comment above); revisit if that changes.
+        flock -n 9
     }
 
     if [ -f .beads/issues.jsonl ] && ! _bd_hydrated; then
@@ -188,16 +198,26 @@ if command -v bd >/dev/null 2>&1; then
                 echo "beads-bootstrap: bd init reported success but the DB has no issues — treating as a failed hydration so it retries next session." >&2
                 rm -rf .beads/embeddeddolt
             fi
-            # The tracked-file restore and the lock release both happen in
-            # the EXIT trap above, so they also fire on an interrupted hook,
-            # not just a clean finish.
+            # The tracked-file restore happens in the EXIT trap above, so it
+            # also fires on an interrupted hook, not just a clean finish;
+            # the flock itself needs no explicit release — it's tied to fd 9
+            # and the kernel drops it when this process's descriptors close,
+            # on any exit path including SIGKILL.
         else
-            echo "beads-bootstrap: another bootstrap appears to be in progress (lock held) — skipping hydration this session; it will retry next session." >&2
+            # Another process holds the lock and is actively hydrating (or
+            # tearing down and rebuilding) .beads/embeddeddolt right now.
+            # Don't call `bd prime` here — it can read mid-rebuild state, or
+            # itself write to the DB (see the comment above `rm -rf
+            # .beads/embeddeddolt`) — race the concurrent hydration. Skip
+            # priming this session entirely; the next session's `bd count`
+            # probe re-evaluates from scratch.
+            echo "beads-bootstrap: another bootstrap appears to be in progress (lock held) — skipping this session; it will retry next session." >&2
+            exit 0
         fi
     fi
 
     # 3. Hand off to the beads-managed workflow-context hook.
-    bd prime
+    bd prime || echo "beads-bootstrap: 'bd prime' failed (exit $?)." >&2
 fi
 
 exit 0

--- a/dev/ci/bootstrap-beads.sh
+++ b/dev/ci/bootstrap-beads.sh
@@ -56,12 +56,17 @@ fi
 # never touch the tree.
 _bd_did_init=0
 _bd_pre_dirty=1
+_bd_lockdir=".beads/.bootstrap.lock"
+_bd_lock_held=0
 
 _beads_bootstrap_cleanup() {
+    [ "$_bd_lock_held" = 1 ] && rm -rf "$_bd_lockdir" 2>/dev/null
     [ "$_bd_did_init" = 1 ] || return 0
     [ "$_bd_pre_dirty" = 0 ] || return 0
     for _f in .beads/config.yaml .beads/.gitignore .gitignore; do
-        git ls-files --error-unmatch "$_f" >/dev/null 2>&1 && git checkout -- "$_f" 2>/dev/null
+        if git ls-files --error-unmatch "$_f" >/dev/null 2>&1; then
+            git checkout -- "$_f" || echo "beads-bootstrap: warning: failed to restore $_f — tree may be left dirty" >&2
+        fi
     done
 }
 trap '_beads_bootstrap_cleanup' EXIT
@@ -118,43 +123,77 @@ if command -v bd >/dev/null 2>&1; then
         [ -n "$_n" ] && [ "$_n" -gt 0 ] 2>/dev/null
     }
 
-    if [ -f .beads/issues.jsonl ] && ! _bd_hydrated; then
-        _bd_did_init=1
-        # Record whether the tree already had changes, so the restore below
-        # (via the trap) only runs on a clean fresh container and never
-        # touches a developer's in-progress edits to these config files.
-        # Checked separately from emptiness: a `git status` that itself
-        # errors (index lock contention, git missing, cwd outside a repo)
-        # must not be read as "clean".
-        if _bd_dirty_out="$(git status --porcelain -- .beads/config.yaml .beads/.gitignore .gitignore 2>&1)"; then
-            [ -z "$_bd_dirty_out" ] && _bd_pre_dirty=0
+    # Single-shot mutex around the hydration critical section below: two
+    # SessionStart hooks racing in the same container (e.g. two sessions
+    # attached to one environment) would otherwise both see "not hydrated"
+    # and both rm -rf/reinit .beads/embeddeddolt concurrently. No retry loop
+    # — if the lock is held by a live process we just skip hydration this
+    # run (self-heals next session via the same `bd count` probe); if the
+    # holder's PID is dead (e.g. it was SIGKILLed before it could release —
+    # no trap catches that), steal the lock instead of wedging forever.
+    _beads_bootstrap_acquire_lock() {
+        if mkdir "$_bd_lockdir" 2>/dev/null; then
+            echo "$$" >"$_bd_lockdir/pid" 2>/dev/null
+            _bd_lock_held=1
+            return 0
         fi
+        _lock_pid="$(cat "$_bd_lockdir/pid" 2>/dev/null)"
+        if [ -n "$_lock_pid" ] && ! kill -0 "$_lock_pid" 2>/dev/null; then
+            rm -rf "$_bd_lockdir" 2>/dev/null
+            if mkdir "$_bd_lockdir" 2>/dev/null; then
+                echo "$$" >"$_bd_lockdir/pid" 2>/dev/null
+                _bd_lock_held=1
+                return 0
+            fi
+        fi
+        return 1
+    }
 
-        echo "beads-bootstrap: hydrating beads DB from .beads/issues.jsonl..." >&2
-        # Our own health probe just said "not hydrated", so nothing of value
-        # is lost by clearing whatever's here first. This matters because
-        # step 3's `bd prime` lazily creates an empty Dolt DB as a side
-        # effect whenever none exists (confirmed by testing, not documented
-        # behavior) — so a prior failed/skipped attempt in this same
-        # container can leave an empty DB behind, and `bd init --from-jsonl`
-        # refuses to run against ANY existing DB ("already initialized")
-        # without this.
-        rm -rf .beads/embeddeddolt
-        # --stealth keeps beads files out of git (via .git/info/exclude), so
-        #   init makes NO commits — critical in a hook, which must never
-        #   auto-commit;
-        # --from-jsonl imports the committed .beads/issues.jsonl in the same
-        #   step;
-        # --non-interactive / --quiet for the non-TTY container.
-        if ! bd init --stealth --non-interactive --quiet --from-jsonl >/dev/null; then
-            echo "beads-bootstrap: 'bd init --from-jsonl' failed — beads DB unavailable this session." >&2
+    if [ -f .beads/issues.jsonl ] && ! _bd_hydrated; then
+        if _beads_bootstrap_acquire_lock; then
+            _bd_did_init=1
+            # Record whether the tree already had changes, so the restore
+            # below (via the trap) only runs on a clean fresh container and
+            # never touches a developer's in-progress edits to these config
+            # files. Checked separately from emptiness: a `git status` that
+            # itself errors (index lock contention, git missing, cwd outside
+            # a repo) must not be read as "clean". stderr is discarded, not
+            # merged into the captured text, so incidental stderr noise on
+            # an otherwise-successful, otherwise-empty status can't be
+            # mistaken for "dirty".
+            if _bd_dirty_out="$(git status --porcelain -- .beads/config.yaml .beads/.gitignore .gitignore 2>/dev/null)"; then
+                [ -z "$_bd_dirty_out" ] && _bd_pre_dirty=0
+            fi
+
+            echo "beads-bootstrap: hydrating beads DB from .beads/issues.jsonl..." >&2
+            # Our own health probe just said "not hydrated", so nothing of
+            # value is lost by clearing whatever's here first. This matters
+            # because step 3's `bd prime` lazily creates an empty Dolt DB as
+            # a side effect whenever none exists (confirmed by testing, not
+            # documented behavior) — so a prior failed/skipped attempt in
+            # this same container can leave an empty DB behind, and
+            # `bd init --from-jsonl` refuses to run against ANY existing DB
+            # ("already initialized") without this.
             rm -rf .beads/embeddeddolt
-        elif ! _bd_hydrated; then
-            echo "beads-bootstrap: bd init reported success but the DB has no issues — treating as a failed hydration so it retries next session." >&2
-            rm -rf .beads/embeddeddolt
+            # --stealth keeps beads files out of git (via .git/info/exclude), so
+            #   init makes NO commits — critical in a hook, which must never
+            #   auto-commit;
+            # --from-jsonl imports the committed .beads/issues.jsonl in the same
+            #   step;
+            # --non-interactive / --quiet for the non-TTY container.
+            if ! bd init --stealth --non-interactive --quiet --from-jsonl >/dev/null; then
+                echo "beads-bootstrap: 'bd init --from-jsonl' failed — beads DB unavailable this session." >&2
+                rm -rf .beads/embeddeddolt
+            elif ! _bd_hydrated; then
+                echo "beads-bootstrap: bd init reported success but the DB has no issues — treating as a failed hydration so it retries next session." >&2
+                rm -rf .beads/embeddeddolt
+            fi
+            # The tracked-file restore and the lock release both happen in
+            # the EXIT trap above, so they also fire on an interrupted hook,
+            # not just a clean finish.
+        else
+            echo "beads-bootstrap: another bootstrap appears to be in progress (lock held) — skipping hydration this session; it will retry next session." >&2
         fi
-        # The tracked-file restore itself happens in the EXIT trap above, so
-        # it also fires on an interrupted hook, not just a clean finish.
     fi
 
     # 3. Hand off to the beads-managed workflow-context hook.


### PR DESCRIPTION
### Description of the Change

`dev/ci/bootstrap-beads.sh` is a new `SessionStart` hook that makes `bd` (the beads issue tracker CLAUDE.md mandates for all task tracking) usable in Claude Code web/CI containers. Those containers start from a fresh clone with no `bd` binary and no Dolt database (`.beads/embeddeddolt/` is gitignored), so the committed `bd prime` hook was previously silently no-op'ing for an entire session.

The script:
- Installs `bd` via `go install` through the allowlisted Go module proxy (the upstream `curl|bash` installer's GitHub-release download is blocked by the agent proxy).
- Rehydrates the embedded Dolt DB from the committed `.beads/issues.jsonl`.
- Runs `bd prime` itself as its last step, and is the **only** `SessionStart` hook for beads — Claude Code runs same-event hooks concurrently rather than in array order, so a separate `bd prime` hook entry would race a `bd` this script hasn't finished installing yet.
- Is **opt-in**, not auto-detected: the install+hydrate steps only run when `BEADS_BOOTSTRAP=1` is set in an environment's persistent config. The cold-start install+hydrate can take a couple of minutes, and that cost should be a deliberate per-environment choice, not sprung on every session in every CI/remote container. Without the flag, the hook just primes an already-installed `bd` (near-zero cost) and exits — never installs, never hydrates.
- Checks hydration status via a `bd count` health probe rather than directory presence, since `bd init` creates the DB directory *before* importing — directory presence alone would falsely latch "hydrated" on a partial/failed import.
- Guards the hydration critical section with an `flock(1)` lock: atomic by construction (no TOCTOU window), and self-releasing on any process exit — including `SIGKILL`, which no shell trap can catch — so there's no separate staleness/steal logic to get wrong. A session that loses the lock race skips hydration *and* `bd prime` entirely for that run, rather than risk reading the DB mid-rebuild.
- Restores, via an `EXIT`/`INT`/`TERM` trap, the few tracked files (`.beads/config.yaml`, `.beads/.gitignore`, `.gitignore`) that `bd init --stealth` still normalizes even in stealth mode — but only when the tree was clean beforehand, never clobbering a developer's in-progress edits.

CLAUDE.md and `dev/ci/README.md` document the actual behavior (opt-in gating, idempotency, the concurrency lock, and the one known gap below) rather than an aspirational version.

### Benefits

- `bd` — and the beads-based issue-tracking workflow CLAUDE.md requires for all task tracking — becomes usable in every environment that opts in, instead of silently unavailable.
- No environment pays the cold-start cost unless it explicitly asked for beads tracking.
- Idempotent and strictly non-fatal by design: a warm container skips both install and hydration; any failure logs a warning and the session continues without bd, the same fail-open posture as the existing git hooks.

### Possible Drawbacks

- First cold start in an opted-in environment takes ~2-3 minutes (Go toolchain fetch + build) before the hook completes; an explicit 600s hook timeout is set so this isn't killed prematurely.
- Adds a dependency on the Go toolchain and module proxy being reachable in opted-in environments; if that's ever blocked too, bootstrapping fails the same non-fatal way (warns, session continues without bd) rather than a new failure mode.
- No shell trap can catch `SIGKILL` or survive a hard container teardown. If a hydration is killed that way, `.beads/config.yaml`, `.beads/.gitignore`, and `.gitignore` can be left modified in the working tree, and the *next* session's dirty-check will read that as a developer's in-progress edit and — by design — not auto-restore it either. This is called out explicitly in CLAUDE.md as a known, accepted gap (fixed by a manual `git checkout -- .beads/config.yaml .beads/.gitignore .gitignore`) rather than left as an implied guarantee.
- Opt-in means someone has to remember to set `BEADS_BOOTSTRAP=1` for a given environment; unlike the earlier auto-detected design, a forgotten flag means bd silently stays unavailable there (the original problem this PR set out to fix) — an accepted trade-off in exchange for never surprising an environment with an unwanted multi-minute install.

### Verification Process

- Ran `./dev/ci/preflight.sh` (this diff is shell + Markdown/JSON only, so clang-format/cppcheck/clang-tidy/semgrep auto-skip). The two remaining checks that failed (`json-symbols`, `install-headers`) are pre-existing failures on a clean `origin/master` checkout in this sandbox — confirmed unrelated to this diff by reproducing them against master before any of these changes existed.
- Ran the mandatory pre-PR adversarial-review subagent (per CLAUDE.md) on every substantive commit in this PR, including the opt-in gate rewrite.
- Live-tested extensively in a sandbox that happens to already match the target environment (no `bd` on `PATH`, no `.beads/embeddeddolt/`), by actually installing `bd` and running the script, inspecting real `git status`/`git diff` output for each scenario:
  - Cold hydrate under `BEADS_BOOTSTRAP=1` — install + DB hydration, tree clean afterward.
  - Opt-out default — confirmed install+hydrate is skipped even with `CI=true`/`CLAUDE_CODE_REMOTE=true` set, unless `BEADS_BOOTSTRAP=1` is also set; `BEADS_BOOTSTRAP=0` does not enable it (exact-match check).
  - Warm rerun — both steps no-op.
  - Dirty-tree guard — a pre-existing uncommitted edit to `.gitignore` is preserved, not clobbered.
  - `bd init --from-jsonl` failure path (corrupt JSONL) — warns, retries next session, doesn't leave a poisoned DB.
  - A real bug found *by* this testing: `bd prime` lazily creates an empty Dolt DB as an undocumented side effect, which then made a later `bd init --from-jsonl` abort with "already initialized". Fixed by clearing `.beads/embeddeddolt` before every hydration attempt, not just after a failure.
  - SIGTERM sent mid-hydration — confirmed dash does *not* terminate on a trapped signal unless the handler calls `exit` itself (a real bug caught this way and fixed); the process now exits promptly and the tree is left clean.
  - A genuine TOCTOU race in an earlier hand-rolled mkdir+pid-file lock (found by CodeRabbit's review, verified by hand-tracing) — replaced with `flock(1)`, and re-tested: lock contention against a real concurrent flock holder is skipped cleanly with no `bd prime` race, and release is automatic on any exit.
  - A real bug found while fixing the above: a bare `exec 9>file 2>/dev/null` was silently redirecting the *rest of the script's* stderr to `/dev/null`, not just that one line's — caught because a diagnostic message went missing in testing.
  - Forced `git checkout` failure during restore — now logs a per-file warning instead of silently leaving the tree dirty with no diagnostic trace.

### Applicable Issues

N/A — no linked issue. This fixes a self-discovered gap: `bd` was unavailable for an entire prior session because of exactly the problems fixed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved SessionStart automation in ephemeral web/CI containers to make the `bd` CLI available, bootstrap/hydrate the embedded issue database from committed data, and run `bd prime`.
  * Added an explicit execution timeout and ensured bootstrapping is opt-in via `BEADS_BOOTSTRAP=1`, with idempotent, concurrency-safe behavior and graceful fallbacks.

* **Documentation**
  * Expanded CI/Web bootstrap documentation with the install/bootstrap/prime flow, enablement guidance, cleanup/troubleshooting notes, and issue sync expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->