### PR TITLE
Apply fix for repeated python builds with different version

### DIFF
--- a/dev/generate_headers.py
+++ b/dev/generate_headers.py
@@ -342,7 +342,8 @@ def gitrev_to_file(root_dir):
 
 class DependencyManager:
     def __init__(self, sources: list[Path], destination: Path, cachefile: Path):
-        self.sources = sources
+        # Materialize so generators (e.g. Path.glob) survive repeated iteration
+        self.sources = list(sources)
         self.destination = Path(destination)
         self.cachefile = cachefile
         
@@ -359,14 +360,19 @@ class DependencyManager:
                 return True, f"source file {source} is newer than destination"
         # Check source list if cachefile exists
         if self.cachefile.exists():
-            previous_sources = pickle.load(self.cachefile.open('rb'))['sorted_sources']
-            if sorted(self.sources) != previous_sources:
+            try:
+                previous_sources = pickle.load(self.cachefile.open('rb'))['sorted_sources']
+            except Exception as err:
+                return True, f"cache file could not be read ({err})"
+            if sorted(str(s) for s in self.sources) != previous_sources:
                 return True, "source list has changed"
         return False, ""
-            
+
     def write_cache(self):
+        # Store paths as strings; pickled Path objects are not portable
+        # across Python versions (e.g. pathlib._local moved in 3.13/3.14)
         with self.cachefile.open('wb') as fp:
-            pickle.dump(dict(sorted_sources=sorted(self.sources)), fp)
+            pickle.dump(dict(sorted_sources=sorted(str(s) for s in self.sources)), fp)
         
 def combine_json(root_dir):
 

--- a/dev/generate_headers.py
+++ b/dev/generate_headers.py
@@ -14,7 +14,6 @@ import hashlib
 import struct
 import glob
 from pathlib import Path
-import pickle
 import tempfile
 
 # Vendored stdlib-only CBOR codec (dev/cbor_min.py) — avoids a third-party
@@ -361,18 +360,20 @@ class DependencyManager:
         # Check source list if cachefile exists
         if self.cachefile.exists():
             try:
-                previous_sources = pickle.load(self.cachefile.open('rb'))['sorted_sources']
+                with self.cachefile.open('r') as fp:
+                    previous_sources = json.load(fp)['sorted_sources']
             except Exception as err:
+                # Invalid or legacy pickle-format cache: treat as a miss
                 return True, f"cache file could not be read ({err})"
             if sorted(str(s) for s in self.sources) != previous_sources:
                 return True, "source list has changed"
         return False, ""
 
     def write_cache(self):
-        # Store paths as strings; pickled Path objects are not portable
-        # across Python versions (e.g. pathlib._local moved in 3.13/3.14)
-        with self.cachefile.open('wb') as fp:
-            pickle.dump(dict(sorted_sources=sorted(str(s) for s in self.sources)), fp)
+        # JSON with string paths: portable across Python versions and safe
+        # to load, unlike pickle (arbitrary code execution on load)
+        with self.cachefile.open('w') as fp:
+            json.dump(dict(sorted_sources=sorted(str(s) for s in self.sources)), fp)
         
 def combine_json(root_dir):
 


### PR DESCRIPTION
Resolve #3305 

When repeatedly building CoolProp from the same repository with different python version the build process crashed. This tries to load the pickle and on failure rebuilds the cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency cache validation by consistently comparing source paths.
  * Added clearer rebuild handling when the dependency cache cannot be read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->