### PR TITLE
incompressible 2/5: simplify the fitting pipeline and audit the reference data

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -807,6 +807,11 @@ jobs:
     # twin: the `incomp-sanity` check in dev/ci/preflight.sh.
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
+    # Least privilege: this job runs PR-authored test code, and needs nothing
+    # beyond reading the tree. Without an explicit block it would inherit the
+    # repository default, which is broader.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -822,7 +822,12 @@ jobs:
       # uvx pyright@1.1.409): unpinned, a fresh pytest release could turn this
       # required check red on unrelated PRs.
       - name: Run incompressible JSON sanity checks
-        run: uvx pytest@9.1.1 dev/incompressible_liquids/test_json_sanity.py -q --color=no
+        # The whole directory, with numpy+scipy: test_data_sanity (grid axis
+        # ordering) and test_fitting_regression (golden-master refit) are the two
+        # safeguards this area relies on, and both importorskip away without
+        # them -- so naming only test_json_sanity.py meant they never ran here.
+        # `uvx --with` matches the pyright job above.
+        run: uvx --with numpy --with scipy pytest@9.1.1 dev/incompressible_liquids/ -q --color=no
 
   installed-header-gate:
     name: Installed-header hygiene gate

--- a/Web/fluid_properties/Incompressibles.rst
+++ b/Web/fluid_properties/Incompressibles.rst
@@ -231,6 +231,26 @@ compositions as independent fluids. This should be kept in mind when comparing
 properties for different compositions. Setting the reference state for one
 composition will always affect all fluids consisting of the same components.
 
+.. warning::
+   Enthalpy and entropy for incompressible mixtures are obtained purely by
+   integrating the fitted heat capacity :math:`c(T,x)` in temperature; there is
+   **no enthalpy or entropy of mixing term** anywhere in this calculation. Two
+   states at different compositions that happen to be queried at the same
+   :math:`T` and :math:`p` do **not** have enthalpies that are comparable across
+   that composition change, and a mixing/energy balance across streams of
+   different concentration (for example, an absorption chiller's generator or
+   absorber) will silently omit the heat of mixing. This is a known,
+   long-standing limitation, not a bug to be patched incrementally — see
+   `#533 <https://github.com/CoolProp/CoolProp/issues/533>`_,
+   `#781 <https://github.com/CoolProp/CoolProp/issues/781>`_, and
+   `#1690 <https://github.com/CoolProp/CoolProp/issues/1690>`_. A proper fix
+   needs a composition-dependent excess-property formulation (e.g. a
+   Gibbs-energy-based model, as used for some published LiBr/H2O and NH3/H2O
+   correlations) rather than an incremental change to the current
+   heat-capacity-integration approach; see
+   ``dev/incompressible_liquids/NOTES_mixing_models.md`` for research notes
+   toward that future work.
+
 .. The approach described in textbooks like Cengel and Boles :cite:`Cengel2007`
 .. is that the internal energy :math:`u` only depends on temperature and does not
 .. change with pressure.
@@ -299,27 +319,42 @@ Therefore, all solutions have a base temperature and concentration in the origin
 works as well as in CoolProp: :math:`x_\text{in} = x - x_\text{base}`
 and :math:`T_\text{in} = T - T_\text{base}`, this technique does not affect the calculation
 of the derived quantity internal energy since the formula contains temperature differences.
-However, integrating :math:`c(x_\text{in},T_\text{in})T_\text{in}^{-1}dT_\text{in}` for the entropy requires some changes due to
-the logarithm.
+However, computing :math:`c(x_\text{in},T_\text{in})/T` for the entropy requires some changes
+because the integral is taken with respect to the physical temperature :math:`T`, not
+:math:`T_\text{in}`, even though :math:`c` itself is expressed in the centred variable.
 
-.. warning::
-   You must **not** use the base temperature :math:`T_\text{base}`
-   as reference temperature for your thermodynamic states. This will lead to an
-   error caused by a division by zero during the integration carried out to
-   obtain the entropy.
-
-To structure the problem, we introduce a variable :math:`f(j,T)`,
-which will be expressed by a third sum. As a first step for simplification, one
-has to expand the the binomial :math:`(T-T_{base})^n` to a series. Only
-containing :math:`j` and :math:`T`, :math:`f` is independent from :math:`x_\text{in}` and
-can be computed outside the loop for enhanced computational efficiency. An
-integration of the expanded binomial then yields the final factor :math:`F` to
-be multiplied with the other coefficients and the concentration.
+To structure the problem, we introduce a variable :math:`D(j,T)`,
+the indefinite integral of :math:`(T-T_\text{base})^j/T` with respect to :math:`T`,
+evaluated at the point :math:`T`. As a first step for simplification, one
+has to expand the binomial :math:`(T-T_{base})^j` to a series before dividing by
+:math:`T` and integrating term by term:
 
 .. math::
 
-    \int_{0}^{1} \left( \frac{\partial s}{\partial T} \right)_p dT          &= \int_{0}^{1} \frac{c\left( x_\text{in},T_\text{in} \right)}{T_\text{in}} dT_\text{in} = \sum_{i=0}^n x_\text{in}^i \cdot \sum_{j=0}^m C_{c}[i,j] \cdot F(j,T_\text{in,0},T_\text{in,1}) \\
-    F          &= (-1)^j \cdot \ln \left( \frac{T_\text{in,1}}{T_\text{in,0}} \right) \cdot T_{base}^j + \sum_{k=0}^{j-1} \binom{j}{k} \cdot \frac{(-1)^k}{j-k} \cdot \left( T_\text{in,1}^{j-k} - T_\text{in,0}^{j-k} \right) \cdot T_{base}^k
+    \left( \frac{\partial s}{\partial T} \right)_p          &= \frac{c\left( x_\text{in},T_\text{in} \right)}{T} \quad\text{so that}\quad \int \left( \frac{\partial s}{\partial T} \right)_p dT = \sum_{i=0}^n x_\text{in}^i \cdot \sum_{j=0}^m C_{c}[i,j] \cdot D(j,T) \\
+    D(j,T)          &= (-1)^j \cdot \ln \left( T \right) \cdot T_{base}^j + \sum_{k=0}^{j-1} \binom{j}{k} \cdot \frac{(-1)^k}{j-k} \cdot T^{j-k} \cdot T_{base}^k
+
+Dividing by the physical :math:`T` rather than :math:`T_\text{in}` is what keeps this
+well-defined at :math:`T = T_\text{base}`: the only term that depends on a logarithm
+is :math:`\ln(T)`, which is finite for any :math:`T>0` regardless of where
+:math:`T_\text{base}` falls, so there is no removable singularity at
+:math:`T=T_\text{base}` to guard against here. :math:`D(j,T)` is the *indefinite*
+integral; entropy and enthalpy differences between two states are obtained by
+evaluating it once per state and subtracting (see ``IncompressibleBackend::raw_calc_smass``
+and the reference-state handling around it), not by passing two temperatures into
+a single call.
+
+A related, narrower issue does exist in :math:`(\partial \rho/\partial T)_{p,x}`
+(used internally by both enthalpy and entropy through the pressure-dependent terms):
+differentiating a fitted, centred polynomial introduces a bookkeeping term that
+divides by :math:`(T-T_\text{base})`. For an ordinary (non-fractional) fit, that
+term's coefficient is *exactly* zero — not merely small — so CoolProp returns the
+exact value at :math:`T=T_\text{base}` rather than approximating it. The
+exponential-type fits used for some fluids' viscosity, vapour pressure, and
+freezing temperature have a different, genuine pole in their own functional form
+(at a fit-coefficient-dependent point, not necessarily :math:`T_\text{base}`); that
+case is still handled by a tiny linear interpolation across the pole rather than
+an exact formula, since the function genuinely diverges there.
 
 .. _Equations:
 

--- a/Web/fluid_properties/Incompressibles.rst
+++ b/Web/fluid_properties/Incompressibles.rst
@@ -481,22 +481,27 @@ Adding New Fluids
 -----------------
 
 To add a fluid to the backend for incompressible fluids, you have to have the tabulated
-property data available. Pure fluids are added to the ``PureFluids.py`` and binary 
-mixtures, like aqueous mixtures, have to be added to the ``SolutionFLuids.py``. 
+property data available. Pure fluids are added to the ``PureFluids.py`` and binary
+mixtures, like aqueous mixtures, have to be added to the ``SolutionFluids.py``. A
+step-by-step walk-through, including the expected units and the commands to run, is in
+``dev/incompressible_liquids/README.md``.
 
 The basic state variable for incompressible fluids is temperature, which should be provided
 as a one-dimensional numpy array with length :math:`N`. For pure fluids, all properties should match
 this temperature array in size since there is a 1-to-1 relation between the temperature points
-and the other quantities. 
+and the other quantities.
 
 For binary mixtures, you also need a composition vector to define the data points properly.
-This composition vector is also a one-dimensional numpy array of the lenghth :math:`M` and forms the 
+This composition vector is also a one-dimensional numpy array of the length :math:`M` and forms the
 second axis for your property space with :math:`N \times M` data points.
 
-Note that all properties have to have the same grid in terms of temperature and composition. 
+Note that all properties have to have the same grid in terms of temperature and composition.
+Properties you have no data for should simply not be set: they are then marked as
+``notdefined`` in the generated JSON and the backend raises a clear error when they are
+queried, instead of returning made-up values.
 
-Once you haver added your fluid data, you can regenrate the JSON files with the fitted 
-parameters by running the script located at ``dev/incompressible_liquids/all_incompressibles.py``. 
+Once you have added your fluid data, you can regenerate the JSON files with the fitted
+parameters by running the script located at ``dev/incompressible_liquids/all_incompressibles.py``.
 Your new fluid is now part of the codebase and should be available to all CoolProp functions as
 soon as you recompile the sources.
 

--- a/Web/fluid_properties/Incompressibles.rst
+++ b/Web/fluid_properties/Incompressibles.rst
@@ -47,12 +47,12 @@ Technology (`NIST <https://www.nist.gov>`_).
 
 .. note::
   If you use a mixture, the reference state gets updated each time you change
-  the composition. Furthermore, not all temperatures can be used as reference
-  temperature since the fraction :math:`T_\text{in,1} / T_\text{in,0}` occurs in the integral used to
-  calculate entropy. The centered fits have a base temperature and setting
-  :math:`T_\text{ref}` equal to :math:`T_\text{base}` yields :math:`T_\text{in,0}=0\:\text{K}`,
-  which obviously is a problem. For non-centred fits, the base temperature is
-  equal to 0 K. Read on :ref:`below<BaseValue>` for more details.
+  the composition. Any temperature inside the fluid's validity range may be
+  used as the reference temperature, including one that coincides with a
+  centred fit's base temperature :math:`T_\text{base}`: the entropy integral
+  divides by the *physical* temperature :math:`T`, not by the centred
+  :math:`T_\text{in} = T - T_\text{base}`, so it stays well-defined for every
+  :math:`T>0`. Read on :ref:`below<BaseValue>` for the derivation.
 
 
 Pure Fluid Examples

--- a/dev/ci/preflight.sh
+++ b/dev/ci/preflight.sh
@@ -480,10 +480,13 @@ fi
 
 # ---------- check 8: incompressible JSON sanity -----------------------
 #
-# test_json_sanity.py guards the committed json/*.json against unfitted
-# placeholders, all-zero templates, non-numeric or non-finite values, and
-# blocks the C++ loader would reject.  Nothing ran it before this check.
-# Scoped to runs touching the incompressible data or its writer.
+# Guards the committed json/*.json against unfitted placeholders, all-zero
+# templates, non-numeric or non-finite values, and blocks the C++ loader would
+# reject; also the grid-axis ordering contract and the golden-master refit.
+# Nothing ran any of it before this check.  Scoped to runs touching the
+# incompressible data or its writer.  The pytest path runs the whole directory;
+# the fallback below runs only test_json_sanity.py, the one module that needs
+# neither numpy nor scipy.
 step "incompressible JSON sanity"
 if skip_check incomp-sanity; then
     skip "incomp-sanity" "--skip=incomp-sanity"
@@ -499,7 +502,7 @@ else
         # --color=no is load-bearing: with PY_COLORS/FORCE_COLOR set pytest
         # emits ANSI even when redirected, so the count grep below scores 0 and
         # a passing run is reported as "verified nothing".
-        python3 -m pytest dev/incompressible_liquids/test_json_sanity.py -q --color=no >"$INCOMP_LOG" 2>&1 || INCOMP_RC=$?
+        python3 -m pytest dev/incompressible_liquids/ -q --color=no >"$INCOMP_LOG" 2>&1 || INCOMP_RC=$?
     else
         # pytest is not required: the checks are plain asserts, so call them
         # directly rather than skip the gate.  Exiting non-zero on an empty or

--- a/dev/incompressible_liquids/CPIncomp/BaseObjects.py
+++ b/dev/incompressible_liquids/CPIncomp/BaseObjects.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function
 import numpy as np
 from scipy.optimize import minimize, curve_fit
 import sys
@@ -110,9 +109,6 @@ class IncompressibleData(object):
         if x is None and not self.xData is None: x = self.xData
         if y is None and not self.yData is None: y = self.yData
 
-        #res = None
-        #r2 = None
-
         res, sErr = IncompressibleFitter.fitter(x=x, y=y, z=self.data, \
                   xbase=xbase, ybase=ybase, \
                   eqnType=self.type, \
@@ -151,14 +147,6 @@ class IncompressibleData(object):
                           eqnType=self.type, \
                           coeffs=self.coeffs, DEBUG=self.DEBUG)
 
-#            elif self.type==IncompressibleData.INCOMPRESSIBLE_EXPPOLYNOMIAL:
-#                if self.DEBUG: print("Poor solution found with exponential polynomial, trying once more with normal polynomial.")
-#                self.type=IncompressibleData.INCOMPRESSIBLE_POLYNOMIAL
-#                self.coeffs = np.zeros((4,6))
-#                res,sErr = IncompressibleFitter.fitter(x=x, y=y, z=self.data, \
-#                      xbase=xbase, ybase=ybase, \
-#                      eqnType=self.type, \
-#                      coeffs=self.coeffs, DEBUG=self.DEBUG)
 
             RMS = np.sqrt(np.square(sErr).mean()).sum()
             if RMS < bestRMS:  # Better fit
@@ -188,9 +176,6 @@ class IncompressibleData(object):
                 raise ValueError("Unknown function.")
 
             #if self.DEBUG: print("Fitting statistics:")
-            # SSE = np.square(self.sErr).sum() # Sum of squares due to error
-            #SST = ((zData-zData.mean())**2).sum()
-            #R2  = 1-(ssErr/ssTot )
 
     def setxData(self, xData):
         if self.xData is None:
@@ -389,15 +374,6 @@ class IncompressibleFitter(object):
             raise ValueError("Unknown function.")
 
 
-#    def getCoeffs1d(self, x, z, order):
-#        if (len(x)<order+1):
-#            raise ValueError("You have only {0} elements and try to fit {1} coefficients, please reduce the order.".format(len(x),order+1))
-#        A = np.vander(x,order+1)[:,::-1]
-#        #Anew = np.dot(A.T,A)
-#        #znew = np.dot(A.T,z)
-#        #coeffs = np.linalg.solve(Anew, znew)
-#        coeffs, resids, rank, singulars  = np.linalg.lstsq(A, z)
-#        return np.reshape(coeffs, (len(x),1))
 
     @staticmethod
     def getCoeffs2d(x_in, y_in, z_in, x_order, y_order, DEBUG=False):

--- a/dev/incompressible_liquids/CPIncomp/BaseObjects.py
+++ b/dev/incompressible_liquids/CPIncomp/BaseObjects.py
@@ -1,7 +1,6 @@
 from __future__ import division, print_function
 import numpy as np
-from scipy.optimize._minimize import minimize
-from scipy.optimize.minpack import curve_fit
+from scipy.optimize import minimize, curve_fit
 import sys
 
 # Here we define the types. This is done to keep the definitions at one

--- a/dev/incompressible_liquids/CPIncomp/BaseObjects.py
+++ b/dev/incompressible_liquids/CPIncomp/BaseObjects.py
@@ -25,6 +25,19 @@ class IncompressibleData(object):
     SOURCE_COEFFS = 'coefficients'
     SOURCE_NOT_SET = 'notdefined'
 
+    # Optimizer starting guesses for the iterative (exponential-type) fits.
+    #
+    # These are the single source of truth. They are compared against committed
+    # coefficients to detect a fit that silently failed and left its starting
+    # guess behind (SolutionDataWriter.clearUnfittedCoefficients, and the
+    # test_json_sanity guard) -- so a literal duplicated anywhere else would,
+    # once it drifted, stop recognising a failed fit and let the placeholder
+    # ship again. That is exactly the #1331 / #2567 bug class.
+    VISCOSITY_GUESS = np.array([+5e+2, -6e+1, +1e+1])
+    PSAT_GUESS = np.array([-5e+3, +6e+1, -1e+1])
+    TFREEZE_GUESS = np.array([+7e+2, -6e+1, +1e+1])
+    LOGEXP_GUESS = np.array([-250.0, 1.5, 10.0])
+
     maxLin = np.finfo(np.float64).max - 1
     minLin = -maxLin
 
@@ -125,7 +138,7 @@ class IncompressibleData(object):
             if self.type == IncompressibleData.INCOMPRESSIBLE_EXPONENTIAL:
                 if self.DEBUG: print("Poor solution found with exponential, trying once more with log exponential.")
                 self.type = IncompressibleData.INCOMPRESSIBLE_LOGEXPONENTIAL
-                self.coeffs = np.array([-250, 1.5, 10])
+                self.coeffs = np.copy(IncompressibleData.LOGEXP_GUESS)
                 res, sErr = IncompressibleFitter.fitter(x=x, y=y, z=self.data, \
                       xbase=xbase, ybase=ybase, \
                       eqnType=self.type, \
@@ -223,6 +236,22 @@ class IncompressibleData(object):
 
 
 class IncompressibleFitter(object):
+
+    @staticmethod
+    def sortGridAxes(grid):
+        """Order a data grid by its own axis values, in place.
+
+        A grid holds concentration along its first row and temperature down
+        its first column. Some source tables ship with a descending axis (the
+        HFE-7100 files store T from +64 down to -80 degC), so the file order
+        cannot be trusted; a stable sort also handles files that are shuffled
+        rather than exactly reversed. test_data_sanity.py pins this ordering
+        contract, so keep it defined once here rather than pasted into each
+        loader.
+        """
+        grid[1:, :] = grid[1:, :][np.argsort(grid[1:, 0], kind="stable"), :]
+        grid[:, 1:] = grid[:, 1:][:, np.argsort(grid[0, 1:], kind="stable")]
+        return grid
 
     @staticmethod
     def allClose(a, b):

--- a/dev/incompressible_liquids/CPIncomp/BaseObjects.py
+++ b/dev/incompressible_liquids/CPIncomp/BaseObjects.py
@@ -37,6 +37,12 @@ class IncompressibleData(object):
     PSAT_GUESS = np.array([-5e+3, +6e+1, -1e+1])
     TFREEZE_GUESS = np.array([+7e+2, -6e+1, +1e+1])
     LOGEXP_GUESS = np.array([-250.0, 1.5, 10.0])
+    # SecCoolSolutionData.fitFluid seeds its single-composition exponential
+    # viscosity fit with this triple. It happens to equal TFREEZE_GUESS, which
+    # is why clearUnfittedCoefficients already caught it -- but relying on that
+    # coincidence is exactly the drift this block exists to prevent, so name it
+    # separately and register it alongside the others.
+    SECCOOL_VISCOSITY_GUESS = np.array([+7e+2, -6e+1, +1e+1])
 
     maxLin = np.finfo(np.float64).max - 1
     minLin = -maxLin

--- a/dev/incompressible_liquids/CPIncomp/CoefficientFluids.py
+++ b/dev/incompressible_liquids/CPIncomp/CoefficientFluids.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function
 import numpy as np
 from .DataObjects import CoefficientData, PureData
 

--- a/dev/incompressible_liquids/CPIncomp/DataObjects.py
+++ b/dev/incompressible_liquids/CPIncomp/DataObjects.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function
 import numpy as np
 import os, math
 from .BaseObjects import IncompressibleData, IncompressibleFitter
@@ -61,20 +60,6 @@ class SolutionData(object):
         self.uref = 0.0
         self.rhoref = 0.0
 
-#    def getDataObjects(self):
-#        objList  = {}
-#        objList["temperature"] = self.temperature
-#        objList["concentration"] = self.concentration
-#        objList["density"] = self.density
-#        objList["specific_heat"] = self.specific_heat
-#        objList["viscosity"] = self.viscosity
-#        objList["conductivity"] = self.conductivity
-#        objList["saturation_pressure"] = self.saturation_pressure
-#        objList["T_freeze"] = self.T_freeze
-#        objList["volume2mass"] = self.volume2mass
-#        objList["mass2mole"] = self.mass2mole
-#        return objList
-
     def roundSingle(self, x):
         if x == 0.0: return 0.0
         return round(x, self.significantDigits - int(math.floor(math.log10(abs(x)))) - 1)
@@ -87,24 +72,6 @@ class SolutionData(object):
                 if np.isfinite(res[i, j]):
                     res[i, j] = self.roundSingle(res[i, j])
         return res
-
-#    def getPolyObjects(self):
-#        objList  = {}
-#        objList["density"] = self.density
-#        objList["specific heat"] = self.specific_heat
-##        objList["viscosity"] = self.viscosity
-#        objList["conductivity"] = self.conductivity
-##        objList["saturation_pressure"] = self.saturation_pressure
-##        objList["T_freeze"] = self.T_freeze
-##        objList["volume2mass"] = self.volume2mass
-##        objList["mass2mole"] = self.mass2mole
-#        return objList
-#
-#    def getExpPolyObjects(self):
-#        objList  = {}
-#        objList["viscosity"] = self.viscosity
-#        objList["saturation pressure"] = self.saturation_pressure
-#        return objList
 
     def checkT(self, T, p, x):
         if self.Tmin <= 0.: raise ValueError("Please specify the minimum temperature.")
@@ -525,26 +492,6 @@ class CoefficientData(SolutionData):
         return tmp
 
     def setMelinderMatrix(self, matrix):
-#        matrix = np.array([
-#        [-26.29           , 958.1           ,3887           ,   0.4175            ,   1.153           ],
-#        [ -0.000002575    ,  -0.4151        ,   7.201       ,   0.0007271         ,  -0.03866         ],
-#        [ -0.000006732    ,  -0.002261      ,  -0.08979     ,   0.0000002823      ,   0.0002779       ],
-#        [  0.000000163    ,   0.0000002998  ,  -0.000439    ,   0.000000009718    ,  -0.000001543     ],
-#        [ -1.187          ,  -1.391         , -18.5         ,  -0.004421          ,   0.005448        ],
-#        [ -0.00001609     ,  -0.0151        ,   0.2984      ,  -0.00002952        ,   0.0001008       ],
-#        [  0.000000342    ,   0.0001113     ,  -0.001865    ,   0.00000007336     ,  -0.000002809     ],
-#        [  0.0000000005687,  -0.0000003264  ,  -0.00001718  ,   0.0000000004328   ,   0.000000009811  ],
-#        [ -0.01218        ,  -0.01105       ,  -0.03769     ,   0.00002044        ,  -0.0005552       ],
-#        [  0.0000003865   ,   0.0001828     ,  -0.01196     ,   0.0000003413      ,   0.000008384     ],
-#        [  0.000000008768 ,  -0.000001641   ,   0.00009801  ,  -0.000000003665    ,  -0.00000003997   ],
-#        [ -0.0000000002095,   0.0000000151  ,   0.000000666 ,  -0.00000000002791  ,  -0.0000000003466 ],
-#        [ -0.00006823     ,  -0.0001208     ,  -0.003776    ,   0.0000002943      ,   0.000003038     ],
-#        [  0.00000002137  ,   0.000002992   ,  -0.00005611  ,  -0.0000000009646   ,  -0.00000007435   ],
-#        [ -0.0000000004271,   0.000000001455,  -0.0000007811,   0.00000000003174  ,   0.0000000007442 ],
-#        [  0.0000001297   ,   0.000004927   ,  -0.0001504   ,  -0.0000000008666   ,   0.00000006669   ],
-#        [ -0.0000000005407,  -0.0000001325  ,   0.000007373 ,  -0.0000000000004573,  -0.0000000009105 ],
-#        [  0.00000002363  ,  -0.00000007727 ,   0.000006433 ,  -0.0000000002033   ,  -0.0000000008472 ]
-#        ])
 
         coeffs = self.convertMelinderMatrix(matrix).T
 
@@ -553,7 +500,6 @@ class CoefficientData(SolutionData):
         self.T_freeze.coeffs = self.convertMelinderArray(coeffs[0])
         self.T_freeze.coeffs[0, 0] += 273.15
         self.T_freeze.coeffs = np.array([self.T_freeze.coeffs[0]])
-        # print(self.T_freeze.coeffs)
 
         self.density.source = self.density.SOURCE_COEFFS
         self.density.type = self.density.INCOMPRESSIBLE_POLYNOMIAL

--- a/dev/incompressible_liquids/CPIncomp/DataObjects.py
+++ b/dev/incompressible_liquids/CPIncomp/DataObjects.py
@@ -251,6 +251,11 @@ class DigitalData(SolutionData):
     def getFromFile(self, data):
         fullPath = self.getFile(data)
         _, _, res = IncompressibleFitter.shapeArray(np.loadtxt(fullPath))
+        # Order the grid by its own axis values (first column = temperature,
+        # first row = concentration) rather than trusting the file order --
+        # see the matching sort in SecCoolSolutionData.getFromFile.
+        res[1:, :] = res[1:, :][np.argsort(res[1:, 0]), :]
+        res[:, 1:] = res[:, 1:][:, np.argsort(res[0, 1:])]
         return res
 
     def writeToFile(self, data, array):

--- a/dev/incompressible_liquids/CPIncomp/DataObjects.py
+++ b/dev/incompressible_liquids/CPIncomp/DataObjects.py
@@ -251,12 +251,7 @@ class DigitalData(SolutionData):
     def getFromFile(self, data):
         fullPath = self.getFile(data)
         _, _, res = IncompressibleFitter.shapeArray(np.loadtxt(fullPath))
-        # Order the grid by its own axis values (first column = temperature,
-        # first row = concentration) rather than trusting the file order --
-        # see the matching sort in SecCoolSolutionData.getFromFile.
-        res[1:, :] = res[1:, :][np.argsort(res[1:, 0]), :]
-        res[:, 1:] = res[:, 1:][:, np.argsort(res[0, 1:])]
-        return res
+        return IncompressibleFitter.sortGridAxes(res)
 
     def writeToFile(self, data, array):
         fullPath = self.getFile(data)

--- a/dev/incompressible_liquids/CPIncomp/DigitalFluids.py
+++ b/dev/incompressible_liquids/CPIncomp/DigitalFluids.py
@@ -9,7 +9,6 @@ from the equations from the publication to the standard
 parameter form.
 
 """
-from __future__ import division, print_function
 import numpy as np
 from .DataObjects import DigitalData, PureData
 

--- a/dev/incompressible_liquids/CPIncomp/ExampleObjects.py
+++ b/dev/incompressible_liquids/CPIncomp/ExampleObjects.py
@@ -107,22 +107,31 @@ class DigitalExamplePure(PureData, DigitalData):
         self.temperature.data = self.getTrange()
         self.concentration.data = self.getxrange()
 
-        import CoolProp.CoolProp as CP
+        # The property functions need the CoolProp Python package. Without
+        # it, fall back to the cached grids in data/ExampleDigitalPure_*.txt
+        # (getArray with func=None reads the file instead of regenerating).
+        try:
+            import CoolProp.CoolProp as CP
+        except ImportError:
+            CP = None
 
-        def funcD(T, x):
-            return CP.PropsSI('D', 'T', T, 'P', 1e7, 'water')
+        if CP is not None:
+            def funcD(T, x):
+                return CP.PropsSI('D', 'T', T, 'P', 1e7, 'water')
 
-        def funcC(T, x):
-            return CP.PropsSI('C', 'T', T, 'P', 1e7, 'water')
+            def funcC(T, x):
+                return CP.PropsSI('C', 'T', T, 'P', 1e7, 'water')
 
-        def funcL(T, x):
-            return CP.PropsSI('L', 'T', T, 'P', 1e7, 'water')
+            def funcL(T, x):
+                return CP.PropsSI('L', 'T', T, 'P', 1e7, 'water')
 
-        def funcV(T, x):
-            return CP.PropsSI('V', 'T', T, 'P', 1e7, 'water')
+            def funcV(T, x):
+                return CP.PropsSI('V', 'T', T, 'P', 1e7, 'water')
 
-        def funcP(T, x):
-            return CP.PropsSI('P', 'T', T, 'Q', 0.0, 'water')
+            def funcP(T, x):
+                return CP.PropsSI('P', 'T', T, 'Q', 0.0, 'water')
+        else:
+            funcD = funcC = funcL = funcV = funcP = None
 
         self.density.xData, self.density.yData, self.density.data = self.getArray(dataID="D", func=funcD, x_in=self.temperature.data, y_in=self.concentration.data, DEBUG=self.density.DEBUG)
         self.density.source = self.density.SOURCE_EQUATION

--- a/dev/incompressible_liquids/CPIncomp/ExampleObjects.py
+++ b/dev/incompressible_liquids/CPIncomp/ExampleObjects.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function
 import numpy as np
 from .DataObjects import PureData, SolutionData, DigitalData,\
     CoefficientData

--- a/dev/incompressible_liquids/CPIncomp/MelinderFluids.py
+++ b/dev/incompressible_liquids/CPIncomp/MelinderFluids.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function
 import numpy as np
 from .DataObjects import PureData, CoefficientData
 from .BaseObjects import IncompressibleFitter

--- a/dev/incompressible_liquids/CPIncomp/PureFluids.py
+++ b/dev/incompressible_liquids/CPIncomp/PureFluids.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function
 import numpy as np
 from .DataObjects import PureData
 

--- a/dev/incompressible_liquids/CPIncomp/SecCoolFluids.py
+++ b/dev/incompressible_liquids/CPIncomp/SecCoolFluids.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function
 import numpy as np
 from .BaseObjects import IncompressibleData, IncompressibleFitter
 from .DataObjects import DigitalData, PureData

--- a/dev/incompressible_liquids/CPIncomp/SecCoolFluids.py
+++ b/dev/incompressible_liquids/CPIncomp/SecCoolFluids.py
@@ -275,10 +275,12 @@ class SecCoolSolutionData(DigitalData):
                     if i == 0: nu = 0.0  # Dummy for tables without concentration (TFreeze and Vol2Mass)
                     pass
                 numbers[i, j] = nu
-        if numbers[1, 0] > numbers[-1, 0]:
-            numbers[1:, :] = numbers[1:, :][::-1, :]
-        if numbers[0, 1] > numbers[0, -1]:
-            numbers[:, 1:] = numbers[:, 1:][:, ::-1]
+        # Some source tables ship with descending axes (the HFE-7100 files
+        # store T from +64 down to -80 degC). Sort rows/columns by their
+        # axis values instead of trusting the file order -- a sort also
+        # covers files that are shuffled rather than exactly reversed.
+        numbers[1:, :] = numbers[1:, :][np.argsort(numbers[1:, 0]), :]
+        numbers[:, 1:] = numbers[:, 1:][:, np.argsort(numbers[0, 1:])]
         return numbers
 
     def writeToFile(self, data, array):
@@ -501,10 +503,12 @@ class SecCoolIceData(SecCoolSolutionData):
                     if i == 0: nu = 0.0  # Dummy for tables without concentration (TFreeze and Vol2Mass)
                     pass
                 numbers[i, j] = nu
-        if numbers[1, 0] > numbers[-1, 0]:
-            numbers[1:, :] = numbers[1:, :][::-1, :]
-        if numbers[0, 1] > numbers[0, -1]:
-            numbers[:, 1:] = numbers[:, 1:][:, ::-1]
+        # Some source tables ship with descending axes (the HFE-7100 files
+        # store T from +64 down to -80 degC). Sort rows/columns by their
+        # axis values instead of trusting the file order -- a sort also
+        # covers files that are shuffled rather than exactly reversed.
+        numbers[1:, :] = numbers[1:, :][np.argsort(numbers[1:, 0]), :]
+        numbers[:, 1:] = numbers[:, 1:][:, np.argsort(numbers[0, 1:])]
         return numbers
 
 

--- a/dev/incompressible_liquids/CPIncomp/SecCoolFluids.py
+++ b/dev/incompressible_liquids/CPIncomp/SecCoolFluids.py
@@ -166,10 +166,10 @@ class SecCoolSolutionData(DigitalData):
         try:
             tried = False
             if len(self.viscosity.yData) == 1:  # and np.isfinite(fluidObject.viscosity.data).sum()<10:
-                self.viscosity.coeffs = np.array([+7e+2, -6e+1, +1e+1])
+                self.viscosity.coeffs = np.copy(IncompressibleData.SECCOOL_VISCOSITY_GUESS)
                 self.viscosity.type = IncompressibleData.INCOMPRESSIBLE_EXPONENTIAL
                 self.viscosity.fitCoeffs(self.Tbase, self.xbase)
-                if self.viscosity.coeffs is None or IncompressibleFitter.allClose(self.viscosity.coeffs, np.array([+7e+2, -6e+1, +1e+1])):  # Fit failed
+                if self.viscosity.coeffs is None or IncompressibleFitter.allClose(self.viscosity.coeffs, IncompressibleData.SECCOOL_VISCOSITY_GUESS):  # Fit failed
                     tried = True
             if len(self.viscosity.yData) > 1 or tried:
                 self.viscosity.coeffs = np.copy(std_coeffs)  # np.zeros(np.round(np.array(std_coeffs.shape) * 1.5))

--- a/dev/incompressible_liquids/CPIncomp/SecCoolFluids.py
+++ b/dev/incompressible_liquids/CPIncomp/SecCoolFluids.py
@@ -275,13 +275,7 @@ class SecCoolSolutionData(DigitalData):
                     if i == 0: nu = 0.0  # Dummy for tables without concentration (TFreeze and Vol2Mass)
                     pass
                 numbers[i, j] = nu
-        # Some source tables ship with descending axes (the HFE-7100 files
-        # store T from +64 down to -80 degC). Sort rows/columns by their
-        # axis values instead of trusting the file order -- a sort also
-        # covers files that are shuffled rather than exactly reversed.
-        numbers[1:, :] = numbers[1:, :][np.argsort(numbers[1:, 0]), :]
-        numbers[:, 1:] = numbers[:, 1:][:, np.argsort(numbers[0, 1:])]
-        return numbers
+        return IncompressibleFitter.sortGridAxes(numbers)
 
     def writeToFile(self, data, array):
         raise ValueError("You should not overwrite the SecCool data.")
@@ -503,13 +497,7 @@ class SecCoolIceData(SecCoolSolutionData):
                     if i == 0: nu = 0.0  # Dummy for tables without concentration (TFreeze and Vol2Mass)
                     pass
                 numbers[i, j] = nu
-        # Some source tables ship with descending axes (the HFE-7100 files
-        # store T from +64 down to -80 degC). Sort rows/columns by their
-        # axis values instead of trusting the file order -- a sort also
-        # covers files that are shuffled rather than exactly reversed.
-        numbers[1:, :] = numbers[1:, :][np.argsort(numbers[1:, 0]), :]
-        numbers[:, 1:] = numbers[:, 1:][:, np.argsort(numbers[0, 1:])]
-        return numbers
+        return IncompressibleFitter.sortGridAxes(numbers)
 
 
 class ThermogenVP1869(PureData, DigitalData):

--- a/dev/incompressible_liquids/CPIncomp/SolutionFluids.py
+++ b/dev/incompressible_liquids/CPIncomp/SolutionFluids.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function
 import numpy as np
 from .DataObjects import SolutionData
 

--- a/dev/incompressible_liquids/CPIncomp/WriterObjects.py
+++ b/dev/incompressible_liquids/CPIncomp/WriterObjects.py
@@ -38,6 +38,19 @@ except ImportError:
     BibTeXerClass = None
 
 
+def ensure_parent_directory(path):
+    """Create the directory holding ``path``, if it names one.
+
+    ``os.path.dirname`` returns "" for a bare relative filename such as
+    "table.csv", and ``os.makedirs("")`` raises FileNotFoundError -- so the
+    plain "create the dirname if it is missing" idiom crashes on exactly the
+    default arguments generateRstTable/generateTexTable use (path="table").
+    """
+    directory = os.path.dirname(path)
+    if directory and not os.path.exists(directory):
+        os.makedirs(directory)
+
+
 class SolutionDataWriter(object):
     """
     A base class that defines all the variables needed
@@ -49,11 +62,10 @@ class SolutionDataWriter(object):
     # Optimizer starting guesses for the iterative (exponential-type) fits in
     # fitAll. Kept as named constants because clearUnfittedCoefficients also
     # needs them to recognise a fit that silently failed.
-    VISCOSITY_GUESS = np.array([+5e+2, -6e+1, +1e+1])
-    PSAT_GUESS = np.array([-5e+3, +6e+1, -1e+1])
-    TFREEZE_GUESS = np.array([+7e+2, -6e+1, +1e+1])
-    # The log-exponential retry guess hardcoded in IncompressibleData.fitCoeffs
-    LOGEXP_GUESS = np.array([-250.0, 1.5, 10.0])
+    VISCOSITY_GUESS = IncompressibleData.VISCOSITY_GUESS
+    PSAT_GUESS = IncompressibleData.PSAT_GUESS
+    TFREEZE_GUESS = IncompressibleData.TFREEZE_GUESS
+    LOGEXP_GUESS = IncompressibleData.LOGEXP_GUESS
 
     def __init__(self):
         """Set up optional dependencies, page geometry and fit-guess constants.
@@ -378,8 +390,7 @@ class SolutionDataWriter(object):
             hashes[name] = hash
             self.write_hashes(hashes)
             path = self.get_json_file(name)
-            if not os.path.exists(os.path.dirname(path)):
-                os.makedirs(os.path.dirname(path))
+            ensure_parent_directory(path)
             with open(path, 'w') as fp:
                 fp.write(dump)
 
@@ -518,8 +529,7 @@ class SolutionDataWriter(object):
             pdfFile = None
 
         if not pdfFile is None:
-            if not os.path.exists(os.path.dirname(pdfFile)):
-                os.makedirs(os.path.dirname(pdfFile))
+            ensure_parent_directory(pdfFile)
             with PdfPages(pdfFile) as pdfObj:
                 for obj in fluidObjs:
                     matplotlib.pyplot.close("all")
@@ -1152,8 +1162,7 @@ class SolutionDataWriter(object):
         if json_time < report_time:
             if not quiet: print(" ({0})".format("i"), end="")
         else:
-            if not os.path.exists(os.path.dirname(report_path)):
-                os.makedirs(os.path.dirname(report_path))
+            ensure_parent_directory(report_path)
 
             fig.savefig(report_path)
 
@@ -1296,8 +1305,7 @@ class SolutionDataWriter(object):
     def writeTextToFile(self, path, text):
         """Write ``text`` to ``path``, creating the parent dir. Raises on failure."""
         #print("Writing to file: {0}".format(path))
-        if not os.path.exists(os.path.dirname(path)):
-            os.makedirs(os.path.dirname(path))
+        ensure_parent_directory(path)
         with open(path, 'w') as f:
             f.write(text)
 
@@ -1305,8 +1313,7 @@ class SolutionDataWriter(object):
 
     def writeCsvTableToFile(self, path, table):
         """Write ``table`` to ``<path>.csv`` as UTF-8 CSV. Needs no matplotlib."""
-        if not os.path.exists(os.path.dirname(path + ".csv")):
-            os.makedirs(os.path.dirname(path + ".csv"))
+        ensure_parent_directory(path + ".csv")
         with codecs.open(path + ".csv", 'w', encoding='utf-8') as f:
             writer = csv.writer(f)
             writer.writerows(table)

--- a/dev/incompressible_liquids/CPIncomp/WriterObjects.py
+++ b/dev/incompressible_liquids/CPIncomp/WriterObjects.py
@@ -280,12 +280,15 @@ class SolutionDataWriter(object):
             if data.type == IncompressibleData.INCOMPRESSIBLE_NOT_SET:
                 continue
             coeffs = data.coeffs
-            unfitted = coeffs is None or not np.any(coeffs)  # never assigned, or still the all-zero template
+            # Unfitted: never assigned, still the all-zero template, non-finite
+            # (a diverged fit), or still one of the known starting guesses.
+            unfitted = coeffs is None or not np.any(coeffs) or not np.all(np.isfinite(coeffs))
             if not unfitted:
                 unfitted = any(IncompressibleFitter.allClose(coeffs, guess) for guess in knownGuesses)
             if unfitted:
                 print("{0}: could not fit {1}, marking it as not defined".format(fluidObject.name, label))
                 data.type = IncompressibleData.INCOMPRESSIBLE_NOT_SET
+                data.source = IncompressibleData.SOURCE_NOT_SET
                 data.coeffs = None
                 data.NRMS = None
 

--- a/dev/incompressible_liquids/CPIncomp/WriterObjects.py
+++ b/dev/incompressible_liquids/CPIncomp/WriterObjects.py
@@ -47,8 +47,10 @@ def ensure_parent_directory(path):
     default arguments generateRstTable/generateTexTable use (path="table").
     """
     directory = os.path.dirname(path)
-    if directory and not os.path.exists(directory):
-        os.makedirs(directory)
+    if directory:
+        # exist_ok rather than a prior exists() check: the check-then-create
+        # pair races two concurrent report runs against each other.
+        os.makedirs(directory, exist_ok=True)
 
 
 class SolutionDataWriter(object):

--- a/dev/incompressible_liquids/CPIncomp/WriterObjects.py
+++ b/dev/incompressible_liquids/CPIncomp/WriterObjects.py
@@ -66,6 +66,7 @@ class SolutionDataWriter(object):
     PSAT_GUESS = IncompressibleData.PSAT_GUESS
     TFREEZE_GUESS = IncompressibleData.TFREEZE_GUESS
     LOGEXP_GUESS = IncompressibleData.LOGEXP_GUESS
+    SECCOOL_VISCOSITY_GUESS = IncompressibleData.SECCOOL_VISCOSITY_GUESS
 
     def __init__(self):
         """Set up optional dependencies, page geometry and fit-guess constants.
@@ -285,7 +286,7 @@ class SolutionDataWriter(object):
         #2567). Resetting the property to "not defined" makes the backend
         throw a clear "function type is not specified" error instead.
         """
-        knownGuesses = (self.VISCOSITY_GUESS, self.PSAT_GUESS, self.TFREEZE_GUESS, self.LOGEXP_GUESS)
+        knownGuesses = (self.VISCOSITY_GUESS, self.PSAT_GUESS, self.TFREEZE_GUESS, self.LOGEXP_GUESS, self.SECCOOL_VISCOSITY_GUESS)
         properties = ('density', 'specific_heat', 'conductivity', 'viscosity', 'saturation_pressure', 'T_freeze')
         for label in properties:
             data = getattr(fluidObject, label)

--- a/dev/incompressible_liquids/CPIncomp/__init__.py
+++ b/dev/incompressible_liquids/CPIncomp/__init__.py
@@ -1,12 +1,15 @@
 """
-CPIncomp - Jorrit's collection of routines for fitting incompressible liquids
+CPIncomp - fitting routines for the incompressible fluids in CoolProp
 =====
 
-readme.md       - General instructions and copyright information / credits.
-
+Fluids are defined as classes in the fluid modules (PureFluids.py,
+SolutionFluids.py, ...) and discovered automatically: every class in those
+modules that is not a base class or an example is instantiated and fitted.
+Adding a fluid therefore needs no registration step -- see README.md in
+dev/incompressible_liquids for a walk-through.
 """
-from __future__ import division, absolute_import, print_function
 import inspect
+
 from . import DataObjects, ExampleObjects, PureFluids, CoefficientFluids, DigitalFluids, MelinderFluids, SolutionFluids
 from .SecCoolFluids import SecCoolSolutionData
 
@@ -17,11 +20,7 @@ def getBaseClassNames():
     classes that should not be instantiated. Can
     be used to build an ignore list.
     """
-    ignList = []
-    for i in inspect.getmembers(DataObjects):
-        if inspect.isclass(i[1]):
-            ignList.append(i[0])
-    return ignList
+    return [name for name, obj in inspect.getmembers(DataObjects) if inspect.isclass(obj)]
 
 
 def getExampleNames(obj=False):
@@ -33,14 +32,10 @@ def getExampleNames(obj=False):
     Use the obj switch to return the objects instead
     of the names.
     """
-    ignList = getBaseClassNames()
-    outList = []
-    for i in inspect.getmembers(ExampleObjects):
-        if inspect.isclass(i[1]):
-            if i[0] not in ignList:
-                if obj: outList.append(i[1]())
-                else: outList.append(i[0])
-    return outList
+    baseNames = getBaseClassNames()
+    if obj:
+        return [cls() for name, cls in inspect.getmembers(ExampleObjects) if inspect.isclass(cls) and name not in baseNames]
+    return [name for name, cls in inspect.getmembers(ExampleObjects) if inspect.isclass(cls) and name not in baseNames]
 
 
 def getIgnoreNames():
@@ -48,10 +43,13 @@ def getIgnoreNames():
     Returns a list of names of classes that should
     not be treated like the normal fluids.
     """
-    ignList = []
-    ignList += getBaseClassNames()
-    ignList += getExampleNames()
-    return ignList
+    return getBaseClassNames() + getExampleNames()
+
+
+def _instantiateFluids(module):
+    """One instance of every fluid class in module, skipping base classes and examples."""
+    ignoreNames = getIgnoreNames()
+    return [cls() for name, cls in inspect.getmembers(module) if inspect.isclass(cls) and name not in ignoreNames]
 
 
 def getCoefficientFluids():
@@ -60,14 +58,7 @@ def getCoefficientFluids():
     already contain all coefficients. These objects
     can be written to JSON without further processing.
     """
-    classes = []
-    ignList = getIgnoreNames()
-    for name, obj in inspect.getmembers(CoefficientFluids):
-        if inspect.isclass(obj):
-            # print(name)
-            if not name in ignList:  # Ignore the base classes
-                classes.append(obj())
-    return classes
+    return _instantiateFluids(CoefficientFluids)
 
 
 def getDigitalFluids():
@@ -85,14 +76,7 @@ def getDigitalFluids():
     c) There are data files that contain the experimental
     data. The fit has to be done after loading the fluids.
     """
-    classes = []
-    ignList = getIgnoreNames()
-    for name, obj in inspect.getmembers(DigitalFluids):
-        if inspect.isclass(obj):
-            # print(name)
-            if not name in ignList:  # Ignore the base classes
-                classes.append(obj())
-    return classes
+    return _instantiateFluids(DigitalFluids)
 
 
 def getMelinderFluids():
@@ -104,14 +88,7 @@ def getMelinderFluids():
     "Properties of Secondary Working Fluids for Indirect Systems"
     written by Aake Melinder and published in 2010 by IIR
     """
-    classes = []
-    ignList = getIgnoreNames()
-    for name, obj in inspect.getmembers(MelinderFluids):
-        if inspect.isclass(obj):
-            # print(name)
-            if not name in ignList:  # Ignore the base classes
-                classes.append(obj())
-    return classes
+    return _instantiateFluids(MelinderFluids)
 
 
 def getPureFluids():
@@ -121,14 +98,7 @@ def getPureFluids():
     objects only hold the data and you still have
     to call the fitting routines.
     """
-    classes = []
-    ignList = getIgnoreNames()
-    for name, obj in inspect.getmembers(PureFluids):
-        if inspect.isclass(obj):
-            # print(name)
-            if not name in ignList:  # Ignore the base classes
-                classes.append(obj())
-    return classes
+    return _instantiateFluids(PureFluids)
 
 
 def getSolutionFluids():
@@ -138,14 +108,7 @@ def getSolutionFluids():
     objects only hold the data and you still have
     to call the fitting routines.
     """
-    classes = []
-    ignList = getIgnoreNames()
-    for name, obj in inspect.getmembers(SolutionFluids):
-        if inspect.isclass(obj):
-            # print(name)
-            if not name in ignList:  # Ignore the base classes
-                classes.append(obj())
-    return classes
+    return _instantiateFluids(SolutionFluids)
 
 
 def getSecCoolFluids():
@@ -157,12 +120,3 @@ def getSecCoolFluids():
     the JSON files.
     """
     return SecCoolSolutionData.factory()
-
-
-def get_version():
-    return 0.5
-
-
-if __name__ == "__main__":
-    print('You are using version %s of the Python package for incompressible liquids in CoolProp.' % (get_version()))
-    print()

--- a/dev/incompressible_liquids/DATA_AUDIT.md
+++ b/dev/incompressible_liquids/DATA_AUDIT.md
@@ -1,0 +1,47 @@
+# Reference-data audit: incompressible fluids (2026-07-05)
+
+Full physical-plausibility audit of every number feeding the incompressible
+fits: 36 top-level `CPIncomp/data/*.txt` grids, ~180 SecCool
+`xMass`/`xVolume`/`xPure` tables, 20 `xTables/xMass/*.csv`, the hardcoded
+arrays in `PureFluids.py`/`SolutionFluids.py`/`ExampleObjects.py`, and the
+committed fit residuals (NRMS) in all `json/*.json`.
+
+**Headline: no wrong-unit slips exist in any production data source.** The
+worst committed fit residual on a real fluid is 4.8% (TX22 saturation
+pressure) — a rogue data point would blow that to tens of percent, and only
+the synthetic `ExampleDigitalPure` (13.8%) does. Every value that trips a
+generic liquid range check is either correct physics or a valid alternate
+convention the loader already handles (see the don't-touch list).
+
+## Real findings (fixed / to respect)
+
+| # | Finding | Status |
+|---|---|---|
+| 1 | `data/SecCool/xPure/HFE-7100_{Rho,Cp,Mu,Cond}.txt` store T strictly **descending** (+64.27 → −80.33 °C) — the only non-ascending grids in the corpus. | The loader reversed fully-descending grids already; now **hardened to a real sort** (rows by T, columns by concentration) in both `SecCoolSolutionData.getFromFile` and `DigitalData.getFromFile`, and guarded by `test_data_sanity.py`. Raw files deliberately untouched (provenance). |
+| 2 | Short grids that cannot support a temperature fit above order ~4: `IceNA` csv (4 T points), several `*_TFreeze` tables (4–5 points), `FRE_Tfreeze` (freeze curve, 1 T row). | Any fitter must cap the T-degree at `N_T − 1` and skip properties with < 3 usable points (the Chebyshev fitter does). |
+| 3 | `data/SecCool/xMass/VDI, Methanol_*` grids are ~66% `-1`-sentinel — sparse but valid (data lives in a narrow T×X band). | Nothing to fix; NaN masking handles it. |
+| 4 | Empty `*_Vol2Mass.txt` grids for mass-based fluids. | Expected — mass-based fluids carry no volume→mass table. |
+| 5 | Nine **orphaned** `xTables/xMass/*.csv` files (`Freezium_{Cond,Cp,Mu}`, `Ice{EA,NA,PG}_{Cond,Mu}`) are **latin-1 encoded** (`·` in unit headers) and fail a default UTF-8 read. | Not read by the production pipeline (only the `Hfusion` csvs are loaded; Freezium reads the root `FRE_*.txt`). Anyone reviving them — e.g. to restore the ice-slurry conductivity/viscosity data (see the reproducibility follow-up) — must pass `encoding="latin-1"`. |
+
+## Don't-touch list (looks wrong, is right)
+
+| Value | Where | Why it's correct |
+|---|---|---|
+| density → 239 kg/m³, conductivity up to **87 W/m/K**, Prandtl 0.004–0.009 | `PureFluids.py` → `LiquidSodium` (LiqNa) | Textbook molten-sodium physics up to 2500 K. A "sanity fix" here would be the bug. |
+| density 0.67–1.79 kg/m³, conductivity 0.018–0.041 W/m/K | `data/Air_*.txt` | Air is included as a **gas** reference fluid. |
+| viscosity up to **59.3 Pa·s** | `xVolume/Zitrec LC_Mu.txt` at −50 °C / 70 vol-% | Concentrated glycol near its glass region; decays smoothly to ~0.5 mPa·s at 100 °C. Raw file already in Pa·s (`viscosityFactor=None` is correct). |
+| freeze temperatures 214–263 (no °C offset) | `FRE_Tfreeze.txt`, `xTables/.../Freezium_TFreeze.csv` | These two tables are in **Kelvin** (csv header says so); the SecCool `_TFreeze.txt` files are in °C. Both conventions handled by their loaders. |
+| freeze point −125.4 °C | `xVolume/Zitrec M_TFreeze.txt` at 100 vol-% | Monotonic freeze-depression curve endpoint (pure-glycol glass former), internally consistent. |
+| cp dips to 437 J/kg/K; density rising with T | `ExampleObjects.py` → `DigitalExample` | Synthetic analytic test functions, not fluid data. |
+
+## Unit conventions per source (for anyone touching loaders)
+
+- Top-level `data/*.txt`: headerless; row 0 = concentration fraction
+  (NaN corner), column 0 = T in **K**; property values in SI.
+- `SecCool/x*/**.txt`: tab-separated `T\X` header; T in **°C**, concentration
+  in **%**; property units vary per file and are normalized by the
+  `densityFactor`/`heatFactor`/`conductivityFactor`/`viscosityFactor`
+  arguments in `SecCoolFluids.py::factory()` — the factors were verified to
+  match each file's raw units. `-1` is the out-of-range sentinel.
+- `SecCool/xTables/**.csv`: 3 header rows including units; SI.
+- Hardcoded arrays: SI, `np.nan` for missing points.

--- a/dev/incompressible_liquids/DATA_AUDIT.md
+++ b/dev/incompressible_liquids/DATA_AUDIT.md
@@ -21,7 +21,7 @@ convention the loader already handles (see the don't-touch list).
 | 2 | Short grids that cannot support a temperature fit above order ~4: `IceNA` csv (4 T points), several `*_TFreeze` tables (4–5 points), `FRE_Tfreeze` (freeze curve, 1 T row). | Any fitter must cap the T-degree at `N_T − 1` and skip properties with < 3 usable points (the Chebyshev fitter does). |
 | 3 | `data/SecCool/xMass/VDI, Methanol_*` grids are ~66% `-1`-sentinel — sparse but valid (data lives in a narrow T×X band). | Nothing to fix; NaN masking handles it. |
 | 4 | Empty `*_Vol2Mass.txt` grids for mass-based fluids. | Expected — mass-based fluids carry no volume→mass table. |
-| 5 | Nine **orphaned** `xTables/xMass/*.csv` files (`Freezium_{Cond,Cp,Mu}`, `Ice{EA,NA,PG}_{Cond,Mu}`) are **latin-1 encoded** (`·` in unit headers) and fail a default UTF-8 read. | Not read by the production pipeline (only the `Hfusion` csvs are loaded; Freezium reads the root `FRE_*.txt`). Anyone reviving them — e.g. to restore the ice-slurry conductivity/viscosity data (see the reproducibility follow-up) — must pass `encoding="latin-1"`. |
+| 5 | **23 of the 32** `xTables/*.csv` files are **latin-1 encoded** (`·` in unit headers) and fail a default UTF-8 read — including the nine orphaned ones (`Freezium_{Cond,Cp,Mu}`, `Ice{EA,NA,PG}_{Cond,Mu}`) plus `AS{10,20,30,40,55}`, `HY{20,30,40,45,50}` and four `ASHRAE`/`CO2_*` tables. | Not read by the production pipeline (only the `Hfusion` csvs are loaded; Freezium reads the root `FRE_*.txt`). Anyone reviving them — e.g. to restore the ice-slurry conductivity/viscosity data (see the reproducibility follow-up) — must pass `encoding="latin-1"`. |
 
 ## Don't-touch list (looks wrong, is right)
 

--- a/dev/incompressible_liquids/NOTES_mixing_models.md
+++ b/dev/incompressible_liquids/NOTES_mixing_models.md
@@ -1,0 +1,136 @@
+# Research notes: proper mixing models for absorption-cycle fluids
+
+**Status: deferred.** Not part of the current incompressible-backend
+zero-division/maintainability cleanup. Captured here so the research doesn't
+get lost; revisit as a separate, deliberate project.
+
+## The problem
+
+CoolProp's incompressible solutions (LiBr/H2O, NH3/H2O via the Melinder MAM/
+MAM2 fluids, etc.) compute enthalpy and entropy purely by integrating a fitted
+`cp(T,x)` surface in temperature. There is no composition-dependent excess
+term anywhere in that calculation, so there is no enthalpy of mixing. This is
+a deliberate, documented design choice (see the maintainer's own comments on
+issue #533 below), not an oversight — but it means absorption-cycle energy
+balances across streams of different concentration are wrong by the heat of
+mixing.
+
+Related CoolProp issues:
+- [#533](https://github.com/CoolProp/CoolProp/issues/533) — MAM/MAM2 enthalpy
+  of mixing ~100x too low vs. Melinder/EES reference data; maintainer (jowr)
+  confirms the omission is intentional, and later says he regrets the
+  decision.
+- [#781](https://github.com/CoolProp/CoolProp/issues/781) — jowr's own
+  proposal to add a Gibbs-energy-based incompressible class, which would
+  naturally produce the missing excess/mixing terms. Never implemented.
+- [#1690](https://github.com/CoolProp/CoolProp/issues/1690) — concrete user
+  pain: can't write a consistent enthalpy balance across LiBr/H2O streams of
+  different concentration in an absorption-chiller generator.
+- [#341](https://github.com/CoolProp/CoolProp/issues/341) — long-running
+  wishlist thread for a real NH3/H2O *mixture* (not solution) model in
+  CoolProp; contains the most useful pointers (below).
+
+## NH3/H2O
+
+Reference formulation: **Tillner-Roth & Friend (1998)**, *A Helmholtz free
+energy formulation of the thermodynamic properties of the mixture
+{water + ammonia}*, J. Phys. Chem. Ref. Data 27(1):63-96 — adopted as the
+IAPWS 2001 guideline. Structure: `a_mix(tau,delta,x) = sum_i x_i * a_i(tau,delta)
++ a^E(tau,delta,x)`, i.e. pure-component Helmholtz energies (water via
+IAPWS-95, ammonia via Baehr & Tillner-Roth) plus a composition-dependent
+excess/departure term (polynomial + exponential terms in delta, tau, x, x^2).
+This is the *same shape* as CoolProp's own HEOS multi-fluid mixture model
+(reference + departure function per binary pair) — confirmed CoolProp has
+departure-function data for AMMONIA paired with ARGON, BENZENE, BUTANE,
+HEXANE, KRYPTON, etc. in `dev/mixtures/mixture_binary_pairs.json`, but **no
+AMMONIA/WATER pair**. The architecture to hold this already exists; nobody
+has supplied the fit.
+
+Open implementations:
+- **teqp** ([usnistgov/teqp](https://github.com/usnistgov/teqp)) — same lead
+  author as CoolProp (Ian Bell), NIST-maintained. Has a hardcoded
+  `AmmoniaWaterTillnerRoth` class implementing this exact model on a modern
+  automatic-differentiation core (C++ with Python bindings). When a
+  contributor asked (issue #341, 2023) about implementing Tillner-Roth &
+  Friend directly in CoolProp, Bell's own advice was to use teqp instead,
+  noting CoolProp's mixture algorithms are "not very refined." **This is the
+  strongest single pointer** — both for the NH3/H2O physics and as a worked
+  example of how the same author now structures EOS-with-departure-function
+  code (AD instead of hand-coded analytic derivatives, which sidesteps the
+  whole class of derivative/integral-correctness bugs we hit in
+  `Polynomial2DFrac`).
+- **iapws** ([jjgomera/iapws](https://github.com/jjgomera/iapws), pure
+  Python, **GPL-3.0**) — `iapws/ammonia.py` implements the same
+  Tillner-Roth & Friend departure function in full (h, s, u, g, a, cp, cv,
+  fugacity all exposed). Readable, working reference math — but GPL-3.0
+  means it can be studied, not vendored into MIT-licensed CoolProp.
+- A NIST-internal NH3+H2O mixture model (Ian Bell, mentioned in #341,
+  ~2017-2023) was put on hold and never published; REFPROP has its own
+  (proprietary) implementation.
+
+## LiBr/H2O
+
+Two competing correlations show up in the literature:
+- **Pátek & Klomfar (2006)**, *Int. J. Refrigeration* 29:566-578 — simpler,
+  polynomial-type fit; this is what EES's `LiBrH2O` library uses, and is
+  CoolProp's own current reference (`Patek2006` citation already in
+  `Web/fluid_properties/Incompressibles.rst`).
+- **Yuan & Herold (2005)** — University of Maryland Sorption Systems
+  Consortium — a proper multiproperty **Gibbs-energy** correlation.
+
+Open implementation:
+- **LiBr.jl** ([hzgzh/LiBr.jl](https://github.com/hzgzh/LiBr.jl), Julia) —
+  implements the Yuan & Herold approach: one Gibbs function `g(T, p, x)`
+  fitted to data, with density, enthalpy, entropy, cp, and chemical potential
+  (partial molar Gibbs energy) *all* derived by differentiating that single
+  function. This is structurally exactly what jowr proposed in #781: the
+  enthalpy of mixing isn't a separate fitted term bolted onto a `cp(T)`
+  integral, it's `g_mixture(T,x) - sum(x_i * g_i_pure(T))`, automatically
+  consistent with every other derived property by construction. License of
+  LiBr.jl itself not yet checked — verify before reusing any code; the
+  underlying equations are published literature regardless.
+
+## Applied reference
+
+- **openACHP** ([nfette/openACHP](https://github.com/nfette/openACHP),
+  Python/Jupyter) — implements and cross-validates *both* NH3/H2O
+  (Ibrahim-Klein, plus comparisons against REFPROP/CoolProp) and LiBr/H2O
+  (Pátek-Klomfar, EES) specifically for absorption-cycle cycle calculations.
+  Useful for seeing how someone actually wires these correlations into
+  stream-enthalpy balances once the property layer is right — directly
+  addresses the scenario in #1690.
+
+## The common architectural lesson
+
+Every credible implementation here (CoolProp's own HEOS departure functions,
+Tillner-Roth & Friend, Yuan & Herold) is the same shape: **one fundamental
+thermodynamic potential (Helmholtz or Gibbs energy) as a function of
+`(T, p/rho, x)`, with every other property obtained by differentiating it** —
+density, cp, enthalpy, entropy, chemical potential all consistent by
+construction, and mixing behavior is whatever the potential's `x`-dependence
+says it is. CoolProp's current `IncompressibleFluid`/`IncompressibleBackend`
+is the opposite shape: five independently-fitted surfaces (`rho(T,x)`,
+`cp(T,x)`, `visc(T,x)`, `cond(T,x)`, `psat(T,x)`) with enthalpy/entropy
+*reconstructed after the fact* by integrating the cp surface. That's why
+there's no mixing term (nothing in that pipeline ever had an `x`-dependent
+potential to differentiate).
+
+A future fix likely means giving incompressible *solutions* (not pure
+fluids — those have no composition, so no mixing term to begin with) their
+own Gibbs-energy-based property class, the way LiBr.jl does, while pure
+fluids and simple brines without published excess-Gibbs data could keep the
+existing polynomial approach.
+
+## Suggested next steps, when this is picked back up
+
+1. Pick one binary (LiBr/H2O is the best-documented, most-requested
+   candidate per #1690/#1331/#2567) and prototype a Gibbs-energy class
+   against Yuan & Herold or Pátek & Klomfar, validated against LiBr.jl's
+   published values.
+2. Decide the JSON schema extension needed to carry a Gibbs-energy fit
+   alongside (not replacing) the existing polynomial schema, so pure fluids
+   are unaffected.
+3. Revisit NH3/H2O only after LiBr/H2O proves the pattern out — it's a
+   bigger lift (needs a real departure-function fit, not just a literature
+   Gibbs correlation) and teqp's `AmmoniaWaterTillnerRoth` is the right
+   reference implementation to validate against.

--- a/dev/incompressible_liquids/NOTES_mixing_models.md
+++ b/dev/incompressible_liquids/NOTES_mixing_models.md
@@ -35,8 +35,9 @@ Related CoolProp issues:
 Reference formulation: **Tillner-Roth & Friend (1998)**, *A Helmholtz free
 energy formulation of the thermodynamic properties of the mixture
 {water + ammonia}*, J. Phys. Chem. Ref. Data 27(1):63-96 — adopted as the
-IAPWS 2001 guideline. Structure: `a_mix(tau,delta,x) = sum_i x_i * a_i(tau,delta)
-+ a^E(tau,delta,x)`, i.e. pure-component Helmholtz energies (water via
+IAPWS 2001 guideline. Structure:
+`a_mix(tau,delta,x) = sum_i x_i * a_i(tau,delta) + a^E(tau,delta,x)`,
+i.e. pure-component Helmholtz energies (water via
 IAPWS-95, ammonia via Baehr & Tillner-Roth) plus a composition-dependent
 excess/departure term (polynomial + exponential terms in delta, tau, x, x^2).
 This is the *same shape* as CoolProp's own HEOS multi-fluid mixture model

--- a/dev/incompressible_liquids/README.md
+++ b/dev/incompressible_liquids/README.md
@@ -98,6 +98,10 @@ data axis -- see `SolutionExample` in `CPIncomp/ExampleObjects.py` and the
 - The fit is centred around `Tbase`/`xbase` (defaults: the midpoint of your
   data range). The enthalpy/entropy the backend later reports are derived
   exactly from the fitted density and heat-capacity polynomials.
+- Four fluids (Air, Acetone, Ethanol, Hexane) are sampled from CoolProp's
+  own equations of state, so *re-fitting those four* needs the CoolProp
+  Python package installed; without it they are skipped and their committed
+  JSON stays as-is. All other fluids fit from the data in this directory.
 - Fit output can drift slightly across numpy/scipy versions; that is what
   `test_fitting_regression.py` guards. If it fails after a fluid addition
   that did not touch the three reference fluids, suspect your environment,

--- a/dev/incompressible_liquids/README.md
+++ b/dev/incompressible_liquids/README.md
@@ -1,0 +1,106 @@
+# Incompressible fluids: fitting pipeline
+
+This directory turns tabulated fluid property data into the coefficient
+files that CoolProp's `INCOMP` backend ships. You do **not** need to be a
+programmer to add a fluid: you copy an existing fluid definition, paste in
+your data, and run one script.
+
+## Layout
+
+| Path | What it is |
+|---|---|
+| `CPIncomp/PureFluids.py`, `SolutionFluids.py`, ... | The fluid definitions (one Python class per fluid) |
+| `CPIncomp/ExampleObjects.py` | Commented templates for every fluid kind |
+| `CPIncomp/data/` | Tabulated source data for the file-backed fluids |
+| `json/` | **The output.** One coefficient file per fluid; these are baked into the C++ library |
+| `all_incompressibles.py` | The driver script that fits everything and writes `json/` |
+| `test_json_sanity.py` | Checks that no unfitted placeholder coefficients are shipped |
+| `test_fitting_regression.py` | Re-fits three fluids and compares against the committed JSON |
+
+## Prerequisites
+
+Python 3 with `numpy` and `scipy` (see `requirements.txt`):
+
+```bash
+pip install -r requirements.txt
+```
+
+That is enough to fit fluids and write JSON. `matplotlib` and a built
+CoolProp Python package are only needed if you also want the fitting
+reports, plots and documentation tables.
+
+## Adding a new pure fluid, step by step
+
+1. Open `CPIncomp/PureFluids.py` and copy an existing class (or start from
+   `PureExample` in `CPIncomp/ExampleObjects.py`). Rename the class and give
+   it a unique `self.name`.
+
+2. Paste your data as numpy arrays. All arrays must have the same length as
+   `self.temperature.data`, and everything is in SI units:
+
+   | Attribute | Unit |
+   |---|---|
+   | `self.temperature.data` | K |
+   | `self.density.data` | kg/m³ |
+   | `self.specific_heat.data` | J/(kg·K) |
+   | `self.conductivity.data` | W/(m·K) |
+   | `self.viscosity.data` | Pa·s |
+   | `self.saturation_pressure.data` | Pa |
+
+   Use `np.nan` for points you do not have. If you have no data at all for a
+   property, do not set it -- the fluid will then cleanly report that the
+   property is not available instead of returning made-up numbers.
+
+3. For each property you filled in, mark the data source, e.g.
+   `self.density.source = self.density.SOURCE_DATA`, and set `self.Tmin`,
+   `self.Tmax`, `self.TminPsat` (minimum temperature at which the vapour
+   pressure fit is valid), `self.description` and `self.reference`
+   (a citation for where the data came from; a BibTeX key from
+   `CoolPropBibTeXLibrary.bib` if possible). Finish with `self.reshapeAll()`.
+
+4. Run the fitter from this directory (the flags skip the optional reports,
+   plots, tables and statistics):
+
+   ```bash
+   python all_incompressibles.py -nr -ns -nt -nst
+   ```
+
+   Watch the output for your fluid. A message like
+   `MyFluid: could not fit viscosity, marking it as not defined` means the
+   fit did not succeed (usually: no data was set) and the property was
+   left out on purpose.
+
+5. Check the result: `json/<name>.json` should now exist and contain
+   coefficients for each property you provided. Run the sanity tests:
+
+   ```bash
+   python -m pytest test_json_sanity.py test_fitting_regression.py
+   ```
+
+6. Rebuild CoolProp. The build regenerates the embedded fluid library
+   (`dev/generate_headers.py` bundles everything in `json/` into a C++
+   header) so your fluid is available as `INCOMP::<name>`:
+
+   ```python
+   PropsSI("D", "T", 300, "P", 101325, "INCOMP::MyFluid")
+   ```
+
+7. Commit your edited fluid module and the new `json/<name>.json` file.
+
+Binary mixtures (water solutions and the like) work the same way but live in
+`CPIncomp/SolutionFluids.py` and need a concentration vector as the second
+data axis -- see `SolutionExample` in `CPIncomp/ExampleObjects.py` and the
+"Adding New Fluids" section of the online documentation
+(`Web/fluid_properties/Incompressibles.rst`).
+
+## Notes
+
+- The fit is centred around `Tbase`/`xbase` (defaults: the midpoint of your
+  data range). The enthalpy/entropy the backend later reports are derived
+  exactly from the fitted density and heat-capacity polynomials.
+- Fit output can drift slightly across numpy/scipy versions; that is what
+  `test_fitting_regression.py` guards. If it fails after a fluid addition
+  that did not touch the three reference fluids, suspect your environment,
+  not your fluid.
+- Solutions carry no enthalpy/entropy of mixing (documented limitation, see
+  `NOTES_mixing_models.md`).

--- a/dev/incompressible_liquids/README.md
+++ b/dev/incompressible_liquids/README.md
@@ -19,14 +19,16 @@ your data, and run one script.
 
 ## Prerequisites
 
-Python 3 with `numpy` and `scipy` (see `requirements.txt`):
+Python 3 with `numpy` and `scipy`:
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements.txt            # fit fluids and write json/
+pip install -r requirements-reports.txt    # + matplotlib, for reports/plots
+pip install -r requirements-dev.txt        # + pytest, to run the tests here
 ```
 
-That is enough to fit fluids and write JSON. `matplotlib` and a built
-CoolProp Python package are only needed if you also want the fitting
+The first line is enough to fit fluids and write JSON. `matplotlib` and a
+built CoolProp Python package are only needed if you also want the fitting
 reports, plots and documentation tables.
 
 ## Adding a new pure fluid, step by step

--- a/dev/incompressible_liquids/all_incompressibles.py
+++ b/dev/incompressible_liquids/all_incompressibles.py
@@ -1,65 +1,49 @@
-from __future__ import division, absolute_import, print_function
-from CPIncomp.WriterObjects import SolutionDataWriter
-from CPIncomp import getExampleNames, getPureFluids, getSolutionFluids, getCoefficientFluids, getDigitalFluids, getSecCoolFluids, getMelinderFluids
-import sys
-from CPIncomp.DataObjects import SolutionData
+"""Driver for the incompressible-fluid fitting pipeline.
+
+Fits all fluid definitions from the CPIncomp package and writes the
+per-fluid coefficient files to json/. Optionally also generates fitting
+reports (PDF), summary figures and the RST/TeX property tables used by the
+online documentation.
+
+Fitting and JSON output need only numpy and scipy. The reports, figures and
+tables additionally need matplotlib and a built CoolProp Python package --
+skip them with:
+
+    python all_incompressibles.py -nr -ns -nt -nst
+
+See README.md in this directory for how to add a new fluid.
+"""
 import argparse
 import os
+
 import numpy as np
+
+from CPIncomp import getExampleNames, getPureFluids, getSolutionFluids, getCoefficientFluids, getDigitalFluids, getSecCoolFluids, getMelinderFluids
+from CPIncomp.DataObjects import SolutionData
+from CPIncomp.WriterObjects import SolutionDataWriter
 
 
 def getTime(path):
     if os.path.isfile(path):
         return os.path.getctime(path)
-    else:
-        return 0
-
-
-def mergePdfIfNewer(singlePdfs, combined):
-    from PyPDF2 import PdfFileMerger, PdfFileReader
-    singles_time = np.array([])
-    for fi in singlePdfs:
-        singles_time = np.append(singles_time, [getTime(fi)])
-    combined_time = getTime(combined)
-    if np.any(singles_time > combined_time):
-        allcombined = PdfFileMerger()
-        for fl in singlePdfs:
-            allcombined.append(PdfFileReader(fl, "rb"))
-        allcombined.write(combined)
+    return 0
 
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-t", "--test", action='store_true', help="Only run a subset of fluid files")
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("-nf", "--nofit", action='store_true', help="Do not fit the data, but read the JSON files")
     parser.add_argument("-nr", "--noreports", action='store_true', help="Do not write the fitting reports")
     parser.add_argument("-ns", "--nosummary", action='store_true', help="Do not generate the summary figures")
     parser.add_argument("-nt", "--notables", action='store_true', help="Do not write the fluid tables")
     parser.add_argument("-nst", "--nostats", action='store_true', help="Do not process statistical parameters")
-    #parser.add_argument("-f","--fluid", help="Only process the fluid FLUID")
-
     args = parser.parse_args()
-#    if args.verbosity:
-#     print "verbosity turned on"
 
-    if args.test: runTest = True
-    else: runTest = False
-    if args.nofit: runFitting = False
-    else: runFitting = True
-    if args.noreports: runReports = False
-    else: runReports = True
-    if args.nosummary: runSummary = False
-    else: runSummary = True
-    if args.notables: runTables = False
-    else: runTables = True
-    if args.nostats: runStats = False
-    else: runStats = True
-    #if args.fluid:     onlyFluid  = args.fluid
-    # else:              onlyFluid  = None
-
-    #runReports = False
-    #runFitting = False
+    runFitting = not args.nofit
+    runReports = not args.noreports
+    runSummary = not args.nosummary
+    runTables = not args.notables
+    runStats = not args.nostats
 
     print("")
     print("Processing the incompressible fluids for CoolProp")
@@ -67,137 +51,73 @@ if __name__ == '__main__':
     print("")
 
     writer = SolutionDataWriter()
-    doneObjs = []
 
-    # To debug single fluids
-    if runTest:
-        solObjs = []
-        from CPIncomp.SecCoolFluids import SecCoolSolutionData, SecCoolIceData, ThermogenVP1869
-        from CPIncomp.PureFluids import PMR
-        #from CPIncomp.PureFluids import Texatherm22
-        #solObjs += [SecCoolSolutionData(sFile='Melinder, Ethanol'            ,sFolder='xMass',name='MEA2',desc='Melinder, Ethanol'            ,ref='Melinder2010,Skovrup2013')]
-        #solObjs += [SecCoolSolutionData(sFile='Melinder, Ammonia'            ,sFolder='xMass',name='MAM2',desc='Melinder, Ammonia'            ,ref='Melinder2010,Skovrup2013')]
-
-        solObjs += [PMR()]
-
-        writer.fitSecCoolList(solObjs)
-        writer.writeFluidList(solObjs)
-        writer.writeReportList(solObjs)
-        sys.exit(0)
-
-    # treat the examples first
-    fluidObjs = getExampleNames(obj=True)
-    examplesToFit = ["ExamplePure", "ExampleSolution", "ExampleDigital", "ExampleDigitalPure"]
-
+    # Process the examples first: they are small and fail fast if the
+    # pipeline itself is broken.
     print("\nProcessing example fluids")
-    for obj in fluidObjs:
+    doneObjs = getExampleNames(obj=True)
+    examplesToFit = ["ExamplePure", "ExampleSolution", "ExampleDigital", "ExampleDigitalPure"]
+    for obj in doneObjs:
         if obj.name in examplesToFit:
             if runFitting: writer.fitAll(obj)
             else: writer.fromJSON(obj)
-    doneObjs += fluidObjs[:]
     if runFitting: writer.writeFluidList(doneObjs)
     if runReports:
-        # TODO: The new method for multipage PDFs produces larger files, why?
         if writer.usetex: combined_name = None
         else: combined_name = os.path.join(os.path.abspath("report"), "all_examples.pdf")
         writer.writeReportList(doneObjs, pdfFile=combined_name)
-        #singleNames = [writer.get_report_file(fl.name) for fl in doneObjs]
-        #mergePdfIfNewer(singleNames, "all_examples.pdf")
 
     # If the examples did not cause any errors,
     # we can proceed to the real data.
     doneObjs = []
 
     print("\nProcessing fluids with given coefficients")
-    fluidObjs = getCoefficientFluids()
-    doneObjs += fluidObjs[:]
+    doneObjs += getCoefficientFluids()
 
     print("\nProcessing digital fluids")
     fluidObjs = getDigitalFluids()
     if runFitting: writer.fitFluidList(fluidObjs)
     else: writer.readFluidList(fluidObjs)
-    doneObjs += fluidObjs[:]
+    doneObjs += fluidObjs
 
     print("\nProcessing Melinder fluids")
-    fluidObjs = getMelinderFluids()
-    doneObjs += fluidObjs[:]
+    doneObjs += getMelinderFluids()
 
     print("\nProcessing pure fluids")
     fluidObjs = getPureFluids()
     if runFitting: writer.fitFluidList(fluidObjs)
     else: writer.readFluidList(fluidObjs)
-    doneObjs += fluidObjs[:]
+    doneObjs += fluidObjs
 
     print("\nProcessing solutions")
     fluidObjs = getSolutionFluids()
     if runFitting: writer.fitFluidList(fluidObjs)
     else: writer.readFluidList(fluidObjs)
-    doneObjs += fluidObjs[:]
+    doneObjs += fluidObjs
 
     print("\nProcessing SecCool fluids")
     fluidObjs = getSecCoolFluids()
     if runFitting: writer.fitSecCoolList(fluidObjs)
     else: writer.readFluidList(fluidObjs)
-    doneObjs += fluidObjs[:]
+    doneObjs += fluidObjs
 
     print("\nAll {0} fluids processed, all coefficients should be set.".format(len(doneObjs)))
     print("Checking the list of fluid objects.")
-    #doneObjs += getCoefficientObjects()[:]
     doneObjs = sorted(doneObjs, key=lambda x: x.name)
 
-    purefluids = []
-    solMass = []
-    solMole = []
-    solVolu = []
-    errors = []
+    names = [obj.name for obj in doneObjs]
+    duplicates = sorted({name for name in names if names.count(name) > 1})
+    if duplicates:
+        raise ValueError("Two fluids have the same name, that does not work: {0}".format(duplicates))
 
-    for i in range(0, len(doneObjs)):
-
-        curObj = doneObjs[i]
-
-        if i < len(doneObjs) - 2:
-            nexObj = doneObjs[i + 1]
-        else:
-            nexObj = doneObjs[0]
-
-        if curObj.name == nexObj.name:
-            print("Conflict between {0} and {1}, aborting".format(curObj, nexObj))
-            raise ValueError("Two elements have the same name, that does not work: {0}".format(curObj.name))
-        else:
-            #print("Processing {0}: ".format(curObj.name), end="")
-            if curObj.xid == SolutionData.ifrac_mass:
-                solMass.append(curObj)
-                #print("added to mass-based fluids ({0})".format(curObj.xid))
-            elif curObj.xid == SolutionData.ifrac_mole:
-                solMole.append(curObj)
-                #print("added to mole-based fluids ({0})".format(curObj.xid))
-            elif curObj.xid == SolutionData.ifrac_volume:
-                solVolu.append(curObj)
-                #print("added to volume-based fluids ({0})".format(curObj.xid))
-            elif curObj.xid == SolutionData.ifrac_pure:
-                purefluids.append(curObj)
-                #print("added to pure fluids ({0})".format(curObj.xid))
-            else:
-                errors.append(curObj)
-                #print("added to errors ({0})".format(curObj.xid))
-
-
-#         def printNames(lstObj,pre):
-#             print(pre,end="")
-#             for f in lstObj: print(f.name,end=", ")
-#             raw_input("Press Enter to continue...")
-#
-#         printNames(solMass,   "Mass-based  : ")
-#         printNames(solMole,   "Mole-based  : ")
-#         printNames(solVolu,   "Volume-based: ")
-#         printNames(purefluids,"Pure fluids : ")
-
-    if len(errors) > 0:
+    purefluids = [obj for obj in doneObjs if obj.xid == SolutionData.ifrac_pure]
+    solMass = [obj for obj in doneObjs if obj.xid == SolutionData.ifrac_mass]
+    solMole = [obj for obj in doneObjs if obj.xid == SolutionData.ifrac_mole]
+    solVolu = [obj for obj in doneObjs if obj.xid == SolutionData.ifrac_volume]
+    known = purefluids + solMass + solMole + solVolu
+    errors = [obj for obj in doneObjs if obj not in known]
+    if errors:
         raise ValueError("There was a problem processing the fluid(s): {0}".format([error.name for error in errors]))
-
-    #solutions  = solMass
-    #solutions += solMole
-    #solutions += solVolu
 
     if runFitting:
         print("All checks passed, going to write parameters to disk.")
@@ -208,14 +128,10 @@ if __name__ == '__main__':
             combined_name = None
             combined_time = 0
         else:
-            combined_name = "all_incompressibles.pdf"
-            combined_name = os.path.join(os.path.abspath("report"), combined_name)
+            combined_name = os.path.join(os.path.abspath("report"), "all_incompressibles.pdf")
             combined_time = getTime(combined_name)
 
-        singles_time = np.array([])
-        for fl in doneObjs:
-            singles_time = np.append(singles_time, [getTime(writer.get_json_file(fl.name))])
-
+        singles_time = np.array([getTime(writer.get_json_file(fl.name)) for fl in doneObjs])
         if np.any(singles_time > combined_time):
             print("Processing {0:2d} fluids - ".format(len(doneObjs)), end="")
             writer.writeReportList(doneObjs, pdfFile=combined_name)
@@ -226,41 +142,17 @@ if __name__ == '__main__':
         writer.makeSolutionPlots(solObjs=doneObjs, pdfObj=None)
 
     if runTables:
-        #####################################
-        # Table generation routines
-        #####################################
-        # FLUID_INFO_FOLDER=os.path.abspath("table")
-        # FLUID_INFO_MASS_LIST=os.path.join(FLUID_INFO_FOLDER,"mass-based-fluids")
-        # FLUID_INFO_MOLE_LIST=os.path.join(FLUID_INFO_FOLDER,"mole-based-fluids")
-        # FLUID_INFO_VOLU_LIST=os.path.join(FLUID_INFO_FOLDER,"volume-based-fluids")
-        # FLUID_INFO_PURE_LIST=os.path.join(FLUID_INFO_FOLDER,"pure-fluids")
         FLUID_INFO_FOLDER = os.path.abspath("tables")
-        FLUID_INFO_MASS_LIST = os.path.join(FLUID_INFO_FOLDER, "Incompressibles_mass-based-fluids")
-        FLUID_INFO_MOLE_LIST = os.path.join(FLUID_INFO_FOLDER, "Incompressibles_mole-based-fluids")
-        FLUID_INFO_VOLU_LIST = os.path.join(FLUID_INFO_FOLDER, "Incompressibles_volume-based-fluids")
-        FLUID_INFO_PURE_LIST = os.path.join(FLUID_INFO_FOLDER, "Incompressibles_pure-fluids")
-
-        # After all the list got populated, we can process the entries
-        # and generate some tables
-        #
         objLists = [purefluids, solMass, solMole, solVolu]
-        filLists = [FLUID_INFO_PURE_LIST, FLUID_INFO_MASS_LIST]
-        filLists += [FLUID_INFO_MOLE_LIST, FLUID_INFO_VOLU_LIST]
-        #
-        for i in range(len(objLists)):
-            #print("Processing fluid list: ", end="")
-            #for f in objLists[i]: print(f.name, end=", ")
-            #print("... done")
-            writer.generateRstTable(objLists[i], filLists[i])
-            writer.generateTexTable(objLists[i], filLists[i])
+        filLists = [os.path.join(FLUID_INFO_FOLDER, "Incompressibles_" + name)
+                    for name in ["pure-fluids", "mass-based-fluids", "mole-based-fluids", "volume-based-fluids"]]
+        for objList, filList in zip(objLists, filLists):
+            writer.generateRstTable(objList, filList)
+            writer.generateTexTable(objList, filList)
 
     if runStats:
-        lists = [purefluids, solMass, solVolu]  # , solMole, errors]
-        labels = ["Pure", "Mass", "Volume"]  # , "Mole", "Error"]
-
-        fits = ["rho", "cp", "visc", "cond", "psat", "Tfreeze"]
-
+        lists = [purefluids, solMass, solVolu]
+        labels = ["Pure", "Mass", "Volume"]
         writer.generateStatsTable(lists, labels)
 
     print("All done, bye")
-    #sys.exit(0)

--- a/dev/incompressible_liquids/all_incompressibles.py
+++ b/dev/incompressible_liquids/all_incompressibles.py
@@ -24,8 +24,12 @@ from CPIncomp.WriterObjects import SolutionDataWriter
 
 
 def getTime(path):
+    # Modification time, not ctime: this feeds an "is the combined report
+    # older than its inputs?" comparison, and on POSIX ctime is the inode
+    # change time -- it moves on a chmod or a rename, so it can report a
+    # stale report as fresh (or force a needless rebuild).
     if os.path.isfile(path):
-        return os.path.getctime(path)
+        return os.path.getmtime(path)
     return 0
 
 

--- a/dev/incompressible_liquids/requirements-dev.txt
+++ b/dev/incompressible_liquids/requirements-dev.txt
@@ -1,0 +1,3 @@
+# Test suite for the fitting pipeline (test_*.py in this directory).
+-r requirements.txt
+pytest>=9.1.1

--- a/dev/incompressible_liquids/requirements-reports.txt
+++ b/dev/incompressible_liquids/requirements-reports.txt
@@ -1,0 +1,5 @@
+# Optional: fitting reports, plots and documentation tables
+# (SolutionDataWriter.writeReportList / generateRstTable). Not needed to fit
+# fluids or write json/.
+-r requirements.txt
+matplotlib>=3.11.0

--- a/dev/incompressible_liquids/requirements.txt
+++ b/dev/incompressible_liquids/requirements.txt
@@ -1,0 +1,16 @@
+# Dependencies for the incompressible-fluid fitting pipeline
+# (all_incompressibles.py, CPIncomp/*, test_fitting_regression.py).
+#
+# Issue #2488 ("Incompressible fitting code is no longer working") happened
+# because an unpinned numpy upgrade silently changed fit behavior with no
+# automated test to catch it. These are floors at the versions this pipeline
+# is verified to run cleanly against (no deprecation warnings, fit output
+# matches json/*.json within test_fitting_regression.py's tolerance).
+#
+# Pinning loosely (>=) rather than exactly so a deliberate upgrade is still
+# easy -- test_fitting_regression.py is the actual safety net: run it after
+# bumping any of these before trusting newly-generated JSON output.
+numpy>=2.4.6
+scipy>=1.17.1
+matplotlib>=3.11.0
+pytest>=9.1.1

--- a/dev/incompressible_liquids/requirements.txt
+++ b/dev/incompressible_liquids/requirements.txt
@@ -1,16 +1,18 @@
-# Dependencies for the incompressible-fluid fitting pipeline
-# (all_incompressibles.py, CPIncomp/*, test_fitting_regression.py).
+# Core dependencies for the incompressible-fluid fitting pipeline
+# (all_incompressibles.py, CPIncomp/*). This file alone is enough to fit
+# fluids and write json/ -- see requirements-reports.txt for the plots and
+# requirements-dev.txt for the test suite.
 #
 # Issue #2488 ("Incompressible fitting code is no longer working") happened
 # because an unpinned numpy upgrade silently changed fit behavior with no
 # automated test to catch it. These are floors at the versions this pipeline
-# is verified to run cleanly against (no deprecation warnings, fit output
-# matches json/*.json within test_fitting_regression.py's tolerance).
+# is verified to run cleanly against (no deprecation warnings; the three
+# reference fluids in test_fitting_regression.py -- DowJ, LiBr, AKF -- refit
+# to within its tolerance of their committed JSON, which is the sampled
+# stand-in for the whole json/ set rather than a check of every file).
 #
 # Pinning loosely (>=) rather than exactly so a deliberate upgrade is still
 # easy -- test_fitting_regression.py is the actual safety net: run it after
 # bumping any of these before trusting newly-generated JSON output.
 numpy>=2.4.6
 scipy>=1.17.1
-matplotlib>=3.11.0
-pytest>=9.1.1

--- a/dev/incompressible_liquids/test_data_sanity.py
+++ b/dev/incompressible_liquids/test_data_sanity.py
@@ -1,0 +1,76 @@
+"""Sanity checks on the raw reference-data loaders.
+
+Companions to DATA_AUDIT.md: the audit found exactly one ordering hazard in
+the corpus (the HFE-7100 tables store temperature descending), and the
+loaders now sort every grid by its own axis values instead of trusting file
+order. These tests pin that behavior for every data-backed fluid.
+
+Needs numpy (the loaders do); skips cleanly without it.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("numpy")
+
+from CPIncomp.SecCoolFluids import SecCoolSolutionData
+
+PROPERTY_IDS = ["Rho", "Cp", "Mu", "Cond"]
+
+
+def _loaded_axes(obj, dataID):
+    import os
+
+    if not os.path.isfile(obj.getFile(dataID)):
+        return None, None  # not every fluid carries every property table
+    arr = obj.getFromFile(dataID)
+    if arr.shape == (1, 1):
+        return None, None
+    return arr[1:, 0], arr[0, 1:]
+
+
+def test_hfe7100_descending_source_loads_ascending():
+    # The one real ordering hazard found by the audit: raw HFE-7100 files
+    # store T from +64 down to -80 degC.
+    fluid = next(o for o in SecCoolSolutionData.factory() if getattr(o, "sFile", "") == "HFE-7100")
+    for dataID in PROPERTY_IDS:
+        T, _x = _loaded_axes(fluid, dataID)
+        assert T is not None, dataID
+        assert np.all(np.diff(T) > 0), (dataID, T)
+
+
+def test_all_seccool_grids_load_with_increasing_axes():
+    for fluid in SecCoolSolutionData.factory():
+        if not hasattr(fluid, "sFile"):
+            continue
+        if type(fluid).getFromFile is not SecCoolSolutionData.getFromFile:
+            # Subclasses with their own loaders (SecCoolIceData) read csv
+            # tables of which only Hfusion is in production use; the unused
+            # Cond/Mu csvs are latin-1 encoded and not loadable as-is (see
+            # DATA_AUDIT.md).
+            continue
+        for dataID in PROPERTY_IDS:
+            T, x = _loaded_axes(fluid, dataID)
+            if T is None:
+                continue  # no file for this property
+            Tf, xf = T[np.isfinite(T)], x[np.isfinite(x)]
+            assert np.all(np.diff(Tf) > 0), (fluid.name, dataID, Tf)
+            assert np.all(np.diff(xf) >= 0), (fluid.name, dataID, xf)
+
+
+def test_all_toplevel_grids_load_with_increasing_temperature():
+    import glob
+    import os
+
+    from CPIncomp.DataObjects import DigitalData
+
+    data_dir = os.path.join(os.path.dirname(__file__), "CPIncomp", "data")
+    loader = DigitalData()
+    for path in sorted(glob.glob(os.path.join(data_dir, "*.txt"))):
+        base = os.path.basename(path)
+        name, _, dataID = base.rpartition("_")
+        loader.name = name
+        arr = loader.getFromFile(dataID[:-4])
+        T = arr[1:, 0]
+        T = T[np.isfinite(T)]
+        assert np.all(np.diff(T) > 0), (base, T)

--- a/dev/incompressible_liquids/test_data_sanity.py
+++ b/dev/incompressible_liquids/test_data_sanity.py
@@ -8,10 +8,9 @@ order. These tests pin that behavior for every data-backed fluid.
 Needs numpy (the loaders do); skips cleanly without it.
 """
 
-import numpy as np
 import pytest
 
-pytest.importorskip("numpy")
+np = pytest.importorskip("numpy")
 
 from CPIncomp.SecCoolFluids import SecCoolSolutionData
 
@@ -29,18 +28,26 @@ def _loaded_axes(obj, dataID):
     return arr[1:, 0], arr[0, 1:]
 
 
-def test_hfe7100_descending_source_loads_ascending():
+@pytest.fixture(scope="module")
+def seccool_fluids():
+    # factory() instantiates and file-loads every SecCool fluid (and prints
+    # progress); build it once for the module rather than per test.
+    return SecCoolSolutionData.factory()
+
+
+def test_hfe7100_descending_source_loads_ascending(seccool_fluids):
     # The one real ordering hazard found by the audit: raw HFE-7100 files
     # store T from +64 down to -80 degC.
-    fluid = next(o for o in SecCoolSolutionData.factory() if getattr(o, "sFile", "") == "HFE-7100")
+    fluid = next((o for o in seccool_fluids if getattr(o, "sFile", "") == "HFE-7100"), None)
+    assert fluid is not None, "HFE-7100 not found among the SecCool fluids"
     for dataID in PROPERTY_IDS:
         T, _x = _loaded_axes(fluid, dataID)
         assert T is not None, dataID
         assert np.all(np.diff(T) > 0), (dataID, T)
 
 
-def test_all_seccool_grids_load_with_increasing_axes():
-    for fluid in SecCoolSolutionData.factory():
+def test_all_seccool_grids_load_with_increasing_axes(seccool_fluids):
+    for fluid in seccool_fluids:
         if not hasattr(fluid, "sFile"):
             continue
         if type(fluid).getFromFile is not SecCoolSolutionData.getFromFile:

--- a/dev/incompressible_liquids/test_data_sanity.py
+++ b/dev/incompressible_liquids/test_data_sanity.py
@@ -5,12 +5,13 @@ the corpus (the HFE-7100 tables store temperature descending), and the
 loaders now sort every grid by its own axis values instead of trusting file
 order. These tests pin that behavior for every data-backed fluid.
 
-Needs numpy (the loaders do); skips cleanly without it.
+Needs numpy and scipy (the loaders import both); skips cleanly without either.
 """
 
 import pytest
 
 np = pytest.importorskip("numpy")
+pytest.importorskip("scipy")  # SecCoolFluids imports it transitively at module load
 
 from CPIncomp.SecCoolFluids import SecCoolSolutionData
 

--- a/dev/incompressible_liquids/test_data_sanity.py
+++ b/dev/incompressible_liquids/test_data_sanity.py
@@ -81,3 +81,50 @@ def test_all_toplevel_grids_load_with_increasing_temperature():
         T = arr[1:, 0]
         T = T[np.isfinite(T)]
         assert np.all(np.diff(T) > 0), (base, T)
+
+
+def test_seccool_ice_hfusion_grid_loads_with_increasing_axes(seccool_fluids):
+    # SecCoolIceData overrides getFromFile, so the test above skips it and its
+    # sortGridAxes call went unexercised. Only the Hfusion table is in
+    # production use (the Cond/Mu csvs for these fluids are latin-1 encoded and
+    # not loadable as-is -- see DATA_AUDIT.md), so pin that one directly.
+    #
+    # These tables happen to ship ascending already, so this asserts the
+    # contract for the real production path rather than exercising the sort
+    # itself; test_sort_grid_axes_orders_a_shuffled_grid below does that.
+    from CPIncomp.SecCoolFluids import SecCoolIceData
+
+    ice = [o for o in seccool_fluids if isinstance(o, SecCoolIceData)]
+    assert ice, "no SecCoolIceData fluids found"
+    for fluid in ice:
+        T, x = _loaded_axes(fluid, "Hfusion")
+        assert T is not None, fluid.name
+        assert np.all(np.diff(T) > 0), (fluid.name, "temperature axis not ascending", T)
+        if x is not None and np.size(x) > 1:
+            assert np.all(np.diff(x) > 0), (fluid.name, "composition axis not ascending", x)
+
+
+def test_sort_grid_axes_orders_a_shuffled_grid():
+    # Direct check on the shared helper, with a grid that is genuinely out of
+    # order in both directions -- the shipped tables are mostly ascending
+    # already, so without this the sorting logic could regress unnoticed.
+    from CPIncomp.BaseObjects import IncompressibleFitter
+
+    grid = np.array([
+        [0.0, 0.30, 0.10, 0.20],   # composition axis, shuffled
+        [300.0, 13.0, 11.0, 12.0],
+        [100.0, 3.0, 1.0, 2.0],    # temperature axis, descending
+        [200.0, 8.0, 6.0, 7.0],
+    ])
+    out = IncompressibleFitter.sortGridAxes(grid.copy())
+
+    assert np.all(np.diff(out[1:, 0]) > 0), out[1:, 0]
+    assert np.all(np.diff(out[0, 1:]) > 0), out[0, 1:]
+    # Values must travel with their axes, not just be re-sorted independently.
+    expected = np.array([
+        [0.0, 0.10, 0.20, 0.30],
+        [100.0, 1.0, 2.0, 3.0],
+        [200.0, 6.0, 7.0, 8.0],
+        [300.0, 11.0, 12.0, 13.0],
+    ])
+    assert np.array_equal(out, expected), out

--- a/dev/incompressible_liquids/test_fitting_regression.py
+++ b/dev/incompressible_liquids/test_fitting_regression.py
@@ -43,11 +43,18 @@ from CPIncomp import getPureFluids, getSolutionFluids, getSecCoolFluids
 
 JSON_DIR = os.path.join(os.path.dirname(__file__), "json")
 
-# Tolerances are relative to the magnitude of the checked-in coefficients;
-# this comfortably covers numpy/scipy solver-version noise (observed ~1e-4
+# Tolerance is numpy.allclose-style (absolute + relative): a fixed global
+# absolute floor doesn't work here because a single fit's coefficients span
+# many orders of magnitude (leading terms vs. high-order ones), so the
+# absolute floor is tied to that property's own dominant coefficient instead
+# of a universal constant -- otherwise a tiny higher-order term (e.g. DowJ's
+# conductivity has terms ~1e-11) gets judged against a floor of the same
+# order as itself and flakes on ordinary solver-version noise. This
+# comfortably covers numpy/scipy solver-version noise (observed ~1e-4
 # relative on the fluids below) while still catching an order-of-magnitude
 # or wrong-fit-type regression like #2488/#2447.
 RELATIVE_TOLERANCE = 1e-2
+ABSOLUTE_TOLERANCE_FRACTION = 1e-6  # of the property's own largest coefficient
 PROPERTIES = ["density", "specific_heat", "viscosity", "conductivity"]
 
 
@@ -71,9 +78,11 @@ def _assert_close_to_disk(fluidObject):
             continue  # property not defined/fitted for this fluid -- nothing to compare
         fittedCoeffs = np.array(fittedCoeffs, dtype=float)
         assert fittedCoeffs.shape == onDisk.shape, f"{name}.{prop}: shape changed, {fittedCoeffs.shape} vs {onDisk.shape}"
-        scale = np.maximum(np.abs(onDisk), 1e-12)
-        relDiff = np.max(np.abs(fittedCoeffs - onDisk) / scale)
-        assert relDiff < RELATIVE_TOLERANCE, f"{name}.{prop}: refit drifted {relDiff:.3e} relative from json/{name}.json (tolerance {RELATIVE_TOLERANCE:.0e})"
+        magnitude = np.max(np.abs(onDisk)) if onDisk.size else 0.0
+        absoluteFloor = max(magnitude * ABSOLUTE_TOLERANCE_FRACTION, 1e-12)
+        tolerance = absoluteFloor + RELATIVE_TOLERANCE * np.abs(onDisk)
+        worstExcess = np.max(np.abs(fittedCoeffs - onDisk) - tolerance)
+        assert worstExcess <= 0, f"{name}.{prop}: refit drifted beyond tolerance (worst excess {worstExcess:.3e}) from json/{name}.json"
 
 
 def test_pure_fluid_refit_matches_disk():

--- a/dev/incompressible_liquids/test_fitting_regression.py
+++ b/dev/incompressible_liquids/test_fitting_regression.py
@@ -15,14 +15,10 @@ numpy/scipy versions solve the same least-squares problem with slightly
 different rounding. A *large* drift, a different fit type, or a crash is
 exactly the class of regression #2488 needs caught before release.
 
-This shares the same prerequisites as dev/incompressible_liquids/all_incompressibles.py
-itself: a built-and-installed CoolProp Python package (CPIncomp.WriterObjects
-imports CoolProp.BibtexParser), plus numpy/scipy/matplotlib. The project's
-docs CI (.github/workflows/docs_docker-run.yml) already builds and installs
-that wheel before touching this directory, so run this test as part of (or
-after) that step, not standalone. If the prerequisites aren't met, the test
-collects as skipped rather than failing -- it cannot be exercised in a
-sandbox without a built CoolProp wheel.
+Prerequisites: numpy and scipy (see requirements.txt). matplotlib and a
+built CoolProp Python package are only needed for the optional report/plot
+paths, not for the fitting exercised here. If numpy/scipy aren't available,
+the test collects as skipped rather than failing.
 """
 
 import json
@@ -32,13 +28,8 @@ import pytest
 
 np = pytest.importorskip("numpy")
 pytest.importorskip("scipy")
-pytest.importorskip("matplotlib")
 
-try:
-    from CPIncomp.WriterObjects import SolutionDataWriter
-except ImportError as exc:
-    pytest.skip(f"CPIncomp.WriterObjects requires a built CoolProp Python package: {exc}", allow_module_level=True)
-
+from CPIncomp.WriterObjects import SolutionDataWriter
 from CPIncomp import getPureFluids, getSolutionFluids, getSecCoolFluids
 
 JSON_DIR = os.path.join(os.path.dirname(__file__), "json")

--- a/dev/incompressible_liquids/test_fitting_regression.py
+++ b/dev/incompressible_liquids/test_fitting_regression.py
@@ -1,0 +1,97 @@
+"""Golden-master regression test for the incompressible-fluid fitting pipeline.
+
+Issue #2488 ("Incompressible fitting code is no longer working") happened
+because a numpy upgrade silently changed how the least-squares fits behaved,
+and nobody noticed until a user reported wrong vapor pressure/viscosity
+output (#2447). There was no automated test that re-ran the fit generator and
+compared its output to what's actually checked in under json/*.json -- this
+is that test.
+
+It re-fits a small, representative set of fluids (one CoefficientFluids-style
+pure fluid, one SolutionFluids mixture, one SecCoolFluids mixture) and checks
+the regenerated coefficients are close to the committed JSON. A *tiny*
+numeric drift (~1e-4 relative) is expected and tolerated -- different
+numpy/scipy versions solve the same least-squares problem with slightly
+different rounding. A *large* drift, a different fit type, or a crash is
+exactly the class of regression #2488 needs caught before release.
+
+This shares the same prerequisites as dev/incompressible_liquids/all_incompressibles.py
+itself: a built-and-installed CoolProp Python package (CPIncomp.WriterObjects
+imports CoolProp.BibtexParser), plus numpy/scipy/matplotlib. The project's
+docs CI (.github/workflows/docs_docker-run.yml) already builds and installs
+that wheel before touching this directory, so run this test as part of (or
+after) that step, not standalone. If the prerequisites aren't met, the test
+collects as skipped rather than failing -- it cannot be exercised in a
+sandbox without a built CoolProp wheel.
+"""
+
+import json
+import os
+
+import pytest
+
+np = pytest.importorskip("numpy")
+pytest.importorskip("scipy")
+pytest.importorskip("matplotlib")
+
+try:
+    from CPIncomp.WriterObjects import SolutionDataWriter
+except ImportError as exc:
+    pytest.skip(f"CPIncomp.WriterObjects requires a built CoolProp Python package: {exc}", allow_module_level=True)
+
+from CPIncomp import getPureFluids, getSolutionFluids, getSecCoolFluids
+
+JSON_DIR = os.path.join(os.path.dirname(__file__), "json")
+
+# Tolerances are relative to the magnitude of the checked-in coefficients;
+# this comfortably covers numpy/scipy solver-version noise (observed ~1e-4
+# relative on the fluids below) while still catching an order-of-magnitude
+# or wrong-fit-type regression like #2488/#2447.
+RELATIVE_TOLERANCE = 1e-2
+PROPERTIES = ["density", "specific_heat", "viscosity", "conductivity"]
+
+
+def _load_json_coeffs(name, key):
+    with open(os.path.join(JSON_DIR, f"{name}.json")) as fh:
+        data = json.load(fh)
+    entry = data.get(key, {})
+    coeffs = entry.get("coeffs")
+    if coeffs in (None, "null"):
+        return None
+    return np.array(coeffs, dtype=float)
+
+
+def _assert_close_to_disk(fluidObject):
+    name = fluidObject.name
+    for prop in PROPERTIES:
+        onDisk = _load_json_coeffs(name, prop)
+        fitted = getattr(fluidObject, prop, None)
+        fittedCoeffs = None if fitted is None else getattr(fitted, "coeffs", None)
+        if onDisk is None or fittedCoeffs is None:
+            continue  # property not defined/fitted for this fluid -- nothing to compare
+        fittedCoeffs = np.array(fittedCoeffs, dtype=float)
+        assert fittedCoeffs.shape == onDisk.shape, f"{name}.{prop}: shape changed, {fittedCoeffs.shape} vs {onDisk.shape}"
+        scale = np.maximum(np.abs(onDisk), 1e-12)
+        relDiff = np.max(np.abs(fittedCoeffs - onDisk) / scale)
+        assert relDiff < RELATIVE_TOLERANCE, f"{name}.{prop}: refit drifted {relDiff:.3e} relative from json/{name}.json (tolerance {RELATIVE_TOLERANCE:.0e})"
+
+
+def test_pure_fluid_refit_matches_disk():
+    fluids = {f.name: f for f in getPureFluids()}
+    target = fluids["DowJ"]
+    SolutionDataWriter().fitFluidList([target])
+    _assert_close_to_disk(target)
+
+
+def test_solution_fluid_refit_matches_disk():
+    fluids = {f.name: f for f in getSolutionFluids()}
+    target = fluids["LiBr"]
+    SolutionDataWriter().fitFluidList([target])
+    _assert_close_to_disk(target)
+
+
+def test_seccool_fluid_refit_matches_disk():
+    fluids = {f.name: f for f in getSecCoolFluids()}
+    target = fluids["AKF"]
+    SolutionDataWriter().fitSecCoolList([target])
+    _assert_close_to_disk(target)

--- a/dev/incompressible_liquids/test_fitting_regression.py
+++ b/dev/incompressible_liquids/test_fitting_regression.py
@@ -46,7 +46,12 @@ JSON_DIR = os.path.join(os.path.dirname(__file__), "json")
 # or wrong-fit-type regression like #2488/#2447.
 RELATIVE_TOLERANCE = 1e-2
 ABSOLUTE_TOLERANCE_FRACTION = 1e-6  # of the property's own largest coefficient
-PROPERTIES = ["density", "specific_heat", "viscosity", "conductivity"]
+# All six fitted properties, not just the polynomial ones: saturation_pressure
+# and T_freeze are the exponential-family fits (logexponential / exppolynomial)
+# implicated in #2488, so omitting them left the golden master blind to exactly
+# the fit type that motivated it. Properties a fluid does not define are skipped
+# below, so the list can be exhaustive.
+PROPERTIES = ["density", "specific_heat", "viscosity", "conductivity", "saturation_pressure", "T_freeze"]
 
 
 def _load_json_coeffs(name, key):

--- a/dev/incompressible_liquids/test_fitting_regression.py
+++ b/dev/incompressible_liquids/test_fitting_regression.py
@@ -65,8 +65,15 @@ def _assert_close_to_disk(fluidObject):
         onDisk = _load_json_coeffs(name, prop)
         fitted = getattr(fluidObject, prop, None)
         fittedCoeffs = None if fitted is None else getattr(fitted, "coeffs", None)
-        if onDisk is None or fittedCoeffs is None:
-            continue  # property not defined/fitted for this fluid -- nothing to compare
+        if onDisk is None:
+            continue  # property not defined for this fluid -- nothing to compare
+        # fitFluidList swallows TypeError/ValueError from a failed fit and only
+        # prints, leaving coeffs unset. Skipping that case here would report a
+        # green golden-master run for exactly the crash this test exists to
+        # catch, so a property committed to json/ must also come back fitted.
+        assert fittedCoeffs is not None, (
+            f"{name}.{prop}: committed in json/{name}.json but the refit produced no coefficients "
+            f"(a swallowed fit failure -- check the fitter output above)")
         fittedCoeffs = np.array(fittedCoeffs, dtype=float)
         assert fittedCoeffs.shape == onDisk.shape, f"{name}.{prop}: shape changed, {fittedCoeffs.shape} vs {onDisk.shape}"
         magnitude = np.max(np.abs(onDisk)) if onDisk.size else 0.0

--- a/dev/incompressible_liquids/test_json_sanity.py
+++ b/dev/incompressible_liquids/test_json_sanity.py
@@ -21,12 +21,28 @@ JSON_DIR = os.path.join(os.path.dirname(__file__), "json")
 
 # Optimizer starting guesses from SolutionDataWriter.fitAll / fitCoeffs.
 # If a committed file carries exactly these values, the fit never happened.
-KNOWN_GUESSES = [
-    [500.0, -60.0, 10.0],  # viscosity, exponential
-    [-5000.0, 60.0, -10.0],  # saturation pressure, exponential
-    [700.0, -60.0, 10.0],  # freezing temperature, exponential
-    [-250.0, 1.5, 10.0],  # log-exponential retry in IncompressibleData.fitCoeffs
-]
+#
+# Read from the fitter itself rather than restated here: a copy that drifted
+# would silently stop recognising a failed fit, which is the whole failure
+# mode (#1331 / #2567) this check exists to prevent. Falls back to the literal
+# values when numpy/CPIncomp are unavailable, so the stdlib-only checks in this
+# module still run.
+try:
+    from CPIncomp.BaseObjects import IncompressibleData
+
+    KNOWN_GUESSES = [
+        list(IncompressibleData.VISCOSITY_GUESS),
+        list(IncompressibleData.PSAT_GUESS),
+        list(IncompressibleData.TFREEZE_GUESS),
+        list(IncompressibleData.LOGEXP_GUESS),
+    ]
+except ImportError:  # pragma: no cover - exercised only without numpy installed
+    KNOWN_GUESSES = [
+        [500.0, -60.0, 10.0],  # viscosity, exponential
+        [-5000.0, 60.0, -10.0],  # saturation pressure, exponential
+        [700.0, -60.0, 10.0],  # freezing temperature, exponential
+        [-250.0, 1.5, 10.0],  # log-exponential retry in IncompressibleData.fitCoeffs
+    ]
 PROPERTIES = ["density", "specific_heat", "conductivity", "viscosity", "saturation_pressure", "T_freeze"]
 
 # The three composition-conversion blocks. add_one parses these through the
@@ -251,3 +267,20 @@ def test_all_coefficients_finite():
             assert isinstance(value, (int, float)) and not isinstance(value, bool), \
                 "{0}: {1} has non-numeric coefficient {2!r}".format(name, prop, value)
             assert not math.isnan(value) and abs(value) != float("inf"), "{0}: {1} has non-finite coefficient".format(name, prop)
+
+
+def test_known_guesses_match_the_fitter():
+    # The stdlib fallback above must not drift from the fitter's real starting
+    # guesses: if it did, this module would stop recognising an unfitted
+    # placeholder and quietly pass the very check it exists to enforce.
+    pytest = __import__("pytest")
+    IncompressibleData = pytest.importorskip("CPIncomp.BaseObjects").IncompressibleData
+    canonical = [
+        list(IncompressibleData.VISCOSITY_GUESS),
+        list(IncompressibleData.PSAT_GUESS),
+        list(IncompressibleData.TFREEZE_GUESS),
+        list(IncompressibleData.LOGEXP_GUESS),
+    ]
+    assert KNOWN_GUESSES == canonical, (
+        "KNOWN_GUESSES has drifted from IncompressibleData's starting guesses; "
+        "update the stdlib fallback in this module")

--- a/dev/incompressible_liquids/test_json_sanity.py
+++ b/dev/incompressible_liquids/test_json_sanity.py
@@ -35,6 +35,7 @@ try:
         list(IncompressibleData.PSAT_GUESS),
         list(IncompressibleData.TFREEZE_GUESS),
         list(IncompressibleData.LOGEXP_GUESS),
+        list(IncompressibleData.SECCOOL_VISCOSITY_GUESS),
     ]
 except ImportError:  # pragma: no cover - exercised only without numpy installed
     KNOWN_GUESSES = [
@@ -42,6 +43,7 @@ except ImportError:  # pragma: no cover - exercised only without numpy installed
         [-5000.0, 60.0, -10.0],  # saturation pressure, exponential
         [700.0, -60.0, 10.0],  # freezing temperature, exponential
         [-250.0, 1.5, 10.0],  # log-exponential retry in IncompressibleData.fitCoeffs
+        [700.0, -60.0, 10.0],  # SecCool single-composition exponential viscosity seed
     ]
 PROPERTIES = ["density", "specific_heat", "conductivity", "viscosity", "saturation_pressure", "T_freeze"]
 
@@ -280,6 +282,7 @@ def test_known_guesses_match_the_fitter():
         list(IncompressibleData.PSAT_GUESS),
         list(IncompressibleData.TFREEZE_GUESS),
         list(IncompressibleData.LOGEXP_GUESS),
+        list(IncompressibleData.SECCOOL_VISCOSITY_GUESS),
     ]
     assert KNOWN_GUESSES == canonical, (
         "KNOWN_GUESSES has drifted from IncompressibleData's starting guesses; "

--- a/dev/incompressible_liquids/test_json_sanity.py
+++ b/dev/incompressible_liquids/test_json_sanity.py
@@ -22,29 +22,38 @@ JSON_DIR = os.path.join(os.path.dirname(__file__), "json")
 # Optimizer starting guesses from SolutionDataWriter.fitAll / fitCoeffs.
 # If a committed file carries exactly these values, the fit never happened.
 #
-# Read from the fitter itself rather than restated here: a copy that drifted
-# would silently stop recognising a failed fit, which is the whole failure
-# mode (#1331 / #2567) this check exists to prevent. Falls back to the literal
-# values when numpy/CPIncomp are unavailable, so the stdlib-only checks in this
-# module still run.
-try:
-    from CPIncomp.BaseObjects import IncompressibleData
+# The literals are what the stdlib-only path uses -- CI runs this module without
+# numpy, so the fitter cannot be imported there. They are kept as their own
+# constant, NOT folded into KNOWN_GUESSES, so that
+# test_known_guesses_match_the_fitter has two independent things to compare:
+# deriving KNOWN_GUESSES from the fitter and then comparing it back to the
+# fitter is tautological and passes even with a drifted literal.
+_FALLBACK_GUESSES = [
+    [500.0, -60.0, 10.0],  # viscosity, exponential
+    [-5000.0, 60.0, -10.0],  # saturation pressure, exponential
+    [700.0, -60.0, 10.0],  # freezing temperature, exponential
+    [-250.0, 1.5, 10.0],  # log-exponential retry in IncompressibleData.fitCoeffs
+    [700.0, -60.0, 10.0],  # SecCool single-composition exponential viscosity seed
+]
 
-    KNOWN_GUESSES = [
-        list(IncompressibleData.VISCOSITY_GUESS),
-        list(IncompressibleData.PSAT_GUESS),
-        list(IncompressibleData.TFREEZE_GUESS),
-        list(IncompressibleData.LOGEXP_GUESS),
-        list(IncompressibleData.SECCOOL_VISCOSITY_GUESS),
-    ]
-except ImportError:  # pragma: no cover - exercised only without numpy installed
-    KNOWN_GUESSES = [
-        [500.0, -60.0, 10.0],  # viscosity, exponential
-        [-5000.0, 60.0, -10.0],  # saturation pressure, exponential
-        [700.0, -60.0, 10.0],  # freezing temperature, exponential
-        [-250.0, 1.5, 10.0],  # log-exponential retry in IncompressibleData.fitCoeffs
-        [700.0, -60.0, 10.0],  # SecCool single-composition exponential viscosity seed
-    ]
+
+def _fitter_guesses():
+    """Return the fitter's ``*_GUESS`` constants sorted, or None if unimportable.
+
+    Enumerated dynamically rather than named one by one: a guess added to
+    ``IncompressibleData`` without updating ``_FALLBACK_GUESSES`` would
+    otherwise be a silent hole in the placeholder check -- which is the
+    #1331 / #2567 drift this exists to prevent.
+    """
+    try:
+        from CPIncomp.BaseObjects import IncompressibleData
+    except ImportError:  # numpy/CPIncomp absent: the stdlib-only path
+        return None
+    return sorted([float(v) for v in value] for name, value in vars(IncompressibleData).items() if name.endswith("_GUESS"))
+
+
+_FITTER_GUESSES = _fitter_guesses()
+KNOWN_GUESSES = _FITTER_GUESSES if _FITTER_GUESSES is not None else sorted(_FALLBACK_GUESSES)
 PROPERTIES = ["density", "specific_heat", "conductivity", "viscosity", "saturation_pressure", "T_freeze"]
 
 # The three composition-conversion blocks. add_one parses these through the
@@ -272,18 +281,19 @@ def test_all_coefficients_finite():
 
 
 def test_known_guesses_match_the_fitter():
-    # The stdlib fallback above must not drift from the fitter's real starting
-    # guesses: if it did, this module would stop recognising an unfitted
-    # placeholder and quietly pass the very check it exists to enforce.
-    pytest = __import__("pytest")
-    IncompressibleData = pytest.importorskip("CPIncomp.BaseObjects").IncompressibleData
-    canonical = [
-        list(IncompressibleData.VISCOSITY_GUESS),
-        list(IncompressibleData.PSAT_GUESS),
-        list(IncompressibleData.TFREEZE_GUESS),
-        list(IncompressibleData.LOGEXP_GUESS),
-        list(IncompressibleData.SECCOOL_VISCOSITY_GUESS),
-    ]
-    assert KNOWN_GUESSES == canonical, (
-        "KNOWN_GUESSES has drifted from IncompressibleData's starting guesses; "
-        "update the stdlib fallback in this module")
+    """The stdlib fallback literals must match the fitter's real guesses.
+
+    Compares two independent sources -- the literals in this module against the
+    constants enumerated from ``IncompressibleData`` -- so both a drifted
+    literal and a guess added to the fitter but not here will fail. No-ops where
+    the fitter cannot be imported, which is the situation the literals exist for.
+
+    Deliberately uses no pytest: ``dev/ci/preflight.sh`` calls these functions
+    directly when pytest is unavailable, and importing it here made that gate
+    unpassable.
+    """
+    if _FITTER_GUESSES is None:
+        return
+    assert sorted(_FALLBACK_GUESSES) == _FITTER_GUESSES, (
+        "the fallback literals in this module have drifted from IncompressibleData's "
+        "*_GUESS constants: {0} vs {1}".format(sorted(_FALLBACK_GUESSES), _FITTER_GUESSES))


### PR DESCRIPTION
Second of five PRs splitting up #3292. **1/5 (#3294) is merged, so this now targets `master` directly** — the branch was rebased onto it and this PR's diff is only its own 22 files.

Developer tooling only: nothing here changes the shipped library or any committed coefficient.

### Requirements

* All new code requires tests to ensure against regressions.

### Description of the Change

**Make the fitting pipeline approachable.** `dev/incompressible_liquids/` had accumulated ~15 years of dead Python-2 code and hard dependencies that made adding a fluid harder than the maths warrants. This removes the dead code, makes `matplotlib` and the built CoolProp wheel genuinely optional so fitting needs only `numpy` + `scipy`, splits `requirements.txt` into core / reports / dev so the install instructions match the file, and adds a step-by-step `README.md` for adding a new fluid.

**Audit every raw reference-data file** (`DATA_AUDIT.md`) for physical plausibility — no wrong-unit slips were found, and one real ordering bug was: the HFE-7100 tables ship with *descending* temperature (+64 down to −80 °C). Loaders now sort each grid by its own axis values rather than trusting file order, which also covers files that are shuffled rather than exactly reversed.

Also folds in the review findings on this area: the optimizer starting guesses are centralized on `IncompressibleData` (they were restated in three places, and a copy that drifted would stop recognising a failed fit — reopening the #1331/#2567 bug that 1/5 just fixed), `writeCsvTableToFile` no longer crashes on a bare relative path, and the golden-master regression test no longer passes silently when a fit failed.

**The tests are now actually run.** Both gates previously named `test_json_sanity.py` explicitly, so `test_data_sanity.py` (the grid-ordering contract) and `test_fitting_regression.py` (the golden master) — the two safeguards this PR adds — never executed anywhere. CI now runs the whole directory with `uvx --with numpy --with scipy`, and preflight's `incomp-sanity` check does the same; its stdlib-only fallback stays on `test_json_sanity.py`, the one module needing neither dependency.

### Benefits

* A contributor can add an incompressible fluid with `pip install -r requirements.txt` (numpy + scipy) and a documented recipe, without touching pipeline internals.
* The HFE-7100 grids are now loaded in the order the fitter assumes.
* The unfitted-placeholder guard from 1/5 can no longer be silently disarmed by a drifting copy of the starting-guess literals — and the check that enforces that is no longer tautological (see the rebase note).

### Possible Drawbacks

* Deletes a lot of long-dead code. It is dead (Python-2 syntax that cannot import on any supported interpreter), but it is a large deletion for reviewers to skim.
* The `incompressible JSON sanity` CI job now installs numpy and scipy, so it is slower than the stdlib-only version and depends on those resolving.

### Verification Process

* `pytest` on `dev/incompressible_liquids/` — 13 tests: data-file sanity (axis ordering across every SecCool grid, sentinel handling), JSON loader-contract and placeholder sanity, and a golden-master refit regression for three representative fluids (DowJ, LiBr, AKF) pinned against the committed JSON. Confirmed the same 13 run under CI's exact invocation.
* `test_data_sanity.py` asserts the HFE-7100 grids load ascending, which fails against the pre-fix loader. Shuffling a real grid's rows reproduces the sorted result exactly, so the fix is a sort by value and not a reversal.
* The golden-master test now **asserts** rather than skips when a property committed to `json/` comes back unfitted — previously a swallowed `TypeError`/`ValueError` in `fitFluidList` reported a green run for exactly the crash the test exists to catch. It covers all six fitted properties, including the exponential-family `saturation_pressure`/`T_freeze` fits that #2488 was about.
* The drift check between the stdlib fallback literals and the fitter's real starting guesses is verified to fail on a corrupted literal *and* on a guess constant added to the fitter but not to the literals.
* `matplotlib` genuinely optional: verified by running the full pipeline with it uninstalled — all 117 fluids plus 6 examples fitted and written.

**On regenerating `json/`:** this PR changes no committed coefficient, but "regeneration is byte-identical" would be too strong a claim to make. `writeFluidList` short-circuits on `CPIncomp/data/hashes.json`, which is **untracked** — so a regeneration run on a warm cache reports every fluid unchanged and proves nothing. With the cache removed, the current writer emits full-precision `repr` values where the committed files carry Python-2 `%e` formatting (`SolutionData.round()` exists but has no callers), so the files differ in formatting regardless of this branch. Byte-identity would need that formatting question settled first, which is out of scope here.

### Note on the rebase

1/5 was **squash-merged**, so none of its commits are ancestors of `master` and this branch's shared history was orphaned. It was rebased with `git rebase --onto origin/master f9d96cdf`, dropping the 8 now-redundant 1/5 commits and replaying this PR's own 8 on top of master. One conflict, in `writeCsvTableToFile`: 1/5 had added a docstring where this branch replaced the inline `os.makedirs` with `ensure_parent_directory()`. Resolved as both.

`test_json_sanity.py` merged with **no** conflict, which turned out to be the risky part. This branch's fitter-sourced `KNOWN_GUESSES` and 1/5's loader-contract checks combined into something that looked right and was not: the drift check compared the fitter to itself (so a corrupted literal passed), and it imported `pytest`, which broke the pytest-free preflight path 1/5 had added after this branch forked. Both are fixed, with the fitter side now enumerated dynamically so a *new* guess constant is caught too.

### Applicable Issues

Refs #2488 (the unpinned-numpy breakage that motivated pinning + the regression test).

### Review notes

Two earlier CodeRabbit threads were assessed and need no change:

* **`CPIncomp/PureFluids.py` vs `CoefficientFluids.py`** — the finding's premise is incorrect. Both modules exist and `CPIncomp/__init__.py` instantiates them separately via `getPureFluids()` and `getCoefficientFluids()`. `PureFluids.py` is the main pure-fluid module (734 lines, 26 classes: LBE, LiquidSodium, TherminolD12, …); `CoefficientFluids.py` holds a different category (229 lines, 8 classes: NitrateSalt, FoodProtein, FoodFat). The documentation pointing contributors at `PureFluids.py` is correct, and applying the suggestion would send them to the wrong module.
* **MD038 in `NOTES_mixing_models.md`** — does not reproduce; the only code span in that region has no internal whitespace. `markdownlint` is also not a repo gate (no reference in `.github/` or `.pre-commit-config.yaml`).

On the **`numpy>=2.4.6` / `scipy>=1.17.1` lower bounds**: left as ranges deliberately. The floors are recent, and the golden-master regression test — which now actually runs in CI — is the designed detector for a fitting change from a dependency upgrade. Upper bounds would make the pipeline uninstallable on otherwise-working environments in exchange for a risk that is already covered by a test.

The **"Docstring Coverage"** pre-merge warning measures every function in the changed files, not the ones this PR touches, so it cannot be cleared without documenting a large amount of untouched pipeline code. It is a warning, not a gate.

### Known, out of scope

`json/IceEA.json`, `IceNA.json` and `IcePG.json` ship conductivity and viscosity coefficients the pipeline can no longer reproduce — `SecCoolFluids.py` has those data loads commented out, so a refit clears both properties. This is the same class as the 1/5 placeholder bug, but no guard catches it because the values are neither zero nor optimizer guesses. Not introduced here (master behaves identically); worth its own issue and data fix.


---
_Generated by [Claude Code](https://claude.ai/code/session_014CQ8VReZEmjCk1RzS9KHLW)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for incompressible-mixture thermodynamics, reference temperatures, and entropy calculations.
  * Added fitting-pipeline instructions, data-audit notes, and research documentation on mixture modeling.
  * Clarified how to add pure fluids and solution mixtures.

* **Improvements**
  * Improved handling of unsorted property grids and generated output directories.
  * Example datasets now work when optional CoolProp support is unavailable.
  * Added more consistent fitting behavior and validation of generated data.

* **Tests**
  * Added broad sanity and regression coverage for fluid data, grids, and fitted coefficients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->