### PR TITLE
fix(ci): stop expanding the dispatch input into set_vars' shell

### DIFF
--- a/.github/workflows/release_all_files.yml
+++ b/.github/workflows/release_all_files.yml
@@ -82,6 +82,22 @@ jobs:
               ;;
           esac
 
+          # The character class above still admits '..', '//', and a leading or
+          # trailing '/', none of which are legal in a ref and all of which
+          # traverse out of the rsync destination: BRANCH='../../foo' yields
+          # TARGET='../../foo' and a destination of
+          # /home/frs/project/coolprop/CoolProp/../../foo -> /home/frs/project/foo.
+          # git's own validator is the authority on ref syntax; prefixing
+          # refs/heads/ makes a single-level name like 'master' valid without
+          # --allow-onelevel.  Both checks are needed and neither subsumes the
+          # other: check-ref-format permits ';', '$', '&' and quotes, which
+          # have no business in a path we interpolate into a shell command,
+          # while the character class permits the traversal forms above.
+          if ! git check-ref-format "refs/heads/$BRANCH"; then
+            echo "::error::Refusing branch input '$BRANCH': not a well-formed git ref name."
+            exit 1
+          fi
+
           # Read a version number out of the ref if there is one, so that
           # 'v7.1.0' publishes to the 7.1.0 directory.  grep exits 1 when
           # nothing matches, which is the normal branch-name case, not an

--- a/.github/workflows/release_all_files.yml
+++ b/.github/workflows/release_all_files.yml
@@ -41,27 +41,80 @@ jobs:
   
   set_vars:
     runs-on: ubuntu-latest
+    # This job only derives strings from the dispatch input; it makes no API
+    # call, so it needs no token at all.  It is also the job an injected
+    # payload would land in, so an empty token is the cheapest blast-radius
+    # reduction available (CoolProp-4i70).
+    permissions: {}
     outputs:
       branch: ${{ steps.propagate_vars.outputs.branch }}
       target: ${{ steps.propagate_vars.outputs.target }}
       webdir: ${{ steps.propagate_vars.outputs.webdir }}
 
     steps:
-      # Start with the branch or tag for the source code
-      - run: echo "BRANCH=${{ (inputs.branch == ''        && 'master') || inputs.branch }}" >> $GITHUB_ENV
-      # Try to parse the branch as a version number
-      - run: |
-          set +e
-          echo "TARGET=$(echo ${{ env.BRANCH }} | grep -Eo '[0-9]+(\.[0-9]+)*')" >> $GITHUB_ENV
-      # Check whether we could parse it or not, use branch or nightly otherwise
-      - if: "${{ env.TARGET == '' }}"
-        run: echo "TARGET=${{ (env.BRANCH    == 'master'  && 'nightly') || env.BRANCH    }}" >> $GITHUB_ENV
-      - run: echo "WEBDIR=${{ (env.TARGET    == 'nightly' && 'dev')     || '.'           }}" >> $GITHUB_ENV
       - id: propagate_vars
+        shell: bash
+        # INPUT_BRANCH arrives through env instead of being interpolated into
+        # the script body.  A ${{ }} expression is substituted into the shell
+        # SOURCE TEXT before bash parses it, so the previous
+        #     echo "BRANCH=${{ ... || inputs.branch }}" >> $GITHUB_ENV
+        # executed a dispatch input of  x" ; <cmd> ; echo "  as shell code, in
+        # a job holding a write-scoped GITHUB_TOKEN.  Through env it is data.
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
         run: |
-          echo "branch=${{ env.BRANCH }}" >> $GITHUB_OUTPUT
-          echo "target=${{ env.TARGET }}" >> $GITHUB_OUTPUT
-          echo "webdir=${{ env.WEBDIR }}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+
+          # Branch or tag to collect the binaries from; schedule/push events
+          # carry no inputs at all, so an empty value means master.
+          BRANCH="${INPUT_BRANCH:-master}"
+
+          # Validate before the value reaches any other job.  branch, and the
+          # target derived from it, are interpolated into run: blocks
+          # downstream -- including the rsync destination in deploy_files,
+          # which holds the SourceForge SSH key -- and are written to
+          # GITHUB_OUTPUT, where an embedded newline would forge extra
+          # outputs.  Restricting to git ref-name characters closes both.
+          case "$BRANCH" in
+            *[!A-Za-z0-9._/-]*)
+              echo "::error::Refusing branch input '$BRANCH': only A-Z a-z 0-9 . _ / - are allowed in a ref name."
+              exit 1
+              ;;
+          esac
+
+          # Read a version number out of the ref if there is one, so that
+          # 'v7.1.0' publishes to the 7.1.0 directory.  grep exits 1 when
+          # nothing matches, which is the normal branch-name case, not an
+          # error -- hence '|| true'.  Keep only the first match: grep -Eo
+          # prints one line per match, and a multi-line value would corrupt
+          # GITHUB_OUTPUT the same way a newline in the input would.
+          TARGET="$(printf '%s' "$BRANCH" | grep -Eo '[0-9]+(\.[0-9]+)*' || true)"
+          TARGET="${TARGET%%$'\n'*}"
+
+          # No version in the name: master publishes as the nightly, any other
+          # branch publishes under its own name.
+          if [ -z "$TARGET" ]; then
+            if [ "$BRANCH" = "master" ]; then
+              TARGET="nightly"
+            else
+              TARGET="$BRANCH"
+            fi
+          fi
+
+          # Nightlies go to the 'dev' subdirectory of the web root, releases
+          # to the root itself.
+          if [ "$TARGET" = "nightly" ]; then
+            WEBDIR="dev"
+          else
+            WEBDIR="."
+          fi
+
+          echo "branch=$BRANCH  target=$TARGET  webdir=$WEBDIR"
+          {
+            echo "branch=$BRANCH"
+            echo "target=$TARGET"
+            echo "webdir=$WEBDIR"
+          } >> "$GITHUB_OUTPUT"
 
 
   # Single source of truth for the builder workflows whose artifacts make up a


### PR DESCRIPTION
Closes `CoolProp-4i70`. Independent of #3319 — no overlap.

### Description of the Change

`release_all_files.yml` interpolated `${{ inputs.branch }}` and the env vars derived from it directly into five `run:` script bodies. GitHub substitutes a `${{ }}` expression into the shell **source text** before bash parses it, so the input was code rather than data:

```yaml
- run: echo "BRANCH=${{ (inputs.branch == '' && 'master') || inputs.branch }}" >> $GITHUB_ENV
```

A `workflow_dispatch` with `branch` = `x" ; <cmd> ; echo "` produced:

```bash
echo "BRANCH=x" ; <cmd> ; echo "" >> $GITHUB_ENV
```

Two things made it matter. The repository's `default_workflow_permissions` is **`write`** and this workflow declares no top-level `permissions:` block, so that ran with a read/write `GITHUB_TOKEN`. And the value propagates: `outputs.branch` feeds `actions/checkout ref:` in two jobs, while `outputs.target` and `outputs.webdir` are interpolated into the **rsync destination in `deploy_files`** — the job holding `SF_SSH_KEY`.

**Severity: moderate, not critical.** Only collaborators can dispatch a workflow, so this is a collaborator-to-CI-token escalation, not anonymous RCE. Worth fixing, not worth panicking about.

The five steps become one that takes the input through `env:` and references `$INPUT_BRANCH`, with validation against git ref-name characters before the value reaches any other job. That closes the shell injection and, with it, the `GITHUB_OUTPUT` forging that an embedded newline would allow. `set_vars` is scoped to `permissions: {}` — it makes no API call, and it is the job an injected payload lands in.

One deliberate behaviour change: `grep -Eo` prints one line per match, so a ref like `v1.2-v3.4` previously wrote a two-line `TARGET` unfenced into `GITHUB_ENV` — an env-injection of its own. Only the first match is kept now.

### Verification Process

This workflow has **no `pull_request` trigger** — it runs only on the 02:00 cron and manual dispatch, and a dispatch performs a real SourceForge deploy. So CI cannot verify this change and a live test is not safe. Verification is therefore local and exhaustive: the step's script was extracted from the YAML with a parser and run over a table of inputs.

| input | result | matches previous behaviour |
|---|---|---|
| `` (schedule/push) | `master` / `nightly` / `dev` | ✅ |
| `master` | `master` / `nightly` / `dev` | ✅ |
| `v7.1.0` | `v7.1.0` / `7.1.0` / `.` | ✅ |
| `7.1.0` | `7.1.0` / `7.1.0` / `.` | ✅ |
| `develop` | `develop` / `develop` / `.` | ✅ |
| `feat/x-y` | `feat/x-y` / `feat/x-y` / `.` | ✅ |
| `v1.2-v3.4` | `v1.2-v3.4` / `1.2` / `.` | first match only (see above) |
| `x" ; id ; echo "` | **rejected**, exit 1 | — |
| `x$(id)` | **rejected**, exit 1 | — |
| `` x`id` `` | **rejected**, exit 1 | — |
| newline forging `target=evil` | **rejected**, exit 1 | — |
| `x;rm -rf /` | **rejected**, exit 1 | — |
| `../release` | **rejected**, exit 1 | — |
| `release/../prod` | **rejected**, exit 1 | — |
| `release//prod` | **rejected**, exit 1 | — |
| `..` / `/x` / `x/` | **rejected**, exit 1 | — |

**Update (7b25c41cf), after CodeRabbit review:** the character allowlist alone accepted `../release`, `release/../prod`, `release//prod`, `..`, `/x` and `x/`. None contains a digit, so `TARGET` fell through to the ref verbatim and the rsync destination resolved out of the project directory — `/home/frs/project/coolprop/CoolProp/../../foo` is `/home/frs/project/foo`. `git check-ref-format "refs/heads/$BRANCH"` is now a second gate. Both layers are kept because neither subsumes the other: `check-ref-format` accepts `x;id` (git permits `;`, `$`, `&` and quotes in ref names), while the character class permits the traversal forms. The table below is now 19 cases.

`actionlint` on this file drops from 13 shellcheck findings to 5; the eight that disappear were the unquoted redirections in the steps this replaces.

### Possible Drawbacks

**`collect_binaries`, `prepare_sources` and `deploy_files` still inherit the default write token.** Nothing in them uses it for a write — `deploy_files` reaches SourceForge over SSH/rsync, not the GitHub API — so a top-level `permissions: contents: read` (plus `actions: read` for `action-download-artifact`) should be correct. I left it out on purpose: with no `pull_request` trigger, a mistake there would not surface until the 02:00 cron, and the nightly has only just been restored from six weeks down (#3315). That change wants to ride a nightly someone is watching. Tracked as follow-up in `CoolProp-4i70`.

The ref-name allowlist also rejects inputs that git itself would tolerate in exotic cases (e.g. unicode branch names). Given the destination is an rsync path and a checkout ref, that seems like the right trade.

### AI assistance

Per [AGENTS.md](../blob/master/AGENTS.md#ai-assistance-and-attribution): **Claude Opus 5, via Claude Code, did all of the work in this PR** — it found the issue while auditing `actionlint` output on #3319 (which actionlint itself does not flag), wrote the fix, the test table, the commit message and this description. The commit carries the corresponding `Co-authored-by:` trailer.

What was actually verified rather than asserted: the twelve-case table above was executed against the script extracted from the committed YAML, not written from memory; `default_workflow_permissions=write` was read from the repository API rather than assumed; and the `deploy_files` interpolation claim was confirmed by reading the step. No thermophysical model or correlation is involved. @ibell remains author of record and should review the trade-off in *Possible Drawbacks* in particular, since that is a judgement call rather than a technical finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release workflow reliability, validation, and error handling.
  * Added safer handling for branch names and release version detection.
  * Standardized release output paths, including development and nightly releases.
  * Restricted workflow permissions to improve security.
  * Improved handling of invalid release references.
  * Added Java builder support to release automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
