### PR TITLE
Add modern CMake package support

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -864,6 +864,7 @@ jobs:
         run: |
           cmake -B build_shared -S . \
             -DCOOLPROP_SHARED_LIBRARY=ON \
+            -DCMAKE_INSTALL_INCLUDEDIR=cp-headers \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache

--- a/.github/workflows/gui_builder.yml
+++ b/.github/workflows/gui_builder.yml
@@ -189,15 +189,27 @@ jobs:
       # to be hand-merged. The dedicated `release` job below downloads each
       # OS's uploaded bundle artifact and creates a single consolidated
       # release in one shot.
-      - name: Build Tauri bundle
+      # Pull requests, especially those from forks, cannot access updater
+      # signing secrets. Build the normal installers without requesting updater
+      # artifacts, which require a private signing key.
+      - name: Build Tauri bundle (pull request)
+        if: github.event_name == 'pull_request'
         uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Tauri auto-updater signing — when present, tauri-action signs the
-          # update artifacts and emits latest.json next to each platform
-          # bundle. Without these the build still succeeds; the updater
-          # plugin just won't accept the signatures, so updates won't work
-          # for that release. Activate by adding both repo secrets.
+        with:
+          projectPath: wrappers/GUI
+          tauriScript: npm run tauri
+          args: >-
+            --config '{"bundle":{"createUpdaterArtifacts":false}}'
+
+      - name: Build Tauri bundle (trusted ref)
+        if: github.event_name != 'pull_request'
+        uses: tauri-apps/tauri-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Trusted refs create signed updater artifacts, so both repository
+          # secrets are required by Tauri's createUpdaterArtifacts setting.
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:

--- a/.github/workflows/library_shared.yml
+++ b/.github/workflows/library_shared.yml
@@ -1,5 +1,8 @@
 name: CMake library builds
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ 'master', 'main', 'develop', 'actions_shared' ]

--- a/.github/workflows/library_shared.yml
+++ b/.github/workflows/library_shared.yml
@@ -208,17 +208,38 @@ jobs:
         set -euo pipefail
 
         python - <<'PY'
+        import re
+        import xml.etree.ElementTree as ET
         from pathlib import Path
 
         expected = {
             "CoolProp_static.vcxproj": "MultiThreadedDebugDLL",
             "CoolProp_shared.vcxproj": "MultiThreadedDebug",
         }
+        namespace = {"msbuild": "http://schemas.microsoft.com/developer/msbuild/2003"}
+        debug_condition = re.compile(
+            r"\s*'\$\(Configuration\)\|\$\(Platform\)'\s*==\s*'Debug\|([^']+)'\s*"
+        )
         for project, runtime in expected.items():
-            content = (Path("build") / project).read_text(encoding="utf-8-sig")
-            setting = f"<RuntimeLibrary>{runtime}</RuntimeLibrary>"
-            if setting not in content:
-                raise SystemExit(f"{project} does not contain {setting}")
+            project_path = Path("build") / project
+            root = ET.parse(project_path).getroot()
+            debug_groups = []
+            for group in root.findall("msbuild:ItemDefinitionGroup", namespace):
+                match = debug_condition.fullmatch(group.get("Condition", ""))
+                if match:
+                    debug_groups.append((group, match.group(1)))
+            if not debug_groups:
+                raise SystemExit(f"{project} has no Debug ItemDefinitionGroup")
+            for group, platform in debug_groups:
+                setting = group.find(
+                    "msbuild:ClCompile/msbuild:RuntimeLibrary", namespace
+                )
+                actual = None if setting is None else setting.text
+                if actual != runtime:
+                    raise SystemExit(
+                        f"{project} Debug|{platform} runtime is {actual!r}; "
+                        f"expected {runtime!r}"
+                    )
         PY
 
         cmake --build build --config Debug --parallel 1

--- a/.github/workflows/library_shared.yml
+++ b/.github/workflows/library_shared.yml
@@ -1,4 +1,4 @@
-name: Library builds (shared)
+name: CMake library builds
 
 on:
   push:
@@ -28,6 +28,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macOS-latest]
+        linkage: [shared, static]
+        include:
+          - os: ubuntu-latest
+            linkage: both
+          - os: windows-latest
+            linkage: both
 
     steps:
     - uses: actions/checkout@v7
@@ -48,8 +54,7 @@ jobs:
         COOLPROP_VERSION=$(python dev/extract_version.py --cmake-only)
         echo COOLPROP_VERSION=$COOLPROP_VERSION >> $GITHUB_ENV
 
-    # cmake/dependencies.cmake fetches its CPM deps from network with no
-    # cache, so every OS leg here re-downloads the same dependency set.
+    # Reuse the pinned CPM dependency sources across builds on each OS.
     - name: Cache CPM packages
       uses: actions/cache@v6
       with:
@@ -59,7 +64,19 @@ jobs:
           cpm-${{ runner.os }}-
 
     - name: Configure CMake
-      run: cmake -B build -S . -DCMAKE_BUILD_TYPE:STRING=${{ env.BUILD_TYPE }} -DCOOLPROP_SHARED_LIBRARY:BOOL=ON
+      shell: bash
+      run: |
+        static=OFF
+        shared=OFF
+        case "${{ matrix.linkage }}" in
+          static) static=ON ;;
+          shared) shared=ON ;;
+          both) static=ON; shared=ON ;;
+        esac
+        cmake -B build -S . \
+          -DCMAKE_BUILD_TYPE:STRING=${{ env.BUILD_TYPE }} \
+          -DCOOLPROP_STATIC_LIBRARY:BOOL="$static" \
+          -DCOOLPROP_SHARED_LIBRARY:BOOL="$shared"
 
     - name: Build
       shell: bash
@@ -70,6 +87,11 @@ jobs:
       # under bash on all three runners. Mirrors csharp_builder.yml.
       run: |
         JOBS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 2)
+        if [ "${{ runner.os }}" = Windows ] && [ "${{ matrix.linkage }}" = both ]; then
+          # Each MSVC project already uses /MP. Building both projects in
+          # parallel can exhaust the compiler heap on hosted runners.
+          JOBS=1
+        fi
         echo "Building with -j$JOBS"
         cmake --build build --target install -j "$JOBS" --config ${{ env.BUILD_TYPE }}
 
@@ -78,7 +100,7 @@ jobs:
       # dynamic export table. Rides the shared build produced above (ELF on
       # ubuntu, Mach-O on macOS) — no separate build. nm-based, so the Windows
       # PE legs are skipped (exports are opt-in via src/CoolPropLib.def).
-      if: runner.os == 'Linux' || runner.os == 'macOS'
+      if: matrix.linkage != 'static' && (runner.os == 'Linux' || runner.os == 'macOS')
       shell: bash
       run: |
         set -euo pipefail
@@ -93,42 +115,165 @@ jobs:
         echo "Gating $lib"
         ./dev/ci/check-json-symbols.sh "$lib"
 
+    - name: Test installed CMake package
+      shell: bash
+      run: |
+        set -euo pipefail
+        prefix_a="$RUNNER_TEMP/coolprop-prefix-a-${{ matrix.linkage }}"
+        prefix_b="$RUNNER_TEMP/coolprop-prefix-b-${{ matrix.linkage }}"
+        cmake -E remove_directory "$prefix_a"
+        cmake -E remove_directory "$prefix_b"
+        cmake --install build --config "${{ env.BUILD_TYPE }}" --prefix "$prefix_a"
+        cmake -E rename "$prefix_a" "$prefix_b"
+
+        python - "$prefix_b" "$GITHUB_WORKSPACE" "$prefix_a" <<'PY'
+        from pathlib import Path
+        import sys
+
+        package_dir = Path(sys.argv[1]) / "lib" / "cmake" / "CoolProp"
+        required_files = {
+            package_dir / "CoolPropConfig.cmake",
+            package_dir / "CoolPropTargets.cmake",
+        }
+        missing = sorted(path for path in required_files if not path.is_file())
+        if missing:
+            raise SystemExit(f"CMake package files are missing: {missing}")
+
+        cmake_files = list(package_dir.glob("*.cmake"))
+        if not cmake_files:
+            raise SystemExit(f"No CMake package files found under {package_dir}")
+
+        forbidden = {
+            value.replace("\\", "/")
+            for value in (sys.argv[2], sys.argv[3])
+        }
+        for cmake_file in cmake_files:
+            content = cmake_file.read_text(encoding="utf-8").replace("\\", "/")
+            leaked = [value for value in forbidden if value and value in content]
+            if leaked:
+                raise SystemExit(f"{cmake_file} contains non-relocatable paths: {leaked}")
+        PY
+
+        expected=""
+        case "${{ matrix.linkage }}" in
+          static) expected=STATIC ;;
+          shared) expected=SHARED ;;
+        esac
+        cmake -S dev/ci/cmake-consumer -B consumer-build \
+          -DCMAKE_PREFIX_PATH="$prefix_b" \
+          -DCOOLPROP_EXPECTED_LINKAGE="$expected"
+        cmake --build consumer-build --config "${{ env.BUILD_TYPE }}"
+        ctest --test-dir consumer-build -C "${{ env.BUILD_TYPE }}" --output-on-failure
+
+        if [ "${{ matrix.linkage }}" != static ]; then
+          cmake -S dev/ci/cmake-consumer -B c-consumer-build \
+            -DCMAKE_PREFIX_PATH="$prefix_b" \
+            -DCOOLPROP_EXPECTED_LINKAGE=SHARED \
+            -DCOOLPROP_C_ONLY=ON
+          cmake --build c-consumer-build --config "${{ env.BUILD_TYPE }}"
+          ctest --test-dir c-consumer-build -C "${{ env.BUILD_TYPE }}" --output-on-failure
+        fi
+
+    - name: Test add_subdirectory consumer
+      if: runner.os == 'Linux' && matrix.linkage == 'static'
+      shell: bash
+      run: |
+        set -euo pipefail
+        cmake -S dev/ci/cmake-consumer -B source-consumer \
+          -DCOOLPROP_SOURCE_DIR="$GITHUB_WORKSPACE" \
+          -DCOOLPROP_EXPECTED_LINKAGE=STATIC
+        cmake --build source-consumer --config "${{ env.BUILD_TYPE }}"
+        ctest --test-dir source-consumer -C "${{ env.BUILD_TYPE }}" --output-on-failure
+
+    - name: Configure add_subdirectory consumer with CMP0091-old parent
+      if: runner.os == 'Windows' && matrix.linkage == 'static'
+      shell: bash
+      run: |
+        set -euo pipefail
+        cmake -S dev/ci/cmake-consumer -B source-consumer-windows \
+          -DCOOLPROP_SOURCE_DIR="$GITHUB_WORKSPACE" \
+          -DCOOLPROP_EXPECTED_LINKAGE=STATIC
+
     # Create a special case for Windows since we also need 2 flavours of 32bit binaries
     - name: Configure CMake for 32bit Windows stdcall
-      if: startsWith(matrix.os, 'windows')
+      if: startsWith(matrix.os, 'windows') && matrix.linkage == 'shared'
       run: cmake -B build_stdc  -S . -DCMAKE_BUILD_TYPE:STRING=${{ env.BUILD_TYPE }} -DCOOLPROP_SHARED_LIBRARY:BOOL=ON -DCOOLPROP_STDCALL_LIBRARY:BOOL=ON -A Win32
       
     - name: Build with CMake for 32bit Windows stdcall
-      if: startsWith(matrix.os, 'windows')
+      if: startsWith(matrix.os, 'windows') && matrix.linkage == 'shared'
       shell: bash
       run: |
         JOBS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 2)
         echo "Building with -j$JOBS"
         cmake --build build_stdc --target install -j "$JOBS" --config ${{ env.BUILD_TYPE }}
 
+    - name: Test 32bit Windows stdcall package
+      if: startsWith(matrix.os, 'windows') && matrix.linkage == 'shared'
+      shell: bash
+      run: |
+        set -euo pipefail
+        prefix="$RUNNER_TEMP/coolprop-stdcall"
+        cmake -E remove_directory "$prefix"
+        cmake --install build_stdc --config "${{ env.BUILD_TYPE }}" --prefix "$prefix"
+        cmake -S dev/ci/cmake-consumer -B consumer-stdcall -A Win32 \
+          -DCMAKE_PREFIX_PATH="$prefix" \
+          -DCOOLPROP_EXPECTED_LINKAGE=SHARED \
+          -DCOOLPROP_C_ONLY=ON
+        cmake --build consumer-stdcall --config "${{ env.BUILD_TYPE }}"
+        ctest --test-dir consumer-stdcall -C "${{ env.BUILD_TYPE }}" --output-on-failure
+
     - name: Configure CMake for 32bit Windows cdecl
-      if: startsWith(matrix.os, 'windows')
+      if: startsWith(matrix.os, 'windows') && matrix.linkage == 'shared'
       run: cmake -B build_cdecl -S . -DCMAKE_BUILD_TYPE:STRING=${{ env.BUILD_TYPE }} -DCOOLPROP_SHARED_LIBRARY:BOOL=ON -DCOOLPROP_CDECL_LIBRARY:BOOL=ON   -A Win32
       
     - name: Build with CMake for 32bit Windows cdecl
-      if: startsWith(matrix.os, 'windows')
+      if: startsWith(matrix.os, 'windows') && matrix.linkage == 'shared'
       shell: bash
       run: |
         JOBS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 2)
         echo "Building with -j$JOBS"
         cmake --build build_cdecl --target install -j "$JOBS" --config ${{ env.BUILD_TYPE }}
 
+    - name: Test 32bit Windows cdecl package
+      if: startsWith(matrix.os, 'windows') && matrix.linkage == 'shared'
+      shell: bash
+      run: |
+        set -euo pipefail
+        prefix="$RUNNER_TEMP/coolprop-cdecl"
+        cmake -E remove_directory "$prefix"
+        cmake --install build_cdecl --config "${{ env.BUILD_TYPE }}" --prefix "$prefix"
+        cmake -S dev/ci/cmake-consumer -B consumer-cdecl -A Win32 \
+          -DCMAKE_PREFIX_PATH="$prefix" \
+          -DCOOLPROP_EXPECTED_LINKAGE=SHARED \
+          -DCOOLPROP_C_ONLY=ON
+        cmake --build consumer-cdecl --config "${{ env.BUILD_TYPE }}"
+        ctest --test-dir consumer-cdecl -C "${{ env.BUILD_TYPE }}" --output-on-failure
+
     - name: Configure CMake for 64bit Windows arm64
-      if: startsWith(matrix.os, 'windows')
+      if: startsWith(matrix.os, 'windows') && matrix.linkage == 'shared'
       run: cmake -B build_arm64 -S . -DCMAKE_BUILD_TYPE:STRING=${{ env.BUILD_TYPE }} -DCOOLPROP_SHARED_LIBRARY:BOOL=ON -A ARM64
       
     - name: Build with CMake for 64bit Windows arm64
-      if: startsWith(matrix.os, 'windows')
+      if: startsWith(matrix.os, 'windows') && matrix.linkage == 'shared'
       shell: bash
       run: |
         JOBS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 2)
         echo "Building with -j$JOBS"
         cmake --build build_arm64 --target install -j "$JOBS" --config ${{ env.BUILD_TYPE }}
+
+    - name: Link CMake consumer for Windows arm64
+      if: startsWith(matrix.os, 'windows') && matrix.linkage == 'shared'
+      shell: bash
+      run: |
+        set -euo pipefail
+        prefix="$RUNNER_TEMP/coolprop-arm64"
+        cmake -E remove_directory "$prefix"
+        cmake --install build_arm64 --config "${{ env.BUILD_TYPE }}" --prefix "$prefix"
+        cmake -S dev/ci/cmake-consumer -B consumer-arm64 -A ARM64 \
+          -DCMAKE_PREFIX_PATH="$prefix" \
+          -DCOOLPROP_EXPECTED_LINKAGE=SHARED \
+          -DCOOLPROP_C_ONLY=ON
+        cmake --build consumer-arm64 --config "${{ env.BUILD_TYPE }}"
 
 
     # - name: Tar.gz the shared library to maintain case sensitivy and file permissions
@@ -139,10 +284,11 @@ jobs:
     #     tar -cvzf CoolProp-${{ env.COOLPROP_VERSION }}-shared-${{ matrix.os }}.tar.gz ./*
 
     - name: Archive artifacts
+      if: matrix.linkage == 'shared'
       uses: actions/upload-artifact@v7
       with:
           # Upload to unique artifact names tagged with suffix of matrix.os
-          # This is now requried by upload-artifact@v4, but will be merged later
+          # This is now required by upload-artifact@v4, but will be merged later
           name: shared_library-${{ matrix.os }}
           path: install_root/shared_library
 

--- a/.github/workflows/library_shared.yml
+++ b/.github/workflows/library_shared.yml
@@ -76,10 +76,17 @@ jobs:
           shared) shared=ON ;;
           both) static=ON; shared=ON ;;
         esac
+        extra_args=()
+        if [ "${{ runner.os }}" = Windows ] && [ "${{ matrix.linkage }}" = both ]; then
+          # Regression gate: Debug must still select the debug CRT even when
+          # the deprecated compatibility switch is explicitly disabled.
+          extra_args+=("-DCOOLPROP_MSVC_DEBUG:BOOL=OFF")
+        fi
         cmake -B build -S . \
           -DCMAKE_BUILD_TYPE:STRING=${{ env.BUILD_TYPE }} \
           -DCOOLPROP_STATIC_LIBRARY:BOOL="$static" \
-          -DCOOLPROP_SHARED_LIBRARY:BOOL="$shared"
+          -DCOOLPROP_SHARED_LIBRARY:BOOL="$shared" \
+          "${extra_args[@]}"
 
     - name: Build
       shell: bash
@@ -134,13 +141,16 @@ jobs:
         import sys
 
         package_dir = Path(sys.argv[1]) / "lib" / "cmake" / "CoolProp"
+        license_dir = Path(sys.argv[1]) / "share" / "licenses" / "CoolProp"
         required_files = {
             package_dir / "CoolPropConfig.cmake",
             package_dir / "CoolPropTargets.cmake",
+            license_dir / "Eigen" / "COPYING.MPL2",
+            license_dir / "fmt" / "LICENSE",
         }
         missing = sorted(path for path in required_files if not path.is_file())
         if missing:
-            raise SystemExit(f"CMake package files are missing: {missing}")
+            raise SystemExit(f"Required installed files are missing: {missing}")
 
         cmake_files = list(package_dir.glob("*.cmake"))
         if not cmake_files:
@@ -157,14 +167,27 @@ jobs:
                 raise SystemExit(f"{cmake_file} contains non-relocatable paths: {leaked}")
         PY
 
+        if [ "${{ runner.os }}" = Linux ] && [ "${{ matrix.linkage }}" != static ]; then
+          cmake_version="${COOLPROP_VERSION/-/}"
+          test -f "$prefix_b/lib/libCoolProp.so.$cmake_version"
+        fi
+
         expected=""
+        disable_threads=FALSE
         case "${{ matrix.linkage }}" in
           static) expected=STATIC ;;
-          shared) expected=SHARED ;;
+          shared)
+            expected=SHARED
+            # A shared-only imported target has no Threads link interface.
+            # Prove that its config does not impose that static-only consumer
+            # dependency.
+            disable_threads=TRUE
+            ;;
         esac
         cmake -S dev/ci/cmake-consumer -B consumer-build \
           -DCMAKE_PREFIX_PATH="$prefix_b" \
-          -DCOOLPROP_EXPECTED_LINKAGE="$expected"
+          -DCOOLPROP_EXPECTED_LINKAGE="$expected" \
+          -DCMAKE_DISABLE_FIND_PACKAGE_Threads:BOOL="$disable_threads"
         cmake --build consumer-build --config "${{ env.BUILD_TYPE }}"
         ctest --test-dir consumer-build -C "${{ env.BUILD_TYPE }}" --output-on-failure
 
@@ -172,10 +195,39 @@ jobs:
           cmake -S dev/ci/cmake-consumer -B c-consumer-build \
             -DCMAKE_PREFIX_PATH="$prefix_b" \
             -DCOOLPROP_EXPECTED_LINKAGE=SHARED \
-            -DCOOLPROP_C_ONLY=ON
+            -DCOOLPROP_C_ONLY=ON \
+            -DCMAKE_DISABLE_FIND_PACKAGE_Threads:BOOL="$disable_threads"
           cmake --build c-consumer-build --config "${{ env.BUILD_TYPE }}"
           ctest --test-dir c-consumer-build -C "${{ env.BUILD_TYPE }}" --output-on-failure
         fi
+
+    - name: Build Debug MSVC runtimes and installed consumers
+      if: runner.os == 'Windows' && matrix.linkage == 'both'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        python - <<'PY'
+        from pathlib import Path
+
+        expected = {
+            "CoolProp_static.vcxproj": "MultiThreadedDebugDLL",
+            "CoolProp_shared.vcxproj": "MultiThreadedDebug",
+        }
+        for project, runtime in expected.items():
+            content = (Path("build") / project).read_text(encoding="utf-8-sig")
+            setting = f"<RuntimeLibrary>{runtime}</RuntimeLibrary>"
+            if setting not in content:
+                raise SystemExit(f"{project} does not contain {setting}")
+        PY
+
+        cmake --build build --config Debug --parallel 1
+        prefix="$RUNNER_TEMP/coolprop-debug-both"
+        cmake -E remove_directory "$prefix"
+        cmake --install build --config Debug --prefix "$prefix"
+        cmake -S dev/ci/cmake-consumer -B consumer-debug \
+          -DCMAKE_PREFIX_PATH="$prefix"
+        cmake --build consumer-debug --config Debug --parallel 1
 
     - name: Test add_subdirectory consumer
       if: runner.os == 'Linux' && matrix.linkage == 'static'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,19 +57,23 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(CheckIncludeFileCXX)
 
-if(DEFINED COOLPROP_INSTALL_PREFIX)
-  message(STATUS "COOLPROP_INSTALL_PREFIX=${COOLPROP_INSTALL_PREFIX}")
-  set(CMAKE_INSTALL_PREFIX
-      "${COOLPROP_INSTALL_PREFIX}"
-      CACHE PATH "CoolProp install path" FORCE)
-elseif(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR
-       AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  # Preserve the historical in-tree release layout for top-level builds, but
-  # never overwrite a parent project's install prefix when used via
-  # add_subdirectory()/FetchContent.
-  set(CMAKE_INSTALL_PREFIX
-      "${CMAKE_CURRENT_SOURCE_DIR}/install_root"
-      CACHE PATH "CoolProp install path" FORCE)
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  if(DEFINED COOLPROP_INSTALL_PREFIX)
+    message(STATUS "COOLPROP_INSTALL_PREFIX=${COOLPROP_INSTALL_PREFIX}")
+    set(CMAKE_INSTALL_PREFIX
+        "${COOLPROP_INSTALL_PREFIX}"
+        CACHE PATH "CoolProp install path" FORCE)
+  elseif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    # Preserve the historical in-tree release layout for top-level builds.
+    set(CMAKE_INSTALL_PREFIX
+        "${CMAKE_CURRENT_SOURCE_DIR}/install_root"
+        CACHE PATH "CoolProp install path" FORCE)
+  endif()
+elseif(DEFINED COOLPROP_INSTALL_PREFIX)
+  message(
+    WARNING
+      "Ignoring COOLPROP_INSTALL_PREFIX='${COOLPROP_INSTALL_PREFIX}' in a nested CoolProp build; set CMAKE_INSTALL_PREFIX in the parent project instead."
+  )
 endif()
 
 # Dependency management via CPM.cmake (replaces git submodules).
@@ -2166,6 +2170,7 @@ endif()
 if(COOLPROP_CPP_EXAMPLE_TEST)
   # C++ Documentation Test
   add_executable(docuTest.exe "Web/examples/C++/Example.cpp")
+  _coolprop_set_canonical_msvc_runtime(docuTest.exe)
   add_dependencies(docuTest.exe ${app_name})
   target_link_libraries(docuTest.exe ${app_name})
   if(UNIX)
@@ -2237,6 +2242,7 @@ if(COOLPROP_SNIPPETS)
        "${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_SOURCE}")
   # Make the static library with which the snippets will be linked
   add_library(${app_name} STATIC ${APP_SOURCES})
+  _coolprop_set_msvc_runtime("${app_name}" STATIC)
   add_dependencies(${app_name} generate_headers)
   set_property(
     TARGET ${app_name}
@@ -2255,6 +2261,7 @@ if(COOLPROP_SNIPPETS)
     message(STATUS "snippet_name = ${snippet_name}")
 
     add_executable(${snippet_exe} ${snippet})
+    _coolprop_set_msvc_runtime("${snippet_exe}" STATIC)
     add_dependencies(${snippet_exe} CoolProp)
     target_link_libraries(${snippet_exe} CoolProp)
     if(UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,55 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
+
+# CMP0091 makes the MSVC runtime a target property.  This is required when a
+# single build contains both a static and a shared CoolProp library, because
+# the two variants historically use different runtimes.
+cmake_policy(SET CMP0091 NEW)
+
+set(project_name "CoolProp")
+set(app_name ${project_name})
+
+# REVISION is concatenated onto the patch and PEP 440-normalized by the version
+# tooling (dev/extract_version.py, dev/coolprop_version_provider.py): "b1" ->
+# 8.0.0b1 (a beta pre-release), "dev" -> 8.0.0.dev0, "" -> 8.0.0 (final).
+# Keep a numeric version for CMake's project/package version machinery.
+set(COOLPROP_VERSION_MAJOR 8)
+set(COOLPROP_VERSION_MINOR 0)
+set(COOLPROP_VERSION_PATCH 1)
+set(COOLPROP_VERSION_REVISION dev)
+set(COOLPROP_VERSION_NUMERIC
+    "${COOLPROP_VERSION_MAJOR}.${COOLPROP_VERSION_MINOR}.${COOLPROP_VERSION_PATCH}"
+)
+set(COOLPROP_VERSION "${COOLPROP_VERSION_NUMERIC}${COOLPROP_VERSION_REVISION}")
+
+# CMAKE_OSX_DEPLOYMENT_TARGET and Xcode toolchain attributes must be selected
+# before the first project()/enable_language() call. A parent may provide this
+# legacy CoolProp option from its cache when using add_subdirectory().
+if(DEFINED DARWIN_USE_LIBCPP)
+  if(DARWIN_USE_LIBCPP)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET
+        "10.9"
+        CACHE STRING "Minimum OS X deployment version")
+    set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
+  else()
+    set(CMAKE_OSX_DEPLOYMENT_TARGET
+        "10.5"
+        CACHE STRING "Minimum OS X deployment version")
+    set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libstdc++")
+  endif()
+endif()
+
+# If an older parent already enabled MSVC languages while CMP0091 used OLD
+# behavior, a nested project() can make the directory-local policy state look
+# modern even though the compiler flags were initialized in legacy mode.
+# Snapshot that condition before CoolProp's project() call.
+set(_coolprop_needs_msvc_runtime_fallback OFF)
+if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR
+   AND MSVC
+   AND NOT CMAKE_MSVC_RUNTIME_LIBRARY_DEFAULT)
+  set(_coolprop_needs_msvc_runtime_fallback ON)
+endif()
+
+project(${project_name} VERSION ${COOLPROP_VERSION_NUMERIC} LANGUAGES C CXX)
 
 # Always export compile_commands.json for clang-tidy, IWYU, and editor LSPs
 # (CoolProp-2uw.7). Honored by Makefile and Ninja generators; harmless on others.
@@ -6,22 +57,25 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(CheckIncludeFileCXX)
 
+if(DEFINED COOLPROP_INSTALL_PREFIX)
+  message(STATUS "COOLPROP_INSTALL_PREFIX=${COOLPROP_INSTALL_PREFIX}")
+  set(CMAKE_INSTALL_PREFIX
+      "${COOLPROP_INSTALL_PREFIX}"
+      CACHE PATH "CoolProp install path" FORCE)
+elseif(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR
+       AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  # Preserve the historical in-tree release layout for top-level builds, but
+  # never overwrite a parent project's install prefix when used via
+  # add_subdirectory()/FetchContent.
+  set(CMAKE_INSTALL_PREFIX
+      "${CMAKE_CURRENT_SOURCE_DIR}/install_root"
+      CACHE PATH "CoolProp install path" FORCE)
+endif()
+
 # Dependency management via CPM.cmake (replaces git submodules).
 # Set CPM_SOURCE_CACHE (e.g. ~/.cache/CPM) to share downloads across worktrees.
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/CPM.cmake")
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies.cmake")
-
-if(DEFINED COOLPROP_INSTALL_PREFIX)
-  #set(COOLPROP_INSTALL_PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/install_root)
-  message(STATUS "COOLPROP_INSTALL_PREFIX=${COOLPROP_INSTALL_PREFIX}")
-else()
-  set(COOLPROP_INSTALL_PREFIX ${CMAKE_CURRENT_SOURCE_DIR}/install_root)
-  message(STATUS "COOLPROP_INSTALL_PREFIX=${COOLPROP_INSTALL_PREFIX}")
-endif()
-
-set(CMAKE_INSTALL_PREFIX
-    ${COOLPROP_INSTALL_PREFIX}
-    CACHE PATH "default install path" FORCE)
 
 #######################################
 #           BUILD OPTIONS             #
@@ -123,12 +177,10 @@ if (COOLPROP_ASAN)
 
   # Optimize the Asan build: -O2 -g -DNDEBUG (the RelWithDebInfo level, plus
   # ASan).  ASan instrumentation is unaffected by optimization level, so this
-  # is the standard way to run ASan; -O is set EXPLICITLY rather than inherited
-  # from ${CMAKE_*_FLAGS_RELWITHDEBINFO} because this block executes before the
-  # project() call (line ~217) that canonically populates those per-config
-  # defaults -- depending on them here is order-fragile.  (Historically this
-  # referenced the mixed-case ${CMAKE_*_FLAGS_RelWithDebInfo}, an undefined ->
-  # empty variable, so the Asan build silently compiled at -O0.  That made the
+  # is the standard way to run ASan; -O is set explicitly rather than inherited
+  # from ${CMAKE_*_FLAGS_RELWITHDEBINFO}. (Historically this referenced the
+  # mixed-case ${CMAKE_*_FLAGS_RelWithDebInfo}, an undefined -> empty variable,
+  # so the Asan build silently compiled at -O0. That made the
   # dense-SVD SVDSBTL surface builds crawl and was the primary reason the ASan
   # CI job took ~45 min; with -O2 the full suite runs ~3 min locally / ~10 min
   # on the 2-vCPU runner.)  Keep these in sync with RelWithDebInfo if it changes.
@@ -160,23 +212,15 @@ endif()
 # https://gitlab.kitware.com/cmake/cmake/issues/18396
 if(DEFINED DARWIN_USE_LIBCPP)
   if(DARWIN_USE_LIBCPP)
-    set(CMAKE_OSX_DEPLOYMENT_TARGET
-        "10.9"
-        CACHE STRING "Minimum OS X deployment version")
     set(OSX_COMPILE_FLAGS "${OSX_COMPILE_FLAGS} -stdlib=libc++")
     set(OSX_COMPILE_FLAGS "${OSX_COMPILE_FLAGS} -mmacosx-version-min=10.9")
     #set(OSX_COMPILE_FLAGS "${OSX_COMPILE_FLAGS} -std=c++11")
     set(OSX_LINK_FLAGS "${OSX_LINK_FLAGS} -lc++")
     set(OSX_LINK_FLAGS "${OSX_LINK_FLAGS} -nodefaultlibs")
-    set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
   else(DARWIN_USE_LIBCPP)
-    set(CMAKE_OSX_DEPLOYMENT_TARGET
-        "10.5"
-        CACHE STRING "Minimum OS X deployment version") # Default is 10.7
     set(OSX_COMPILE_FLAGS "${OSX_COMPILE_FLAGS} -stdlib=libstdc++")
     set(OSX_COMPILE_FLAGS "${OSX_COMPILE_FLAGS} -mmacosx-version-min=10.5")
     set(OSX_LINK_FLAGS "${OSX_LINK_FLAGS} -lstdc++")
-    set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libstdc++")
   endif(DARWIN_USE_LIBCPP)
   message(STATUS "DARWIN_USE_LIBCPP was set added some flags:")
   message(STATUS "  OSX_COMPILE_FLAGS: ${OSX_COMPILE_FLAGS}")
@@ -213,24 +257,8 @@ endif(DEFINED DARWIN_USE_LIBCPP)
 # version information.                #
 #######################################
 
-# Project name
-set(project_name "CoolProp")
-set(app_name ${project_name})
-project(${project_name})
-
-# Project version
-# REVISION is concatenated onto the patch and PEP 440-normalized by the version
-# tooling (dev/extract_version.py, dev/coolprop_version_provider.py): "b1" ->
-# 8.0.0b1 (a beta pre-release), "dev" -> 8.0.0.dev0, "" -> 8.0.0 (final).
 # The dev_checks tag gate (dev/ci/check_tag_version.py) requires a v* tag to
-# match this version, so bump here before tagging a release/beta.
-set(COOLPROP_VERSION_MAJOR 8)
-set(COOLPROP_VERSION_MINOR 0)
-set(COOLPROP_VERSION_PATCH 1)
-set(COOLPROP_VERSION_REVISION dev)
-set(COOLPROP_VERSION
-    "${COOLPROP_VERSION_MAJOR}.${COOLPROP_VERSION_MINOR}.${COOLPROP_VERSION_PATCH}${COOLPROP_VERSION_REVISION}"
-)
+# match this version, so bump the variables above before tagging a release.
 message(STATUS "CoolProp version: ${COOLPROP_VERSION}")
 
 string(TIMESTAMP COOLPROP_YEAR 2010-%Y)
@@ -437,10 +465,6 @@ message(STATUS "Looking for Python")
 find_package(Python REQUIRED COMPONENTS Interpreter)
 set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
 
-if(CMAKE_DL_LIBS)
-  find_package(${CMAKE_DL_LIBS} REQUIRED)
-endif()
-
 include(FlagFunctions) # Is found since it is in the module path.
 macro(modify_msvc_flag_release flag_new) # Use a macro to avoid a new scope
   foreach(flag_old IN LISTS COOLPROP_MSVC_ALL)
@@ -592,310 +616,8 @@ endif()
 # settings. Let us rely on that and only handle
 # calling conventions and shared/static issues.
 
-option(COOLPROP_STDCALL_LIBRARY
-       "Build CoolProp as a 32bit shared library with stdcall" OFF)
-
-option(COOLPROP_CDECL_LIBRARY
-       "Build CoolProp as a 32bit shared library with cdecl" OFF)
-
-option(COOLPROP_EXTERNC_LIBRARY
-       "Overwrite the export settings to force extern C" OFF)
-
-set(COOLPROP_LIBRARY_SOURCE
-    "src/CoolPropLib.cpp"
-    CACHE STRING "The file that contains the exported functions")
-
-set(COOLPROP_LIBRARY_HEADER
-    "include/CoolProp/CoolPropLib.h"
-    CACHE STRING "The file that contains the export header")
-
-set(COOLPROP_LIBRARY_NAME
-    "${app_name}"
-    CACHE STRING "The name of the generated library")
-
-set(COOLPROP_LIBRARY_EXPORTS
-    ""
-    CACHE STRING "The file that contains the export alias list")
-
-# Rule out cases that do not make sense
-if("${BITNESS}" STREQUAL "32")
-  if(COOLPROP_CDECL_LIBRARY)
-    set(CONVENTION "__cdecl")
-  elseif(COOLPROP_STDCALL_LIBRARY)
-    set(CONVENTION "__stdcall")
-  else()
-    set(CONVENTION "")
-  endif()
-elseif("${BITNESS}" STREQUAL "64")
-  if(COOLPROP_CDECL_LIBRARY)
-    message(WARNING "You cannot use cdecl conventions in a 64-bit library.")
-  elseif(COOLPROP_STDCALL_LIBRARY)
-    message(WARNING "You cannot use stdcall conventions in a 64-bit library.")
-  endif()
-  set(CONVENTION "")
-elseif("${BITNESS}" STREQUAL "NATIVE")
-  set(CONVENTION "")
-else()
-  message(FATAL_ERROR "Bitness is not defined. Set it and run cmake again.")
-endif()
-
-if((COOLPROP_OBJECT_LIBRARY AND COOLPROP_STATIC_LIBRARY)
-   OR (COOLPROP_OBJECT_LIBRARY AND COOLPROP_SHARED_LIBRARY)
-   OR (COOLPROP_STATIC_LIBRARY AND COOLPROP_SHARED_LIBRARY))
-  message(FATAL_ERROR "You can only use one of the library switches!")
-endif()
-
-if(COOLPROP_OBJECT_LIBRARY
-   OR COOLPROP_STATIC_LIBRARY
-   OR COOLPROP_SHARED_LIBRARY)
-  # Project name
-  set(LIB_NAME ${COOLPROP_LIBRARY_NAME})
-  # Object, static or shared?
-  if(COOLPROP_OBJECT_LIBRARY)
-    add_library(${LIB_NAME} OBJECT ${APP_SOURCES})
-    set(COOLPROP_LIBRARY_SOURCE "")
-    set(COOLPROP_LIBRARY_HEADER "")
-  elseif(COOLPROP_STATIC_LIBRARY)
-    list(APPEND APP_SOURCES
-         "${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_SOURCE}")
-    add_library(${LIB_NAME} STATIC ${APP_SOURCES} ${COOLPROP_LIBRARY_EXPORTS})
-    if(MSVC)
-      # Add postfix for debugging
-      set_property(TARGET ${LIB_NAME} PROPERTY DEBUG_POSTFIX d)
-      set_property(TARGET ${LIB_NAME} PROPERTY RELEASE_POSTFIX)
-      modify_msvc_flags("/MD")
-
-      # Note that the default is not used if ${COOLPROP_MSVC_REL} or ${COOLPROP_MSVC_DBG} is set
-    endif(MSVC)
-    install(
-      TARGETS ${LIB_NAME}
-      DESTINATION
-        static_library/${CMAKE_SYSTEM_NAME}/${BITNESS}bit_${CMAKE_CXX_COMPILER_ID}_${CMAKE_CXX_COMPILER_VERSION}
-    )
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_HEADER}
-            DESTINATION static_library)
-    # GH #1280: ship the installable C++ header tree so downstream CMake can
-    # find_package(CoolProp) and get usable include paths. The flat deprecation
-    # shims ship alongside so consumers on the old "X.h" includes keep building
-    # (removed at v9). Excluded as internal-only / non-self-contained: generated
-    # DB headers (*_JSON.h / *_CBOR.h), and detail/json.h + detail/msgpack.h
-    # (they pull the un-shipped nlohmann/valijson and msgpack.hpp) plus the
-    # CPmsgpack.h shim that forwards to the latter. The shipped fluids/numerics/
-    # superancillary tiers transitively require Eigen on the include path, and
-    # fmt unless NO_FMTLIB is defined (boost is NOT required -- the superancillary
-    # rootfinder is defined out-of-line in src/superancillary.cpp);
-    # dev/ci/check-installed-headers.sh compile-checks every shipped header
-    # standalone (Eigen-only) to keep this honest.
-    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/CoolProp
-            DESTINATION static_library/include FILES_MATCHING PATTERN "*.h"
-            REGEX "detail/(json|msgpack)\\.h$" EXCLUDE)
-    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
-            DESTINATION static_library/include FILES_MATCHING PATTERN "*.h"
-            PATTERN "CoolProp" EXCLUDE PATTERN "*_JSON*.h" EXCLUDE PATTERN "*_CBOR*.h" EXCLUDE PATTERN "CPmsgpack.h" EXCLUDE
-            PATTERN "gitrevision.h" EXCLUDE PATTERN "cpversion.h" EXCLUDE)
-  elseif(COOLPROP_SHARED_LIBRARY)
-    list(APPEND APP_SOURCES
-         "${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_SOURCE}")
-    # Embed Windows VERSIONINFO so CoolProp.dll's Properties dialog shows
-    # FileVersion/ProductVersion fields (#2391). The .rc is configured from
-    # COOLPROP_VERSION_{MAJOR,MINOR,PATCH} above and added to the source
-    # list only on MSVC and MSYS2 (MinGW), where rc.exe (or MSYS2 windres) is available.
-    if(MSVC OR MINGW)
-      configure_file(
-        "${CMAKE_CURRENT_SOURCE_DIR}/dev/CoolProp.rc.in"
-        "${CMAKE_CURRENT_BINARY_DIR}/CoolProp.rc"
-        @ONLY)
-      list(APPEND APP_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/CoolProp.rc")
-    endif()
-    add_library(${LIB_NAME} SHARED ${APP_SOURCES} ${COOLPROP_LIBRARY_EXPORTS})
-	
-	## For arm64 builds, put the shared library in the Windows/64bit__arm64 folder
-	if(MSVC AND ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "ARM64" OR "${CMAKE_VS_PLATFORM_NAME}" STREQUAL "arm64"))
-		set(OUTPUT_FOLDER "shared_library/${CMAKE_SYSTEM_NAME}/${BITNESS}bit__arm64")
-	else()
-		set(OUTPUT_FOLDER "shared_library/${CMAKE_SYSTEM_NAME}/${BITNESS}bit${CONVENTION}")
-	endif()
-	
-    install(
-      TARGETS ${LIB_NAME}
-      DESTINATION ${OUTPUT_FOLDER}
-    )
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_HEADER}
-            DESTINATION shared_library)
-    # GH #1280: ship the installable C++ header tree (+ flat back-compat shims,
-    # removed at v9; generated *_JSON.h excluded). See the static branch above.
-    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/CoolProp
-            DESTINATION shared_library/include FILES_MATCHING PATTERN "*.h"
-            REGEX "detail/(json|msgpack)\\.h$" EXCLUDE)
-    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
-            DESTINATION shared_library/include FILES_MATCHING PATTERN "*.h"
-            PATTERN "CoolProp" EXCLUDE PATTERN "*_JSON*.h" EXCLUDE PATTERN "*_CBOR*.h" EXCLUDE PATTERN "CPmsgpack.h" EXCLUDE
-            PATTERN "gitrevision.h" EXCLUDE PATTERN "cpversion.h" EXCLUDE)
-    set_property(
-      TARGET ${LIB_NAME}
-      APPEND_STRING
-      PROPERTY COMPILE_FLAGS " -DCOOLPROP_LIB")
-    # Now all the compiler specific settings for Visual Studio
-    if(MSVC)
-      # Add postfix for debugging
-      set_property(TARGET ${LIB_NAME} PROPERTY DEBUG_POSTFIX d)
-      set_property(TARGET ${LIB_NAME} PROPERTY RELEASE_POSTFIX)
-      # No lib prefix for the shared library
-      set_property(TARGET ${LIB_NAME} PROPERTY PREFIX "")
-      modify_msvc_flags("/MT")
-
-      # Note that the default is not used if ${COOLPROP_MSVC_REL} or ${COOLPROP_MSVC_DBG} is set
-      add_custom_command(
-        TARGET ${LIB_NAME}
-        POST_BUILD
-        COMMAND dumpbin /EXPORTS $<TARGET_FILE:${LIB_NAME}> >
-                ${CMAKE_CURRENT_BINARY_DIR}/exports.txt)
-      install(
-        FILES ${CMAKE_CURRENT_BINARY_DIR}/exports.txt
-        DESTINATION ${OUTPUT_FOLDER}
-	  )
-		  
-      add_custom_command(
-        TARGET ${LIB_NAME}
-        POST_BUILD
-        COMMAND dumpbin /HEADERS $<TARGET_FILE:${LIB_NAME}> >
-                ${CMAKE_CURRENT_BINARY_DIR}/headers.txt)
-      install(
-        FILES ${CMAKE_CURRENT_BINARY_DIR}/headers.txt
-        DESTINATION ${OUTPUT_FOLDER}
-	  )
-    endif()
-
-    # MSYS2(MINGW) specific stuff
-    if(MINGW AND DEFINED ENV{MSYSTEM})
-      # Add postfix for debugging (same as MSVC)
-      set_property(TARGET ${LIB_NAME} PROPERTY DEBUG_POSTFIX d)
-      set_property(TARGET ${LIB_NAME} PROPERTY RELEASE_POSTFIX)
-      # No lib prefix for the shared library (same as MSVC)
-      set_property(TARGET ${LIB_NAME} PROPERTY PREFIX "")
-      set_target_properties(${LIB_NAME} PROPERTIES IMPORT_PREFIX "" IMPORT_SUFFIX ".a")
-      # Statically link all MINGW libraries and make the file truly portable
-      # See (https://stackoverflow.com/questions/13768515/how-to-do-static-linking-of-libwinpthread-1-dll-in-mingw)
-      # NOTE: use MSYS2/UCRT64 ntldd to check dependencies, MSYS2 & cygwin ldd will give false ucrt64 dependencies
-      target_link_options(${LIB_NAME} PRIVATE -static-libgcc -static-libstdc++)
-      target_link_libraries(${LIB_NAME} PRIVATE -Wl,-Bstatic -lwinpthread -Wl,-Bdynamic)  #scopes only winpthreads
-      # Note that Windows system DLLs (ucrt, kernel32, etc.) remain dynamically linked.
-    endif()
-
-    # For Linux
-    if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
-      set_property(TARGET ${LIB_NAME} PROPERTY VERSION ${COOLPROP_VERSION})
-      set_property(TARGET ${LIB_NAME} PROPERTY SOVERSION
-                                               ${COOLPROP_VERSION_MAJOR})
-    endif()
-  else()
-    message(FATAL_ERROR "You have to build a static or shared library.")
-  endif()
-
-  if(NOT COOLPROP_OBJECT_LIBRARY)
-    target_link_libraries(${LIB_NAME} ${CMAKE_DL_LIBS})
-  endif()
-  coolprop_hide_json_symbols(${LIB_NAME})
-
-  # For windows systems, bug workaround for Eigen
-  if(MSVC90)
-    message(STATUS "EIGEN WORKAROUND ACTIVE!!")
-    set_property(
-      TARGET ${LIB_NAME}
-      APPEND_STRING
-      PROPERTY COMPILE_FLAGS " -DEIGEN_DONT_VECTORIZE")
-  endif()
-
-  # For mac systems, explicitly set the c++ libraries
-  if("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
-    if(DEFINED OSX_COMPILE_FLAGS)
-      set_target_properties(
-        ${LIB_NAME} PROPERTIES APPEND_STRING PROPERTY COMPILE_FLAGS
-                                                      "${OSX_COMPILE_FLAGS}")
-    endif(DEFINED OSX_COMPILE_FLAGS)
-    if(DEFINED OSX_COMPILE_FLAGS)
-      set_target_properties(
-        ${LIB_NAME} PROPERTIES APPEND_STRING PROPERTY LINK_FLAGS
-                                                      "${OSX_LINK_FLAGS}")
-    endif(DEFINED OSX_COMPILE_FLAGS)
-  endif()
-
-  # Name mangling settings
-  if(COOLPROP_EXTERNC_LIBRARY)
-    set_property(
-      TARGET ${LIB_NAME}
-      APPEND_STRING
-      PROPERTY COMPILE_FLAGS " -DEXTERNC")
-  endif()
-  ### All options are set, we are building a library ###
-  add_dependencies(${LIB_NAME} generate_headers)
-  #
-  if(CMAKE_VERSION VERSION_GREATER 3.0)
-    # Add target include directories for easy linking with other applications
-    target_include_directories(${LIB_NAME} PUBLIC ${APP_INCLUDE_DIRS})
-  endif()
-
-  # Set the bitness
-  if(NOT MSVC)
-    if(NOT "${BITNESS}" STREQUAL "NATIVE")
-      message(STATUS "Setting bitness flag -m${BITNESS}")
-      set_property(
-        TARGET ${LIB_NAME}
-        APPEND_STRING
-        PROPERTY COMPILE_FLAGS " -m${BITNESS}")
-      set_property(
-        TARGET ${LIB_NAME}
-        APPEND_STRING
-        PROPERTY LINK_FLAGS " -m${BITNESS}")
-    endif()
-  endif()
-
-  # ADD -fPIC flag if needed
-  if(COOLPROP_FPIC)
-    message(STATUS "Setting fPIC flag")
-    set_property(
-      TARGET ${LIB_NAME}
-      APPEND_STRING
-      PROPERTY COMPILE_FLAGS " -fPIC")
-  endif()
-  #
-  # calling conventions
-  if(("${CONVENTION}" STREQUAL "NULL") OR ("${CONVENTION}" STREQUAL ""))
-    #MESSAGE(STATUS "Skipping unknown calling convention.")
-  else()
-    set_property(
-      TARGET ${LIB_NAME}
-      APPEND_STRING
-      PROPERTY COMPILE_FLAGS " -DCONVENTION=${CONVENTION}")
-  endif()
-  #
-  #set_property(SOURCE MyFile.cpp APPEND_STRING PROPERTY COMPILE_FLAGS " -msse4.1 ")
-  message(STATUS "Library compilation detected:")
-  message(STATUS "Creating ${LIB_NAME}, a ${BITNESS}-bit library")
-  message(STATUS "CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
-  message(STATUS "COOLPROP_STATIC_LIBRARY: ${COOLPROP_STATIC_LIBRARY}")
-  message(STATUS "COOLPROP_SHARED_LIBRARY: ${COOLPROP_SHARED_LIBRARY}")
-  message(STATUS "COOLPROP_OBJECT_LIBRARY: ${COOLPROP_OBJECT_LIBRARY}")
-  if(("${CONVENTION}" STREQUAL "NULL") OR ("${CONVENTION}" STREQUAL ""))
-     message(STATUS "CONVENTION: Not Set")
-  else()
-     message(STATUS "CONVENTION: ${CONVENTION}")
-  endif()
-  message(STATUS "COOLPROP_LIBRARY_HEADER: ${COOLPROP_LIBRARY_HEADER}")
-  message(STATUS "COOLPROP_LIBRARY_SOURCE: ${COOLPROP_LIBRARY_SOURCE}")
-  #
-  get_property(
-    tmpVar
-    TARGET ${LIB_NAME}
-    PROPERTY COMPILE_FLAGS)
-  message(STATUS "COMPILE_FLAGS: ${tmpVar}")
-  get_property(
-    tmpVar
-    TARGET ${LIB_NAME}
-    PROPERTY LINK_FLAGS)
-  message(STATUS "LINK_FLAGS: ${tmpVar}")
-  #
-endif()
+include(CoolPropLibrary)
+coolprop_add_library_targets()
 
 if(COOLPROP_IOS_TARGET)
   # Set the Base SDK (only change the SDKVER value, if for instance, you are building for iOS 5.0):
@@ -933,15 +655,15 @@ if(COOLPROP_DEBIAN_PACKAGE)
     ${app_name} PROPERTIES VERSION ${COOLPROP_VERSION}
                            SOVERSION ${COOLPROP_VERSION_MAJOR})
   add_dependencies(${app_name} generate_headers)
-  install(TARGETS ${app_name} DESTINATION "${CMAKE_INSTALL_PREFIX}/usr/lib")
+  install(TARGETS ${app_name} DESTINATION usr/lib)
   # GH #1280: install the C++ header tree (incl. CoolProp/CoolPropLib.h) plus
   # the flat back-compat shims, so both <CoolProp/CoolPropLib.h> and the legacy
   # <CoolPropLib.h> resolve from /usr/include. Shims removed at v9.
   install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/CoolProp
-          DESTINATION "${CMAKE_INSTALL_PREFIX}/usr/include" FILES_MATCHING PATTERN "*.h"
+          DESTINATION usr/include FILES_MATCHING PATTERN "*.h"
           REGEX "detail/(json|msgpack)\\.h$" EXCLUDE)
   install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
-          DESTINATION "${CMAKE_INSTALL_PREFIX}/usr/include" FILES_MATCHING PATTERN "*.h"
+          DESTINATION usr/include FILES_MATCHING PATTERN "*.h"
           PATTERN "CoolProp" EXCLUDE PATTERN "*_JSON*.h" EXCLUDE PATTERN "*_CBOR*.h" EXCLUDE PATTERN "CPmsgpack.h" EXCLUDE
           PATTERN "gitrevision.h" EXCLUDE PATTERN "cpversion.h" EXCLUDE)
 endif()
@@ -978,7 +700,7 @@ if(COOLPROP_VXWORKS_LIBRARY_MODULE OR COOLPROP_VXWORKS_LIBRARY)
                                          "${COMPILE_FLAGS} -DEXTERNC")
   add_dependencies(${app_name} generate_headers)
   install(TARGETS ${app_name}
-          DESTINATION "${COOLPROP_INSTALL_PREFIX}/shared_library/VxWorks")
+          DESTINATION "shared_library/VxWorks")
 endif()
 
 if(COOLPROP_PRIME_MODULE)
@@ -1018,7 +740,7 @@ if(COOLPROP_PRIME_MODULE)
   set_target_properties(CoolPropMathcadWrapper PROPERTIES SUFFIX ".dll" PREFIX
                                                                         "")
   install(TARGETS CoolPropMathcadWrapper
-          DESTINATION "${COOLPROP_INSTALL_PREFIX}/MathcadPrime")
+          DESTINATION MathcadPrime)
   install(
     FILES
       "${CMAKE_CURRENT_SOURCE_DIR}/wrappers/MathCAD/Prime/CoolPropFluidProperties.mcdx"
@@ -1057,7 +779,7 @@ if(COOLPROP_MATHCAD15_MODULE)
   set_target_properties(CoolPropMathcadWrapper PROPERTIES SUFFIX ".dll" PREFIX
                                                                         "")
   install(TARGETS CoolPropMathcadWrapper
-          DESTINATION "${COOLPROP_INSTALL_PREFIX}/MathCAD15")
+          DESTINATION MathCAD15)
   install(
     FILES
       "${CMAKE_CURRENT_SOURCE_DIR}/wrappers/MathCAD/CoolPropFluidProperties.xmcdz"
@@ -1120,14 +842,14 @@ if(COOLPROP_EES_MODULE)
     VERBATIM)
   # install the generated library and the other files
   install(TARGETS COOLPROP_EES
-          DESTINATION "${CMAKE_INSTALL_PREFIX}/EES/${CMAKE_SYSTEM_NAME}")
+          DESTINATION "EES/${CMAKE_SYSTEM_NAME}")
   install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/wrappers/EES/CoolProp.htm"
-          DESTINATION "${CMAKE_INSTALL_PREFIX}/EES/${CMAKE_SYSTEM_NAME}")
+          DESTINATION "EES/${CMAKE_SYSTEM_NAME}")
   install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/wrappers/EES/CoolProp.LIB"
-          DESTINATION "${CMAKE_INSTALL_PREFIX}/EES/${CMAKE_SYSTEM_NAME}")
+          DESTINATION "EES/${CMAKE_SYSTEM_NAME}")
   install(
     FILES "${CMAKE_CURRENT_SOURCE_DIR}/wrappers/EES/CoolProp_EES_Sample.EES"
-    DESTINATION "${CMAKE_INSTALL_PREFIX}/EES/${CMAKE_SYSTEM_NAME}")
+    DESTINATION "EES/${CMAKE_SYSTEM_NAME}")
 endif()
 
 # Windows package
@@ -1587,7 +1309,7 @@ if(COOLPROP_CSHARP_MODULE)
   #                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/dev/scripts/examples")
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Example.cs" DESTINATION Csharp)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/platform-independent.7z"
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/Csharp)
+          DESTINATION Csharp)
   install(TARGETS ${app_name}
           DESTINATION Csharp/${CMAKE_SYSTEM_NAME}_${BITNESS}bit)
   enable_testing()
@@ -1683,7 +1405,7 @@ if(COOLPROP_VBDOTNET_MODULE)
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/VB.net_VS2012_example.7z"
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/VB.NET)
+          DESTINATION VB.NET)
 
 endif()
 
@@ -1842,14 +1564,14 @@ if(COOLPROP_JAVA_MODULE)
   #
   # Install all the generated java files
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Example.java"
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/Java)
+          DESTINATION Java)
   # Ship the archive alongside the unpacked tree, matching the Csharp layout.
   # #3245 dropped this rule when it replaced the flat-glob install with the
   # package-tree DIRECTORY install, which left the release area without the
   # archive that dev/scripts/examples/win64run.py still fetches from
   # nightly/Java/platform-independent.7z (CoolProp-qrn3).
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/platform-independent.7z"
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/Java)
+          DESTINATION Java)
   if(NOT JAVA_PACKAGE_DIR STREQUAL "")
     # Install the package tree rooted at its FIRST path component so the full
     # package layout is preserved under platform-independent/.  The parent-of-
@@ -1869,14 +1591,14 @@ if(COOLPROP_JAVA_MODULE)
     # the DIRECTORY form above would install the entire binary dir.
     install(
       CODE "file( GLOB _GeneratedJavaSources \"${CMAKE_CURRENT_BINARY_DIR}/*.java\" )"
-      CODE "file( INSTALL \${_GeneratedJavaSources} DESTINATION ${CMAKE_INSTALL_PREFIX}/Java/platform-independent )"
+      CODE "file( INSTALL \${_GeneratedJavaSources} DESTINATION \${CMAKE_INSTALL_PREFIX}/Java/platform-independent )"
     )
   endif()
 
 
   install(
     TARGETS ${app_name}
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/Java/${CMAKE_SYSTEM_NAME}_${BITNESS}bit)
+    DESTINATION Java/${CMAKE_SYSTEM_NAME}_${BITNESS}bit)
   enable_testing()
   execute_process(
     COMMAND ${CMAKE_COMMAND} -E make_directory
@@ -1999,9 +1721,9 @@ if(COOLPROP_PHP_MODULE)
   add_dependencies(CoolProp generate_headers)
 
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CoolProp.php
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/PHP/cross-platform OPTIONAL)
+          DESTINATION PHP/cross-platform OPTIONAL)
   install(TARGETS ${app_name}
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/PHP/${CMAKE_SYSTEM_NAME})
+          DESTINATION PHP/${CMAKE_SYSTEM_NAME})
 
 endif()
 
@@ -2108,9 +1830,9 @@ if(COOLPROP_LIBREOFFICE_MODULE)
 
    # install LibreOffice extension and example spreadsheet file
    install(FILES "${COOLPROP_LIBREOFFICE_TMP_DIR}/CoolProp.oxt"
-           DESTINATION "${COOLPROP_INSTALL_PREFIX}/LibreOffice")
+           DESTINATION LibreOffice)
    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/wrappers/LibreOffice/TestLibreOffice.ods"
-           DESTINATION "${COOLPROP_INSTALL_PREFIX}/LibreOffice")
+           DESTINATION LibreOffice)
 endif()
 
 if(COOLPROP_JAVASCRIPT_MODULE)
@@ -2148,14 +1870,14 @@ if(COOLPROP_JAVASCRIPT_MODULE)
   set_target_properties(coolprop PROPERTIES PREFIX "" SUFFIX .js)
   #install (TARGETS coolprop DESTINATION ${CMAKE_INSTALL_PREFIX}/Javascript)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/coolprop.js"
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/Javascript)
+          DESTINATION Javascript)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/coolprop.wasm"
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/Javascript)
+          DESTINATION Javascript)
   #install (FILES "${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt" DESTINATION ${CMAKE_INSTALL_PREFIX}/Javascript)
   install(
     FILES
       "${CMAKE_CURRENT_SOURCE_DIR}/Web/coolprop/wrappers/Javascript/index.html"
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/Javascript)
+    DESTINATION Javascript)
 endif()
 
 if(COOLPROP_MATHEMATICA_MODULE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,9 @@ option(COOLPROP_SHARED_LIBRARY "Build CoolProp as a shared library (.dll, .so)"
 option(COOLPROP_OBJECT_LIBRARY
        "Build CoolProp objects, but do not link them (.obj, .o)" OFF)
 
+option(COOLPROP_FPIC
+       "Build CoolProp libraries with position-independent code" OFF)
+
 option(COOLPROP_EES_MODULE "Build the EES module" OFF)
 
 option(COOLPROP_WINDOWS_PACKAGE "Build the Windows installer" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,6 @@ endif()
 
 # Dependency management via CPM.cmake (replaces git submodules).
 # Set CPM_SOURCE_CACHE (e.g. ~/.cache/CPM) to share downloads across worktrees.
-include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/CPM.cmake")
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies.cmake")
 
 #######################################
@@ -130,7 +129,7 @@ option(
 
 option(
   COOLPROP_MSVC_DEBUG
-  "Link the debug version of Microsoft Standard library to the debug builds."
+  "Deprecated compatibility option; Debug builds always use the debug MSVC runtime."
   ON)
 
 option(COOLPROP_NO_EXAMPLES
@@ -968,7 +967,8 @@ if(COOLPROP_WINDOWS_PACKAGE)
     PRE_BUILD
     COMMAND
       ${CMAKE_COMMAND} ARGS "-G${COOLPROP_WINDOWS_PACKAGE_DLL_GEN}" "-AWin32"
-      "${CMAKE_CURRENT_SOURCE_DIR}" "-DCOOLPROP_SHARED_LIBRARY=ON"
+      "${CMAKE_CURRENT_SOURCE_DIR}" "-DCOOLPROP_STATIC_LIBRARY=OFF"
+      "-DCOOLPROP_SHARED_LIBRARY=ON"
       "-DCOOLPROP_STDCALL_LIBRARY=ON"
     COMMAND ${CMAKE_COMMAND} ARGS "--build" "." "--target" "CoolProp" "--config"
             "Release"
@@ -984,7 +984,8 @@ if(COOLPROP_WINDOWS_PACKAGE)
     PRE_BUILD
     COMMAND
       ${CMAKE_COMMAND} ARGS "-G${COOLPROP_WINDOWS_PACKAGE_DLL_GEN}" "-AWin32"
-      "${CMAKE_CURRENT_SOURCE_DIR}" "-DCOOLPROP_SHARED_LIBRARY=ON"
+      "${CMAKE_CURRENT_SOURCE_DIR}" "-DCOOLPROP_STATIC_LIBRARY=OFF"
+      "-DCOOLPROP_SHARED_LIBRARY=ON"
       "-DCOOLPROP_CDECL_LIBRARY=ON"
     COMMAND ${CMAKE_COMMAND} ARGS "--build" "." "--target" "CoolProp" "--config"
             "Release"
@@ -1000,7 +1001,8 @@ if(COOLPROP_WINDOWS_PACKAGE)
     TARGET COOLPROP_WINDOWS_PACKAGE_SHARED_LIBRARIES
     PRE_BUILD
     COMMAND ${CMAKE_COMMAND} ARGS "-G${COOLPROP_WINDOWS_PACKAGE_DLL_GEN}"
-            "-Ax64" "${CMAKE_CURRENT_SOURCE_DIR}" "-DCOOLPROP_SHARED_LIBRARY=ON"
+            "-Ax64" "${CMAKE_CURRENT_SOURCE_DIR}"
+            "-DCOOLPROP_STATIC_LIBRARY=OFF" "-DCOOLPROP_SHARED_LIBRARY=ON"
     COMMAND ${CMAKE_COMMAND} ARGS "--build" "." "--target" "CoolProp" "--config"
             "Release"
     COMMAND
@@ -1016,7 +1018,8 @@ if(COOLPROP_WINDOWS_PACKAGE)
     TARGET COOLPROP_WINDOWS_PACKAGE_SHARED_LIBRARIES
     PRE_BUILD
     COMMAND ${CMAKE_COMMAND} ARGS "-G${COOLPROP_WINDOWS_PACKAGE_DLL_GEN}"
-            "-Aarm64" "${CMAKE_CURRENT_SOURCE_DIR}" "-DCOOLPROP_SHARED_LIBRARY=ON"
+            "-Aarm64" "${CMAKE_CURRENT_SOURCE_DIR}"
+            "-DCOOLPROP_STATIC_LIBRARY=OFF" "-DCOOLPROP_SHARED_LIBRARY=ON"
     COMMAND ${CMAKE_COMMAND} ARGS "--build" "." "--target" "CoolProp" "--config"
             "Release"
     COMMAND
@@ -1286,9 +1289,7 @@ if(COOLPROP_CSHARP_MODULE)
   if(WIN32)
     set_target_properties(CoolProp PROPERTIES PREFIX "")
     if(MSVC)
-      modify_msvc_flags("/MT")
-
-      # Note that the default is not used if ${COOLPROP_MSVC_REL} or ${COOLPROP_MSVC_DBG} is set
+      _coolprop_set_msvc_runtime(CoolProp SHARED)
     endif()
   endif()
   if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
@@ -1532,9 +1533,7 @@ if(COOLPROP_JAVA_MODULE)
   if(WIN32)
     set_target_properties(CoolProp PROPERTIES PREFIX "")
     if(MSVC)
-      modify_msvc_flags("/MT")
-
-      # Note that the default is not used if ${COOLPROP_MSVC_REL} or ${COOLPROP_MSVC_DBG} is set
+      _coolprop_set_msvc_runtime(CoolProp SHARED)
     endif()
   endif()
 
@@ -1884,12 +1883,6 @@ if(COOLPROP_JAVASCRIPT_MODULE)
 endif()
 
 if(COOLPROP_MATHEMATICA_MODULE)
-
-  if(MSVC)
-    modify_msvc_flags("/MT")
-    # Note that the default is not used if ${COOLPROP_MSVC_REL} or ${COOLPROP_MSVC_DBG} is set
-  endif()
-
   set(CMAKE_MODULE_PATH
       ${CMAKE_MODULE_PATH}
       "${FindMathematica_SOURCE_DIR}/CMake/Mathematica/"
@@ -1929,6 +1922,9 @@ if(COOLPROP_MATHEMATICA_MODULE)
   add_library(CoolProp SHARED ${MATHEMATICA_SOURCES})
   add_dependencies(CoolProp generate_headers)
   coolprop_hide_json_symbols(CoolProp)
+  if(MSVC)
+    _coolprop_set_msvc_runtime(CoolProp SHARED)
+  endif()
   if(MINGW AND DEFINED ENV{MSYSTEM})
     # Add postfix for debugging (same as MSVC)
     set_property(TARGET ${app_name} PROPERTY PREFIX "")

--- a/README.md
+++ b/README.md
@@ -24,6 +24,41 @@ It was originally developed by Ian Bell, at the time a post-doc at the Universit
 
 * If you are new to Git and Github, please see the [CoolProp Wiki](https://github.com/CoolProp/CoolProp/wiki) for guidance on becoming a contributor to the project.
 
+## CMake package
+
+CoolProp can build and install static and shared libraries independently or in
+the same build:
+
+```sh
+cmake -S . -B build \
+  -DCOOLPROP_STATIC_LIBRARY=ON \
+  -DCOOLPROP_SHARED_LIBRARY=ON
+cmake --build build --config Release
+cmake --install build --config Release --prefix /path/to/prefix
+```
+
+An installed package is consumed through imported targets, without manually
+adding include directories or platform libraries:
+
+```cmake
+find_package(CoolProp 8 CONFIG REQUIRED)
+target_link_libraries(my_app PRIVATE CoolProp::CoolProp)
+```
+
+When both variants are installed, `CoolProp::Static` and `CoolProp::Shared`
+select one explicitly. `CoolProp::CoolProp` selects the value of
+`COOLPROP_DEFAULT_LIBRARY` (`SHARED` by default). On Windows, the portable
+shared-library interface is the C API from `CoolProp/CoolPropLib.h`; use the
+static target for the complete C++ API.
+
+Source-tree consumers can use the same canonical target:
+
+```cmake
+set(COOLPROP_STATIC_LIBRARY ON CACHE BOOL "" FORCE)
+add_subdirectory(externals/CoolProp)
+target_link_libraries(my_app PRIVATE CoolProp::CoolProp)
+```
+
 ## Sponsors
 
 Free code signing on Windows provided by [SignPath.io](https://about.signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).

--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ target_link_libraries(my_app PRIVATE CoolProp::CoolProp)
 
 When both variants are installed, `CoolProp::Static` and `CoolProp::Shared`
 select one explicitly. `CoolProp::CoolProp` selects the value of
-`COOLPROP_DEFAULT_LIBRARY` (`SHARED` by default). On Windows, the portable
-shared-library interface is the C API from `CoolProp/CoolPropLib.h`; use the
-static target for the complete C++ API.
+`COOLPROP_DEFAULT_LIBRARY` (`SHARED` by default). Separate consumer targets may
+select different variants, but one final binary must not link both variants.
+On Windows, the portable shared-library interface is the C API from
+`CoolProp/CoolPropLib.h`; use the static target for the complete C++ API.
 
 Source-tree consumers can use the same canonical target:
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,13 @@ find_package(CoolProp 8 CONFIG REQUIRED)
 target_link_libraries(my_app PRIVATE CoolProp::CoolProp)
 ```
 
-When both variants are installed, `CoolProp::Static` and `CoolProp::Shared`
-select one explicitly. `CoolProp::CoolProp` selects the value of
-`COOLPROP_DEFAULT_LIBRARY` (`SHARED` by default). Separate consumer targets may
-select different variants, but one final binary must not link both variants.
+When CoolProp is configured with both variants, the producer-side
+`COOLPROP_DEFAULT_LIBRARY` cache setting chooses which variant is exported
+through `CoolProp::CoolProp` (`SHARED` by default). This choice is recorded in
+the installed package and cannot be changed by a package consumer. Consumers
+that require explicit linkage should use `CoolProp::Static` or
+`CoolProp::Shared`. Separate consumer targets may select different variants,
+but one final binary must not link both variants.
 On Windows, the portable shared-library interface is the C API from
 `CoolProp/CoolPropLib.h`; use the static target for the complete C++ API.
 
@@ -59,6 +62,10 @@ set(COOLPROP_STATIC_LIBRARY ON CACHE BOOL "" FORCE)
 add_subdirectory(externals/CoolProp)
 target_link_libraries(my_app PRIVATE CoolProp::CoolProp)
 ```
+
+Nested builds add no CoolProp install rules by default. A parent project that
+intentionally packages CoolProp can enable `COOLPROP_INSTALL_CMAKE_PACKAGE`
+and/or `COOLPROP_INSTALL_LEGACY_LAYOUT` before calling `add_subdirectory`.
 
 ## Sponsors
 

--- a/Web/coolprop/changelog.rst
+++ b/Web/coolprop/changelog.rst
@@ -36,6 +36,7 @@ Highlights:
 
   The critical enhancement is not included for any of them; the correlations are the
   background viscosity, which is what the comparisons above are against.
+
 * **Relocatable CMake package.** See GitHub issue `#2144
   <https://github.com/CoolProp/CoolProp/issues/2144>`_. Static and shared
   CoolProp libraries can now be built and installed in one build. Installation
@@ -115,7 +116,8 @@ Highlights:
     enabled that tree can additionally contain the conventional ``bin``,
     ``lib``, ``include``, ``lib/cmake/CoolProp``, and ``share/licenses``
     directories, as applicable to the selected library variants.
-  - MSVC runtime selection is target-local. ``COOLPROP_MSVC_STATIC`` and
+  - MSVC runtime selection is target-local for CoolProp libraries and linked
+    in-tree executables. ``COOLPROP_MSVC_STATIC`` and
     ``COOLPROP_MSVC_DYNAMIC`` no longer rewrite the global C and C++ flags of
     unrelated targets in a parent build. Debug configurations always use the
     corresponding debug CRT; the legacy ``COOLPROP_MSVC_DEBUG`` option remains
@@ -126,8 +128,8 @@ Highlights:
   - In a dual static/shared producer build, the un-namespaced ``CoolProp``
     build-tree target is an INTERFACE selector and is not itself a build-system
     target. Build the normal ``all`` target or the concrete
-     ``CoolProp_static`` / ``CoolProp_shared`` target instead of invoking
-     ``cmake --build ... --target CoolProp``.
+    ``CoolProp_static`` / ``CoolProp_shared`` target instead of invoking
+    ``cmake --build ... --target CoolProp``.
 
 * **Compositions with two or more exactly-zero mole fractions no longer return
   NaN for the bulk properties.**  ``GERG2008ReducingFunction::f_Y_ij``

--- a/Web/coolprop/changelog.rst
+++ b/Web/coolprop/changelog.rst
@@ -6,6 +6,12 @@ Changelog for CoolProp
 
 Breaking Changes:
 
+* **CMake library consumers and packagers:** the minimum supported CMake
+  version is now 3.15.  The exported library targets model CoolProp's C++17,
+  header, and link requirements, and nested ``add_subdirectory`` /
+  ``FetchContent`` builds no longer add CoolProp install rules by default.
+  See the detailed CMake behavior changes below.
+
 * Reintroduced Java wrapper compilation. Java classes generated have been moved from default package, to "org.coolprop" package, in line with Java convention and recommended practice. Applications that previously used the Java wrappers will need to update their import references for CoolProp classes if switching to this version. Java wrappers are built with target Java 11, as Java 8 support has been deprecated. A JDK 11+ must be used to compile using these wrappers.
 
 Highlights:
@@ -30,6 +36,15 @@ Highlights:
 
   The critical enhancement is not included for any of them; the correlations are the
   background viscosity, which is what the comparisons above are against.
+* **Relocatable CMake package.** See GitHub issue `#2144
+  <https://github.com/CoolProp/CoolProp/issues/2144>`_. Static and shared
+  CoolProp libraries can now be built and installed in one build. Installation
+  exports the config-mode targets ``CoolProp::CoolProp``,
+  ``CoolProp::Static``, and ``CoolProp::Shared`` and supports relocation of the
+  installed prefix. In a dual build the producer-side
+  ``COOLPROP_DEFAULT_LIBRARY`` setting selects the variant exported through
+  ``CoolProp::CoolProp``; that choice is baked into the package, while
+  consumers can select either explicit variant target.
 
 * Added the :doc:`GERG-2004 and GERG-2008 </coolprop/GERG>` wide-range equations of state for natural gases as two new *strict* backend families (``GERG2004::...``, ``GERG2008::...``).  Strict means the backends admit only the 18 / 21 components each model publishes, carry only that model's own pure-fluid EOS, ideal-gas coefficients, binary reducing parameters and departure functions, use GERG's ``R = 8.314472 J/mol/K`` rather than the CODATA value, and throw rather than answer from a different model — transport properties, superancillaries, and mutable binary interaction parameters are all deliberately unavailable.  Validated against `teqp <https://github.com/usnistgov/teqp>`_ at relative tolerances of 1e-12 on the Helmholtz energies and 1e-10 on pressure, isochoric heat capacity and speed of sound.  See the :doc:`GERG documentation </coolprop/GERG>` for the component tables, the enforced range of validity, the reference-state convention (``h = s = 0`` for the **ideal gas** at 298.15 K / 101325 Pa, which differs from every other CoolProp backend), and the known limitations.  GERG publishes no acentric factor, which CoolProp's VLE and density guess machinery needs; rather than borrow one from a different equation of state, the backends **derive** it from GERG's own equation as :math:`\omega = -1 - \log_{10}(p_{sat}(0.7 T_c)/p_c)` with a converged saturation solve.  Mixture saturation, phase envelopes, VLE flashes and ``DmolarP`` therefore all work.  One limitation deserves calling out here: for **pure** GERG fluids the pressure-plus-caloric input pairs (``HmolarP``, ``PSmolar``, ``PUmolar``) do not work **at all** — through ``PropsSI`` they return ``inf`` plus an error string rather than raising.  That has two separate causes, neither of them the acentric factor: GERG publishes no triple point either, so the flash's temperature bracket falls back to the model's ``Tmin`` instead of the saturation temperature; and the bracket's upper end (1.5x ``Tmax``) is outside the range the backend enforces.  Use ``PT``, ``DmolarT`` or ``DmolarP`` inputs for pure GERG fluids, or ``HEOS`` when you need a caloric input pair.
 * Added wasm32 Python wheels for the Pyodide runtime. These wheels are compatible with Pyodide 0.28.x and later. See the :ref:`Python wrapper docs <python_wasm_demo>` for an example of using these wheels in a browser environment.
@@ -64,6 +79,55 @@ Highlights:
   There is no version gate and no compatibility shim: a third-party expression
   block written against the previous format fails when the fluid is loaded, with a
   message naming the available set.  Blocks shipped with CoolProp are unaffected.
+
+* **CMake library and package integration.** See GitHub issue `#2144
+  <https://github.com/CoolProp/CoolProp/issues/2144>`_.
+
+  - Library targets now propagate ``cxx_std_17`` to C++ compilation units. A
+    downstream target configured for C++11 or C++14 can therefore be promoted
+    to C++17; pure-C consumers are unaffected.
+  - On Windows, ``CoolProp::Shared`` propagates
+    ``COOLPROP_SHARED_LIBRARY_USE``. ``CoolPropLib.h`` consequently declares
+    the C API with ``__declspec(dllimport)``, C linkage, and the calling
+    convention selected when CoolProp was built. Hand-written declarations
+    must use the same convention. Caller-defined ``EXPORT_CODE`` and
+    ``CONVENTION`` macros now remain authoritative when ``EXTERNC`` or
+    ``__powerpc__`` is defined; Windows ``EXTERNC`` builds also retain their
+    symbol-visibility decoration rather than discarding it.
+  - Nested ``add_subdirectory`` / ``FetchContent`` builds leave
+    ``COOLPROP_INSTALL_CMAKE_PACKAGE`` and
+    ``COOLPROP_INSTALL_LEGACY_LAYOUT`` disabled by default and no longer change
+    the parent project's install prefix. A parent which intentionally packages
+    CoolProp must enable the desired install option explicitly.
+  - Build-tree consumers receive the supported ``include/CoolProp`` public
+    header tree plus the Eigen and fmt usage requirements, rather than every
+    source, development, and third-party include directory used internally by
+    CoolProp. Code which included CoolProp's non-public in-tree headers must
+    now provide those unsupported include paths itself.
+  - The installed package carries the pinned Eigen and fmt headers required by
+    CoolProp's public C++ headers under ``include/CoolProp/third_party`` and
+    publishes those directories as SYSTEM usage requirements. A downstream
+    project which also exposes a different Eigen or fmt revision must avoid
+    mixing both revisions in one program.
+  - An explicitly supplied top-level ``CMAKE_INSTALL_PREFIX`` is now honored.
+    With no explicit prefix, a top-level CoolProp build keeps the historical
+    ``<source>/install_root`` default; when CMake-package installation is
+    enabled that tree can additionally contain the conventional ``bin``,
+    ``lib``, ``include``, ``lib/cmake/CoolProp``, and ``share/licenses``
+    directories, as applicable to the selected library variants.
+  - MSVC runtime selection is target-local. ``COOLPROP_MSVC_STATIC`` and
+    ``COOLPROP_MSVC_DYNAMIC`` no longer rewrite the global C and C++ flags of
+    unrelated targets in a parent build. Debug configurations always use the
+    corresponding debug CRT; the legacy ``COOLPROP_MSVC_DEBUG`` option remains
+    accepted but no longer changes that selection.
+  - Configuring a CoolProp library requires CMake's ``Threads`` package. The
+    installed static target records that link dependency; a shared-only
+    installed package does not impose it on consumers.
+  - In a dual static/shared producer build, the un-namespaced ``CoolProp``
+    build-tree target is an INTERFACE selector and is not itself a build-system
+    target. Build the normal ``all`` target or the concrete
+     ``CoolProp_static`` / ``CoolProp_shared`` target instead of invoking
+     ``cmake --build ... --target CoolProp``.
 
 * **Compositions with two or more exactly-zero mole fractions no longer return
   NaN for the bulk properties.**  ``GERG2008ReducingFunction::f_Y_ij``

--- a/Web/coolprop/wrappers/SharedLibrary/index.rst
+++ b/Web/coolprop/wrappers/SharedLibrary/index.rst
@@ -165,6 +165,22 @@ On Linux, installation could be done by::
     sudo ln -sf libCoolProp.so.5 libCoolProp.so
     popd
 
+CMake package usage
+-------------------
+
+The CMake install step also provides a relocatable package configuration. A
+consumer does not need to add CoolProp's include or library directories
+manually::
+
+    find_package(CoolProp 8 CONFIG REQUIRED COMPONENTS Shared)
+    add_executable(main main.c)
+    target_link_libraries(main PRIVATE CoolProp::Shared)
+
+Static and shared libraries can be produced together by enabling both
+``COOLPROP_STATIC_LIBRARY`` and ``COOLPROP_SHARED_LIBRARY``. In that case the
+canonical ``CoolProp::CoolProp`` target selects ``COOLPROP_DEFAULT_LIBRARY``;
+use ``CoolProp::Static`` or ``CoolProp::Shared`` when linkage must be explicit.
+
 
 Using
 =====

--- a/Web/coolprop/wrappers/SharedLibrary/index.rst
+++ b/Web/coolprop/wrappers/SharedLibrary/index.rst
@@ -178,7 +178,9 @@ manually::
 
 Static and shared libraries can be produced together by enabling both
 ``COOLPROP_STATIC_LIBRARY`` and ``COOLPROP_SHARED_LIBRARY``. In that case the
-canonical ``CoolProp::CoolProp`` target selects ``COOLPROP_DEFAULT_LIBRARY``;
+producer-side ``COOLPROP_DEFAULT_LIBRARY`` cache setting chooses the variant
+exported through ``CoolProp::CoolProp`` (``SHARED`` by default). The choice is
+recorded in the installed package and cannot be changed by a package consumer;
 use ``CoolProp::Static`` or ``CoolProp::Shared`` when linkage must be explicit.
 Separate consumer targets may select different variants, but one final binary
 must not link both variants.

--- a/Web/coolprop/wrappers/SharedLibrary/index.rst
+++ b/Web/coolprop/wrappers/SharedLibrary/index.rst
@@ -180,6 +180,8 @@ Static and shared libraries can be produced together by enabling both
 ``COOLPROP_STATIC_LIBRARY`` and ``COOLPROP_SHARED_LIBRARY``. In that case the
 canonical ``CoolProp::CoolProp`` target selects ``COOLPROP_DEFAULT_LIBRARY``;
 use ``CoolProp::Static`` or ``CoolProp::Shared`` when linkage must be explicit.
+Separate consumer targets may select different variants, but one final binary
+must not link both variants.
 
 
 Using

--- a/Web/coolprop/wrappers/StaticLibrary/index.rst
+++ b/Web/coolprop/wrappers/StaticLibrary/index.rst
@@ -31,13 +31,19 @@ If you are using CMake, the process is quite trivial to integrate the CoolProp s
 
 Then CMakeLists.txt might have the contents::
 
-    # See also https://stackoverflow.com/a/18697099
-    cmake_minimum_required (VERSION 2.8.11)
-    project (main)
-    set(COOLPROP_STATIC_LIBRARY true)
-    add_subdirectory ("${CMAKE_SOURCE_DIR}/externals/CoolProp" CoolProp)
-    add_executable (main "${CMAKE_SOURCE_DIR}/mycode.cpp")
-    target_link_libraries (main CoolProp)
+    cmake_minimum_required(VERSION 3.15)
+    project(main LANGUAGES CXX)
+    set(COOLPROP_STATIC_LIBRARY ON CACHE BOOL "" FORCE)
+    add_subdirectory("${CMAKE_SOURCE_DIR}/externals/CoolProp" CoolProp)
+    add_executable(main "${CMAKE_SOURCE_DIR}/mycode.cpp")
+    target_link_libraries(main PRIVATE CoolProp::CoolProp)
+
+An already-installed CoolProp package can instead be used without embedding
+its source tree::
+
+    find_package(CoolProp 8 CONFIG REQUIRED COMPONENTS Static)
+    add_executable(main mycode.cpp)
+    target_link_libraries(main PRIVATE CoolProp::Static)
 
 Pre-compiled Binaries
 =====================

--- a/cmake/CoolPropConfig.cmake.in
+++ b/cmake/CoolPropConfig.cmake.in
@@ -1,0 +1,33 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+
+include("${CMAKE_CURRENT_LIST_DIR}/CoolPropTargets.cmake")
+
+set(CoolProp_VERSION "@COOLPROP_VERSION_NUMERIC@")
+set(CoolProp_STATIC_AVAILABLE @COOLPROP_PACKAGE_HAS_STATIC@)
+set(CoolProp_SHARED_AVAILABLE @COOLPROP_PACKAGE_HAS_SHARED@)
+set(CoolProp_Static_FOUND ${CoolProp_STATIC_AVAILABLE})
+set(CoolProp_Shared_FOUND ${CoolProp_SHARED_AVAILABLE})
+
+# Single-variant builds export the real library as CoolProp::CoolProp to keep
+# the historical build target name stable.  Supply the corresponding explicit
+# linkage target as a small imported wrapper.  Dual builds export these targets
+# directly, so the guards leave them untouched.
+if(CoolProp_STATIC_AVAILABLE AND NOT TARGET CoolProp::Static)
+  add_library(CoolProp::Static INTERFACE IMPORTED)
+  set_property(TARGET CoolProp::Static PROPERTY INTERFACE_LINK_LIBRARIES
+                                                CoolProp::CoolProp)
+endif()
+
+if(CoolProp_SHARED_AVAILABLE AND NOT TARGET CoolProp::Shared)
+  add_library(CoolProp::Shared INTERFACE IMPORTED)
+  set_property(TARGET CoolProp::Shared PROPERTY INTERFACE_LINK_LIBRARIES
+                                                CoolProp::CoolProp)
+endif()
+
+set_and_check(CoolProp_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+set(CoolProp_LIBRARIES CoolProp::CoolProp)
+
+check_required_components(CoolProp)

--- a/cmake/CoolPropConfig.cmake.in
+++ b/cmake/CoolPropConfig.cmake.in
@@ -1,7 +1,9 @@
 @PACKAGE_INIT@
 
-include(CMakeFindDependencyMacro)
-find_dependency(Threads)
+if(@COOLPROP_PACKAGE_HAS_STATIC@)
+  include(CMakeFindDependencyMacro)
+  find_dependency(Threads)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/CoolPropTargets.cmake")
 

--- a/cmake/CoolPropLibrary.cmake
+++ b/cmake/CoolPropLibrary.cmake
@@ -89,6 +89,22 @@ function(_coolprop_set_msvc_runtime target linkage)
   endif()
 endfunction()
 
+# Keep executables linked through the canonical target on the same CRT as the
+# concrete library variant selected by the producer.
+function(_coolprop_set_canonical_msvc_runtime target)
+  if(COOLPROP_STATIC_LIBRARY AND COOLPROP_SHARED_LIBRARY)
+    string(TOUPPER "${COOLPROP_DEFAULT_LIBRARY}" _linkage)
+  elseif(COOLPROP_STATIC_LIBRARY)
+    set(_linkage STATIC)
+  elseif(COOLPROP_SHARED_LIBRARY)
+    set(_linkage SHARED)
+  else()
+    return()
+  endif()
+
+  _coolprop_set_msvc_runtime("${target}" "${_linkage}")
+endfunction()
+
 function(_coolprop_configure_core_target target linkage)
   # CMake applies cxx_* features only to C++ translation units. This promotes
   # C++ consumers to the standard required by the public headers without

--- a/cmake/CoolPropLibrary.cmake
+++ b/cmake/CoolPropLibrary.cmake
@@ -84,8 +84,9 @@ function(_coolprop_set_msvc_runtime target linkage)
   if(_coolprop_needs_msvc_runtime_fallback)
     target_compile_options(
       "${target}"
-      PRIVATE "$<$<CONFIG:Debug>:${_runtime_flag}d>"
-              "$<$<NOT:$<CONFIG:Debug>>:${_runtime_flag}>")
+      PRIVATE
+        "$<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<CONFIG:Debug>>:${_runtime_flag}d>"
+        "$<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<NOT:$<CONFIG:Debug>>>:${_runtime_flag}>")
   endif()
 endfunction()
 

--- a/cmake/CoolPropLibrary.cmake
+++ b/cmake/CoolPropLibrary.cmake
@@ -65,12 +65,13 @@ function(_coolprop_set_msvc_runtime target linkage)
     set(_runtime_flag "/MT")
   endif()
 
-  if(COOLPROP_MSVC_DEBUG)
-    if(_runtime STREQUAL "MultiThreadedDLL")
-      set(_runtime "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
-    else()
-      set(_runtime "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-    endif()
+  # Debug configurations must always use the matching debug CRT.  Keeping a
+  # release CRT in a d-postfixed library causes _ITERATOR_DEBUG_LEVEL and heap
+  # ownership mismatches in otherwise ordinary Debug consumers.
+  if(_runtime STREQUAL "MultiThreadedDLL")
+    set(_runtime "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+  else()
+    set(_runtime "MultiThreaded$<$<CONFIG:Debug>:Debug>")
   endif()
 
   set_property(TARGET "${target}" PROPERTY MSVC_RUNTIME_LIBRARY "${_runtime}")
@@ -81,14 +82,10 @@ function(_coolprop_set_msvc_runtime target linkage)
   # target-local option so add_subdirectory consumers still get the requested
   # runtime without rewriting the parent's global CMAKE_CXX_FLAGS_* values.
   if(_coolprop_needs_msvc_runtime_fallback)
-    if(COOLPROP_MSVC_DEBUG)
-      target_compile_options(
-        "${target}"
-        PRIVATE "$<$<CONFIG:Debug>:${_runtime_flag}d>"
-                "$<$<NOT:$<CONFIG:Debug>>:${_runtime_flag}>")
-    else()
-      target_compile_options("${target}" PRIVATE "${_runtime_flag}")
-    endif()
+    target_compile_options(
+      "${target}"
+      PRIVATE "$<$<CONFIG:Debug>:${_runtime_flag}d>"
+              "$<$<NOT:$<CONFIG:Debug>>:${_runtime_flag}>")
   endif()
 endfunction()
 
@@ -162,7 +159,7 @@ function(_coolprop_configure_core_target target linkage)
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
       set_target_properties(
         "${target}"
-        PROPERTIES VERSION "${COOLPROP_VERSION_NUMERIC}"
+        PROPERTIES VERSION "${COOLPROP_VERSION}"
                    SOVERSION "${COOLPROP_VERSION_MAJOR}")
     endif()
   endif()
@@ -223,11 +220,9 @@ function(_coolprop_install_standard_headers)
           DESTINATION "${_third_party_dir}/fmt")
 
   install(FILES "${Eigen_SOURCE_DIR}/COPYING.MPL2"
-          DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/licenses/CoolProp/Eigen"
-          OPTIONAL)
+          DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/licenses/CoolProp/Eigen")
   install(FILES "${fmt_SOURCE_DIR}/LICENSE"
-          DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/licenses/CoolProp/fmt"
-          OPTIONAL)
+          DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/licenses/CoolProp/fmt")
 endfunction()
 
 function(coolprop_add_library_targets)

--- a/cmake/CoolPropLibrary.cmake
+++ b/cmake/CoolPropLibrary.cmake
@@ -1,0 +1,503 @@
+include_guard(GLOBAL)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+option(COOLPROP_STDCALL_LIBRARY
+       "Build CoolProp as a 32-bit shared library with stdcall" OFF)
+option(COOLPROP_CDECL_LIBRARY
+       "Build CoolProp as a 32-bit shared library with cdecl" OFF)
+option(COOLPROP_EXTERNC_LIBRARY
+       "Force C linkage for the CoolProp C API" OFF)
+
+set(COOLPROP_LIBRARY_SOURCE
+    "src/CoolPropLib.cpp"
+    CACHE STRING "The file that contains the exported functions")
+set(COOLPROP_LIBRARY_HEADER
+    "include/CoolProp/CoolPropLib.h"
+    CACHE STRING "The file that contains the export header")
+set(COOLPROP_LIBRARY_NAME
+    "${app_name}"
+    CACHE STRING "The legacy name of the generated library target")
+set(COOLPROP_LIBRARY_EXPORTS
+    ""
+    CACHE STRING "The file that contains the export alias list")
+
+set(COOLPROP_DEFAULT_LIBRARY
+    "SHARED"
+    CACHE STRING
+          "Variant selected by CoolProp::CoolProp when static and shared are built")
+set_property(CACHE COOLPROP_DEFAULT_LIBRARY PROPERTY STRINGS STATIC SHARED)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  set(_coolprop_top_level_install_default ON)
+else()
+  set(_coolprop_top_level_install_default OFF)
+endif()
+option(COOLPROP_INSTALL_CMAKE_PACKAGE
+       "Install the standard CoolProp CMake package and development headers"
+       ${_coolprop_top_level_install_default})
+option(COOLPROP_INSTALL_LEGACY_LAYOUT
+       "Install the historical static_library/shared_library release layout"
+       ${_coolprop_top_level_install_default})
+set(COOLPROP_INSTALL_CMAKEDIR
+    "${CMAKE_INSTALL_LIBDIR}/cmake/CoolProp"
+    CACHE STRING "CoolProp CMake package installation directory")
+
+function(_coolprop_set_msvc_runtime target linkage)
+  if(NOT MSVC)
+    return()
+  endif()
+
+  if(COOLPROP_MSVC_STATIC)
+    set(_runtime "MultiThreaded")
+    set(_runtime_flag "/MT")
+  elseif(COOLPROP_MSVC_DYNAMIC)
+    set(_runtime "MultiThreadedDLL")
+    set(_runtime_flag "/MD")
+  elseif(linkage STREQUAL "STATIC")
+    # Preserve the existing defaults: static CoolProp uses the DLL CRT.
+    set(_runtime "MultiThreadedDLL")
+    set(_runtime_flag "/MD")
+  else()
+    # Preserve the existing defaults: shared CoolProp embeds the static CRT.
+    set(_runtime "MultiThreaded")
+    set(_runtime_flag "/MT")
+  endif()
+
+  if(COOLPROP_MSVC_DEBUG)
+    if(_runtime STREQUAL "MultiThreadedDLL")
+      set(_runtime "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    else()
+      set(_runtime "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    endif()
+  endif()
+
+  set_property(TARGET "${target}" PROPERTY MSVC_RUNTIME_LIBRARY "${_runtime}")
+
+  # A parent with cmake_minimum_required(VERSION 3.14) may have enabled MSVC
+  # languages while CMP0091 was OLD. In that case CMake leaves this internal
+  # default empty and ignores MSVC_RUNTIME_LIBRARY. Append an explicit
+  # target-local option so add_subdirectory consumers still get the requested
+  # runtime without rewriting the parent's global CMAKE_CXX_FLAGS_* values.
+  if(_coolprop_needs_msvc_runtime_fallback)
+    if(COOLPROP_MSVC_DEBUG)
+      target_compile_options(
+        "${target}"
+        PRIVATE "$<$<CONFIG:Debug>:${_runtime_flag}d>"
+                "$<$<NOT:$<CONFIG:Debug>>:${_runtime_flag}>")
+    else()
+      target_compile_options("${target}" PRIVATE "${_runtime_flag}")
+    endif()
+  endif()
+endfunction()
+
+function(_coolprop_configure_core_target target linkage)
+  # CMake applies cxx_* features only to C++ translation units. This promotes
+  # C++ consumers to the standard required by the public headers without
+  # imposing a C++ compiler on projects which link only the shared C API.
+  target_compile_features("${target}" PUBLIC cxx_std_17)
+  target_include_directories(
+    "${target}"
+    PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+           "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+    PRIVATE ${APP_INCLUDE_DIRS})
+
+  target_compile_definitions("${target}" PRIVATE VALIJSON_USE_EXCEPTIONS=1)
+  target_link_libraries("${target}" PUBLIC coolprop_eigen_headers
+                                           coolprop_fmt_headers)
+
+  if(NOT linkage STREQUAL "OBJECT")
+    target_link_libraries("${target}" PRIVATE Threads::Threads)
+    if(CMAKE_DL_LIBS)
+      target_link_libraries("${target}" PRIVATE ${CMAKE_DL_LIBS})
+    endif()
+  endif()
+
+  add_dependencies("${target}" generate_headers)
+
+  if(MSVC90)
+    target_compile_definitions("${target}" PRIVATE EIGEN_DONT_VECTORIZE)
+  endif()
+
+  if(APPLE)
+    if(DEFINED OSX_COMPILE_FLAGS)
+      set_property(TARGET "${target}" APPEND_STRING PROPERTY COMPILE_FLAGS
+                                                               "${OSX_COMPILE_FLAGS}")
+    endif()
+    if(DEFINED OSX_LINK_FLAGS AND NOT linkage STREQUAL "OBJECT")
+      set_property(TARGET "${target}" APPEND_STRING PROPERTY LINK_FLAGS
+                                                            "${OSX_LINK_FLAGS}")
+    endif()
+  endif()
+
+  if(COOLPROP_EXTERNC_LIBRARY)
+    target_compile_definitions("${target}" PUBLIC EXTERNC)
+  endif()
+
+  if(NOT MSVC AND NOT BITNESS STREQUAL "NATIVE")
+    target_compile_options("${target}" PRIVATE "-m${BITNESS}")
+    if(NOT linkage STREQUAL "OBJECT")
+      target_link_options("${target}" PRIVATE "-m${BITNESS}")
+    endif()
+  endif()
+
+  if(COOLPROP_FPIC)
+    set_property(TARGET "${target}" PROPERTY POSITION_INDEPENDENT_CODE ON)
+  endif()
+
+  if(NOT CONVENTION STREQUAL "")
+    target_compile_definitions("${target}" PUBLIC "CONVENTION=${CONVENTION}")
+  endif()
+
+  if(linkage STREQUAL "STATIC")
+    _coolprop_set_msvc_runtime("${target}" STATIC)
+  elseif(linkage STREQUAL "SHARED")
+    target_compile_definitions("${target}"
+                               PRIVATE COOLPROP_SHARED_LIBRARY_BUILD
+                               INTERFACE COOLPROP_SHARED_LIBRARY_USE)
+    _coolprop_set_msvc_runtime("${target}" SHARED)
+    coolprop_hide_json_symbols("${target}")
+
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+      set_target_properties(
+        "${target}"
+        PROPERTIES VERSION "${COOLPROP_VERSION_NUMERIC}"
+                   SOVERSION "${COOLPROP_VERSION_MAJOR}")
+    endif()
+  endif()
+endfunction()
+
+function(_coolprop_install_legacy_headers directory)
+  install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_HEADER}"
+          DESTINATION "${directory}")
+  install(
+    DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/CoolProp"
+    DESTINATION "${directory}/include"
+    FILES_MATCHING
+    PATTERN "*.h"
+    REGEX "detail/(json|msgpack)\\.h$" EXCLUDE)
+  install(
+    DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
+    DESTINATION "${directory}/include"
+    FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "CoolProp" EXCLUDE
+    PATTERN "*_JSON*.h" EXCLUDE
+    PATTERN "*_CBOR*.h" EXCLUDE
+    PATTERN "CPmsgpack.h" EXCLUDE
+    PATTERN "gitrevision.h" EXCLUDE
+    PATTERN "cpversion.h" EXCLUDE)
+endfunction()
+
+function(_coolprop_install_standard_headers)
+  install(
+    DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/CoolProp"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    FILES_MATCHING
+    PATTERN "*.h"
+    REGEX "detail/(json|msgpack)\\.h$" EXCLUDE)
+  install(
+    DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "CoolProp" EXCLUDE
+    PATTERN "*_JSON*.h" EXCLUDE
+    PATTERN "*_CBOR*.h" EXCLUDE
+    PATTERN "CPmsgpack.h" EXCLUDE
+    PATTERN "gitrevision.h" EXCLUDE
+    PATTERN "cpversion.h" EXCLUDE)
+
+  # Eigen and fmt are header-only implementation dependencies which also occur
+  # in installed public headers.  Install private copies under the CoolProp
+  # include tree so the exported package is self-contained and relocatable.
+  set(_third_party_dir "${CMAKE_INSTALL_INCLUDEDIR}/CoolProp/third_party")
+  install(DIRECTORY "${Eigen_SOURCE_DIR}/Eigen"
+          DESTINATION "${_third_party_dir}/eigen")
+  install(FILES "${Eigen_SOURCE_DIR}/unsupported/Eigen/Polynomials"
+          DESTINATION "${_third_party_dir}/eigen/unsupported/Eigen")
+  install(DIRECTORY "${Eigen_SOURCE_DIR}/unsupported/Eigen/src/Polynomials"
+          DESTINATION "${_third_party_dir}/eigen/unsupported/Eigen/src")
+  install(DIRECTORY "${fmt_SOURCE_DIR}/include/fmt"
+          DESTINATION "${_third_party_dir}/fmt")
+
+  install(FILES "${Eigen_SOURCE_DIR}/COPYING.MPL2"
+          DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/licenses/CoolProp/Eigen"
+          OPTIONAL)
+  install(FILES "${fmt_SOURCE_DIR}/LICENSE"
+          DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/licenses/CoolProp/fmt"
+          OPTIONAL)
+endfunction()
+
+function(coolprop_add_library_targets)
+  if(COOLPROP_CDECL_LIBRARY AND COOLPROP_STDCALL_LIBRARY)
+    message(
+      FATAL_ERROR
+        "COOLPROP_CDECL_LIBRARY and COOLPROP_STDCALL_LIBRARY are mutually exclusive"
+    )
+  endif()
+
+  if(COOLPROP_MSVC_STATIC AND COOLPROP_MSVC_DYNAMIC)
+    message(
+      FATAL_ERROR
+        "COOLPROP_MSVC_STATIC and COOLPROP_MSVC_DYNAMIC are mutually exclusive"
+    )
+  endif()
+
+  if(COOLPROP_OBJECT_LIBRARY
+     AND (COOLPROP_STATIC_LIBRARY OR COOLPROP_SHARED_LIBRARY))
+    message(
+      FATAL_ERROR
+        "COOLPROP_OBJECT_LIBRARY cannot be combined with COOLPROP_STATIC_LIBRARY or COOLPROP_SHARED_LIBRARY"
+    )
+  endif()
+
+  string(TOUPPER "${COOLPROP_DEFAULT_LIBRARY}" _default_library)
+  if(NOT _default_library STREQUAL "STATIC"
+     AND NOT _default_library STREQUAL "SHARED")
+    message(FATAL_ERROR
+            "COOLPROP_DEFAULT_LIBRARY must be STATIC or SHARED")
+  endif()
+
+  if("${BITNESS}" STREQUAL "32")
+    if(COOLPROP_CDECL_LIBRARY)
+      set(CONVENTION "__cdecl" PARENT_SCOPE)
+      set(CONVENTION "__cdecl")
+    elseif(COOLPROP_STDCALL_LIBRARY)
+      set(CONVENTION "__stdcall" PARENT_SCOPE)
+      set(CONVENTION "__stdcall")
+    else()
+      set(CONVENTION "" PARENT_SCOPE)
+      set(CONVENTION "")
+    endif()
+  elseif("${BITNESS}" STREQUAL "64" OR "${BITNESS}" STREQUAL "NATIVE")
+    if(COOLPROP_CDECL_LIBRARY OR COOLPROP_STDCALL_LIBRARY)
+      message(WARNING
+              "Explicit x86 calling conventions are ignored for ${BITNESS}-bit builds")
+    endif()
+    set(CONVENTION "" PARENT_SCOPE)
+    set(CONVENTION "")
+  else()
+    message(FATAL_ERROR "Bitness is not defined. Set it and run CMake again.")
+  endif()
+
+  if(NOT (COOLPROP_OBJECT_LIBRARY OR COOLPROP_STATIC_LIBRARY
+          OR COOLPROP_SHARED_LIBRARY))
+    return()
+  endif()
+
+  find_package(Threads REQUIRED)
+
+  add_library(coolprop_eigen_headers INTERFACE)
+  set_property(TARGET coolprop_eigen_headers PROPERTY EXPORT_NAME
+                                                        _EigenHeaders)
+  target_include_directories(
+    coolprop_eigen_headers SYSTEM
+    INTERFACE "$<BUILD_INTERFACE:${Eigen_SOURCE_DIR}>"
+              "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/CoolProp/third_party/eigen>"
+  )
+
+  add_library(coolprop_fmt_headers INTERFACE)
+  set_property(TARGET coolprop_fmt_headers PROPERTY EXPORT_NAME _FmtHeaders)
+  target_include_directories(
+    coolprop_fmt_headers SYSTEM
+    INTERFACE "$<BUILD_INTERFACE:${fmt_SOURCE_DIR}/include>"
+              "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/CoolProp/third_party/fmt>"
+  )
+  if(MSVC)
+    target_compile_options(coolprop_fmt_headers
+                           INTERFACE "$<$<COMPILE_LANGUAGE:CXX>:/utf-8>")
+  endif()
+
+  set(_core_sources ${APP_SOURCES})
+  if(NOT COOLPROP_LIBRARY_SOURCE STREQUAL "")
+    list(APPEND _core_sources
+         "${CMAKE_CURRENT_SOURCE_DIR}/${COOLPROP_LIBRARY_SOURCE}")
+  endif()
+
+  set(_shared_sources ${_core_sources})
+  if((MSVC OR MINGW) AND COOLPROP_SHARED_LIBRARY)
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/dev/CoolProp.rc.in"
+                   "${CMAKE_CURRENT_BINARY_DIR}/CoolProp.rc" @ONLY)
+    list(APPEND _shared_sources "${CMAKE_CURRENT_BINARY_DIR}/CoolProp.rc")
+  endif()
+
+  set(_static_target "")
+  set(_shared_target "")
+  set(_canonical_target "")
+  set(_export_targets "")
+
+  if(COOLPROP_OBJECT_LIBRARY)
+    add_library("${COOLPROP_LIBRARY_NAME}" OBJECT ${APP_SOURCES})
+    set(_canonical_target "${COOLPROP_LIBRARY_NAME}")
+    _coolprop_configure_core_target("${_canonical_target}" OBJECT)
+    if(NOT TARGET CoolProp::Objects)
+      add_library(CoolProp::Objects ALIAS "${_canonical_target}")
+    endif()
+  elseif(COOLPROP_STATIC_LIBRARY AND COOLPROP_SHARED_LIBRARY)
+    set(_static_target "${COOLPROP_LIBRARY_NAME}_static")
+    set(_shared_target "${COOLPROP_LIBRARY_NAME}_shared")
+    set(_canonical_target "${COOLPROP_LIBRARY_NAME}")
+
+    add_library("${_static_target}" STATIC ${_core_sources})
+    add_library("${_shared_target}" SHARED ${_shared_sources}
+                                           ${COOLPROP_LIBRARY_EXPORTS})
+    add_library("${_canonical_target}" INTERFACE)
+
+    if(_default_library STREQUAL "STATIC")
+      target_link_libraries("${_canonical_target}" INTERFACE
+                            "${_static_target}")
+    else()
+      target_link_libraries("${_canonical_target}" INTERFACE
+                            "${_shared_target}")
+    endif()
+
+    set_target_properties("${_canonical_target}" PROPERTIES EXPORT_NAME
+                                                             CoolProp)
+    set_target_properties("${_static_target}" PROPERTIES EXPORT_NAME Static)
+    set_target_properties("${_shared_target}" PROPERTIES EXPORT_NAME Shared
+                                                         OUTPUT_NAME
+                                                         "${COOLPROP_LIBRARY_NAME}")
+    if(WIN32)
+      set_target_properties("${_static_target}" PROPERTIES OUTPUT_NAME
+                                                           "${COOLPROP_LIBRARY_NAME}_static")
+    else()
+      set_target_properties("${_static_target}" PROPERTIES OUTPUT_NAME
+                                                           "${COOLPROP_LIBRARY_NAME}")
+    endif()
+
+    list(APPEND _export_targets "${_canonical_target}" "${_static_target}"
+         "${_shared_target}")
+  elseif(COOLPROP_STATIC_LIBRARY)
+    set(_static_target "${COOLPROP_LIBRARY_NAME}")
+    set(_canonical_target "${_static_target}")
+    add_library("${_static_target}" STATIC ${_core_sources})
+    set_target_properties("${_static_target}" PROPERTIES EXPORT_NAME CoolProp)
+    list(APPEND _export_targets "${_static_target}")
+  elseif(COOLPROP_SHARED_LIBRARY)
+    set(_shared_target "${COOLPROP_LIBRARY_NAME}")
+    set(_canonical_target "${_shared_target}")
+    add_library("${_shared_target}" SHARED ${_shared_sources}
+                                           ${COOLPROP_LIBRARY_EXPORTS})
+    set_target_properties("${_shared_target}" PROPERTIES EXPORT_NAME CoolProp)
+    list(APPEND _export_targets "${_shared_target}")
+  endif()
+
+  if(_static_target)
+    _coolprop_configure_core_target("${_static_target}" STATIC)
+    if(MSVC)
+      set_target_properties("${_static_target}" PROPERTIES DEBUG_POSTFIX d)
+    endif()
+  endif()
+
+  if(_shared_target)
+    _coolprop_configure_core_target("${_shared_target}" SHARED)
+
+    if(MSVC OR (MINGW AND DEFINED ENV{MSYSTEM}))
+      set_target_properties("${_shared_target}" PROPERTIES DEBUG_POSTFIX d
+                                                         PREFIX "")
+    endif()
+
+    if(MINGW AND DEFINED ENV{MSYSTEM})
+      set_target_properties("${_shared_target}" PROPERTIES IMPORT_PREFIX ""
+                                                         IMPORT_SUFFIX ".a")
+      target_link_options("${_shared_target}" PRIVATE -static-libgcc
+                                                      -static-libstdc++)
+      target_link_libraries("${_shared_target}" PRIVATE -Wl,-Bstatic
+                                                        -lwinpthread
+                                                        -Wl,-Bdynamic)
+    endif()
+  endif()
+
+  if(_canonical_target AND NOT TARGET CoolProp::CoolProp)
+    add_library(CoolProp::CoolProp ALIAS "${_canonical_target}")
+  endif()
+  if(_static_target AND NOT TARGET CoolProp::Static)
+    add_library(CoolProp::Static ALIAS "${_static_target}")
+  endif()
+  if(_shared_target AND NOT TARGET CoolProp::Shared)
+    add_library(CoolProp::Shared ALIAS "${_shared_target}")
+  endif()
+
+  if(COOLPROP_INSTALL_LEGACY_LAYOUT AND _static_target)
+    set(_legacy_static_dir
+        "static_library/${CMAKE_SYSTEM_NAME}/${BITNESS}bit_${CMAKE_CXX_COMPILER_ID}_${CMAKE_CXX_COMPILER_VERSION}"
+    )
+    install(TARGETS "${_static_target}" DESTINATION "${_legacy_static_dir}")
+    _coolprop_install_legacy_headers(static_library)
+  endif()
+
+  if(COOLPROP_INSTALL_LEGACY_LAYOUT AND _shared_target)
+    if(MSVC AND (CMAKE_VS_PLATFORM_NAME STREQUAL "ARM64"
+                 OR CMAKE_VS_PLATFORM_NAME STREQUAL "arm64"))
+      set(_legacy_shared_dir
+          "shared_library/${CMAKE_SYSTEM_NAME}/${BITNESS}bit__arm64")
+    else()
+      set(_legacy_shared_dir
+          "shared_library/${CMAKE_SYSTEM_NAME}/${BITNESS}bit${CONVENTION}")
+    endif()
+    install(TARGETS "${_shared_target}" DESTINATION "${_legacy_shared_dir}")
+    _coolprop_install_legacy_headers(shared_library)
+
+    if(MSVC)
+      add_custom_command(
+        TARGET "${_shared_target}"
+        POST_BUILD
+        COMMAND dumpbin /EXPORTS "$<TARGET_FILE:${_shared_target}>" >
+                "${CMAKE_CURRENT_BINARY_DIR}/exports.txt"
+        VERBATIM)
+      add_custom_command(
+        TARGET "${_shared_target}"
+        POST_BUILD
+        COMMAND dumpbin /HEADERS "$<TARGET_FILE:${_shared_target}>" >
+                "${CMAKE_CURRENT_BINARY_DIR}/headers.txt"
+        VERBATIM)
+      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/exports.txt"
+                    "${CMAKE_CURRENT_BINARY_DIR}/headers.txt"
+              DESTINATION "${_legacy_shared_dir}")
+    endif()
+  endif()
+
+  if(COOLPROP_INSTALL_CMAKE_PACKAGE AND _export_targets)
+    install(
+      TARGETS ${_export_targets} coolprop_eigen_headers coolprop_fmt_headers
+      EXPORT CoolPropTargets
+      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+    _coolprop_install_standard_headers()
+
+    install(
+      EXPORT CoolPropTargets
+      FILE CoolPropTargets.cmake
+      NAMESPACE CoolProp::
+      DESTINATION "${COOLPROP_INSTALL_CMAKEDIR}")
+
+    set(COOLPROP_PACKAGE_HAS_STATIC "${COOLPROP_STATIC_LIBRARY}")
+    set(COOLPROP_PACKAGE_HAS_SHARED "${COOLPROP_SHARED_LIBRARY}")
+    configure_package_config_file(
+      "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CoolPropConfig.cmake.in"
+      "${CMAKE_CURRENT_BINARY_DIR}/CoolPropConfig.cmake"
+      INSTALL_DESTINATION "${COOLPROP_INSTALL_CMAKEDIR}"
+      PATH_VARS CMAKE_INSTALL_INCLUDEDIR)
+    write_basic_package_version_file(
+      "${CMAKE_CURRENT_BINARY_DIR}/CoolPropConfigVersion.cmake"
+      VERSION "${COOLPROP_VERSION_NUMERIC}"
+      COMPATIBILITY SameMajorVersion)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/CoolPropConfig.cmake"
+                  "${CMAKE_CURRENT_BINARY_DIR}/CoolPropConfigVersion.cmake"
+            DESTINATION "${COOLPROP_INSTALL_CMAKEDIR}")
+  endif()
+
+  message(STATUS "CoolProp library targets:")
+  message(STATUS "  static: ${_static_target}")
+  message(STATUS "  shared: ${_shared_target}")
+  message(STATUS "  canonical: ${_canonical_target}")
+  message(STATUS "  bitness: ${BITNESS}")
+  if(CONVENTION STREQUAL "")
+    message(STATUS "  calling convention: default")
+  else()
+    message(STATUS "  calling convention: ${CONVENTION}")
+  endif()
+endfunction()

--- a/cmake/CoolPropLibrary.cmake
+++ b/cmake/CoolPropLibrary.cmake
@@ -474,8 +474,14 @@ function(coolprop_add_library_targets)
       NAMESPACE CoolProp::
       DESTINATION "${COOLPROP_INSTALL_CMAKEDIR}")
 
-    set(COOLPROP_PACKAGE_HAS_STATIC "${COOLPROP_STATIC_LIBRARY}")
-    set(COOLPROP_PACKAGE_HAS_SHARED "${COOLPROP_SHARED_LIBRARY}")
+    set(COOLPROP_PACKAGE_HAS_STATIC OFF)
+    set(COOLPROP_PACKAGE_HAS_SHARED OFF)
+    if(_static_target)
+      set(COOLPROP_PACKAGE_HAS_STATIC ON)
+    endif()
+    if(_shared_target)
+      set(COOLPROP_PACKAGE_HAS_SHARED ON)
+    endif()
     configure_package_config_file(
       "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CoolPropConfig.cmake.in"
       "${CMAKE_CURRENT_BINARY_DIR}/CoolPropConfig.cmake"

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -3,10 +3,9 @@
 # to share the download cache across git worktrees and build directories.
 # Without a stable cache location, FetchContent re-runs on every cmake configure,
 # touching header timestamps and forcing a complete C++ rebuild each time.
-if(NOT CPM_SOURCE_CACHE AND "$ENV{CPM_SOURCE_CACHE}" STREQUAL "")
-  set(CPM_SOURCE_CACHE
-      "${CMAKE_CURRENT_LIST_DIR}/../.cpm_cache"
-      CACHE PATH "CPM source cache" FORCE)
+if(NOT DEFINED CPM_SOURCE_CACHE AND "$ENV{CPM_SOURCE_CACHE}" STREQUAL "")
+  set(CPM_SOURCE_CACHE "${CMAKE_CURRENT_LIST_DIR}/../.cpm_cache"
+      CACHE PATH "CPM source cache")
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/CPM.cmake")

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -3,8 +3,10 @@
 # to share the download cache across git worktrees and build directories.
 # Without a stable cache location, FetchContent re-runs on every cmake configure,
 # touching header timestamps and forcing a complete C++ rebuild each time.
-if(NOT DEFINED CPM_SOURCE_CACHE AND "$ENV{CPM_SOURCE_CACHE}" STREQUAL "")
-  set(CPM_SOURCE_CACHE "${CMAKE_CURRENT_LIST_DIR}/../.cpm_cache" CACHE PATH "CPM source cache")
+if(NOT CPM_SOURCE_CACHE AND "$ENV{CPM_SOURCE_CACHE}" STREQUAL "")
+  set(CPM_SOURCE_CACHE
+      "${CMAKE_CURRENT_LIST_DIR}/../.cpm_cache"
+      CACHE PATH "CPM source cache" FORCE)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/CPM.cmake")

--- a/dev/ci/check-installed-headers.sh
+++ b/dev/ci/check-installed-headers.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Fail if forbidden internal headers are shipped in the installed tree.
 #
-# Two assertions:
+# Three assertions:
 #
 #  1. detail/json.h must NOT ship.  That header #includes nlohmann/json.hpp
 #     and valijson; it is internal-only and is excluded by CMake's install
@@ -81,11 +81,13 @@ if [ -n "$LEAKING_INCLUDES" ]; then
     exit 1
 fi
 
-# Assertion 3: every installed header must compile STANDALONE.  This catches the
-# general non-self-contained case the grep above cannot -- e.g. a shipped header
-# that #includes a non-installed header by some other path (the old
+# Assertion 3: every installed CoolProp-owned header must compile STANDALONE.
+# Vendored third-party headers are intentionally excluded: their internal
+# headers are not part of CoolProp's self-containedness contract.  This catches
+# the general non-self-contained case the grep above cannot -- e.g. a shipped
+# header that #includes a non-installed header by some other path (the old
 # detail/msgpack.h pulling msgpack.hpp slipped past the nlohmann/valijson grep).
-# Compile each installed *.h as its own translation unit.  The installed surface
+# Compile each CoolProp-owned *.h as its own translation unit.  That surface
 # depends only on Eigen (the fluids/numerics/superancillary tiers) and on fmt
 # unless NO_FMTLIB is defined; resolve Eigen from the build's CPM cache and
 # define NO_FMTLIB so fmt is not required.  Boost is deliberately NOT on the
@@ -103,16 +105,22 @@ if [ -z "$EIGEN_DIR" ] || [ ! -d "$EIGEN_DIR" ]; then
     echo "FAIL: could not resolve the Eigen include dir from $CACHE -- cannot run the self-containedness check (fail-closed)." >&2
     exit 1
 fi
-INC_ROOT="$(find "$PREFIX" -path '*/include/CoolProp/CoolProp.h' | head -1)"
-INC_ROOT="${INC_ROOT%/CoolProp/CoolProp.h}"
-if [ -z "$INC_ROOT" ] || [ ! -d "$INC_ROOT" ]; then
-    echo "FAIL: could not locate the installed include root (no CoolProp/CoolProp.h) -- cannot validate self-containedness." >&2
+INSTALL_INCLUDEDIR="$(sed -n 's/^CMAKE_INSTALL_INCLUDEDIR:[^=]*=//p' "$CACHE" | head -1)"
+if [ -z "$INSTALL_INCLUDEDIR" ]; then
+    echo "FAIL: could not resolve CMAKE_INSTALL_INCLUDEDIR from $CACHE -- cannot select the canonical package include root." >&2
+    exit 1
+fi
+INC_ROOT="$PREFIX/$INSTALL_INCLUDEDIR"
+if [ ! -f "$INC_ROOT/CoolProp/CoolProp.h" ]; then
+    echo "FAIL: canonical installed header $INC_ROOT/CoolProp/CoolProp.h is missing -- cannot validate self-containedness." >&2
     exit 1
 fi
 SC_LOG=/tmp/installed-headers-selfcontained.log
 : >"$SC_LOG"
 SC_FAIL=0
+SC_HEADERS=0
 while IFS= read -r hdr; do
+    SC_HEADERS=$((SC_HEADERS + 1))
     rel="${hdr#"$INC_ROOT"/}"
     if ! printf '#include "%s"\n' "$rel" | "$CXX_BIN" -std=c++17 -fsyntax-only \
             -DNO_FMTLIB -DCOOLPROP_NO_DEPRECATED_HEADER_WARNINGS \
@@ -120,7 +128,11 @@ while IFS= read -r hdr; do
         echo "FAIL: installed header is not self-contained: $rel" >&2
         SC_FAIL=$((SC_FAIL + 1))
     fi
-done < <(find "$INC_ROOT" -name '*.h')
+done < <(find "$INC_ROOT" -path "$INC_ROOT/CoolProp/third_party" -prune -o -type f -name '*.h' -print)
+if [ "$SC_HEADERS" -eq 0 ]; then
+    echo "FAIL: canonical include root $INC_ROOT contains no CoolProp-owned headers -- cannot validate self-containedness." >&2
+    exit 1
+fi
 if [ "$SC_FAIL" -ne 0 ]; then
     echo "FAIL: $SC_FAIL installed header(s) do not compile standalone (see $SC_LOG)." >&2
     echo "      A shipped header that #includes a non-installed header (internal or third-party)" >&2
@@ -128,4 +140,4 @@ if [ "$SC_FAIL" -ne 0 ]; then
     exit 1
 fi
 
-echo "OK: internal json/msgpack headers not installed; no shipped header pulls nlohmann/valijson/msgpack/boost; all ${NHEADERS} installed headers compile standalone (-DNO_FMTLIB, Eigen-only on the path) from ${BUILD_DIR}"
+echo "OK: internal json/msgpack headers not installed; no shipped header pulls nlohmann/valijson/msgpack/boost; all ${SC_HEADERS} CoolProp-owned installed headers compile standalone (-DNO_FMTLIB, Eigen-only on the path) from ${BUILD_DIR}"

--- a/dev/ci/cmake-consumer/CMakeLists.txt
+++ b/dev/ci/cmake-consumer/CMakeLists.txt
@@ -52,6 +52,10 @@ if(COOLPROP_SOURCE_DIR)
   set(CMAKE_INSTALL_PREFIX
       "${_coolprop_prefix_sentinel}"
       CACHE PATH "Consumer install prefix" FORCE)
+  set(COOLPROP_INSTALL_PREFIX
+      "${CMAKE_CURRENT_BINARY_DIR}/ignored-coolprop-install-prefix"
+      CACHE PATH "Legacy CoolProp install prefix that nested builds must ignore"
+            FORCE)
   set(COOLPROP_STATIC_LIBRARY ON CACHE BOOL "" FORCE)
   set(COOLPROP_SHARED_LIBRARY OFF CACHE BOOL "" FORCE)
   set(COOLPROP_OBJECT_LIBRARY OFF CACHE BOOL "" FORCE)
@@ -63,6 +67,15 @@ if(COOLPROP_SOURCE_DIR)
     message(
       FATAL_ERROR
         "CoolProp changed its parent project's CMAKE_INSTALL_PREFIX from '${_coolprop_prefix_sentinel}' to '${CMAKE_INSTALL_PREFIX}'"
+    )
+  endif()
+  get_property(_coolprop_cached_install_prefix CACHE CMAKE_INSTALL_PREFIX
+               PROPERTY VALUE)
+  if(NOT "${_coolprop_cached_install_prefix}" STREQUAL
+     "${_coolprop_prefix_sentinel}")
+    message(
+      FATAL_ERROR
+        "CoolProp changed the cached parent CMAKE_INSTALL_PREFIX from '${_coolprop_prefix_sentinel}' to '${_coolprop_cached_install_prefix}'"
     )
   endif()
   if(COOLPROP_INSTALL_LEGACY_LAYOUT)

--- a/dev/ci/cmake-consumer/CMakeLists.txt
+++ b/dev/ci/cmake-consumer/CMakeLists.txt
@@ -73,7 +73,7 @@ if(COOLPROP_SOURCE_DIR)
   endif()
 
   if(MSVC AND NOT CMAKE_MSVC_RUNTIME_LIBRARY_DEFAULT)
-    get_target_property(_coolprop_source_compile_options CoolProp
+    get_target_property(_coolprop_source_compile_options CoolProp::Static
                         COMPILE_OPTIONS)
     string(FIND "${_coolprop_source_compile_options}" "/MD"
                 _coolprop_msvc_runtime_index)

--- a/dev/ci/cmake-consumer/CMakeLists.txt
+++ b/dev/ci/cmake-consumer/CMakeLists.txt
@@ -1,0 +1,263 @@
+cmake_minimum_required(VERSION 3.14)
+
+option(COOLPROP_C_ONLY "Configure a consumer with no C++ compiler enabled" OFF)
+if(COOLPROP_C_ONLY)
+  project(CoolPropCMakeConsumerSmoke LANGUAGES C)
+else()
+  project(CoolPropCMakeConsumerSmoke LANGUAGES C CXX)
+endif()
+
+# Keep the consumer deliberately below CoolProp's public C++ requirement.  A
+# correctly exported CoolProp target must promote the C++ smoke executable to
+# C++17 through its INTERFACE_COMPILE_FEATURES usage requirement.
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+if(NOT COOLPROP_C_ONLY)
+  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
+set(
+  COOLPROP_EXPECTED_LINKAGE
+  ""
+  CACHE STRING "Expected installed CoolProp linkage: STATIC, SHARED, or empty")
+set_property(CACHE COOLPROP_EXPECTED_LINKAGE PROPERTY STRINGS "" STATIC SHARED)
+string(TOUPPER "${COOLPROP_EXPECTED_LINKAGE}" _coolprop_expected_linkage)
+
+set(COOLPROP_SOURCE_DIR "" CACHE PATH
+    "Optional CoolProp checkout to consume with add_subdirectory")
+
+if(NOT _coolprop_expected_linkage STREQUAL ""
+   AND NOT _coolprop_expected_linkage STREQUAL "STATIC"
+   AND NOT _coolprop_expected_linkage STREQUAL "SHARED")
+  message(
+    FATAL_ERROR
+      "COOLPROP_EXPECTED_LINKAGE must be STATIC, SHARED, or empty; got '${COOLPROP_EXPECTED_LINKAGE}'"
+  )
+endif()
+
+if(COOLPROP_C_ONLY AND NOT _coolprop_expected_linkage STREQUAL "SHARED")
+  message(
+    FATAL_ERROR
+      "COOLPROP_C_ONLY exercises the portable shared-library C ABI and requires COOLPROP_EXPECTED_LINKAGE=SHARED"
+  )
+endif()
+
+if(COOLPROP_SOURCE_DIR)
+  get_filename_component(_coolprop_source_dir "${COOLPROP_SOURCE_DIR}" ABSOLUTE)
+  set(_coolprop_prefix_sentinel
+      "${CMAKE_CURRENT_BINARY_DIR}/parent-install-prefix")
+  set(CMAKE_INSTALL_PREFIX
+      "${_coolprop_prefix_sentinel}"
+      CACHE PATH "Consumer install prefix" FORCE)
+  set(COOLPROP_STATIC_LIBRARY ON CACHE BOOL "" FORCE)
+  set(COOLPROP_SHARED_LIBRARY OFF CACHE BOOL "" FORCE)
+  set(COOLPROP_OBJECT_LIBRARY OFF CACHE BOOL "" FORCE)
+  set(COOLPROP_INSTALL_CMAKE_PACKAGE OFF CACHE BOOL "" FORCE)
+  add_subdirectory("${_coolprop_source_dir}"
+                   "${CMAKE_CURRENT_BINARY_DIR}/coolprop-build")
+
+  if(NOT "${CMAKE_INSTALL_PREFIX}" STREQUAL "${_coolprop_prefix_sentinel}")
+    message(
+      FATAL_ERROR
+        "CoolProp changed its parent project's CMAKE_INSTALL_PREFIX from '${_coolprop_prefix_sentinel}' to '${CMAKE_INSTALL_PREFIX}'"
+    )
+  endif()
+  if(COOLPROP_INSTALL_LEGACY_LAYOUT)
+    message(
+      FATAL_ERROR
+        "CoolProp enabled its legacy release install layout inside a parent project"
+    )
+  endif()
+
+  if(MSVC AND NOT CMAKE_MSVC_RUNTIME_LIBRARY_DEFAULT)
+    get_target_property(_coolprop_source_compile_options CoolProp
+                        COMPILE_OPTIONS)
+    string(FIND "${_coolprop_source_compile_options}" "/MD"
+                _coolprop_msvc_runtime_index)
+    if(_coolprop_msvc_runtime_index EQUAL -1)
+      message(
+        FATAL_ERROR
+          "CoolProp did not provide a target-local MSVC runtime fallback for a CMP0091-OLD parent"
+      )
+    endif()
+  endif()
+
+  set(_coolprop_required_variant_targets CoolProp::Static)
+else()
+  if(_coolprop_expected_linkage STREQUAL "STATIC")
+    find_package(CoolProp 8 CONFIG REQUIRED COMPONENTS Static)
+    set(_coolprop_required_variant_targets CoolProp::Static)
+  elseif(_coolprop_expected_linkage STREQUAL "SHARED")
+    find_package(CoolProp 8 CONFIG REQUIRED COMPONENTS Shared)
+    set(_coolprop_required_variant_targets CoolProp::Shared)
+  else()
+    find_package(CoolProp 8 CONFIG REQUIRED COMPONENTS Static Shared)
+    set(_coolprop_required_variant_targets CoolProp::Static CoolProp::Shared)
+  endif()
+endif()
+
+if(NOT TARGET CoolProp::CoolProp)
+  message(
+    FATAL_ERROR
+      "The installed CoolProp package did not define the canonical CoolProp::CoolProp target"
+  )
+endif()
+
+foreach(_coolprop_required_target IN LISTS _coolprop_required_variant_targets)
+  if(NOT TARGET "${_coolprop_required_target}")
+    message(
+      FATAL_ERROR
+        "The CoolProp package reported the requested component as available but did not define ${_coolprop_required_target}"
+    )
+  endif()
+endforeach()
+
+# CoolProp::CoolProp is the required public API. Link through all requested
+# linkage-specific targets too, so the documented component targets cannot
+# silently disappear.
+set(_coolprop_provider_targets CoolProp::CoolProp
+                               ${_coolprop_required_variant_targets})
+list(REMOVE_DUPLICATES _coolprop_provider_targets)
+
+enable_testing()
+
+foreach(_coolprop_provider_target IN LISTS _coolprop_provider_targets)
+  get_target_property(_coolprop_target_type "${_coolprop_provider_target}" TYPE)
+  set(_coolprop_effective_linkage "")
+
+  if(_coolprop_provider_target STREQUAL "CoolProp::Static")
+    set(_coolprop_effective_linkage STATIC)
+    if(NOT _coolprop_target_type STREQUAL "STATIC_LIBRARY"
+       AND NOT _coolprop_target_type STREQUAL "INTERFACE_LIBRARY")
+      message(
+        FATAL_ERROR
+          "CoolProp::Static exists but has incompatible type ${_coolprop_target_type}"
+      )
+    endif()
+  elseif(_coolprop_provider_target STREQUAL "CoolProp::Shared")
+    set(_coolprop_effective_linkage SHARED)
+    if(NOT _coolprop_target_type STREQUAL "SHARED_LIBRARY"
+       AND NOT _coolprop_target_type STREQUAL "INTERFACE_LIBRARY")
+      message(
+        FATAL_ERROR
+          "CoolProp::Shared exists but has incompatible type ${_coolprop_target_type}"
+      )
+    endif()
+  elseif(_coolprop_target_type STREQUAL "STATIC_LIBRARY")
+    set(_coolprop_effective_linkage STATIC)
+  elseif(_coolprop_target_type STREQUAL "SHARED_LIBRARY")
+    set(_coolprop_effective_linkage SHARED)
+  elseif(_coolprop_target_type STREQUAL "INTERFACE_LIBRARY")
+    set(_coolprop_effective_linkage "${_coolprop_expected_linkage}")
+  else()
+    message(
+      FATAL_ERROR
+        "${_coolprop_provider_target} has unsupported type ${_coolprop_target_type}"
+    )
+  endif()
+
+  # A canonical selector or single-variant compatibility target may be an
+  # INTERFACE wrapper. Resolve one level to find its actual provider type and,
+  # on Windows, the DLL that must be copied beside the smoke executable.
+  set(_coolprop_runtime_target "${_coolprop_provider_target}")
+  if(_coolprop_target_type STREQUAL "INTERFACE_LIBRARY")
+    get_target_property(
+      _coolprop_interface_links "${_coolprop_provider_target}"
+      INTERFACE_LINK_LIBRARIES)
+    foreach(_coolprop_link_candidate IN LISTS _coolprop_interface_links)
+      if(TARGET "${_coolprop_link_candidate}")
+        get_target_property(_coolprop_link_candidate_type
+                            "${_coolprop_link_candidate}" TYPE)
+        if(NOT _coolprop_link_candidate_type STREQUAL "INTERFACE_LIBRARY")
+          set(_coolprop_runtime_target "${_coolprop_link_candidate}")
+          break()
+        endif()
+      endif()
+    endforeach()
+  endif()
+
+  get_target_property(_coolprop_runtime_target_type
+                      "${_coolprop_runtime_target}" TYPE)
+  if(_coolprop_effective_linkage STREQUAL "")
+    if(_coolprop_runtime_target_type STREQUAL "STATIC_LIBRARY")
+      set(_coolprop_effective_linkage STATIC)
+    elseif(_coolprop_runtime_target_type STREQUAL "SHARED_LIBRARY")
+      set(_coolprop_effective_linkage SHARED)
+    endif()
+  endif()
+
+  if(_coolprop_provider_target STREQUAL "CoolProp::CoolProp"
+     AND _coolprop_expected_linkage STREQUAL "STATIC"
+     AND NOT _coolprop_effective_linkage STREQUAL "STATIC")
+    message(
+      FATAL_ERROR
+        "Expected a static CoolProp package, but CoolProp::CoolProp has type ${_coolprop_target_type}"
+    )
+  endif()
+  if(_coolprop_provider_target STREQUAL "CoolProp::CoolProp"
+     AND _coolprop_expected_linkage STREQUAL "SHARED"
+     AND NOT _coolprop_effective_linkage STREQUAL "SHARED")
+    message(
+      FATAL_ERROR
+        "Expected a shared CoolProp package, but CoolProp::CoolProp has type ${_coolprop_target_type}"
+    )
+  endif()
+
+  string(REPLACE "::" "_" _coolprop_target_id "${_coolprop_provider_target}")
+  string(TOLOWER "${_coolprop_target_id}" _coolprop_target_id)
+
+  set(_coolprop_c_executable "coolprop_c_smoke_${_coolprop_target_id}")
+  if(_coolprop_effective_linkage STREQUAL "STATIC")
+    set(_coolprop_c_api_source c_api_cpp.cpp)
+  else()
+    set(_coolprop_c_api_source c_api.c)
+  endif()
+  add_executable("${_coolprop_c_executable}" "${_coolprop_c_api_source}")
+  target_link_libraries("${_coolprop_c_executable}" PRIVATE
+                        "${_coolprop_provider_target}")
+
+  set(_coolprop_smoke_executables "${_coolprop_c_executable}")
+  set(_coolprop_smoke_tests "${_coolprop_target_id}.c-api")
+  add_test(NAME "${_coolprop_target_id}.c-api"
+           COMMAND "${_coolprop_c_executable}")
+
+  # The shared library's portable contract is the C ABI in CoolPropLib.h.
+  # Its C++ symbols are not exported on every platform (notably Windows), so
+  # exercise the documented C++ API only for an installed static archive.
+  if(_coolprop_effective_linkage STREQUAL "STATIC" AND NOT COOLPROP_C_ONLY)
+    set(_coolprop_cxx_executable "coolprop_cxx_smoke_${_coolprop_target_id}")
+    add_executable("${_coolprop_cxx_executable}" cpp_api.cpp)
+    target_link_libraries("${_coolprop_cxx_executable}" PRIVATE
+                          "${_coolprop_provider_target}")
+    list(APPEND _coolprop_smoke_executables "${_coolprop_cxx_executable}")
+    list(APPEND _coolprop_smoke_tests "${_coolprop_target_id}.cxx-api")
+    add_test(NAME "${_coolprop_target_id}.cxx-api"
+             COMMAND "${_coolprop_cxx_executable}")
+  endif()
+
+  # Windows does not search the linked DLL's install directory at runtime.
+  # Copying TARGET_FILE is CMake-3.14-compatible.
+  if(WIN32 AND _coolprop_runtime_target_type STREQUAL "SHARED_LIBRARY")
+    foreach(_coolprop_executable IN LISTS _coolprop_smoke_executables)
+      add_custom_command(
+        TARGET "${_coolprop_executable}"
+        POST_BUILD
+        COMMAND
+          "${CMAKE_COMMAND}" -E copy_if_different
+          "$<TARGET_FILE:${_coolprop_runtime_target}>"
+          "$<TARGET_FILE_DIR:${_coolprop_executable}>"
+        VERBATIM)
+    endforeach()
+  endif()
+
+  set_tests_properties(${_coolprop_smoke_tests}
+                       PROPERTIES LABELS "cmake-consumer")
+
+  message(
+    STATUS
+      "Testing ${_coolprop_provider_target} (${_coolprop_target_type}, ${_coolprop_effective_linkage})"
+  )
+endforeach()

--- a/dev/ci/cmake-consumer/c_api.c
+++ b/dev/ci/cmake-consumer/c_api.c
@@ -1,0 +1,16 @@
+#include <CoolProp/CoolPropLib.h>
+
+#include <math.h>
+#include <stdio.h>
+
+int main(void) {
+    const double temperature = PropsSI("T", "P", 101325.0, "Q", 0.0, "Water");
+
+    if (!isfinite(temperature) || temperature < 350.0 || temperature > 400.0) {
+        fprintf(stderr, "CoolProp C API returned an invalid boiling temperature: %.17g K\n", temperature);
+        return 1;
+    }
+
+    printf("CoolProp C API water boiling temperature: %.12g K\n", temperature);
+    return 0;
+}

--- a/dev/ci/cmake-consumer/c_api_cpp.cpp
+++ b/dev/ci/cmake-consumer/c_api_cpp.cpp
@@ -1,0 +1,16 @@
+#include <CoolProp/CoolPropLib.h>
+
+#include <cmath>
+#include <cstdio>
+
+int main() {
+    const double temperature = PropsSI("T", "P", 101325.0, "Q", 0.0, "Water");
+
+    if (!std::isfinite(temperature) || temperature < 350.0 || temperature > 400.0) {
+        std::fprintf(stderr, "CoolProp static C wrapper returned an invalid boiling temperature: %.17g K\n", temperature);
+        return 1;
+    }
+
+    std::printf("CoolProp static C wrapper water boiling temperature: %.12g K\n", temperature);
+    return 0;
+}

--- a/dev/ci/cmake-consumer/cpp_api.cpp
+++ b/dev/ci/cmake-consumer/cpp_api.cpp
@@ -1,4 +1,5 @@
 #include <CoolProp/CoolProp.h>
+// Intentionally unused: verifies nested installed headers and transitive Eigen includes.
 #include <CoolProp/numerics/PolyMath.h>
 
 #include <cmath>

--- a/dev/ci/cmake-consumer/cpp_api.cpp
+++ b/dev/ci/cmake-consumer/cpp_api.cpp
@@ -1,0 +1,20 @@
+#include <CoolProp/CoolProp.h>
+#include <CoolProp/numerics/PolyMath.h>
+
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+int main() {
+    constexpr std::string_view output = "T";
+    const double temperature = CoolProp::PropsSI(std::string(output), "P", 101325.0, "Q", 0.0, "Water");
+
+    if (!std::isfinite(temperature) || temperature < 350.0 || temperature > 400.0) {
+        std::cerr << "CoolProp C++ API returned an invalid boiling temperature: " << temperature << " K\n";
+        return 1;
+    }
+
+    std::cout << "CoolProp C++ API water boiling temperature: " << temperature << " K\n";
+    return 0;
+}

--- a/include/CoolProp/CoolPropLib.h
+++ b/include/CoolProp/CoolPropLib.h
@@ -43,8 +43,8 @@
 #    define COOLPROP_SHARED_LIBRARY_BUILD
 #endif
 
-#if defined(__cplusplus) && \
-  (defined(COOLPROP_SHARED_LIBRARY_BUILD) || defined(COOLPROP_SHARED_LIBRARY_USE) || defined(EXTERNC) || defined(__powerpc__))
+#if defined(__cplusplus) \
+  && (defined(COOLPROP_SHARED_LIBRARY_BUILD) || defined(COOLPROP_SHARED_LIBRARY_USE) || defined(EXTERNC) || defined(__powerpc__))
 #    define COOLPROP_EXTERN_C extern "C"
 #else
 #    define COOLPROP_EXTERN_C

--- a/include/CoolProp/CoolPropLib.h
+++ b/include/CoolProp/CoolPropLib.h
@@ -9,7 +9,9 @@
  * EXPORT_CODE void CONVENTION AFunction(double, double);
  * will be exported to the DLL
  *
- * The exact symbol that will be exported depends on the values of the preprocessor macros COOLPROP_LIB, EXPORT_CODE, CONVENTION, etc.
+ * The exact symbol that will be exported depends on the values of the
+ * preprocessor macros COOLPROP_SHARED_LIBRARY_BUILD,
+ * COOLPROP_SHARED_LIBRARY_USE, EXPORT_CODE, CONVENTION, etc.
  *
  * In order to have 100% control over the export macros, you can specify EXPORT_CODE and CONVENTION directly. Check out
  * CMakeLists.txt in the repo root to see some examples.
@@ -35,42 +37,50 @@
 #    pragma error
 #endif
 
-#if defined(COOLPROP_LIB)
-#    ifndef EXPORT_CODE
-#        if defined(__ISWINDOWS__)
-#            define EXPORT_CODE extern "C" __declspec(dllexport)
-#        else
-#            define EXPORT_CODE extern "C"
-#        endif
-#    endif
-#    ifndef CONVENTION
-#        if defined(__ISWINDOWS__)
-#            define CONVENTION __stdcall
-#        else
-#            define CONVENTION
-#        endif
-#    endif
+// Backwards compatibility: COOLPROP_LIB historically selected producer-side
+// DLL exports. New CMake consumers receive the unambiguous BUILD/USE macros.
+#if defined(COOLPROP_LIB) && !defined(COOLPROP_SHARED_LIBRARY_BUILD) && !defined(COOLPROP_SHARED_LIBRARY_USE)
+#    define COOLPROP_SHARED_LIBRARY_BUILD
+#endif
+
+#if defined(__cplusplus) && \
+  (defined(COOLPROP_SHARED_LIBRARY_BUILD) || defined(COOLPROP_SHARED_LIBRARY_USE) || defined(EXTERNC) || defined(__powerpc__))
+#    define COOLPROP_EXTERN_C extern "C"
 #else
-#    ifndef EXPORT_CODE
-#        define EXPORT_CODE
+#    define COOLPROP_EXTERN_C
+#endif
+
+#ifndef COOLPROP_SYMBOL_VISIBILITY
+#    if defined(__ISWINDOWS__) && defined(COOLPROP_SHARED_LIBRARY_USE)
+#        define COOLPROP_SYMBOL_VISIBILITY __declspec(dllimport)
+#    elif defined(__ISWINDOWS__) && defined(COOLPROP_SHARED_LIBRARY_BUILD)
+#        define COOLPROP_SYMBOL_VISIBILITY __declspec(dllexport)
+#    else
+#        define COOLPROP_SYMBOL_VISIBILITY
 #    endif
-#    ifndef CONVENTION
+#endif
+
+#ifndef EXPORT_CODE
+#    define EXPORT_CODE COOLPROP_EXTERN_C COOLPROP_SYMBOL_VISIBILITY
+#endif
+
+#ifndef CONVENTION
+#    if defined(__ISWINDOWS__) && (defined(COOLPROP_SHARED_LIBRARY_BUILD) || defined(COOLPROP_SHARED_LIBRARY_USE))
+#        define CONVENTION __stdcall
+#    else
 #        define CONVENTION
 #    endif
 #endif
 
 #ifndef __cplusplus
-#    if defined(__STDC_VERSION__)
-#        if (__STDC_VERSION__ >= 199901L)
-#            include <stdbool.h>
-#        endif
-#    endif
+#    include <stdbool.h>
 #endif
 
-// Hack for PowerPC compilation to only use extern "C"
+// Keep the legacy overrides while retaining the correct producer/consumer
+// visibility decoration selected above.
 #if defined(__powerpc__) || defined(EXTERNC)
 #    undef EXPORT_CODE
-#    define EXPORT_CODE extern "C"
+#    define EXPORT_CODE COOLPROP_EXTERN_C COOLPROP_SYMBOL_VISIBILITY
 #endif
 
 #if defined(__powerpc__)

--- a/include/CoolProp/CoolPropLib.h
+++ b/include/CoolProp/CoolPropLib.h
@@ -76,13 +76,6 @@
 #    include <stdbool.h>
 #endif
 
-// Keep the legacy overrides while retaining the correct producer/consumer
-// visibility decoration selected above.
-#if defined(__powerpc__) || defined(EXTERNC)
-#    undef EXPORT_CODE
-#    define EXPORT_CODE COOLPROP_EXTERN_C COOLPROP_SYMBOL_VISIBILITY
-#endif
-
 #if defined(__powerpc__)
 // From https://rowley.zendesk.com/entries/46176--Undefined-reference-to-assert-error-message
 // The __assert function is an error handler function that is invoked when an assertion fails.

--- a/include/CoolProp/CoolPropLib.h
+++ b/include/CoolProp/CoolPropLib.h
@@ -73,7 +73,9 @@
 #endif
 
 #ifndef __cplusplus
-#    include <stdbool.h>
+#    if (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)) || (defined(_MSC_VER) && (_MSC_VER >= 1800))
+#        include <stdbool.h>
+#    endif
 #endif
 
 #if defined(__powerpc__)


### PR DESCRIPTION
## Summary

- Add an installable and relocatable CMake package
- Provide `CoolProp::CoolProp`, `CoolProp::Static`, and `CoolProp::Shared`
- Support building static and shared libraries simultaneously
- Preserve compatibility with existing single-library builds
- Avoid modifying a parent project's install prefix
- Add downstream C and C++ consumer tests
- Extend CI coverage for installed packages and relocated prefixes
- Document the CMake behavior and compatibility changes in the changelog

## Validation

- Built static and shared libraries together in MSVC Debug with
  `COOLPROP_MSVC_DEBUG=OFF`; verified `/MDd` for Static and `/MTd` for Shared
- Installed the Debug package and compiled/linked downstream C and C++
  consumers through the canonical, Static, and Shared targets
- Ran the installed shared-library C API smoke test successfully
- Verified mandatory Eigen and fmt license installation
- Verified that a shared-only package does not impose Threads on consumers,
  while the static export retains its link dependency
- Verified default and explicitly disabled `CPM_SOURCE_CACHE` behavior
- Parsed the updated workflow YAML and ran clang-format 18.1.8 plus
  `git diff --check`
- Confirmed that this PR contains no teqp/autodiff additions

## AI assistance and verification process

OpenAI Codex materially assisted with the CMake package design, implementation,
consumer fixtures, CI changes, documentation, and review follow-ups. Codex and
the repository's automated tooling performed the local verification listed
above in the contributor's workspace. Tobias Reiter remains responsible for
the submitted changes and has confirmed the project CLA. Every AI-shaped
commit also carries the required `Co-authored-by` trailer.

## CI note

The GUI workflow is path-triggered by changes to `CMakeLists.txt` and
`cmake/**`, so it runs for this CMake PR. Fork pull requests cannot receive the
updater-signing secrets: the previous jobs built the installers successfully
and then failed while signing updater artifacts. The workflow change disables
only updater artifacts for pull requests; trusted push and tag builds retain
the signed updater path.

Closes #2144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added relocatable CMake packages for installed CoolProp libraries.
  * Added flexible static and shared builds with selectable linkage targets.
  * Added source-tree and installed-package integration for C and C++ projects.
  * Improved Windows build support, including calling conventions and architecture-specific configurations.

* **Documentation**
  * Added CMake build, installation, integration, and linking guidance.
  * Documented the CMake 3.15 requirement and updated packaging behavior.

* **Tests**
  * Added validation for package contents, relocatability, linkage, consumer projects, and C/C++ API usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
