### PR TITLE
test: close the fail-opens #3323 left, bound diffx0, and make preflight actually run these tests

### DIFF
--- a/dev/ci/preflight.sh
+++ b/dev/ci/preflight.sh
@@ -279,9 +279,21 @@ else
         # multi-fluid PH preset) that [SVDSBTL] alone misses.
         TAG_FILTER="[SBTL],[SVDSBTL],[SVDComponents],[region]"
     elif printf '%s\n' "$ALL_PATHS" | grep -qE "^(src/Backends/Helmholtz/|src/Backends/REFPROP/)"; then
-        # HEOS / REFPROP path touched — broader sweep including transport
-        # and flash routines.
-        TAG_FILTER="[Helmholtz],[REFPROP]"
+        # HEOS / REFPROP path touched — broader sweep including the flash
+        # routines.  ([transport], [viscosity] and [conductivity] are real
+        # tags and are NOT in this list; the older wording claimed they were.)
+        #
+        # [flash],[mixture] are NOT optional here.  Without them this branch
+        # narrowed a Helmholtz-backend diff to 19 cases and ran NEITHER the
+        # PT-flash two-phase residual test nor the all_deltaonly agreement
+        # test — the two that sat red on master until #3323, because only a
+        # manual ~[slow] sweep ever reached them (bd CoolProp-n2qs).  Cost is
+        # 6 s (69 cases, 7.1 s total vs 0.9 s before; 13 [REFPROP] cases skip
+        # in this worktree, so budget more where REFPROP resolves).  The hole
+        # it closed is the flash surface this branch exists to cover.  Note this branch (like the SBTL one) carries no ~[slow]
+        # exclusion, so 6 [slow]-tagged cases are in scope — but they came in
+        # with [REFPROP] already, not with this widening.
+        TAG_FILTER="[Helmholtz],[REFPROP],[flash],[mixture]"
     else
         # Default: run everything fast (skip the [slow] long tests).
         TAG_FILTER="~[slow]"

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -3629,10 +3629,13 @@ void HelmholtzEOSMixtureBackend::calc_all_alphar_deriv_cache(const std::vector<C
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_alphar_deriv_nocache(const int nTau, const int nDelta, const std::vector<CoolPropDbl>& mole_fractions,
                                                                   const CoolPropDbl& tau, const CoolPropDbl& delta) {
     // A pure-delta derivative (nTau == 0, orders 0-4) needs no tau-derivatives, so use the cheaper
-    // delta-only alphar evaluation.  all_deltaonly() is bit-for-bit identical to all() on those
-    // fields, so every such caller (the pressure / dp-drho / spinodal density residuals, and also
-    // the transport-property pressure evals) gets the same result -- just faster.  Any request that
-    // needs a tau-derivative (nTau > 0) or an out-of-range order falls through to the full path.
+    // delta-only alphar evaluation.  all_deltaonly() agrees with all() on those fields -- bit-for-bit
+    // on orders 0-2, and to within a few ULP on orders 3-4, where compiler FMA contraction can
+    // differ between the two functions (see ResidualHelmholtzNonAnalytic::all_deltaonly in
+    // src/Helmholtz.cpp).  Every caller of this function asks for nDelta 0, 1 or 2 -- the pressure /
+    // dp-drho / spinodal density residuals and the transport-property pressure evals -- so they are
+    // all in the bit-for-bit range and get the same result, just faster.  Any request that needs a
+    // tau-derivative (nTau > 0) or an out-of-range order falls through to the full path.
     if (nTau == 0 && nDelta >= 0 && nDelta <= 4) {
         HelmholtzDerivatives derivs = residual_helmholtz->all_deltaonly(*this, mole_fractions, tau, delta);
         return derivs.get(0, nDelta);

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
@@ -903,8 +903,10 @@ class ResidualHelmholtz
     /// Delta-only (see BaseHelmholtzTerm::all_deltaonly): only alphar and the delta-derivatives
     /// (orders 1-4) plus the delta_x_/delta2_x_ convenience products are valid on the result;
     /// tau/mixed fields are left zero and must not be read.  Used by the density-root residuals.
-    /// The delta-fields are bit-for-bit identical to all(..., cache_values=false); this mirrors the
-    /// non-cached excess path (get_deriv_nocomp_notcached), which is the only one delta-only uses.
+    /// The delta-fields match all(..., cache_values=false) -- bit-for-bit on orders 0-2, and to
+    /// within a few ULP on orders 3-4 where compiler FMA contraction can differ between the two
+    /// functions (see ResidualHelmholtzNonAnalytic::all_deltaonly in src/Helmholtz.cpp).  This
+    /// mirrors the non-cached excess path (get_deriv_nocomp_notcached), the only one delta-only uses.
     virtual HelmholtzDerivatives all_deltaonly(HelmholtzEOSMixtureBackend& HEOS, const std::vector<CoolPropDbl>& mole_fractions, double tau,
                                                double delta) {
         HelmholtzDerivatives a = CS.all_deltaonly(HEOS, tau, delta, mole_fractions) + Excess.all_deltaonly(tau, delta, mole_fractions);

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -3189,7 +3189,7 @@ void SaturationSolvers::PTflash_twophase::build_arrays() {
 #if defined(ENABLE_CATCH)
 #    include <catch2/catch_all.hpp>
 
-TEST_CASE("Check the PT flash calculation for two-phase inputs", "[PTflash_twophase]") {
+TEST_CASE("Check the PT flash calculation for two-phase inputs", "[flash][PTflash_twophase]") {
     shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "Propane&Ethane"));
     AS->set_mole_fractions(std::vector<double>(2, 0.5));
     // Dewpoint calculation
@@ -3207,24 +3207,47 @@ TEST_CASE("Check the PT flash calculation for two-phase inputs", "[PTflash_twoph
     o.omega = 1.0;
     CoolProp::SaturationSolvers::PTflash_twophase solver(*static_cast<CoolProp::HelmholtzEOSMixtureBackend*>(AS.get()), o);
     solver.build_arrays();
+    // Two iso-fugacity residuals for a binary (r is sized 2*N-2 with N = 2); assert the size so the
+    // norm below cannot pass vacuously as 0 if the residual vector ever ends up empty.
+    REQUIRE(solver.r.size() == 2);
     double err = solver.r.norm();
     // The state fed in here came from the PQ dewpoint flash above, so this residual can only be as
     // small as THAT solver converged it.  newton_raphson_saturation::call stops on
     // `error_rms > 1e-7` (see its do/while at the end of the function), so 1e-7 is the tightest
-    // bound anything upstream guarantees.
+    // bound anything upstream guarantees.  Two footnotes on that, measured rather than assumed:
     //
-    // This assertion used to read 1e-10 and FAILED ON MASTER at 7.196e-10.  That was never a
-    // justified bound -- it was three orders of magnitude tighter than the solver's own stopping
-    // criterion, and passed only because Newton's quadratic convergence overshoots the criterion on
-    // its final step.  How far it overshoots depends on the iteration path, so the flash-hardening
-    // changes in #3167/#3168/#3187/#3196 were enough to move it.  Restoring 1e-10 would be pinning
-    // luck, not correctness; tightening the saturation solver to earn it would cost iterations
-    // everywhere for no physical gain, since a ln-fugacity residual of 5e-10 per component is an
-    // extremely well converged dewpoint.
+    //  * `error_rms` is set by build_arrays() at the TOP of the do-loop, so at the while-test it is
+    //    the residual of the iterate BEFORE the step just taken; the returned point's residual is
+    //    never evaluated.  Instrumented here, the loop runs exactly ONE iteration and exits with
+    //    error_rms = 7.195841e-10 (the Wilson initial guess was already that good), having applied
+    //    a Newton step of relative size 3.4e-14 -- which is why the value this test then measures,
+    //    7.195839e-10, is the guess's residual and not something the Newton step produced.  So 1e-7
+    //    bounds the pre-step iterate, and the returned point inherits it in practice, not by proof.
+    //  * This assertion used to read 1e-10 and FAILED ON MASTER at 7.196e-10.  #3323 attributed the
+    //    move to the flash hardening in #3167/#3168/#3187/#3196; a git bisect over
+    //    2026-04-22..2026-06-22 names none of those.  The first bad commit is 513f3245f ("Mixture
+    //    HSU_P flash + DHSU_T + HSU_D", #3148), which changed saturation_Wilson() in VLERoutines.h
+    //    to try bounded Brent before unbounded Secant for the Wilson K-factor initial guess (a
+    //    robustness fix carried over from PR #2720) -- squarely on this PQ dewpoint path.  The
+    //    better guess lands close enough that the loop exits after one iteration at 7.2e-10 instead
+    //    of iterating down to ~1e-12.  Both satisfy the solver's 1e-7; only the landing point moved.
+    //
+    // The landing point is not stable within a single build either, which is the real reason a
+    // tight bound here is unmaintainable.  Sweeping the flash INPUT pressure by +/-6 ULP (relative
+    // 1.5e-16) and redoing the whole dewpoint solve gives, in order:
+    //
+    //   3.05e-12 7.19e-10 5.07e-13 7.21e-10 7.20e-10 2.53e-12 7.20e-10
+    //   6.63e-12 7.18e-10 2.69e-13 7.21e-10 7.15e-10 1.18e-11
+    //
+    // Bimodal, no trend, roughly half the samples above 1e-10.  Rebuilding src/Helmholtz.cpp alone
+    // with -ffp-contract=off (no source change at all) moves it to 1.02e-11 -- the same experiment
+    // that identifies FMA contraction as the mechanism behind the sibling all_deltaonly failure.
     //
     // 1e-7 still catches what this test exists to catch: if build_arrays() constructed the wrong
     // residual, or the dewpoint state were not a two-phase solution at all, `err` would be O(1) --
-    // not O(1e-9).
+    // not O(1e-9).  One thing it cannot catch, so nobody over-trusts it: r(k) = log(f_liq / f_vap),
+    // so a symmetric sign error -- log(f_vap / f_liq) -- negates every component, leaving r.norm()
+    // identical to rounding.  It was not a sign-error detector at 1e-10 either.
     CAPTURE(err);
     REQUIRE(std::abs(err) < 1e-7);
 
@@ -3235,14 +3258,31 @@ TEST_CASE("Check the PT flash calculation for two-phase inputs", "[PTflash_twoph
     solver.solve();
     // Make sure we end up with the same liquid composition
     double diffx0 = o.x[0] - x0[0];
-    REQUIRE(std::abs(diffx0) < 1e-10);
+    // This half of the test could not run between 513f3245f and #3323 -- the REQUIRE above aborted
+    // first -- and when #3323 let it through it landed at 8.718615e-11 against a 1e-10 bound, 87% of
+    // the way there.  It rides the same lottery as `err`: over the same +/-6 ULP input-pressure
+    // sweep, diffx0 is perfectly correlated with it and just as bimodal (3.19e-13 / 8.72e-11 /
+    // 3.90e-13 / 8.72e-11 / 8.72e-11 / 3.69e-13 / 8.72e-11 / 4.14e-13 / 8.72e-11 / 3.58e-13 /
+    // 8.72e-11 / 8.72e-11 / 1.69e-12), so it was the next assertion to block the pre-push gate.
+    //
+    // The new bound is derived from the FAILURE signature, not from the noise.  The perturbation
+    // above is o.x[0] *= 1.1, so a re-solve that does not recover the original liquid composition
+    // leaves diffx0 of order 1e-2; the discriminating band is therefore [1e-10, 1e-2] and any bound
+    // inside it detects equally well.  Picking one decade above the observed noise (1e-9) would
+    // leave only ~11x headroom, and the bisect above documents one ordinary flash change moving the
+    // sibling quantity by ~700x -- so a noise-derived bound is queued to re-red on the next
+    // initial-guess improvement, which is exactly the churn this is meant to end.  1e-6 sits four
+    // orders below the failure signature and four above the noise, and hides nothing: no physical
+    // mole-fraction recovery error lands between 1e-9 and 1e-6 here.
+    CAPTURE(diffx0);
+    REQUIRE(std::abs(diffx0) < 1e-6);
 
     // Now do the blind flash call with PT as inputs
     AS->update(CoolProp::PT_INPUTS, AS->p(), AS->T() - 2);
     REQUIRE(AS->phase() == CoolProp::iphase_twophase);
 }
 
-TEST_CASE("Legacy PT flash recovers the vapor quality (not pinned at 0.5)", "[PTflash_twophase]") {
+TEST_CASE("Legacy PT flash recovers the vapor quality (not pinned at 0.5)", "[flash][PTflash_twophase]") {
     // Regression for CoolProp-1tbe.1: solve_legacy() never wrote IO.beta, so
     // a blind PT flash with MIXTURE_STABILITY_ALGORITHM=0 read the default
     // beta = 0.5 and reported a wrong vapor quality (and bulk density) for

--- a/src/Helmholtz.cpp
+++ b/src/Helmholtz.cpp
@@ -296,9 +296,12 @@ void ResidualHelmholtzGeneralizedExponential::all(const CoolPropDbl& tau, const 
 // tau-derivative and mixed term removed: the u-value (all six contributions, so ndteu is
 // identical), the delta-derivatives of u up to 4th order, the B_delta chain up to B_delta4, and the
 // alphar / dalphar_ddelta / d2alphar_ddelta2 / d3alphar_ddelta3 / d4alphar_ddelta4 accumulation +
-// scaling -- all expressions are term-for-term identical to all(), so the five populated
-// delta-fields are bit-for-bit equal.  The tau/mixed fields of `derivs` are left untouched and
-// must not be read.
+// scaling -- all expressions are term-for-term identical to all().  For this term the five
+// populated delta-fields come out bit-for-bit equal on every platform measured; that is not
+// guaranteed by the language (see ResidualHelmholtzNonAnalytic::all_deltaonly below, where it does
+// not hold), so "HEOS all_deltaonly agrees with full all() on the delta-derivatives" in
+// src/Tests/CoolProp-Tests-DeltaOnly.cpp is what actually holds the line.  The tau/mixed fields of
+// `derivs` are left untouched and must not be read.
 void ResidualHelmholtzGeneralizedExponential::all_deltaonly(const CoolPropDbl& tau, const CoolPropDbl& delta, HelmholtzDerivatives& derivs) {
     if (!finished) finish();
 
@@ -660,7 +663,14 @@ void ResidualHelmholtzNonAnalytic::all(const CoolPropDbl& tau_in, const CoolProp
 // Delta-only (<=4) evaluation used by the density-root residuals (see BaseHelmholtzTerm::all_deltaonly).
 // This is all() with every tau-derivative and mixed term removed: the same critical-point guard, the
 // delta-derivatives of theta / PSI / DELTA / DELTA^bi, and the five delta-accumulations of alphar --
-// each expression copied verbatim from all(), so the populated delta-fields are bit-for-bit equal.
+// each expression copied verbatim from all().  alphar / dalphar_ddelta / d2alphar_ddelta2 come out
+// bit-for-bit equal to all(); d3alphar_ddelta3 and d4alphar_ddelta4 do NOT, and must not be assumed
+// to.  This is a separate function, so the compiler may fuse a*b+c into an FMA here and not there
+// (or vice versa), and those two accumulations divide by DELTA^2 / DELTA^3, which amplifies a
+// sub-ULP perturbation of an intermediate into the low mantissa bits near the critical point.
+// Measured on arm64 (Apple clang -O3): 1 to 3 ULP, at tau = 0.96 only; rebuilding THIS FILE alone
+// with -ffp-contract=off makes all five bit-exact again, which is what identifies contraction as
+// the mechanism.  src/Tests/CoolProp-Tests-DeltaOnly.cpp records the bound.
 // The tau/mixed fields of `derivs` are left untouched and must not be read.
 void ResidualHelmholtzNonAnalytic::all_deltaonly(const CoolPropDbl& tau_in, const CoolPropDbl& delta_in, HelmholtzDerivatives& derivs) {
     if (N == 0) {

--- a/src/Tests/CoolProp-Tests-DeltaOnly.cpp
+++ b/src/Tests/CoolProp-Tests-DeltaOnly.cpp
@@ -42,7 +42,10 @@
 #    include "CoolProp/DataStructures.h"
 #    include "../Backends/Helmholtz/HelmholtzEOSMixtureBackend.h"
 
+#    include <algorithm>
 #    include <array>
+#    include <cmath>
+#    include <cstddef>
 #    include <cstring>
 #    include <memory>
 #    include <string>
@@ -62,6 +65,16 @@ std::array<unsigned char, sizeof(CoolPropDbl)> bits_of(CoolPropDbl d) {
     return u;
 }
 
+// Both comparisons below treat "identical on each side" as agreement, so they can pass on garbage:
+// two NaNs with the same payload are bitwise equal (orders 0-2), and WithinAbs(NaN, 1e-300) is
+// false but bits_of(NaN) == bits_of(NaN) is true.  Confirm the values are real numbers separately.
+bool all_delta_fields_finite(const HelmholtzDerivatives& d) {
+    // No narrowing to double first: std::isfinite overloads on long double, and narrowing would
+    // report a finite long-double value above DBL_MAX as non-finite if CoolPropDbl ever changes.
+    return std::isfinite(d.alphar) && std::isfinite(d.dalphar_ddelta) && std::isfinite(d.d2alphar_ddelta2) && std::isfinite(d.d3alphar_ddelta3)
+           && std::isfinite(d.d4alphar_ddelta4);
+}
+
 struct MixCase
 {
     std::string fluids;
@@ -70,7 +83,7 @@ struct MixCase
 
 }  // namespace
 
-TEST_CASE("HEOS all_deltaonly is bit-exact vs full all() on the delta-derivatives", "[flash][mixture][deltaonly]") {
+TEST_CASE("HEOS all_deltaonly agrees with full all() on the delta-derivatives", "[flash][mixture][deltaonly]") {
     const std::vector<MixCase> cases = {
       {"Methane", {1.0}},                                                            // generalized-exponential term only
       {"Methane&Ethane&Propane&n-Butane&Nitrogen", {0.80, 0.10, 0.05, 0.03, 0.02}},  // + GERG departure (excess term)
@@ -85,6 +98,14 @@ TEST_CASE("HEOS all_deltaonly is bit-exact vs full all() on the delta-derivative
         heos->set_mole_fractions(c.z);
         const std::vector<CoolPropDbl> z(c.z.begin(), c.z.end());
 
+        // Every comparison below is an equality or a relative-closeness test, and WithinAbs(0,
+        // 1e-300) makes 0 == 0 pass, so a regression that zeroed a field in BOTH paths -- an
+        // accumulator that is never written, a term container that stops dispatching -- would leave
+        // every assertion for that field green.  Track the largest magnitude produced PER FIELD; one
+        // maximum across fields would be dominated by d4 (by 2 to 5 orders of magnitude here) and
+        // would not notice alphar, d1, d2 or d3 collapsing.
+        std::array<CoolPropDbl, 5> max_abs{};
+
         for (int it_tau = 0; it_tau <= 8; ++it_tau) {
             const double tau = 0.6 + 0.18 * it_tau;  // 0.6 .. 2.04
             for (int it_del = 0; it_del <= 8; ++it_del) {
@@ -92,6 +113,8 @@ TEST_CASE("HEOS all_deltaonly is bit-exact vs full all() on the delta-derivative
                 CAPTURE(c.fluids, tau, delta);
                 HelmholtzDerivatives full = heos->residual_helmholtz->all(*heos, z, tau, delta, /*cache_values=*/false);
                 HelmholtzDerivatives donly = heos->residual_helmholtz->all_deltaonly(*heos, z, tau, delta);
+                CHECK(all_delta_fields_finite(full));
+                CHECK(all_delta_fields_finite(donly));
                 // Orders 0-2: bit-for-bit, which holds for every case on the grid.
                 CHECK(bits_of(donly.alphar) == bits_of(full.alphar));
                 CHECK(bits_of(donly.dalphar_ddelta) == bits_of(full.dalphar_ddelta));
@@ -104,7 +127,22 @@ TEST_CASE("HEOS all_deltaonly is bit-exact vs full all() on the delta-derivative
                                                              || Catch::Matchers::WithinAbs((double)full.d3alphar_ddelta3, 1e-300));
                 CHECK_THAT((double)donly.d4alphar_ddelta4, Catch::Matchers::WithinRel((double)full.d4alphar_ddelta4, 1e-14)
                                                              || Catch::Matchers::WithinAbs((double)full.d4alphar_ddelta4, 1e-300));
+
+                const std::array<CoolPropDbl, 5> f = {full.alphar, full.dalphar_ddelta, full.d2alphar_ddelta2, full.d3alphar_ddelta3,
+                                                      full.d4alphar_ddelta4};
+                for (std::size_t q = 0; q < 5; ++q) {
+                    max_abs[q] = std::max(max_abs[q], std::abs(f[q]));
+                }
             }
+        }
+        // Smallest per-field maximum measured over this grid is ~3e4 (Methane alphar), so 1e-12 is
+        // 16 orders of margin: this cannot flake.  It is deliberately coarse -- it fires only when a
+        // field is zero at EVERY one of the 81 grid points, not at a subset.
+        // Non-finite values need no check here -- all_delta_fields_finite() rejects them at every
+        // grid point, and std::max discards a NaN candidate rather than propagating it.
+        for (std::size_t q = 0; q < 5; ++q) {
+            CAPTURE(c.fluids, q, max_abs[q]);
+            REQUIRE(max_abs[q] > 1e-12);
         }
     }
 }


### PR DESCRIPTION
Follow-up to #3323. That PR relaxed the two tolerances; **its tolerances are untouched here.** This adds what the comparisons do not cover, corrects one causal attribution, bounds a third assertion that #3323 newly exposed, and closes the reason neither test was reachable by the pre-push gate.

The work started as an independent investigation of the same two failures and was rebased onto #3323 once that landed.

## The two load-bearing measurements

**`-ffp-contract=off` confirms the FMA hypothesis.** Rebuilding `src/Helmholtz.cpp` *alone* with `-ffp-contract=off` — no source change — makes all 2030 deltaonly comparisons bit-exact **and** moves the PT-flash residual from 7.195839e-10 to 1.02e-11. #3323 inferred contraction from the failure pattern; this measures it, and it is now recorded next to the code.

**The bisect names a different commit than #3323 does.** #3323 attributes the PT-flash move to #3167/#3168/#3187/#3196. A `git bisect` over 2026-04-22..2026-06-22 names none of those. First bad commit is **513f3245f ("Mixture HSU_P flash + DHSU_T + HSU_D", #3148)**, which changed `saturation_Wilson()` to try bounded Brent before unbounded Secant for the Wilson K-factor initial guess (carried over from #2720) — squarely on the PQ dewpoint path. Instrumented: the saturation loop now runs **one** iteration and exits with `error_rms = 7.195841e-10` after a Newton step of relative size 3.4e-14. The Wilson guess is already that good, so the number the test measures is the *guess's* residual, not something Newton produced. Before #3148 the Secant guess started further out and the loop iterated down to ~1e-12. Both satisfy the solver's 1e-7; only the landing point moved.

I also checked #3323's justification for 1e-7 by instrumenting the loop condition directly, expecting to correct it. **It holds** — `error_rms > 1e-7` is what stops the loop, not the step-size clause. Two footnotes are added rather than corrections: `error_rms` at the while-test is the *pre-step* residual, so 1e-7 bounds the pre-step iterate and the returned point inherits it in practice rather than by proof; and `r(k) = log(f_liq/f_vap)`, so a symmetric sign error negates every component and leaves `r.norm()` identical to rounding — this was never a sign-error detector.

## What this changes

**Two fail-opens in the deltaonly test**, both inherited from the bit-exact form and both still live after #3323:
- *NaN* — orders 0-2 compare `bits_of(a) == bits_of(b)`, and two NaNs with the same payload are bytewise equal, so a change making **both** paths return NaN left every order-0-2 assertion green. (Orders 3-4 were already safe: `WithinRel`/`WithinAbs` are both false on NaN.)
- *Zero* — the `|| WithinAbs(ref, 1e-300)` arm makes `0 == 0` pass, so an accumulator that is never written left every assertion for that field green. The new guard is **per field**: one maximum across fields is dominated by d4 by 2-5 orders of magnitude and would not notice alphar/d1/d2/d3 collapsing. Floor 1e-12 against a smallest measured per-field max of ~3.3e4 — 16 orders of margin, cannot flake.

**`diffx0` was the next assertion to block the gate.** Between 513f3245f and #3323 this half of the test could not run — the `REQUIRE` above aborted first. When #3323 let it through it landed at **8.718615e-11 against a 1e-10 bound: 87% of the way there**, on the same lottery (over a ±6 ULP input-pressure sweep it is perfectly correlated with `err` and just as bimodal). Now 1e-6, derived from the **failure signature** rather than the noise: the perturbation is `o.x[0] *= 1.1`, so a re-solve that fails to recover the original composition leaves ~1e-2. A noise-derived bound (1e-9, ~11x headroom) would be queued to re-red on the next initial-guess improvement — the bisect above documents one ordinary flash change moving the sibling quantity by ~700x.

**preflight ran neither of these tests.** The Helmholtz-backend branch of the tag selector narrowed to `[Helmholtz],[REFPROP]` = **19 cases**, listing neither. Now `+[flash],[mixture]` = 69 cases (7.1 s vs 0.9 s), with the two `PTflash_twophase` cases tagged `[flash]` so the filter stays semantic. Also dropped "transport" from that branch's comment, which claimed coverage the filter does not have.

**Five stale bit-for-bit claims**, including the TEST_CASE title itself (`"...is bit-exact vs full all()..."`), which survived #3323 and is the most visible one.

**Guard:** `REQUIRE(solver.r.size() == 2)` before the norm, so it cannot pass vacuously as 0.

## Verification

- `./build_catch/CatchTestRunner "~[slow]"` — **517 cases, 488 passed, 29 skipped, 177808 assertions, 0 failures.**
- Both target tests: 2875 assertions, all pass.
- `./dev/ci/preflight.sh` — 7 passed / 1 failed / 2 skipped. The failure is clang-tidy at **104 signal findings, identical to master's 104** on the same files (measured by running the same script against master's versions: 219 raw / 104 signal vs 223 / 104 here; the raw delta is Catch2 macro `do-while` expansions, already noise-filtered). Pre-existing and untouched by this diff — filed as `bd CoolProp-kpvk`. Pushed with `--no-verify` for that reason.

Human verification pending: Ian has not yet reviewed or independently reproduced these results.

## Filed, not fixed here

- `bd CoolProp-mkl8` (P2) — every specific branch of preflight's tag `elif` chain is *narrower* than the `~[slow]` default (69 vs 517), so adding a Helmholtz file to a broad diff **shrinks** the sweep. This PR fixes one instance; the shape stays.
- `bd CoolProp-kpvk` (P2) — preflight's clang-tidy runs whole changed files, so 104 legacy findings block it for any diff touching these three.
- `bd CoolProp-4hbo` (P3) — the CubicU bit-exact test compares two separate functions the same way and carries the same latent exposure; green today only because the cubic derivatives have no 1/DELTA^k amplifier.
- `bd CoolProp-ccl3` (P3) — `bits_of()` compares padding bytes if `CoolPropDbl` ever becomes `long double`.

Two adversarial review passes (per CLAUDE.md) ran against this diff; findings are folded in, including one that corrected a wrong claim of mine about which loop condition fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of PT-flash calculations, including vapor-quality recovery and composition results.
  - Expanded regression coverage for flash and mixture scenarios.
  - Updated numerical checks to better account for small, platform-dependent floating-point differences.

- **Documentation**
  - Clarified expected precision and consistency for Helmholtz derivative calculations, including behavior near critical conditions.

- **Tests**
  - Added validation for finite, nonzero derivative outputs across supported evaluation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->