### PR TITLE
Transport expression DSL: per-block state_variables, validated on three 2021-2025 correlations

### DIFF
--- a/Web/coolprop/changelog.rst
+++ b/Web/coolprop/changelog.rst
@@ -15,6 +15,35 @@ Highlights:
 
 **Behavior changes (potentially breaking):**
 
+* **Transport-property** ``"type": "expression"`` **blocks in fluid JSON now
+  require a** ``"state_variables"`` **declaration, and use CoolProp's own parameter
+  names.**  A block must list the thermodynamic quantities its formula reads::
+
+      "state_variables": ["T", "Dmolar"]
+
+  A name that is not declared there is not a state variable inside that block, so
+  a formula that never asks for pressure keeps ``p`` for its own coefficients —
+  which is the point: a dilute term of the form :math:`\eta_0 = \sum n_i T_r^{p_i}`
+  previously could not name its exponent array ``p``, because the language reserved
+  that name in every formula whether the block used it or not.
+
+  The DSL's own spellings ``rhomolar``, ``rhomass`` and ``p`` are **removed**; use
+  CoolProp's canonical ``Dmolar``, ``Dmass`` and ``P``.  CoolProp's back-compatible
+  aliases (``A``, ``C``, ``D``, ``G``, ``M``, ``O``, ``S``, ``U``, and the
+  upper-cased form of any name) are **not** accepted as state variables, precisely
+  because they collide with the single-letter coefficient names correlations use.
+
+  The quantities a block may declare are an explicit set — ``T``, ``P``,
+  ``Dmolar``, ``Dmass``, ``molar_mass``, ``Smolar_residual``, ``Bvirial``,
+  ``dBvirial_dT`` — which grows on demand.  Anything else is refused at fluid-load
+  time, including the critical point and the EOS reducing state (both are
+  configuration-dependent, and a correlation's reducing parameters belong in
+  ``constants``, frozen at the values its authors regressed against).
+
+  There is no version gate and no compatibility shim: a third-party expression
+  block written against the previous format fails when the fluid is loaded, with a
+  message naming the available set.  Blocks shipped with CoolProp are unaffected.
+
 * **Compositions with two or more exactly-zero mole fractions no longer return
   NaN for the bulk properties.**  ``GERG2008ReducingFunction::f_Y_ij``
   evaluates :math:`x_i x_j (x_i + x_j) / (\beta^2 x_i + x_j)`, which is

--- a/dev/ci/preflight.sh
+++ b/dev/ci/preflight.sh
@@ -292,7 +292,7 @@ else
     # "[Helmholtz],[REFPROP]" -- which contains ZERO [expression] test cases.  Before
     # this, a branch touching the DSL, its tests and shipped fluid data reported a
     # green preflight having run none of them.
-    if printf '%s\n' "$ALL_PATHS" | grep -qE "^(src/expression/|include/CoolProp/expression/|src/Tests/CoolProp-Tests-Expression\.cpp|dev/fluids/)"; then
+    if printf '%s\n' "$ALL_PATHS" | grep -qE "^(src/expression/|include/CoolProp/expression/|src/Backends/Helmholtz/|src/Tests/CoolProp-Tests-Expression\.cpp|dev/fluids/)"; then
         case "$TAG_FILTER" in
             "~[slow]") : ;;  # already runs everything except [slow]
             *) TAG_FILTER="${TAG_FILTER},[expression]" ;;

--- a/dev/ci/preflight.sh
+++ b/dev/ci/preflight.sh
@@ -286,6 +286,18 @@ else
         # Default: run everything fast (skip the [slow] long tests).
         TAG_FILTER="~[slow]"
     fi
+    # The expression-DSL surface is ORTHOGONAL to the branches above, so it has to
+    # be OR-ed in rather than being another elif.  Its parse branch and dispatch arm
+    # live under src/Backends/Helmholtz/, so any change to them selects
+    # "[Helmholtz],[REFPROP]" -- which contains ZERO [expression] test cases.  Before
+    # this, a branch touching the DSL, its tests and shipped fluid data reported a
+    # green preflight having run none of them.
+    if printf '%s\n' "$ALL_PATHS" | grep -qE "^(src/expression/|include/CoolProp/expression/|src/Tests/CoolProp-Tests-Expression\.cpp|dev/fluids/)"; then
+        case "$TAG_FILTER" in
+            "~[slow]") : ;;  # already runs everything except [slow]
+            *) TAG_FILTER="${TAG_FILTER},[expression]" ;;
+        esac
+    fi
     echo "  tag filter: $TAG_FILTER"
     # Gate on the runner's EXIT CODE, not on grepping its output.  The old
     # form piped into `grep -qE "failed|Errors:"`, so the `if` saw grep's

--- a/docs/superpowers/specs/2026-06-12-transport-expression-dsl-design.md
+++ b/docs/superpowers/specs/2026-06-12-transport-expression-dsl-design.md
@@ -42,6 +42,24 @@ forms that are pure functions of `(T, ρ, τ, δ)` plus coefficient arrays:
 
 Reproducing all of these to ULP is the **completeness proof** for the scope.
 
+**Amendment (initial-density stage wired, PR follow-up to #3185).** Two of the
+listed forms have no golden test and, as the stage is now wired, one of them
+cannot have a like-for-like one:
+
+- `initial_density_dependence_Rainwater_Friend` — the host arm scales the routine's
+  return by `eta_dilute * rho`, whereas an `initial_density` expression block yields
+  the stage's contribution **directly** (see §3a). So an expression block is not a
+  drop-in replacement for an RF entry: to reproduce one it must compute
+  `eta_0 * B_eta * rho` itself, recomputing the dilute term inside the block. That
+  is what the shipped ethene and propylene-glycol correlations do, and it works —
+  but it is a re-expression rather than a substitution, so "reproduces the RF
+  routine to ULP" is not the right test and none is claimed.
+- `dilute_kinetic_theory` — simply untested; no shipped fluid exercises it through
+  the DSL yet.
+
+The completeness claim therefore covers the eight golden-tested Tier-A forms plus
+`initial_density_dependence_empirical`, not the full list above.
+
 ### Out of scope (v1 non-goals)
 
 - **Tier B** — closed-form but requiring EOS-derived scalars:
@@ -67,7 +85,7 @@ Reproducing all of these to ULP is the **completeness proof** for the scope.
 | Evaluator | Tree-walking AST, compiled once per fluid at load, evaluated many |
 | Sum syntax | `sum(i: <body>)` explicit index; arrays subscripted `arr[i]` |
 | Variables | Raw state + JSON-declared constants/arrays + `let` bindings; **all quantities base SI, always** |
-| Thermodynamic inputs | ONE bucket, keyed by the existing `CoolProp::parameters` enum; the host fills every requested key with `AbstractState::keyed_output()`. A curated allowlist (`T`, `rhomolar`, `rhomass`, `molar_mass`, `p` in v1), not an open door onto `get_parameter_index()` |
+| Thermodynamic inputs | ONE bucket, keyed by the existing `CoolProp::parameters` enum; the host fills every requested key with `AbstractState::keyed_output()`. Resolved per-block from a declared `state_variables` list via `is_valid_parameter()` — CoolProp's own names, no list kept here — minus a policy denylist (transport outputs; critical/reducing state) |
 
 ### Why tree-walking AST, not bytecode VM
 
@@ -114,13 +132,15 @@ At bind time each identifier resolves against, in order:
    earlier in the same formula. A `let` may therefore shadow an input/constant
    name within its formula (conventional local-shadows-global scoping); this is
    intentional and harmless. The remaining buckets follow.
-1. **Thermodynamic inputs** (§2b) — one table of DSL names, each bound to an
-   existing `CoolProp::parameters` key: `T` (K), `rhomolar` (mol/m³), `rhomass`
-   (kg/m³), `molar_mass` (kg/mol), `p` (Pa). Checked *before* constants, so a
-   block-declared constant can never shadow a state variable. A `constants` key
-   that collides with an input name is a **compile error**, not a silently
-   discarded constant: resolving it either way would give the author a number
-   they did not write.
+1. **Declared state variables** (§2b) — the names in this block's
+   `state_variables`, each bound to an existing `CoolProp::parameters` key by
+   `is_valid_parameter()`: `T` (K), `Dmolar` (mol/m³), `Dmass` (kg/m³),
+   `molar_mass` (kg/mol), `P` (Pa), `Smolar_residual` (J/mol/K) — CoolProp's own
+   spellings, whatever `keyed_output()` supports. A name **not** declared here is
+   never state, so an undeclared `p` is the author's to use. Checked *before*
+   constants, and declaring a name that is also a `constants` or `arrays` key is a
+   **compile error**: resolving it either way would give the author a number they
+   did not write.
 2. **Block-declared constants** — scalars from the JSON `constants` object
    (e.g. `T_reduce`, `epsilon_over_k`, `sigma_eta`, `C`).
 
@@ -131,7 +151,7 @@ A name found in none of the buckets is a descriptive compile error
 (`unknown variable '<name>' at col <n>`).
 
 **All inputs are exposed in base SI, always** (`T` in
-K, `rhomolar` in mol/m³, `p` in Pa, result in Pa·s or W/m/K). The DSL imposes no
+K, `Dmolar` in mol/m³, `P` in Pa, result in Pa·s or W/m/K). The DSL imposes no
 unit handling and there is no units metadata field — a formula yields base SI by
 construction. Where the underlying physics needs a non-SI quantity (e.g. a
 collision-integral correlation tabulated in nm and kg/kmol), the conversion
@@ -140,16 +160,18 @@ current C++ does.
 
 ### 2b. Thermodynamic inputs — one bucket keyed by `CoolProp::parameters`
 
-There is no separate "intrinsic" vs "derived" split. A single table maps each DSL
-spelling to a key of the existing `CoolProp::parameters` enum:
+There is no separate "intrinsic" vs "derived" split, and no list of thermodynamic
+names lives in this library at all. A block declares what it reads:
 
-| DSL name | `CoolProp::parameters` | Unit | Needs the EOS? |
-|---|---|---|---|
-| `T` | `iT` | K | no |
-| `rhomolar` | `iDmolar` | mol/m³ | no |
-| `rhomass` | `iDmass` | kg/m³ | no |
-| `molar_mass` | `imolar_mass` | kg/mol | no (trivial) |
-| `p` | `iP` | Pa | yes |
+```json
+"state_variables": ["T", "Dmolar"]
+```
+
+Each name is resolved by `CoolProp::is_valid_parameter()`, so **the DSL's
+vocabulary is CoolProp's vocabulary** — every quantity `keyed_output()` can produce
+is reachable, in CoolProp's own canonical spelling (`P`, `Dmolar`, `Dmass`,
+`Smolar_residual`, `Bvirial`, ...). Adding a thermodynamic quantity to the language
+costs nothing: no table row, no recompile.
 
 Whether a key is free or costs an EOS call is not the DSL's business: the compiled
 `Program` reports `requiredInputs()` as a `std::vector<CoolProp::parameters>` and
@@ -158,30 +180,94 @@ which holds the backend — fills it with one `HEOS.keyed_output(key)` per key. 
 evaluator itself stays EOS-free, and there is no per-quantity `switch` on either
 side to extend.
 
-The DSL spells the state variables the way the C++ members do (`rhomolar`,
-`rhomass`), not the way `PropsSI` does (`Dmolar`, `Dmass`); the table is the
-translation layer, so fluid JSON is unaffected by CoolProp's shorthand naming.
+**Why declared rather than global.** The first design resolved a curated allowlist
+(`T`, `rhomolar`, `rhomass`, `molar_mass`, `p`) in one namespace shared with the
+author's own constants and arrays. That has two defects, and they compound.
 
-**Why an allowlist rather than `get_parameter_index()`.** Resolving any parameter
-name would let a viscosity formula reference `V`, whose `keyed_output()` re-enters
-the very correlation being compiled — unbounded recursion, at eval time, in
-fluid-file data. The table is the recursion guard. (An author who wants an
-arbitrary name declares it in `constants`, which is the normal path.)
+*Every name the language knows is reserved everywhere.* Propylene glycol's dilute
+term is η₀ = Σ nᵢ·Tr^pᵢ; its exponent array had to be renamed `np` because `p` was
+pressure — in a block that never reads pressure. Across the eleven shipped blocks,
+local identifiers outnumber state reads about 5:1 (median 11 against 2), and **not
+one of them declares `P`**. The reservation was pure cost.
 
-Extension cost, made explicit:
+**Only the canonical spelling is accepted.** `is_valid_parameter()` also resolves
+CoolProp's back-compat aliases and an upper-cased form of every name: `A` is the
+speed of sound, `D` is `Dmass`, `M` is `molar_mass`, `TAU` is `Tau`. Harmless in
+`PropsSI`; a trap here, because a DSL formula is full of single-letter coefficient
+names. An author who forgets to declare a paper coefficient `A` in `constants` is
+told to add it to `state_variables` — and doing so would silently bind the speed of
+sound, with the compiler's own diagnostic having steered them there. So a
+declaration must match `get_parameter_information(key, "short")` exactly. One name
+per quantity, and still no list kept in this library.
 
-- Adding a new input later is one line in the table in `Expression.cpp`, e.g.
-  `{"smolar_residual", iSmolar_residual}`, plus a CoolProp recompile. No host-side
-  change at all — `keyed_output()` already knows every parameter.
-- After that, **every fluid and formula** can use that name as pure JSON data,
-  no further code. The grammar/parser never changes.
+*The DSL invented spellings CoolProp does not use.* `rhomolar`/`rhomass`/`p` are
+not `get_parameter_index()` names; CoolProp says `Dmolar`/`Dmass`/`P`. That
+divergence is what created the lowercase `p` that collided. The aliases are gone:
+one name per quantity, and it is CoolProp's.
 
-`p` is in the v1 table both because pressure is genuinely useful and because it
-exercises the EOS-backed path end-to-end. No Tier-A *completeness* form uses `p`;
-it is proven by a dedicated unit test, not by the golden regression.
+Declaration inverts both. A name the block did not declare is never state, however
+well CoolProp knows it, so `p` is simply the author's. `requiredInputs()` is still
+read off the AST walk, but the declaration now gates it: a name reaches the walk only
+if the block asked for it. (The *order* remains first-reference, not declaration
+order — the declaration says what may be read, the formula says in what order.)
 
-This is the designed bridge to Tier B: each Tier-B input becomes a registry
-one-liner rather than a new hardcoded routine + enum + switch case.
+Dropping the aliases costs nothing ergonomically, because **renaming is already in
+the language**. A `let` binds any state variable to whatever reads best — including
+the source paper's own symbol, which neither CoolProp's spelling nor a second
+vocabulary maintained here would have given:
+
+```
+let rho = Dmolar
+let tau = Tc/T
+sum(i: n[i]*rho^d[i]*tau^t[i])
+```
+
+A `let` may not shadow a *declared* state variable at all: that is a compile error.
+An earlier draft leaned on the "declared but never used" rule to catch it, but that
+only fires when the declared name is read *nowhere* — `let a = T*2 / let T = 500 /
+a + T` compiled, with `T` meaning the state on one line and 500 on the next. The
+guard is explicit now rather than emergent.
+
+**Compatibility.** This changed the fluid-JSON contract with no version gate and no
+shim: a block written against the previous format does not compile. That is
+deliberate — the retired spellings were the defect, so silently accepting them is the
+one outcome worth avoiding — but it puts the whole burden on the failure being
+legible. The three retired names are therefore kept in a table that produces *only
+error text*:
+
+```
+unknown variable 'rhomolar' -- it was this DSL's own spelling for a thermodynamic
+quantity before blocks declared their inputs; CoolProp calls it 'Dmolar', and it
+must be listed in this block's "state_variables"
+```
+
+A version field was considered and rejected. It would only help if v1 were still
+supported, which is exactly what we do not want; an *optional* version is
+indistinguishable from a new block that omitted it; and a version on this block type
+alone would be the only such field in CoolProp's fluid JSON. The failure above works
+for every old block, including the ones that never carried a version. If schema
+versioning is wanted later it belongs on the fluid file, not on one block type.
+
+**What is still refused, and why opt-in is not enough.** Two classes are rejected at
+compile time even when explicitly declared, because these are the cases where the
+author's intent cannot be honoured:
+
+| Refused | Reason |
+|---|---|
+| `V`, `viscosity`, `L`, `conductivity`, `Prandtl`, `surface_tension` | `keyed_output()` re-enters the correlation being defined — unbounded recursion, at eval time, in fluid-file data |
+| `T_critical`, `P_critical`, `rhomolar_critical`, `rhomass_critical` | `calc_T_critical()`/`calc_rhomolar_critical()` return the *numerical* critical point under `ENABLE_SUPERANCILLARIES` (the default), so a correlation reducing on them changes answer with configuration. Xenon missed its reference values by 7e-5 exactly this way. Freeze the paper's own value as a constant instead. |
+| the `*_reducing` family, **and `Tau`/`Delta`** | A different reason, worth stating separately: superancillaries do not touch `get_reducing_state()`. A correlation writing `T_reducing` means its *own* fitted reducing parameter, which is generally not the EOS's and moves when the EOS section is revised. `Tau` and `Delta` are that same state wearing another name — `keyed_output()` computes them as `_reducing.T/_T` and `_rhomolar/_reducing.rhomolar` — so refusing one while admitting the other would be a guard with a door next to it. |
+| `Phase`, `Q`, `Qmass` | Not continuous state functions: `Phase` is an enum ordinal widened to `double` (and depends on any imposed phase), `Q` is `-1` outside the dome. Both would compile into plausible-looking arithmetic. |
+| `T_freeze`, `fraction_min`, `fraction_max`, `GWP20/100/500`, `ODP`, `FH`, `HH`, `PH` | Fluid metadata, not functions of the current state; several are unimplemented for HEOS and throw from inside the evaluation, where fluid-file data has no business failing. |
+
+Three further errors are compile-time, not runtime:
+
+- declaring a name that is also a `constants` or `arrays` key (the collision, now
+  raised only when the author actually asked for both);
+- declaring a name the formula never reads (it would cost a `keyed_output()` per
+  evaluation and misstate the block's dependencies);
+- reading a valid parameter that was *not* declared — the message names
+  `state_variables` rather than saying "unknown variable".
 
 ### 3. JSON schema (additive)
 
@@ -191,7 +277,8 @@ A transport sub-block (`dilute`, `initial_density`, `higher_order`, `residual`,
 ```json
 "higher_order": {
   "type": "expression",
-  "formula": "let delta = rhomolar/rhomolar_reduce\nlet tau = T_reduce/T\nsum(i: a[i]*delta^d1[i]*tau^t1[i]*exp(gamma[i]*delta^l[i]))",
+  "formula": "let delta = Dmolar/rhomolar_reduce\nlet tau = T_reduce/T\nsum(i: a[i]*delta^d1[i]*tau^t1[i]*exp(gamma[i]*delta^l[i]))",
+  "state_variables": ["Dmolar", "T"],
   "constants": { "T_reduce": 132.6312, "rhomolar_reduce": 10447.7 },
   "arrays": { "a": [1.072e-05], "d1": [1], "t1": [0.2], "gamma": [0], "l": [0] }
 }
@@ -205,6 +292,29 @@ A transport sub-block (`dilute`, `initial_density`, `higher_order`, `residual`,
 
 There is no units field: every exposed quantity and the result are base SI
 always (§2), so a units annotation would be redundant.
+
+### 3a. What a block returns, per stage
+
+**Every expression block yields its own stage's contribution, in base SI, ready to
+be summed.** The host adds the stages; it applies no scaling of its own to an
+expression result. That is the `EMPIRICAL` convention, and it is deliberately NOT
+the `RAINWATER_FRIEND` one, whose hardcoded arm returns a second viscosity virial
+`B_eta` that the host then multiplies by `eta_dilute * rho`.
+
+The consequence is worth stating plainly: a formula cannot see any other stage's
+output. `eta_dilute` is a within-correlation intermediate, not a thermodynamic
+input, and exposing it would mean a stage reading another stage's result — the
+same self-reference the transport-output denylist exists to prevent. A correlation whose
+initial-density term is defined as `eta_1 = eta_0 * B_eta` therefore **recomputes
+`eta_0` inside the initial-density block**. That duplicates coefficient data in the
+fluid file, which is the price of not adding a code path; the two copies sit side
+by side in one file, and a divergence shows up immediately against the
+correlation's published verification values.
+
+Stages must stay honest about what they report: `calc_viscosity_dilute()` is
+consumed independently by conductivity models, and `viscosity_contributions()` is
+public API. Collapsing a whole correlation into one block would be simpler to
+write and wrong for both reasons.
 
 ### 4. Components
 
@@ -352,13 +462,16 @@ e.evaluate(AS)
   `std::pow`) vs a hand-written `x*x` in some routines. Golden gate is `1e-14`
   relative (~tens of ULP) with per-form bit-exact assertions where applicable.
   Accepted.
-- **Input table, five entries in v1:** the binder records the
-  `CoolProp::parameters` keys a formula references and the host fills them with
-  `keyed_output()`. Accepted as cheap insurance that makes Tier B additive (one
-  row in the table) rather than a binder rewrite, and the `p` entry proves the
-  EOS-backed path end-to-end.
+- **Per-block declared state variables:** the binder records the
+  `CoolProp::parameters` keys a formula declares and reads, and the host fills them
+  with `keyed_output()`. This replaced a curated five-entry allowlist, which made
+  Tier B additive but only one row at a time — krypton's entropy scaling cost three
+  rows and a recompile for quantities `keyed_output()` already knew, and its
+  reserved names collided with coefficient arrays in blocks that never used them.
+  Declaration makes Tier B free and the reservation local. `P` is still exercised
+  end-to-end by a dedicated unit test, proving the EOS-backed path.
 - **Evaluation requires an `AbstractState`,** even for a formula that reads only
-  `T` and `rhomolar` (or nothing at all): the caller must stand up a backend for
+  `T` and `Dmolar` (or nothing at all): the caller must stand up a backend for
   some fluid. An earlier draft took `(T, rhomolar, fluid_name)` and could evaluate
   with no fluid at all, which suited authoring a correlation for a fluid CoolProp
   does not ship yet. **Accepted deliberately** (PR #3185 review): this code lives

--- a/docs/superpowers/specs/2026-06-12-transport-expression-dsl-design.md
+++ b/docs/superpowers/specs/2026-06-12-transport-expression-dsl-design.md
@@ -85,7 +85,7 @@ The completeness claim therefore covers the eight golden-tested Tier-A forms plu
 | Evaluator | Tree-walking AST, compiled once per fluid at load, evaluated many |
 | Sum syntax | `sum(i: <body>)` explicit index; arrays subscripted `arr[i]` |
 | Variables | Raw state + JSON-declared constants/arrays + `let` bindings; **all quantities base SI, always** |
-| Thermodynamic inputs | ONE bucket, keyed by the existing `CoolProp::parameters` enum; the host fills every requested key with `AbstractState::keyed_output()`. Resolved per-block from a declared `state_variables` list via `is_valid_parameter()` — CoolProp's own names, no list kept here — minus a policy denylist (transport outputs; critical/reducing state) |
+| Thermodynamic inputs | ONE bucket, keyed by the existing `CoolProp::parameters` enum; the host fills every requested key with `AbstractState::keyed_output()`. Resolved per-block from a declared `state_variables` list, against an explicit opt-in set of CoolProp's own canonical names (8 today, one line to extend). A denylist over `is_valid_parameter()` was implemented first and rejected: it fails open, leaving 59 of 92 names declarable |
 
 ### Why tree-walking AST, not bytecode VM
 
@@ -167,11 +167,11 @@ names lives in this library at all. A block declares what it reads:
 "state_variables": ["T", "Dmolar"]
 ```
 
-Each name is resolved by `CoolProp::is_valid_parameter()`, so **the DSL's
-vocabulary is CoolProp's vocabulary** — every quantity `keyed_output()` can produce
-is reachable, in CoolProp's own canonical spelling (`P`, `Dmolar`, `Dmass`,
-`Smolar_residual`, `Bvirial`, ...). Adding a thermodynamic quantity to the language
-costs nothing: no table row, no recompile.
+Each name is checked against an explicit opt-in set and then resolved to its
+`CoolProp::parameters` key by `is_valid_parameter()`, so the spellings are CoolProp's
+own canonical ones (`P`, `Dmolar`, `Dmass`, `Smolar_residual`, `Bvirial`, ...) with
+nothing invented. The set is small and deliberate — see "What may be declared" below
+for what is in it, and why it is an allowlist rather than a denylist.
 
 Whether a key is free or costs an EOS call is not the DSL's business: the compiled
 `Program` reports `requiredInputs()` as a `std::vector<CoolProp::parameters>` and
@@ -231,34 +231,53 @@ guard is explicit now rather than emergent.
 **Compatibility.** This changed the fluid-JSON contract with no version gate and no
 shim: a block written against the previous format does not compile. That is
 deliberate — the retired spellings were the defect, so silently accepting them is the
-one outcome worth avoiding — but it puts the whole burden on the failure being
-legible. The three retired names are therefore kept in a table that produces *only
-error text*:
-
-```
-unknown variable 'rhomolar' -- it was this DSL's own spelling for a thermodynamic
-quantity before blocks declared their inputs; CoolProp calls it 'Dmolar', and it
-must be listed in this block's "state_variables"
-```
+one outcome worth avoiding. No migration table is carried for them either; the
+allowlist's own refusal message names `Dmolar` where an old block wrote `rhomolar`,
+which is the same answer without a second list to maintain.
 
 A version field was considered and rejected. It would only help if v1 were still
 supported, which is exactly what we do not want; an *optional* version is
 indistinguishable from a new block that omitted it; and a version on this block type
-alone would be the only such field in CoolProp's fluid JSON. The failure above works
-for every old block, including the ones that never carried a version. If schema
-versioning is wanted later it belongs on the fluid file, not on one block type.
+alone would be the only such field in CoolProp's fluid JSON. If schema versioning is
+wanted later it belongs on the fluid file, not on one block type.
 
-**What is still refused, and why opt-in is not enough.** Two classes are rejected at
-compile time even when explicitly declared, because these are the cases where the
-author's intent cannot be honoured:
+**What may be declared: an explicit set.** The DSL exposes
 
-| Refused | Reason |
+    T   P   Dmolar   Dmass   molar_mass   Smolar_residual   Bvirial   dBvirial_dT
+
+and refuses everything else. The set grows on demand — one line — and each addition
+should require the deliberate judgement that the quantity is a continuous function of
+the *current* state (not fluid metadata, not a range limit, not a phase index or a
+sentinel-valued quality), is free of configuration dependence, and is not a transport
+output whose `keyed_output()` re-enters the correlation being defined.
+
+*Why an allowlist and not a denylist.* Resolving anything `is_valid_parameter()`
+knows, minus the harmful ones, was implemented first and is structurally unsound
+because it **fails open**. The denylist reached four categories and still left **59 of
+CoolProp's 92 canonical names declarable**, including:
+
+| slipped through | why it matters |
 |---|---|
-| `V`, `viscosity`, `L`, `conductivity`, `Prandtl`, `surface_tension` | `keyed_output()` re-enters the correlation being defined — unbounded recursion, at eval time, in fluid-file data |
-| `T_critical`, `P_critical`, `rhomolar_critical`, `rhomass_critical` | `calc_T_critical()`/`calc_rhomolar_critical()` return the *numerical* critical point under `ENABLE_SUPERANCILLARIES` (the default), so a correlation reducing on them changes answer with configuration. Xenon missed its reference values by 7e-5 exactly this way. Freeze the paper's own value as a constant instead. |
-| the `*_reducing` family, **and `Tau`/`Delta`** | A different reason, worth stating separately: superancillaries do not touch `get_reducing_state()`. A correlation writing `T_reducing` means its *own* fitted reducing parameter, which is generally not the EOS's and moves when the EOS section is revised. `Tau` and `Delta` are that same state wearing another name — `keyed_output()` computes them as `_reducing.T/_T` and `_rhomolar/_reducing.rhomolar` — so refusing one while admitting the other would be a guard with a door next to it. |
-| `Phase`, `Q`, `Qmass` | Not continuous state functions: `Phase` is an enum ordinal widened to `double` (and depends on any imposed phase), `Q` is `-1` outside the dome. Both would compile into plausible-looking arithmetic. |
-| `T_freeze`, `fraction_min`, `fraction_max`, `GWP20/100/500`, `ODP`, `FH`, `HH`, `PH` | Fluid metadata, not functions of the current state; several are unimplemented for HEOS and throw from inside the evaluation, where fluid-file data has no business failing. |
+| `HFORMATION` | fluid metadata; evaluates to a number that means nothing here |
+| `P_min`, `T_max`, `T_triple`, `p_triple` | range limits and fluid constants, not state — and `P_min` reads back `p_triple()`, so the name silently means something else |
+| `alphar`, `alpha0`, `dalphar_ddelta_consttau` | EOS internals in **reduced** variables, so they carry the reducing state — precisely the defect `Tau` and `Delta` were denied for |
+| `gas_constant`, `acentric`, `dipole_moment` | fluid constants; freeze them in `constants` if a correlation needs them |
+
+Two gaps were found by review before the third category above was noticed at all. A
+denylist would need patching for every parameter CoolProp ever adds; an allowlist
+refuses them until someone decides otherwise.
+
+This is **not** the input table that was removed. That table mapped *invented*
+spellings (`rhomolar`, `rhomass`, `p`) and reserved every one of them in every
+formula. These are CoolProp's own canonical names, and a block reserves only what it
+declares — so `p` remains the author's wherever pressure is not asked for, which is
+the collision the redesign existed to fix. What the allowlist costs is the claim that
+a new quantity is free: krypton's three cost three lines. What it buys is that the
+next quantity CoolProp adds is refused rather than silently admitted.
+
+The refusal names the whole available set, which is short enough to print and answers
+"then what do I write?" — including for the DSL's own retired spellings, where
+`rhomolar` is met with `Dmolar` in the list.
 
 Three further errors are compile-time, not runtime:
 
@@ -304,7 +323,7 @@ the `RAINWATER_FRIEND` one, whose hardcoded arm returns a second viscosity viria
 The consequence is worth stating plainly: a formula cannot see any other stage's
 output. `eta_dilute` is a within-correlation intermediate, not a thermodynamic
 input, and exposing it would mean a stage reading another stage's result — the
-same self-reference the transport-output denylist exists to prevent. A correlation whose
+same self-reference that keeps transport outputs off the allowlist. A correlation whose
 initial-density term is defined as `eta_1 = eta_0 * B_eta` therefore **recomputes
 `eta_0` inside the initial-density block**. That duplicates coefficient data in the
 fluid file, which is the price of not adding a code path; the two copies sit side

--- a/include/CoolProp/CoolPropFluid.h
+++ b/include/CoolProp/CoolPropFluid.h
@@ -286,11 +286,13 @@ struct ViscosityInitialDensityVariables
     {
         VISCOSITY_INITIAL_DENSITY_RAINWATER_FRIEND,  ///< Use \ref TransportRoutines::viscosity_initial_density_dependence_Rainwater_Friend
         VISCOSITY_INITIAL_DENSITY_EMPIRICAL,         ///< Use \ref TransportRoutines::viscosity_initial_density_dependence_empirical
+        VISCOSITY_INITIAL_DENSITY_EXPRESSION,        ///< Runtime expression DSL block
         VISCOSITY_INITIAL_DENSITY_NOT_SET
     };
     ViscosityInitialDensityEnum type = VISCOSITY_INITIAL_DENSITY_NOT_SET;
     ViscosityRainWaterFriendData rainwater_friend;   ///< Data for \ref TransportRoutines::viscosity_initial_density_dependence_Rainwater_Friend
     ViscosityInitialDensityEmpiricalData empirical;  ///< Data for \ref TransportRoutines::viscosity_initial_density_dependence_empirical
+    ExpressionData expression_data{};
 };
 
 struct ViscosityModifiedBatschinskiHildebrandData

--- a/include/CoolProp/expression/Expression.h
+++ b/include/CoolProp/expression/Expression.h
@@ -22,16 +22,33 @@ namespace expression {
 /// The DSL spellings that resolve to a thermodynamic input, paired with the
 /// CoolProp::parameters key each binds to, in name-resolution order.
 ///
-/// This is deliberately a curated allowlist rather than an open door onto
-/// get_parameter_index():
-///  * the DSL spells state variables the way the C++ members do (`rhomolar`,
-///    `rhomass`), which get_parameter_index() does not recognise -- it spells
-///    them `Dmolar`/`Dmass` -- and those spellings are baked into fluid JSON;
-///  * an open door would let a viscosity formula reference `V`, whose
-///    keyed_output() re-enters the very correlation being defined.
-const std::vector<std::pair<std::string, parameters>>& inputTable();
+/// Resolve `name` as a state variable a correlation may declare.
+///
+/// The DSL does NOT maintain its own list of thermodynamic quantities.  A name is
+/// resolved by CoolProp::is_valid_parameter(), so the DSL's vocabulary IS CoolProp's
+/// vocabulary -- every quantity keyed_output() can produce is reachable, and adding
+/// a new one never requires touching this library.  The spellings are CoolProp's
+/// canonical ones (`P`, `Dmolar`, `Dmass`); the DSL invents no aliases of its own,
+/// because an invented lowercase `p` is precisely what once collided with the
+/// exponent array every viscosity paper calls p_i.
+///
+/// Returns true and sets `key` when `name` is resolvable and permitted.  Otherwise
+/// returns false and sets `reason` to a message fit for a compile error.  Two
+/// classes are refused even though CoolProp resolves them:
+///
+///  * transport outputs (`V`, `L`, `Prandtl`, ...) -- keyed_output() for these
+///    re-enters the very correlation being defined;
+///  * the critical point and the EOS reducing state -- calc_T_critical() and
+///    calc_rhomolar_critical() return the NUMERICAL critical point when
+///    ENABLE_SUPERANCILLARIES is set, so a correlation reducing on them would
+///    silently change answer with configuration.  Freeze those as `constants`
+///    instead, at the value the paper's authors regressed against.
+bool resolveStateVariable(const std::string& name, parameters& key, std::string& reason);
 
-/// DSL spelling for `key`.  Throws CoolProp::ValueError if `key` is not in inputTable().
+/// CoolProp's canonical spelling for `key`, as used in error messages and in
+/// ExpressionBlock::required_inputs().  Since only the canonical spelling is
+/// accepted as a declaration, this round-trips whatever the author wrote.  Throws
+/// CoolProp::ValueError for a key outside the parameter-information table.
 std::string inputName(parameters key);
 
 namespace detail {
@@ -46,7 +63,10 @@ class Program
     /// that order; pass an empty vector when none are required.  A size mismatch
     /// throws CoolProp::ValueError rather than reading past the end.
     [[nodiscard]] double evaluate(const std::vector<double>& inputVals) const;
-    /// Thermodynamic inputs this program references, in the order evaluate() expects them.
+    /// Thermodynamic inputs this program references, in the order evaluate() expects
+    /// them: the block's DECLARED `state_variables`, in order of FIRST REFERENCE in
+    /// the formula -- which is not necessarily the order they were declared in.  The
+    /// declaration gates what may be read; the formula fixes the order.
     [[nodiscard]] const std::vector<parameters>& requiredInputs() const;
 
    private:
@@ -54,7 +74,8 @@ class Program
     /// compiled body); every public accessor goes through it before dereferencing.
     const detail::ProgramData& data() const;
 
-    friend Program compile(const std::string&, const std::map<std::string, double>&, const std::map<std::string, std::vector<double>>&);
+    friend Program compile(const std::string&, const std::map<std::string, double>&, const std::map<std::string, std::vector<double>>&,
+                           const std::vector<std::string>&);
     std::shared_ptr<const detail::ProgramData> m_data;
 };
 
@@ -66,7 +87,14 @@ class Program
 ///
 /// Compile a formula string. `constants` are scalar names -> SI values; `arrays`
 /// are vector names -> values. Throws CoolProp::ValueError on any lex/parse/bind error.
-Program compile(const std::string& source, const std::map<std::string, double>& constants, const std::map<std::string, std::vector<double>>& arrays);
+/// `state_variables` names the thermodynamic quantities this formula is allowed to
+/// read, in CoolProp's spelling.  It is opt-in and per-formula: a name not declared
+/// here is never state, so a block that does not ask for pressure keeps `P` -- and,
+/// more to the point, keeps every lowercase coefficient name -- for its own use.
+/// Declaring a name the formula never reads is an error, as is declaring one that
+/// also appears in `constants` or `arrays`.
+Program compile(const std::string& source, const std::map<std::string, double>& constants, const std::map<std::string, std::vector<double>>& arrays,
+                const std::vector<std::string>& state_variables = {});
 
 }  // namespace expression
 }  // namespace CoolProp

--- a/include/CoolProp/expression/ExpressionBlock.h
+++ b/include/CoolProp/expression/ExpressionBlock.h
@@ -14,7 +14,12 @@ namespace expression {
 
 /// Compile a transport `"type": "expression"` block from its JSON text:
 ///
-///     {"formula": "...", "constants": {...}, "arrays": {...}}
+///     {"formula": "...", "state_variables": [...], "constants": {...}, "arrays": {...}}
+///
+/// `state_variables` names the thermodynamic quantities the formula may read, in
+/// CoolProp's canonical spelling.  It is opt-in and per-block: a name not listed
+/// there is never state, so a block that does not ask for pressure keeps `p` for
+/// its own coefficients.
 ///
 /// Any other key -- `"type"` included -- is ignored, so the text can be lifted
 /// verbatim out of (or pasted verbatim into) a fluid JSON file.  `context`, when
@@ -35,8 +40,9 @@ class ExpressionBlock
    public:
     /// `json_text` is the block as it appears in fluid JSON (see compile_block()).
     explicit ExpressionBlock(const std::string& json_text) : m_program(compile_block(json_text)) {}
-    /// DSL names of the thermodynamic inputs the formula references, in the order
-    /// they are fetched.  Empty for a formula built only from constants and arrays.
+    /// The declared state variables the formula actually reads, in the order they
+    /// are fetched (first reference in the formula, NOT declaration order).  Empty
+    /// for a formula built only from constants and arrays.
     [[nodiscard]] std::vector<std::string> required_inputs() const;
     /// Evaluate at the state `AS` is currently sitting at; the result is in whatever
     /// base-SI unit the formula produces.  The caller sets the state through the

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.h
@@ -637,6 +637,9 @@ class JSONFluidLibrary
 
             // Set the type flag
             fluid.transport.viscosity_initial.type = CoolProp::ViscosityInitialDensityVariables::VISCOSITY_INITIAL_DENSITY_EMPIRICAL;
+        } else if (!type.compare("expression")) {
+            fluid.transport.viscosity_initial.expression_data = parse_expression_block(initial_density, fluid.name);
+            fluid.transport.viscosity_initial.type = CoolProp::ViscosityInitialDensityVariables::VISCOSITY_INITIAL_DENSITY_EXPRESSION;
         } else {
             throw ValueError(format("type [%s] is not understood for fluid %s", type.c_str(), fluid.name.c_str()));
         }

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -771,6 +771,17 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity_background(CoolPropDbl et
             initial_density = TransportRoutines::viscosity_initial_density_dependence_empirical(*this);
             break;
         }
+        case ViscosityInitialDensityVariables::VISCOSITY_INITIAL_DENSITY_EXPRESSION: {
+            // The formula yields this stage's contribution directly, in Pa-s -- the
+            // same convention as the EMPIRICAL form and as the other four stages.
+            // It is NOT the Rainwater-Friend B_eta, which the host would have to
+            // scale by eta_dilute*rho; the dilute viscosity is a within-correlation
+            // intermediate and is deliberately not exposed to the DSL.
+            if (!components[0].transport.viscosity_initial.expression_data.correlation)
+                throw ValueError(format("expression correlation not set for fluid %s", name().c_str()));
+            initial_density = components[0].transport.viscosity_initial.expression_data.correlation->eval(*this);
+            break;
+        }
         case ViscosityInitialDensityVariables::VISCOSITY_INITIAL_DENSITY_NOT_SET: {
             break;
         }

--- a/src/Tests/CoolProp-Tests-Expression.cpp
+++ b/src/Tests/CoolProp-Tests-Expression.cpp
@@ -132,16 +132,16 @@ TEST_CASE("DSL pressure and temperature share one input bucket", "[expression]")
 
 TEST_CASE("declared state variables resolve through CoolProp's own vocabulary", "[expression]") {
     using namespace CoolProp::expression;
-    // The DSL keeps no list of thermodynamic names.  A declared name is resolved by
-    // is_valid_parameter(), so anything keyed_output() can produce is reachable
-    // without touching this library -- which is the whole point: krypton's
-    // Smolar_residual/Bvirial/dBvirial_dT each cost a C++ row under the old design.
+    // Names are CoolProp's own, resolved to CoolProp's own keys.  The set is opt-in
+    // and deliberately small (see "the DSL exposes an explicit set" below); a state
+    // function that is legitimate but unused -- Hmolar, say -- is simply not exposed
+    // until a correlation needs it, which is one line rather than a design decision.
     CHECK(compile("T", {}, {}, {"T"}).requiredInputs()[0] == CoolProp::iT);
     CHECK(compile("Dmolar", {}, {}, {"Dmolar"}).requiredInputs()[0] == CoolProp::iDmolar);
     CHECK(compile("Dmass", {}, {}, {"Dmass"}).requiredInputs()[0] == CoolProp::iDmass);
     CHECK(compile("molar_mass", {}, {}, {"molar_mass"}).requiredInputs()[0] == CoolProp::imolar_mass);
     CHECK(compile("P", {}, {}, {"P"}).requiredInputs()[0] == CoolProp::iP);
-    CHECK(compile("Hmolar", {}, {}, {"Hmolar"}).requiredInputs()[0] == CoolProp::iHmolar);
+    CHECK_THROWS_AS(compile("Hmolar", {}, {}, {"Hmolar"}), CoolProp::ValueError);
     CHECK(inputName(CoolProp::iDmolar) == "Dmolar");
 
     // The spellings are CoolProp's, with nothing invented.  The DSL used to accept
@@ -154,124 +154,73 @@ TEST_CASE("declared state variables resolve through CoolProp's own vocabulary", 
     }
 }
 
-TEST_CASE("two classes of parameter stay refused even when declared", "[expression]") {
+TEST_CASE("the DSL exposes an explicit set of state variables", "[expression]") {
     using namespace CoolProp::expression;
-    // Opt-in expresses the author's intent, but these are the cases where the intent
-    // cannot be honoured, so declaring them is an error rather than a licence.
-    //
-    // Transport outputs: keyed_output() re-enters the correlation being defined.
-    for (const char* nm : {"V", "viscosity", "L", "conductivity", "Prandtl", "surface_tension"}) {
-        CAPTURE(nm);
-        CHECK_THROWS_AS(compile(nm, {}, {}, {nm}), CoolProp::ValueError);
-    }
-    // Critical point and reducing state: calc_T_critical()/calc_rhomolar_critical()
-    // return the NUMERICAL critical point under ENABLE_SUPERANCILLARIES, so a
-    // correlation reducing on them changes answer with configuration.  Xenon missed
-    // its reference values by 7e-5 exactly this way.
-    for (const char* nm : {"T_critical", "P_critical", "rhomolar_critical", "rhomass_critical", "T_reducing", "rhomolar_reducing"}) {
-        CAPTURE(nm);
-        CHECK_THROWS_AS(compile(nm, {}, {}, {nm}), CoolProp::ValueError);
-        // ...but each stays usable as an ordinary frozen constant, which is where a
-        // correlation's reducing parameters belong: at the precision the paper quotes.
-        CHECK(compile(nm, {{nm, 7.0}}, {}).evaluate({}) == Catch::Approx(7.0));
-    }
-    // The error names the reason, not just the refusal.
+    // Opt-in, and small on purpose.  Each name must be one of CoolProp's own AND its
+    // canonical spelling -- an alias here would silently re-admit `A` for the speed of
+    // sound and the single-letter coefficient names papers use.
     CoolProp::parameters key;
     std::string reason;
-    REQUIRE_FALSE(resolveStateVariable("V", key, reason));
-    CHECK(reason.find("re-enters") != std::string::npos);
-    REQUIRE_FALSE(resolveStateVariable("T_critical", key, reason));
-    CHECK(reason.find("ENABLE_SUPERANCILLARIES") != std::string::npos);
-    REQUIRE_FALSE(resolveStateVariable("not_a_parameter", key, reason));
-    CHECK(reason.find("not a CoolProp parameter") != std::string::npos);
-    // A denied quantity gives its real reason even when spelled as an alias -- being
-    // told to use `viscosity` and then refused `viscosity` would be a runaround.
-    REQUIRE_FALSE(resolveStateVariable("V", key, reason));
-    CHECK(reason.find("re-enters") != std::string::npos);
-
-    // Tau and Delta ARE the reducing state (keyed_output computes them as
-    // _reducing.T/_T and _rhomolar/_reducing.rhomolar), so refusing T_reducing while
-    // admitting them would be a guard with a door next to it.
-    for (const char* nm : {"Tau", "Delta"}) {
+    const std::vector<std::string> expected = {"T", "P", "Dmolar", "Dmass", "molar_mass", "Smolar_residual", "Bvirial", "dBvirial_dT"};
+    for (const auto& nm : expected) {
         CAPTURE(nm);
-        REQUIRE_FALSE(resolveStateVariable(nm, key, reason));
-        CHECK(reason.find("reducing state") != std::string::npos);
-        CHECK_THROWS_AS(compile(nm, {}, {}, {nm}), CoolProp::ValueError);
-    }
-    // Phase is an enum ordinal widened to double; Q is -1 outside the dome.  Neither
-    // is a continuous state function, and both would compile into plausible arithmetic.
-    for (const char* nm : {"Phase", "Q", "Qmass"}) {
-        CAPTURE(nm);
-        CHECK_THROWS_AS(compile(nm, {}, {}, {nm}), CoolProp::ValueError);
-    }
-    // Fluid metadata is not a function of the state, and several throw from inside
-    // the evaluation -- where fluid-file data has no business failing.
-    for (const char* nm : {"T_freeze", "GWP100", "ODP", "fraction_min"}) {
-        CAPTURE(nm);
-        CHECK_THROWS_AS(compile(nm, {}, {}, {nm}), CoolProp::ValueError);
+        REQUIRE(resolveStateVariable(nm, key, reason));
+        CHECK(inputName(key) == nm);                                    // canonical, not an alias
+        CHECK(compile(nm, {}, {}, {nm}).requiredInputs().size() == 1);  // and actually declarable
     }
 }
 
-TEST_CASE("a block in the previous format fails saying what changed", "[expression]") {
+TEST_CASE("anything outside that set is refused, and the message names the set", "[expression]") {
     using namespace CoolProp::expression;
-    // Fluid JSON is data third parties ship, and this branch changed its contract:
-    // blocks must declare `state_variables`, and the DSL's own spellings `rhomolar`,
-    // `rhomass` and `p` are gone in favour of CoolProp's `Dmolar`, `Dmass`, `P`.
-    // There is no version gate and no shim -- so the load-time failure has to name
-    // the migration, or an author sees only "unknown variable 'rhomolar'".
-    const std::pair<const char*, const char*> retired[] = {{"rhomolar", "Dmolar"}, {"rhomass", "Dmass"}, {"p", "P"}};
-    for (const auto& r : retired) {
-        CAPTURE(r.first);
-        // ...used in a formula, the way an old block has it
-        try {
-            compile(r.first, {}, {});
-            FAIL("expected a throw");
-        } catch (const CoolProp::ValueError& e) {
-            const std::string msg = e.what();
-            CHECK(msg.find(r.second) != std::string::npos);           // names the replacement
-            CHECK(msg.find("state_variables") != std::string::npos);  // and the new requirement
-        }
-        // ...and declared, the way a half-finished migration has it
-        CoolProp::parameters key;
-        std::string reason;
+    // A denylist was tried first and fails OPEN: 59 of CoolProp's 92 canonical names
+    // slipped past one that had already grown to four categories.  Each name below is
+    // a distinct way that went wrong, and all are refused by construction now.
+    const std::pair<const char*, const char*> refused[] = {
+      {"viscosity", "a transport output; keyed_output() re-enters the correlation being defined"},
+      {"V", "the same, spelled as an alias"},
+      {"T_critical", "configuration-dependent under ENABLE_SUPERANCILLARIES"},
+      {"T_reducing", "the EOS reducing state is not the correlation's own fitted parameter"},
+      {"Tau", "the reducing state wearing another name: _reducing.T/_T"},
+      {"Delta", "likewise: _rhomolar/_reducing.rhomolar"},
+      {"alphar", "an EOS internal in REDUCED variables, so it carries the reducing state too"},
+      {"dalphar_ddelta_consttau", "the same, and a denylist missed it"},
+      {"Phase", "an enum ordinal widened to double"},
+      {"Q", "-1 outside the dome: a sentinel entering arithmetic as data"},
+      {"HFORMATION", "fluid metadata; evaluates to a number that means nothing here"},
+      {"P_min", "a range limit, not state -- and it reads back p_triple()"},
+      {"T_triple", "likewise a fluid constant"},
+      {"gas_constant", "a fluid constant; freeze it if the correlation needs it"},
+      {"A", "CoolProp's alias for speed_of_sound -- and a coefficient name in every paper"},
+      {"M", "CoolProp's alias for molar_mass"},
+      {"DMOLAR", "an upper-cased spelling; one name per quantity"},
+    };
+    CoolProp::parameters key;
+    std::string reason;
+    for (const auto& r : refused) {
+        CAPTURE(r.first, r.second);
         REQUIRE_FALSE(resolveStateVariable(r.first, key, reason));
-        CHECK(reason.find(r.second) != std::string::npos);
+        // The message answers "then what do I write?" by naming the whole set.
+        CHECK(reason.find("Dmolar") != std::string::npos);
+        CHECK_THROWS_AS(compile(r.first, {}, {}, {r.first}), CoolProp::ValueError);
+        // ...and every one of them stays usable as the author's own frozen constant,
+        // which is where a correlation's reducing parameters belong anyway.
+        CHECK(compile(r.first, {{r.first, 7.0}}, {}).evaluate({}) == Catch::Approx(7.0));
     }
-    // A retired name is still just an identifier: as the author's own constant it is
-    // fine, which is exactly why it cannot be silently reinterpreted as state.
-    CHECK(compile("p*2", {{"p", 21.0}}, {}).evaluate({}) == Catch::Approx(42.0));
-}
-
-TEST_CASE("only CoolProp's canonical spelling is accepted, never an alias", "[expression]") {
-    using namespace CoolProp::expression;
-    // is_valid_parameter() also accepts back-compat aliases and an upper-cased
-    // spelling of every name.  Those are harmless in PropsSI and a trap here, because
-    // a DSL formula is FULL of single-letter coefficient names: an author who forgot
-    // to declare a paper coefficient `A` in `constants` is told to add it to
-    // state_variables, and doing so would silently bind the speed of sound.
-    CoolProp::parameters key;
-    std::string reason;
-    for (const char* alias : {"A", "C", "D", "G", "M", "O", "S", "U", "DMOLAR", "HMOLAR"}) {
-        CAPTURE(alias);
-        REQUIRE_FALSE(resolveStateVariable(alias, key, reason));
-        CHECK(reason.find("alias") != std::string::npos);
-        CHECK_THROWS_AS(compile(alias, {}, {}, {alias}), CoolProp::ValueError);
+    // The DSL's own retired spellings land here too, and the same message answers
+    // them: `rhomolar` is met with `Dmolar` in the available set.
+    for (const char* old : {"rhomolar", "rhomass", "p"}) {
+        CAPTURE(old);
+        REQUIRE_FALSE(resolveStateVariable(old, key, reason));
+        CHECK_THROWS_AS(compile(old, {}, {}, {old}), CoolProp::ValueError);
     }
-    // ...so each stays free for the author, which is the point.
-    CHECK(compile("A*M", {{"A", 3.0}, {"M", 4.0}}, {}).evaluate({}) == Catch::Approx(12.0));
-    // Every spelling this branch's fluid data actually ships is canonical.
-    for (const char* nm : {"T", "P", "Dmolar", "Dmass", "molar_mass", "Smolar_residual", "Bvirial", "dBvirial_dT"}) {
-        CAPTURE(nm);
-        CHECK(resolveStateVariable(nm, key, reason));
-        CHECK(inputName(key) == nm);
-    }
+    // `p` in particular stays the author's, which is the collision this all fixed.
+    CHECK(compile("sum(i: n[i]*p[i])", {}, {{"n", {2.0, 3.0}}, {"p", {5.0, 7.0}}}).evaluate({}) == Catch::Approx(2.0 * 5.0 + 3.0 * 7.0));
 }
 
 TEST_CASE("two names for one quantity are rejected rather than fetched twice", "[expression]") {
     using namespace CoolProp::expression;
-    // Aliases are already refused, so this needs the canonical/alias pair to both be
-    // canonical -- but pin the rule directly: dedupe is on the resolved key, because
-    // two slots for one quantity would cost two keyed_output() calls per evaluation.
+    // Dedupe is on the resolved key: two slots for one quantity would cost two
+    // keyed_output() calls per evaluation.
     CHECK_THROWS_AS(compile("T + T", {}, {}, {"T", "T"}), CoolProp::ValueError);
 }
 

--- a/src/Tests/CoolProp-Tests-Expression.cpp
+++ b/src/Tests/CoolProp-Tests-Expression.cpp
@@ -16,6 +16,7 @@
 #    include <string>
 #    include <vector>
 
+#    include "CoolProp/Configuration.h"
 #    include "CoolProp/CoolProp.h"
 #    include "CoolProp/CoolPropFluid.h"
 #    include "CoolProp/DataStructures.h"
@@ -80,7 +81,7 @@ TEST_CASE("compile sum over co-indexed arrays", "[expression]") {
 
 TEST_CASE("compile binds inputs in required order", "[expression]") {
     using namespace CoolProp::expression;
-    Program p = compile("T + rhomolar", {}, {});
+    Program p = compile("T + Dmolar", {}, {}, {"T", "Dmolar"});
     REQUIRE(p.requiredInputs().size() == 2);
     std::vector<double> iv(2);
     for (std::size_t k = 0; k < 2; ++k)
@@ -116,7 +117,7 @@ TEST_CASE("DSL nested summation is rejected in v1", "[expression]") {
 
 TEST_CASE("DSL pressure and temperature share one input bucket", "[expression]") {
     using namespace CoolProp::expression;
-    Program p = compile("p*2 + T", {}, {});
+    Program p = compile("P*2 + T", {}, {}, {"P", "T"});
     // p costs an EOS call and T does not, but both are plain CoolProp::parameters
     // keys to the program: one vector, reported in first-reference order.
     const std::vector<CoolProp::parameters>& req = p.requiredInputs();
@@ -129,50 +130,208 @@ TEST_CASE("DSL pressure and temperature share one input bucket", "[expression]")
     CHECK(p.evaluate(iv) == Catch::Approx(2e5 + 300.0));
 }
 
-TEST_CASE("expression input names map onto CoolProp::parameters", "[expression]") {
+TEST_CASE("declared state variables resolve through CoolProp's own vocabulary", "[expression]") {
     using namespace CoolProp::expression;
-    // Every DSL spelling must round-trip through the shared parameters enum, and
-    // the state variables must keep their CoolProp member spellings (NOT the
-    // PropsSI shorthands) so existing fluid JSON keeps compiling.
-    for (const auto& e : inputTable())
-        CHECK(inputName(e.second) == e.first);
-    CHECK(compile("T", {}, {}).requiredInputs()[0] == CoolProp::iT);
-    CHECK(compile("rhomolar", {}, {}).requiredInputs()[0] == CoolProp::iDmolar);
-    CHECK(compile("rhomass", {}, {}).requiredInputs()[0] == CoolProp::iDmass);
-    CHECK(compile("molar_mass", {}, {}).requiredInputs()[0] == CoolProp::imolar_mass);
-    CHECK(compile("p", {}, {}).requiredInputs()[0] == CoolProp::iP);
-    CHECK_THROWS_AS(inputName(CoolProp::iHmolar), CoolProp::ValueError);
-}
+    // The DSL keeps no list of thermodynamic names.  A declared name is resolved by
+    // is_valid_parameter(), so anything keyed_output() can produce is reachable
+    // without touching this library -- which is the whole point: krypton's
+    // Smolar_residual/Bvirial/dBvirial_dT each cost a C++ row under the old design.
+    CHECK(compile("T", {}, {}, {"T"}).requiredInputs()[0] == CoolProp::iT);
+    CHECK(compile("Dmolar", {}, {}, {"Dmolar"}).requiredInputs()[0] == CoolProp::iDmolar);
+    CHECK(compile("Dmass", {}, {}, {"Dmass"}).requiredInputs()[0] == CoolProp::iDmass);
+    CHECK(compile("molar_mass", {}, {}, {"molar_mass"}).requiredInputs()[0] == CoolProp::imolar_mass);
+    CHECK(compile("P", {}, {}, {"P"}).requiredInputs()[0] == CoolProp::iP);
+    CHECK(compile("Hmolar", {}, {}, {"Hmolar"}).requiredInputs()[0] == CoolProp::iHmolar);
+    CHECK(inputName(CoolProp::iDmolar) == "Dmolar");
 
-TEST_CASE("only allowlisted parameter names resolve", "[expression]") {
-    using namespace CoolProp::expression;
-    // `V` and `L` are valid get_parameter_index() names but MUST NOT resolve: a
-    // transport formula naming its own output would recurse through keyed_output().
-    CHECK_THROWS_AS(compile("V", {}, {}), CoolProp::ValueError);
-    CHECK_THROWS_AS(compile("L", {}, {}), CoolProp::ValueError);
-    CHECK_THROWS_AS(compile("Hmolar", {}, {}), CoolProp::ValueError);
-    // ...unless the fluid JSON declares it as a constant, which is the normal
-    // way an author introduces an arbitrary name.
-    CHECK(compile("V", {{"V", 4.0}}, {}).evaluate({}) == Catch::Approx(4.0));
-}
-
-TEST_CASE("a JSON constant that collides with an input is rejected", "[expression]") {
-    using namespace CoolProp::expression;
-    // Inputs resolve before constants, so a constant named `T` would be dead data
-    // and the formula would quietly mean the state temperature.  Silently
-    // discarding what the author wrote is the wrong answer: reject it at compile
-    // time, for every name in the table.
-    for (const auto& e : inputTable()) {
-        CAPTURE(e.first);
-        CHECK_THROWS_AS(compile("1", {{e.first, 1.0}}, {}), CoolProp::ValueError);
+    // The spellings are CoolProp's, with nothing invented.  The DSL used to accept
+    // `rhomolar`/`rhomass`/`p`; the lowercase `p` in particular is what collided with
+    // the exponent array every viscosity paper writes as p_i, and inventing it bought
+    // nothing.  They are gone, and the error says so.
+    for (const char* legacy : {"rhomolar", "rhomass", "p"}) {
+        CAPTURE(legacy);
+        CHECK_THROWS_AS(compile(legacy, {}, {}, {legacy}), CoolProp::ValueError);
     }
-    // A constant whose name is merely close to an input is fine.
-    CHECK(compile("T_reduce", {{"T_reduce", 132.0}}, {}).evaluate({}) == Catch::Approx(132.0));
+}
+
+TEST_CASE("two classes of parameter stay refused even when declared", "[expression]") {
+    using namespace CoolProp::expression;
+    // Opt-in expresses the author's intent, but these are the cases where the intent
+    // cannot be honoured, so declaring them is an error rather than a licence.
+    //
+    // Transport outputs: keyed_output() re-enters the correlation being defined.
+    for (const char* nm : {"V", "viscosity", "L", "conductivity", "Prandtl", "surface_tension"}) {
+        CAPTURE(nm);
+        CHECK_THROWS_AS(compile(nm, {}, {}, {nm}), CoolProp::ValueError);
+    }
+    // Critical point and reducing state: calc_T_critical()/calc_rhomolar_critical()
+    // return the NUMERICAL critical point under ENABLE_SUPERANCILLARIES, so a
+    // correlation reducing on them changes answer with configuration.  Xenon missed
+    // its reference values by 7e-5 exactly this way.
+    for (const char* nm : {"T_critical", "P_critical", "rhomolar_critical", "rhomass_critical", "T_reducing", "rhomolar_reducing"}) {
+        CAPTURE(nm);
+        CHECK_THROWS_AS(compile(nm, {}, {}, {nm}), CoolProp::ValueError);
+        // ...but each stays usable as an ordinary frozen constant, which is where a
+        // correlation's reducing parameters belong: at the precision the paper quotes.
+        CHECK(compile(nm, {{nm, 7.0}}, {}).evaluate({}) == Catch::Approx(7.0));
+    }
+    // The error names the reason, not just the refusal.
+    CoolProp::parameters key;
+    std::string reason;
+    REQUIRE_FALSE(resolveStateVariable("V", key, reason));
+    CHECK(reason.find("re-enters") != std::string::npos);
+    REQUIRE_FALSE(resolveStateVariable("T_critical", key, reason));
+    CHECK(reason.find("ENABLE_SUPERANCILLARIES") != std::string::npos);
+    REQUIRE_FALSE(resolveStateVariable("not_a_parameter", key, reason));
+    CHECK(reason.find("not a CoolProp parameter") != std::string::npos);
+    // A denied quantity gives its real reason even when spelled as an alias -- being
+    // told to use `viscosity` and then refused `viscosity` would be a runaround.
+    REQUIRE_FALSE(resolveStateVariable("V", key, reason));
+    CHECK(reason.find("re-enters") != std::string::npos);
+
+    // Tau and Delta ARE the reducing state (keyed_output computes them as
+    // _reducing.T/_T and _rhomolar/_reducing.rhomolar), so refusing T_reducing while
+    // admitting them would be a guard with a door next to it.
+    for (const char* nm : {"Tau", "Delta"}) {
+        CAPTURE(nm);
+        REQUIRE_FALSE(resolveStateVariable(nm, key, reason));
+        CHECK(reason.find("reducing state") != std::string::npos);
+        CHECK_THROWS_AS(compile(nm, {}, {}, {nm}), CoolProp::ValueError);
+    }
+    // Phase is an enum ordinal widened to double; Q is -1 outside the dome.  Neither
+    // is a continuous state function, and both would compile into plausible arithmetic.
+    for (const char* nm : {"Phase", "Q", "Qmass"}) {
+        CAPTURE(nm);
+        CHECK_THROWS_AS(compile(nm, {}, {}, {nm}), CoolProp::ValueError);
+    }
+    // Fluid metadata is not a function of the state, and several throw from inside
+    // the evaluation -- where fluid-file data has no business failing.
+    for (const char* nm : {"T_freeze", "GWP100", "ODP", "fraction_min"}) {
+        CAPTURE(nm);
+        CHECK_THROWS_AS(compile(nm, {}, {}, {nm}), CoolProp::ValueError);
+    }
+}
+
+TEST_CASE("a block in the previous format fails saying what changed", "[expression]") {
+    using namespace CoolProp::expression;
+    // Fluid JSON is data third parties ship, and this branch changed its contract:
+    // blocks must declare `state_variables`, and the DSL's own spellings `rhomolar`,
+    // `rhomass` and `p` are gone in favour of CoolProp's `Dmolar`, `Dmass`, `P`.
+    // There is no version gate and no shim -- so the load-time failure has to name
+    // the migration, or an author sees only "unknown variable 'rhomolar'".
+    const std::pair<const char*, const char*> retired[] = {{"rhomolar", "Dmolar"}, {"rhomass", "Dmass"}, {"p", "P"}};
+    for (const auto& r : retired) {
+        CAPTURE(r.first);
+        // ...used in a formula, the way an old block has it
+        try {
+            compile(r.first, {}, {});
+            FAIL("expected a throw");
+        } catch (const CoolProp::ValueError& e) {
+            const std::string msg = e.what();
+            CHECK(msg.find(r.second) != std::string::npos);           // names the replacement
+            CHECK(msg.find("state_variables") != std::string::npos);  // and the new requirement
+        }
+        // ...and declared, the way a half-finished migration has it
+        CoolProp::parameters key;
+        std::string reason;
+        REQUIRE_FALSE(resolveStateVariable(r.first, key, reason));
+        CHECK(reason.find(r.second) != std::string::npos);
+    }
+    // A retired name is still just an identifier: as the author's own constant it is
+    // fine, which is exactly why it cannot be silently reinterpreted as state.
+    CHECK(compile("p*2", {{"p", 21.0}}, {}).evaluate({}) == Catch::Approx(42.0));
+}
+
+TEST_CASE("only CoolProp's canonical spelling is accepted, never an alias", "[expression]") {
+    using namespace CoolProp::expression;
+    // is_valid_parameter() also accepts back-compat aliases and an upper-cased
+    // spelling of every name.  Those are harmless in PropsSI and a trap here, because
+    // a DSL formula is FULL of single-letter coefficient names: an author who forgot
+    // to declare a paper coefficient `A` in `constants` is told to add it to
+    // state_variables, and doing so would silently bind the speed of sound.
+    CoolProp::parameters key;
+    std::string reason;
+    for (const char* alias : {"A", "C", "D", "G", "M", "O", "S", "U", "DMOLAR", "HMOLAR"}) {
+        CAPTURE(alias);
+        REQUIRE_FALSE(resolveStateVariable(alias, key, reason));
+        CHECK(reason.find("alias") != std::string::npos);
+        CHECK_THROWS_AS(compile(alias, {}, {}, {alias}), CoolProp::ValueError);
+    }
+    // ...so each stays free for the author, which is the point.
+    CHECK(compile("A*M", {{"A", 3.0}, {"M", 4.0}}, {}).evaluate({}) == Catch::Approx(12.0));
+    // Every spelling this branch's fluid data actually ships is canonical.
+    for (const char* nm : {"T", "P", "Dmolar", "Dmass", "molar_mass", "Smolar_residual", "Bvirial", "dBvirial_dT"}) {
+        CAPTURE(nm);
+        CHECK(resolveStateVariable(nm, key, reason));
+        CHECK(inputName(key) == nm);
+    }
+}
+
+TEST_CASE("two names for one quantity are rejected rather than fetched twice", "[expression]") {
+    using namespace CoolProp::expression;
+    // Aliases are already refused, so this needs the canonical/alias pair to both be
+    // canonical -- but pin the rule directly: dedupe is on the resolved key, because
+    // two slots for one quantity would cost two keyed_output() calls per evaluation.
+    CHECK_THROWS_AS(compile("T + T", {}, {}, {"T", "T"}), CoolProp::ValueError);
+}
+
+TEST_CASE("a name the block did not declare is the author's to use", "[expression]") {
+    using namespace CoolProp::expression;
+    // THE point of opt-in.  Propylene glycol's dilute term is eta_0 = sum n_i Tr^p_i;
+    // under one shared namespace its exponent array had to be renamed to np_i for a
+    // collision with pressure, a quantity that block never reads.  Now `p` is simply
+    // the author's, because the block never asked for pressure.
+    Program q = compile("sum(i: n[i]*p[i])", {}, {{"n", {2.0, 3.0}}, {"p", {5.0, 7.0}}});
+    CHECK(q.requiredInputs().empty());
+    CHECK(q.evaluate({}) == Catch::Approx(2.0 * 5.0 + 3.0 * 7.0));
+    // Same name, same formula, but declared: now it is pressure, and the array of
+    // that name is a collision rather than a silent shadowing.
+    CHECK_THROWS_AS(compile("sum(i: n[i]*p[i])", {}, {{"n", {2.0}}, {"p", {5.0}}}, {"P"}), CoolProp::ValueError);
+    CHECK_THROWS_AS(compile("T", {{"T", 1.0}}, {}, {"T"}), CoolProp::ValueError);
+    CHECK_THROWS_AS(compile("T", {}, {{"T", {1.0}}}, {"T"}), CoolProp::ValueError);
+
+    // Reading a thermodynamic quantity you did not declare is an error, and the
+    // message says which fix is wanted rather than "unknown variable".
+    try {
+        compile("Bvirial", {}, {});
+        FAIL("expected a throw");
+    } catch (const CoolProp::ValueError& e) {
+        const std::string msg = e.what();
+        CHECK(msg.find("state_variables") != std::string::npos);
+    }
+    // Declaring something the formula never reads is also an error: it would cost a
+    // keyed_output() per evaluation and misstate the block's dependencies.
+    CHECK_THROWS_AS(compile("1", {}, {}, {"T"}), CoolProp::ValueError);
+    CHECK_THROWS_AS(compile("T", {}, {}, {"T", "T"}), CoolProp::ValueError);
+}
+
+TEST_CASE("`let` renames a state variable to whatever reads best", "[expression]") {
+    using namespace CoolProp::expression;
+    // Dropping the invented aliases (`rhomolar`, `rhomass`, `p`) costs nothing
+    // ergonomically: renaming is already in the language, and a `let` can carry the
+    // source paper's own symbol rather than either CoolProp's spelling or a second
+    // vocabulary maintained here.  This is the answer to "but I preferred rhomolar".
+    Program p = compile("let rho = Dmolar\nlet tau = Tc/T\nrho*tau", {{"Tc", 456.83}}, {}, {"Dmolar", "T"});
+    REQUIRE(p.requiredInputs().size() == 2);
+    CHECK(p.requiredInputs()[0] == CoolProp::iDmolar);
+    CHECK(p.requiredInputs()[1] == CoolProp::iT);
+    CHECK(p.evaluate({1e4, 300.0}) == Catch::Approx(1e4 * 456.83 / 300.0));
+
+    // A `let` may not shadow a DECLARED state variable at all.  Leaning on the
+    // "declared but never used" rule to catch this was not enough: that only fires
+    // when the declared name is read NOWHERE, so the formula below compiled, with
+    // `T` meaning the state on one line and 500 on the next.
+    CHECK_THROWS_AS(compile("let T = 5\nT", {}, {}, {"T"}), CoolProp::ValueError);
+    CHECK_THROWS_AS(compile("let a = T*2\nlet T = 500\na + T", {}, {}, {"T"}), CoolProp::ValueError);
+    // Undeclared, that same name is simply a local, with no state involved at all.
+    Program q = compile("let T = 5\nT", {}, {});
+    CHECK(q.requiredInputs().empty());
+    CHECK(q.evaluate({}) == Catch::Approx(5.0));
 }
 
 TEST_CASE("evaluate rejects a wrong-sized input vector", "[expression]") {
     using namespace CoolProp::expression;
-    Program p = compile("T + p", {}, {});
+    Program p = compile("T + P", {}, {}, {"T", "P"});
     REQUIRE(p.requiredInputs().size() == 2);
     CHECK_THROWS_AS(p.evaluate({}), CoolProp::ValueError);
     CHECK_THROWS_AS(p.evaluate({300.0}), CoolProp::ValueError);
@@ -189,7 +348,7 @@ TEST_CASE("a default-constructed Program throws instead of dereferencing null", 
 
 TEST_CASE("DSL inputs rhomass and molar_mass resolve", "[expression]") {
     using namespace CoolProp::expression;
-    Program p = compile("rhomass * molar_mass", {}, {});
+    Program p = compile("Dmass * molar_mass", {}, {}, {"Dmass", "molar_mass"});
     REQUIRE(p.requiredInputs().size() == 2);
     std::vector<double> iv(2);
     for (std::size_t k = 0; k < 2; ++k)
@@ -206,7 +365,8 @@ TEST_CASE("expression block compile path (constants+arrays) yields expected valu
     using namespace CoolProp::expression;
     std::map<std::string, double> consts{{"T_reduce", 132.0}, {"rhomolar_reduce", 10000.0}};
     std::map<std::string, std::vector<double>> arrays{{"a", {1.0e-5}}, {"d1", {1.0}}, {"t1", {0.2}}};
-    Program p = compile("let delta = rhomolar/rhomolar_reduce\nlet tau = T_reduce/T\nsum(i: a[i]*delta^d1[i]*tau^t1[i])", consts, arrays);
+    Program p =
+      compile("let delta = Dmolar/rhomolar_reduce\nlet tau = T_reduce/T\nsum(i: a[i]*delta^d1[i]*tau^t1[i])", consts, arrays, {"Dmolar", "T"});
     std::vector<double> iv(p.requiredInputs().size());
     for (std::size_t k = 0; k < iv.size(); ++k) {
         const CoolProp::parameters key = p.requiredInputs()[k];
@@ -264,7 +424,7 @@ TEST_CASE("golden: viscosity dilute powers_of_T", "[expression][golden]") {
     REQUIRE(!data.a.empty());
     // C++: summer += a[i]*pow(T, t[i]);  return summer;
     Program p = compile("sum(i: a[i]*T^t[i])", {},
-                        {{"a", std::vector<double>(data.a.begin(), data.a.end())}, {"t", std::vector<double>(data.t.begin(), data.t.end())}});
+                        {{"a", std::vector<double>(data.a.begin(), data.a.end())}, {"t", std::vector<double>(data.t.begin(), data.t.end())}}, {"T"});
     int checks = 0;
     for (double T : {250.0, 300.0, 400.0, 500.0}) {
         for (double rho : {0.1, 100.0, 5000.0}) {
@@ -289,7 +449,7 @@ TEST_CASE("golden: viscosity dilute powers_of_Tr", "[expression][golden]") {
     REQUIRE(!data.a.empty());
     // C++: Tr = T/T_reducing; summer += a[i]*pow(Tr, t[i]);
     Program p = compile("let Tr = T/T_reducing\nsum(i: a[i]*Tr^t[i])", {{"T_reducing", static_cast<double>(data.T_reducing)}},
-                        {{"a", std::vector<double>(data.a.begin(), data.a.end())}, {"t", std::vector<double>(data.t.begin(), data.t.end())}});
+                        {{"a", std::vector<double>(data.a.begin(), data.a.end())}, {"t", std::vector<double>(data.t.begin(), data.t.end())}}, {"T"});
     int checks = 0;
     for (double T : {120.0, 200.0, 300.0, 450.0}) {
         for (double rho : {0.1, 100.0, 10000.0}) {
@@ -328,7 +488,7 @@ TEST_CASE("golden: viscosity dilute collision_integral", "[expression][golden]")
                          {"sigma_eta", sigma_eta},
                          {"molar_mass_data", static_cast<double>(data.molar_mass)},
                          {"C", static_cast<double>(data.C)}},
-                        {{"a", std::vector<double>(data.a.begin(), data.a.end())}, {"t", std::vector<double>(data.t.begin(), data.t.end())}});
+                        {{"a", std::vector<double>(data.a.begin(), data.a.end())}, {"t", std::vector<double>(data.t.begin(), data.t.end())}}, {"T"});
     int checks = 0;
     for (double T : {200.0, 300.0, 400.0, 500.0}) {
         for (double rho : {0.1, 100.0, 5000.0}) {
@@ -357,7 +517,7 @@ TEST_CASE("golden: viscosity higher_order modified_Batschinski_Hildebrand", "[ex
     //   F = sum f[i]*delta^d2[i]*tau^t2[i];
     //   delta0 = (sum g[i]*tau^h[i]) / (sum p[i]*tau^q[i]);
     //   return S + F*(1/(delta0-delta) - 1/delta0);
-    Program p = compile("let delta = rhomolar/rhomolar_reduce\n"
+    Program p = compile("let delta = Dmolar/rhomolar_reduce\n"
                         "let tau = T_reduce/T\n"
                         "let S = sum(i: a[i]*delta^d1[i]*tau^t1[i]*exp(gamma[i]*delta^l[i]))\n"
                         "let F = sum(i: f[i]*delta^d2[i]*tau^t2[i])\n"
@@ -377,7 +537,8 @@ TEST_CASE("golden: viscosity higher_order modified_Batschinski_Hildebrand", "[ex
                          {"g", std::vector<double>(HO.g.begin(), HO.g.end())},
                          {"h", std::vector<double>(HO.h.begin(), HO.h.end())},
                          {"pp", std::vector<double>(HO.p.begin(), HO.p.end())},
-                         {"q", std::vector<double>(HO.q.begin(), HO.q.end())}});
+                         {"q", std::vector<double>(HO.q.begin(), HO.q.end())}},
+                        {"Dmolar", "T"});
     int checks = 0;
     for (double T : {200.0, 300.0, 400.0, 500.0}) {
         for (double rho : {100.0, 2000.0, 8000.0, 12000.0}) {
@@ -403,7 +564,7 @@ TEST_CASE("DSL throughput is comparable to the hardcoded routine", "[expression]
 
     auto& HO = HEOS->get_components()[0].transport.viscosity_higher_order.modified_Batschinski_Hildebrand;
     REQUIRE(!HO.a.empty());
-    Program prog = compile("let delta = rhomolar/rhomolar_reduce\n"
+    Program prog = compile("let delta = Dmolar/rhomolar_reduce\n"
                            "let tau = T_reduce/T\n"
                            "let S = sum(i: a[i]*delta^d1[i]*tau^t1[i]*exp(gamma[i]*delta^l[i]))\n"
                            "let F = sum(i: f[i]*delta^d2[i]*tau^t2[i])\n"
@@ -423,7 +584,8 @@ TEST_CASE("DSL throughput is comparable to the hardcoded routine", "[expression]
                             {"g", std::vector<double>(HO.g.begin(), HO.g.end())},
                             {"h", std::vector<double>(HO.h.begin(), HO.h.end())},
                             {"pp", std::vector<double>(HO.p.begin(), HO.p.end())},
-                            {"q", std::vector<double>(HO.q.begin(), HO.q.end())}});
+                            {"q", std::vector<double>(HO.q.begin(), HO.q.end())}},
+                           {"Dmolar", "T"});
     auto corr = std::make_shared<ExpressionCorrelation>(std::move(prog));
 
     const int N = 2'000'000;
@@ -455,7 +617,8 @@ TEST_CASE("golden: conductivity dilute ratio_of_polynomials", "[expression][gold
                         {{"A", std::vector<double>(data.A.begin(), data.A.end())},
                          {"n", std::vector<double>(data.n.begin(), data.n.end())},
                          {"B", std::vector<double>(data.B.begin(), data.B.end())},
-                         {"m", std::vector<double>(data.m.begin(), data.m.end())}});
+                         {"m", std::vector<double>(data.m.begin(), data.m.end())}},
+                        {"T"});
     int checks = 0;
     for (double T : {150.0, 250.0, 350.0, 500.0}) {
         for (double rho : {0.1, 100.0, 5000.0}) {
@@ -495,7 +658,7 @@ TEST_CASE("golden: conductivity dilute eta0_and_poly", "[expression][golden]") {
             Program p = compile("let tau = T_reduce/T\n"
                                 "A0*eta0_uPas + sum(i: A_rest[i]*tau^t_rest[i])",
                                 {{"A0", static_cast<double>(E.A[0])}, {"eta0_uPas", eta0_uPas}, {"T_reduce", T_reduce}},
-                                {{"A_rest", A_rest}, {"t_rest", t_rest}});
+                                {{"A_rest", A_rest}, {"t_rest", t_rest}}, {"T"});
             double expected = CoolProp::TransportRoutines::conductivity_dilute_eta0_and_poly(*HEOS);
             std::vector<double> iv;
             fill_inputs(p, *HEOS, iv);
@@ -518,12 +681,13 @@ TEST_CASE("golden: conductivity residual polynomial", "[expression][golden]") {
     //   tau = T_reducing/T;  delta = rhomass/rhomass_reducing;
     //   summer += B[i]*pow(tau, t[i])*pow(delta, d[i]);
     Program p = compile("let tau = T_reducing/T\n"
-                        "let delta = rhomass/rhomass_reducing\n"
+                        "let delta = Dmass/rhomass_reducing\n"
                         "sum(i: B[i]*tau^t[i]*delta^d[i])",
                         {{"T_reducing", static_cast<double>(data.T_reducing)}, {"rhomass_reducing", static_cast<double>(data.rhomass_reducing)}},
                         {{"B", std::vector<double>(data.B.begin(), data.B.end())},
                          {"t", std::vector<double>(data.t.begin(), data.t.end())},
-                         {"d", std::vector<double>(data.d.begin(), data.d.end())}});
+                         {"d", std::vector<double>(data.d.begin(), data.d.end())}},
+                        {"T", "Dmass"});
     int checks = 0;
     for (double T : {200.0, 300.0, 400.0, 500.0}) {
         for (double rho : {100.0, 2000.0, 8000.0}) {
@@ -553,14 +717,15 @@ TEST_CASE("golden: conductivity residual polynomial_and_exponential", "[expressi
     const double T_reduce = HEOS->T_reducing();
     const double rhomolar_reduce = HEOS->rhomolar_reducing();
     Program p = compile("let tau = T_reduce/T\n"
-                        "let delta = rhomolar/rhomolar_reduce\n"
+                        "let delta = Dmolar/rhomolar_reduce\n"
                         "sum(i: A[i]*tau^t[i]*delta^d[i]*exp(-gamma[i]*delta^l[i]))",
                         {{"T_reduce", T_reduce}, {"rhomolar_reduce", rhomolar_reduce}},
                         {{"A", std::vector<double>(data.A.begin(), data.A.end())},
                          {"t", std::vector<double>(data.t.begin(), data.t.end())},
                          {"d", std::vector<double>(data.d.begin(), data.d.end())},
                          {"gamma", std::vector<double>(data.gamma.begin(), data.gamma.end())},
-                         {"l", std::vector<double>(data.l.begin(), data.l.end())}});
+                         {"l", std::vector<double>(data.l.begin(), data.l.end())}},
+                        {"T", "Dmolar"});
     int checks = 0;
     for (double T : {80.0, 120.0, 200.0, 300.0}) {
         for (double rho : {100.0, 5000.0, 20000.0}) {
@@ -589,7 +754,7 @@ TEST_CASE("ExpressionBlock compiles a fluid-JSON block verbatim", "[expression]"
     // straight out of a fluid file.
     ExpressionBlock b(R"({"type": "expression",
                           "formula": "sum(i: a[i]*T^t[i]) + c",
-                          "constants": {"c": 1.0},
+  "state_variables": ["T"], "constants": {"c": 1.0},
                           "arrays": {"a": [2.0, 3.0], "t": [0.0, 1.0]}})");
     REQUIRE(b.required_inputs() == std::vector<std::string>{"T"});
     auto HEOS = make_HEOS_for("R123");
@@ -613,8 +778,9 @@ TEST_CASE("ExpressionBlock reports bad blocks as ValueError", "[expression]") {
 
 TEST_CASE("ExpressionBlock reads whatever state the AbstractState is sitting at", "[expression]") {
     using namespace CoolProp::expression;
-    ExpressionBlock b(R"({"formula": "p"})");
-    REQUIRE(b.required_inputs() == std::vector<std::string>{"p"});
+    ExpressionBlock b(R"({"formula": "P",
+  "state_variables": ["P"] })");
+    REQUIRE(b.required_inputs() == std::vector<std::string>{"P"});
     std::shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "R123"));
     AS->update(CoolProp::DmolarT_INPUTS, 2000.0, 400.0);
     CHECK(b.evaluate(*AS) == Catch::Approx(CoolProp::PropsSI("P", "T", 400.0, "Dmolar", 2000.0, "R123")).epsilon(1e-14));
@@ -628,7 +794,8 @@ TEST_CASE("ExpressionBlock refuses a state that was never updated", "[expression
     using namespace CoolProp::expression;
     // AbstractState::p() on a fresh state returns -_HUGE rather than throwing, and
     // the formula would propagate it into a plausible-looking -inf.
-    ExpressionBlock b(R"({"formula": "p*2"})");
+    ExpressionBlock b(R"({"formula": "P*2",
+  "state_variables": ["P"] })");
     std::shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "R123"));
     // Pin the message, not just the type: any unrelated ValueError would otherwise
     // satisfy a bare CHECK_THROWS_AS and the guard could quietly stop working.
@@ -641,7 +808,8 @@ TEST_CASE("ExpressionBlock works on a mixture state the caller set up", "[expres
     using namespace CoolProp::expression;
     // Nothing in the block is pure-fluid-specific: the caller owns the state, so a
     // mixture composition is just another state the formula reads.
-    ExpressionBlock b(R"({"formula": "molar_mass*rhomolar"})");
+    ExpressionBlock b(R"({"formula": "molar_mass*Dmolar",
+  "state_variables": ["molar_mass", "Dmolar"] })");
     std::shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "R32&R125"));
     AS->set_mole_fractions({0.4, 0.6});
     AS->update(CoolProp::PT_INPUTS, 1e5, 350.0);  // HEOS mixtures do not take DmolarT
@@ -704,6 +872,8 @@ TEST_CASE("expression end-to-end: JSON load + dispatch round-trip (dilute viscos
     json expr_block;
     expr_block["type"] = "expression";
     expr_block["formula"] = "sum(i: a[i]*T^t[i])";
+    // The block declares what it reads; `a` and `t` stay the author's names.
+    expr_block["state_variables"] = json::array({"T"});
     expr_block["arrays"]["a"] = a;
     expr_block["arrays"]["t"] = t;
     visc["dilute"] = expr_block;
@@ -739,7 +909,7 @@ TEST_CASE("expression end-to-end: JSON load + dispatch round-trip (dilute viscos
 
 // ---------------------------------------------------------------------------
 // Task 10/11 follow-up: derived-`p` HOST-path check.  Build an
-// ExpressionCorrelation from compile("p", {}, {}) and evaluate it against a
+// ExpressionCorrelation from compile("P", {}, {}, {"P"}) and evaluate it against a
 // backend at a known state; the registry `p` getter is wired to HEOS.p(), so
 // the result must equal HEOS->p() bit-for-bit (same getter, no algebra).  This
 // proves the `p` input threads through ExpressionCorrelation::eval ->
@@ -748,7 +918,7 @@ TEST_CASE("expression end-to-end: JSON load + dispatch round-trip (dilute viscos
 TEST_CASE("expression host path: p equals HEOS.p()", "[expression]") {
     using namespace CoolProp::expression;
     auto HEOS = make_HEOS_for("R123");
-    Program prog = compile("p", {}, {});
+    Program prog = compile("P", {}, {}, {"P"});
     REQUIRE(prog.requiredInputs().size() == 1);
     REQUIRE(prog.requiredInputs()[0] == CoolProp::iP);
     ExpressionCorrelation corr(std::move(prog));
@@ -771,6 +941,421 @@ TEST_CASE("expression host path: p equals HEOS.p()", "[expression]") {
         }
     }
     CHECK(checks > 0);
+}
+
+// ---------------------------------------------------------------------------
+// GOLDEN: the 5th transport stage, viscosity initial_density (empirical form).
+//
+// CycloHexane is the only shipped fluid using the empirical form; the other 19
+// initial-density fluids use Rainwater-Friend, whose host arm scales the routine's
+// B_eta by eta_dilute*rho.  eta_dilute is a within-correlation intermediate that
+// the DSL cannot see, so an expression block yields this stage's contribution
+// DIRECTLY (the empirical convention).  See the dispatch comment.
+// ---------------------------------------------------------------------------
+TEST_CASE("golden: viscosity initial_density empirical", "[expression][golden]") {
+    using namespace CoolProp::expression;
+    auto HEOS = make_HEOS_for("CycloHexane");
+    auto& data = HEOS->get_components()[0].transport.viscosity_initial.empirical;
+    REQUIRE(!data.n.empty());
+    // C++: tau = T_reducing/T; delta = rhomolar/rhomolar_reducing;
+    //      summer += n[i]*pow(delta,d[i])*pow(tau,t[i]);
+    // The constants keep the routine's own names: the EOS reducing state is
+    // deliberately NOT in the input table, precisely so `T_reducing` stays available
+    // to correlations that mean their own fitted value (see the test below).
+    Program p = compile("let tau = T_reducing/T\nlet delta = Dmolar/rhomolar_reducing\nsum(i: n[i]*delta^d[i]*tau^t[i])",
+                        {{"T_reducing", static_cast<double>(data.T_reducing)}, {"rhomolar_reducing", static_cast<double>(data.rhomolar_reducing)}},
+                        {{"n", std::vector<double>(data.n.begin(), data.n.end())},
+                         {"d", std::vector<double>(data.d.begin(), data.d.end())},
+                         {"t", std::vector<double>(data.t.begin(), data.t.end())}},
+                        {"T", "Dmolar"});
+    int checks = 0;
+    for (double T : {300.0, 400.0, 500.0}) {
+        for (double rho : {100.0, 2000.0, 8000.0}) {
+            HEOS->update(CoolProp::DmolarT_INPUTS, rho, T);
+            double expected = CoolProp::TransportRoutines::viscosity_initial_density_dependence_empirical(*HEOS);
+            std::vector<double> iv;
+            fill_inputs(p, *HEOS, iv);
+            double got = p.evaluate(iv);
+            CAPTURE(T, rho, expected, got);
+            CHECK(got == Catch::Approx(expected).epsilon(1e-14));
+            ++checks;
+        }
+    }
+    CHECK(checks > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Huber, Perkins & Lemmon, Int. J. Thermophys. 45:146 (2024), CC BY 4.0 --
+// "Reference Correlation for the Viscosity of Nitrogen from the Triple Point to
+// 1000 K and Pressures up to 2200 MPa".  A correlation published AFTER the DSL
+// was designed, implemented as pure JSON data with no C++ added.
+//
+//   eta = (eta_0(T) + Delta_eta_res(T,rho)) * Delta_eta_c            Eq. 1
+//   eta_0(T) = eta_0(298.15 K) * exp{ sum_i a_i [ln(T/298.15)]^i }   Eq. 3
+//   Delta_eta_res = sum_i N_i Tr^t_i rhor^d_i                        Eq. 5
+//
+// Delta_eta_c (the crossover critical enhancement) is NOT expressible today and is
+// out of scope here; the paper's Table 7 sets it to 1, which is what we check.
+// Reducing parameters are frozen constants.  Both Span et al. and this correlation
+// use rho_c = 11.1839 mol/L; CoolProp's Nitrogen.json currently carries
+// 11183.901464580624 mol/m^3 from a 2020 unit-conversion defect (under audit), and
+// rho_r^8.4 turns that difference into a ~1e-6 shift -- enough to lose the paper's
+// own check values.
+// ---------------------------------------------------------------------------
+namespace {
+// clang-format off
+const char* const N2_DILUTE_2024 = R"JSON({
+  "type": "expression",
+  "formula": "let L = ln(T/T_ref)\n1e-6*eta_ref*exp(sum(i: a[i]*L^p[i]))",
+  "state_variables": ["T"],
+  "constants": {"T_ref": 298.15, "eta_ref": 17.7494},
+  "arrays": {
+    "a": [7.734578e-1, -9.310761e-2, 2.716958e-2, 6.175553e-3, -7.201594e-3,
+          2.094372e-3, 1.922676e-4, -3.454323e-4, 1.051771e-4, -1.126739e-5],
+    "p": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
+})JSON";
+
+const char* const N2_RESIDUAL_2024 = R"JSON({
+  "type": "expression",
+  "formula": "let Tr = T/Tc\nlet rhor = Dmolar/1000/rhoc\n1e-6*sum(i: N[i]*Tr^t[i]*rhor^d[i])",
+  "state_variables": ["T", "Dmolar"],
+  "constants": {"Tc": 126.192, "rhoc": 11.1839},
+  "arrays": {
+    "N": [9.955235691668, -6.165266404871, 0.213120936996, -8.473713006806, 10.013103356639,
+          0.638966874603, 0.311620258213, 9.241856768911, -5.252828814854, -0.667072279228],
+    "t": [-0.77512218631, -2.00109608805, -5.814455, -0.67602596996, 0,
+          -0.71613185456, -1.14069399597, -2.3652583598, -2.5463699255, -1.00794034515],
+    "d": [1, 1, 2, 2, 2, 6.96423363249, 8.38651257501, 2.99224857471, 3.42744617975, 7.97371767411]}
+})JSON";
+// clang-format on
+constexpr double MUPAS = 1e-6;  // the paper tabulates muPa.s; the DSL yields Pa.s
+}  // namespace
+
+TEST_CASE("Nitrogen 2024: dilute and residual blocks match the paper's Table 8", "[expression][golden]") {
+    using namespace CoolProp::expression;
+    // Table 8 lists eta_0 and eta_res SEPARATELY, so each block is pinned on its own.
+    ExpressionBlock dilute(N2_DILUTE_2024), residual(N2_RESIDUAL_2024);
+    CHECK(dilute.required_inputs() == std::vector<std::string>{"T"});
+    CHECK(residual.required_inputs() == std::vector<std::string>{"T", "Dmolar"});
+
+    std::shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "Nitrogen"));
+    // T (K), rho (kg/m^3), eta_0 (muPa.s), eta_res (muPa.s)
+    const double tab8[3][4] = {
+      {126.192, 265, 8.43716205, 7.20032032}, {126.212, 333, 8.43843818, 11.03805357}, {126.952, 300, 8.48562461, 9.04720938}};
+    for (const auto& row : tab8) {
+        AS->update(CoolProp::DmassT_INPUTS, row[1], row[0]);
+        CAPTURE(row[0], row[1]);
+        CHECK(dilute.evaluate(*AS) == Catch::Approx(row[2] * MUPAS).epsilon(1e-9));
+        CHECK(residual.evaluate(*AS) == Catch::Approx(row[3] * MUPAS).epsilon(1e-9));
+    }
+}
+
+TEST_CASE("Nitrogen 2024: end-to-end through the fluid library matches Table 7", "[expression]") {
+    using nlohmann::json;
+    // Graft the two blocks onto a copy of Nitrogen and register it as a new fluid,
+    // so PropsSI("V") exercises the real load + dispatch path, not compile() direct.
+    json fluid = json::parse(CoolProp::get_fluid_param_string("Nitrogen", "JSON"))[0];
+    json visc = json::object();
+    // The loader requires a BibTeX member on the viscosity block; cite the new paper.
+    visc["BibTeX"] = "Huber-IJT-2024";
+    visc["dilute"] = json::parse(N2_DILUTE_2024);
+    visc["higher_order"] = json::parse(N2_RESIDUAL_2024);
+    fluid["TRANSPORT"]["viscosity"] = visc;
+    fluid["INFO"]["NAME"] = "N2_HUBER_2024";
+    fluid["INFO"]["CAS"] = "999-99-91";
+    fluid["INFO"]["ALIASES"] = json::array({"N2_HUBER_2024_ALIAS"});
+    REQUIRE(CoolProp::add_fluids_as_JSON("HEOS", json::array({fluid}).dump()));
+
+    // Table 7, the paper's computer-verification values (Delta_eta_c = 1).  The
+    // rho = 0 rows are covered by the dilute-block test above; PropsSI needs a
+    // physical state, so only the finite-density rows go through here.
+    const double tab7[3][3] = {{90, 756, 108.42550781}, {300, 28, 18.23478803}, {300, 560, 50.59605975}};
+    for (const auto& row : tab7) {
+        double got = CoolProp::PropsSI("V", "T", row[0], "Dmass", row[1], "N2_HUBER_2024");
+        CAPTURE(row[0], row[1], row[2]);
+        REQUIRE(ValidNumber(got));
+        CHECK(got == Catch::Approx(row[2] * MUPAS).epsilon(1e-9));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sotiriadou, Antoniadis, Assael & Huber, Int. J. Thermophys. 46:133 (2025) --
+// "Reference Correlation of the Viscosity of Argon".  Three stages, all data:
+//
+//   eta   = eta_0(T) + eta_1(T)*rho + Delta_eta(rho,T)
+//   eta_0 = eta_0(298.15 K) exp( sum_i a_i [ln(T/298.15)]^i )          Eq. 2
+//   eta_1 = eta_0(T) B_eta(T),  B_eta = B*_eta N_A sigma^3             Eqs. 3,4
+//   B*_eta(T*) = sum_{i=0..6} c_i (T*)^-i,  T* = T/(eps/kB)            Eq. 5
+//   Delta_eta = rhor^(2/3) Tr^(1/2) { f1 rhor + f2 rhor^2/Tr
+//               + (f1 rhor - rhor^2)/Tr^5
+//               + (rhor - f3 rhor^5)/(rhor - f4 - Tr) - f5 }           Eq. 6
+//
+// Three things this exercises that nitrogen did not:
+//
+//  * A REAL Rainwater-Friend initial-density stage.  eta_1 needs eta_0, which is
+//    a within-correlation intermediate the DSL cannot see -- so the block simply
+//    RECOMPUTES eta_0.  Duplicated data, zero new C++.  Collapsing all three
+//    stages into one block would be tidier but wrong: calc_viscosity_dilute() is
+//    consumed independently by conductivity models (TransportRoutines.cpp:845,855)
+//    and viscosity_contributions() is public API, so each stage must report only
+//    its own contribution.
+//  * TWO sums in one formula (12-term dilute, 7-term virial) in separate lets.
+//    Only NESTED sums are forbidden; sequential ones each get their own index.
+//  * Eq. 6 came out of SYMBOLIC REGRESSION -- not a sum of power terms at all,
+//    but a rational expression with fractional exponents and a genuine pole at
+//    rhor - f4 - Tr = 0, which the paper warns about.  Our IEEE-semantics policy
+//    reproduces that rather than papering over it.
+//
+// WHY THE TABLE 9 GRID IS THE TEST, not the three verification points:
+// Section 3.2 gives three points for checking an implementation, and all three
+// are at T = 300 K.  There ln(T/298.15) ~ 6.2e-3, so the i=6 term of Eq. 2
+// contributes ~1e-14 relative and the high-order coefficients are unexercised.
+// A transcription error in a_6 (10^-5 misread as 10^-3) still matched all three
+// points to 6e-8 while being 36 % wrong at 2000 K; only Table 9, which spans
+// 100-2000 K, caught it.  Hence the 41-point grid below.
+// ---------------------------------------------------------------------------
+namespace {
+// clang-format off
+const char* const AR_A_COEFFS =
+  R"([8.395115e-1, -1.062564e-1, 1.065796e-2, 1.879809e-2, -8.881774e-3, -9.613779e-5,
+      1.404406e-3, -4.321739e-4, -2.544782e-5, 4.398471e-5, -9.997908e-6, 7.753453e-7])";
+const char* const AR_P_POWERS = "[1,2,3,4,5,6,7,8,9,10,11,12]";
+
+std::string ar_dilute() {
+    return std::string(R"JSON({"type": "expression",
+      "formula": "let L = ln(T/T_ref)\n1e-6*eta_ref*exp(sum(i: a[i]*L^p[i]))",
+  "state_variables": ["T"],
+      "constants": {"T_ref": 298.15, "eta_ref": 22.5666},
+      "arrays": {"a": )JSON") + AR_A_COEFFS + R"JSON(, "p": )JSON" + AR_P_POWERS + R"JSON(}})JSON";
+}
+std::string ar_initial_density() {
+    return std::string(R"JSON({"type": "expression",
+      "formula": "let L = ln(T/T_ref)\nlet eta0 = 1e-6*eta_ref*exp(sum(i: a[i]*L^p[i]))\nlet Tstar = T/epsilon_over_k\nlet Bstar = sum(i: c[i]*Tstar^q[i])\neta0*Bstar*N_A*sigma^3*Dmolar",
+  "state_variables": ["T", "Dmolar"],
+      "constants": {"T_ref": 298.15, "eta_ref": 22.5666, "epsilon_over_k": 143.235,
+                    "sigma": 0.33501e-9, "N_A": 6.02214076e23},
+      "arrays": {"a": )JSON") + AR_A_COEFFS + R"JSON(, "p": )JSON" + AR_P_POWERS + R"JSON(,
+                 "c": [-0.2571, 3.033, 1.144, -5.586, 3.089, -0.8824, -0.03856],
+                 "q": [0, -1, -2, -3, -4, -5, -6]}})JSON";
+}
+const char* const AR_RESIDUAL = R"JSON({"type": "expression",
+  "formula": "let Tr = T/Tc\nlet rhor = Dmolar/rhoc\n1e-6*rhor^(2/3)*Tr^0.5*(f1*rhor + f2*rhor^2/Tr + (f1*rhor - rhor^2)/Tr^5 + (rhor - f3*rhor^5)/(rhor - f4 - Tr) - f5)",
+  "state_variables": ["T", "Dmolar"],
+  "constants": {"Tc": 150.687, "rhoc": 13407.42965855612,
+                "f1": 3.62648753859904, "f2": 6.655428299399591, "f3": 0.39751160825739,
+                "f4": 2.6697983930209,  "f5": 0.0472018570860789}})JSON";
+// clang-format on
+}  // namespace
+
+TEST_CASE("Argon 2025: two sums in one formula, in separate lets", "[expression]") {
+    using namespace CoolProp::expression;
+    // The initial-density block needs a 12-term and a 7-term sum in one formula.
+    // Nested sums are rejected; sequential ones must each get their own index scope.
+    ExpressionBlock b(ar_initial_density());
+    CHECK(b.required_inputs() == std::vector<std::string>{"T", "Dmolar"});
+    Program p = compile("let u = sum(i: a[i])\nlet v = sum(i: b[i])\nu*v", {}, {{"a", {1, 2, 3}}, {"b", {10, 20}}});
+    CHECK(p.evaluate({}) == Catch::Approx(6.0 * 30.0));
+}
+
+TEST_CASE("Argon 2025: stages match the paper's computer-verification points", "[expression][golden]") {
+    using namespace CoolProp::expression;
+    ExpressionBlock dilute(ar_dilute()), initial(ar_initial_density()), residual(AR_RESIDUAL);
+    std::shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "Argon"));
+    // Section 3.2: T (K), rho (kg/m^3), eta (muPa.s).  rho = 0 is the dilute limit.
+    const double verif[3][3] = {{300, 0.0, 22.6840}, {300, 4.0, 22.7334}, {300, 700.0, 49.3360}};
+    for (const auto& row : verif) {
+        // rho = 0 is not a state the EOS will take; evaluate the stages at a valid
+        // state and zero the density-dependent ones by hand for that row.
+        const double rho = (row[1] > 0) ? row[1] : 1e-6;
+        AS->update(CoolProp::DmassT_INPUTS, rho, row[0]);
+        double got = dilute.evaluate(*AS);
+        if (row[1] > 0) got += initial.evaluate(*AS) + residual.evaluate(*AS);
+        CAPTURE(row[0], row[1]);
+        CHECK(got == Catch::Approx(row[2] * 1e-6).epsilon(1e-5));
+    }
+}
+
+TEST_CASE("Argon 2025: end-to-end over the paper's Table 9 grid", "[expression]") {
+    using nlohmann::json;
+    json fluid = json::parse(CoolProp::get_fluid_param_string("Argon", "JSON"))[0];
+    json visc = json::object();
+    visc["BibTeX"] = "Sotiriadou-IJT-2025";
+    visc["dilute"] = json::parse(ar_dilute());
+    visc["initial_density"] = json::parse(ar_initial_density());
+    visc["higher_order"] = json::parse(AR_RESIDUAL);
+    fluid["TRANSPORT"]["viscosity"] = visc;
+    fluid["INFO"]["NAME"] = "AR_SOTIRIADOU_2025";
+    fluid["INFO"]["CAS"] = "999-99-92";
+    fluid["INFO"]["ALIASES"] = json::array({"AR_SOTIRIADOU_2025_ALIAS"});
+    REQUIRE(CoolProp::add_fluids_as_JSON("HEOS", json::array({fluid}).dump()));
+
+    // Table 9: T (K), rho (kg/m^3), eta (muPa.s), printed to 5 significant figures.
+    const double tab9[][3] = {
+      {100, 4.9152, 8.0810},  {150, 3.2255, 12.095},   {200, 2.4093, 15.889},   {400, 1.2012, 28.642},   {600, 0.80058, 38.804},
+      {800, 0.60042, 47.571}, {1000, 0.48034, 55.485}, {1500, 0.32025, 73.039}, {2000, 0.24019, 88.656}, {100, 1349.4, 204.28},
+      {150, 964.88, 67.573},  {200, 337.74, 23.007},   {400, 119.43, 30.618},   {600, 78.026, 39.869},   {800, 58.472, 48.214},
+      {1000, 46.880, 55.893}, {1500, 31.435, 73.167},  {2000, 23.672, 88.666},  {100, 1448.5, 290.45},   {150, 1234.3, 129.45},
+      {200, 1023.7, 79.043},  {400, 511.19, 43.770},   {600, 342.22, 46.526},   {800, 261.22, 52.428},   {1000, 212.57, 58.820},
+      {1500, 146.25, 74.560}, {2000, 111.88, 89.378},  {150, 1363.4, 187.48},   {200, 1213.1, 121.19},   {400, 787.37, 61.681},
+      {600, 574.15, 56.530},  {800, 454.97, 59.113},   {1000, 378.65, 63.713},  {1500, 269.06, 77.260},  {2000, 209.61, 91.054},
+      {150, 1510.1, 309.68},  {200, 1398.8, 198.36},   {400, 1065.5, 93.995},   {600, 856.29, 76.295},   {800, 717.53, 73.178},
+      {1000, 619.24, 74.551}};
+    // Two ways of hitting the same 41 points, with different error floors.
+    //
+    // Table 9 prints rho to five significant figures, and in the dense liquid
+    // dln(eta)/dln(rho) ~ 6, so feeding the TABLE's rho amplifies its rounding
+    // (drho/rho ~ 2.6e-5 at 50 MPa / 100 K) into ~1.6e-4 in viscosity.  That is
+    // the table's precision, not ours.  Letting the EOS supply rho from (p,T) --
+    // CoolProp's argon EOS is Tegeler-JPCRD-1999 with R = 8.31451, exactly the
+    // equation and gas constant of the paper's Table 1 -- drops the worst
+    // deviation to ~4e-5.  The implementation's true fidelity is better still:
+    // the Section 3.2 verification points, whose densities are exact by
+    // construction, agree to 6e-8 / 4.6e-7 / 8.7e-7 (see the test above).
+    const double pres[41] = {0.1e6, 0.1e6, 0.1e6, 0.1e6, 0.1e6, 0.1e6, 0.1e6, 0.1e6, 0.1e6, 10e6,  10e6,  10e6,  10e6, 10e6,
+                             10e6,  10e6,  10e6,  10e6,  50e6,  50e6,  50e6,  50e6,  50e6,  50e6,  50e6,  50e6,  50e6, 100e6,
+                             100e6, 100e6, 100e6, 100e6, 100e6, 100e6, 100e6, 200e6, 200e6, 200e6, 200e6, 200e6, 200e6};
+    static_assert(std::size(tab9) == 41, "tab9 and pres must stay in lockstep");
+    static_assert(std::size(pres) == std::size(tab9), "tab9 and pres must stay in lockstep");
+    double worst_d = 0, worst_pt = 0;
+    int checks = 0;
+    for (std::size_t k = 0; k < std::size(tab9); ++k) {
+        const double T = tab9[k][0], rho = tab9[k][1], ref = tab9[k][2] * 1e-6;
+        const double gd = CoolProp::PropsSI("V", "T", T, "Dmass", rho, "AR_SOTIRIADOU_2025");
+        const double gp = CoolProp::PropsSI("V", "T", T, "P", pres[k], "AR_SOTIRIADOU_2025");
+        CAPTURE(T, rho, pres[k], ref);
+        REQUIRE(ValidNumber(gd));
+        REQUIRE(ValidNumber(gp));
+        worst_d = std::max(worst_d, std::abs(gd - ref) / ref);
+        worst_pt = std::max(worst_pt, std::abs(gp - ref) / ref);
+        CHECK(std::abs(gd - ref) / ref < 2e-4);  // limited by the table's rho
+        CHECK(std::abs(gp - ref) / ref < 1e-4);  // EOS-supplied rho
+        ++checks;
+    }
+    WARN("Argon 2025 vs Table 9 (41 pts): worst " << worst_d << " with table rho, " << worst_pt << " with EOS rho from (p,T)");
+    CHECK(checks == 41);
+}
+
+// ---------------------------------------------------------------------------
+// Velliadou, Tasidou, Antoniadis, Assael, Perkins & Huber, Int. J. Thermophys.
+// 42:74 (2021), "Reference Correlation for the Viscosity of Xenon", WITH the
+// published Correction, Int. J. Thermophys. (2023), doi:10.1007/s10765-023-03175-5:
+// Eq. 6's third bracket term uses rho_r^12, not the rho_r^7 originally printed.
+// That is not cosmetic -- rho_r^7 is 34 % low in the saturated liquid at 170 K.
+//
+// CoolProp ships NO viscosity model for xenon, so this is purely additive.
+//
+// Two things this adds over nitrogen and argon:
+//  * The CLASSIC Vogel/Bich second-viscosity-virial form, B*(T*) = sum b_i
+//    T*^(-i/4) + b_7 T*^-2.5 + b_8 T*^-5.5 -- nine terms with fractional
+//    exponents, a different shape from argon's Najafi/Aziz sum c_i T*^-i.
+//  * The fluid that killed the critical-point inputs.  The paper says it adopts
+//    Tc and rho_c from the Lemmon-Span EOS, and Xenon.json carries exactly
+//    289.733 K and 8400 mol/m^3 -- so reading them from a live input looked not
+//    just safe but more correct than copying.  It was neither: with
+//    superancillaries enabled (the default) those accessors return the NUMERICAL
+//    critical point, and Eq. 6 moved by 7e-5.  T_critical/rhomolar_critical/
+//    p_critical were removed from the input table as a result; Tc and rho_c below
+//    are frozen constants, as every correlation's reducing parameters should be.
+//
+// The paper writes B_eta in m^3/kg and scales by mass density; expressing it on a
+// molar basis makes the molar mass cancel (rho_mass/M == rho_molar), which is why
+// no molar mass appears below.
+// ---------------------------------------------------------------------------
+namespace {
+// clang-format off
+const char* const XE_A = R"([9.652514e-1, -5.237199e-2, -6.758414e-2, 2.855787e-2, 1.002789e-2, -9.639621e-3,
+                             1.329770e-3, 1.114305e-3, -5.992234e-4, 1.224218e-4, -9.584978e-6])";
+const char* const XE_P = "[1,2,3,4,5,6,7,8,9,10,11]";
+
+std::string xe_dilute() {
+    return std::string(R"JSON({"type": "expression",
+      "formula": "let L = ln(T/T_ref)\n1e-6*eta_ref*exp(sum(i: a[i]*L^p[i]))",
+  "state_variables": ["T"],
+      "constants": {"T_ref": 298.15, "eta_ref": 23.0183},
+      "arrays": {"a": )JSON") + XE_A + R"JSON(, "p": )JSON" + XE_P + R"JSON(}})JSON";
+}
+std::string xe_initial_density() {
+    return std::string(R"JSON({"type": "expression",
+      "formula": "let L = ln(T/T_ref)\nlet eta0 = 1e-6*eta_ref*exp(sum(i: a[i]*L^p[i]))\nlet Tstar = T/epsilon_over_k\nlet Bstar = sum(i: b[i]*Tstar^e[i])\neta0*Bstar*N_A*sigma^3*Dmolar",
+  "state_variables": ["T", "Dmolar"],
+      "constants": {"T_ref": 298.15, "eta_ref": 23.0183, "epsilon_over_k": 250.0,
+                    "sigma": 0.396e-9, "N_A": 6.02214076e23},
+      "arrays": {"a": )JSON") + XE_A + R"JSON(, "p": )JSON" + XE_P + R"JSON(,
+                 "b": [-19.572881, 219.73999, -1015.3226, 2471.0125, -3375.1717,
+                       2491.6597, -787.26086, 14.085455, -0.34664158],
+                 "e": [0, -0.25, -0.5, -0.75, -1.0, -1.25, -1.5, -2.5, -5.5]}})JSON";
+}
+// Eq. 6 AS CORRECTED (rho_r^12).  Tc and rho_c are FROZEN CONSTANTS, not read from
+// the fluid -- see the block comment above for why the critical-point inputs were
+// removed.  289.733 K and 8400 mol/m^3 are the Lemmon-Span values the paper adopts.
+const char* const XE_RESIDUAL = R"JSON({"type": "expression",
+  "formula": "let Tr = T/Tc\nlet rhor = Dmolar/rhoc\n1e-6*rhor^(2/3)*Tr^0.5*(Tr + c0*Tr*rhor^4 + c1*rhor^12/Tr + (c2 + c3*rhor)/Tr^2)",
+  "state_variables": ["T", "Dmolar"],
+  "constants": {"Tc": 289.733, "rhoc": 8400.0, "c0": 1.396328251, "c1": 5.418871011e-4,
+                "c2": 4.478809952, "c3": 24.91698858}})JSON";
+// clang-format on
+}  // namespace
+
+TEST_CASE("Xenon 2021+correction: stages and critical-point inputs", "[expression][golden]") {
+    using namespace CoolProp::expression;
+    ExpressionBlock dilute(xe_dilute()), initial(xe_initial_density()), residual(XE_RESIDUAL);
+    CHECK(residual.required_inputs() == std::vector<std::string>{"T", "Dmolar"});
+    // Pin the reason the critical-point inputs were removed: keyed_output does NOT
+    // return Xenon.json's STATES.critical (8400 mol/m^3) with superancillaries on.
+    {
+        std::shared_ptr<CoolProp::AbstractState> X(CoolProp::AbstractState::factory("HEOS", "Xenon"));
+        X->update(CoolProp::DmassT_INPUTS, 2500.0, 300.0);
+        CAPTURE(X->keyed_output(CoolProp::irhomolar_critical));
+        // Only meaningful with superancillaries on, which is the default; with
+        // COOLPROP_DISABLE_SUPERANCILLARIES_ENTIRELY the accessor DOES return
+        // STATES.critical, and the hazard this pins simply does not exist.
+        if (CoolProp::get_config_bool(ENABLE_SUPERANCILLARIES)) {
+            CHECK(X->keyed_output(CoolProp::irhomolar_critical) != 8400.0);
+        }
+    }
+    std::shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "Xenon"));
+    // Section 4 verification points, background only (T (K), rho (kg/m^3), eta (muPa.s)).
+    const double verif[3][3] = {{300, 0.0, 23.1561}, {300, 6.0, 23.3186}, {300, 2500.0, 206.449}};
+    for (const auto& row : verif) {
+        AS->update(CoolProp::DmassT_INPUTS, (row[1] > 0) ? row[1] : 1e-6, row[0]);
+        double got = dilute.evaluate(*AS);
+        if (row[1] > 0) got += initial.evaluate(*AS) + residual.evaluate(*AS);
+        CAPTURE(row[0], row[1]);
+        CHECK(got == Catch::Approx(row[2] * 1e-6).epsilon(1e-5));
+    }
+}
+
+TEST_CASE("Xenon 2021+correction: end-to-end along the saturation line", "[expression]") {
+    using nlohmann::json;
+    json fluid = json::parse(CoolProp::get_fluid_param_string("Xenon", "JSON"))[0];
+    json visc = json::object();
+    visc["BibTeX"] = "Velliadou-IJT-2021";
+    visc["dilute"] = json::parse(xe_dilute());
+    visc["initial_density"] = json::parse(xe_initial_density());
+    visc["higher_order"] = json::parse(XE_RESIDUAL);
+    fluid["TRANSPORT"]["viscosity"] = visc;
+    fluid["INFO"]["NAME"] = "XE_VELLIADOU_2021";
+    fluid["INFO"]["CAS"] = "999-99-93";
+    fluid["INFO"]["ALIASES"] = json::array({"XE_VELLIADOU_2021_ALIAS"});
+    REQUIRE(CoolProp::add_fluids_as_JSON("HEOS", json::array({fluid}).dump()));
+
+    // Table 8: T (K), rho_liq, rho_vap (kg/m^3), eta_liq, eta_vap (muPa.s).
+    const double tab8[7][5] = {{170, 2908.8, 12.88, 442.32, 13.56}, {190, 2768.4, 31.19, 326.28, 15.19}, {210, 2614.9, 64.37, 248.25, 17.00},
+                               {230, 2441.5, 120.1, 193.12, 19.19}, {250, 2235.4, 212.1, 150.75, 22.14}, {270, 1962.2, 376.6, 113.51, 26.93},
+                               {285, 1607.3, 655.3, 81.276, 35.30}};
+    double worst = 0;
+    for (const auto& row : tab8) {
+        for (int k = 0; k < 2; ++k) {
+            const double rho = row[1 + k], ref = row[3 + k] * 1e-6;
+            double got = CoolProp::PropsSI("V", "T", row[0], "Dmass", rho, "XE_VELLIADOU_2021");
+            CAPTURE(row[0], rho, ref);
+            REQUIRE(ValidNumber(got));
+            const double rel = std::abs(got - ref) / ref;
+            worst = std::max(worst, rel);
+            CHECK(rel < 5e-4);
+        }
+    }
+    WARN("Xenon 2021 vs Table 8: worst relative deviation " << worst << " over 14 points");
 }
 
 #endif  // ENABLE_CATCH

--- a/src/expression/Expression.cpp
+++ b/src/expression/Expression.cpp
@@ -601,7 +601,7 @@ class Binder
             // would quietly detach the formula from the state -- and only partly, in
             // a formula that also read `T` on an earlier line.  Declaring a name and
             // then rebinding it is never what an author means.
-            if (declaredState.count(L.name))
+            if (declaredState.count(L.name) > 0)
                 throw ValueError(format("let '%s' shadows the declared state variable of the same name", L.name.c_str()));
             NodePtr bound = bind(L.expr, /*indexName*/ "");
             int slot = newScalarSlot();
@@ -837,8 +837,8 @@ Program compile(const std::string& source, const std::map<std::string, double>& 
         // and quietly change what the formula means.  This is the collision the old
         // single-namespace design hit from the other direction, where the language
         // reserved the name whether the block wanted it or not.
-        if (constants.count(nm)) throw ValueError(format("state variable '%s' collides with the constant of the same name", nm.c_str()));
-        if (arrays.count(nm)) throw ValueError(format("state variable '%s' collides with the array of the same name", nm.c_str()));
+        if (constants.count(nm) > 0) throw ValueError(format("state variable '%s' collides with the constant of the same name", nm.c_str()));
+        if (arrays.count(nm) > 0) throw ValueError(format("state variable '%s' collides with the array of the same name", nm.c_str()));
     }
     std::vector<Token> toks = lex(source);
     Parser parser(std::move(toks));

--- a/src/expression/Expression.cpp
+++ b/src/expression/Expression.cpp
@@ -1,6 +1,7 @@
 #include "CoolProp/expression/Expression.h"
 #include "CoolProp/expression/detail/Lexer.h"
 #include "CoolProp/Exceptions.h"
+#include "CoolProp/DataStructures.h"
 #include "CoolProp/detail/strings.h"
 #include <array>
 #include <cctype>
@@ -8,6 +9,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
+#include <algorithm>
 #include <map>
 #include <memory>
 #include <string>
@@ -500,22 +502,105 @@ std::vector<Token> lex(const std::string& s) {
 // Name-resolution helpers
 // ---------------------------------------------------------------------------
 
-// The single bucket of thermodynamic inputs: DSL spelling -> CoolProp::parameters
-// key.  See the rationale for the curated allowlist in Expression.h.
-static const std::vector<std::pair<std::string, parameters>>& inputTableImpl() {
-    static const std::vector<std::pair<std::string, parameters>> table = {
-      {"T", iT}, {"rhomolar", iDmolar}, {"rhomass", iDmass}, {"molar_mass", imolar_mass}, {"p", iP}};
-    return table;
+// Thermodynamic names are NOT resolved from a list kept here.  They are resolved by
+// CoolProp::is_valid_parameter(), so the DSL's vocabulary is exactly CoolProp's and a
+// new quantity costs no code at all -- krypton's entropy-scaling correlation needed
+// Smolar_residual, Bvirial and dBvirial_dT, and under the old curated table each was
+// a row plus a recompile for something keyed_output() already knew how to produce.
+//
+// What replaces the table is not "resolve everything", but two narrower rules.
+//
+// FIRST, resolution is opt-in per formula.  A block declares `state_variables`, and
+// only those names are state inside it.  The old design had one namespace shared by
+// state and by the author's own constants and arrays, so every name the DSL knew was
+// reserved everywhere -- and the DSL spelled pressure with an invented lowercase `p`,
+// which is what viscosity papers universally call their exponent array.  Propylene
+// glycol's dilute term had to rename p_i to np_i for a collision with a quantity it
+// never referenced.  Under opt-in that block declares ["T"] and keeps `p`.
+//
+// SECOND, two classes stay refused even when declared, because opt-in expresses the
+// author's intent and these are cases where the intent cannot be honoured:
+// Spellings the DSL used to accept, mapped to what replaced them.  This exists ONLY
+// to produce a good error: fluid JSON is data that third parties ship, and a block
+// written against the previous format must fail at load time saying WHAT changed,
+// not "unknown variable 'rhomolar'".  These names were the DSL's own inventions --
+// CoolProp always called them Dmolar/Dmass/P -- and the invented lowercase `p` is
+// what once collided with the exponent array every viscosity paper writes as p_i.
+static const char* retiredSpelling(const std::string& nm) {
+    if (nm == "rhomolar") return "Dmolar";
+    if (nm == "rhomass") return "Dmass";
+    if (nm == "p") return "P";
+    return nullptr;
 }
 
-static bool inputForName(const std::string& nm, parameters& out) {
-    for (const auto& e : inputTableImpl())
-        if (nm == e.first) {
-            out = e.second;
+static bool deniedStateVariable(parameters key, std::string& why) {
+    switch (key) {
+        // keyed_output() for a transport output re-enters the correlation being
+        // defined.  A viscosity formula that reads `V` is asking for itself.
+        case iviscosity:
+        case iconductivity:
+        case iPrandtl:
+        case isurface_tension:
+            why = "it is a transport output, so reading it re-enters the correlation being defined";
             return true;
-        }
-    return false;
+        // calc_T_critical()/calc_rhomolar_critical() return the NUMERICAL critical
+        // point when ENABLE_SUPERANCILLARIES is set (the default), not STATES.critical.
+        // A correlation reducing on them changes answer with configuration, which is
+        // how xenon once missed its reference values by 7e-5.  The fix is to freeze
+        // the number the paper's authors actually regressed against, as a constant.
+        case iT_critical:
+        case iP_critical:
+        case irhomolar_critical:
+        case irhomass_critical:
+            why = "the critical point is configuration-dependent (ENABLE_SUPERANCILLARIES); "
+                  "freeze the paper's value as a constant instead";
+            return true;
+        // The EOS reducing state is refused for a DIFFERENT reason, and saying so
+        // matters: superancillaries do not touch get_reducing_state().  A correlation
+        // that writes `T_reducing` means its OWN fitted reducing parameter, which is
+        // in general not the EOS's and moves whenever the EOS section is revised.
+        //
+        // Tau and Delta are the same quantities wearing a different name --
+        // keyed_output() computes them as _reducing.T/_T and _rhomolar/_reducing.rhomolar
+        // -- so refusing the reducing state while admitting these would be a guard
+        // with a door next to it.  They are also composition-dependent for mixtures.
+        case iT_reducing:
+        case iP_reducing:
+        case irhomolar_reducing:
+        case irhomass_reducing:
+        case iTau:
+        case iDelta:
+            why = "the EOS reducing state is not the correlation's own; freeze the paper's "
+                  "reducing parameters as constants instead (Tau and Delta are that state too)";
+            return true;
+        // Not real numbers.  Phase is an enum ordinal widened to double (and depends
+        // on any imposed phase); Q is -1 outside the dome, a sentinel that would enter
+        // arithmetic as data.  Both would compile into a plausible-looking formula.
+        case iPhase:
+        case iQ:
+        case iQmass:
+            why = "it is a phase index or a sentinel-valued quality, not a continuous state function";
+            return true;
+        // Fluid metadata and incompressible-only accessors: not functions of the
+        // current state at all.  Several are unimplemented for HEOS and throw from
+        // inside the evaluation, where fluid-file data has no business failing.
+        case ifraction_min:
+        case ifraction_max:
+        case iT_freeze:
+        case iGWP20:
+        case iGWP100:
+        case iGWP500:
+        case iFH:
+        case iHH:
+        case iPH:
+        case iODP:
+            why = "it is fluid metadata, not a function of the current state";
+            return true;
+        default:
+            return false;
+    }
 }
+
 static bool funcForName(const std::string& nm, Func& out, int& arity) {
     struct E
     {
@@ -557,6 +642,7 @@ struct ProgramData
     NodePtr result{};
     std::vector<std::vector<double>> arrays{};  // by array slot
     std::vector<parameters> inputOrder{};       // cached for requiredInputs()
+    std::vector<std::string> inputNames{};      // same order, as the author spelled them
 };
 
 // ---------------------------------------------------------------------------
@@ -566,11 +652,18 @@ struct ProgramData
 class Binder
 {
    public:
-    Binder(ProgramData& pd, const std::map<std::string, double>& consts, const std::map<std::string, std::vector<double>>& arrays)
-      : d(pd), constants(consts), arraysIn(arrays) {}
+    Binder(ProgramData& pd, const std::map<std::string, double>& consts, const std::map<std::string, std::vector<double>>& arrays,
+           const std::map<std::string, parameters>& declared)
+      : d(pd), constants(consts), arraysIn(arrays), declaredState(declared) {}
 
     void run(ParseResult& pr) {
         for (auto& L : pr.lets) {
+            // A `let` resolves before a declared state variable, so `let T = 500`
+            // would quietly detach the formula from the state -- and only partly, in
+            // a formula that also read `T` on an earlier line.  Declaring a name and
+            // then rebinding it is never what an author means.
+            if (declaredState.count(L.name))
+                throw ValueError(format("let '%s' shadows the declared state variable of the same name", L.name.c_str()));
             NodePtr bound = bind(L.expr, /*indexName*/ "");
             int slot = newScalarSlot();
             letNames[L.name] = slot;  // available to later statements + result
@@ -586,6 +679,7 @@ class Binder
     ProgramData& d;
     const std::map<std::string, double>& constants;
     const std::map<std::string, std::vector<double>>& arraysIn;
+    const std::map<std::string, parameters>& declaredState;
     // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
     int nextScalar = 0;
     std::map<std::string, int> letNames{};
@@ -598,19 +692,20 @@ class Binder
     }
 
     int resolveScalar(const std::string& nm) {
-        // Resolution order: let -> thermodynamic input -> JSON constant.
-        // Inputs are checked before constants so that a JSON constant can never
-        // shadow a state variable (T/rhomolar/rhomass/molar_mass/p).
+        // Resolution order: let -> DECLARED state variable -> JSON constant.  A name
+        // the block did not declare is never state, however well CoolProp knows it.
         auto itL = letNames.find(nm);
         if (itL != letNames.end()) return itL->second;
-        parameters key;
-        if (inputForName(nm, key)) {
+        auto itS = declaredState.find(nm);
+        if (itS != declaredState.end()) {
+            const parameters key = itS->second;
             auto s = inputSlots.find(nm);
             if (s != inputSlots.end()) return s->second;
             int slot = newScalarSlot();
             inputSlots[nm] = slot;
             d.inputSlots.emplace_back(key, slot);
             d.inputOrder.push_back(key);
+            d.inputNames.push_back(nm);
             return slot;
         }
         auto itC = constants.find(nm);
@@ -621,6 +716,21 @@ class Binder
             constSlots[nm] = slot;
             d.constantInits.emplace_back(slot, itC->second);
             return slot;
+        }
+        // A name CoolProp knows, but that this block did not declare, is the most
+        // likely authoring mistake -- say so instead of "unknown variable".
+        if (const char* now = retiredSpelling(nm)) {
+            throw ValueError(format("unknown variable '%s' -- it was this DSL's own spelling for a thermodynamic "
+                                    "quantity before blocks declared their inputs; CoolProp calls it '%s', and it must "
+                                    "be listed in this block's \"state_variables\"",
+                                    nm.c_str(), now));
+        }
+        parameters probe;
+        std::string ignored;
+        if (resolveStateVariable(nm, probe, ignored)) {
+            throw ValueError(format("unknown variable '%s' -- it is a thermodynamic quantity; add it to this block's "
+                                    "\"state_variables\" to read it from the state",
+                                    nm.c_str()));
         }
         throw ValueError(format("unknown variable '%s'", nm.c_str()));
     }
@@ -713,14 +823,43 @@ class Binder
 // Program methods + compile (namespace CoolProp::expression)
 // ---------------------------------------------------------------------------
 
-const std::vector<std::pair<std::string, parameters>>& inputTable() {
-    return detail::inputTableImpl();
+bool resolveStateVariable(const std::string& name, parameters& key, std::string& reason) {
+    key = iundefined_parameter;  // both out-params written on every path
+    reason.clear();
+    parameters k;
+    if (!is_valid_parameter(name, k)) {
+        if (const char* now = detail::retiredSpelling(name)) {
+            reason = format("'%s' was this DSL's own spelling; CoolProp calls it '%s'", name.c_str(), now);
+        } else {
+            reason = format("'%s' is not a CoolProp parameter name", name.c_str());
+        }
+        return false;
+    }
+    std::string why;
+    if (detail::deniedStateVariable(k, why)) {
+        reason = format("'%s' may not be used as a state variable: %s", name.c_str(), why.c_str());
+        return false;
+    }
+
+    // is_valid_parameter() also accepts CoolProp's back-compat aliases and an
+    // upper-cased spelling of every name: `A` is the speed of sound, `D` is Dmass,
+    // `M` is molar_mass, `TAU` is Tau.  Those are a trap here in a way they are not
+    // in PropsSI, because a DSL formula is FULL OF single-letter coefficient names.
+    // An author who forgets to declare a paper coefficient `A` in `constants` gets
+    // told to add it to state_variables, and doing so silently binds the speed of
+    // sound.  Only the canonical spelling is accepted, so the DSL's vocabulary is
+    // CoolProp's with exactly one name per quantity -- and still no list kept here.
+    const std::string canonical = get_parameter_information(static_cast<int>(k), "short");
+    if (canonical != name) {
+        reason = format("'%s' is an alias; use CoolProp's canonical name '%s'", name.c_str(), canonical.c_str());
+        return false;
+    }
+    key = k;
+    return true;
 }
 
 std::string inputName(parameters key) {
-    for (const auto& e : detail::inputTableImpl())
-        if (e.second == key) return e.first;
-    throw ValueError(format("parameter key %d is not an expression input", static_cast<int>(key)));
+    return get_parameter_information(static_cast<int>(key), "short");
 }
 
 const detail::ProgramData& Program::data() const {
@@ -751,24 +890,43 @@ const std::vector<parameters>& Program::requiredInputs() const {
     return data().inputOrder;
 }
 
-Program compile(const std::string& source, const std::map<std::string, double>& constants, const std::map<std::string, std::vector<double>>& arrays) {
+Program compile(const std::string& source, const std::map<std::string, double>& constants, const std::map<std::string, std::vector<double>>& arrays,
+                const std::vector<std::string>& state_variables) {
     using namespace detail;
-    // Inputs resolve before constants, so a constant named `T` or `p` would be
-    // dead data and the formula would quietly mean something other than what its
-    // author wrote.  Reject the collision at compile time rather than silently
-    // discarding the constant.
-    for (const auto& c : constants) {
+    // Resolve the declaration first, so that a bad `state_variables` entry is
+    // reported as such rather than surfacing later as "unknown variable".
+    std::map<std::string, parameters> declared;
+    for (const auto& nm : state_variables) {
         parameters key;
-        if (inputForName(c.first, key)) {
-            throw ValueError(format("constant '%s' collides with the thermodynamic input of the same name", c.first.c_str()));
+        std::string reason;
+        if (!resolveStateVariable(nm, key, reason)) throw ValueError(format("state_variables: %s", reason.c_str()));
+        if (!declared.emplace(nm, key).second) throw ValueError(format("state_variables lists '%s' twice", nm.c_str()));
+        // Dedupe on the resolved key, not the spelling: two names for one quantity
+        // would take two slots and cost two keyed_output() calls per evaluation.
+        for (const auto& prev : declared) {
+            if (prev.first != nm && prev.second == key)
+                throw ValueError(format("state_variables lists '%s' and '%s', which are the same quantity", prev.first.c_str(), nm.c_str()));
         }
+        // A declared name shadowing the author's own data would make that data dead
+        // and quietly change what the formula means.  This is the collision the old
+        // single-namespace design hit from the other direction, where the language
+        // reserved the name whether the block wanted it or not.
+        if (constants.count(nm)) throw ValueError(format("state variable '%s' collides with the constant of the same name", nm.c_str()));
+        if (arrays.count(nm)) throw ValueError(format("state variable '%s' collides with the array of the same name", nm.c_str()));
     }
     std::vector<Token> toks = lex(source);
     Parser parser(std::move(toks));
     ParseResult pr = parser.parse();
     auto pd = std::make_shared<ProgramData>();
-    Binder binder(*pd, constants, arrays);
+    Binder binder(*pd, constants, arrays, declared);
     binder.run(pr);
+    // Declaring a state variable the formula never reads costs a keyed_output() call
+    // per evaluation and misstates the block's dependencies, so it is an error rather
+    // than dead weight.
+    for (const auto& nm : state_variables) {
+        if (std::find(pd->inputNames.begin(), pd->inputNames.end(), nm) == pd->inputNames.end())
+            throw ValueError(format("state variable '%s' is declared but never used in the formula", nm.c_str()));
+    }
     Program prog;
     prog.m_data = pd;
     return prog;

--- a/src/expression/Expression.cpp
+++ b/src/expression/Expression.cpp
@@ -502,103 +502,42 @@ std::vector<Token> lex(const std::string& s) {
 // Name-resolution helpers
 // ---------------------------------------------------------------------------
 
-// Thermodynamic names are NOT resolved from a list kept here.  They are resolved by
-// CoolProp::is_valid_parameter(), so the DSL's vocabulary is exactly CoolProp's and a
-// new quantity costs no code at all -- krypton's entropy-scaling correlation needed
-// Smolar_residual, Bvirial and dBvirial_dT, and under the old curated table each was
-// a row plus a recompile for something keyed_output() already knew how to produce.
+// What the DSL exposes as state.  OPT-IN: this is the complete set a formula may
+// declare, and anything absent is refused.
 //
-// What replaces the table is not "resolve everything", but two narrower rules.
+// The alternative -- resolve anything is_valid_parameter() knows, minus a denylist of
+// the harmful ones -- was tried and is structurally unsound, because it fails OPEN.
+// 59 of CoolProp's 92 canonical parameter names slipped past a denylist that had
+// already grown to four categories, among them fluid metadata that evaluates to
+// nonsense (HFORMATION), fluid limits that are not state at all (P_min, T_max,
+// p_triple), and -- the very defect the denylist existed to prevent -- the EOS
+// internals alphar / alpha0 / dalphar_ddelta_consttau, which are functions of the
+// REDUCED variables and therefore carry the reducing state exactly as Tau and Delta
+// do.  A denylist would need patching for every parameter CoolProp ever adds.
 //
-// FIRST, resolution is opt-in per formula.  A block declares `state_variables`, and
-// only those names are state inside it.  The old design had one namespace shared by
-// state and by the author's own constants and arrays, so every name the DSL knew was
-// reserved everywhere -- and the DSL spelled pressure with an invented lowercase `p`,
-// which is what viscosity papers universally call their exponent array.  Propylene
-// glycol's dilute term had to rename p_i to np_i for a collision with a quantity it
-// never referenced.  Under opt-in that block declares ["T"] and keeps `p`.
+// So the list is small and grows on demand.  Adding a name is one line, and should
+// require the deliberate judgement that the quantity is
+//   * a continuous function of the CURRENT state -- not fluid metadata, not a range
+//     limit, not a phase index or a sentinel-valued quality;
+//   * free of configuration dependence -- calc_T_critical()/calc_rhomolar_critical()
+//     return the NUMERICAL critical point under ENABLE_SUPERANCILLARIES, and the EOS
+//     reducing state is not a correlation's own fitted reducing parameter.  Both
+//     belong in `constants`, frozen at the value the paper's authors regressed
+//     against; and
+//   * not a transport output, whose keyed_output() re-enters the correlation being
+//     defined.
 //
-// SECOND, two classes stay refused even when declared, because opt-in expresses the
-// author's intent and these are cases where the intent cannot be honoured:
-// Spellings the DSL used to accept, mapped to what replaced them.  This exists ONLY
-// to produce a good error: fluid JSON is data that third parties ship, and a block
-// written against the previous format must fail at load time saying WHAT changed,
-// not "unknown variable 'rhomolar'".  These names were the DSL's own inventions --
-// CoolProp always called them Dmolar/Dmass/P -- and the invented lowercase `p` is
-// what once collided with the exponent array every viscosity paper writes as p_i.
-static const char* retiredSpelling(const std::string& nm) {
-    if (nm == "rhomolar") return "Dmolar";
-    if (nm == "rhomass") return "Dmass";
-    if (nm == "p") return "P";
-    return nullptr;
-}
-
-static bool deniedStateVariable(parameters key, std::string& why) {
-    switch (key) {
-        // keyed_output() for a transport output re-enters the correlation being
-        // defined.  A viscosity formula that reads `V` is asking for itself.
-        case iviscosity:
-        case iconductivity:
-        case iPrandtl:
-        case isurface_tension:
-            why = "it is a transport output, so reading it re-enters the correlation being defined";
-            return true;
-        // calc_T_critical()/calc_rhomolar_critical() return the NUMERICAL critical
-        // point when ENABLE_SUPERANCILLARIES is set (the default), not STATES.critical.
-        // A correlation reducing on them changes answer with configuration, which is
-        // how xenon once missed its reference values by 7e-5.  The fix is to freeze
-        // the number the paper's authors actually regressed against, as a constant.
-        case iT_critical:
-        case iP_critical:
-        case irhomolar_critical:
-        case irhomass_critical:
-            why = "the critical point is configuration-dependent (ENABLE_SUPERANCILLARIES); "
-                  "freeze the paper's value as a constant instead";
-            return true;
-        // The EOS reducing state is refused for a DIFFERENT reason, and saying so
-        // matters: superancillaries do not touch get_reducing_state().  A correlation
-        // that writes `T_reducing` means its OWN fitted reducing parameter, which is
-        // in general not the EOS's and moves whenever the EOS section is revised.
-        //
-        // Tau and Delta are the same quantities wearing a different name --
-        // keyed_output() computes them as _reducing.T/_T and _rhomolar/_reducing.rhomolar
-        // -- so refusing the reducing state while admitting these would be a guard
-        // with a door next to it.  They are also composition-dependent for mixtures.
-        case iT_reducing:
-        case iP_reducing:
-        case irhomolar_reducing:
-        case irhomass_reducing:
-        case iTau:
-        case iDelta:
-            why = "the EOS reducing state is not the correlation's own; freeze the paper's "
-                  "reducing parameters as constants instead (Tau and Delta are that state too)";
-            return true;
-        // Not real numbers.  Phase is an enum ordinal widened to double (and depends
-        // on any imposed phase); Q is -1 outside the dome, a sentinel that would enter
-        // arithmetic as data.  Both would compile into a plausible-looking formula.
-        case iPhase:
-        case iQ:
-        case iQmass:
-            why = "it is a phase index or a sentinel-valued quality, not a continuous state function";
-            return true;
-        // Fluid metadata and incompressible-only accessors: not functions of the
-        // current state at all.  Several are unimplemented for HEOS and throw from
-        // inside the evaluation, where fluid-file data has no business failing.
-        case ifraction_min:
-        case ifraction_max:
-        case iT_freeze:
-        case iGWP20:
-        case iGWP100:
-        case iGWP500:
-        case iFH:
-        case iHH:
-        case iPH:
-        case iODP:
-            why = "it is fluid metadata, not a function of the current state";
-            return true;
-        default:
-            return false;
-    }
+// This is NOT the input table that was removed.  That table mapped INVENTED spellings
+// (`rhomolar`, `rhomass`, `p`) and reserved every one of them in every formula.  These
+// are CoolProp's own canonical names, and a block reserves only what it declares -- so
+// `p` remains the author's wherever pressure is not asked for, which is the collision
+// the redesign existed to fix.
+static const std::vector<std::string>& allowedStateVariables() {
+    static const std::vector<std::string> names = {"T", "P", "Dmolar", "Dmass", "molar_mass",
+                                                   // Entropy scaling and the second virial: what an entropy-scaling correlation
+                                                   // reduces on, rather than the dilute/residual decomposition.
+                                                   "Smolar_residual", "Bvirial", "dBvirial_dT"};
+    return names;
 }
 
 static bool funcForName(const std::string& nm, Func& out, int& arity) {
@@ -717,21 +656,20 @@ class Binder
             d.constantInits.emplace_back(slot, itC->second);
             return slot;
         }
-        // A name CoolProp knows, but that this block did not declare, is the most
-        // likely authoring mistake -- say so instead of "unknown variable".
-        if (const char* now = retiredSpelling(nm)) {
-            throw ValueError(format("unknown variable '%s' -- it was this DSL's own spelling for a thermodynamic "
-                                    "quantity before blocks declared their inputs; CoolProp calls it '%s', and it must "
-                                    "be listed in this block's \"state_variables\"",
-                                    nm.c_str(), now));
-        }
+        // Three different mistakes, three different messages.  An exposed name that
+        // this block simply did not declare is the common one; a CoolProp quantity
+        // the DSL does not expose gets the available set (which is also what answers
+        // a formula written against the DSL's own retired spellings); anything else
+        // is an ordinary typo.
         parameters probe;
-        std::string ignored;
-        if (resolveStateVariable(nm, probe, ignored)) {
-            throw ValueError(format("unknown variable '%s' -- it is a thermodynamic quantity; add it to this block's "
-                                    "\"state_variables\" to read it from the state",
+        std::string reason;
+        if (resolveStateVariable(nm, probe, reason)) {
+            throw ValueError(format("unknown variable '%s' -- it is a state variable this DSL exposes; add it to this "
+                                    "block's \"state_variables\" to read it from the state",
                                     nm.c_str()));
         }
+        parameters known;
+        if (is_valid_parameter(nm, known)) throw ValueError(format("unknown variable '%s' -- %s", nm.c_str(), reason.c_str()));
         throw ValueError(format("unknown variable '%s'", nm.c_str()));
     }
 
@@ -826,35 +764,23 @@ class Binder
 bool resolveStateVariable(const std::string& name, parameters& key, std::string& reason) {
     key = iundefined_parameter;  // both out-params written on every path
     reason.clear();
-    parameters k;
-    if (!is_valid_parameter(name, k)) {
-        if (const char* now = detail::retiredSpelling(name)) {
-            reason = format("'%s' was this DSL's own spelling; CoolProp calls it '%s'", name.c_str(), now);
-        } else {
-            reason = format("'%s' is not a CoolProp parameter name", name.c_str());
-        }
+    const std::vector<std::string>& ok = detail::allowedStateVariables();
+    if (std::find(ok.begin(), ok.end(), name) == ok.end()) {
+        // Naming the whole set is what makes this diagnostic self-servicing: it is
+        // short, and it answers "then what do I write?" -- including for the DSL's
+        // own retired spellings, where `rhomolar` is met with `Dmolar` in the list.
+        std::string avail;
+        for (const auto& n : ok)
+            avail += (avail.empty() ? "" : ", ") + n;
+        reason = format("'%s' is not a state variable the DSL exposes; available: %s", name.c_str(), avail.c_str());
         return false;
     }
-    std::string why;
-    if (detail::deniedStateVariable(k, why)) {
-        reason = format("'%s' may not be used as a state variable: %s", name.c_str(), why.c_str());
+    // Every allowed name is one of CoolProp's own, so this cannot fail; a test pins
+    // that, and pins that each is the CANONICAL spelling rather than an alias.
+    if (!is_valid_parameter(name, key)) {
+        reason = format("'%s' is not a CoolProp parameter name", name.c_str());
         return false;
     }
-
-    // is_valid_parameter() also accepts CoolProp's back-compat aliases and an
-    // upper-cased spelling of every name: `A` is the speed of sound, `D` is Dmass,
-    // `M` is molar_mass, `TAU` is Tau.  Those are a trap here in a way they are not
-    // in PropsSI, because a DSL formula is FULL OF single-letter coefficient names.
-    // An author who forgets to declare a paper coefficient `A` in `constants` gets
-    // told to add it to state_variables, and doing so silently binds the speed of
-    // sound.  Only the canonical spelling is accepted, so the DSL's vocabulary is
-    // CoolProp's with exactly one name per quantity -- and still no list kept here.
-    const std::string canonical = get_parameter_information(static_cast<int>(k), "short");
-    if (canonical != name) {
-        reason = format("'%s' is an alias; use CoolProp's canonical name '%s'", name.c_str(), canonical.c_str());
-        return false;
-    }
-    key = k;
     return true;
 }
 

--- a/src/expression/ExpressionBlock.cpp
+++ b/src/expression/ExpressionBlock.cpp
@@ -25,7 +25,17 @@ Program compile_block(const std::string& json_text, const std::string& context) 
             for (auto it = j["arrays"].begin(); it != j["arrays"].end(); ++it)
                 arrays[it.key()] = it.value().get<std::vector<double>>();
         }
-        return compile(cpjson::get_string(j, "formula"), constants, arrays);
+        std::vector<std::string> state_variables;
+        if (j.contains("state_variables")) {
+            // Must be an array: nlohmann happily iterates a bare string as a single
+            // element, so "state_variables": "T" would be silently accepted.
+            if (!j["state_variables"].is_array()) throw ValueError("\"state_variables\" must be an array of names");
+            for (const auto& v : j["state_variables"]) {
+                if (!v.is_string()) throw ValueError("\"state_variables\" must contain only names");
+                state_variables.push_back(v.get<std::string>());
+            }
+        }
+        return compile(cpjson::get_string(j, "formula"), constants, arrays, state_variables);
     } catch (std::exception& e) {
         const std::string where = context.empty() ? std::string() : " for " + context;
         throw ValueError(format("expression block failed%s: %s", where.c_str(), e.what()));

--- a/src/expression/ExpressionCorrelation.cpp
+++ b/src/expression/ExpressionCorrelation.cpp
@@ -14,7 +14,7 @@ namespace expression {
 double evaluate_at(const Program& prog, AbstractState& AS) {
     // One bucket: every input the program asked for is a CoolProp::parameters key,
     // so the whole host side is a keyed_output() per key -- no per-quantity switch
-    // to extend when a new input name is added to the table in Expression.cpp.
+    // to extend when a block declares a new state variable.
     const std::vector<parameters>& keys = prog.requiredInputs();
     std::vector<double> vals(keys.size());
     for (std::size_t i = 0; i < keys.size(); ++i) {

--- a/src/nanobind_interface.cxx
+++ b/src/nanobind_interface.cxx
@@ -1198,10 +1198,19 @@ void init_CoolProp(nb::module_& m) {
     nb::class_<expression::ExpressionBlock>(m, "Expression",
                                             "A compiled transport-property expression block.\n\n"
                                             "Construct from the JSON text of a `\"type\": \"expression\"` block\n"
-                                            "({\"formula\": ..., \"constants\": {...}, \"arrays\": {...}}), then\n"
-                                            "evaluate it at a state.  Raises ValueError on a bad formula.")
+                                            "({\"formula\": ..., \"state_variables\": [...], \"constants\": {...},\n"
+                                            " \"arrays\": {...}}), then evaluate it at a state.\n\n"
+                                            "`state_variables` lists the thermodynamic quantities the formula reads,\n"
+                                            "in CoolProp's own spelling (\"T\", \"P\", \"Dmolar\", \"Smolar_residual\",\n"
+                                            "...).  It is opt-in: a name not declared there is never state, so a\n"
+                                            "block that does not ask for pressure keeps `p` for its own coefficients.\n"
+                                            "Raises ValueError on a bad formula, on reading an undeclared quantity,\n"
+                                            "or on declaring one that cannot be honoured (a transport output, which\n"
+                                            "would re-enter the correlation; or the configuration-dependent critical\n"
+                                            "point and reducing state).")
       .def(nb::init<const std::string&>(), nb::arg("json_block"))
-      .def("required_inputs", &expression::ExpressionBlock::required_inputs, "DSL names of the thermodynamic inputs the formula references.")
+      .def("required_inputs", &expression::ExpressionBlock::required_inputs,
+           "The declared state variables the formula actually reads, in declaration order.")
       .def("evaluate", &expression::ExpressionBlock::evaluate, nb::arg("AS"),
            "Evaluate at the state `AS` (an AbstractState) is currently sitting at.\n"
            "Set the state the usual way -- AS.update(DmolarT_INPUTS, rhomolar, T) --\n"

--- a/src/nanobind_interface.cxx
+++ b/src/nanobind_interface.cxx
@@ -1210,7 +1210,8 @@ void init_CoolProp(nb::module_& m) {
                                             "point and reducing state).")
       .def(nb::init<const std::string&>(), nb::arg("json_block"))
       .def("required_inputs", &expression::ExpressionBlock::required_inputs,
-           "The declared state variables the formula actually reads, in declaration order.")
+           "The declared state variables the formula actually reads, in first-reference order\n"
+           "(the order the formula mentions them, NOT the order they were declared).")
       .def("evaluate", &expression::ExpressionBlock::evaluate, nb::arg("AS"),
            "Evaluate at the state `AS` (an AbstractState) is currently sitting at.\n"
            "Set the state the usual way -- AS.update(DmolarT_INPUTS, rhomolar, T) --\n"

--- a/wrappers/Python/_nanobind/CoolProp.pyi
+++ b/wrappers/Python/_nanobind/CoolProp.pyi
@@ -1549,7 +1549,8 @@ class Expression:
     def __init__(self, json_block: str) -> None: ...
 
     def required_inputs(self) -> list[str]:
-        """The declared state variables the formula actually reads, in declaration order."""
+        """The declared state variables the formula actually reads, in first-reference order
+        (the order the formula mentions them, NOT the order they were declared)."""
 
     def evaluate(self, AS: AbstractState) -> float:
         """

--- a/wrappers/Python/_nanobind/CoolProp.pyi
+++ b/wrappers/Python/_nanobind/CoolProp.pyi
@@ -1549,8 +1549,10 @@ class Expression:
     def __init__(self, json_block: str) -> None: ...
 
     def required_inputs(self) -> list[str]:
-        """The declared state variables the formula actually reads, in first-reference order
-        (the order the formula mentions them, NOT the order they were declared)."""
+        """
+        The declared state variables the formula actually reads, in first-reference order
+        (the order the formula mentions them, NOT the order they were declared).
+        """
 
     def evaluate(self, AS: AbstractState) -> float:
         """

--- a/wrappers/Python/_nanobind/CoolProp.pyi
+++ b/wrappers/Python/_nanobind/CoolProp.pyi
@@ -1533,14 +1533,23 @@ class Expression:
     A compiled transport-property expression block.
 
     Construct from the JSON text of a `"type": "expression"` block
-    ({"formula": ..., "constants": {...}, "arrays": {...}}), then
-    evaluate it at a state.  Raises ValueError on a bad formula.
+    ({"formula": ..., "state_variables": [...], "constants": {...},
+     "arrays": {...}}), then evaluate it at a state.
+
+    `state_variables` lists the thermodynamic quantities the formula reads,
+    in CoolProp's own spelling ("T", "P", "Dmolar", "Smolar_residual",
+    ...).  It is opt-in: a name not declared there is never state, so a
+    block that does not ask for pressure keeps `p` for its own coefficients.
+    Raises ValueError on a bad formula, on reading an undeclared quantity,
+    or on declaring one that cannot be honoured (a transport output, which
+    would re-enter the correlation; or the configuration-dependent critical
+    point and reducing state).
     """
 
     def __init__(self, json_block: str) -> None: ...
 
     def required_inputs(self) -> list[str]:
-        """DSL names of the thermodynamic inputs the formula references."""
+        """The declared state variables the formula actually reads, in declaration order."""
 
     def evaluate(self, AS: AbstractState) -> float:
         """

--- a/wrappers/Python/pytest/test_expression.py
+++ b/wrappers/Python/pytest/test_expression.py
@@ -56,7 +56,9 @@ def block(formula, constants=None, arrays=None, state=None):
             if m.group(2) or tok in local or tok not in _STATE or tok in state:
                 continue
             state.append(tok)
-    if state:
+    # `state=[]` must emit an EXPLICIT empty declaration, not omit the key -- those
+    # are different inputs to the parser and both need exercising.
+    if state is not None:
         b["state_variables"] = list(state)
     if constants:
         b["constants"] = constants
@@ -269,14 +271,24 @@ def test_let_renames_a_state_variable_to_whatever_reads_best():
     assert Expression(block("let T = 5\nT", state=[])).evaluate(state()) == 5.0
 
 
-def test_only_the_canonical_spelling_is_accepted():
-    """CoolProp's back-compat aliases are a trap in a formula full of coefficients."""
-    # `A` is the speed of sound, `D` is Dmass, `M` is molar_mass, `DMOLAR` is Dmolar.
+def test_only_the_exposed_set_is_declarable():
+    """Opt-in: the DSL exposes an explicit set and refuses everything else."""
+    EXPOSED = ("T", "P", "Dmolar", "Dmass", "molar_mass", "Smolar_residual", "Bvirial", "dBvirial_dT")
+    for nm in EXPOSED:
+        assert Expression(block(nm, state=[nm])).required_inputs() == [nm]
+    # CoolProp's back-compat aliases are a trap in a formula full of coefficient
+    # names -- `A` is the speed of sound, `D` is Dmass, `M` is molar_mass -- and they
+    # are refused for free, because the exposed set holds canonical names only.
     for alias in ("A", "C", "D", "G", "M", "O", "S", "U", "DMOLAR"):
-        with pytest.raises(ValueError, match="alias"):
+        with pytest.raises(ValueError, match="not a state variable the DSL exposes"):
             Expression(block(alias, state=[alias]))
     # ...so each stays free for the author, which is the point.
     assert Expression(block("A*M", constants={"A": 3.0, "M": 4.0}, state=[])).evaluate(state()) == 12.0
+    # The refusal names the whole set, so it answers "then what do I write?" --
+    # including for this DSL's own retired spellings.
+    for old, now in (("rhomolar", "Dmolar"), ("rhomass", "Dmass"), ("p", "P")):
+        with pytest.raises(ValueError, match=now):
+            Expression(block(old, state=[old]))
 
 
 def test_tau_and_delta_are_the_reducing_state_by_another_name():

--- a/wrappers/Python/pytest/test_expression.py
+++ b/wrappers/Python/pytest/test_expression.py
@@ -14,6 +14,7 @@ the reported inputs match the formula, and that the numbers agree with what the
 same algebra gives through ``PropsSI``.
 """
 import json
+import re
 import math
 
 import pytest
@@ -37,9 +38,26 @@ def state(fluid="R123", rhomolar=1e4, T=300.0):
     return AS
 
 
-def block(formula, constants=None, arrays=None):
+# Every thermodynamic name a block reads must be declared in "state_variables";
+# anything undeclared is the author's own.  The suite derives the declaration from
+# the formula so each test can say what it is actually about, but the contract
+# itself is pinned explicitly in test_state_variables_* below.
+_STATE = ("T", "P", "Dmolar", "Dmass", "molar_mass", "Smolar_residual", "Bvirial", "dBvirial_dT")
+
+
+def block(formula, constants=None, arrays=None, state=None):
     """Build the JSON text of a `"type": "expression"` transport block."""
     b = {"type": "expression", "formula": formula}
+    if state is None:
+        local = set(re.findall(r"\blet\s+(\w+)", formula)) | set(constants or ()) | set(arrays or ())
+        state = []
+        for m in re.finditer(r"\b([A-Za-z_]\w*)\b(\s*\[)?", formula):
+            tok = m.group(1)
+            if m.group(2) or tok in local or tok not in _STATE or tok in state:
+                continue
+            state.append(tok)
+    if state:
+        b["state_variables"] = list(state)
     if constants:
         b["constants"] = constants
     if arrays:
@@ -57,21 +75,22 @@ def test_constant_only_formula_reads_no_state():
 
 
 def test_required_inputs_reports_the_names_the_formula_uses():
-    e = Expression(block("p*2 + T"))
-    # Reported in first-reference order, spelled the way the formula spells them.
-    assert e.required_inputs() == ["p", "T"]
-    assert Expression(block("rhomass*molar_mass")).required_inputs() == ["rhomass", "molar_mass"]
+    e = Expression(block("P*2 + T"))
+    # Reported in first-reference order (NOT declaration order); only the canonical
+    # spelling is accepted, so it round-trips whatever the author wrote.
+    assert e.required_inputs() == ["P", "T"]
+    assert Expression(block("Dmass*molar_mass")).required_inputs() == ["Dmass", "molar_mass"]
 
 
 def test_constants_and_arrays_and_let_and_sum():
     e = Expression(
         block(
-            "let delta = rhomolar/rhomolar_reduce\nsum(i: a[i]*delta^d[i])",
+            "let delta = Dmolar/rhomolar_reduce\nsum(i: a[i]*delta^d[i])",
             constants={"rhomolar_reduce": 10000.0},
             arrays={"a": [2.0, 3.0], "d": [1.0, 2.0]},
         )
     )
-    assert e.required_inputs() == ["rhomolar"]
+    assert e.required_inputs() == ["Dmolar"]
     assert e.evaluate(state(rhomolar=5000.0)) == pytest.approx(2.0 * 0.5 + 3.0 * 0.25)
 
 
@@ -89,12 +108,15 @@ def test_bad_formula_raises_at_construction():
         Expression('{"type": "expression"}')  # no "formula"
 
 
-def test_a_constant_colliding_with_an_input_is_rejected():
-    # Inputs resolve before constants, so a constant named `T` would be dead data
-    # and the formula would quietly mean the state temperature.  Hard error.
-    for name in ("T", "rhomolar", "rhomass", "molar_mass", "p"):
+def test_a_constant_colliding_with_a_declared_state_variable_is_rejected():
+    # A declared name resolves before constants, so a constant of that name would be
+    # dead data and the formula would quietly mean the state value.  Hard error --
+    # but only when the block actually declared it.
+    for name in ("T", "Dmolar", "Dmass", "molar_mass", "P"):
         with pytest.raises(ValueError):
-            Expression(block("1", constants={name: 1.0}))
+            Expression(block(name, constants={name: 1.0}, state=[name]))
+        # Undeclared, the very same constant is simply the author's own number.
+        assert Expression(block(name, constants={name: 1.0}, state=[])).evaluate(state()) == 1.0
     Expression(block("T_reduce", constants={"T_reduce": 132.0}))  # near-miss is fine
 
 
@@ -111,7 +133,7 @@ def test_a_transport_output_name_does_not_resolve():
 # --------------------------------------------------------------------------- #
 def test_state_variables_come_from_the_AbstractState():
     assert Expression(block("T")).evaluate(state(T=321.5)) == pytest.approx(321.5)
-    assert Expression(block("rhomolar")).evaluate(state(rhomolar=1234.0)) == pytest.approx(1234.0)
+    assert Expression(block("Dmolar")).evaluate(state(rhomolar=1234.0)) == pytest.approx(1234.0)
 
 
 def test_the_block_follows_the_state_object():
@@ -129,11 +151,11 @@ def test_molar_mass_and_pressure_come_from_the_EOS():
     T, rhomolar = 400.0, 2000.0
     AS = state(T=T, rhomolar=rhomolar)
     assert Expression(block("molar_mass")).evaluate(AS) == pytest.approx(CP.PropsSI("molar_mass", "R123"))
-    assert Expression(block("p")).evaluate(AS) == pytest.approx(
+    assert Expression(block("P")).evaluate(AS) == pytest.approx(
         CP.PropsSI("P", "T", T, "Dmolar", rhomolar, "R123"), rel=1e-12
     )
     # rhomass is the EOS's own mass density at that state, not a re-derivation.
-    assert Expression(block("rhomass")).evaluate(AS) == pytest.approx(
+    assert Expression(block("Dmass")).evaluate(AS) == pytest.approx(
         CP.PropsSI("Dmass", "T", T, "Dmolar", rhomolar, "R123"), rel=1e-12
     )
 
@@ -149,13 +171,13 @@ def test_a_mixture_state_is_just_another_state():
     # pure-component values.
     M_mix = 0.4 * CP.PropsSI("molar_mass", "R32") + 0.6 * CP.PropsSI("molar_mass", "R125")
     assert AS.rhomolar() > 0.0
-    assert Expression(block("molar_mass*rhomolar")).evaluate(AS) == pytest.approx(M_mix * AS.rhomolar(), rel=1e-12)
+    assert Expression(block("molar_mass*Dmolar")).evaluate(AS) == pytest.approx(M_mix * AS.rhomolar(), rel=1e-12)
 
 
 def test_evaluating_against_an_unset_state_raises():
     # AbstractState.p() on a fresh state hands back -inf rather than raising, and
     # the formula would propagate it into a plausible-looking answer.
-    e = Expression(block("p*2"))
+    e = Expression(block("P*2"))
     with pytest.raises(ValueError, match="finite"):
         e.evaluate(CP.AbstractState("HEOS", "R123"))  # never update()d
 
@@ -182,10 +204,93 @@ def test_reproduces_the_hardcoded_dilute_viscosity_of_R123():
 
 
 def test_a_compiled_block_is_reusable_across_states():
-    e = Expression(block("T*rhomolar"))
+    e = Expression(block("T*Dmolar"))
     AS = CP.AbstractState("HEOS", "R123")
     out = []
     for T in (300.0, 400.0):
         AS.update(CP.DmolarT_INPUTS, 100.0, T)
         out.append(e.evaluate(AS))
     assert out == pytest.approx([30000.0, 40000.0])
+
+
+# --------------------------------------------------------------------------- #
+# Declared state variables
+# --------------------------------------------------------------------------- #
+def test_state_variables_use_coolprops_own_names():
+    """The DSL keeps no vocabulary of its own; the names are CoolProp's."""
+    assert Expression(block("T", state=["T"])).required_inputs() == ["T"]
+    assert Expression(block("Dmolar", state=["Dmolar"])).required_inputs() == ["Dmolar"]
+    # The DSL once spelled these `rhomolar`/`rhomass`/`p`.  It no longer invents
+    # names -- and the invented lowercase `p` is what used to collide with the
+    # exponent array every viscosity paper writes as p_i.
+    for legacy in ("rhomolar", "rhomass", "p"):
+        with pytest.raises(ValueError):
+            Expression(block(legacy, state=[legacy]))
+
+
+def test_state_variables_are_opt_in_so_undeclared_names_are_yours():
+    """A block that never asks for pressure keeps `p` for its own coefficients."""
+    e = Expression(block("sum(i: n[i]*p[i])", arrays={"n": [2.0, 3.0], "p": [5.0, 7.0]}, state=[]))
+    assert e.required_inputs() == []
+    assert e.evaluate(state()) == pytest.approx(2.0 * 5.0 + 3.0 * 7.0)
+    # Declare pressure and the same name is a collision, not a silent shadowing.
+    with pytest.raises(ValueError):
+        Expression(block("sum(i: n[i]*p[i])", arrays={"n": [2.0], "p": [5.0]}, state=["P"]))
+
+
+def test_reading_an_undeclared_quantity_names_the_fix():
+    with pytest.raises(ValueError, match="state_variables"):
+        Expression(block("Bvirial", state=[]))
+
+
+def test_two_classes_stay_refused_even_when_declared():
+    """Opt-in is not a licence: these cannot be honoured whatever the author asks."""
+    for nm in ("V", "viscosity", "conductivity"):  # re-enters the correlation
+        with pytest.raises(ValueError):
+            Expression(block(nm, state=[nm]))
+    for nm in ("T_critical", "rhomolar_critical", "T_reducing"):  # config-dependent
+        with pytest.raises(ValueError):
+            Expression(block(nm, state=[nm]))
+        # ...but each stays usable as an ordinary frozen constant.
+        assert Expression(block(nm, constants={nm: 7.0}, state=[])).evaluate(state()) == 7.0
+
+
+def test_let_renames_a_state_variable_to_whatever_reads_best():
+    """Dropping the invented aliases costs nothing: renaming is in the language."""
+    e = Expression(block("let rho = Dmolar\nlet tau = Tc/T\nrho*tau",
+                         constants={"Tc": 456.83}, state=["Dmolar", "T"]))
+    assert e.required_inputs() == ["Dmolar", "T"]
+    assert e.evaluate(state(rhomolar=1e4, T=300.0)) == pytest.approx(1e4 * 456.83 / 300.0)
+    # A `let` cannot silently shadow a DECLARED name: the declaration then goes
+    # unread, which is already an error.
+    with pytest.raises(ValueError):
+        Expression(block("let T = 5\nT", state=["T"]))
+    # Undeclared, the same name is simply a local -- no state involved at all.
+    assert Expression(block("let T = 5\nT", state=[])).evaluate(state()) == 5.0
+
+
+def test_only_the_canonical_spelling_is_accepted():
+    """CoolProp's back-compat aliases are a trap in a formula full of coefficients."""
+    # `A` is the speed of sound, `D` is Dmass, `M` is molar_mass, `DMOLAR` is Dmolar.
+    for alias in ("A", "C", "D", "G", "M", "O", "S", "U", "DMOLAR"):
+        with pytest.raises(ValueError, match="alias"):
+            Expression(block(alias, state=[alias]))
+    # ...so each stays free for the author, which is the point.
+    assert Expression(block("A*M", constants={"A": 3.0, "M": 4.0}, state=[])).evaluate(state()) == 12.0
+
+
+def test_tau_and_delta_are_the_reducing_state_by_another_name():
+    """keyed_output computes them as _reducing.T/_T and _rhomolar/_reducing.rhomolar."""
+    for nm in ("Tau", "Delta", "T_reducing", "rhomolar_reducing"):
+        with pytest.raises(ValueError):
+            Expression(block(nm, state=[nm]))
+
+
+def test_non_state_quantities_are_refused():
+    for nm in ("Phase", "Q", "Qmass"):          # enum ordinal / sentinel-valued
+        with pytest.raises(ValueError):
+            Expression(block(nm, state=[nm]))
+    for nm in ("T_freeze", "GWP100", "ODP"):    # fluid metadata, not state
+        with pytest.raises(ValueError):
+            Expression(block(nm, state=[nm]))
+


### PR DESCRIPTION
Builds on the runtime transport-property DSL merged in #3185. Supersedes the language half of #3325.

**No fluid data ships here.** The three correlations below are grafted under synthetic names inside the test file, so this validates the language while touching nothing a user can load. The correlations themselves are #3334.

## Why

The DSL kept its own curated list of thermodynamic names — `T`, `rhomolar`, `rhomass`, `molar_mass`, `p` — resolved in **one namespace shared with the author's own constants and arrays**. Two defects, and they compound.

*Every name the language knew was reserved everywhere.* A dilute term of the form η₀ = Σ nᵢ·Tr^pᵢ cannot call its exponent array `p`, because `p` is pressure — in a block that never reads pressure. Across real correlations, local identifiers outnumber state reads about **5:1**, and pressure is read by none of them.

*The DSL invented spellings CoolProp does not use.* `rhomolar`/`rhomass`/`p` are not CoolProp names — it says `Dmolar`/`Dmass`/`P`. That divergence is what created the lowercase `p` that collided.

## What changes

A block declares what it reads:

```json
"state_variables": ["T", "Dmolar"]
```

Declaration is **per block and opt-in**: a name not declared there is never state, however well CoolProp knows it. So the exponent array can be `p` again. Renaming stays available where it reads better — `let rho = Dmolar` — which is also how a formula carries the source paper's own symbol.

Also adds the `initial_density` stage the Rainwater–Friend correlations need.

## What may be declared

An explicit, deliberately small set of CoolProp's **own canonical** names:

```
T   P   Dmolar   Dmass   molar_mass   Smolar_residual   Bvirial   dBvirial_dT
```

Everything else is refused. Adding a name is one line, and should require the judgement that the quantity is a continuous function of the *current* state, free of configuration dependence, and not a transport output whose `keyed_output()` re-enters the correlation being defined.

**Why an allowlist and not a denylist.** A denylist over `is_valid_parameter()` was implemented first and is structurally unsound because it **fails open** — after growing to four categories it still left **59 of 92 canonical names declarable**, including `alphar` / `dalphar_ddelta_consttau` (EOS internals in *reduced* variables, so they carry the reducing state — the very defect `Tau`/`Delta` were denied for), `P_min` (which reads back `p_triple()`), and `HFORMATION`. Two gaps were found by review before that third category was noticed at all.

This is **not** the input table that was removed: that table mapped *invented* spellings and reserved every one of them in *every* formula. These are canonical names, and a block reserves only what it declares. The cost is that a new quantity is no longer free — krypton's three cost three lines — and the gain is that the next parameter CoolProp adds is refused rather than silently admitted.

## Breaking change

Third-party `"type": "expression"` blocks must be updated. No version gate and no compatibility shim — the retired spellings *were* the defect. It fails at load time, and the refusal names the whole available set, which answers "then what do I write?":

```
'rhomolar' is not a state variable the DSL exposes; available:
T, P, Dmolar, Dmass, molar_mass, Smolar_residual, Bvirial, dBvirial_dT
```

Changelog entry tracked in `CoolProp-lg3o`.

## Validation

Three recently published correlations as fixtures, against their authors' own tabulated values — plus every hardcoded transport form the DSL already reproduces bit-for-bit:

| | source | check |
|---|---|---|
| Nitrogen | Huber, Perkins & Lemmon, IJT **45**:146 (2024) | Tables 7 and 8 |
| Argon | Sotiriadou et al., IJT **46** (2025) | Table 9 grid, 41 points |
| Xenon | Velliadou et al., IJT **42**:74 (2021) + correction | saturation line, 14 points |

```
[expression]  649 assertions / 47 cases     ~[slow]  177308 assertions, 0 failures
pytest        22 passed                     preflight  6 passed / 0 failed
```

Design, and the reasoning behind the exposed set: `docs/superpowers/specs/2026-06-12-transport-expression-dsl-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expression-based initial-density viscosity correlations for fluid configurations.
  * Expression formulas can explicitly declare supported thermodynamic state variables using canonical CoolProp names.
  * Added per-block state-variable declarations and isolation.
  * Added validation for undeclared, unsupported, duplicate, conflicting, or unused variables.

* **Bug Fixes**
  * Expression-related changes now trigger the appropriate automated test coverage.
  * Improved handling and diagnostics for invalid expression configuration.
  * Added regression coverage for multiple fluid viscosity correlations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->