### PR TITLE
Add apply_simple_mixing_rule to the CoolPropLib C-API

### DIFF
--- a/include/CoolProp/CoolPropLib.h
+++ b/include/CoolProp/CoolPropLib.h
@@ -215,7 +215,7 @@ EXPORT_CODE void CONVENTION set_departure_functions(const char* string_data, lon
      * \sa \ref CoolProp::apply_simple_mixing_rule
      */
 EXPORT_CODE void CONVENTION apply_simple_mixing_rule(const char* identifier1, const char* identifier2, const char* rule, long* errcode,
-                                                      char* message_buffer, const long buffer_length);
+                                                     char* message_buffer, const long buffer_length);
 /**
      * \overload
      * \sa \ref CoolProp::set_reference_stateS

--- a/include/CoolProp/CoolPropLib.h
+++ b/include/CoolProp/CoolPropLib.h
@@ -201,6 +201,22 @@ EXPORT_CODE void CONVENTION set_config_bool(const char* key, const bool val);
      */
 EXPORT_CODE void CONVENTION set_departure_functions(const char* string_data, long* errcode, char* message_buffer, const long buffer_length);
 /**
+     * @brief Apply a simple mixing rule for a binary pair in the mixture binary pair library
+     * @param identifier1 The CAS number (or name) of the first component of the binary pair
+     * @param identifier2 The CAS number (or name) of the second component of the binary pair
+     * @param rule The simple mixing rule to apply; one of "linear" or "Lorentz-Berthelot"
+     * @param errcode The errorcode that is returned (0 = no error, !0 = error)
+     * @param message_buffer A buffer for the error message
+     * @param buffer_length The length of the buffer for the error message
+     *
+     * @note By default, if this binary pair already has an entry in the library, this is an
+     *       error, unless the configuration variable OVERWRITE_BINARY_INTERACTION is set to true
+     *
+     * \sa \ref CoolProp::apply_simple_mixing_rule
+     */
+EXPORT_CODE void CONVENTION apply_simple_mixing_rule(const char* identifier1, const char* identifier2, const char* rule, long* errcode,
+                                                      char* message_buffer, const long buffer_length);
+/**
      * \overload
      * \sa \ref CoolProp::set_reference_stateS
      * @returns error_code 1 = Ok 0 = error

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -447,7 +447,7 @@ EXPORT_CODE void CONVENTION set_departure_functions(const char* string_data, lon
     }
 }
 EXPORT_CODE void CONVENTION apply_simple_mixing_rule(const char* identifier1, const char* identifier2, const char* rule, long* errcode,
-                                                      char* message_buffer, const long buffer_length) {
+                                                     char* message_buffer, const long buffer_length) {
     *errcode = 0;
     fpu_reset_guard guard;
     try {

--- a/src/CoolPropLib.cpp
+++ b/src/CoolPropLib.cpp
@@ -446,6 +446,16 @@ EXPORT_CODE void CONVENTION set_departure_functions(const char* string_data, lon
         HandleException(errcode, message_buffer, buffer_length);
     }
 }
+EXPORT_CODE void CONVENTION apply_simple_mixing_rule(const char* identifier1, const char* identifier2, const char* rule, long* errcode,
+                                                      char* message_buffer, const long buffer_length) {
+    *errcode = 0;
+    fpu_reset_guard guard;
+    try {
+        CoolProp::apply_simple_mixing_rule(identifier1, identifier2, rule);
+    } catch (...) {
+        HandleException(errcode, message_buffer, buffer_length);
+    }
+}
 EXPORT_CODE double CONVENTION HAPropsSI(const char* Output, const char* Name1, double Prop1, const char* Name2, double Prop2, const char* Name3,
                                         double Prop3) {
     fpu_reset_guard guard;


### PR DESCRIPTION
### Description of the Change

`CoolProp::apply_simple_mixing_rule` was previously only reachable from
wrappers that link the C++ library directly (Python's Cython/nanobind
bindings, the Mathcad wrapper). It was never exposed through
CoolPropLib.h.

This PR adds `apply_simple_mixing_rule` to `CoolPropLib.h` /
`CoolPropLib.cpp`, exposing it through the C ABI.

### Benefits

Lets any wrapper built on CoolPropLib.h's C ABI apply mixing rules for
a fluid pair without depending on CoolProp's C++ headers directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a C/DLL interface for applying a specified mixing rule to two components.
  * Added error reporting through error codes and descriptive message buffers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->