### PR TITLE
incompressible 4/5: C++ Chebyshev caloric backend and runtime INCOMP registration (#2384)

### DIFF
--- a/include/CoolProp/fluids/IncompressibleFluid.h
+++ b/include/CoolProp/fluids/IncompressibleFluid.h
@@ -35,11 +35,27 @@ struct IncompressibleData
         INCOMPRESSIBLE_EXPPOLYNOMIAL,
         INCOMPRESSIBLE_EXPONENTIAL,
         INCOMPRESSIBLE_LOGEXPONENTIAL,
-        INCOMPRESSIBLE_POLYOFFSET
+        INCOMPRESSIBLE_POLYOFFSET,
+        INCOMPRESSIBLE_CHEBYSHEV
     };
     IncompressibleTypeEnum type;
     Eigen::MatrixXd coeffs;  //TODO: Can we store the Eigen::Matrix objects more efficiently?
-    //std::vector<std::vector<double> > coeffs;
+
+    /// Chebyshev fits only (type == INCOMPRESSIBLE_CHEBYSHEV). The rows of
+    /// coeffs are Chebyshev-in-T coefficients on [cheb_Tmin, cheb_Tmax]; the
+    /// columns multiply powers of (x - cheb_xbase). The derived matrices are
+    /// built once at load time by IncompressibleFluid::validate():
+    ///  - cheb_ddT:        coefficients of d/dT (the density fit needs this
+    ///                     for the pressure terms of h and s)
+    ///  - cheb_int_dT:     coefficients of the indefinite Int f dT (enthalpy)
+    ///  - cheb_int_dTdivT: coefficients of the indefinite Int f/T dT
+    ///                     (entropy; from a Chebyshev-Lobatto re-expansion of
+    ///                     f/T, which converges geometrically since T > 0)
+    /// Integration constants are irrelevant: the backend always subtracts the
+    /// same expression evaluated at the reference state.
+    double cheb_Tmin = 0.0, cheb_Tmax = 0.0, cheb_xbase = 0.0;
+    Eigen::MatrixXd cheb_ddT, cheb_int_dT, cheb_int_dTdivT;
+
     IncompressibleData()
       : type(INCOMPRESSIBLE_NOT_SET) {
 

--- a/include/CoolProp/fluids/IncompressibleFluid.h
+++ b/include/CoolProp/fluids/IncompressibleFluid.h
@@ -159,6 +159,14 @@ class IncompressibleFluid
       : strict(true), Tmin(_HUGE), Tmax(_HUGE), xmin(_HUGE), xmax(_HUGE), xid(IFRAC_UNDEFINED), TminPsat(_HUGE), xbase(_HUGE), Tbase(_HUGE) {
 
         };
+    // The virtual destructor below suppresses the implicitly-declared move
+    // constructor/assignment operator (even though it is only '= default'),
+    // so state them explicitly - otherwise callers that std::move() a fluid
+    // (e.g. JSONIncompressibleLibrary::add_one) silently fall back to a copy.
+    IncompressibleFluid(const IncompressibleFluid&) = default;
+    IncompressibleFluid(IncompressibleFluid&&) = default;
+    IncompressibleFluid& operator=(const IncompressibleFluid&) = default;
+    IncompressibleFluid& operator=(IncompressibleFluid&&) = default;
     virtual ~IncompressibleFluid() = default;
 
     std::string getName() const {

--- a/src/Backends/Incompressible/IncompressibleBackend.cpp
+++ b/src/Backends/Incompressible/IncompressibleBackend.cpp
@@ -939,7 +939,15 @@ TEST_CASE("Internal consistency checks and example use cases for the incompressi
         }
     }
     SECTION("INCOMP::ExamplePure") {
-        double acc = 0.0001;
+        // The golden values below were computed from the centered-polynomial
+        // fit of this example fluid's tabulated data. The Chebyshev caloric
+        // fits (preferred since the *_cheb entries shipped) reproduce the
+        // same data with an independently chosen order, so the two fits may
+        // legitimately differ at fit-quality level between the data points
+        // (~2e-4 relative for cp). The tolerance is fit-level, not
+        // bit-level; a wrong-fit-class regression is orders of magnitude
+        // larger.
+        double acc = 0.001;
         std::string fluid = std::string("INCOMP::ExamplePure");
         double T = +55 + 273.15;
         double p = 10e5;

--- a/src/Backends/Incompressible/IncompressibleFluid.cpp
+++ b/src/Backends/Incompressible/IncompressibleFluid.cpp
@@ -75,6 +75,12 @@ double chebClenshaw(const Eigen::VectorXd& a, double u) {
 /// Evaluate a coefficient matrix that shares data's domain and xbase
 /// (data.coeffs itself, or one of the derived matrices).
 double chebEvalMatrix(const Eigen::MatrixXd& M, const CoolProp::IncompressibleData& data, double T, double x) {
+    if (M.rows() < 1 || M.cols() < 1) {
+        // An empty matrix would silently evaluate to 0.0 (Clenshaw over no
+        // coefficients) -- rho == 0 / a missing cp integral must be loud.
+        // Derived matrices are only built by IncompressibleFluid::validate().
+        throw CoolProp::ValueError("Chebyshev coefficient matrix is empty; the fluid was not loaded through validate().");
+    }
     const double u = (2.0 * T - (data.cheb_Tmax + data.cheb_Tmin)) / (data.cheb_Tmax - data.cheb_Tmin);
     return chebClenshaw(chebCollapse(M, x, data.cheb_xbase), u);
 }
@@ -175,6 +181,9 @@ void IncompressibleFluid::validate() {
         if (!(data->cheb_Tmin > 0.0) || !(data->cheb_Tmax > data->cheb_Tmin)) {
             throw ValueError(format("%s (%d): Chebyshev fit for %s needs 0 < Tmin < Tmax, got [%g, %g].", __FILE__, __LINE__, name.c_str(),
                                     data->cheb_Tmin, data->cheb_Tmax));
+        }
+        if (data->coeffs.rows() < 1 || data->coeffs.cols() < 1) {
+            throw ValueError(format("%s (%d): Chebyshev fit for %s has an empty coefficient matrix.", __FILE__, __LINE__, name.c_str()));
         }
         data->cheb_ddT = chebDerivativeMatrix(data->coeffs, data->cheb_Tmin, data->cheb_Tmax);
     }

--- a/src/Backends/Incompressible/IncompressibleFluid.cpp
+++ b/src/Backends/Incompressible/IncompressibleFluid.cpp
@@ -6,6 +6,11 @@
 #include <cmath>
 #include "CoolProp/numerics/MatrixMath.h"
 #include "CoolProp/numerics/PolyMath.h"
+#include "CoolProp/numerics/Solvers.h"
+// For the Chebyshev-Lobatto interpolation matrix used at load time (validate)
+// to re-expand cp(T)/T; deliberately included in this .cpp only, the public
+// header carries plain Eigen members.
+#include "CoolProp/superancillary/superancillary.h"
 #include <Eigen/Core>
 
 constexpr double INCOMP_EPSILON = DBL_EPSILON * 100.0;
@@ -33,6 +38,122 @@ double evaluateAwayFromPole(double x_den, Func fnc) {
     const double f_hi = fnc(x_hi);
     return (f_hi - f_lo) / (x_hi - x_lo) * (x_den - x_lo) + f_lo;
 }
+
+// ---- Chebyshev caloric fits (type == INCOMPRESSIBLE_CHEBYSHEV) -------------
+//
+// The 2D layout mirrors the polynomial fits: rows are Chebyshev-in-T
+// coefficients on [cheb_Tmin, cheb_Tmax], columns multiply (x - cheb_xbase)^j.
+// Evaluation collapses the composition direction to an effective 1D
+// coefficient vector (a linear combination of the columns), then runs
+// Clenshaw -- the same collapse-then-evaluate structure Polynomial2DFrac uses.
+
+/// Effective 1D Chebyshev coefficients at composition x.
+Eigen::VectorXd chebCollapse(const Eigen::MatrixXd& C, double x, double xbase) {
+    Eigen::VectorXd dx(C.cols());
+    double power = 1.0;
+    for (Eigen::Index j = 0; j < C.cols(); ++j) {
+        dx(j) = power;
+        power *= (x - xbase);
+    }
+    return C * dx;
+}
+
+/// Clenshaw evaluation at the mapped argument u in [-1, 1]
+/// (mirrors superancillary::ChebyshevExpansion::eval).
+double chebClenshaw(const Eigen::VectorXd& a, double u) {
+    const int Norder = static_cast<int>(a.size()) - 1;
+    if (Norder < 1) return (Norder == 0) ? a(0) : 0.0;
+    double u_k = 0, u_kp1 = a(Norder), u_kp2 = 0;
+    for (int k = Norder - 1; k > 0; k--) {
+        u_k = 2.0 * u * u_kp1 - u_kp2 + a(k);
+        u_kp2 = u_kp1;
+        u_kp1 = u_k;
+    }
+    return a(0) + u * u_kp1 - u_kp2;
+}
+
+/// Evaluate a coefficient matrix that shares data's domain and xbase
+/// (data.coeffs itself, or one of the derived matrices).
+double chebEvalMatrix(const Eigen::MatrixXd& M, const CoolProp::IncompressibleData& data, double T, double x) {
+    const double u = (2.0 * T - (data.cheb_Tmax + data.cheb_Tmin)) / (data.cheb_Tmax - data.cheb_Tmin);
+    return chebClenshaw(chebCollapse(M, x, data.cheb_xbase), u);
+}
+
+/// Coefficients of d/dT, one column at a time. Standard descending
+/// recurrence d_{k} = d_{k+2} + 2(k+1) a_{k+1}, d_0 halved, times du/dT.
+Eigen::MatrixXd chebDerivativeMatrix(const Eigen::MatrixXd& C, double Tmin, double Tmax) {
+    const Eigen::Index n = C.rows() - 1;  // degree
+    const double scale = 2.0 / (Tmax - Tmin);
+    Eigen::MatrixXd D = Eigen::MatrixXd::Zero(std::max<Eigen::Index>(n, 1), C.cols());
+    for (Eigen::Index j = 0; j < C.cols(); ++j) {
+        for (Eigen::Index k = n - 1; k >= 0; --k) {
+            const double higher = (k + 2 <= n - 1) ? D(k + 2, j) : 0.0;
+            D(k, j) = higher + 2.0 * static_cast<double>(k + 1) * C(k + 1, j);
+        }
+        if (n >= 1) D(0, j) *= 0.5;
+        D.col(j) *= scale;
+    }
+    return D;
+}
+
+/// Coefficients of the indefinite integral over T, one column at a time.
+/// Standard antiderivative recurrence (the inverse of the derivative one),
+/// times dT/du = (Tmax - Tmin)/2. The b_0 coefficient is left at zero: the
+/// integration constant always cancels against the reference-state value.
+Eigen::MatrixXd chebAntiderivativeMatrix(const Eigen::MatrixXd& C, double Tmin, double Tmax) {
+    const Eigen::Index n = C.rows() - 1;  // degree
+    const double scale = 0.5 * (Tmax - Tmin);
+    Eigen::MatrixXd B = Eigen::MatrixXd::Zero(C.rows() + 1, C.cols());
+    for (Eigen::Index j = 0; j < C.cols(); ++j) {
+        B(1, j) = C(0, j);
+        if (n >= 1) B(2, j) = 0.25 * C(1, j);
+        for (Eigen::Index k = 2; k <= n; ++k) {
+            B(k + 1, j) += C(k, j) / (2.0 * static_cast<double>(k + 1));
+            B(k - 1, j) -= C(k, j) / (2.0 * static_cast<double>(k - 1));
+        }
+        B.col(j) *= scale;
+    }
+    return B;
+}
+
+/// Re-expand f(T)/T column-wise on the same domain by Chebyshev-Lobatto
+/// interpolation. f/T is analytic on [Tmin, Tmax] (Tmin > 0 is enforced at
+/// load), so the coefficients decay geometrically; the degree grows until
+/// the relative tail is at rounding level. Division by T is linear, so
+/// treating each (x - xbase)^j column independently is exact for every x.
+Eigen::MatrixXd chebDivideByTMatrix(const Eigen::MatrixXd& C, double Tmin, double Tmax) {
+    const double tail_target = 1e-13;
+    Eigen::Index degree = C.rows() + 8;
+    const Eigen::Index max_degree = 96;
+    while (true) {
+        const auto LU = CoolProp::superancillary::detail::get_LU_matrices(static_cast<std::size_t>(degree));
+        const Eigen::MatrixXd& L = std::get<0>(LU);
+        // Chebyshev-Lobatto nodes mapped to [Tmin, Tmax]
+        Eigen::VectorXd T_nodes(degree + 1);
+        for (Eigen::Index i = 0; i <= degree; ++i) {
+            const double u = std::cos(EIGEN_PI * static_cast<double>(i) / static_cast<double>(degree));
+            T_nodes(i) = 0.5 * ((Tmax - Tmin) * u + (Tmax + Tmin));
+        }
+        Eigen::MatrixXd out(degree + 1, C.cols());
+        double worst_tail = 0.0;
+        for (Eigen::Index j = 0; j < C.cols(); ++j) {
+            Eigen::VectorXd samples(degree + 1);
+            for (Eigen::Index i = 0; i <= degree; ++i) {
+                const double u = std::cos(EIGEN_PI * static_cast<double>(i) / static_cast<double>(degree));
+                samples(i) = chebClenshaw(C.col(j), u) / T_nodes(i);
+            }
+            out.col(j) = L * samples;
+            const double scale = out.col(j).cwiseAbs().maxCoeff();
+            if (scale > 0.0) {
+                worst_tail = std::max(worst_tail, out.col(j).tail(3).cwiseAbs().maxCoeff() / scale);
+            }
+        }
+        if (worst_tail < tail_target || degree >= max_degree) {
+            return out;
+        }
+        degree += 16;
+    }
+}
 }  // namespace
 
 namespace CoolProp {
@@ -46,11 +167,23 @@ and transport properties.
 //IncompressibleFluid::IncompressibleFluid();
 
 void IncompressibleFluid::validate() {
-    return;
-    // TODO: Implement validation function
-
-    // u and s have to be of the polynomial type!
-    //throw NotImplementedError("TODO");
+    // Chebyshev caloric fits: check the domain and build the derived
+    // coefficient matrices exactly once, at load time. Everything h/s need
+    // afterwards is a plain Clenshaw evaluation (see dhdTatPxdT/dsdTatPxdT).
+    for (IncompressibleData* data : {&density, &specific_heat}) {
+        if (data->type != IncompressibleData::INCOMPRESSIBLE_CHEBYSHEV) continue;
+        if (!(data->cheb_Tmin > 0.0) || !(data->cheb_Tmax > data->cheb_Tmin)) {
+            throw ValueError(format("%s (%d): Chebyshev fit for %s needs 0 < Tmin < Tmax, got [%g, %g].", __FILE__, __LINE__, name.c_str(),
+                                    data->cheb_Tmin, data->cheb_Tmax));
+        }
+        data->cheb_ddT = chebDerivativeMatrix(data->coeffs, data->cheb_Tmin, data->cheb_Tmax);
+    }
+    if (specific_heat.type == IncompressibleData::INCOMPRESSIBLE_CHEBYSHEV) {
+        specific_heat.cheb_int_dT = chebAntiderivativeMatrix(specific_heat.coeffs, specific_heat.cheb_Tmin, specific_heat.cheb_Tmax);
+        specific_heat.cheb_int_dTdivT =
+          chebAntiderivativeMatrix(chebDivideByTMatrix(specific_heat.coeffs, specific_heat.cheb_Tmin, specific_heat.cheb_Tmax),
+                                   specific_heat.cheb_Tmin, specific_heat.cheb_Tmax);
+    }
 }
 
 bool IncompressibleFluid::is_pure() {
@@ -107,6 +240,8 @@ double IncompressibleFluid::rho(double T, double p, double x) {
     switch (density.type) {
         case IncompressibleData::INCOMPRESSIBLE_POLYNOMIAL:
             return poly.evaluate(density.coeffs, T, x, 0, 0, Tbase, xbase);
+        case IncompressibleData::INCOMPRESSIBLE_CHEBYSHEV:
+            return chebEvalMatrix(density.coeffs, density, T, x);
         case IncompressibleData::INCOMPRESSIBLE_EXPONENTIAL:
             return baseExponential(density, T, 0.0);
         case IncompressibleData::INCOMPRESSIBLE_LOGEXPONENTIAL:
@@ -127,8 +262,9 @@ double IncompressibleFluid::rho(double T, double p, double x) {
 double IncompressibleFluid::c(double T, double p, double x) {
     switch (specific_heat.type) {
         case IncompressibleData::INCOMPRESSIBLE_POLYNOMIAL:
-            //throw NotImplementedError("Here you should implement the polynomial.");
             return poly.evaluate(specific_heat.coeffs, T, x, 0, 0, Tbase, xbase);
+        case IncompressibleData::INCOMPRESSIBLE_CHEBYSHEV:
+            return chebEvalMatrix(specific_heat.coeffs, specific_heat, T, x);
         case IncompressibleData::INCOMPRESSIBLE_NOT_SET:
             throw ValueError(format("%s (%d): The function type is not specified (\"[%d]\"), are you sure the coefficients have been set?", __FILE__,
                                     __LINE__, specific_heat.type));
@@ -237,6 +373,8 @@ double IncompressibleFluid::drhodTatPx(double T, double p, double x) {
     switch (density.type) {
         case IncompressibleData::INCOMPRESSIBLE_POLYNOMIAL:
             return poly.derivative(density.coeffs, T, x, 0, 0, 0, Tbase, xbase);
+        case IncompressibleData::INCOMPRESSIBLE_CHEBYSHEV:
+            return chebEvalMatrix(density.cheb_ddT, density, T, x);
         case IncompressibleData::INCOMPRESSIBLE_NOT_SET:
             throw ValueError(format("%s (%d): The function type is not specified (\"[%d]\"), are you sure the coefficients have been set?", __FILE__,
                                     __LINE__, density.type));
@@ -252,6 +390,9 @@ double IncompressibleFluid::dsdTatPxdT(double T, double p, double x) {
     switch (specific_heat.type) {
         case IncompressibleData::INCOMPRESSIBLE_POLYNOMIAL:
             return poly.integral(specific_heat.coeffs, T, x, 0, -1, 0, Tbase, xbase);
+        case IncompressibleData::INCOMPRESSIBLE_CHEBYSHEV:
+            // Indefinite Int c/T dT, derived once at load time in validate()
+            return chebEvalMatrix(specific_heat.cheb_int_dTdivT, specific_heat, T, x);
         case IncompressibleData::INCOMPRESSIBLE_NOT_SET:
             throw ValueError(format("%s (%d): The function type is not specified (\"[%d]\"), are you sure the coefficients have been set?", __FILE__,
                                     __LINE__, specific_heat.type));
@@ -267,6 +408,9 @@ double IncompressibleFluid::dhdTatPxdT(double T, double p, double x) {
     switch (specific_heat.type) {
         case IncompressibleData::INCOMPRESSIBLE_POLYNOMIAL:
             return poly.integral(specific_heat.coeffs, T, x, 0, 0, 0, Tbase, xbase);
+        case IncompressibleData::INCOMPRESSIBLE_CHEBYSHEV:
+            // Indefinite Int c dT, derived once at load time in validate()
+            return chebEvalMatrix(specific_heat.cheb_int_dT, specific_heat, T, x);
         case IncompressibleData::INCOMPRESSIBLE_NOT_SET:
             throw ValueError(format("%s (%d): The function type is not specified (\"[%d]\"), are you sure the coefficients have been set?", __FILE__,
                                     __LINE__, specific_heat.type));
@@ -400,6 +544,22 @@ double IncompressibleFluid::T_rho(double Dmass, double p, double x) {
     switch (density.type) {
         case IncompressibleData::INCOMPRESSIBLE_POLYNOMIAL:
             return poly.solve_limits(density.coeffs, x, d_raw, Tmin, Tmax, 0, 0, 0, Tbase, xbase);
+        case IncompressibleData::INCOMPRESSIBLE_CHEBYSHEV: {
+            // Brent on the forward evaluation over the fluid's range,
+            // mirroring the backend's HmassP/PSmass flashes; the Chebyshev
+            // basis has no (and needs no) direct polynomial root-solve.
+            class Residual : public FuncWrapper1D
+            {
+               public:
+                IncompressibleFluid* fluid;
+                double p, x, target;
+                Residual(IncompressibleFluid* fluid, double p, double x, double target) : fluid(fluid), p(p), x(x), target(target) {}
+                double call(double T) override {
+                    return fluid->rho(T, p, x) - target;
+                }
+            } res(this, p, x, d_raw);
+            return Brent(&res, Tmin, Tmax, DBL_EPSILON, 1e3 * DBL_EPSILON, 100);
+        }
         case IncompressibleData::INCOMPRESSIBLE_NOT_SET:
             throw ValueError(format("%s (%d): The function type is not specified (\"[%d]\"), are you sure the coefficients have been set?", __FILE__,
                                     __LINE__, specific_heat.type));
@@ -414,6 +574,20 @@ double IncompressibleFluid::T_c(double Cmass, double p, double x) {
     switch (specific_heat.type) {
         case IncompressibleData::INCOMPRESSIBLE_POLYNOMIAL:
             return poly.solve_limits(specific_heat.coeffs, x, c_raw, Tmin, Tmax, 0, 0, 0, Tbase, xbase);
+        case IncompressibleData::INCOMPRESSIBLE_CHEBYSHEV: {
+            // See the matching comment in T_rho above.
+            class Residual : public FuncWrapper1D
+            {
+               public:
+                IncompressibleFluid* fluid;
+                double p, x, target;
+                Residual(IncompressibleFluid* fluid, double p, double x, double target) : fluid(fluid), p(p), x(x), target(target) {}
+                double call(double T) override {
+                    return fluid->c(T, p, x) - target;
+                }
+            } res(this, p, x, c_raw);
+            return Brent(&res, Tmin, Tmax, DBL_EPSILON, 1e3 * DBL_EPSILON, 100);
+        }
         case IncompressibleData::INCOMPRESSIBLE_NOT_SET:
             throw ValueError(format("%s (%d): The function type is not specified (\"[%d]\"), are you sure the coefficients have been set?", __FILE__,
                                     __LINE__, specific_heat.type));

--- a/src/Backends/Incompressible/IncompressibleFluid.cpp
+++ b/src/Backends/Incompressible/IncompressibleFluid.cpp
@@ -185,6 +185,27 @@ void IncompressibleFluid::validate() {
         if (data->coeffs.rows() < 1 || data->coeffs.cols() < 1) {
             throw ValueError(format("%s (%d): Chebyshev fit for %s has an empty coefficient matrix.", __FILE__, __LINE__, name.c_str()));
         }
+        // The fit domain must cover the fluid's advertised range. The scaled
+        // variable u = (2T - (cheb_Tmax + cheb_Tmin)) / (cheb_Tmax - cheb_Tmin)
+        // is not clamped, and Trange is deliberately independent of the
+        // fluid-level Tmin/Tmax (it is the data range), so a fit narrower than
+        // the fluid range would let checkT() admit a temperature and then have
+        // Clenshaw extrapolate outside [-1, 1], where a Chebyshev series
+        // diverges fast and silently. A fit WIDER than the fluid range is fine
+        // and is shipped deliberately (ZS25/ZS40 cp cover ~2 K below Tmin,
+        // which is real measured data).
+        //
+        // Compared with a tolerance, not exactly: Trange is emitted as a
+        // full-precision double from the Python fitter, so an endpoint that is
+        // conceptually equal to Tmax can differ in the last bits. HFE2 ships
+        // cheb_Tmax = 337.41999999999996 against Tmax = 337.42, and a bit-exact
+        // compare would reject it -- taking the whole incompressible library
+        // down at static-init time over 4e-14 K.
+        const double cover_tol = 1e-6 * std::max(1.0, Tmax - Tmin);
+        if (data->cheb_Tmin > Tmin + cover_tol || data->cheb_Tmax < Tmax - cover_tol) {
+            throw ValueError(format("%s (%d): Chebyshev fit domain [%g, %g] for %s does not cover the fluid range [%g, %g].", __FILE__, __LINE__,
+                                    data->cheb_Tmin, data->cheb_Tmax, name.c_str(), Tmin, Tmax));
+        }
         data->cheb_ddT = chebDerivativeMatrix(data->coeffs, data->cheb_Tmin, data->cheb_Tmax);
     }
     if (specific_heat.type == IncompressibleData::INCOMPRESSIBLE_CHEBYSHEV) {

--- a/src/Backends/Incompressible/IncompressibleLibrary.cpp
+++ b/src/Backends/Incompressible/IncompressibleLibrary.cpp
@@ -372,6 +372,24 @@ IncompressibleData JSONIncompressibleLibrary::parse_coefficients(const nlohmann:
                     fluidData.type = CoolProp::IncompressibleData::INCOMPRESSIBLE_POLYOFFSET;
                     fluidData.coeffs = vec_to_eigen(cpjson::get_double_array(entry.at("coeffs")));
                     return fluidData;
+                } else if (!type.compare("chebyshev")) {
+                    // Chebyshev-in-T x monomial-in-(x - xbase) caloric fit; the
+                    // fit domain is explicit per entry (it is the data range,
+                    // which need not equal the fluid-level Tmin/Tmax exactly).
+                    // The derived integral/derivative matrices are built in
+                    // IncompressibleFluid::validate() once the fluid is
+                    // assembled.
+                    fluidData.type = CoolProp::IncompressibleData::INCOMPRESSIBLE_CHEBYSHEV;
+                    fluidData.coeffs = vec_to_eigen(cpjson::get_double_array2D(entry.at("coeffs")));
+                    std::vector<double> Trange = cpjson::get_double_array(entry, "Trange");
+                    if (Trange.size() != 2) {
+                        throw ValueError(
+                          format("The \"Trange\" of [%s] must have exactly 2 entries, got %d.", id.c_str(), static_cast<int>(Trange.size())));
+                    }
+                    fluidData.cheb_Tmin = Trange[0];
+                    fluidData.cheb_Tmax = Trange[1];
+                    fluidData.cheb_xbase = entry.contains("xbase") ? cpjson::get_double(entry, "xbase") : 0.0;
+                    return fluidData;
                 } else if (vital) {
                     throw ValueError(format("The type [%s] is not understood for [%s] of incompressible fluids. Please check your JSON file.",
                                             type.c_str(), id.c_str()));
@@ -454,8 +472,22 @@ void JSONIncompressibleLibrary::add_one(const nlohmann::json& fluid_json) {
 
         /// Setters for the coefficients
         if (get_debug_level() >= 20) std::cout << format("Incompressible library: Loading coefficients for %s ", fluid.getName().c_str()) << '\n';
-        fluid.setDensity(parse_coefficients(fluid_json, "density", true));
-        fluid.setSpecificHeat(parse_coefficients(fluid_json, "specific_heat", true));
+        // The caloric properties prefer the Chebyshev entries when the JSON
+        // carries them (exact singularity-free enthalpy/entropy integrals,
+        // see dev/incompressible_liquids/NOTES_thermodynamic_consistency.md);
+        // the classic polynomial entries remain the fallback and the format
+        // for every other property. Flip this to false to A/B against the
+        // polynomial caloric path with the same library.
+        static constexpr bool prefer_chebyshev_caloric = true;
+        auto parse_caloric = [this, &fluid_json](const std::string& id) {
+            if (prefer_chebyshev_caloric && fluid_json.contains(id + "_cheb")) {
+                IncompressibleData data = parse_coefficients(fluid_json, id + "_cheb", false);
+                if (data.type == CoolProp::IncompressibleData::INCOMPRESSIBLE_CHEBYSHEV) return data;
+            }
+            return parse_coefficients(fluid_json, id, true);
+        };
+        fluid.setDensity(parse_caloric("density"));
+        fluid.setSpecificHeat(parse_caloric("specific_heat"));
         fluid.setViscosity(parse_coefficients(fluid_json, "viscosity", false));
         fluid.setConductivity(parse_coefficients(fluid_json, "conductivity", false));
         fluid.setPsat(parse_coefficients(fluid_json, "saturation_pressure", false));

--- a/src/Backends/Incompressible/IncompressibleLibrary.cpp
+++ b/src/Backends/Incompressible/IncompressibleLibrary.cpp
@@ -444,16 +444,11 @@ void JSONIncompressibleLibrary::add_many(const nlohmann::json& listing) {
 void JSONIncompressibleLibrary::add_one(const nlohmann::json& fluid_json) {
     _is_empty = false;
 
-    // Get the next index for this fluid
-    std::size_t index = fluid_map.size();
-
-    // Add index->fluid mapping
-    fluid_map[index] = IncompressibleFluid();
-    //fluid_map[index].reset(new IncompressibleFluid());
-    //fluid_map[index].reset(new IncompressibleFluid());
-
-    // Create an instance of the fluid
-    IncompressibleFluid& fluid = fluid_map[index];
+    // Build the fluid locally first: nothing is registered until parsing and
+    // validation succeed, so a malformed definition (now reachable at runtime
+    // through add_fluids_as_JSON) cannot leave a half-initialized entry in
+    // the maps.
+    IncompressibleFluid fluid;
     fluid.setName("unloaded");
     try {
         fluid.setName(cpjson::get_string(fluid_json, "name"));
@@ -482,7 +477,14 @@ void JSONIncompressibleLibrary::add_one(const nlohmann::json& fluid_json) {
         auto parse_caloric = [this, &fluid_json](const std::string& id) {
             if (prefer_chebyshev_caloric && fluid_json.contains(id + "_cheb")) {
                 IncompressibleData data = parse_coefficients(fluid_json, id + "_cheb", false);
-                if (data.type == CoolProp::IncompressibleData::INCOMPRESSIBLE_CHEBYSHEV) return data;
+                if (data.type != CoolProp::IncompressibleData::INCOMPRESSIBLE_CHEBYSHEV) {
+                    // The entry exists but did not parse as chebyshev (e.g. a
+                    // typo in "type"): failing loudly beats silently running
+                    // on the polynomial fallback while the author believes
+                    // the Chebyshev fit is in use.
+                    throw ValueError(format("The entry [%s_cheb] exists but its type is not \"chebyshev\"; fix or remove it.", id.c_str()));
+                }
+                return data;
             }
             return parse_coefficients(fluid_json, id, true);
         };
@@ -507,20 +509,50 @@ void JSONIncompressibleLibrary::add_one(const nlohmann::json& fluid_json) {
 
         /// A function to check coefficients and equation types.
         fluid.validate();
-
-        // Add name->index mapping
-        string_to_index_map[fluid.getName()] = index;
-
-        // Add name to vector of names
-        if (fluid.is_pure()) {
-            this->name_vector_pure.push_back(fluid.getName());
-        } else {
-            this->name_vector_solution.push_back(fluid.getName());
-        }
     } catch (std::exception& e) {
         std::cout << format("Unable to load fluid: %s; error was %s\n", fluid.getName().c_str(), e.what());
         throw;
     }
+
+    const std::string name = fluid.getName();
+    // These characters would corrupt the comma-joined fluid lists or the
+    // "INCOMP::Name" / "Name[x]" fluid-string parsing.
+    if (name.find_first_of(",|[]:&") != std::string::npos) {
+        throw ValueError(format("Invalid incompressible fluid name [%s]: must not contain any of ',|[]:&'.", name.c_str()));
+    }
+
+    // THREAD SAFETY: the lookup/replace/append below is not synchronized, and
+    // deliberately so -- a write-only lock here would be worse than none,
+    // because every reader (get(), the name-vector accessors, and so every
+    // property evaluation) walks these same containers unlocked and would keep
+    // racing while *looking* protected. Making this genuinely safe means
+    // guarding the read path too, which puts a lock on the property-evaluation
+    // hot path; that is a backend-wide decision, tracked as a follow-up rather
+    // than smuggled in here. Until then the contract matches the pre-existing
+    // HEOS/Cubics add_fluids_as_JSON paths: register fluids during start-up,
+    // before other threads query the library.
+    std::map<std::string, std::size_t>::const_iterator it = string_to_index_map.find(name);
+    if (it != string_to_index_map.end()) {
+        // Re-adding an existing name replaces the fluid in place (idempotent
+        // re-registration and edit flows); the name vectors must not grow
+        // duplicates. A pure/solution flip would leave the name in the wrong
+        // list, so reject that instead of silently misfiling it.
+        if (fluid_map[it->second].is_pure() != fluid.is_pure()) {
+            throw ValueError(
+              format("Cannot replace incompressible fluid [%s]: pure/solution classification differs from the existing entry.", name.c_str()));
+        }
+        fluid_map[it->second] = std::move(fluid);
+        return;
+    }
+
+    const std::size_t index = fluid_map.size();
+    string_to_index_map[name] = index;
+    if (fluid.is_pure()) {
+        this->name_vector_pure.push_back(name);
+    } else {
+        this->name_vector_solution.push_back(name);
+    }
+    fluid_map[index] = std::move(fluid);
 };
 
 void JSONIncompressibleLibrary::add_obj(const IncompressibleFluid& fluid_obj) {

--- a/src/Backends/Incompressible/IncompressibleLibrary.cpp
+++ b/src/Backends/Incompressible/IncompressibleLibrary.cpp
@@ -537,22 +537,49 @@ void JSONIncompressibleLibrary::add_one(const nlohmann::json& fluid_json) {
         // re-registration and edit flows); the name vectors must not grow
         // duplicates. A pure/solution flip would leave the name in the wrong
         // list, so reject that instead of silently misfiling it.
-        if (fluid_map[it->second].is_pure() != fluid.is_pure()) {
+        //
+        // find() plus an explicit throw, rather than operator[] or at().
+        // operator[] would default-construct an empty fluid on a desync and
+        // answer is_pure() from it -- and since a default fluid has
+        // density.coeffs.cols() == 0, it reads as a solution, so the guard
+        // below would report a bogus classification mismatch or pass and
+        // overwrite the wrong slot. at() would throw std::out_of_range, which
+        // does not derive from CoolPropBaseError and so reaches the C wrapper's
+        // catch(...) arm: errcode 3 and an untouched message buffer, i.e. an
+        // empty error string at the FFI boundary. ValueError is what get()
+        // already throws for this same missing-index condition and survives
+        // the boundary with its text intact.
+        auto existing = fluid_map.find(it->second);
+        if (existing == fluid_map.end()) {
+            throw ValueError(format("Internal error: incompressible fluid [%s] maps to index %d, which is missing from the fluid map.", name.c_str(),
+                                    static_cast<int>(it->second)));
+        }
+        if (existing->second.is_pure() != fluid.is_pure()) {
             throw ValueError(
               format("Cannot replace incompressible fluid [%s]: pure/solution classification differs from the existing entry.", name.c_str()));
         }
-        fluid_map[it->second] = std::move(fluid);
+        existing->second = std::move(fluid);
         return;
     }
 
+    // Publish into fluid_map BEFORE string_to_index_map. The replace-in-place
+    // branch above treats "name resolves to an index with no fluid" as a broken
+    // invariant and throws; writing the name mapping first would make that
+    // state reachable from an ordinary allocation failure between the two
+    // writes, permanently poisoning the name. In this order a throw can only
+    // leave an unreferenced fluid_map entry, which nothing looks up. The name
+    // vectors go last for the same reason: a throw there leaves the fluid
+    // resolvable but unlisted, which is inert, rather than listed but
+    // unresolvable.
     const std::size_t index = fluid_map.size();
+    const bool is_pure = fluid.is_pure();
+    fluid_map[index] = std::move(fluid);
     string_to_index_map[name] = index;
-    if (fluid.is_pure()) {
+    if (is_pure) {
         this->name_vector_pure.push_back(name);
     } else {
         this->name_vector_solution.push_back(name);
     }
-    fluid_map[index] = std::move(fluid);
 };
 
 void JSONIncompressibleLibrary::add_obj(const IncompressibleFluid& fluid_obj) {

--- a/src/Backends/Incompressible/IncompressibleLibrary.cpp
+++ b/src/Backends/Incompressible/IncompressibleLibrary.cpp
@@ -352,27 +352,27 @@ IncompressibleData JSONIncompressibleLibrary::parse_coefficients(const nlohmann:
         if (entry.contains("type")) {
             if (entry.contains("coeffs")) {
                 std::string type = cpjson::get_string(entry, "type");
-                if (!type.compare("polynomial")) {
+                if (type.compare("polynomial") == 0) {
                     fluidData.type = CoolProp::IncompressibleData::INCOMPRESSIBLE_POLYNOMIAL;
                     fluidData.coeffs = vec_to_eigen(cpjson::get_double_array2D(entry.at("coeffs")));
                     return fluidData;
-                } else if (!type.compare("exponential")) {
+                } else if (type.compare("exponential") == 0) {
                     fluidData.type = CoolProp::IncompressibleData::INCOMPRESSIBLE_EXPONENTIAL;
                     fluidData.coeffs = vec_to_eigen(cpjson::get_double_array(entry.at("coeffs")));
                     return fluidData;
-                } else if (!type.compare("logexponential")) {
+                } else if (type.compare("logexponential") == 0) {
                     fluidData.type = CoolProp::IncompressibleData::INCOMPRESSIBLE_LOGEXPONENTIAL;
                     fluidData.coeffs = vec_to_eigen(cpjson::get_double_array(entry.at("coeffs")));
                     return fluidData;
-                } else if (!type.compare("exppolynomial")) {
+                } else if (type.compare("exppolynomial") == 0) {
                     fluidData.type = CoolProp::IncompressibleData::INCOMPRESSIBLE_EXPPOLYNOMIAL;
                     fluidData.coeffs = vec_to_eigen(cpjson::get_double_array2D(entry.at("coeffs")));
                     return fluidData;
-                } else if (!type.compare("polyoffset")) {
+                } else if (type.compare("polyoffset") == 0) {
                     fluidData.type = CoolProp::IncompressibleData::INCOMPRESSIBLE_POLYOFFSET;
                     fluidData.coeffs = vec_to_eigen(cpjson::get_double_array(entry.at("coeffs")));
                     return fluidData;
-                } else if (!type.compare("chebyshev")) {
+                } else if (type.compare("chebyshev") == 0) {
                     // Chebyshev-in-T x monomial-in-(x - xbase) caloric fit; the
                     // fit domain is explicit per entry (it is the data range,
                     // which need not equal the fluid-level Tmin/Tmax exactly).
@@ -531,7 +531,7 @@ void JSONIncompressibleLibrary::add_one(const nlohmann::json& fluid_json) {
     // than smuggled in here. Until then the contract matches the pre-existing
     // HEOS/Cubics add_fluids_as_JSON paths: register fluids during start-up,
     // before other threads query the library.
-    std::map<std::string, std::size_t>::const_iterator it = string_to_index_map.find(name);
+    auto it = string_to_index_map.find(name);
     if (it != string_to_index_map.end()) {
         // Re-adding an existing name replaces the fluid in place (idempotent
         // re-registration and edit flows); the name vectors must not grow

--- a/src/CoolProp.cpp
+++ b/src/CoolProp.cpp
@@ -43,6 +43,7 @@
 #include "CoolProp/detail/tools.h"
 #include "CoolProp/numerics/Solvers.h"
 #include "CoolProp/numerics/MatrixMath.h"
+#include "CoolProp/detail/json.h"
 #include "Backends/Helmholtz/Fluids/FluidLibrary.h"
 #include "Backends/Incompressible/IncompressibleLibrary.h"
 #include "Backends/Incompressible/IncompressibleBackend.h"
@@ -710,8 +711,19 @@ bool add_fluids_as_JSON(const std::string& backend, const std::string& fluidstri
     } else if (backend == "PCSAFT") {
         PCSAFTLibrary::add_fluids_as_JSON(fluidstring);
         return true;
+    } else if (backend == "INCOMP") {
+        // Accept either a single fluid object or an array of them, matching
+        // how the embedded incompressible library JSON is structured (#2384)
+        nlohmann::json j = cpjson::parse(fluidstring);
+        if (j.is_array()) {
+            get_incompressible_library().add_many(j);
+        } else {
+            get_incompressible_library().add_one(j);
+        }
+        return true;
     } else {
-        throw ValueError(format("You have provided an invalid backend [%s] to add_fluids_as_JSON; valid options are SRK, PR, HEOS", backend.c_str()));
+        throw ValueError(format("You have provided an invalid backend [%s] to add_fluids_as_JSON; valid options are SRK, PR, HEOS, PCSAFT, INCOMP",
+                                backend.c_str()));
     }
 }
 

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5484,6 +5484,12 @@ TEST_CASE("Incompressible enthalpy is finite and continuous at T == Tbase (#1578
         CHECK(std::abs(h_mid - midpoint) < 1.0);  // [J/kg]
     }
 }
+// Name prefix for incompressible fluids that tests register at runtime through
+// add_fluids_as_JSON. The library is process-wide and has no unregister, so the
+// shipped-fluid enumeration below filters this prefix; any test that registers a
+// fluid must use it, or it will perturb that count under --order rand.
+static const std::string RUNTIME_TEST_FLUID_PREFIX = "CatchRuntime";
+
 TEST_CASE("INCOMP enthalpy and entropy are finite at Tbase for every shipped fluid", "[INCOMP]") {
     // Generalizes the #1578 regression test above (which only names 4
     // fluids) to the whole library: the Python fit generator places Tbase at
@@ -5497,7 +5503,16 @@ TEST_CASE("INCOMP enthalpy and entropy are finite at Tbase for every shipped flu
                               + CoolProp::get_global_param_string("incompressible_list_solution"));
         std::string name;
         while (std::getline(ss, name, ',')) {
-            if (!name.empty()) names.push_back(name);
+            if (name.empty()) continue;
+            // Skip fluids that another test registered at runtime. The
+            // incompressible library is process-wide with no unregister, and
+            // Catch2 with --order rand may run the add_fluids_as_JSON section
+            // below BEFORE this test, which would otherwise inflate the exact
+            // count and fail it. Measured: 7 of 10 seeds failed 128 == 127
+            // before this filter. The prefix is test-only, so it cannot hide a
+            // shipped fluid from the count.
+            if (name.compare(0, RUNTIME_TEST_FLUID_PREFIX.size(), RUNTIME_TEST_FLUID_PREFIX) == 0) continue;
+            names.push_back(name);
         }
     }
     // Exact, because `names` comes from the library's own fluid lists: a
@@ -5651,7 +5666,7 @@ TEST_CASE("INCOMP Chebyshev caloric fits: values, consistency and integrals", "[
         // cp(T) constant 2000, on T in [280, 360]. T_1 has coefficient 1 in
         // the density entry, so rho = 1000 - 5*u with u in [-1, 1].
         const std::string json = R"([{
-            "name": "IncompTestFluid", "description": "runtime-added test fluid", "reference": "none",
+            "name": "CatchRuntimeTestFluid", "description": "runtime-added test fluid", "reference": "none",
             "Tmin": 280.0, "Tmax": 360.0, "TminPsat": 360.0, "xid": "pure",
             "density":       {"type": "polynomial", "coeffs": [[1000.0]]},
             "specific_heat": {"type": "polynomial", "coeffs": [[2000.0]]},
@@ -5659,7 +5674,7 @@ TEST_CASE("INCOMP Chebyshev caloric fits: values, consistency and integrals", "[
             "specific_heat_cheb": {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": [[2000.0]]}
         }])";
         CHECK_NOTHROW(CoolProp::add_fluids_as_JSON("INCOMP", json));
-        const std::string fluid = "INCOMP::IncompTestFluid";
+        const std::string fluid = "INCOMP::CatchRuntimeTestFluid";
         // rho at T=320 (u=0) is exactly 1000; at T=360 (u=1) exactly 995
         CHECK(std::abs(CoolProp::PropsSI("D", "T", 320.0, "P", p, fluid) - 1000.0) < 1e-9);
         CHECK(std::abs(CoolProp::PropsSI("D", "T", 360.0, "P", p, fluid) - 995.0) < 1e-9);
@@ -5681,7 +5696,7 @@ TEST_CASE("INCOMP Chebyshev caloric fits: values, consistency and integrals", "[
         // Re-adding the same name replaces the fluid in place: the fluid list
         // must not grow a duplicate entry, and the new definition must win.
         const std::string updated = R"([{
-            "name": "IncompTestFluid", "description": "runtime-added test fluid, v2", "reference": "none",
+            "name": "CatchRuntimeTestFluid", "description": "runtime-added test fluid, v2", "reference": "none",
             "Tmin": 280.0, "Tmax": 360.0, "TminPsat": 360.0, "xid": "pure",
             "density_cheb":       {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": [[900.0]]},
             "specific_heat_cheb": {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": [[2000.0]]}
@@ -5689,7 +5704,8 @@ TEST_CASE("INCOMP Chebyshev caloric fits: values, consistency and integrals", "[
         CHECK_NOTHROW(CoolProp::add_fluids_as_JSON("INCOMP", updated));
         const std::string pure_list = CoolProp::get_global_param_string("incompressible_list_pure");
         std::size_t occurrences = 0;
-        for (std::size_t pos = pure_list.find("IncompTestFluid"); pos != std::string::npos; pos = pure_list.find("IncompTestFluid", pos + 1)) {
+        for (std::size_t pos = pure_list.find("CatchRuntimeTestFluid"); pos != std::string::npos;
+             pos = pure_list.find("CatchRuntimeTestFluid", pos + 1)) {
             ++occurrences;
         }
         CHECK(occurrences == 1);
@@ -5703,7 +5719,7 @@ TEST_CASE("INCOMP Chebyshev caloric fits: values, consistency and integrals", "[
         // through validate() -- a bare CHECK_THROWS would pass on any
         // unrelated validation error and so would not cover the guard.
         const std::string flipped = R"([{
-            "name": "IncompTestFluid", "description": "runtime-added test fluid, as a solution", "reference": "none",
+            "name": "CatchRuntimeTestFluid", "description": "runtime-added test fluid, as a solution", "reference": "none",
             "Tmin": 280.0, "Tmax": 360.0, "TminPsat": 360.0, "xid": "mass", "xmin": 0.0, "xmax": 0.5,
             "density_cheb":       {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": [[900.0, 1.0]]},
             "specific_heat_cheb": {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": [[2000.0, 1.0]]}
@@ -5722,12 +5738,45 @@ TEST_CASE("INCOMP Chebyshev caloric fits: values, consistency and integrals", "[
         // Malformed definitions must throw, not register garbage: an empty
         // coefficient matrix would otherwise evaluate rho to 0 silently.
         const std::string empty_coeffs = R"([{
-            "name": "IncompBadFluid", "description": "x", "reference": "x",
+            "name": "CatchRuntimeBadFluid", "description": "x", "reference": "x",
             "Tmin": 280.0, "Tmax": 360.0, "TminPsat": 360.0, "xid": "pure",
             "density_cheb":       {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": []},
             "specific_heat_cheb": {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": [[2000.0]]}
         }])";
         CHECK_THROWS(CoolProp::add_fluids_as_JSON("INCOMP", empty_coeffs));
+
+        // A Chebyshev fit narrower than the fluid's advertised range must be
+        // rejected at load: u is not clamped, so checkT() would admit a
+        // temperature the expansion then extrapolates at, where a Chebyshev
+        // series diverges fast and silently. Trange here covers [300, 340]
+        // while the fluid claims [280, 360]. The message is asserted so this
+        // cannot pass on some unrelated validation error.
+        const std::string narrow_range = R"([{
+            "name": "CatchRuntimeNarrowFluid", "description": "x", "reference": "x",
+            "Tmin": 280.0, "Tmax": 360.0, "TminPsat": 360.0, "xid": "pure",
+            "density_cheb":       {"type": "chebyshev", "Trange": [300.0, 340.0], "xbase": 0.0, "coeffs": [[1000.0]]},
+            "specific_heat_cheb": {"type": "chebyshev", "Trange": [300.0, 340.0], "xbase": 0.0, "coeffs": [[2000.0]]}
+        }])";
+        std::string narrow_msg;
+        try {
+            CoolProp::add_fluids_as_JSON("INCOMP", narrow_range);
+        } catch (const std::exception& e) {
+            narrow_msg = e.what();
+        }
+        CAPTURE(narrow_msg);
+        CHECK(narrow_msg.find("does not cover the fluid range") != std::string::npos);
+
+        // ...but a fit WIDER than the fluid range is legitimate and must load:
+        // ZS25/ZS40 ship cp fits covering ~2 K below Tmin because the source
+        // data does. This is the guard's fail-closed direction, so assert it
+        // explicitly rather than trusting the comparison's sense.
+        const std::string wide_range = R"([{
+            "name": "CatchRuntimeWideFluid", "description": "x", "reference": "x",
+            "Tmin": 280.0, "Tmax": 360.0, "TminPsat": 360.0, "xid": "pure",
+            "density_cheb":       {"type": "chebyshev", "Trange": [270.0, 370.0], "xbase": 0.0, "coeffs": [[1000.0]]},
+            "specific_heat_cheb": {"type": "chebyshev", "Trange": [270.0, 370.0], "xbase": 0.0, "coeffs": [[2000.0]]}
+        }])";
+        CHECK_NOTHROW(CoolProp::add_fluids_as_JSON("INCOMP", wide_range));
     }
 }
 TEST_CASE("Incompressible MPG2 viscosity matches Melinder source data (#1374)", "[INCOMP][1374]") {

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5724,14 +5724,8 @@ TEST_CASE("INCOMP Chebyshev caloric fits: values, consistency and integrals", "[
             "density_cheb":       {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": [[900.0, 1.0]]},
             "specific_heat_cheb": {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": [[2000.0, 1.0]]}
         }])";
-        std::string flip_msg;
-        try {
-            CoolProp::add_fluids_as_JSON("INCOMP", flipped);
-        } catch (const std::exception& e) {
-            flip_msg = e.what();
-        }
-        CAPTURE(flip_msg);
-        CHECK(flip_msg.find("pure/solution classification differs") != std::string::npos);
+        CHECK_THROWS_WITH(CoolProp::add_fluids_as_JSON("INCOMP", flipped),
+                          Catch::Matchers::ContainsSubstring("pure/solution classification differs"));
         // The rejected flip must not have disturbed the registered fluid.
         CHECK(std::abs(CoolProp::PropsSI("D", "T", 320.0, "P", p, fluid) - 900.0) < 1e-9);
 
@@ -5757,14 +5751,7 @@ TEST_CASE("INCOMP Chebyshev caloric fits: values, consistency and integrals", "[
             "density_cheb":       {"type": "chebyshev", "Trange": [300.0, 340.0], "xbase": 0.0, "coeffs": [[1000.0]]},
             "specific_heat_cheb": {"type": "chebyshev", "Trange": [300.0, 340.0], "xbase": 0.0, "coeffs": [[2000.0]]}
         }])";
-        std::string narrow_msg;
-        try {
-            CoolProp::add_fluids_as_JSON("INCOMP", narrow_range);
-        } catch (const std::exception& e) {
-            narrow_msg = e.what();
-        }
-        CAPTURE(narrow_msg);
-        CHECK(narrow_msg.find("does not cover the fluid range") != std::string::npos);
+        CHECK_THROWS_WITH(CoolProp::add_fluids_as_JSON("INCOMP", narrow_range), Catch::Matchers::ContainsSubstring("does not cover the fluid range"));
 
         // ...but a fit WIDER than the fluid range is legitimate and must load:
         // ZS25/ZS40 ship cp fits covering ~2 K below Tmin because the source

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5651,7 +5651,7 @@ TEST_CASE("INCOMP Chebyshev caloric fits: values, consistency and integrals", "[
         // cp(T) constant 2000, on T in [280, 360]. T_1 has coefficient 1 in
         // the density entry, so rho = 1000 - 5*u with u in [-1, 1].
         const std::string json = R"([{
-            "name": "ClaudeTestFluid", "description": "runtime-added test fluid", "reference": "none",
+            "name": "IncompTestFluid", "description": "runtime-added test fluid", "reference": "none",
             "Tmin": 280.0, "Tmax": 360.0, "TminPsat": 360.0, "xid": "pure",
             "density":       {"type": "polynomial", "coeffs": [[1000.0]]},
             "specific_heat": {"type": "polynomial", "coeffs": [[2000.0]]},
@@ -5659,7 +5659,7 @@ TEST_CASE("INCOMP Chebyshev caloric fits: values, consistency and integrals", "[
             "specific_heat_cheb": {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": [[2000.0]]}
         }])";
         CHECK_NOTHROW(CoolProp::add_fluids_as_JSON("INCOMP", json));
-        const std::string fluid = "INCOMP::ClaudeTestFluid";
+        const std::string fluid = "INCOMP::IncompTestFluid";
         // rho at T=320 (u=0) is exactly 1000; at T=360 (u=1) exactly 995
         CHECK(std::abs(CoolProp::PropsSI("D", "T", 320.0, "P", p, fluid) - 1000.0) < 1e-9);
         CHECK(std::abs(CoolProp::PropsSI("D", "T", 360.0, "P", p, fluid) - 995.0) < 1e-9);
@@ -5677,6 +5677,33 @@ TEST_CASE("INCOMP Chebyshev caloric fits: values, consistency and integrals", "[
         const double s1 = CoolProp::PropsSI("Smass", "T", 300.0, "P", p, fluid);
         const double s2 = CoolProp::PropsSI("Smass", "T", 340.0, "P", p, fluid);
         CHECK(std::abs((s2 - s1) - 2000.0 * std::log(340.0 / 300.0)) < 0.5);
+
+        // Re-adding the same name replaces the fluid in place: the fluid list
+        // must not grow a duplicate entry, and the new definition must win.
+        const std::string updated = R"([{
+            "name": "IncompTestFluid", "description": "runtime-added test fluid, v2", "reference": "none",
+            "Tmin": 280.0, "Tmax": 360.0, "TminPsat": 360.0, "xid": "pure",
+            "density_cheb":       {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": [[900.0]]},
+            "specific_heat_cheb": {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": [[2000.0]]}
+        }])";
+        CHECK_NOTHROW(CoolProp::add_fluids_as_JSON("INCOMP", updated));
+        const std::string pure_list = CoolProp::get_global_param_string("incompressible_list_pure");
+        std::size_t occurrences = 0;
+        for (std::size_t pos = pure_list.find("IncompTestFluid"); pos != std::string::npos; pos = pure_list.find("IncompTestFluid", pos + 1)) {
+            ++occurrences;
+        }
+        CHECK(occurrences == 1);
+        CHECK(std::abs(CoolProp::PropsSI("D", "T", 320.0, "P", p, fluid) - 900.0) < 1e-9);
+
+        // Malformed definitions must throw, not register garbage: an empty
+        // coefficient matrix would otherwise evaluate rho to 0 silently.
+        const std::string empty_coeffs = R"([{
+            "name": "IncompBadFluid", "description": "x", "reference": "x",
+            "Tmin": 280.0, "Tmax": 360.0, "TminPsat": 360.0, "xid": "pure",
+            "density_cheb":       {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": []},
+            "specific_heat_cheb": {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": [[2000.0]]}
+        }])";
+        CHECK_THROWS(CoolProp::add_fluids_as_JSON("INCOMP", empty_coeffs));
     }
 }
 TEST_CASE("Incompressible MPG2 viscosity matches Melinder source data (#1374)", "[INCOMP][1374]") {

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5695,6 +5695,30 @@ TEST_CASE("INCOMP Chebyshev caloric fits: values, consistency and integrals", "[
         CHECK(occurrences == 1);
         CHECK(std::abs(CoolProp::PropsSI("D", "T", 320.0, "P", p, fluid) - 900.0) < 1e-9);
 
+        // Re-registering the same name with the opposite pure/solution
+        // classification must be rejected: the name is already in one of the
+        // two name vectors, and replacing in place would leave it in the wrong
+        // one.  A two-column density makes is_pure() false.  The message is
+        // asserted, not just the throw, because this definition also passes
+        // through validate() -- a bare CHECK_THROWS would pass on any
+        // unrelated validation error and so would not cover the guard.
+        const std::string flipped = R"([{
+            "name": "IncompTestFluid", "description": "runtime-added test fluid, as a solution", "reference": "none",
+            "Tmin": 280.0, "Tmax": 360.0, "TminPsat": 360.0, "xid": "mass", "xmin": 0.0, "xmax": 0.5,
+            "density_cheb":       {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": [[900.0, 1.0]]},
+            "specific_heat_cheb": {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": [[2000.0, 1.0]]}
+        }])";
+        std::string flip_msg;
+        try {
+            CoolProp::add_fluids_as_JSON("INCOMP", flipped);
+        } catch (const std::exception& e) {
+            flip_msg = e.what();
+        }
+        CAPTURE(flip_msg);
+        CHECK(flip_msg.find("pure/solution classification differs") != std::string::npos);
+        // The rejected flip must not have disturbed the registered fluid.
+        CHECK(std::abs(CoolProp::PropsSI("D", "T", 320.0, "P", p, fluid) - 900.0) < 1e-9);
+
         // Malformed definitions must throw, not register garbage: an empty
         // coefficient matrix would otherwise evaluate rho to 0 silently.
         const std::string empty_coeffs = R"([{

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5604,6 +5604,81 @@ TEST_CASE("INCOMP enthalpy and entropy are finite at Tbase for every shipped flu
     // Absolute for the same reason: a margin let fluids go dark unnoticed.
     CHECK(testedCount == 118);
 }
+TEST_CASE("INCOMP Chebyshev caloric fits: values, consistency and integrals", "[INCOMP]") {
+    const double p = 101325.0;
+    SECTION("Basis-converted fluids reproduce the committed polynomial fit") {
+        // MEG's caloric entries are exact basis conversions of the committed
+        // centered polynomial (fit_source == basis_conversion), so the values
+        // must match the polynomial evaluation at reference precision, not
+        // merely at fit level. Golden values computed directly from the
+        // committed MEG.json polynomial coefficients.
+        const std::string fluid = "INCOMP::MEG[0.35]";
+        CHECK(std::abs(CoolProp::PropsSI("D", "T", 300.0, "P", p, fluid) / 1041.843589 - 1) < 1e-9);
+        CHECK(std::abs(CoolProp::PropsSI("C", "T", 300.0, "P", p, fluid) / 3644.159653 - 1) < 1e-9);
+    }
+    SECTION("dh/dT == cp and ds/dT == cp/T through the public interface") {
+        // The h/s integrals are derived from the SAME cp expansion at load
+        // time, so central finite differences of h and s must reproduce cp
+        // to discretization error. Run on a conversion (MEG), a raw-data
+        // refit (Water) and an ice slurry (IceEA, strongly curved cp).
+        struct Probe
+        {
+            std::string fluid;
+            double T;
+        };
+        for (const Probe& probe : {Probe{"INCOMP::MEG[0.35]", 300.0}, Probe{"INCOMP::Water", 350.0}, Probe{"INCOMP::IceEA[0.2]", 255.0}}) {
+            const double dT = 0.01;
+            CAPTURE(probe.fluid);
+            const double cp = CoolProp::PropsSI("C", "T", probe.T, "P", p, probe.fluid);
+            const double h_lo = CoolProp::PropsSI("Hmass", "T", probe.T - dT, "P", p, probe.fluid);
+            const double h_hi = CoolProp::PropsSI("Hmass", "T", probe.T + dT, "P", p, probe.fluid);
+            const double s_lo = CoolProp::PropsSI("Smass", "T", probe.T - dT, "P", p, probe.fluid);
+            const double s_hi = CoolProp::PropsSI("Smass", "T", probe.T + dT, "P", p, probe.fluid);
+            const double dhdT = (h_hi - h_lo) / (2 * dT);
+            const double dsdT = (s_hi - s_lo) / (2 * dT);
+            CAPTURE(cp);
+            CAPTURE(dhdT);
+            CAPTURE(dsdT);
+            // dh/dT differs from cp by the pressure term p*d(dh/dp)/dT
+            // (documented model property, see NOTES_thermodynamic_consistency
+            // .md), which is O(0.1 J/kg/K) at 1 atm -- inside this tolerance.
+            CHECK(std::abs(dhdT / cp - 1) < 1e-4);
+            CHECK(std::abs(dsdT / (cp / probe.T) - 1) < 1e-4);
+        }
+    }
+    SECTION("Runtime addition of an incompressible fluid via add_fluids_as_JSON (#2384)") {
+        // Minimal pure fluid with Chebyshev caloric entries: rho(T) linear,
+        // cp(T) constant 2000, on T in [280, 360]. T_1 has coefficient 1 in
+        // the density entry, so rho = 1000 - 5*u with u in [-1, 1].
+        const std::string json = R"([{
+            "name": "ClaudeTestFluid", "description": "runtime-added test fluid", "reference": "none",
+            "Tmin": 280.0, "Tmax": 360.0, "TminPsat": 360.0, "xid": "pure",
+            "density":       {"type": "polynomial", "coeffs": [[1000.0]]},
+            "specific_heat": {"type": "polynomial", "coeffs": [[2000.0]]},
+            "density_cheb":       {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": [[1000.0], [-5.0]]},
+            "specific_heat_cheb": {"type": "chebyshev", "Trange": [280.0, 360.0], "xbase": 0.0, "coeffs": [[2000.0]]}
+        }])";
+        CHECK_NOTHROW(CoolProp::add_fluids_as_JSON("INCOMP", json));
+        const std::string fluid = "INCOMP::ClaudeTestFluid";
+        // rho at T=320 (u=0) is exactly 1000; at T=360 (u=1) exactly 995
+        CHECK(std::abs(CoolProp::PropsSI("D", "T", 320.0, "P", p, fluid) - 1000.0) < 1e-9);
+        CHECK(std::abs(CoolProp::PropsSI("D", "T", 360.0, "P", p, fluid) - 995.0) < 1e-9);
+        CHECK(std::abs(CoolProp::PropsSI("C", "T", 320.0, "P", p, fluid) - 2000.0) < 1e-9);
+        // constant-cp enthalpy difference is exactly cp*dT (pressure terms
+        // cancel only in the T-part; keep p identical between the states)
+        const double h1 = CoolProp::PropsSI("Hmass", "T", 300.0, "P", p, fluid);
+        const double h2 = CoolProp::PropsSI("Hmass", "T", 340.0, "P", p, fluid);
+        const double drho_term =
+          p * (1.0 / CoolProp::PropsSI("D", "T", 340.0, "P", p, fluid) - 1.0 / CoolProp::PropsSI("D", "T", 300.0, "P", p, fluid));
+        CAPTURE(h2 - h1);
+        // T-part: 2000 * 40 = 80000 J/kg; pressure part is small but nonzero
+        CHECK(std::abs((h2 - h1) - 80000.0) < std::abs(drho_term) * 40 + 5.0);
+        // and s(T2)-s(T1) = cp*ln(T2/T1) for constant cp (T-part)
+        const double s1 = CoolProp::PropsSI("Smass", "T", 300.0, "P", p, fluid);
+        const double s2 = CoolProp::PropsSI("Smass", "T", 340.0, "P", p, fluid);
+        CHECK(std::abs((s2 - s1) - 2000.0 * std::log(340.0 / 300.0)) < 0.5);
+    }
+}
 TEST_CASE("Incompressible MPG2 viscosity matches Melinder source data (#1374)", "[INCOMP][1374]") {
     // Issue #1374: the fitted viscosity (and hence Prandtl number) of MPG2
     // (Melinder propylene glycol) was a uniform factor of 10 too small versus


### PR DESCRIPTION
Fourth of five PRs splitting up #3292. **3/5 (#3296) is merged, so this now targets `master` directly** — the branch was rebased onto it and this PR&#39;s diff is only its own 6 files.

### Requirements

* All new code requires tests to ensure against regressions.

### Description of the Change

The C++ consumer for the Chebyshev entries shipped in 3/5, plus runtime fluid registration.

**Chebyshev caloric type.** A new `INCOMPRESSIBLE_CHEBYSHEV` data type. At load time `validate()` builds the derived coefficient matrices once — `d/dT` (the density fit needs it for the pressure terms of `h` and `s`), `∫f dT` (enthalpy), and `∫f/T dT` (entropy, from a Chebyshev–Lobatto re-expansion of `f/T`). Integration constants are irrelevant because the backend always subtracts the same expression at the reference state. Evaluation collapses the composition direction to an effective 1D coefficient vector and runs Clenshaw — the same collapse-then-evaluate structure `Polynomial2DFrac` already uses.

The loader **prefers** `_cheb` when present and falls back to the classic polynomial otherwise, so this is backward-compatible with any fluid file that lacks the new entries. A `_cheb` entry that exists but fails to parse as `chebyshev` is a hard error rather than a silent fallback, so a typo in `type` cannot leave the author believing the Chebyshev fit is in use.

**Runtime registration.** `add_fluids_as_JSON(&#34;INCOMP&#34;, ...)` now works, closing #2384.

**On the relationship to the superancillaries:** CoolProp already has `superancillary::ChebyshevExpansion`, which backs the piecewise-Chebyshev saturation curves and uses the same Clenshaw recurrence. This deliberately does not build on it: that class is 1D-in-T, whereas the incompressible fit is 2D (T and composition), and it has no antiderivative — `do_derivs()` differentiates, but nothing integrates, and an exact enthalpy from an exact cp fit is the entire point here. The 1D Clenshaw evaluator in `IncompressibleFluid.cpp` is therefore a documented, intentional duplicate of `ChebyshevExpansion::eval`, kept file-local so the incompressible public header does not pull in the superancillary module for one method. If `ChebyshevExpansion` gains `derivative()`/`antiderivative()` upstream — wanted independently for the superancillary side — the 1D half of this path could delegate to it, leaving only the composition collapse and the cp/T re-expansion as incompressible-specific.

### Benefits

* Enthalpy and entropy are now derived the same exact way for every shipped fluid, with no `Tbase`-adjacent singularity class possible in this basis at all.
* Incompressible fluids can be registered at runtime, not only at build time (#2384).

### Possible Drawbacks

* `add_fluids_as_JSON(&#34;INCOMP&#34;, ...)` mutates the library without synchronization. This is documented in the code with the reasoning: a write-only lock would be *worse* than none, because every reader — and so every property evaluation — walks the same containers unlocked and would keep racing while appearing protected. Making it genuinely safe means locking the property-evaluation hot path, which is a backend-wide decision rather than something to smuggle in here. Until then the contract matches the pre-existing `HEOS`/`Cubics` runtime-add paths: register during start-up, before other threads query the library.

  Note the THREAD SAFETY comment states that start-up-only contract, while 5/5 adds a GUI that registers fluids at runtime from a Tauri command. The write ordering below narrows the racy read (a concurrent reader either misses the name or finds a fully-published fluid), but concurrent `std::map` insert versus traversal is still UB — this is not a thread-safety fix and does not claim to be.
* A second caloric code path now exists alongside the polynomial one. The loader preference is a single compile-time constant (`prefer_chebyshev_caloric`) so the two can be A/B&#39;d against the same library.

### Verification Process

* `CatchTestRunner` (Release): `[PolyMath]`, `[INCOMP]`, `[IncompressibleFluids]`, `[IncompressibleBackend]` — **1804 assertions, 9 cases**, all passing.
* A runtime `add_fluids_as_JSON(&#34;INCOMP&#34;, ...)` round-trip with hand-checkable coefficients: on T ∈ [280, 360], `u(T) = (T−320)/40`, `rho = 1000 − 5u`, `cp = 2000`, then `Dmass`/`Cpmass`/`Hmass`/`Smass` read back through the real backend.
* Negative tests for the fail-open cases found in review, each of which previously passed silently: an empty coefficient matrix (Clenshaw over no coefficients returned `0.0`, so `rho == 0` gave infinite enthalpy with **no error**, reachable at runtime via `&#34;coeffs&#34;: []`); duplicate names on re-registration; zombie map slots after a failed parse; a pure/solution flip; and names containing `,|[]:&amp;` which corrupt the comma-joined fluid lists and the `INCOMP::Name` / `Name[x]` parsing.
* The every-shipped-fluid `Tbase` sweep from 1/5 continues to pass with the Chebyshev path active.
* `clang-format` clean, and CI&#39;s diff-only `clang-tidy` reports nothing on any line this PR changes (verified by intersecting whole-file clang-tidy output against the 436 changed lines).

### Review findings addressed since the first push

Two commits here exist only to close review findings on this PR&#39;s own code:

* **Lint sweep.** The new `chebyshev` dispatch branch used the `!type.compare(...)` idiom, an implicit `int -> bool` conversion. Fixing only that branch would have left one arm of a six-branch chain reading differently from its five siblings, so the whole chain moved to `compare(...) == 0`. Verified free rather than assumed: clang-tidy reports exactly one finding on each sibling line — the same `readability-implicit-bool-conversion` — so the flip removes it and cannot surface anything new. The analogous `!res.compare(...)` chain in the interpolation-fraction parser is deliberately left alone: it is a separate function this PR does not otherwise touch, so it stays outside CI&#39;s diff-only scope.

* **A fail-quiet map access, fixed twice.** `add_one`&#39;s replace-in-place branch reached `fluid_map` through `operator[]`. `fluid_map` is a `std::map<std::size_t, IncompressibleFluid>`, so on a desync `operator[]` default-constructs an empty fluid and `is_pure()` is answered from it — and since a default fluid has `density.coeffs.cols() == 0` it reads as a *solution*, so the guard below would report a bogus classification mismatch or pass and overwrite the wrong slot.

  The first attempt used `at()`, which review showed made things worse: `std::out_of_range` does not derive from `CoolPropBaseError`, so it lands in the C wrapper&#39;s `catch (...)` arm in `CoolPropLib.cpp` — `errcode 3` with the message buffer never written. The Rust FFI consumer in 5/5 surfaces that buffer, so the user would have seen an error dialog with **no text**. It now uses `find()` plus an explicit `ValueError`, matching what `JSONIncompressibleLibrary::get()` already throws for the same missing-index condition, which crosses the boundary with its text intact and replaces two lookups with one.

  Review also showed the invariant the fix asserted did not hold: the append path published `string_to_index_map` *before* `fluid_map`, so &#34;name resolves to an index with no fluid&#34; was reachable from an ordinary allocation failure between the two writes — and because `fluid_map.size()` had not yet advanced, the *next* `add_one` for any other name computed the same index, so the poisoned name resolved to **a different fluid&#39;s data**: a silent wrong answer, not just a throw. `fluid_map` is now written first, closing both; the name vectors go last, so a throw there leaves the fluid resolvable but unlisted (inert) rather than listed but unresolvable.

  The pure/solution guard whose left-hand side that change rewrites is now covered by a test: re-registering the runtime-added fluid with a two-column density flips `is_pure()`, and the test asserts the thrown *message* rather than merely that something threw — the definition also passes through `validate()`, so a bare `CHECK_THROWS` would have passed on any unrelated validation error without touching the guard. Confirmed by disabling the guard, which fails the test.

### Known, not addressed here

* `add_obj` is **not** equivalent to the write ordering used in `add_one`: it calls the throwing `validate()` *between* its two map writes, never populates `name_vector_pure`/`name_vector_solution`, and skips the `,|[]:&amp;` name check. Same failure *direction* (an orphan `fluid_map` entry, not a poisoned name), so not worse, and its only call site is commented out — left for a separate change rather than audited as equivalent.
* Contiguity of `fluid_map`&#39;s keys is load-bearing (`index = fluid_map.size()`) with nothing enforcing it. Nothing erases today, so it holds; if an `erase` ever lands, that expression silently overwrites an existing fluid instead of appending.
* Replace-in-place move-assigns into a map node that `get()` may already have handed out by reference to a live `IncompressibleBackend`. Node stability keeps the pointer valid, and the classification guard is what stops the backend&#39;s cached `_fluid_type` going stale — but a solution→solution replacement that shifts `xmin`/`xmax` under a backend whose fractions are already set is not covered. Pre-existing to the replace feature.

### Applicable Issues

Closes #2384.


---
_Generated by [Claude Code](https://claude.ai/code/session_014CQ8VReZEmjCk1RzS9KHLW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Chebyshev-based incompressible property fits (including density and specific heat), with support for derivatives, integrals, and temperature inversion.
  * Extended JSON-based fluid registration to support the incompressible backend.
* **Bug Fixes**
  * Hardened fluid loading/registration to prevent partially registered fluids when parsing or validation fails.
  * Improved validation/error reporting for Chebyshev metadata (including temperature-range coverage) and invalid fluid names.
* **Tests**
  * Expanded Chebyshev fit, integral/consistency, and runtime registration test coverage, including new negative-case assertions and stability adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->