### PR TITLE
fix(fluids): reducing densities that disagree with the published value

### DIFF
--- a/dev/cubics/all_cubic_fluids.json
+++ b/dev/cubics/all_cubic_fluids.json
@@ -1086,12 +1086,12 @@
         "type": "IdealGasHelmholtzEnthalpyEntropyOffset"
       }
     ], 
-    "molemass": 0.02805376, 
+    "molemass": 0.02805316, 
     "molemass_units": "kg/mol", 
     "name": "ETHYLENE", 
     "pc": 5041800.0, 
     "pc_units": "Pa", 
-    "rhomolarc": 7636.765980745539, 
+    "rhomolarc": 7636.9293156279, 
     "rhomolarc_units": "mol/m^3"
   }, 
   {
@@ -3223,12 +3223,12 @@
         "type": "IdealGasHelmholtzPlanckEinstein"
       }
     ], 
-    "molemass": 0.00201594, 
+    "molemass": 0.00201588, 
     "molemass_units": "kg/mol", 
     "name": "ORTHOHYDROGEN", 
     "pc": 1310650.0, 
     "pc_units": "Pa", 
-    "rhomolarc": 15444.540313699812, 
+    "rhomolarc": 15445.0, 
     "rhomolarc_units": "mol/m^3"
   }, 
   {

--- a/dev/fluids/Ethylene.json
+++ b/dev/fluids/Ethylene.json
@@ -217,25 +217,25 @@
         "hs_anchor": {
           "T": 310.58500000000004,
           "T_units": "K",
-          "hmolar": 13467.302769838352,
+          "hmolar": 13467.390338886373,
           "hmolar_units": "J/mol",
-          "p": 7935253.189623128,
+          "p": 7935347.517167401,
           "p_units": "Pa",
           "rhomolar": 6873.089382670986,
           "rhomolar_units": "mol/m^3",
-          "smolar": 52.91020757486265,
+          "smolar": 52.910524840657374,
           "smolar_units": "J/mol/K"
         },
         "reducing": {
           "T": 282.35,
           "T_units": "K",
-          "hmolar": 11207.797265456176,
+          "hmolar": 11205.622917124289,
           "hmolar_units": "J/mol",
           "p": 5041800,
           "p_units": "Pa",
-          "rhomolar": 7636.76598074554,
+          "rhomolar": 7636.9293156279,
           "rhomolar_units": "mol/m^3",
-          "smolar": 46.61566511698445,
+          "smolar": 46.60945286278083,
           "smolar_units": "J/mol/K"
         },
         "sat_min_liquid": {
@@ -4170,7 +4170,7 @@
       },
       "gas_constant": 8.31451,
       "gas_constant_units": "J/mol/K",
-      "molar_mass": 0.02805376,
+      "molar_mass": 0.02805316,
       "molar_mass_units": "kg/mol",
       "p_max": 300000000,
       "p_max_units": "Pa",
@@ -4223,13 +4223,13 @@
     "critical": {
       "T": 282.35,
       "T_units": "K",
-      "hmolar": 11205.622917124283,
+      "hmolar": 11205.622917124289,
       "hmolar_units": "J/mol",
       "p": 5041800.0,
       "p_units": "Pa",
-      "rhomolar": 7636.765980745539,
+      "rhomolar": 7636.9293156279,
       "rhomolar_units": "mol/m^3",
-      "smolar": 46.60945286278082,
+      "smolar": 46.60945286278083,
       "smolar_units": "J/mol/K"
     },
     "triple_liquid": {

--- a/dev/fluids/Nitrogen.json
+++ b/dev/fluids/Nitrogen.json
@@ -205,25 +205,25 @@
         "hs_anchor": {
           "T": 138.8112,
           "T_units": "K",
-          "hmolar": 1620.7799325355165,
+          "hmolar": 1620.779697687099,
           "hmolar_units": "J/mol",
-          "p": 5255537.623499568,
+          "p": 5255537.235676806,
           "p_units": "Pa",
           "rhomolar": 10065.511318122559,
           "rhomolar_units": "mol/m^3",
-          "smolar": 122.81946369699095,
+          "smolar": 122.81946179012627,
           "smolar_units": "J/mol/K"
         },
         "reducing": {
           "T": 126.192,
           "T_units": "K",
-          "hmolar": 819.5750673520055,
+          "hmolar": 818.906585624006,
           "hmolar_units": "J/mol",
           "p": 3395800,
           "p_units": "Pa",
-          "rhomolar": 11183.901464580624,
+          "rhomolar": 11183.9,
           "rhomolar_units": "mol/m^3",
-          "smolar": 118.07697126543378,
+          "smolar": 118.0731441114819,
           "smolar_units": "J/mol/K"
         },
         "sat_min_liquid": {
@@ -3929,15 +3929,15 @@
   },
   "STATES": {
     "critical": {
-      "T": 126.19200000000001,
+      "T": 126.192,
       "T_units": "K",
-      "hmolar": 818.9065856240063,
+      "hmolar": 818.906585624006,
       "hmolar_units": "J/mol",
       "p": 3395800.0,
       "p_units": "Pa",
-      "rhomolar": 11183.901464580624,
+      "rhomolar": 11183.9,
       "rhomolar_units": "mol/m^3",
-      "smolar": 118.07314411148191,
+      "smolar": 118.0731441114819,
       "smolar_units": "J/mol/K"
     },
     "triple_liquid": {

--- a/dev/fluids/OrthoHydrogen.json
+++ b/dev/fluids/OrthoHydrogen.json
@@ -190,13 +190,13 @@
         "hs_anchor": {
           "T": 36.541796083914974,
           "T_units": "K",
-          "hmolar": 1637.6998779646178,
+          "hmolar": 1637.7117464321825,
           "hmolar_units": "J/mol",
-          "p": 1871183.326695314,
+          "p": 1871218.9756558198,
           "p_units": "Pa",
           "rhomolar": 13899.052839017835,
           "rhomolar_units": "mol/m^3",
-          "smolar": 56.69866343660209,
+          "smolar": 56.69902769299489,
           "smolar_units": "J/mol/K"
         },
         "reducing": {
@@ -206,7 +206,7 @@
           "hmolar_units": "J/mol",
           "p": 1309826.8737474547,
           "p_units": "Pa",
-          "rhomolar": 15444.54031369981,
+          "rhomolar": 15445.0,
           "rhomolar_units": "mol/m^3",
           "smolar": 53.8927818430645,
           "smolar_units": "J/mol/K"
@@ -3605,7 +3605,7 @@
       },
       "gas_constant": 8.314472,
       "gas_constant_units": "J/mol/K",
-      "molar_mass": 0.00201594,
+      "molar_mass": 0.00201588,
       "molar_mass_units": "kg/mol",
       "p_max": 2000000000,
       "p_max_units": "Pa",
@@ -3653,13 +3653,13 @@
     "critical": {
       "T": 33.22,
       "T_units": "K",
-      "hmolar": 1501.6553720185898,
+      "hmolar": 1501.6553720185902,
       "hmolar_units": "J/mol",
       "p": 1309826.87374745,
       "p_units": "Pa",
-      "rhomolar": 15444.540313699812,
+      "rhomolar": 15445.0,
       "rhomolar_units": "mol/m^3",
-      "smolar": 53.89278184306449,
+      "smolar": 53.8927818430645,
       "smolar_units": "J/mol/K"
     },
     "triple_liquid": {

--- a/dev/fluids/n-Undecane.json
+++ b/dev/fluids/n-Undecane.json
@@ -186,25 +186,25 @@
         "hs_anchor": {
           "T": 702.68,
           "T_units": "K",
-          "hmolar": 127628.1058009144,
+          "hmolar": 127627.97668024687,
           "hmolar_units": "J/mol",
-          "p": 3618202.056993505,
+          "p": 3618184.546809557,
           "p_units": "Pa",
           "rhomolar": 1363.4251772747004,
           "rhomolar_units": "mol/m^3",
-          "smolar": 215.69418664755148,
+          "smolar": 215.6939791293523,
           "smolar_units": "J/mol/K"
         },
         "reducing": {
           "T": 638.8,
           "T_units": "K",
-          "hmolar": 93359.55548558297,
+          "hmolar": 93327.98776171959,
           "hmolar_units": "J/mol",
           "p": 1990400,
           "p_units": "Pa",
-          "rhomolar": 1514.916863638556,
+          "rhomolar": 1514.9,
           "rhomolar_units": "mol/m^3",
-          "smolar": 166.26132495269127,
+          "smolar": 166.21379050394822,
           "smolar_units": "J/mol/K"
         },
         "sat_min_liquid": {
@@ -4038,15 +4038,15 @@
   },
   "STATES": {
     "critical": {
-      "T": 638.8000000000001,
+      "T": 638.8,
       "T_units": "K",
-      "hmolar": 93327.99205930215,
+      "hmolar": 93327.98776171959,
       "hmolar_units": "J/mol",
       "p": 1990400.0,
       "p_units": "Pa",
-      "rhomolar": 1514.9168636385564,
+      "rhomolar": 1514.9,
       "rhomolar_units": "mol/m^3",
-      "smolar": 166.2137972315449,
+      "smolar": 166.21379050394822,
       "smolar_units": "J/mol/K"
     },
     "triple_liquid": {

--- a/dev/scripts/check_superanc_release_pin.py
+++ b/dev/scripts/check_superanc_release_pin.py
@@ -68,6 +68,21 @@ DOCS_SCRIPT = REPO / 'Web' / 'scripts' / 'fluid_properties.Superancillary.py'
 # whenever the pinned release is fully current.
 PENDING_UPSTREAM = {
     # 'R1243zf': 'awaiting fastchebpure regen, CoolProp/fastchebpure#6',
+    #
+    # CoolProp/CoolProp#3326 corrected the reducing density of these four to the
+    # constant their EOS authors published (each stored value had been
+    # reconstructed through a unit conversion rather than taken from the
+    # publication).  The docs-pinned fastchebpure release still describes the
+    # pre-correction EOS for them, so the deviation plots would be comparing
+    # against a different equation until the release is regenerated and the pin
+    # bumped.  The relative shift is the size of the rho_red change --
+    # OrthoHydrogen 3.0e-5, Ethylene 2.1e-5, n-Undecane 1.1e-5, Nitrogen 1.3e-7
+    # -- so the plots are readable meanwhile, just not exact.  Delete each entry
+    # as the bumped release lands.
+    'Nitrogen': 'awaiting fastchebpure regen after CoolProp/CoolProp#3326',
+    'Ethylene': 'awaiting fastchebpure regen after CoolProp/CoolProp#3326',
+    'OrthoHydrogen': 'awaiting fastchebpure regen after CoolProp/CoolProp#3326',
+    'n-Undecane': 'awaiting fastchebpure regen after CoolProp/CoolProp#3326',
 }
 
 

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -3736,9 +3736,30 @@ TEST_CASE("Superancillary source_eos_hash matches current EOS at bit level", "[a
     // Known-stale fluids: EOS edited in master since the last fastchebpure
     // release, with no yet-released SA to match. Adding a fluid here makes
     // the test assert on the *mismatch* (so an accidental regen also forces
-    // an update here). Currently empty — fastchebpure 2026.04.23 covers
-    // every master fluid that has an SA.
-    static const std::set<std::string> known_stale_SA = {};
+    // an update here).
+    //
+    // These four had a wrong reducing density corrected to the constant the
+    // EOS authors published (see CoolProp-wu2i).  Each stored rho_red was
+    // reconstructed through a unit conversion rather than taken from the
+    // publication, but the four fail in four different ways -- Nitrogen's
+    // conversion used the *correct* molar mass and went wrong by unrounding a
+    // measured mass density, so this is not uniformly a rounded-M artifact:
+    //
+    //   Nitrogen       11183.901464580624 -> 11183.9         (313.3 kg/m^3 / 28.01348)
+    //   Ethylene       7636.76598074554   -> 7636.9293156279 (214.24 kg/m^3 / stale M)
+    //   OrthoHydrogen  15444.54031369981  -> 15445.0         (31.1352666 kg/m^3 / stale M)
+    //   n-Undecane     1514.916863638556  -> 1514.9          (1.5149 * 156.31 / 156.30826)
+    //
+    // Their superancillaries were fit against the pre-correction EOS and so
+    // carry a relative inconsistency of the same order as the rho_red change
+    // (worst case ~3e-5, OrthoHydrogen) until fastchebpure reissues them.
+    // Remove each entry as its regenerated SA lands.
+    //
+    // R236EA is deliberately NOT here: REFPROP's 3.71616644 is a nine-digit
+    // truncation of 565.0 kg/m^3 / 152.0384, and CoolProp's
+    // 3716.16644216198 is the faithful conversion.  Aligning to REFPROP
+    // there would have been a regression, so its EOS is untouched.
+    static const std::set<std::string> known_stale_SA = {"Nitrogen", "Ethylene", "OrthoHydrogen", "n-Undecane"};
 
     // ---------------------------------------------------------------------
     // TreeHasher: FNV-1a 64 over a deterministic byte serialization of a


### PR DESCRIPTION
Corrects the reducing density of four fluids to the constant the EOS authors published, verified against REFPROP 10.1 beta.

## Method

Joined `dev/fluids/*.json` to the REFPROP 10.1 beta `.FLD` files by CAS, and confirmed for each fluid that the comparison is valid by matching residual-term coefficients against the FLD `FEQ` block — a fluid running a different equation is not comparable, and "correcting" it toward REFPROP would be wrong.

Two REFPROP fields are easy to confuse: the file **header** `!Critical density [mol/L]` is the recommended *fluid* value and is often rounded, while the **`FEQ` block** carries the equation's own constants. The `FEQ` block is the target. Values convert mol/L → mol/m³ by **shifting the decimal point three places**, not by a float multiply by 1000 — `1.5149*1000 == 1514.8999999999999`, one ULP off `1514.9`.

## The four fixes

They fail in four different ways, so no single rule describes them. Two publish the density in molar units, so any mass-basis round trip is a detour; the other two are corrupted by a molar mass rather than by rounding.

| fluid | paper is | before → after | check |
|---|---|---|---|
| **Nitrogen** | molar-primary | `11183.901464580624` → `11183.9` | old value = 313.3 / 28.01348 using the **correct** M |
| **Ethylene** | mass-primary | `7636.76598074554` → `7636.9293156279` | ρ_red × M = **214.240000000** kg/m³ ✓ |
| **OrthoHydrogen** | molar-primary | `15444.54031369981` → `15445.0` | ρ_red × M = **31.135266600** kg/m³ ✓ |
| **n-Undecane** | molar-primary | `1514.916863638556` → `1514.9` | old value = 1.5149 × 156.31 / 156.30826 |

**Nitrogen.** Span et al., JPCRD 29:1361 (2000) tabulate `rho_c = 11.1839 mol/dm³` as the equation's constant. The stored double was `313.3 / 28.01348` — note the molar mass used was correct, so this is *not* a rounded-M artifact. The defect is that 313.3 kg/m³ is Nowak et al.'s **measured** value, quoted in Eq. (2) as 313.3 ± 0.4 kg/m³ (= 11.1839 ± 0.014 mol/dm³). Unrounding a measurement manufactures precision it never had: the quoted uncertainty is ~4 orders of magnitude larger than the 1.5e-6 mol/dm³ the conversion appeared to recover. The FLD changelog records both the 2020 edit and its 2024 reversal.

**Ethylene** (also `molar_mass` 28.05376 → 28.05316). Smukala et al. give rho_c in kg/m³ (214.24), so the molar value depends on M and the two constants must move together — either half alone lands at 214.2446 or 214.2354. The publication uses 28.05316, confirmed against the paper. Worth flagging because it looks wrong from the atomic weights: 28.05376 is 2(12.011)+4(1.00794), the 1995/2007 IUPAC carbon, while 28.05316 uses the 2005 value, which postdates this 2000 paper. Do not "correct" it back.

**OrthoHydrogen** (also `molar_mass` 2.01594 → 2.01588). Leachman et al. publish 15.445 mol/L. The stored value was 31.1352666 / 2.01594, where that mass density is not itself published but is 15.445 × 2.01588 — the molar constant drifted when the mass value was carried across a molar mass CoolProp's own Hydrogen and ParaHydrogen files already reject (both use 2.01588, with round reducing densities 15508 and 15538). OrthoHydrogen was the lone holdout in its own family.

**n-Undecane.** `1.5149 × 156.31 (a rounded M, not CoolProp's own 156.30826) / 156.30826` reproduces the stored digits exactly. The intermediate 236.794019 kg/m³ is nobody's published number.

## Two fluids deliberately excluded

REFPROP is **not** uniformly the higher-precision source. Where a publication states rho_c in kg/m³, its FLD stores a mol/L value divided out and then truncated. Two fluids were in an earlier draft and were dropped, because CoolProp already held the more faithful number:

| fluid | CoolProp (kept) | REFPROP | CoolProp × M | REFPROP × M |
|---|---|---|---|---|
| R236EA | `3716.16644216198` | `3.71616644` | **565.000000000** | 564.999999671 |
| R152A | `5571.452362568319` | `5.57145` | **368.000000000** | 367.99984395 |

Not hypothetical: REFPROP unrounded the R-152a *coefficients* to 16 digits in 2021 while leaving that same fluid's critical density at six. A library-wide scan for this signature returns exactly two fluids — R236EA and Nitrogen — and Nitrogen is the documented inverse, since there the paper's primary constant is the molar one. Tracked as `CoolProp-1z6p`, which also gates the deferred ULP work.

## Superancillary staleness

The four fluids' superancillaries were fit against the pre-correction EOS. Because only ρ_red moved and every coefficient is unchanged, `alphar` is the identical function of reduced variables, so saturation densities scale exactly with ρ_red: OrthoHydrogen 3.0e-5, Ethylene 2.1e-5, n-Undecane 1.1e-5, Nitrogen 1.3e-7. Well inside each equation's stated uncertainty, but not polished away — `update_QT_pure_superanc` uses the superancillary directly. All four are listed in the existing `known_stale_SA` set, which asserts on the mismatch so a future `fastchebpure` regeneration is forced to update it.

## Nitrogen and n-Undecane `STATES.critical.T`

Both fluids in this PR that stored their critical temperature twice as two different doubles are corrected: Nitrogen `126.19200000000001` → `126.192` and n-Undecane `638.8000000000001` → `638.8`, each matching its own `reducing.T`. Thirteen other fluids library-wide carry the identical one-ULP duplication and are left alone (their files are otherwise untouched); tracked in `CoolProp-b89z`. n-Undecane's stored critical h/s were already computed at 638.8 rather than at its stored `crit.T`, so this also makes that pair self-consistent.

This is not cosmetic: `Wilson_lnK_factor` (`VLERoutines.h:68`) reads `get_fluid_constant(i, iT_critical)` / `iP_critical`, which map to `components[i].crit.T` / `.crit.p`, so these seed the K-factors for **every mixture flash**. They are not superseded by superancillaries — that applies only to pure-fluid `rhomolar_critical`.

The Nitrogen one-ULP change is also what takes the suite from two failures to zero, and this PR is explicit that it does **not** fix the underlying flash. The failing pair was `HSU_P flash: near saturation 5-component N2-HC`; the mixture sits at Q = 0.998773 (0.12% liquid by mole) where any seed perturbation moves the phase split, and the UP solver was landing at 242.418 K against an expected 243.433 K — 1.01 K out, residual 6.0e-3 — caught by the deliberate gate at `FlashRoutines.cpp:3612` (#3192). Latent, tracked as `CoolProp-ft05` (P1), with a warning not to "fix" a recurrence by relaxing the gate or nudging a constant: an earlier draft carried an n-Pentane `crit.p` change that made the suite green, and its pass window turned out to be ~9 Pa wide — masking, not fixing.

## Two disclosures

**OrthoHydrogen's `reducing.p` / `critical.p` are now 3.0e-5 stale, deliberately.** Unlike the other three, its stored pressure was never the published constant but an EOS-derived value: `p(33.22, 15444.54031369981) = 1309826.8737474547` exactly on master, the corrected density gives `1309865.859`, and `ORTHOHYD.FLD:12` publishes 1310.65 kPa — three different numbers. Left alone because this change is scoped to molar mass, temperature and density, but `crit.p` does feed `Wilson_lnK_factor`, so it should be resolved deliberately rather than forgotten. Tracked in `CoolProp-b89z`.

**`dev/cubics/all_cubic_fluids.json`** is a committed derived file the build compiles in but never regenerates. Both `molemass` and `rhomolarc` are updated for the two M-changed fluids, for two different reasons. `molemass` is read straight back out — `PropsSI("M", ..., "PR::Ethylene")` returns `components[i].molemass` (`CubicBackend.h:105`) — so leaving it would make it disagree with the HEOS value. `rhomolarc` is updated because it reaches the cubic **mixture** paths via `get_fluid_constant(i, irhomolar_critical / irhomolar_reducing)` (`CubicBackend.h:111-113`), where pairing the new molar mass with the old density gives M × ρc = 214.2354 against the publication's 214.24.

No claim is made that this aligns pure-fluid `rhomolar_critical` across backends: `CubicBackend::calc_rhomolar_critical` (`CubicBackend.h:166-172`) ignores `rhomolarc` for pure fluids and returns a Kazakov curve fit of Tc and pc, so `PR::Ethylene` reports 7834.82 mol/m³ against HEOS `Ethylene`'s 7636.77 — a 2.6% gap that exists on master and is untouched here.

## Verification

- `./build_catch/CatchTestRunner "~[slow]"` — **176972 assertions, 0 failures**, matching the pre-change baseline.
- Every changed density confirmed bit-identical to the REFPROP `FEQ` decimal.
- `./dev/ci/preflight.sh` — 7 passed / 2 failed. Both failures (cppcheck, clang-tidy) are pre-existing whole-file noise on `src/Tests/CoolProp-Tests.cpp`, which enters the diff only through a comment-and-set-literal change. No finding is at a changed line, and cppcheck exits 1 on master's unmodified copy of that file. Preflight runs these whole-file; CI runs `clang-tidy-diff` on changed lines only.

## Follow-ups filed

| issue | what |
|---|---|
| `CoolProp-ft05` (P1) | mixture PT flash misclassifies at Q~0.9988 — latent, exposed here |
| `CoolProp-1z6p` | REFPROP FLD densities are sometimes truncations — check direction before aligning |
| `CoolProp-yr5d` | `STATES.critical` h/s disagree with their own stored (T, ρ) for 57 fluids, worst 72% |
| `CoolProp-b89z` | 19 reducing densities 1 ULP off the REFPROP decimal — fold into the next fastchebpure regen |
| `CoolProp-0s2s` | `ANCILLARIES.reducing_value` carries the same CoolProp 4.2 fossil |
| `CoolProp-y2ot` | `all_cubic_fluids.json` is a committed derived file the build never regenerates |
| `CoolProp-my86` | `generate_headers` can leave the embedded fluid CBOR stale within a build, making green runs untrustworthy |

A wider sweep (nine `STATES.critical` values fossilised from CoolProp 4.2, and 29 fluids storing one constant twice as two different doubles) was analysed and deliberately left out of this PR; that analysis is preserved in the issues above.

Refs: CoolProp-wu2i

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected thermodynamic reference data for Ethylene, Nitrogen, OrthoHydrogen, and n-Undecane.
  * Updated molar mass, critical-state, reducing-state, and reference-state values for improved calculation accuracy.

* **Tests**
  * Updated validation checks to recognize refreshed fluid data and detect outdated equation-of-state results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->