### PR TITLE
fix(ci): preflight clang-format and build gates could never fail

### DIFF
--- a/dev/ci/preflight.sh
+++ b/dev/ci/preflight.sh
@@ -135,12 +135,24 @@ else
     # existed and the gate reported PASS.  With no violations clang-format
     # exits 0 but grep finds nothing and exits 1 -- also false, also PASS.
     # Both branches led to PASS, so the gate could never fail.
-    CF_OUT="$(uvx clang-format@"$CF_VER" --dry-run --Werror $ALL_CPP 2>&1 || true)"
-    if [ -n "$CF_OUT" ]; then
+    # ALL_CPP is a newline-separated scalar; read it into an array so paths
+    # containing spaces or glob characters survive as single arguments.
+    CF_FILES=()
+    while IFS= read -r _f; do
+        [ -n "$_f" ] && CF_FILES+=("$_f")
+    done <<< "$ALL_CPP"
+
+    # Branch on clang-format's EXIT STATUS, not on whether it printed
+    # anything.  uvx writes progress to stderr on a cold cache
+    # ("Downloading clang-format (1.3MiB)"), which 2>&1 captures, so a
+    # non-empty-output test reports a formatting failure on a clean tree
+    # the first time preflight runs on any machine.
+    CF_OUT="$(uvx clang-format@"$CF_VER" --dry-run --Werror "${CF_FILES[@]}" 2>&1)" && CF_RC=0 || CF_RC=$?
+    if [ "$CF_RC" -ne 0 ]; then
         printf '%s\n' "$CF_OUT" | head -20
         fail "clang-format (run: uvx clang-format@$CF_VER -i <files>)"
     else
-        ok "clang-format ($CF_VER, $(printf '%s\n' "$ALL_CPP" | wc -l | tr -d ' ') file(s))"
+        ok "clang-format ($CF_VER, ${#CF_FILES[@]} file(s))"
     fi
 fi
 

--- a/dev/ci/preflight.sh
+++ b/dev/ci/preflight.sh
@@ -126,8 +126,18 @@ else
         CF_VER="18.1.8"
     fi
     # uvx caches the binary; first invocation downloads, subsequent are
-    # ~instant.  --dry-run --Werror returns non-zero on any reformatting.
-    if uvx clang-format@"$CF_VER" --dry-run --Werror $ALL_CPP 2>&1 | grep -q .; then
+    # ~instant.  --dry-run --Werror prints one diagnostic per violation AND
+    # exits non-zero.
+    #
+    # Capture the output and test that, rather than piping into `grep -q`:
+    # under `set -o pipefail` (line 35) the pipeline inherits clang-format's
+    # non-zero exit, so `if <pipeline>` was false exactly when violations
+    # existed and the gate reported PASS.  With no violations clang-format
+    # exits 0 but grep finds nothing and exits 1 -- also false, also PASS.
+    # Both branches led to PASS, so the gate could never fail.
+    CF_OUT="$(uvx clang-format@"$CF_VER" --dry-run --Werror $ALL_CPP 2>&1 || true)"
+    if [ -n "$CF_OUT" ]; then
+        printf '%s\n' "$CF_OUT" | head -20
         fail "clang-format (run: uvx clang-format@$CF_VER -i <files>)"
     else
         ok "clang-format ($CF_VER, $(printf '%s\n' "$ALL_CPP" | wc -l | tr -d ' ') file(s))"
@@ -146,10 +156,17 @@ elif [ ! -d build_catch ]; then
     }
 fi
 if ! skip_check build && [ -d build_catch ]; then
-    if cmake --build build_catch --target CatchTestRunner -j8 2>&1 | tee /tmp/preflight-build.log | tail -5 | grep -qE "error:|FAILED"; then
-        fail "build (see /tmp/preflight-build.log)"
-    else
+    # Test cmake's own exit status.  The previous form piped the build log
+    # through `tee | tail -5 | grep -qE "error:|FAILED"` under `set -o
+    # pipefail`: a failing build made the pipeline non-zero, so `if
+    # <pipeline>` was false and the gate reported the build as PASSING.
+    # Grepping the last 5 lines was independently unreliable -- a link
+    # error, an OOM kill or a cmake usage error need not print "error:".
+    if cmake --build build_catch --target CatchTestRunner -j8 >/tmp/preflight-build.log 2>&1; then
         ok "build CatchTestRunner"
+    else
+        tail -20 /tmp/preflight-build.log
+        fail "build (see /tmp/preflight-build.log)"
     fi
 fi
 


### PR DESCRIPTION
`dev/ci/preflight.sh` runs under `set -euo pipefail` (line 35). Two gates tested a **pipeline** whose first command exits non-zero exactly when the check should fail. pipefail propagates that non-zero status to the whole pipeline, so the `if` was false and control fell to the `else` (success) branch.

Neither gate could report a failure.

## clang-format (line 130)

```bash
if uvx clang-format@"$CF_VER" --dry-run --Werror $ALL_CPP 2>&1 | grep -q .; then
    fail "clang-format ..."
else
    ok "clang-format ..."
fi
```

`--Werror` makes clang-format exit non-zero precisely when there are violations.

| | clang-format | grep -q | pipeline (pipefail) | branch |
|---|---|---|---|---|
| violations | **non-zero** | 0 | **non-zero** | else → **PASS** |
| clean | 0 | 1 | 1 | else → PASS |

Both paths report PASS.

## build (line 149)

```bash
if cmake --build build_catch --target CatchTestRunner -j8 2>&1 | tee ... | tail -5 | grep -qE "error:|FAILED"; then
```

A failing build exits non-zero → pipeline non-zero → else → **the build is reported as passing**. Grepping the last five lines was independently unreliable: a link error, an OOM kill or a cmake usage error need not print `error:` or `FAILED` at all.

## Observed impact

On #3309, preflight reported `✓ clang-format (18.1.8, 13 file(s))` on **every** run against a tree that CI's `clang-format (PR diff)` job then rejected for two files. That is what prompted this.

This matters beyond one PR: `CLAUDE.md` tells contributors that "if preflight passes, CI should pass with high probability," and the pre-push hook runs the same script. For the two most basic questions a gate can ask — *does it compile* and *is it formatted* — the answer has been unconditionally yes.

## The fix

Capture, then test. The build gate now checks cmake's own exit status rather than pattern-matching its log.

The clang-format gate also **prints the violations it found**. The old form piped them into `grep -q`, which discards stdout, so even a hypothetical failure told you nothing about what or where.

## Verification

- **clang-format, end to end.** With a deliberately misformatted function appended to `src/AbstractState.cpp`, preflight now exits 1, reports `✗ clang-format` and prints the diagnostics. With canonically formatted code (run through `clang-format -i` first, so it is genuinely canonical rather than my guess) it reports `✓`.
- **build gate**, against stubbed cmake exits under the same `set -euo pipefail`:

  | | good build | broken build |
  |---|---|---|
  | old | ok | **ok** ← false pass |
  | new | ok | **fail** |

  A real broken-build run was not exercised, as it requires deliberately breaking the tree and a full rebuild; the change is a direct exit-status test replacing a log grep.
- **No hidden backlog.** A pristine checkout has zero clang-format violations, so re-enabling the gate does not suddenly fail unrelated work.

## Scope

Only the pipefail inversion. The tag-selection greps at lines 247/252/458/493 pipe from `printf`, which always exits 0, so they are unaffected and untouched.

Deliberately **not** included, each filed separately:

- `build_catch` / `build_shared` are guarded on directory existence rather than cache validity, so a configure that fails after cmake creates the directory leaves the gate permanently failing (`CoolProp-bvdb`)
- gate detail logs use fixed `/tmp/preflight-*.log` paths shared across worktrees, so a failing gate can cite another branch's log (`CoolProp-5j35`)
- the `build_catch` auto-configure omits `-DCMAKE_BUILD_TYPE=Release`, which `CLAUDE.md` calls mandatory

Closes `CoolProp-onfy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting validation to reliably detect and report diagnostics.
  * Improved test-runner build failure detection and reporting.
  * Build errors now include the final lines of relevant output for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->