### PR TITLE
fix(R1233zd(E)): restore the viscosity model dropped by #2768, and refit its constants

### DIFF
--- a/Web/coolprop/changelog.rst
+++ b/Web/coolprop/changelog.rst
@@ -82,6 +82,23 @@ Highlights:
   ``include/CoolProp/DataStructures.h`` are appended at the end of their enums
   and are ABI-safe.
 
+Bug fixes:
+
+* **R1233zd(E) viscosity works again.**  v8.0.0 replaced the R1233zd(E) equation
+  of state with the Akasaka & Lemmon (JPCRD 2022) international standard, but
+  the fluid's ``TRANSPORT`` block was not carried across, so ``PropsSI("V",
+  ...)`` returned ``inf`` with *"Viscosity model is not available for this
+  fluid"* where v7.2.0 had answered.  The ``rhosr-CS`` correlation
+  (``Bell-PURDUE-2016-ETA``) is restored verbatim, matching what was already
+  done for the seven sibling fluids that use the same model.  Note that
+  ``rhosr_critical`` was fitted against the superseded Mondejar et al. EOS, so
+  values differ from v7.2.0 by up to ~2.5% along the saturated liquid line
+  (largest at low temperature, tapering to ~0% above 50 degC) and by more in the
+  deep compressed liquid near the triple point; that coupling is the same one
+  already shipping for the siblings.  Thermal conductivity remains unavailable
+  for this fluid, as it was in v7.2.0.  See GitHub
+  `#3330 <https://github.com/CoolProp/CoolProp/issues/3330>`_.
+
 8.0.0
 -----
 

--- a/Web/coolprop/changelog.rst
+++ b/Web/coolprop/changelog.rst
@@ -84,20 +84,30 @@ Highlights:
 
 Bug fixes:
 
-* **R1233zd(E) viscosity works again.**  v8.0.0 replaced the R1233zd(E) equation
-  of state with the Akasaka & Lemmon (JPCRD 2022) international standard, but
-  the fluid's ``TRANSPORT`` block was not carried across, so ``PropsSI("V",
-  ...)`` returned ``inf`` with *"Viscosity model is not available for this
-  fluid"* where v7.2.0 had answered.  The ``rhosr-CS`` correlation
-  (``Bell-PURDUE-2016-ETA``) is restored verbatim, matching what was already
-  done for the seven sibling fluids that use the same model.  Note that
-  ``rhosr_critical`` was fitted against the superseded Mondejar et al. EOS, so
-  values differ from v7.2.0 by up to ~2.5% along the saturated liquid line
-  (largest at low temperature, tapering to ~0% above 50 degC) and by more in the
-  deep compressed liquid near the triple point; that coupling is the same one
-  already shipping for the siblings.  Thermal conductivity remains unavailable
-  for this fluid, as it was in v7.2.0.  See GitHub
-  `#3330 <https://github.com/CoolProp/CoolProp/issues/3330>`_.
+* **R1233zd(E) viscosity works again, with refit constants.**  v8.0.0 replaced
+  this fluid's equation of state with the Akasaka & Lemmon (JPCRD 2022)
+  international standard but did not carry over its ``TRANSPORT`` block, so
+  ``PropsSI("V", ...)`` returned ``inf`` where v7.2.0 had answered
+  (`#3330 <https://github.com/CoolProp/CoolProp/issues/3330>`_).  The
+  ``rhosr-CS`` correlation is restored.
+
+  It does **not** reproduce v7.2.0, deliberately: saturated liquid viscosity is
+  29-38% lower (3.99e-4 rather than 6.37e-4 Pa-s at 0 degC, against 3.71e-4 from
+  REFPROP 10).  The published ``C = 1.2474`` was fitted to a 2012 dataset that
+  later measurements superseded and ran 40-75% high in the liquid
+  (`#1826 <https://github.com/CoolProp/CoolProp/issues/1826>`_, open since 2019).
+  ``rhosr_critical`` is now recomputed from the shipped EOS - it is
+  :math:`\rho_c R (\tau \alpha^r_\tau - \alpha^r)` at the critical point, not a
+  fitted parameter - and ``C = 0.8089`` is fitted on top of it to the 61 liquid
+  data points of `Miyara et al. (2018)
+  <https://doi.org/10.1016/j.ijrefrig.2018.05.021>`_, giving AAD 2.6% against a
+  stated 3.0% experimental uncertainty.  Rerun with ``python
+  dev/scripts/fit_R1233zdE_viscosity.py``.
+
+  Two limitations remain, both noted in the fluid file: saturated *vapor* is
+  ~10% high whatever ``C`` is (the dilute-gas term uses Chung-estimated
+  Lennard-Jones parameters, which ``C`` cannot correct), and thermal
+  conductivity is still unavailable, as it was in v7.2.0.
 
 8.0.0
 -----

--- a/dev/fluids/R1233zd(E).json
+++ b/dev/fluids/R1233zd(E).json
@@ -4133,7 +4133,8 @@
   "TRANSPORT": {
     "viscosity": {
       "BibTeX": "Bell-PURDUE-2016-ETA",
-      "C": 1.2474,
+      "C": 0.8089,
+      "_note": "C and rhosr_critical were both refit for the Akasaka and Lemmon (JPCRD 2022) EOS that replaced Mondejar et al. in v8.0.0. rhosr_critical is not a fitted parameter: it is rho_c*R*(tau*dalphar_dtau - alphar) at the EOS critical point, the quantity that normalises x = rho*s_r/rhosr_critical, so it tracks whichever EOS ships. For R32, R22 and R152A, whose EOS were never replaced, the stored constant equals the value computed from the current EOS to seven digits. The value here is what the shipped EOS gives; the previous -47978.147551213806 came from Mondejar and left x = 1.011 rather than 1 at the critical point. C = 0.8089 is then fitted on top of it against the 61 primary liquid viscosity points of Miyara, Alam and Kariya, Int. J. Refrig. 92:86-93, 2018 (doi 10.1016/j.ijrefrig.2018.05.021), Table 3: 313.67-433.32 K, 1.005-4.074 MPa, stated combined standard uncertainty 3.0%. AAD 2.62%, bias -0.07%, comparable to REFPROP 10 ECS (2.78%) over the same states. The published C = 1.2474 was fitted to Hulse, Basu, Singh and Thomas, JCED 57:3581-3586, 2012, superseded by the later measurements; it runs ~50-70% high in the liquid. That diagnosis, and the first refit (C = 0.671156, against figure-digitized Meng and Cui data; on the superseded normaliser that is 13.9% low against Miyara, and 15.5% low if rescored on the rhosr_critical shipping here), are due to J. P. Kauffman in GitHub issue #1826, 2019-05-07. Miyara covers only 314-433 K; over 243-313 K, where only the paywalled Meng and Cui measurements exist, this pair sits 6.7% above REFPROP 10 ECS. c_liq, c_vap and x_crossover are the universal reference-fluid coefficients and are unchanged. Remaining limitation: saturated vapor is ~10% high whatever C is, because the vapor is dominated by the dilute-gas term, whose Lennard-Jones parameters are Chung estimates rather than fitted values. Fitting script: dev/scripts/fit_R1233zdE_viscosity.py",
       "c_liq": [
         0.6100913843,
         0.4508958312,
@@ -4146,7 +4147,7 @@
         -0.308598,
         0.035317
       ],
-      "rhosr_critical": -47978.147551213806,
+      "rhosr_critical": -48503.78752999625,
       "type": "rhosr-CS",
       "x_crossover": 2
     }

--- a/dev/fluids/R1233zd(E).json
+++ b/dev/fluids/R1233zd(E).json
@@ -4129,5 +4129,26 @@
       "smolar": 261.44580746049974,
       "smolar_units": "J/mol/K"
     }
+  },
+  "TRANSPORT": {
+    "viscosity": {
+      "BibTeX": "Bell-PURDUE-2016-ETA",
+      "C": 1.2474,
+      "c_liq": [
+        0.6100913843,
+        0.4508958312,
+        -0.017063,
+        0.000564
+      ],
+      "c_vap": [
+        0.0,
+        1.2,
+        -0.308598,
+        0.035317
+      ],
+      "rhosr_critical": -47978.147551213806,
+      "type": "rhosr-CS",
+      "x_crossover": 2
+    }
   }
 }

--- a/dev/scripts/fit_R1233zdE_viscosity.py
+++ b/dev/scripts/fit_R1233zdE_viscosity.py
@@ -1,0 +1,181 @@
+"""Refit the rhosr-CS viscosity constants for R1233zd(E).
+
+Reproduces the two constants in ``dev/fluids/R1233zd(E).json`` ->
+``TRANSPORT.viscosity``: ``rhosr_critical`` and ``C``.  See CoolProp/CoolProp#3330
+and CoolProp/CoolProp#1826.
+
+``rhosr_critical`` is not fitted.  It is rho_c * R * (tau * dalphar_dtau - alphar)
+evaluated at the EOS critical point -- the quantity that normalises the reduced
+variable x = rho * s_r / rhosr_critical -- so it is a property of whichever
+equation of state ships, and is simply recomputed here.
+
+``C`` is the one fluid-specific fitted parameter.  Because
+
+    eta = eta_dilute * (1 + C * (etastar_ref - 1))
+
+is linear in C at fixed state, the objective is evaluated on a two-point basis
+(C = 0 and C = 1) rather than by re-entering the backend for every trial value.
+
+Data: Miyara, A., Alam, M. J. and Kariya, K., "Measurement of viscosity of
+trans-1-chloro-3,3,3-trifluoropropene (R-1233zd(E)) by tandem capillary tubes
+method", Int. J. Refrigeration 92 (2018) 86-93, doi:10.1016/j.ijrefrig.2018.05.021.
+Table 3, liquid phase: 61 points, 313.67-433.32 K, 1.005-4.074 MPa, stated
+combined standard uncertainty 3.0 percent.  The accepted manuscript carries the
+notice "This manuscript is made available under the Elsevier user license".
+
+Usage:  python dev/scripts/fit_R1233zdE_viscosity.py
+"""
+
+import copy
+import json
+import os
+import statistics
+
+import CoolProp.CoolProp as CP
+
+# T [K], p [MPa], eta [micro Pa s] -- Miyara et al. (2018), Table 3, liquid phase
+MIYARA_LIQUID = [
+    ( 313.90,  1.005,  244.50),
+    ( 353.70,  3.056,  168.80),
+    ( 313.90,  1.005,  243.81),
+    ( 353.68,  3.055,  169.19),
+    ( 313.81,  1.010,  243.98),
+    ( 353.63,  2.046,  166.86),
+    ( 313.83,  1.938,  246.29),
+    ( 353.66,  2.039,  166.83),
+    ( 313.89,  1.907,  245.77),
+    ( 353.63,  2.042,  167.15),
+    ( 313.88,  2.032,  246.54),
+    ( 374.31,  4.049,  142.14),
+    ( 313.85,  2.032,  246.47),
+    ( 374.31,  4.048,  142.11),
+    ( 313.83,  2.024,  245.77),
+    ( 374.31,  4.048,  142.09),
+    ( 313.91,  3.033,  247.58),
+    ( 374.24,  3.031,  138.63),
+    ( 313.91,  3.027,  248.21),
+    ( 374.22,  3.030,  138.63),
+    ( 313.91,  3.027,  247.73),
+    ( 374.23,  3.032,  138.47),
+    ( 313.87,  4.025,  250.11),
+    ( 374.24,  2.031,  135.40),
+    ( 313.67,  4.028,  249.04),
+    ( 374.24,  2.031,  135.45),
+    ( 313.77,  4.023,  248.75),
+    ( 374.23,  2.033,  135.41),
+    ( 313.78,  4.022,  249.55),
+    ( 393.52,  4.031,  116.79),
+    ( 333.90,  4.037,  204.78),
+    ( 393.52,  4.031,  116.49),
+    ( 334.00,  4.041,  205.16),
+    ( 393.52,  4.031,  116.57),
+    ( 334.00,  4.044,  204.80),
+    ( 393.50,  3.087,  112.17),
+    ( 333.83,  3.050,  203.71),
+    ( 393.54,  3.011,  112.10),
+    ( 333.93,  3.011,  202.96),
+    ( 393.57,  3.007,  112.17),
+    ( 333.90,  3.015,  203.22),
+    ( 393.57,  3.007,  111.76),
+    ( 333.93,  2.050,  201.74),
+    ( 413.49,  4.074,   90.54),
+    ( 333.93,  2.048,  201.61),
+    ( 413.49,  4.056,   90.47),
+    ( 333.94,  2.050,  201.55),
+    ( 413.55,  4.031,   91.80),
+    ( 333.91,  1.033,  199.83),
+    ( 412.90,  3.027,   87.03),
+    ( 333.93,  1.037,  199.07),
+    ( 413.31,  3.052,   86.48),
+    ( 333.90,  1.037,  199.15),
+    ( 413.45,  3.059,   86.11),
+    ( 353.68,  4.043,  172.90),
+    ( 433.32,  3.927,   62.85),
+    ( 353.68,  4.037,  172.53),
+    ( 433.32,  3.927,   62.49),
+    ( 353.65,  4.027,  172.44),
+    ( 433.32,  3.927,   62.67),
+    ( 353.67,  3.054,  169.34),
+]
+
+FLUID_JSON = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "fluids", "R1233zd(E).json")
+
+
+def probe(C, rhosr_critical):
+    """Register a private clone of the fluid carrying the given constants."""
+    with open(FLUID_JSON, encoding="utf-8") as fp:
+        fluid = json.load(fp)
+    fluid = copy.deepcopy(fluid[0] if isinstance(fluid, list) else fluid)
+    probe.counter += 1
+    name = "R1233zdE_fit_{0}".format(probe.counter)
+    fluid["INFO"]["NAME"] = name
+    fluid["INFO"]["ALIASES"] = []
+    fluid["INFO"]["CAS"] = "999-00-{0}".format(probe.counter)
+    fluid["INFO"]["REFPROP_NAME"] = "N/A"
+    for key in ("INCHI_KEY", "INCHI_STRING", "SMILES", "CHEMSPIDER_ID", "2DPNG_URL"):
+        fluid["INFO"].pop(key, None)
+    fluid["TRANSPORT"]["viscosity"]["C"] = C
+    fluid["TRANSPORT"]["viscosity"]["rhosr_critical"] = rhosr_critical
+    CP.add_fluids_as_JSON("HEOS", json.dumps([fluid]))
+    return CP.AbstractState("HEOS", name)
+
+
+probe.counter = 0
+
+
+def rhosr_critical_from_eos():
+    """rho_c * R * (tau * dalphar_dtau - alphar) at the EOS critical point.
+
+    Deliberately evaluated on a clone built from the repository's fluid file
+    rather than on the built-in "R1233zd(E)", so that the constant printed here
+    always belongs to the EOS in the tree.  Querying the installed CoolProp
+    would silently report the wheel's EOS while C was being fitted against the
+    repository's, the moment the two diverge.
+    """
+    state = probe(0.0, 0.0)  # transport constants are irrelevant to alphar
+    Tc, rhoc = state.T_critical(), state.rhomolar_critical()
+    state.update(CP.DmolarT_INPUTS, rhoc, Tc)
+    return rhoc * state.gas_constant() * (state.tau() * state.dalphar_dTau() - state.alphar())
+
+
+def main():
+    """Recompute rhosr_critical, refit C, and print both with their fit statistics."""
+    rhosr_critical = rhosr_critical_from_eos()
+    print("rhosr_critical from the shipped EOS = {0:.17g}".format(rhosr_critical))
+
+    # eta is linear in C, so two evaluations per state span the whole family.
+    zero, one = probe(0.0, rhosr_critical), probe(1.0, rhosr_critical)
+    basis = []
+    for T, p_MPa, eta_uPas in MIYARA_LIQUID:
+        zero.update(CP.PT_INPUTS, p_MPa * 1e6, T)
+        dilute = zero.viscosity()
+        one.update(CP.PT_INPUTS, p_MPa * 1e6, T)
+        basis.append((dilute, one.viscosity() - dilute, eta_uPas * 1e-6))
+
+    def aad(C):
+        """Mean absolute relative deviation from the measurements, in percent."""
+        return statistics.mean(abs((a + C * b) / e - 1) for a, b, e in basis) * 100
+
+    # AAD(C) is a sum of terms |b_i/e_i| * |C - (e_i - a_i)/b_i|, i.e. piecewise
+    # linear and convex with kinks only at those breakpoints.  The exact
+    # minimiser is therefore one of them -- no grid, and no chance of silently
+    # returning a scan boundary as if it were an optimum.
+    candidates = [(e - a) / b for a, b, e in basis if b != 0.0]
+    C_exact = min(candidates, key=aad)
+    C = round(C_exact, 4)
+
+    # The shipped constant is the rounded one, so report the rounded one; assert
+    # the rounding costs nothing meaningful against a 3.0% measurement uncertainty.
+    assert abs(aad(C) - aad(C_exact)) < 1e-3, "rounding C to 4 dp moved the AAD"
+
+    deviations = [((a + C * b) / e - 1) * 100 for a, b, e in basis]
+    print("C = {0:.4f}   (exact minimiser {1:.9f})".format(C, C_exact))
+    print(
+        "  N = {0}   AAD = {1:.2f}%   bias = {2:+.2f}%   range {3:+.1f}% .. {4:+.1f}%".format(
+            len(basis), aad(C), statistics.mean(deviations), min(deviations), max(deviations)
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -606,22 +606,31 @@ TEST_CASE_METHOD(TransportValidationFixture, "Compare thermal conductivities aga
 
 // #2768 swapped R1233zd(E) to the Akasaka & Lemmon (JPCRD 2022) international
 // standard EOS and dropped the rho*s_r corresponding-states viscosity
-// correlation that had shipped since v6.  Restoring the block verbatim -- the
-// same thing that was done for the seven sibling rhosr-CS fluids whose EOS were
-// also replaced -- brings viscosity back.
+// correlation that had shipped since v6, so viscosity became unavailable
+// entirely (#3330).  The block is back, with the entropy-scaling constant C
+// refit -- the published C = 1.2474 came from a dataset that later measurements
+// superseded, and ran ~50-70% high in the liquid (#1826).  rhosr_critical is
+// now the value the current EOS gives at its own critical point, and C is
+// fitted on top of it to the primary data of Miyara, Alam & Kariya,
+// Int. J. Refrig. 92:86-93 (2018).
 //
-// The pinned values are a regression lock on "the restored coefficients are the
-// published ones and the EOS feeding them has not moved", NOT an accuracy claim:
-// rhosr_critical was fitted against the superseded Mondejar et al. EOS, so these
-// differ from the v7.2.0 numbers by up to ~2.5% along the saturated liquid line.
-// If an EOS or coefficient change moves them, that is a decision to make
-// consciously, not to absorb silently.
+// These values therefore deliberately do NOT reproduce v7.2.0; they are roughly
+// 29-38% lower along the saturated liquid line, and agree with Miyara's
+// measurements to 2.6% AAD against a stated 3.0% experimental uncertainty.  They
+// are a regression lock on "the coefficients are the ones we intend and the EOS
+// feeding them has not moved".
+//
+// If an EOS or coefficient change moves these, that is a decision to make
+// consciously rather than absorb silently -- in particular rhosr_critical must
+// be recomputed from the new EOS and C refitted on top of it, since the two are
+// coupled through x = rho*s_r/rhosr_critical.
 TEST_CASE("R1233zd(E) has a viscosity model (#3330)", "[viscosity],[transport],[3330]") {
     SECTION("the state from the bug report is finite") {
         const double eta = CoolProp::PropsSI("V", "T", 273.15, "Q", 0, "R1233zd(E)");
         CAPTURE(eta);
         REQUIRE(ValidNumber(eta));
-        // Saturated liquid at 0 C; the v7.2.0 value was 6.3689e-4 Pa-s.
+        // Saturated liquid at 0 C.  v7.2.0 answered 6.3689e-4 Pa-s here; with the
+        // refit constants this is 3.99e-4, against 3.71e-4 from REFPROP 10 ECS.
         CHECK(eta > 1e-4);
         CHECK(eta < 1e-3);
     }
@@ -635,12 +644,14 @@ TEST_CASE("R1233zd(E) has a viscosity model (#3330)", "[viscosity],[transport],[
         };
         // T [K], rhomolar [mol/m^3], eta [Pa-s]
         // All four are single phase at the stated (T, rho): rhoL(300 K) = 9643.6 and
-        // rhoL(400 K) = 7219.8 mol/m^3, rhoV(350 K) = 246.0 mol/m^3.
+        // rhoL(400 K) = 7219.8 mol/m^3, rhoV(350 K) = 246.0 mol/m^3.  The two
+        // compressed-liquid rows sit at 18.2 and 10.8 MPa, outside the 1.0-4.1 MPa
+        // range C was fitted over, so they lock extrapolation behaviour on purpose.
         const row rows[] = {
-          {250.0, 1e-10, 9.2922657253765002e-06},    // dilute-gas limit
-          {350.0, 100.0, 1.3159482156137667e-05},    // vapor
-          {300.0, 10000.0, 5.7811787177563785e-04},  // compressed liquid, liquid branch of the crossover
-          {400.0, 8000.0, 1.9385792402999729e-04},   // compressed liquid, near-critical temperature
+          {250.0, 1e-10, 9.2922657253765002e-06},  // dilute-gas limit; C drops out here
+          {350.0, 100.0, 1.314939784502e-05},      // vapor
+          {300.0, 10000.0, 3.6854833102371e-04},   // compressed liquid, liquid branch of the crossover
+          {400.0, 8000.0, 1.289196192878e-04},     // compressed liquid, rho = 2.2 rho_c
         };
         shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "R1233zd(E)"));
         for (const auto& r : rows) {

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -604,6 +604,56 @@ TEST_CASE_METHOD(TransportValidationFixture, "Compare thermal conductivities aga
 
 }; /* namespace TransportValidation */
 
+// #2768 swapped R1233zd(E) to the Akasaka & Lemmon (JPCRD 2022) international
+// standard EOS and dropped the rho*s_r corresponding-states viscosity
+// correlation that had shipped since v6.  Restoring the block verbatim -- the
+// same thing that was done for the seven sibling rhosr-CS fluids whose EOS were
+// also replaced -- brings viscosity back.
+//
+// The pinned values are a regression lock on "the restored coefficients are the
+// published ones and the EOS feeding them has not moved", NOT an accuracy claim:
+// rhosr_critical was fitted against the superseded Mondejar et al. EOS, so these
+// differ from the v7.2.0 numbers by up to ~2.5% along the saturated liquid line.
+// If an EOS or coefficient change moves them, that is a decision to make
+// consciously, not to absorb silently.
+TEST_CASE("R1233zd(E) has a viscosity model (#3330)", "[viscosity],[transport],[3330]") {
+    SECTION("the state from the bug report is finite") {
+        const double eta = CoolProp::PropsSI("V", "T", 273.15, "Q", 0, "R1233zd(E)");
+        CAPTURE(eta);
+        REQUIRE(ValidNumber(eta));
+        // Saturated liquid at 0 C; the v7.2.0 value was 6.3689e-4 Pa-s.
+        CHECK(eta > 1e-4);
+        CHECK(eta < 1e-3);
+    }
+    SECTION("the correlation is the published one") {
+        CHECK(CoolProp::get_fluid_param_string("R1233zd(E)", "BibTeX-VISCOSITY") == "Bell-PURDUE-2016-ETA");
+    }
+    SECTION("pinned values") {
+        struct row
+        {
+            double T, rhomolar, eta;
+        };
+        // T [K], rhomolar [mol/m^3], eta [Pa-s]
+        // All four are single phase at the stated (T, rho): rhoL(300 K) = 9643.6 and
+        // rhoL(400 K) = 7219.8 mol/m^3, rhoV(350 K) = 246.0 mol/m^3.
+        const row rows[] = {
+          {250.0, 1e-10, 9.2922657253765002e-06},    // dilute-gas limit
+          {350.0, 100.0, 1.3159482156137667e-05},    // vapor
+          {300.0, 10000.0, 5.7811787177563785e-04},  // compressed liquid, liquid branch of the crossover
+          {400.0, 8000.0, 1.9385792402999729e-04},   // compressed liquid, near-critical temperature
+        };
+        shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("HEOS", "R1233zd(E)"));
+        for (const auto& r : rows) {
+            CAPTURE(r.T);
+            CAPTURE(r.rhomolar);
+            AS->update(CoolProp::DmolarT_INPUTS, r.rhomolar, r.T);
+            const double eta = AS->viscosity();
+            CAPTURE(eta);
+            CHECK(std::abs(eta / r.eta - 1) < 1e-6);
+        }
+    }
+}
+
 static CoolProp::input_pairs inputs[] = {
   CoolProp::DmolarT_INPUTS,
   //CoolProp::SmolarT_INPUTS,


### PR DESCRIPTION
Fixes #3330. Also closes the viscosity half of #1826, open since April 2019.

## The regression

#2768 replaced the R1233zd(E) EOS with the Akasaka & Lemmon (JPCRD 2022)
international standard and did not carry over the fluid's `TRANSPORT` block:

```python
PropsSI("V", "T", 273.15, "Q", 0, "R1233zd(E)")
# v7.2.0 -> 0.000636889
# v8.0.0 -> inf, "Viscosity model is not available for this fluid"
```

R1233zd(E) was the only one of the ten fluids in that batch that already had a
viscosity model, which is why nothing else regressed and no test caught it.

## Two commits, deliberately separable

**1 — restore the block**, byte-for-byte from `dd0f49528^`. This alone makes the
reported call finite. Nothing else changes.

**2 — refit its two constants for the EOS now shipping.** The restored constants
have been wrong since the model was added.

`rhosr_critical` is not a fitted parameter: it is `rho_c*R*(tau*dalphar_dtau -
alphar)` at the EOS critical point, the quantity normalising `x = rho*s_r /
rhosr_critical`, so it tracks whichever EOS ships. Checkable in the tree — for
R32, R22 and R152A, whose EOS were never replaced, the stored constant matches
the value computed from the current EOS to seven digits. R1233zd(E)'s did not,
because #2768 replaced the EOS underneath it; the old value put `x` at 1.011
rather than 1 at the critical point.

`C` is then fitted on top against the 61 primary liquid points of Miyara, Alam &
Kariya, *Int. J. Refrig.* **92**, 86-93 (2018), Table 3 (313.67-433.32 K,
1.005-4.074 MPa, stated uncertainty 3.0%):

| `C` | `rhosr_critical` | AAD | bias |
|---|---|---|---|
| 1.2474 (published) | -47978.148 | 51.9% | +51.9% |
| 0.671156 (first refit, #1826) | -47978.148 | 13.9% | -13.9% |
| **0.8089 (this PR)** | **-48503.788** | **2.62%** | **-0.07%** |
| REFPROP 10 ECS | n/a | 2.78% | +2.54% |

Each row is scored on the normaliser it was fitted with. Agreement at the level
of the experimental uncertainty from one fitted parameter, matching what
REFPROP's own ECS achieves over the same states. Recomputing `rhosr_critical`
improves every metric, not just the fitted one: saturated liquid vs REFPROP over
243-313 K 7.48% → 6.71%, over 315-433 K 4.60% → 4.47%, and a (T,p) grid over
200-435 K / 0.1-30 MPa 11.9% → 10.9% AAD, worst case 51.4% → 45.5%.

`python dev/scripts/fit_R1233zdE_viscosity.py` reproduces both constants.

## This deliberately does not reproduce v7.2.0

Saturated liquid viscosity is **29-38% lower** (3.99e-4 rather than 6.37e-4 Pa-s
at 0 °C, against 3.71e-4 from REFPROP). The published `C = 1.2474` was fitted to
Hulse et al. (2012), superseded by Miyara (2018), Meng, Wen & Wu (2018) and Cui,
Yan, Bi & Wu (2018). Anyone relying on the v7.2.0 numbers for this fluid was
relying on values 40-75% above every modern measurement.

## Known limitations, recorded in the fluid file

- Miyara covers 314-433 K only. Over 243-313 K, where only the paywalled Meng
  and Cui data exist, this pair sits 6.7% above REFPROP's ECS.
- Saturated **vapor** stays ~10% high whatever `C` is — the dilute-gas term uses
  Chung-estimated Lennard-Jones parameters, which `C` cannot correct.
- Thermal conductivity is still unavailable, as in v7.2.0 (#1826, #2229, #2523
  are unaffected).

## Testing

`R1233zd(E) has a viscosity model` — verified to fail before the change with the
exact error users hit. Pins the reported call, asserts the BibTeX key, and locks
four single-phase `(T, rho)` values at 1e-6 (worst observed platform deviation
9.6e-15).

`./dev/ci/preflight.sh` passes 6/0. `cppcheck` and `clang-tidy` skipped: both
fail only on pre-existing findings in `CoolProp-Tests.cpp` that also fail on the
untouched `HEAD` version, surfacing now only because the file is in the diff.
Full `~[slow]`: 518 cases, 177k assertions, 0 failures.

## Attribution

The diagnosis and the first refit (`C = 0.671156`, fitted to figure-digitized
Meng and Cui data) are due to **@jpkauffman** in #1826, 2019-05-07. This
supersedes that value only because primary tabulated data has since become
reachable; the analysis was his.

Follow-up filed, not done here: R1234yf and R1234ze(E) should get Huber &
Assael, *Int. J. Refrig.* **71**, 39-45 (2016) — REFPROP's primary model for
both, and green open access — rather than a patch to their own stale
`rhosr_critical`.

Written by Claude Opus 5. Ian verified the physics, chose the constant, and
supplied the Miyara manuscript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored viscosity calculations for R1233zd(E) using an updated correlation.
  - Improved saturated-liquid viscosity results, with values now aligned to published measurement data.
  - Added safeguards and validation for viscosity calculations across gas, vapor, and compressed-liquid conditions.
  - Documented known limitations: saturated-vapor viscosity remains approximate, and thermal conductivity is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->