### PR TITLE
Add multitherm pg1

### DIFF
--- a/CoolPropBibTeXLibrary.bib
+++ b/CoolPropBibTeXLibrary.bib
@@ -3433,6 +3433,15 @@
   Timestamp                = {2014.09.22},
   Url                      = {http://paracalc.paratherm.com}
 }
+@Manual{MultiTherm2004,
+  Title                    = {{MultiTherm PG-1 Physical Properties (SI/Expanded Table, form PG-1C EXP 5/04; US units, form PG-1F EXP 5/04)}},
+  Organization             = {{MultiTherm Corporation}},
+  Year                     = {2004},
+
+  Owner                    = {MultiTherm},
+  Timestamp                = {2026.08.10},
+  Url                      = {https://www.multitherm.com}
+}
 
 @Manual{Arteco2010,
   Title                    = {{Technical Information}},

--- a/CoolPropBibTeXLibrary.bib
+++ b/CoolPropBibTeXLibrary.bib
@@ -3435,7 +3435,7 @@
 }
 @Manual{MultiTherm2004,
   Title                    = {{MultiTherm PG-1 Physical Properties (SI/Expanded Table, form PG-1C EXP 5/04; US units, form PG-1F EXP 5/04)}},
-  Organization             = {{MultiTherm Corporation}},
+  Organization             = {{MultiTherm LLC}},
   Year                     = {2004},
 
   Owner                    = {MultiTherm},

--- a/dev/incompressible_liquids/CPIncomp/PureFluids.py
+++ b/dev/incompressible_liquids/CPIncomp/PureFluids.py
@@ -628,7 +628,7 @@ class PNF(PureData):
 # MultiTherm, see https://www.multitherm.com
 class MultiThermPG1(PureData):
     """
-    Heat transfer fluid MultiTherm PG-1 by MultiTherm Corporation
+    Heat transfer fluid MultiTherm PG-1 by MultiTherm LLC
 
     MultiTherm PG-1 is an FDA-certified, USDA-acceptable, NSF HT-1 white
     mineral oil heat transfer fluid for closed-loop, liquid-phase systems,

--- a/dev/incompressible_liquids/CPIncomp/PureFluids.py
+++ b/dev/incompressible_liquids/CPIncomp/PureFluids.py
@@ -625,6 +625,44 @@ class PNF(PureData):
         self.reshapeAll()
 
 
+# MultiTherm, see https://www.multitherm.com
+class MultiThermPG1(PureData):
+    """
+    Heat transfer fluid MultiTherm PG-1 by MultiTherm Corporation
+
+    MultiTherm PG-1 is an FDA-certified, USDA-acceptable, NSF HT-1 white
+    mineral oil heat transfer fluid for closed-loop, liquid-phase systems,
+    rated to a maximum recommended operating temperature of 600 F / 316 C
+    (maximum film temperature 650 F / 343 C).
+    """
+
+    def __init__(self):
+        PureData.__init__(self)
+        self.density.source = self.density.SOURCE_DATA
+        self.specific_heat.source = self.specific_heat.SOURCE_DATA
+        self.conductivity.source = self.conductivity.SOURCE_DATA
+        self.viscosity.source = self.viscosity.SOURCE_DATA
+        self.saturation_pressure.source = self.saturation_pressure.SOURCE_DATA
+        self.temperature.data = np.array([2.431500E+2, 2.531500E+2, 2.631500E+2, 2.731500E+2, 2.831500E+2, 2.931500E+2, 3.031500E+2, 3.131500E+2, 3.231500E+2, 3.331500E+2, 3.431500E+2, 3.531500E+2, 3.631500E+2, 3.731500E+2, 3.831500E+2, 3.931500E+2, 4.031500E+2, 4.131500E+2, 4.231500E+2, 4.331500E+2, 4.431500E+2, 4.531500E+2, 4.631500E+2, 4.731500E+2, 4.831500E+2, 4.931500E+2, 5.031500E+2, 5.131500E+2, 5.231500E+2, 5.331500E+2, 5.431500E+2, 5.531500E+2, 5.631500E+2, 5.731500E+2, 5.831500E+2, 5.931500E+2, 6.031500E+2, 6.131500E+2])  # kelvin
+        self.density.data = np.array([8.940000E+2, 8.900000E+2, 8.860000E+2, 8.820000E+2, 8.770000E+2, 8.730000E+2, 8.690000E+2, 8.650000E+2, 8.610000E+2, 8.560000E+2, 8.520000E+2, 8.480000E+2, 8.440000E+2, 8.400000E+2, 8.350000E+2, 8.310000E+2, 8.270000E+2, 8.230000E+2, 8.190000E+2, 8.140000E+2, 8.100000E+2, 8.060000E+2, 8.020000E+2, 7.980000E+2, 7.940000E+2, 7.890000E+2, 7.850000E+2, 7.810000E+2, 7.770000E+2, 7.730000E+2, 7.680000E+2, 7.640000E+2, 7.600000E+2, 7.560000E+2, 7.520000E+2, 7.470000E+2, 7.430000E+2, 7.390000E+2])         # kg/m3
+        self.specific_heat.data = np.array([1.696000E+3, 1.733000E+3, 1.769000E+3, 1.805000E+3, 1.842000E+3, 1.878000E+3, 1.914000E+3, 1.951000E+3, 1.987000E+3, 2.023000E+3, 2.060000E+3, 2.096000E+3, 2.132000E+3, 2.169000E+3, 2.205000E+3, 2.241000E+3, 2.278000E+3, 2.314000E+3, 2.350000E+3, 2.387000E+3, 2.423000E+3, 2.459000E+3, 2.496000E+3, 2.532000E+3, 2.568000E+3, 2.605000E+3, 2.641000E+3, 2.677000E+3, 2.714000E+3, 2.750000E+3, 2.786000E+3, 2.823000E+3, 2.859000E+3, 2.895000E+3, 2.932000E+3, 2.968000E+3, 3.004000E+3, 3.041000E+3])   # J/kg-K
+        self.conductivity.data = np.array([1.366000E-1, 1.359000E-1, 1.352000E-1, 1.344000E-1, 1.337000E-1, 1.330000E-1, 1.323000E-1, 1.315000E-1, 1.308000E-1, 1.301000E-1, 1.294000E-1, 1.287000E-1, 1.279000E-1, 1.272000E-1, 1.265000E-1, 1.258000E-1, 1.250000E-1, 1.243000E-1, 1.236000E-1, 1.229000E-1, 1.222000E-1, 1.214000E-1, 1.207000E-1, 1.200000E-1, 1.193000E-1, 1.185000E-1, 1.178000E-1, 1.171000E-1, 1.164000E-1, 1.156000E-1, 1.149000E-1, 1.142000E-1, 1.135000E-1, 1.128000E-1, 1.120000E-1, 1.113000E-1, 1.106000E-1, 1.099000E-1])         # W/m-K
+        # Source table gives dynamic viscosity in cP (mPa-s); convert to Pa-s
+        self.viscosity.data = np.array([4.113000E+3, 1.113000E+3, 3.900000E+2, 1.630000E+2, 7.900000E+1, 4.300000E+1, 2.500000E+1, 1.600000E+1, 1.120000E+1, 8.100000E+0, 6.000000E+0, 4.600000E+0, 3.670000E+0, 2.980000E+0, 2.490000E+0, 2.090000E+0, 1.790000E+0, 1.550000E+0, 1.370000E+0, 1.210000E+0, 1.080000E+0, 9.750000E-1, 8.740000E-1, 7.980000E-1, 7.340000E-1, 6.670000E-1, 6.180000E-1, 5.720000E-1, 5.280000E-1, 4.940000E-1, 4.560000E-1, 4.290000E-1, 4.010000E-1, 3.750000E-1, 3.530000E-1, 3.320000E-1, 3.140000E-1, 2.970000E-1]) * 1.E-3        # Pa-s
+        # Vapor pressure only published for T >= 110 C; NaN elsewhere (matches
+        # the pattern CoolProp uses for partially-populated data columns, e.g.
+        # LiquidSodium's specific_heat/viscosity arrays in this same file).
+        # Source values given in hPa, converted to Pa (x100).
+        self.saturation_pressure.data = np.array([np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 1.100000E+1, 1.900000E+1, np.nan, 5.600000E+1, 9.300000E+1, 1.500000E+2, np.nan, 3.700000E+2, np.nan, 8.500000E+2, np.nan, 1.800000E+3, np.nan, 3.570000E+3, 4.900000E+3, 6.400000E+3, np.nan, 1.230000E+4, np.nan, 2.130000E+4, np.nan, 3.680000E+4, np.nan, 6.130000E+4]) # Pa
+        self.Tmin = np.min(self.temperature.data)
+        self.Tmax = np.max(self.temperature.data)
+        self.TminPsat = np.min(self.temperature.data[~np.isnan(self.saturation_pressure.data)])
+        self.name = "PG1"
+        self.description = "MultiTherm PG-1"
+        self.reference = "MultiTherm2004"
+        self.reshapeAll()
+        
+        
 class Water(PureData):
     """
     This is just a fit of the full EOS from Wagner and Pruss

--- a/dev/incompressible_liquids/json/PG1.json
+++ b/dev/incompressible_liquids/json/PG1.json
@@ -1,0 +1,95 @@
+{
+  "T_freeze": {
+    "NRMS": null,
+    "coeffs": "null",
+    "type": "notdefined"
+  },
+  "Tbase": 428.15,
+  "Tmax": 613.15,
+  "Tmin": 243.15,
+  "TminPsat": 383.15,
+  "conductivity": {
+    "NRMS": 0.0010566779557489201,
+    "coeffs": [
+      [0.12323492324561407],
+      [-7.228984631664327e-05],
+      [1.5957252798856972e-10],
+      [1.4011246360247468e-12]
+    ],
+    "type": "polynomial"
+  },
+  "density": {
+    "NRMS": 0.0018034049147509649,
+    "coeffs": [
+      [816.573464912281],
+      [-0.4185387989945099],
+      [4.5592150854645297e-07],
+      [-3.528758342631502e-08]
+    ],
+    "type": "polynomial"
+  },
+  "density_cheb": {
+    "NRMS": 0.0018189182239599798,
+    "Trange": [243.15, 613.15],
+    "coeffs": [
+      [816.5789473684213],
+      [-77.5708502024292]
+    ],
+    "fit_source": "tabular_data",
+    "type": "chebyshev",
+    "xbase": 0.0
+  },
+  "description": "MultiTherm PG-1",
+  "mass2input": {
+    "NRMS": null,
+    "coeffs": "null",
+    "type": "notdefined"
+  },
+  "mole2input": {
+    "NRMS": null,
+    "coeffs": "null",
+    "type": "notdefined"
+  },
+  "name": "PG1",
+  "reference": "MultiTherm2004",
+  "saturation_pressure": {
+    "NRMS": 0.002311512119294138,
+    "coeffs": [-9418.983831376749, 16.471309221761015, -25.95747862443132],
+    "type": "exponential"
+  },
+  "specific_heat": {
+    "NRMS": 0.00020442011443906507,
+    "coeffs": [
+      [2368.500000000001],
+      [3.6330530305658715],
+      [0.0],
+      [1.734725739831535e-08]
+    ],
+    "type": "polynomial"
+  },
+  "specific_heat_cheb": {
+    "NRMS": 0.00020485295365563582,
+    "Trange": [243.15, 613.15],
+    "coeffs": [
+      [2368.500000000001],
+      [672.1842105263154]
+    ],
+    "fit_source": "tabular_data",
+    "type": "chebyshev",
+    "xbase": 0.0
+  },
+  "viscosity": {
+    "NRMS": 0.0032538349447246697,
+    "coeffs": [850.8486133242304, -168.48560429097608, 9.963902307631278],
+    "type": "exponential"
+  },
+  "volume2input": {
+    "NRMS": null,
+    "coeffs": "null",
+    "type": "notdefined"
+  },
+  "xbase": 0.0,
+  "xid": "pure",
+  "xmax": 1.0,
+  "xmin": 0.0
+}


### PR DESCRIPTION
### Requirements

* Fill out this template to the extent possible so that this PR can be reviewed in a timely manner.
* Replace the bracketed text below with your own.
* All new code requires tests to ensure against regressions.

### Description of the Change

 Adds MultiTherm PG-1, a food-grade (FDA/USDA/NSF HT-1) white mineral oil
heat transfer fluid, as a new pure incompressible fluid ("MultiTherm PG-1")
alongside the existing Therminol/Dowtherm/Syltherm/Paratherm fluids in
CPIncomp/PureFluids.py.

Data was digitized directly from MultiTherm's own published property
tables (density, viscosity, specific heat, thermal conductivity, and vapor
pressure from -30 C to 340 C in 10 C steps; SI/expanded table, form
PG-1C EXP 5/04), following the same PureData subclass pattern used by
the neighboring Paratherm and Therminol classes. self.reference points
to a new MultiTherm2004 BibTeX entry in CoolPropBibTeXLibrary.bib
(same style as the existing Paratherm2013/Therminol2014 entries).

### Benefits

[Adds additional fluid to CoolProp ]

### Possible Drawbacks

None expected. This is an additive change (one new fluid class, one new
JSON coefficient file, one new bib entry) that does not touch any existing
fluid definition or shared code path. 

### Verification Process

Ran python all_incompressibles.py -nr -ns -nt -nst from
dev/incompressible_liquids/ -- PG1 fit successfully for all five
properties (density, specific heat, conductivity, viscosity, saturation
pressure) with no "could not fit" warnings, producing
json/PG1.json.
Ran the existing test suite against the new file:
pytest test_json_sanity.py test_fitting_regression.py -- both passed
(regression test confirms the fitting pipeline itself was not
disturbed for the three reference fluids).
Built CoolProp's Python module from this branch from source
(pip install -e .) and queried the compiled library directly:
python
   from CoolProp.CoolProp import PropsSI
   PropsSI('D', 'T', 373.15, 'P', 101325, 'INCOMP::PG1')  # -> 839.64 kg/m3
Compared PropsSI/AbstractState output against the original
MultiTherm PG-1 table across -20 C to 300 C: density, specific heat,
and thermal conductivity all within +/-0.05% of the published values;
viscosity (fit with an exponential model, as it spans four orders of
magnitude over the full range) within +/-4%; vapor pressure within
+/-2.5%. Fit NRMS from the generated JSON: density 0.18%, specific
heat 0.02%, conductivity 0.11%, viscosity 0.33%, saturation pressure
0.23%. 

### Applicable Issues

None -- this was not filed as an issue first; happy to open one if
maintainers prefer that workflow for new-fluid additions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the MultiTherm PG-1 pure fluid.
  * Added tabulated thermophysical properties, including density, heat capacity, conductivity, viscosity, and vapor pressure.
  * Added applicable temperature and vapor-pressure operating ranges.
  * Added reference documentation for the MultiTherm PG-1 source data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->