### PR TITLE
fix(java): ship wrapper sources in the Java artifact, then release it

### DIFF
--- a/.github/workflows/java_builder.yml
+++ b/.github/workflows/java_builder.yml
@@ -113,6 +113,10 @@ jobs:
         with:
           name: Java-${{ matrix.sysname }}
           path: install_root/Java
+          # upload-artifact defaults to 'warn', so a build that installed
+          # nothing would upload no artifact and still pass, leaving the merge
+          # job to assemble a Java tree missing that platform.
+          if-no-files-found: error
 
   merge:
     needs: build
@@ -131,15 +135,84 @@ jobs:
       - name: Assemble unified Java tree
         shell: bash
         run: |
-          set -eux
+          set -euxo pipefail
           mkdir -p Java
-          for d in staging/Java-*/; do
-            [ -f "${d}Example.java" ] && cp -n "${d}Example.java" Java/ || true
-
-            [ -f "${d}platform-independent.7z" ] && cp -n "${d}platform-independent.7z" Java/ || true
+          shopt -s nullglob
+          # An unmatched glob used to leave the literal 'staging/Java-*/' as the
+          # loop's single iteration, so a download that produced nothing still
+          # walked the body once and "succeeded".
+          dirs=(staging/Java-*/)
+          if [ "${#dirs[@]}" -eq 0 ]; then
+            echo "::error::No per-OS Java artifacts were downloaded; nothing to merge."
+            exit 1
+          fi
+          # Example.java, the archive and the unpacked package tree are
+          # identical in all three per-OS artifacts -- that is what
+          # "platform-independent" means -- so take them from the first and
+          # collect only the native library directories from every artifact.
+          # The copies are unconditional: they were guarded with
+          # '[ -f ... ] && cp -n ... || true', which turned a missing file into
+          # a silent skip and is the whole reason the published artifact
+          # carried no wrapper sources (CoolProp-qrn3).  Copying once also
+          # avoids depending on `cp -n`, whose exit status differs between GNU
+          # (0 when it skips) and BSD (1) coreutils.
+          first="${dirs[0]}"
+          cp "${first}Example.java" Java/
+          cp "${first}platform-independent.7z" Java/
+          # The unpacked package tree was never copied at all, so even with the
+          # archive present the sources beside it were missing.
+          cp -R "${first}platform-independent" Java/
+          for d in "${dirs[@]}"; do
             find "$d" -maxdepth 1 -type d -name '*bit' -exec cp -r {} Java/ \;
           done
           ls -R Java
+
+      - name: Verify the assembled tree is complete
+        shell: bash
+        # Everything above can only fail on a file it actually touches.  This
+        # step asserts the SHAPE of the result instead, so a future refactor
+        # that quietly stops copying something is caught here rather than by a
+        # user downloading an unusable Java/ folder.
+        run: |
+          set -euo pipefail
+          fail=0
+          note() { echo "::error::$1"; fail=1; }
+
+          [ -f Java/Example.java ] || note "Java/Example.java is missing from the merged tree."
+          [ -f Java/platform-independent.7z ] || note "Java/platform-independent.7z is missing from the merged tree."
+
+          # The wrapper classes are the whole point of the artifact: native
+          # libraries with nothing to call them are useless.  Check the
+          # directory first rather than letting find fail under `set -e`, so a
+          # tree missing it outright still reports every other problem too.
+          if [ -d Java/platform-independent ]; then
+            classes=$(find Java/platform-independent -name '*.java' -type f | wc -l)
+          else
+            note "Java/platform-independent is missing from the merged tree."
+            classes=0
+          fi
+          if [ "$classes" -lt 2 ]; then
+            note "Java/platform-independent holds $classes .java source(s); expected the full SWIG wrapper package."
+          fi
+
+          # One native library dir per per-OS artifact that fed the merge.
+          expected=$(find staging -maxdepth 1 -type d -name 'Java-*' | wc -l)
+          got=$(find Java -maxdepth 1 -type d -name '*bit' | wc -l)
+          if [ "$got" -ne "$expected" ]; then
+            note "Merged $got native library director(ies) from $expected per-OS artifact(s)."
+          fi
+
+          libs=$(find Java -maxdepth 2 -type f \( -name '*.so' -o -name '*.so.*' -o -name '*.jnilib' -o -name '*.dll' \) | wc -l)
+          if [ "$libs" -lt "$expected" ]; then
+            note "Found $libs native librar(ies) across $expected platform director(ies)."
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            echo "Merged tree as assembled:" >&2
+            find Java | sort >&2
+            exit 1
+          fi
+          echo "OK: $classes wrapper sources, the archive, and $libs native librar(ies) across $expected platform(s)."
 
       - name: Upload unified Java artifact
 
@@ -147,6 +220,7 @@ jobs:
         with:
           name: Java
           path: Java
+          if-no-files-found: error
 
       - name: Delete intermediate per-OS artifacts
         uses: geekyeggo/delete-artifact@v6

--- a/.github/workflows/release_all_files.yml
+++ b/.github/workflows/release_all_files.yml
@@ -105,13 +105,7 @@ jobs:
             libreoffice_builder.yml
             mathcad_builder.yml
             csharp_builder.yml
-            # java_builder.yml -- HOLD until CoolProp-qrn3 is fixed.  The Java
-            #   artifact currently ships Example.java plus the three native
-            #   libs and NO wrapper classes at all: #3245 dropped the
-            #   install(FILES ...platform-independent.7z) rule, and the merge
-            #   job never copies the unpacked platform-independent/ tree
-            #   either.  Publishing it today would give users a Java/ folder
-            #   they cannot call into.  Add this line back in the qrn3 PR.
+            java_builder.yml
             # python_buildwheels.yml -- wheels ship via PyPI, not the file drop
           )
           # An all-commented-out list would otherwise sail through every check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1838,6 +1838,13 @@ if(COOLPROP_JAVA_MODULE)
   # Install all the generated java files
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Example.java"
           DESTINATION ${CMAKE_INSTALL_PREFIX}/Java)
+  # Ship the archive alongside the unpacked tree, matching the Csharp layout.
+  # #3245 dropped this rule when it replaced the flat-glob install with the
+  # package-tree DIRECTORY install, which left the release area without the
+  # archive that dev/scripts/examples/win64run.py still fetches from
+  # nightly/Java/platform-independent.7z (CoolProp-qrn3).
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/platform-independent.7z"
+          DESTINATION ${CMAKE_INSTALL_PREFIX}/Java)
   if(NOT JAVA_PACKAGE_DIR STREQUAL "")
     # Install the package tree rooted at its FIRST path component so the full
     # package layout is preserved under platform-independent/.  The parent-of-


### PR DESCRIPTION
Stacked on #3317 — **review that one first**; this PR targets `claude/fervent-taussig-d8d320`, not `master`. Closes `CoolProp-qrn3` and completes the Java half of the install step suggested in #3245.

### Description of the Change

The published Java artifact has been unusable since #3245: it carried `Example.java` and the three native libraries and **no wrapper classes at all**, so nothing in it could be compiled or called. Two independent defects combined to produce that.

**The merge job never copied the unpacked package tree.** It copied `Example.java`, `platform-independent.7z`, and the `*bit` directories — and `platform-independent/` is none of those. #3267 had already fixed the per-OS install, so the 40 SWIG-generated `org/coolprop` sources were present in each per-OS artifact right up to the merge, then discarded.

**The archive those copies looked for was never installed.** #3245 replaced the flat-glob install with the package-tree `DIRECTORY` install and dropped `install(FILES ...platform-independent.7z)` along the way, so `[ -f "${d}platform-independent.7z" ]` was false on every iteration. `dev/scripts/examples/win64run.py:35` still fetches that path from the nightly area. The rule is restored; Csharp has always shipped both the archive and the unpacked tree, and Java now matches.

**The guards are what let this ship silently for six weeks.** Every copy was written `[ -f ... ] && cp -n ... || true`, which turns a missing input into a no-op and reports success; and an unmatched `staging/Java-*/` glob left the literal pattern as the loop's single iteration, so a download that produced nothing still walked the body once and "succeeded". The copies are now unconditional and the glob uses `nullglob` with an explicit empty check.

Taking the platform-independent pieces from the first artifact rather than re-copying them per OS also removes a portability trap: `cp -n` exits 0 when it skips under GNU coreutils but **1** under BSD, so the old line was load-bearing on the runner's coreutils flavour.

Unconditional copies still only fail on files they actually touch, so a new **Verify the assembled tree is complete** step asserts the *shape* of the result — `Example.java` and the archive present, at least two wrapper sources under `platform-independent/`, one native library directory per per-OS artifact that fed the merge, and at least one library per platform. It collects every problem before exiting rather than dying on the first, and dumps the assembled tree on failure.

Both workflows also get `if-no-files-found: error` on their uploads (CodeRabbit's finding on #3317, which applied equally here): `upload-artifact@v7` defaults to `warn`, so a leg that installed nothing would upload no artifact and still pass.

With the artifact whole, `java_builder.yml` goes back into the builder list in `release_all_files.yml`.

### Verification Process

Locally on macOS with Homebrew openjdk 23 and SWIG 4.3.0:

- **Reproduced the defect first.** A clean `-DCOOLPROP_JAVA_MODULE=ON -DCOOLPROP_SWIG_OPTIONS="-package org.coolprop"` install produced `install_root/Java` with 41 `.java` files and **zero** `.7z`, confirming the archive rule was the missing half.
- After the CMake fix the same install produces `Example.java`, `platform-independent/org/coolprop/` (40 classes) and `platform-independent.7z` (40 entries, package paths intact).
- `ctest -R Javatestbuild` passes.
- Extracted both merge steps from the workflow with a YAML parser and ran them against a fabricated three-OS staging tree: assemble exits 0, verify reports `40 wrapper sources, the archive, and 3 native librar(ies) across 3 platform(s)`.
- **Attacked the verify step with seven mutations** — the historical broken shape (no `platform-independent/`, no archive), archive missing, `Example.java` missing, wrapper sources emptied, the directory removed outright, a platform dropped, a native library deleted. All seven exit 1 with named errors; the complete tree exits 0.
- **End-to-end on the merged tree**: `javac -cp Java/platform-independent` compiles `Example.java`, and `java -Djava.library.path=Java/Darwin_64bit` loads `libCoolPropJava.jnilib` and evaluates real properties (water Tc = 647.096 K, Tb = 373.124 K at 101325 Pa). The run stops only at the REFPROP example line, since REFPROP is not at `/opt/refprop` here — which is why the workflow runs `-R Javatestbuild` rather than the run test.
- `actionlint` reports zero shellcheck findings in `java_builder.yml` before and after; `release_all_files.yml` holds at 13, all pre-existing.
- `./dev/ci/preflight.sh` green apart from the already-tracked `VLERoutines.cpp:3211` PT-flash tolerance failure (`CoolProp-joqz`) — identical numbers to the baseline run, and the only CMake change here sits inside `if(COOLPROP_JAVA_MODULE)`, which is OFF for the Catch build.

### Possible Drawbacks

The `Javatestrun` ctest is still not exercised in CI (it needs REFPROP), so JNI load is covered by `Javatestbuild` plus the symbol-leak gate rather than a full run. Verified manually here instead, as above.

> [!NOTE]
> CLAUDE.md's mandatory pre-PR adversarial review subagent was **not** run — this session prohibits spawning agents unless explicitly requested, and the maintainer chose to proceed without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### AI assistance

Per [AGENTS.md](../blob/master/AGENTS.md#ai-assistance-and-attribution) (policy landed in #3318, after this PR was opened): **Claude Opus 5, via Claude Code, did all of the work in this PR** — the investigation, the CMake and workflow changes, the commit message, and this description. The commit carries the corresponding `Co-authored-by:` trailer.

What was verified, and how, rather than asserted:

- The defect was **reproduced before being fixed** — a clean Java install on master produced 41 `.java` files and zero `.7z`.
- Both merge steps were extracted from the workflow YAML with a parser and executed against a fabricated three-OS staging tree, then **attacked with seven mutations** (including the exact historical broken shape); all seven fail, the good tree passes.
- The `Java` artifact produced by CI run [32575175391](https://github.com/CoolProp/CoolProp/actions/runs/32575175391) was **downloaded and executed**: `javac -cp platform-independent` compiles, and the JVM loads `libCoolPropJava.jnilib` and returns water Tc = 647.096 K.
- `actionlint` and `./dev/ci/preflight.sh` were run locally; the single preflight failure is the pre-existing `VLERoutines.cpp:3211` tolerance issue tracked as `CoolProp-qrn3`'s sibling `CoolProp-joqz`.

No thermophysical model, correlation, or fitted coefficient is involved — this is CI plumbing and a CMake install rule, so there is nothing here requiring validation against a reference. @ibell remains author of record and should review before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Java builds and releases now fail clearly when expected platform files or artifacts are missing.
  * Added validation to ensure merged Java packages contain all required wrapper, archive, and native library files.

* **New Features**
  * Java installations now include the platform-independent archive.
  * Java artifacts are now included in the complete release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
