### PR TITLE
ci(asan): scope the ASan run to ~[slow], make an overrun a real failure, and fix a fail-open preflight gate

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -140,7 +140,25 @@ jobs:
         # and not at 40x80.  This is a deliberate trade of that residual risk
         # against a job that otherwise does not finish at all.
 
-        # (3) margin: budget + --kill-after grace = 4260 s = 71 min, leaving
+        # VERBOSITY: ASAN_OPTIONS deliberately does NOT set verbosity=1.
+        # It used to, and that is pure cost: at verbosity>=1 ASan VReports its
+        # internal container-annotation traffic, which for this Eigen- and
+        # std::vector-heavy suite means a sustained flood of
+        # "==pid==poisoning: 0x... <n>" lines -- 4365 lines/s measured over a
+        # 0.68 s window of the run in PR #3294, ~38 bytes each.  Every line is
+        # a formatted write() into a pipe that the Actions runner reads,
+        # timestamps and uploads.  Extrapolating that rate across a 70 min test
+        # window is ~18 M lines / ~690 MB (an upper bound -- the rate was
+        # sampled in one window, not averaged over the whole run).
+        #
+        # It buys nothing: ASan error reports, leak reports and ODR-violation
+        # reports are printed unconditionally, independent of verbosity.
+        # verbosity only adds ASan's own bookkeeping chatter.  Verified: a
+        # trivial std::vector program emits 0 lines at the default verbosity
+        # and 236 at verbosity=1.  detect_odr_violation=1 is kept -- that is
+        # the setting doing actual diagnostic work here.
+
+        # MARGIN: budget + --kill-after grace = 4260 s = 71 min, leaving
         # ~19 min of the 90 min cap for REFPROP + compile (~8.5 min measured).
         #
         # TIMEOUT: the inner `timeout` is deliberate and must stay below
@@ -155,7 +173,7 @@ jobs:
           budget=4200  # 70 min; with the 60 s --kill-after grace that is 71 min worst case, leaving ~19 min of the 90 min cap for REFPROP + compile (~8.5 min measured)
           set +e
           timeout --signal=INT --kill-after=60 "$budget" \
-            env ASAN_OPTIONS=verbosity=1:detect_odr_violation=1 \
+            env ASAN_OPTIONS=detect_odr_violation=1 \
                 ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-18 \
                 ./CatchTestRunner "~[slow]" --benchmark-samples 1
           rc=$?

--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -104,7 +104,58 @@ jobs:
         # reliable *indicator*-based ODR detection — so a real duplicate-symbol
         # violation (e.g. the JSON-symbol-visibility concern) still fails CI —
         # and drops only the poisoning check.  See CoolProp-xma3.
-        run: cd build && ASAN_OPTIONS=verbosity=1:detect_odr_violation=1 ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-18 ./CatchTestRunner --benchmark-samples 1
+        #
+        # SCOPE: `~[slow]` excludes the 60 [slow]-tagged cases (48 of them in
+        # the SVDSBTL suite).  Those build SVD surfaces at production
+        # resolution -- SurfaceSpec's defaults NT=200, NR=800, rank=20 -- and
+        # the dense BDCSVD over a 200x800 grid is the bulk of this job's time.
+        #
+        # Measured non-ASan with a cold surface cache (as in CI): [slow] alone
+        # is 887 s / 58 cases, against >16 min for the 412-case ~[slow] set --
+        # roughly 40-45% of the total.  That understates the CI saving, since
+        # 6 of those [slow] cases skip locally for want of REFPROP and those
+        # include the 5 SVDSBTL&REFPROP production-resolution builds, which do
+        # run in CI.  See dev/ci/README.md for the full table and caveats.
+        #
+        # Why exclude rather than shrink the grid: the resolution is
+        # load-bearing for those tests.  They pass no `grid` option precisely
+        # so they run at production resolution, then assert agreement with a
+        # truth source (HEOS / REFPROP / IF97) at ~1e-3 relative.  SurfaceSpec
+        # notes the defaults deliver ~7e-5 fractional for Water, so there is
+        # only ~14x headroom; dropping to 40x80/rank-10 (50x fewer points,
+        # half the rank) would breach it and force the tolerances open, which
+        # turns a real accuracy gate into a vacuous one *in the ASan build
+        # only* -- the worst place to lose signal quietly.
+        #
+        # Why this costs no ASan coverage: ASan finds heap overflows, UAF,
+        # leaks and ODR problems, which depend on allocation patterns and code
+        # paths, not on matrix magnitude.  BDCSVD over 40x80 runs the same
+        # Eigen code, the same temporaries and the same allocation sequence as
+        # 200x800.  Eight small-grid SVDSBTL tests (NT=40, NR=80, rank=10) are
+        # NOT [slow] and so still run here, keeping the dense-SVD path covered.
+        # The excluded cases add CPU time, not ASan signal.
+        #
+        # TIMEOUT: the inner `timeout` is deliberate and must stay below
+        # timeout-minutes above.  A job that exceeds `timeout-minutes` is
+        # reported by GitHub with conclusion `cancelled`, which is
+        # indistinguishable from a concurrency-supersede or from
+        # cancel_merged_pr_runs.yml -- the exact ambiguity this job's cap was
+        # added to remove (CoolProp-xuu).  Bounding the test step instead makes
+        # an overrun a real step failure with a message that says so.
+        run: |
+          cd build
+          budget=4200  # 70 min; leaves >=20 min of the 90 min job cap for REFPROP + compile (~8.5 min measured)
+          set +e
+          timeout --signal=INT --kill-after=60 "$budget" \
+            env ASAN_OPTIONS=verbosity=1:detect_odr_violation=1 \
+                ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-18 \
+                ./CatchTestRunner "~[slow]" --benchmark-samples 1
+          rc=$?
+          set -e
+          if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+            echo "::error title=ASan run exceeded its budget::The ASan test run did not finish within ${budget}s. This is a *timeout*, not a memory error and not a cancellation -- see the SCOPE/TIMEOUT notes in dev_checks.yml and dev/ci/README.md before raising the budget."
+          fi
+          exit $rc
 
   clang-format:
     name: clang-format (PR diff)

--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -105,13 +105,13 @@ jobs:
         # violation (e.g. the JSON-symbol-visibility concern) still fails CI —
         # and drops only the poisoning check.  See CoolProp-xma3.
         #
-        # SCOPE: `~[slow]` excludes the 60 [slow]-tagged cases (48 of them in
+        # SCOPE: `~[slow]` excludes the 58 [slow]-tagged cases (49 of them in
         # the SVDSBTL suite).  Those build SVD surfaces at production
         # resolution -- SurfaceSpec's defaults NT=200, NR=800, rank=20 -- and
         # the dense BDCSVD over a 200x800 grid is the bulk of this job's time.
         #
         # Measured non-ASan with a cold surface cache (as in CI): [slow] alone
-        # is 887 s / 58 cases, against >16 min for the 412-case ~[slow] set --
+        # is 887 s / 58 cases, against >16 min for the 410-case ~[slow] set --
         # roughly 40-45% of the total.  That understates the CI saving, since
         # 6 of those [slow] cases skip locally for want of REFPROP and those
         # include the 5 SVDSBTL&REFPROP production-resolution builds, which do

--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -127,13 +127,21 @@ jobs:
         # turns a real accuracy gate into a vacuous one *in the ASan build
         # only* -- the worst place to lose signal quietly.
         #
-        # Why this costs no ASan coverage: ASan finds heap overflows, UAF,
-        # leaks and ODR problems, which depend on allocation patterns and code
-        # paths, not on matrix magnitude.  BDCSVD over 40x80 runs the same
-        # Eigen code, the same temporaries and the same allocation sequence as
-        # 200x800.  Eight small-grid SVDSBTL tests (NT=40, NR=80, rank=10) are
-        # NOT [slow] and so still run here, keeping the dense-SVD path covered.
-        # The excluded cases add CPU time, not ASan signal.
+        # Why the ASan coverage cost is small: ASan finds heap overflows, UAF,
+        # leaks and ODR problems, which are largely properties of code paths
+        # rather than of matrix magnitude.  BDCSVD over 40x80 exercises the
+        # same Eigen algorithmic path as 200x800, and eight small-grid SVDSBTL
+        # tests (NT=40, NR=80, rank=10) are NOT [slow], so that path stays
+        # covered here.  Being precise about the limit of that argument: the
+        # two sizes differ in allocation counts and sizes, in memory pressure,
+        # and in how far index arithmetic is pushed, so a size-dependent bug
+        # (an overflow only reached past some extent, or a narrowing that only
+        # bites at larger indices) could in principle be visible at 200x800
+        # and not at 40x80.  This is a deliberate trade of that residual risk
+        # against a job that otherwise does not finish at all.
+
+        # (3) margin: budget + --kill-after grace = 4260 s = 71 min, leaving
+        # ~19 min of the 90 min cap for REFPROP + compile (~8.5 min measured).
         #
         # TIMEOUT: the inner `timeout` is deliberate and must stay below
         # timeout-minutes above.  A job that exceeds `timeout-minutes` is
@@ -144,7 +152,7 @@ jobs:
         # an overrun a real step failure with a message that says so.
         run: |
           cd build
-          budget=4200  # 70 min; leaves >=20 min of the 90 min job cap for REFPROP + compile (~8.5 min measured)
+          budget=4200  # 70 min; with the 60 s --kill-after grace that is 71 min worst case, leaving ~19 min of the 90 min cap for REFPROP + compile (~8.5 min measured)
           set +e
           timeout --signal=INT --kill-after=60 "$budget" \
             env ASAN_OPTIONS=verbosity=1:detect_odr_violation=1 \
@@ -152,8 +160,14 @@ jobs:
                 ./CatchTestRunner "~[slow]" --benchmark-samples 1
           rc=$?
           set -e
-          if [ "$rc" -eq 124 ] || [ "$rc" -eq 137 ]; then
+          if [ "$rc" -eq 124 ]; then
             echo "::error title=ASan run exceeded its budget::The ASan test run did not finish within ${budget}s. This is a *timeout*, not a memory error and not a cancellation -- see the SCOPE/TIMEOUT notes in dev_checks.yml and dev/ci/README.md before raising the budget."
+          elif [ "$rc" -eq 137 ]; then
+            # 137 == 128+SIGKILL.  That is what `timeout --kill-after` sends
+            # when SIGINT was ignored, but it is also what the OOM killer
+            # sends -- and ASan roughly doubles the memory footprint, so OOM
+            # is a live possibility on a 2-vCPU runner.  Do not assert which.
+            echo "::error title=ASan run was killed (SIGKILL)::Either the ${budget}s budget elapsed and SIGINT was ignored, or the kernel OOM-killed it (ASan ~2x memory). Check the log for an ASan OOM report and the runner's memory before assuming a timeout."
           fi
           exit $rc
 

--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -150,7 +150,11 @@ jobs:
         # against a job that otherwise does not finish at all.
 
         # VERBOSITY: ASAN_OPTIONS deliberately does NOT set verbosity=1.
-        # It used to, and that is pure cost: at verbosity>=1 ASan VReports its
+        # It used to.  Note up front what this is and is NOT worth: removing it
+        # did NOT measurably speed the job up (60.6 min with it, 60.2 min
+        # without -- inside runner noise).  Do not re-add it expecting a
+        # slowdown to reappear, and do not cite it as a wall-time lever.  The
+        # reason it stays out is log hygiene: at verbosity>=1 ASan VReports its
         # internal container-annotation traffic, which for this Eigen- and
         # std::vector-heavy suite means a sustained flood of
         # "==pid==poisoning: 0x... <n>" lines -- 4365 lines/s measured over a

--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -47,12 +47,21 @@ jobs:
     # detect_stack_use_after_return BDCSVD blow-up hid for so long).
     # On the 2-vCPU runner with the optimized (-O2) Asan build the measured
     # steps are REFPROP+config ~1 min and compile ~7.5 min; the single-threaded
-    # test run is the long pole and is much slower per-core than a dev laptop
-    # (~187 s locally).  A prior 30 min cap cancelled the job mid-test (the
-    # test run alone was still going at 21.5 min), so the full duration is not
-    # yet known precisely.  90 min is a deliberately safe envelope that still
-    # surfaces a genuine runaway well under GitHub's 6-hour default; re-tighten
-    # once a clean run reports the true wall time.
+    # test run is the long pole and is much slower per-core than a dev laptop.
+    # A prior 30 min cap cancelled the job mid-test (the test run alone was
+    # still going at 21.5 min), and the full-scope run on PR #3294 hit this
+    # 90 min cap outright with CatchTestRunner still live, so the full-scope
+    # duration is not known -- it exceeds 90 min in CI.
+    #
+    # (This comment used to cite "~187 s locally" for the test run.  That does
+    # not reproduce and is left out rather than repeated: measured locally,
+    # non-ASan with a cold surface cache, [slow] alone is 887 s and ~[slow] is
+    # >16 min, so the whole suite is ~33 min BEFORE ASan's slowdown.  See the
+    # table in dev/ci/README.md.)
+    #
+    # 90 min is a deliberately safe envelope that still surfaces a genuine
+    # runaway well under GitHub's 6-hour default; re-tighten once a clean
+    # ~[slow] run reports the true wall time.
     timeout-minutes: 90
     strategy:
       matrix:

--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -46,8 +46,9 @@ jobs:
     # `cancelled` rather than a real failure (that is exactly how the
     # detect_stack_use_after_return BDCSVD blow-up hid for so long).
     # On the 2-vCPU runner with the optimized (-O2) Asan build the measured
-    # steps are REFPROP+config ~1 min and compile ~7.5 min; the single-threaded
-    # test run is the long pole and is much slower per-core than a dev laptop.
+    # steps are REFPROP 36 s, cmake config 28 s and compile 8.8 min; the
+    # single-threaded test run is the long pole (50.7 min) and is much slower
+    # per-core than a dev laptop.
     # A prior 30 min cap cancelled the job mid-test (the test run alone was
     # still going at 21.5 min), and the full-scope run on PR #3294 hit this
     # 90 min cap outright with CatchTestRunner still live, so the full-scope
@@ -91,7 +92,7 @@ jobs:
         run: cmake --build build --config Asan -j$(nproc)
       - name: run all the compiled Catch tests with address sanitizer
         # detect_stack_use_after_return is deliberately NOT enabled here
-        # (CoolProp-xuu).  With REFPROP present — which CI builds — the 5
+        # (CoolProp-xuu).  With REFPROP present — which CI builds — the 6
         # SVDSBTL&REFPROP [source] tests build large BDCSVD surfaces, and
         # under detect_stack_use_after_return=1 the per-coefficient
         # __asan_stack_malloc inside Eigen's O(n^2-n^3) singular-value inner
@@ -120,11 +121,13 @@ jobs:
         # the dense BDCSVD over a 200x800 grid is the bulk of this job's time.
         #
         # Measured non-ASan with a cold surface cache (as in CI): [slow] alone
-        # is 887 s / 58 cases, against >16 min for the 410-case ~[slow] set --
-        # roughly 40-45% of the total.  That understates the CI saving, since
-        # 6 of those [slow] cases skip locally for want of REFPROP and those
-        # include the 5 SVDSBTL&REFPROP production-resolution builds, which do
-        # run in CI.  See dev/ci/README.md for the full table and caveats.
+        # is 887 s / 58 cases, against >16 min for the 410-case ~[slow] set.
+        # Do not quote a precise share: ~[slow] is only bounded below, so 887 s
+        # is AT MOST ~48% of the local total and cannot be pinned tighter.
+        # Whatever the share, it understates the CI saving, since 6 [slow]
+        # cases skip locally for want of REFPROP and all 6 are
+        # SVDSBTL&REFPROP production-resolution builds that do run in CI.
+        # See dev/ci/README.md for the full table and caveats.
         #
         # Why exclude rather than shrink the grid: the resolution is
         # load-bearing for those tests.  They pass no `grid` option precisely
@@ -136,18 +139,29 @@ jobs:
         # turns a real accuracy gate into a vacuous one *in the ASan build
         # only* -- the worst place to lose signal quietly.
         #
-        # Why the ASan coverage cost is small: ASan finds heap overflows, UAF,
-        # leaks and ODR problems, which are largely properties of code paths
-        # rather than of matrix magnitude.  BDCSVD over 40x80 exercises the
-        # same Eigen algorithmic path as 200x800, and eight small-grid SVDSBTL
-        # tests (NT=40, NR=80, rank=10) are NOT [slow], so that path stays
-        # covered here.  Being precise about the limit of that argument: the
-        # two sizes differ in allocation counts and sizes, in memory pressure,
-        # and in how far index arithmetic is pushed, so a size-dependent bug
-        # (an overflow only reached past some extent, or a narrowing that only
-        # bites at larger indices) could in principle be visible at 200x800
-        # and not at 40x80.  This is a deliberate trade of that residual risk
-        # against a job that otherwise does not finish at all.
+        # Why the ASan coverage cost is small -- and note the mechanism, which
+        # is NOT what an earlier version of this comment claimed.  Production
+        # resolution still runs under ASan: 17 non-[slow] TEST_CASEs call
+        # factory("SVDSBTL&...") with no `grid` option, so they build at the
+        # 200x800/rank-20 defaults.  Dense BDCSVD at full size, its temporaries
+        # and its allocation pattern are therefore all still exercised here,
+        # which is what makes the exclusion cheap for ASan's purposes (heap
+        # overflow, UAF, leaks, ODR).
+        #
+        # Do NOT restate this as "the small-grid tests keep that path covered".
+        # They do not run: all 8 of the NT=40/NR=80/rank=10 grid specs in
+        # src/Tests/CoolProp-Tests-SVDSBTL.cpp sit inside [slow] TEST_CASEs, so
+        # `~[slow]` excludes every one of them.  The only non-[slow] references
+        # to a 40x80 grid are schema/round-trip tests in
+        # CoolProp-Tests-SVDSBTLOptions.cpp, which build no surface.  An earlier
+        # comment here had this backwards; it counted the 8 option-string
+        # literals and assumed their tags.
+        #
+        # What is actually given up is the excluded tests' repeat work and their
+        # REFPROP-sourced surfaces (the 6 SVDSBTL&REFPROP truth-comparison
+        # cases), not the large-matrix code path.  Since 200x800 still runs, a
+        # size-dependent bug reachable only at production extent is still
+        # reachable here.
 
         # VERBOSITY: ASAN_OPTIONS deliberately does NOT set verbosity=1.
         # It used to.  Note up front what this is and is NOT worth: removing it
@@ -172,7 +186,8 @@ jobs:
         # the setting doing actual diagnostic work here.
 
         # MARGIN: budget + --kill-after grace = 4260 s = 71 min, leaving
-        # ~19 min of the 90 min cap for REFPROP + compile (~8.5 min measured).
+        # ~19 min of the 90 min cap for REFPROP + compile (9.9 min measured:
+        # 36 s REFPROP + 28 s cmake + 8.8 min compile -- so 71 + 9.9 = 80.9 min).
         #
         # TIMEOUT: the inner `timeout` is deliberate and must stay below
         # timeout-minutes above.  A job that exceeds `timeout-minutes` is
@@ -183,7 +198,7 @@ jobs:
         # an overrun a real step failure with a message that says so.
         run: |
           cd build
-          budget=4200  # 70 min; with the 60 s --kill-after grace that is 71 min worst case, leaving ~19 min of the 90 min cap for REFPROP + compile (~8.5 min measured)
+          budget=4200  # 70 min; with the 60 s --kill-after grace that is 71 min worst case, leaving ~19 min of the 90 min cap for REFPROP + compile (9.9 min measured)
           set +e
           timeout --signal=INT --kill-after=60 "$budget" \
             env ASAN_OPTIONS=detect_odr_violation=1 \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ cmake --build build_catch --target CatchTestRunner -j8
 # Run the test suite — see "Test filter discipline" below for tag scope
 ./build_catch/CatchTestRunner [SBTL]            # SBTL adapter layer
 ./build_catch/CatchTestRunner [SVDSBTL]         # backend-level tests
-./build_catch/CatchTestRunner "[!slow]"         # everything fast
+./build_catch/CatchTestRunner "~[slow]"         # everything except [slow]
 ```
 
 ## Pre-Push Gate — REQUIRED before every `git push`

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -304,9 +304,36 @@ So when this job goes red, read the annotation first:
 | ASan report in the log (`ERROR: AddressSanitizer: ...`) | A real memory bug. Fix it. |
 | Conclusion `cancelled`, no annotation | Most likely a superseded push or a merged PR (`cancel_merged_pr_runs.yml`). But **check which step was running first**: only the test step is wrapped in `timeout`, so if REFPROP setup or the compile overran the job cap you also get an unannotated `cancelled`. |
 
-The true wall time of a clean `~[slow]` run is not yet recorded. Once one
-completes, tighten both the budget and `timeout-minutes` to roughly 1.3x the
-measured time rather than leaving the current deliberately-loose envelope.
+### Measured wall time (the first clean `~[slow]` run)
+
+PR #3299, run `30364245551`, job `90291277987` — the first ASan job to finish
+rather than hit the cap. Conclusion `success`:
+
+| Step | Wall time |
+| --- | --- |
+| REFPROP build | 36 s |
+| cmake config | 28 s |
+| compile (`-j$(nproc)`) | 8.8 min |
+| **test run (`~[slow]`)** | **50.7 min (3041 s)** |
+| job total | 60.6 min |
+
+That settles the sizing, and both current values turn out to be about right:
+
+- `budget=4200` is **1.38x** the measured 3041 s, leaving 19 min unused —
+  essentially the 1.3x target, so leave it. Runners are shared and vary by
+  tens of percent between runs; a tighter budget would start flagging normal
+  variance as a timeout, which is the failure mode this gate exists to avoid.
+- `timeout-minutes: 90` is 1.49x the 60.6 min job total. Also fine to leave.
+
+Caveat: this baseline was taken with `verbosity=1` still set (see the section
+above, which removed it). The removal only makes the run faster, so 4200 s
+stays safe — but the 3041 s figure is an upper bound on the shipped config,
+not a measurement of it. Re-measure before tightening further, and do not
+tighten on the strength of one run either way.
+
+For contrast, the full-scope (`[slow]` included) predecessor on PR #3294 did
+not finish at all: it ran 09:33:03 -> 11:03:20, hit the 90 min cap, and its
+log ends `Terminate orphan process: pid (4681) (CatchTestRunner)`.
 
 ### Why `verbosity=1` is not set
 

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -256,13 +256,22 @@ half the SVD rank — would breach that and force the tolerances open. The
 result would be a real accuracy gate quietly becoming a vacuous one *in the
 ASan build only*, which is the worst place to lose signal.
 
-**Why excluding them costs no ASan coverage.** ASan detects heap overflows,
-use-after-free, leaks and ODR problems. Those depend on allocation patterns
-and code paths, not on matrix magnitude: BDCSVD over 40x80 runs the same
-Eigen code, the same temporaries and the same allocation sequence as
-200x800. Eight small-grid SVDSBTL tests (`NT=40, NR=80, rank=10`) are not
-tagged `[slow]` and therefore still run under ASan, so the dense-SVD path
-stays covered. The excluded cases contribute CPU time, not ASan signal.
+**Why the ASan coverage cost is small.** ASan detects heap overflows,
+use-after-free, leaks and ODR problems, which are largely properties of code
+paths rather than of matrix magnitude: BDCSVD over 40x80 exercises the same
+Eigen algorithmic path as 200x800, and eight small-grid SVDSBTL tests
+(`NT=40, NR=80, rank=10`) are not tagged `[slow]`, so that path stays
+covered.
+
+Being precise about where that argument stops: the two sizes are *not*
+equivalent for ASan. They differ in allocation counts and sizes, in memory
+pressure, and in how far index arithmetic is pushed. A size-dependent bug --
+an overflow only reached past some extent, or a narrowing that only bites at
+larger indices -- could in principle be caught at 200x800 and missed at
+40x80. This is a deliberate trade of that residual risk against a job that
+otherwise does not produce a verdict at all. If that trade ever looks wrong,
+the answer is more runner minutes, not a resolution cut (see above for why
+lowering the grid breaks assertions on both sides of the filter).
 
 If you add a test that is the *only* coverage of a memory-safety-relevant
 path, do not tag it `[slow]`, or ASan will not see it.
@@ -290,13 +299,35 @@ So when this job goes red, read the annotation first:
 
 | Symptom | Meaning |
 | --- | --- |
-| `::error::ASan run exceeded its budget` | Timeout. Investigate what got slower; do not just raise the budget. |
+| `::error::ASan run exceeded its budget` (exit 124) | Timeout. Investigate what got slower; do not just raise the budget. |
+| `::error::ASan run was killed (SIGKILL)` (exit 137) | Ambiguous: either the budget elapsed and SIGINT was ignored, **or** the kernel OOM-killed it. ASan roughly doubles memory, so OOM is realistic on a 2-vCPU runner — check for an ASan OOM report before assuming a timeout. |
 | ASan report in the log (`ERROR: AddressSanitizer: ...`) | A real memory bug. Fix it. |
-| Conclusion `cancelled`, no annotation | Not this job's doing — superseded push, or the PR was merged. |
+| Conclusion `cancelled`, no annotation | Most likely a superseded push or a merged PR (`cancel_merged_pr_runs.yml`). But **check which step was running first**: only the test step is wrapped in `timeout`, so if REFPROP setup or the compile overran the job cap you also get an unannotated `cancelled`. |
 
 The true wall time of a clean `~[slow]` run is not yet recorded. Once one
 completes, tighten both the budget and `timeout-minutes` to roughly 1.3x the
 measured time rather than leaving the current deliberately-loose envelope.
+
+### The exit code does propagate test failures (two ASan options exist)
+
+There are two ASan switches in `CMakeLists.txt` and only one is used by CI:
+
+- **`COOLPROP_ASAN`** (what `dev_checks.yml` passes, with
+  `-DCMAKE_BUILD_TYPE=Asan`) adds an `Asan` build type at `-O2 -g -DNDEBUG`.
+  `CatchTestRunner` links `Catch2::Catch2WithMain`, so the process exit code
+  is Catch2's failed-assertion count. Verified: injecting one bad `CHECK`
+  yields exit **42** for 5 failed assertions.
+- **`COOLPROP_CLANG_ADDRESS_SANITIZER`** is a separate, older buildbot-era
+  switch. It appends `src/Tests/catch_always_return_success.cxx`, whose
+  `main` runs the session and then returns `EXIT_SUCCESS` **unconditionally**
+  — deliberately, so that buildbot saw ASan's exit code rather than the Catch
+  failure count.
+
+So the `exit $rc` gate in the workflow is meaningful, but only because CI
+uses the first option. If anyone ever switches the job to
+`COOLPROP_CLANG_ADDRESS_SANITIZER`, ordinary test failures would stop failing
+the job while ASan's own aborts still would — a silent narrowing of the gate.
+Don't.
 
 ### Reproducing locally
 
@@ -305,8 +336,14 @@ cmake -B build_asan -S . -DCMAKE_BUILD_TYPE=Asan -DCOOLPROP_ASAN=ON \
       -DCOOLPROP_CATCH_MODULE=ON -DCMAKE_CXX_COMPILER=clang++
 cmake --build build_asan --target CatchTestRunner -j$(nproc)
 ASAN_OPTIONS=verbosity=1:detect_odr_violation=1 \
-  ./build_asan/CatchTestRunner "~[slow]"
+ASAN_SYMBOLIZER_PATH=$(command -v llvm-symbolizer) \
+  timeout --signal=INT --kill-after=60 4200 \
+  ./build_asan/CatchTestRunner "~[slow]" --benchmark-samples 1
 ```
+
+That mirrors what CI runs. Drop the `timeout` wrapper and
+`--benchmark-samples 1` if you only want a functional check and do not care
+about reproducing the budget or the benchmark sampling.
 
 Note `detect_stack_use_after_return` is deliberately **not** enabled, and
 `detect_odr_violation` is lowered to `1`; both have specific justifications

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -205,9 +205,112 @@ to gate. The exception is `asan`, which does fail.
   Scan web UI for the curated view.
 - **IWYU** (`iwyu` job in `dev_checks.yml`) — runs include-what-you-use
   via the `COOLPROP_IWYU` CMake opt-in and uploads `iwyu.log`.
-- **AddressSanitizer** (`asan` job in `dev_checks.yml`) — full Catch test
-  suite under ASan on every PR. This one *does* fail builds, since memory
-  bugs are real bugs.
+- **AddressSanitizer** (`asan` job in `dev_checks.yml`) — the Catch test
+  suite under ASan on every PR, **excluding `[slow]`**. This one *does* fail
+  builds, since memory bugs are real bugs. See
+  [ASan scope and budget](#asan-scope-and-budget) for why `[slow]` is
+  excluded and what to do when the job times out.
+
+## ASan scope and budget
+
+The `asan` job is the longest-running job in CI, so its scope is a
+deliberate trade-off rather than an accident. Two things to know before
+changing it.
+
+### It runs `~[slow]`, not everything
+
+`./CatchTestRunner "~[slow]"` excludes the 60 `[slow]`-tagged cases, 48 of
+which are in the SVDSBTL suite. Those build SVD surfaces at **production
+resolution** (`SurfaceSpec` defaults `NT=200`, `NR=800`, `rank=20`), and the
+dense BDCSVD over a 200x800 grid is the bulk of the job's wall time.
+
+Measured on one machine, non-ASan, with a cold surface cache (no
+`*.svd.bin.z` present, as in CI):
+
+| Scope | Cases | Wall time |
+| --- | --- | --- |
+| `[slow]` | 58 (6 skipped, no REFPROP locally) | 887 s |
+| `~[slow]` | 412 | >16 min |
+
+So `[slow]` is roughly 40-45% of the local total. That is a *lower* bound on
+the CI saving: the 6 cases that skip locally for lack of REFPROP include the
+5 `SVDSBTL&REFPROP` production-resolution builds, which do run in CI. Note
+these are non-ASan figures; ASan scales everything up but the ratio is what
+matters here.
+
+Note also that excluding `[slow]` does **not** remove production-resolution
+surface builds entirely: 15 non-`[slow]` tests construct SVDSBTL surfaces
+with no `grid` option, so they build at 200x800 too. Surfaces are cached per
+`(fluid, source, input_pair, options)` key, so that cost is paid once rather
+than per test -- which is why the saving comes from the excluded tests'
+repeat work and their REFPROP-sourced surfaces, not from eliminating dense
+SVD altogether.
+
+**Why not just shrink the grid under ASan?** The resolution is load-bearing
+for those tests. They deliberately pass no `grid` option so that they run at
+production resolution, then assert agreement with a truth source (HEOS /
+REFPROP / IF97) at about `1e-3` relative. `SurfaceSpec` records that the
+defaults deliver ~`7e-5` fractional error for Water, so there is only ~14x
+headroom. Dropping to `NT=40, NR=80, rank=10` — 50x fewer grid points and
+half the SVD rank — would breach that and force the tolerances open. The
+result would be a real accuracy gate quietly becoming a vacuous one *in the
+ASan build only*, which is the worst place to lose signal.
+
+**Why excluding them costs no ASan coverage.** ASan detects heap overflows,
+use-after-free, leaks and ODR problems. Those depend on allocation patterns
+and code paths, not on matrix magnitude: BDCSVD over 40x80 runs the same
+Eigen code, the same temporaries and the same allocation sequence as
+200x800. Eight small-grid SVDSBTL tests (`NT=40, NR=80, rank=10`) are not
+tagged `[slow]` and therefore still run under ASan, so the dense-SVD path
+stays covered. The excluded cases contribute CPU time, not ASan signal.
+
+If you add a test that is the *only* coverage of a memory-safety-relevant
+path, do not tag it `[slow]`, or ASan will not see it.
+
+One consequence worth knowing before anyone proposes lowering the grid for
+the *surviving* tests instead: some of them also assert accuracy against
+HEOS (`SVDSBTL DT two-phase dome` at `1e-3`, `DT fast_evaluate` at `1e-2`),
+so a global resolution cut is not safe even with `[slow]` excluded.
+
+### A timeout is a step failure, not a cancellation
+
+The test step is wrapped in `timeout` with a 70-minute budget, inside the
+job's 90-minute `timeout-minutes`. That ordering is intentional:
+
+- A job that exceeds `timeout-minutes` is reported by GitHub with conclusion
+  **`cancelled`**, which is indistinguishable from a concurrency-supersede or
+  from `cancel_merged_pr_runs.yml` cancelling a merged PR's runs. That is
+  exactly the ambiguity the job cap was introduced to remove (CoolProp-xuu),
+  so leaving the cap as the only bound reintroduces it.
+- Bounding the *step* makes an overrun exit `124` (or `137` after
+  `--kill-after`), which fails the step with an explicit `::error::`
+  annotation saying it was a timeout rather than a memory error.
+
+So when this job goes red, read the annotation first:
+
+| Symptom | Meaning |
+| --- | --- |
+| `::error::ASan run exceeded its budget` | Timeout. Investigate what got slower; do not just raise the budget. |
+| ASan report in the log (`ERROR: AddressSanitizer: ...`) | A real memory bug. Fix it. |
+| Conclusion `cancelled`, no annotation | Not this job's doing — superseded push, or the PR was merged. |
+
+The true wall time of a clean `~[slow]` run is not yet recorded. Once one
+completes, tighten both the budget and `timeout-minutes` to roughly 1.3x the
+measured time rather than leaving the current deliberately-loose envelope.
+
+### Reproducing locally
+
+```bash
+cmake -B build_asan -S . -DCMAKE_BUILD_TYPE=Asan -DCOOLPROP_ASAN=ON \
+      -DCOOLPROP_CATCH_MODULE=ON -DCMAKE_CXX_COMPILER=clang++
+cmake --build build_asan --target CatchTestRunner -j$(nproc)
+ASAN_OPTIONS=verbosity=1:detect_odr_violation=1 \
+  ./build_asan/CatchTestRunner "~[slow]"
+```
+
+Note `detect_stack_use_after_return` is deliberately **not** enabled, and
+`detect_odr_violation` is lowered to `1`; both have specific justifications
+in the job's comments in `dev_checks.yml`.
 
 ## `git blame` and the one-shot reformat
 

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -332,9 +332,12 @@ Both runs of the same scope, before and after `verbosity=1` was dropped:
 | `30364245551` (`0d2af4f9`) | set | 60.6 min |
 | `30371990208` (`3a0f63a5`) | not set | 60.2 min |
 
-So the sizing above holds for the shipped config, and the two runs also
-bracket the run-to-run spread: 0.4 min apart. Do not tighten on the strength
-of two runs — that spread is a floor on the variance, not a measure of it.
+So the sizing above holds for the shipped config. Read the 0.4 min gap as
+nothing more than that: one observed difference between two runs that also
+differ in one setting. It is not a variance bound in either direction — two
+observations cannot establish one — and it is not enough to infer a
+performance effect. If you ever need the real spread, collect repeated runs
+at a fixed config; do not tighten the budget off a pair of numbers.
 
 For contrast, the full-scope (`[slow]` included) predecessor on PR #3294 did
 not finish at all: it ran 09:33:03 -> 11:03:20, hit the 90 min cap, and its

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -343,7 +343,7 @@ if you are tempted to put it back: it costs a great deal and buys nothing.
 At `verbosity>=1` ASan reports its own container-annotation bookkeeping, which
 for this Eigen- and `std::vector`-heavy suite is a sustained stream of
 
-```
+```text
 ==4681==poisoning: 0x7f7bed013040 800
 ==4681==unpoisoning: 0x7f7bed0141c0 400
 ```

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -325,11 +325,16 @@ That settles the sizing, and both current values turn out to be about right:
   variance as a timeout, which is the failure mode this gate exists to avoid.
 - `timeout-minutes: 90` is 1.49x the 60.6 min job total. Also fine to leave.
 
-Caveat: this baseline was taken with `verbosity=1` still set (see the section
-above, which removed it). The removal only makes the run faster, so 4200 s
-stays safe — but the 3041 s figure is an upper bound on the shipped config,
-not a measurement of it. Re-measure before tightening further, and do not
-tighten on the strength of one run either way.
+Both runs of the same scope, before and after `verbosity=1` was dropped:
+
+| Run | `verbosity=1` | Job total |
+| --- | --- | --- |
+| `30364245551` (`0d2af4f9`) | set | 60.6 min |
+| `30371990208` (`3a0f63a5`) | not set | 60.2 min |
+
+So the sizing above holds for the shipped config, and the two runs also
+bracket the run-to-run spread: 0.4 min apart. Do not tighten on the strength
+of two runs — that spread is a floor on the variance, not a measure of it.
 
 For contrast, the full-scope (`[slow]` included) predecessor on PR #3294 did
 not finish at all: it ran 09:33:03 -> 11:03:20, hit the 90 min cap, and its
@@ -337,8 +342,16 @@ log ends `Terminate orphan process: pid (4681) (CatchTestRunner)`.
 
 ### Why `verbosity=1` is not set
 
-The job used to run with `ASAN_OPTIONS=verbosity=1:...`. That was removed, and
-if you are tempted to put it back: it costs a great deal and buys nothing.
+The job used to run with `ASAN_OPTIONS=verbosity=1:...`. That was removed
+because it buys nothing and produces an enormous amount of log noise.
+
+**It is not a performance fix, despite appearances.** Removing it did not
+measurably speed the job up: 60.6 min with it, 60.2 min without. If you are
+looking for the wall-time lever, it is the `~[slow]` scope, not this. The
+volume figures below are why the noise is worth removing on its own terms —
+they are not evidence of a time saving, and the extrapolation that suggested
+one turned out not to hold (the 4365 lines/s rate is clearly not sustained
+across the whole run, or the difference would have shown up).
 
 At `verbosity>=1` ASan reports its own container-annotation bookkeeping, which
 for this Eigen- and `std::vector`-heavy suite is a sustained stream of

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -308,6 +308,35 @@ The true wall time of a clean `~[slow]` run is not yet recorded. Once one
 completes, tighten both the budget and `timeout-minutes` to roughly 1.3x the
 measured time rather than leaving the current deliberately-loose envelope.
 
+### Why `verbosity=1` is not set
+
+The job used to run with `ASAN_OPTIONS=verbosity=1:...`. That was removed, and
+if you are tempted to put it back: it costs a great deal and buys nothing.
+
+At `verbosity>=1` ASan reports its own container-annotation bookkeeping, which
+for this Eigen- and `std::vector`-heavy suite is a sustained stream of
+
+```
+==4681==poisoning: 0x7f7bed013040 800
+==4681==unpoisoning: 0x7f7bed0141c0 400
+```
+
+In PR #3294's ASan log that ran at **4365 lines/s** (measured across a 0.68 s
+window; ~38 bytes per line). Extrapolated over a 70-minute test window that
+is on the order of 18 M lines and ~690 MB of stderr — treat that total as an
+upper bound, since the rate was sampled in one window rather than averaged
+over the whole run. Every one of those lines is a formatted `write()` into a
+pipe that the Actions runner reads, timestamps and uploads.
+
+It is not a diagnostic setting. ASan's error reports, leak reports and
+ODR-violation reports print unconditionally, at any verbosity; `verbosity`
+only adds ASan's internal chatter. Confirmed directly: a trivial
+`std::vector` program emits **0** lines at the default verbosity and **236**
+at `verbosity=1`.
+
+`detect_odr_violation=1` is kept — that one is doing real work (see the ODR
+note in `dev_checks.yml` for why it is level 1 and not 2).
+
 ### The exit code does propagate test failures (two ASan options exist)
 
 There are two ASan switches in `CMakeLists.txt` and only one is used by CI:
@@ -335,7 +364,7 @@ Don't.
 cmake -B build_asan -S . -DCMAKE_BUILD_TYPE=Asan -DCOOLPROP_ASAN=ON \
       -DCOOLPROP_CATCH_MODULE=ON -DCMAKE_CXX_COMPILER=clang++
 cmake --build build_asan --target CatchTestRunner -j$(nproc)
-ASAN_OPTIONS=verbosity=1:detect_odr_violation=1 \
+ASAN_OPTIONS=detect_odr_violation=1 \
 ASAN_SYMBOLIZER_PATH=$(command -v llvm-symbolizer) \
   timeout --signal=INT --kill-after=60 4200 \
   ./build_asan/CatchTestRunner "~[slow]" --benchmark-samples 1

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -230,7 +230,7 @@ Measured on one machine, non-ASan, with a cold surface cache (no
 | Scope | Cases | Wall time |
 | --- | --- | --- |
 | `[slow]` | 58 (6 skipped, no REFPROP locally) | 887 s |
-| `~[slow]` | 412 | >16 min |
+| `~[slow]` | 410 | >16 min |
 
 So `[slow]` is roughly 40-45% of the local total. That is a *lower* bound on
 the CI saving: the 6 cases that skip locally for lack of REFPROP include the

--- a/dev/ci/README.md
+++ b/dev/ci/README.md
@@ -219,7 +219,7 @@ changing it.
 
 ### It runs `~[slow]`, not everything
 
-`./CatchTestRunner "~[slow]"` excludes the 60 `[slow]`-tagged cases, 48 of
+`./CatchTestRunner "~[slow]"` excludes the 58 `[slow]`-tagged cases, 49 of
 which are in the SVDSBTL suite. Those build SVD surfaces at **production
 resolution** (`SurfaceSpec` defaults `NT=200`, `NR=800`, `rank=20`), and the
 dense BDCSVD over a 200x800 grid is the bulk of the job's wall time.
@@ -239,8 +239,8 @@ these are non-ASan figures; ASan scales everything up but the ratio is what
 matters here.
 
 Note also that excluding `[slow]` does **not** remove production-resolution
-surface builds entirely: 15 non-`[slow]` tests construct SVDSBTL surfaces
-with no `grid` option, so they build at 200x800 too. Surfaces are cached per
+surface builds entirely: 17 non-`[slow]` `TEST_CASE`s construct SVDSBTL
+surfaces with no `grid` option, so they build at 200x800 too. Surfaces are cached per
 `(fluid, source, input_pair, options)` key, so that cost is paid once rather
 than per test -- which is why the saving comes from the excluded tests'
 repeat work and their REFPROP-sourced surfaces, not from eliminating dense
@@ -256,20 +256,28 @@ half the SVD rank — would breach that and force the tolerances open. The
 result would be a real accuracy gate quietly becoming a vacuous one *in the
 ASan build only*, which is the worst place to lose signal.
 
-**Why the ASan coverage cost is small.** ASan detects heap overflows,
-use-after-free, leaks and ODR problems, which are largely properties of code
-paths rather than of matrix magnitude: BDCSVD over 40x80 exercises the same
-Eigen algorithmic path as 200x800, and eight small-grid SVDSBTL tests
-(`NT=40, NR=80, rank=10`) are not tagged `[slow]`, so that path stays
-covered.
+**Why the ASan coverage cost is small.** Because production resolution still
+runs. As noted above, 17 non-`[slow]` `TEST_CASE`s build surfaces at the
+200x800/rank-20 defaults, so full-size dense BDCSVD, its temporaries and its
+allocation pattern are all still exercised under ASan. That is what makes the
+exclusion cheap for the classes ASan detects -- heap overflow, use-after-free,
+leaks, ODR.
 
-Being precise about where that argument stops: the two sizes are *not*
-equivalent for ASan. They differ in allocation counts and sizes, in memory
-pressure, and in how far index arithmetic is pushed. A size-dependent bug --
-an overflow only reached past some extent, or a narrowing that only bites at
-larger indices -- could in principle be caught at 200x800 and missed at
-40x80. This is a deliberate trade of that residual risk against a job that
-otherwise does not produce a verdict at all. If that trade ever looks wrong,
+**Do not restate this as "the small-grid tests keep that path covered."** They
+do not run. All 8 of the `NT=40, NR=80, rank=10` grid specs in
+`src/Tests/CoolProp-Tests-SVDSBTL.cpp` sit inside `[slow]` `TEST_CASE`s, so
+`~[slow]` excludes every one of them; the only non-`[slow]` references to a
+40x80 grid are schema/round-trip tests in `CoolProp-Tests-SVDSBTLOptions.cpp`,
+which build no surface. An earlier version of this section had it backwards --
+it counted the 8 option-string literals and assumed their tags without
+checking them.
+
+What is actually given up is the excluded tests' repeat work and their
+REFPROP-sourced surfaces (the 6 `SVDSBTL&REFPROP` truth-comparison cases), not
+the large-matrix code path. Note the consequence: because 200x800 still runs, a
+size-dependent bug reachable only at production extent is still reachable here,
+so there is no "only visible at full resolution" residual risk to trade away.
+If the trade ever looks wrong,
 the answer is more runner minutes, not a resolution cut (see above for why
 lowering the grid breaks assertions on both sides of the filter).
 
@@ -386,9 +394,15 @@ There are two ASan switches in `CMakeLists.txt` and only one is used by CI:
 
 - **`COOLPROP_ASAN`** (what `dev_checks.yml` passes, with
   `-DCMAKE_BUILD_TYPE=Asan`) adds an `Asan` build type at `-O2 -g -DNDEBUG`.
-  `CatchTestRunner` links `Catch2::Catch2WithMain`, so the process exit code
-  is Catch2's failed-assertion count. Verified: injecting one bad `CHECK`
-  yields exit **42** for 5 failed assertions.
+  `CatchTestRunner` links `Catch2::Catch2WithMain`, so a failed assertion
+  makes the process exit non-zero. Specifically it exits **42** --
+  Catch2's `TestFailureExitCode`, a fixed sentinel, *not* the number of
+  failures (`catch_session.cpp`: `if (totals.assertions.failed) { return
+  TestFailureExitCode; }`). Verified by injecting one bad `CHECK`: 5 failed
+  assertions still yields 42. Catch2's other codes are 1 unspecified error,
+  2 no tests run, 3 unmatched test spec, 4 all skipped, 5 invalid spec.
+  This matters for the `124`/`137` handling below: since 42 is fixed, a test
+  failure can never be mistaken for a `timeout` exit code.
 - **`COOLPROP_CLANG_ADDRESS_SANITIZER`** is a separate, older buildbot-era
   switch. It appends `src/Tests/catch_always_return_success.cxx`, whose
   `main` runs the session and then returns `EXIT_SUCCESS` **unconditionally**

--- a/dev/ci/preflight.sh
+++ b/dev/ci/preflight.sh
@@ -222,25 +222,48 @@ else
     # Tag scope selection.  Path -> tag mapping mirrors how CI's broad
     # workflow runs the full suite, but skips the expensive `[slow]`
     # tests by default for fast local feedback.  Pass --slow to include.
+    # Catch2 filter syntax, since three of these were wrong before:
+    #   ~[tag]   EXCLUDES a tag.  `[!slow]` does NOT exclude -- it selects a
+    #            literal tag named "!slow", which no test carries, so
+    #            `[!slow][!benchmark]` matched 0 test cases and this gate
+    #            passed while running NOTHING.
+    #   ,        inside one spec is OR.
+    #   [!benchmark] is a real Catch2 tag, but benchmarks are HIDDEN from the
+    #            default set already (`~[!benchmark]` and no filter both list
+    #            468).  So appending `,[!benchmark]` to an OR-list ADDED the
+    #            benchmarks instead of excluding them.  No benchmark term is
+    #            needed; --benchmark-samples stays a CI concern.
+    # Separate argv specs are AND-ed (intersected), not OR-ed, so an OR-list
+    # must be one comma-separated argument.
     TAG_FILTER=""
     if printf '%s\n' "$ALL_PATHS" | grep -qE "^(src/SBTL/|include/CoolProp/sbtl/|src/Backends/SVDSBTL/|src/Region/|src/SVD/|include/CoolProp/region/|include/CoolProp/svd/)"; then
         # SBTL/SVDSBTL surface area touched — run the umbrella tags.
         # [SBTL] catches the adapter-layer tests (serializer round-trip,
         # multi-fluid PH preset) that [SVDSBTL] alone misses.
-        TAG_FILTER="[SBTL],[SVDSBTL],[SVDComponents],[region],[!benchmark]"
+        TAG_FILTER="[SBTL],[SVDSBTL],[SVDComponents],[region]"
     elif printf '%s\n' "$ALL_PATHS" | grep -qE "^(src/Backends/Helmholtz/|src/Backends/REFPROP/)"; then
         # HEOS / REFPROP path touched — broader sweep including transport
         # and flash routines.
-        TAG_FILTER="[Helmholtz],[REFPROP],[!benchmark]"
+        TAG_FILTER="[Helmholtz],[REFPROP]"
     else
         # Default: run everything fast (skip the [slow] long tests).
-        TAG_FILTER="[!slow][!benchmark]"
+        TAG_FILTER="~[slow]"
     fi
     echo "  tag filter: $TAG_FILTER"
-    if ./build_catch/CatchTestRunner $TAG_FILTER 2>&1 | tee /tmp/preflight-tests.log | tail -3 | grep -qE "failed|Errors:"; then
-        fail "tests (see /tmp/preflight-tests.log)"
+    # Gate on the runner's EXIT CODE, not on grepping its output.  The old
+    # form piped into `grep -qE "failed|Errors:"`, so the `if` saw grep's
+    # status and the runner's was discarded -- a zero-match run (exit 2,
+    # "No tests ran") contains neither word and was reported as a pass.
+    # Also require a non-zero test count, so a filter that stops matching
+    # after a rename fails loudly instead of silently testing nothing.
+    matched=$(./build_catch/CatchTestRunner "$TAG_FILTER" --list-tests 2>/dev/null \
+                | grep -oE '[0-9]+ matching test case' | grep -oE '[0-9]+' || echo 0)
+    if [ "${matched:-0}" -eq 0 ]; then
+        fail "tests (filter '$TAG_FILTER' matched 0 test cases -- filter is stale, not a pass)"
+    elif ./build_catch/CatchTestRunner "$TAG_FILTER" 2>&1 | tee /tmp/preflight-tests.log; then
+        ok "tests ($TAG_FILTER, $matched cases)"
     else
-        ok "tests ($TAG_FILTER)"
+        fail "tests (see /tmp/preflight-tests.log)"
     fi
 fi
 

--- a/dev/ci/preflight.sh
+++ b/dev/ci/preflight.sh
@@ -256,14 +256,30 @@ else
     # "No tests ran") contains neither word and was reported as a pass.
     # Also require a non-zero test count, so a filter that stops matching
     # after a rename fails loudly instead of silently testing nothing.
-    matched=$(./build_catch/CatchTestRunner "$TAG_FILTER" --list-tests 2>/dev/null \
-                | grep -oE '[0-9]+ matching test case' | grep -oE '[0-9]+' || echo 0)
-    if [ "${matched:-0}" -eq 0 ]; then
-        fail "tests (filter '$TAG_FILTER' matched 0 test cases -- filter is stale, not a pass)"
-    elif ./build_catch/CatchTestRunner "$TAG_FILTER" 2>&1 | tee /tmp/preflight-tests.log; then
-        ok "tests ($TAG_FILTER, $matched cases)"
+    #
+    # Count the cases via `--list-tests --verbosity quiet`, which prints one
+    # test name per line and nothing else.  Deliberately NOT parsing the
+    # human-readable "N matching test cases" summary: that string is a
+    # presentation detail that a Catch2 upgrade can reword, and if it ever
+    # stopped matching, the count would silently read 0.  Line counting also
+    # lets the listing's own exit status stay meaningful -- a non-zero exit
+    # here means the listing itself failed (missing/broken runner), which is
+    # distinct from a filter that legitimately matches nothing (exit 0, no
+    # lines).  No `2>/dev/null` and no `|| echo 0`: swallowing either the
+    # stderr or the status is what lets a gate fail open.
+    test_log="$(mktemp "${TMPDIR:-/tmp}/preflight-tests.XXXXXX")"
+    if ! listed_tests=$(./build_catch/CatchTestRunner "$TAG_FILTER" \
+                            --list-tests --verbosity quiet); then
+        fail "tests (could not list cases for filter '$TAG_FILTER' -- is the runner intact?)"
     else
-        fail "tests (see /tmp/preflight-tests.log)"
+        matched=$(printf '%s\n' "$listed_tests" | awk 'NF { c++ } END { print c + 0 }')
+        if [ "$matched" -eq 0 ]; then
+            fail "tests (filter '$TAG_FILTER' matched 0 test cases -- filter is stale, not a pass)"
+        elif ./build_catch/CatchTestRunner "$TAG_FILTER" 2>&1 | tee "$test_log"; then
+            ok "tests ($TAG_FILTER, $matched cases)"
+        else
+            fail "tests (see $test_log)"
+        fi
     fi
 fi
 

--- a/dev/ci/preflight.sh
+++ b/dev/ci/preflight.sh
@@ -40,7 +40,10 @@ SKIP_CHECKS=""
 for arg in "$@"; do
     case "$arg" in
         --base=*) BASE_REF="${arg#*=}" ;;
-        --skip=*) SKIP_CHECKS="${arg#*=}" ;;
+        # Append rather than assign: a repeated --skip= used to overwrite the
+        # earlier one, so `--skip=a --skip=b` silently skipped only b and ran a.
+        # Both forms now work -- CSV in one flag, or the flag repeated.
+        --skip=*) SKIP_CHECKS="${SKIP_CHECKS:+$SKIP_CHECKS,}${arg#*=}" ;;
         --help|-h)
             sed -n '2,30p' "$0"
             exit 0
@@ -221,7 +224,8 @@ elif [ ! -x ./build_catch/CatchTestRunner ]; then
 else
     # Tag scope selection.  Path -> tag mapping mirrors how CI's broad
     # workflow runs the full suite, but skips the expensive `[slow]`
-    # tests by default for fast local feedback.  Pass --slow to include.
+    # tests by default for fast local feedback.  (There is no --slow flag;
+    # run `./build_catch/CatchTestRunner "[slow]"` directly for those.)
     # Catch2 filter syntax, since three of these were wrong before:
     #   ~[tag]   EXCLUDES a tag.  `[!slow]` does NOT exclude -- it selects a
     #            literal tag named "!slow", which no test carries, so
@@ -255,7 +259,14 @@ else
     # status and the runner's was discarded -- a zero-match run (exit 2,
     # "No tests ran") contains neither word and was reported as a pass.
     # Also require a non-zero test count, so a filter that stops matching
-    # after a rename fails loudly instead of silently testing nothing.
+    # after a rename fails loudly instead of silently testing nothing.  That
+    # count alone only catches a TOTALLY stale filter, though: rename one tag
+    # out of the comma-separated OR-lists below and the rest still match, so
+    # the gate would pass while testing less.  `--warn UnmatchedTestSpec` on
+    # the run closes that -- Catch2 then exits 3 (UnmatchedTestSpecExitCode)
+    # if any single term matched nothing.  Verified: "[cbor],[NoSuchTag]"
+    # exits 3 on a run.  Note it does NOT work on --list-tests (exits 0
+    # there), which is why it is on the run and not the listing.
     #
     # Count the cases via `--list-tests --verbosity quiet`, which prints one
     # test name per line and nothing else.  Deliberately NOT parsing the
@@ -275,10 +286,21 @@ else
         matched=$(printf '%s\n' "$listed_tests" | awk 'NF { c++ } END { print c + 0 }')
         if [ "$matched" -eq 0 ]; then
             fail "tests (filter '$TAG_FILTER' matched 0 test cases -- filter is stale, not a pass)"
-        elif ./build_catch/CatchTestRunner "$TAG_FILTER" 2>&1 | tee "$test_log"; then
-            ok "tests ($TAG_FILTER, $matched cases)"
+        # tee to the log but NOT to the terminal: streaming all ~410 cases here
+        # would bury the cppcheck/clang-tidy/semgrep results and the summary
+        # below it.  `>/dev/null` does not cost the exit status -- under
+        # pipefail the pipeline still reports the runner's non-zero status, not
+        # tee's (verified).  On failure the tail is echoed so there is context
+        # without having to open the log.
+        elif ./build_catch/CatchTestRunner "$TAG_FILTER" \
+                 --warn UnmatchedTestSpec 2>&1 | tee "$test_log" >/dev/null; then
+            ok "tests ($TAG_FILTER, $matched cases listed)"
         else
-            fail "tests (see $test_log)"
+            # `|| true` guards the DISPLAY only: without it a tail failure
+            # would abort the script under `set -e` before `fail` records the
+            # result.  It cannot mask the gate -- `fail` runs unconditionally.
+            tail -15 "$test_log" || true
+            fail "tests ($TAG_FILTER; full log: $test_log)"
         fi
     fi
 fi


### PR DESCRIPTION
Independent of the incompressible stack (#3294–#3298); branched straight off `master`. Four files, no source changes.

Prompted by #3294, where the `asan` job exceeded its 90-minute cap and GitHub reported it as **`cancelled`**. Its log ends `Terminate orphan process: pid (4681) (CatchTestRunner)` — so the full-scope run does not merely run long, it does not finish.

### Requirements

* All new code requires tests to ensure against regressions.

### Description of the Change

**1. Scope: run `~[slow]`.** The job ran the entire Catch suite, including the **58** `[slow]` cases (**49** of them SVDSBTL) that build SVD surfaces at production resolution — `SurfaceSpec` defaults `NT=200`, `NR=800`, `rank=20`. Dense BDCSVD over a 200×800 grid is the bulk of the runtime.

Measured non-ASan with a cold surface cache (no `*.svd.bin.z` present, as in CI):

| Scope | Cases | Wall time |
|---|---|---|
| `[slow]` | 58 (6 skipped — no REFPROP locally) | **887 s** |
| `~[slow]` | 410 | >16 min |

No precise share is quoted: `~[slow]` is only bounded below, so 887 s is *at most* ~48% of the local total and cannot be pinned tighter. Whatever the share, it **understates** the CI saving — the 6 cases skipping locally are all 6 `SVDSBTL&REFPROP` production-resolution builds, which do run in CI.

**Why not lower the grid resolution under ASan instead?** That was the first idea and it doesn't hold up on either side. The `[slow]` tests pass no `grid` option *precisely so* they run at production resolution, then assert agreement with HEOS/REFPROP/IF97 at ~`1e-3`; `SurfaceSpec` records the defaults delivering ~`7e-5` for Water, so there's only ~14× headroom, and `40×80/rank-10` (50× fewer points, half the rank) would breach it. Relaxing the tolerances to compensate would turn a real accuracy gate vacuous *in the ASan build only* — the worst place to lose signal quietly. And a cut isn't safe for the surviving tests either: `SVDSBTL DT two-phase dome` asserts `1e-3` and `DT fast_evaluate` asserts `1e-2` against HEOS.

**Why the exclusion costs little: production resolution still runs.** 17 non-`[slow]` `TEST_CASE`s call `factory("SVDSBTL&…")` with no `grid` option, so they build at the 200×800/rank-20 defaults. Full-size dense BDCSVD, its temporaries and its allocation pattern are therefore all still exercised under ASan — which is what makes the exclusion cheap for the classes ASan detects (heap overflow, use-after-free, leaks, ODR).

Worth stating because an earlier revision of this PR had it backwards: this is **not** "the small-grid tests keep that path covered." They don't run. All 8 of the `NT=40, NR=80, rank=10` grid specs in `CoolProp-Tests-SVDSBTL.cpp` sit inside `[slow]` cases, so `~[slow]` excludes every one; the only non-`[slow]` 40×80 references are schema/round-trip tests that build no surface. What is actually given up is the excluded tests' repeat work and their REFPROP-sourced surfaces, not the large-matrix code path — and because 200×800 still runs, there is no "size-dependent bug only visible at full resolution" residual risk to trade away either.

Surfaces are cached per `(fluid, source, input_pair, options)` key, so production-resolution cost is paid once rather than per test.

**2. Signal: bound the step, not just the job.** A job exceeding `timeout-minutes` is reported as `cancelled` — indistinguishable from a concurrency supersede or from `cancel_merged_pr_runs.yml`. That's the exact ambiguity this job's cap was introduced to remove (CoolProp-xuu), so leaving the cap as the only bound reintroduces it. The test step is now wrapped in `timeout` with a 70-minute budget inside the 90-minute job cap, so an overrun fails the step with an annotation saying so.

Exit codes are distinguished rather than conflated: **124** is annotated as a definite timeout, while **137** (128+SIGKILL) gets an explicitly ambiguous message — `timeout --kill-after` sends SIGKILL when SIGINT is ignored, but so does the OOM killer, and ASan roughly doubles memory on a 2-vCPU runner.

There is no collision between these and a test failure: Catch2 returns `TestFailureExitCode`, a **fixed 42**, for any non-zero failure count — not the count itself. The README documents this along with Catch2's other codes (1 unspecified, 2 no tests ran, 3 unmatched spec, 4 all skipped, 5 invalid spec), because the wrong model here would make a hypothetical 124-failure run look like a timeout.

**3. Drop `ASAN_OPTIONS=verbosity=1`.** At `verbosity>=1` ASan reports its own container-annotation bookkeeping — a stream of `==pid==poisoning: 0x… <n>` lines, measured at 4365 lines/s across a 0.68 s window of #3294's log. It is not a diagnostic setting: error, leak and ODR reports print unconditionally at any verbosity (a trivial `std::vector` program emits 0 lines at default verbosity and 236 at `verbosity=1`).

**This is not a performance fix, despite appearances.** Removing it did not measurably change wall time — 60.6 min with it, 60.2 min without. The initial extrapolation suggesting a large saving did not hold; that rate is evidently not sustained across the run. It stays out for log hygiene, and the notes say so explicitly so nobody hunts a regression that isn't there. `detect_odr_violation=1` is kept — that one does real work.

**4. Fix a fail-open preflight gate (`dev/ci/preflight.sh`).** Found while running the mandated pre-push gate for this PR. The Catch2 check could not fail, in two independent ways, and the default branch — the one most changes take — hit both:

* **The filter matched nothing.** `[!slow][!benchmark]` selects tests tagged literally `!slow` **and** `!benchmark`; Catch2 exclusion is `~[tag]`. Measured: 0 matching cases, versus 410 for `~[slow]`. The runner exits 2 and prints "No tests ran".
* **`pipefail` inverted the status check.** The gate was `if runner | tee log | tail -3 | grep -qE "failed|Errors:"`. With `set -o pipefail` the pipeline's status is the *runner's* non-zero exit, not grep's, so a genuinely failing run took the `else` branch and was reported as a pass. Verified with a stub that prints "5 failed" and exits 42: the old form reports **PASS**.

Together these meant a passing run exits 0 with no "failed" text and a failing run poisons the pipeline — so the gate could essentially never report failure. It now gates on the runner's exit status, fails when the filter matches zero cases, and passes `--warn UnmatchedTestSpec` so a *partially* stale OR-list (rename one tag, the rest still match) also fails rather than silently testing less. Also drops `,[!benchmark]` from the SBTL and Helmholtz OR-lists (comma is OR, and benchmarks are already hidden from the default set, so that term was *adding* benchmark cases — narrowing those branches 133→130 and 25→17), `mktemp`s the test log, and fixes a parser bug where a repeated `--skip=` overwrote the earlier one instead of appending.

**5. Documentation.** `dev/ci/README.md` gains an **ASan scope and budget** section: the measurements below, the resolution trade-off and why it was rejected on both sides, the correct coverage mechanism, the timeout-vs-cancellation distinction with a triage table, Catch2's exit-code contract, why `verbosity=1` stays out, a warning **not to tag sole memory-safety coverage as `[slow]`**, and local reproduction steps matching CI. Its existing entry claiming ASan runs the "full Catch test suite" is corrected.

It also records which ASan switch CI uses, since a fail-open was suspected there: `COOLPROP_ASAN` links `Catch2::Catch2WithMain`, so a failed assertion exits 42. The separate, older `COOLPROP_CLANG_ADDRESS_SANITIZER` appends `catch_always_return_success.cxx`, whose `main` returns `EXIT_SUCCESS` unconditionally by design; that file is real but is not in the CI build. The README warns against switching the job to it.

**Drive-by fix:** CLAUDE.md documented `CatchTestRunner "[!slow]"` as "everything fast", but Catch2's exclusion syntax is `~[slow]`. `[!slow]` matches **zero** test cases — the same defect that made the preflight gate vacuous.

### Measured ASan wall time

First ASan job to finish rather than hit the cap — run `30364245551`, conclusion `success`:

| Step | Wall time |
|---|---|
| REFPROP build | 36 s |
| cmake config | 28 s |
| compile (`-j$(nproc)`) | 8.8 min |
| **test run (`~[slow]`)** | **50.7 min (3041 s)** |
| job total | 60.6 min |

Both limits turn out to be about right, so **neither is changed**: `budget=4200` is **1.38×** the measured 3041 s (essentially the 1.3× target), and `timeout-minutes: 90` is 1.49× the job total. The margin closes on measured numbers: 71 min worst case (budget + `--kill-after` grace) + 9.9 min of setup and compile = 80.9 min, inside the 90 min cap. Tightening further would start flagging ordinary shared-runner variance as a timeout — the false signal this gate exists to remove.

A second run without `verbosity=1` (`30371990208`) came in at 60.2 min. Read that 0.4 min gap as one observed difference between two runs that also differ in a setting — it is not a variance bound and not enough to infer a performance effect.

### Benefits

* Brings the ASan job back inside its budget, so it produces a verdict instead of an ambiguous `cancelled` — now demonstrated, not predicted.
* When it *does* go red, the annotation distinguishes a timeout (124) from an ambiguous SIGKILL/OOM (137) from a real memory bug.
* The pre-push Catch2 gate actually gates. It previously reported ✓ while running zero tests; it now runs 410 cases / 159,988 assertions, and fails on a partially stale filter too.
* The `[!slow]` correction means the documented "everything fast" command actually runs tests.

### Possible Drawbacks

* `[slow]` tests no longer run under ASan. The large-matrix path survives via the 17 non-`[slow]` production-resolution builders, but the excluded tests' REFPROP-sourced surfaces and repeat work are genuinely gone. If someone disagrees, the alternative is more runner minutes, not a resolution cut.
* The budget and cap are justified by a single clean run each. Two data points cannot establish run-to-run spread; collect repeated runs at a fixed config before tightening.
* `timeout --signal=INT` lets Catch2 print partial results on overrun; if a test ignores SIGINT, `--kill-after=60` escalates to SIGKILL and the exit code becomes 137 rather than 124. Both are handled, with 137 deliberately not claimed as proof of timeout. Note Catch2 does install a SIGINT handler, so a slow handler under ASan is a likelier route to 137 than SIGINT being ignored outright.
* The preflight fix is arguably a separate concern from the ASan job. It is included because it was found *by* running the gate for this PR, and shipping a CI-signal fix while leaving the local gate vacuous seemed worse than the larger diff. Happy to split it out.

### Verification Process

* **Filter is self-contained:** ran the full `~[slow]` suite locally — **410 cases, 383 passed, 27 skipped, 159,988 assertions, zero failures**. Confirms no ordering dependency or shared state coming from the excluded `[slow]` tests.
* **Counts taken from the binary, not asserted:** `--list-tests` gives 58 `[slow]`, 49 `[slow][SVDSBTL]`, 410 `~[slow]`, 468 total (58 + 410 ✓), 6 `[slow][refprop]` all named `SVDSBTL&REFPROP`. The 8 small-grid specs and their owning `TEST_CASE` tags were extracted from the source, which is how the backwards coverage claim was caught.
* **Timing measured, not assumed** — both tables above. Cold cache verified by checking no `*.svd.bin.z` existed.
* **`timeout` exit semantics verified explicitly**: success passes through as `0`, an inner failure passes through unchanged (`3` → `3`), and an overrun yields `124`. So the wrapper cannot mask a genuine ASan failure.
* **Catch2's exit contract read from source** (`catch_session.cpp`) rather than inferred from one observation, after the "failed-assertion count" reading proved wrong.
* **The preflight fail-open reproduced and then closed**: a stub runner printing "5 failed" and exiting 42 makes the old form report PASS; the new form reports FAIL. All four paths checked — pass, tests failing, filter matching zero, listing itself failing — plus `--warn UnmatchedTestSpec` verified to exit 3 on a partially stale spec and to be a no-op on `--list-tests`.
* **`verbosity=1` claim tested both ways** rather than reasoned about: 0 lines at default verbosity, 236 at `verbosity=1` on a trivial program; and the two CI runs above show no wall-time effect, which is why the PR no longer claims one.
* Workflow YAML re-parsed after every edit (`yaml.safe_load`); for the comment-only commits, the parsed YAML was confirmed identical to the last fully-green commit.
* An adversarial review pass over the final diff produced three blocking findings — the backwards coverage claim, the stale README prose, and the exit-code error — all fixed in `f0e99d9c` rather than argued away.

### Applicable Issues

None open. Follows up CoolProp-xuu (the cap and the `detect_stack_use_after_return` finding) and CoolProp-xma3 (the `detect_odr_violation` level), both referenced in the job's comments.

---
_Generated by [Claude Code](https://claude.ai/code/session_014CQ8VReZEmjCk1RzS9KHLW)_