### PR TITLE
ci: restore csharp_builder.yml and guard the release builder list (#3315)

### DIFF
--- a/.github/workflows/csharp_builder.yml
+++ b/.github/workflows/csharp_builder.yml
@@ -98,6 +98,10 @@ jobs:
         with:
           name: Csharp-${{ matrix.sysname }}
           path: install_root/Csharp
+          # upload-artifact defaults to 'warn', so a build that installed
+          # nothing would upload no artifact and still pass, leaving the merge
+          # job to publish a Csharp tree missing that platform.
+          if-no-files-found: error
 
   merge:
     needs: build
@@ -130,6 +134,7 @@ jobs:
         with:
           name: Csharp
           path: Csharp
+          if-no-files-found: error
 
       - name: Delete intermediate per-OS artifacts
         uses: geekyeggo/delete-artifact@v6

--- a/.github/workflows/csharp_builder.yml
+++ b/.github/workflows/csharp_builder.yml
@@ -1,0 +1,137 @@
+name: C# wrapper
+
+# The unified "Csharp" artifact produced by the merge job below is consumed by
+# release_all_files.yml -> release_get_artifact.yml.  Deleting or renaming this
+# file breaks the nightly deploy (see gh#3315: PR #3245 repurposed this file
+# into java_builder.yml, which silently killed the nightly for six weeks).  If
+# you need a workflow for another language, COPY this file -- do not rename it
+# -- and add the copy to the builder list in release_all_files.yml.
+
+on:
+  push:
+    branches: [ 'master', 'main', 'develop' ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ 'master', 'main', 'develop' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' && !startsWith(github.ref, 'refs/tags/') }}
+
+# Default the GITHUB_TOKEN to read-only; jobs that need more opt in explicitly.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            sysname: Linux
+          - os: windows-latest
+            sysname: Windows
+          - os: macos-latest
+            sysname: Darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install SWIG + mono + 7zip (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update -y && sudo apt-get install -y swig mono-mcs p7zip-full
+
+      - name: Install SWIG + mono + 7zip (macOS)
+        if: runner.os == 'macOS'
+        run: brew install swig mono p7zip
+
+      - name: Install SWIG (Windows)
+        if: runner.os == 'Windows'
+        run: choco install swig -y --no-progress
+
+      - name: Configure
+        shell: bash
+        run: cmake -B build -S . -DCOOLPROP_CSHARP_MODULE=ON -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build and install
+        shell: bash
+        # Bound parallelism to the core count.  A bare `-j` lets make spawn an
+        # unlimited number of concurrent compiles (~60+ for the CoolProp lib),
+        # which exhausts RAM on the 16 GB ubuntu runner and gets the runner
+        # OOM-killed ("runner received a shutdown signal", exit 143).  Matches
+        # every other wrapper workflow (library_shared, javascript, mathcad...).
+        # `nproc` is Linux-only (and present in Git-Bash on Windows) but absent
+        # on macOS, so fall back to `sysctl`, then a bounded constant.
+        run: |
+          JOBS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 2)
+          cmake --build build --target install --config Release -j "$JOBS"
+
+      - name: JSON symbol-leak gate (C# native wrapper)
+        # The SWIG C# module compiles the CoolProp sources (incl. the JSON
+        # loaders) into CoolPropCsharp.{so,dylib} — the same exposure the Octave
+        # .oct carries, the wrapper where the hidden-visibility regression
+        # (CoolProp-rj2i) bit. Assert the link-time export control keeps
+        # nlohmann/valijson/rapidjson out of the wrapper's dynamic symbol table.
+        # nm-based, so ELF/Mach-O only — the Windows PE .dll exports nothing by
+        # default (opt-in .def) and is skipped.
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The shared object keeps the platform 'lib' prefix on ELF/Mach-O
+          # (PREFIX "" is Windows-only) → libCoolPropCsharp.{so,dylib}. Include
+          # the SONAME-versioned forms (libCoolPropCsharp.so.<ver>, the regular
+          # file behind the symlink) so -type f still finds it if versioned.
+          wrapper=$(find build install_root -type f \( -name '*CoolPropCsharp.so' -o -name '*CoolPropCsharp.so.*' -o -name '*CoolPropCsharp.dylib' -o -name '*CoolPropCsharp.*.dylib' \) | head -1)
+          if [ -z "$wrapper" ]; then
+            echo "FAIL: CoolPropCsharp shared object not found under build/ or install_root/" >&2
+            exit 1
+          fi
+          echo "Gating $wrapper"
+          ./dev/ci/check-json-symbols.sh "$wrapper"
+
+      - name: Upload per-OS artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: Csharp-${{ matrix.sysname }}
+          path: install_root/Csharp
+
+  merge:
+    needs: build
+    runs-on: ubuntu-latest
+    # delete-artifact removes the per-OS intermediates via the Actions API.
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Download per-OS artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: Csharp-*
+          path: staging
+
+      - name: Assemble unified Csharp tree
+        shell: bash
+        run: |
+          set -eux
+          mkdir -p Csharp
+          for d in staging/Csharp-*/; do
+            [ -f "${d}Example.cs" ] && cp -n "${d}Example.cs" Csharp/ || true
+            [ -f "${d}platform-independent.7z" ] && cp -n "${d}platform-independent.7z" Csharp/ || true
+            find "$d" -maxdepth 1 -type d -name '*bit' -exec cp -r {} Csharp/ \;
+          done
+          ls -R Csharp
+
+      - name: Upload unified Csharp artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: Csharp
+          path: Csharp
+
+      - name: Delete intermediate per-OS artifacts
+        uses: geekyeggo/delete-artifact@v6
+        with:
+          name: Csharp-*

--- a/.github/workflows/release_all_files.yml
+++ b/.github/workflows/release_all_files.yml
@@ -64,13 +64,92 @@ jobs:
           echo "webdir=${{ env.WEBDIR }}" >> $GITHUB_OUTPUT
 
 
-  collect_binaries:
+  # Single source of truth for the builder workflows whose artifacts make up a
+  # release, and a preflight that every one of them still exists on the target
+  # branch.  Without this, deleting or renaming a builder makes the matching
+  # collect_binaries leg die with a bare "Not Found" annotation from
+  # action-download-artifact and takes the whole deploy down with it -- which is
+  # exactly how gh#3315 went unnoticed for six weeks after PR #3245 renamed
+  # csharp_builder.yml into java_builder.yml.
+  list_builders:
     needs: [set_vars]
+    name: Resolve the builder workflow list
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      workflows: ${{ steps.resolve.outputs.workflows }}
+    steps:
+
+      - name: Fetch the sources
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.set_vars.outputs.branch }}
+
+      - name: Resolve and validate the builder list
+        id: resolve
+        shell: bash
+        # BRANCH goes through env rather than being interpolated into the
+        # script body, so a crafted workflow_dispatch input cannot inject shell.
+        env:
+          BRANCH: ${{ needs.set_vars.outputs.branch }}
+        run: |
+          set -euo pipefail
+          # Add a builder here to have its artifacts included in the release.
+          # Every entry must name a file under .github/workflows/.
+          builders=(
+            javascript_builder.yml
+            library_shared.yml
+            windows_installer.yml
+            docs_docker-run.yml
+            libreoffice_builder.yml
+            mathcad_builder.yml
+            csharp_builder.yml
+            # java_builder.yml -- HOLD until CoolProp-qrn3 is fixed.  The Java
+            #   artifact currently ships Example.java plus the three native
+            #   libs and NO wrapper classes at all: #3245 dropped the
+            #   install(FILES ...platform-independent.7z) rule, and the merge
+            #   job never copies the unpacked platform-independent/ tree
+            #   either.  Publishing it today would give users a Java/ folder
+            #   they cannot call into.  Add this line back in the qrn3 PR.
+            # python_buildwheels.yml -- wheels ship via PyPI, not the file drop
+          )
+          # An all-commented-out list would otherwise sail through every check
+          # below, hand collect_binaries an empty matrix, and let deploy_files
+          # publish a release containing nothing but the source zip.
+          if [ "${#builders[@]}" -eq 0 ]; then
+            echo "::error::The builders list in release_all_files.yml is empty; there would be no binaries to release."
+            exit 1
+          fi
+          missing=()
+          for wf in "${builders[@]}"; do
+            if [ -f ".github/workflows/$wf" ]; then
+              echo "found   $wf"
+            else
+              echo "MISSING $wf"
+              missing+=("$wf")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "::error::Builder workflows listed by release_all_files.yml do not exist on '${BRANCH}': ${missing[*]}. A builder was renamed, deleted, or never landed on this branch; fix the file or update the builders list in release_all_files.yml."
+            exit 1
+          fi
+          # jq --args quotes each element for us, so the JSON stays valid no
+          # matter what ends up in the list.  Assign first rather than inlining
+          # the substitution into echo: `echo "x=$(jq ...)"` exits 0 even when
+          # jq dies, which would emit an empty output and fail downstream with
+          # an unrelated fromJSON error.  A bare assignment propagates jq's
+          # status, so `set -e` stops here instead.
+          workflows=$(jq -cn '$ARGS.positional' --args "${builders[@]}")
+          echo "workflows=$workflows" >> "$GITHUB_OUTPUT"
+
+  collect_binaries:
+    needs: [set_vars, list_builders]
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        workflow: [javascript_builder.yml, library_shared.yml, windows_installer.yml, docs_docker-run.yml, libreoffice_builder.yml, mathcad_builder.yml, csharp_builder.yml] # , python_buildwheels.yml]
+        workflow: ${{ fromJSON(needs.list_builders.outputs.workflows) }}
     uses: ./.github/workflows/release_get_artifact.yml
     with:
       branch: ${{ needs.set_vars.outputs.branch }}


### PR DESCRIPTION
Fixes #3315.

### Description of the Change

The nightly file drop has been dead since 2026-07-09. PR #3245 created `java_builder.yml` by **renaming** `csharp_builder.yml` rather than copying it, so the C# builder disappeared from master. `release_all_files.yml` still lists `csharp_builder.yml` in its `collect_binaries` matrix, and `release_get_artifact.yml` runs `action-download-artifact` with `if_no_artifact_found: fail`. The API returns `Not Found` for a workflow that no longer exists → that matrix leg dies → `deploy_files` (`needs: collect_binaries`) never runs.

Every scheduled nightly since has failed at exactly that leg while all seven other legs stayed green (verified across runs `29982310623` … `32547680217`). The last published nightly is dated 2026-07-06.

It went unnoticed because git scored the two files 63% similar, so the PR rendered as a single rename — CodeRabbit's walkthrough said only "Adds a Java workflow" and never mentioned a removed one, and no CI failed at merge time since `release_all_files` only runs on the 02:00 cron.

This PR:

1. **Restores `.github/workflows/csharp_builder.yml`** from `5ad9628da^`. The C# branch of `CMakeLists.txt` was untouched by #3245, so it applies verbatim; the only edits are dropping the now-deleted `actions_csharp` push trigger and adding a header comment explaining that this file feeds the nightly. This also brings back the `CoolPropCsharp` JSON symbol-leak gate from #3116, which went with it.

2. **Adds a `list_builders` job** that owns the builder list as a single source of truth and asserts every entry exists under `.github/workflows/` on the target branch before the matrix fans out, feeding `collect_binaries` via `fromJSON`. A renamed or deleted builder now fails at the top of the run with a readable `::error::` naming the missing files, instead of an opaque `Not Found` buried in one matrix leg that silently takes the whole deploy down.

Two fail-open paths in that guard are closed deliberately:

- An all-commented-out list would pass every check, hand `collect_binaries` an empty matrix, and let `deploy_files` publish a release containing nothing but the source zip → explicit empty-list check.
- The `GITHUB_OUTPUT` line assigns the `jq` result to a variable before echoing it. `echo "x=$(jq ...)"` exits 0 even when `jq` dies, which would emit an empty output and surface later as an unrelated `fromJSON` error; a bare assignment propagates `jq`'s status so `set -e` stops at the real cause.

### Possible Drawbacks

**`java_builder.yml` is deliberately held out of the builder list**, so this PR does not yet deliver the Java half of the install step suggested in #3245. Its unified `Java` artifact currently contains `Example.java` plus the three native libs and **no wrapper classes at all** — verified by downloading run `31887648293` — because #3245 also dropped the `install(FILES ...platform-independent.7z)` rule and the merge job never copies the unpacked `platform-independent/` tree. Adding it today would publish a `Java/` folder users cannot call into. The list has a commented-out line with a pointer; it gets uncommented once that artifact is whole.

### Verification Process

Verified locally on macOS (SWIG 4.3.0 + mono):

- `cmake -B build -S . -DCOOLPROP_CSHARP_MODULE=ON -DCMAKE_BUILD_TYPE=Release` configures clean.
- `cmake --build build --target install` succeeds, producing `install_root/Csharp/{Example.cs, platform-independent.7z, Darwin_64bit/libCoolPropCsharp.dylib}`; the 7z holds 40 wrapper classes.
- `dev/ci/check-json-symbols.sh` passes on the built dylib (`OK: no symbols matching /nlohmann|valijson|rapidjson/`).
- Both workflows parse as YAML; `actionlint` reports 13 shellcheck findings before and after — all pre-existing in `set_vars`/`deploy_files`, none in the new job.
- All three paths of the guard exercised: happy path emits valid JSON; empty list exits 1 with the error; a failing `jq` aborts under `set -e` instead of emitting an empty output.
- `./dev/ci/preflight.sh` green apart from the already-tracked `VLERoutines.cpp:3211` PT-flash tolerance failure (`CoolProp-joqz`), which this diff cannot affect since it touches only two `.yml` files.

The restored `csharp_builder.yml` triggers on `pull_request`, so this PR's own CI exercises it end-to-end on Linux/Windows/macOS.

> [!NOTE]
> CLAUDE.md's mandatory pre-PR adversarial review subagent was **not** run — this session prohibits spawning agents unless explicitly requested, and the maintainer chose to proceed without it. CodeRabbit and human review are the only gates on this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated C# builds for Linux, Windows, and macOS.
  * C# build outputs are consolidated into a unified release artifact.

* **Release Improvements**
  * Release packaging now dynamically detects and validates configured platform builders.
  * Binary collection adapts automatically to available build workflows.
  * Release artifacts are checked for expected files, helping prevent incomplete packages from being published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->