### PR TITLE
fix(REFPROP): Qmass dispatch gate tested a vector that is never size 1

### DIFF
--- a/include/CoolProp/AbstractState.h
+++ b/include/CoolProp/AbstractState.h
@@ -323,6 +323,24 @@ class AbstractState
     /// Mixture backends must override.
     virtual PhaseMolarMasses calc_phase_molar_masses();
 
+    /// A Qmass input pair's molar sibling, and which slot (1=value1, 2=value2)
+    /// carries the Qmass value.
+    struct QmassPairMapping
+    {
+        CoolProp::input_pairs molar;
+        int qmass_slot;
+    };
+
+    /// Map a Qmass input pair to its molar sibling and Qmass slot.
+    static QmassPairMapping qmass_pair_mapping(CoolProp::input_pairs pair);
+
+    /// Throw if the Qmass component of a Qmass input pair is not in [0,1] (NaN
+    /// included).  update_Qmass_pair applies this itself; a backend that rewrites
+    /// the pair to its molar sibling instead of iterating must call it directly,
+    /// or the range goes unchecked -- REFPROP's DQFL2 will extrapolate a quality
+    /// above 1 rather than refuse it.
+    void check_Qmass_pair_range(CoolProp::input_pairs pair, double v1, double v2);
+
     /// Default iterative Qmass-pair solver (secant on Qmolar). Backends may
     /// override to use a native fast path (e.g. REFPROP TQFLSHdll kq=2).
     virtual void update_Qmass_pair(CoolProp::input_pairs pair, double v1, double v2);

--- a/src/AbstractState.cpp
+++ b/src/AbstractState.cpp
@@ -829,6 +829,14 @@ CoolPropDbl AbstractState::calc_Qmass() {
     // This avoids NaN propagation when one phase is unpopulated by the backend
     // at a saturation-curve endpoint (e.g. Q=0 on the bubble line).
     if (_Q == 0.0 || _Q == 1.0) return static_cast<CoolPropDbl>(_Q);
+    // Pure / pseudo-pure: Qmass IS Qmolar, for every quality and not just the
+    // endpoints.  calc_phase_molar_masses() returns {mm, mm} here, so the lever
+    // rule below is an identity in exact arithmetic -- but not in floating point:
+    // (Q*mm)/(Q*mm + (1-Q)*mm) rounds, and comes back an ULP off the caller's
+    // value for a good fraction of molar masses (CO2 and Nitrogen at Q=0.75 both
+    // do; Water happens not to).  It would also divide by zero if a backend left
+    // the phase compositions unpopulated.  Return _Q directly.
+    if (get_mole_fractions().size() == 1) return static_cast<CoolPropDbl>(_Q);
     const auto MM = calc_phase_molar_masses();
     return static_cast<CoolPropDbl>(detail::Qmolar_to_Qmass(_Q, MM.liquid, MM.vapor));
 }
@@ -841,14 +849,11 @@ AbstractState::PhaseMolarMasses AbstractState::calc_phase_molar_masses() {
     }
     throw NotImplementedError("calc_phase_molar_masses must be overridden by mixture backends");
 }
-void AbstractState::update_Qmass_pair(CoolProp::input_pairs pair, double v1, double v2) {
-    // Map Qmass-pair to its molar sibling and identify which slot (1=value1, 2=value2)
-    // holds the Qmass value.
-    struct Mapping
-    {
-        CoolProp::input_pairs molar;
-        int qmass_slot;
-    };
+/// Map a Qmass input pair to its molar sibling and to the slot (1=value1, 2=value2)
+/// that carries the Qmass value.  Shared by update_Qmass_pair and by the range check
+/// backends need when they rewrite the pair themselves instead of iterating.
+AbstractState::QmassPairMapping AbstractState::qmass_pair_mapping(CoolProp::input_pairs pair) {
+    using Mapping = AbstractState::QmassPairMapping;
     Mapping m;
     switch (pair) {
         case QmassT_INPUTS:
@@ -876,14 +881,25 @@ void AbstractState::update_Qmass_pair(CoolProp::input_pairs pair, double v1, dou
             m = {DmassQ_INPUTS, 2};
             break;
         default:
-            throw ValueError("update_Qmass_pair called with non-Qmass pair");
+            throw ValueError("qmass_pair_mapping called with non-Qmass pair");
     }
+    return m;
+}
+
+void AbstractState::check_Qmass_pair_range(CoolProp::input_pairs pair, double v1, double v2) {
+    const QmassPairMapping m = qmass_pair_mapping(pair);
+    const double Qmass_target = (m.qmass_slot == 1) ? v1 : v2;
+    if (!(Qmass_target >= 0 && Qmass_target <= 1)) {
+        throw ValueError(format("Qmass out of range [0,1]: %g", Qmass_target));
+    }
+}
+
+void AbstractState::update_Qmass_pair(CoolProp::input_pairs pair, double v1, double v2) {
+    const QmassPairMapping m = qmass_pair_mapping(pair);
     const double Qmass_target = (m.qmass_slot == 1) ? v1 : v2;
     const double partner = (m.qmass_slot == 1) ? v2 : v1;
 
-    if (Qmass_target < 0 || Qmass_target > 1) {
-        throw ValueError(format("Qmass out of range [0,1]: %g", Qmass_target));
-    }
+    check_Qmass_pair_range(pair, v1, v2);
 
     auto run_molar = [&](double Qmolar) {
         if (m.qmass_slot == 1)

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -1032,7 +1032,12 @@ CoolPropDbl REFPROPMixtureBackend::calc_molar_mass() {
     return static_cast<CoolPropDbl>(_molar_mass.pt());
 };
 AbstractState::PhaseMolarMasses REFPROPMixtureBackend::calc_phase_molar_masses() {
-    if (mole_fractions.size() == 1) {
+    // get_mole_fractions() is sized Ncomp; the mole_fractions member is padded to
+    // ncmax and is never 1.  Same dead-guard bug that update()'s Qmass dispatch had.
+    // The shortcut matters: without it a pure fluid runs WMOLdll on the liquid and
+    // vapor composition arrays, which are all-zero until a two-phase flash fills
+    // them in -- a molar mass of zero waiting to divide.
+    if (get_mole_fractions().size() == 1) {
         const double mm = molar_mass();
         return {mm, mm};
     }
@@ -1458,14 +1463,39 @@ phases REFPROPMixtureBackend::GetRPphase() {
 }
 
 void REFPROPMixtureBackend::update(CoolProp::input_pairs input_pair, double value1, double value2) {
-    // Mass-quality input pair on a true mixture: handle via update_Qmass_pair.
-    // Pure / pseudo-pure (mole_fractions.size() == 1) goes through the existing
-    // mass_to_molar_inputs path.
-    if (CoolProp::is_Qmass_pair(input_pair) && mole_fractions.size() > 1) {
-        update_Qmass_pair(input_pair, value1, value2);
-        return;
-    }
     this->check_loaded_fluid();
+
+    // Mass-quality input pair.  On a true mixture Qmass != Qmolar, so it needs the
+    // dedicated update_Qmass_pair path.  For a pure or pseudo-pure fluid the two are
+    // the same number, so rewrite the pair to its molar sibling and fall through to
+    // the switch below.
+    //
+    // Test get_mole_fractions(), which is sized Ncomp -- NOT the mole_fractions
+    // member, which every success branch of set_REFPROP_fluids resize(ncmax)'s to 20
+    // and so is never 1.  An empty vector means the composition was never set; send
+    // that to update_Qmass_pair, whose check_status() reports it properly.
+    if (CoolProp::is_Qmass_pair(input_pair)) {
+        if (get_mole_fractions().size() == 1) {
+            // The rewrite skips AbstractState::update_Qmass_pair, so its [0,1] range
+            // check has to be applied here.  REFPROP will not do it for us: DQFL2
+            // extrapolates a quality above 1 and returns a state whose Q() reads 1.05
+            // and phase() reads gas, while Qmass() on it throws.
+            check_Qmass_pair_range(input_pair, value1, value2);
+            // NOTE: mass_to_molar_inputs runs two switches.  The first rewrites the
+            // Qmass pair to its molar sibling; the second converts any remaining
+            // mass-basis value to molar (DmassQmass -> DmassQ -> DmolarQ, dividing by
+            // the molar mass once).  That lands on case DmolarQ_INPUTS below, NOT on
+            // this backend's own case DmassQ_INPUTS, so the density is not divided
+            // twice -- a fact worth rechecking if either switch changes.
+            CoolPropDbl v1 = value1, v2 = value2;
+            mass_to_molar_inputs(input_pair, v1, v2);
+            value1 = static_cast<double>(v1);
+            value2 = static_cast<double>(v2);
+        } else {
+            update_Qmass_pair(input_pair, value1, value2);
+            return;
+        }
+    }
     double rho_mol_L = _HUGE, rhoLmol_L = _HUGE, rhoVmol_L = _HUGE, hmol = _HUGE, emol = _HUGE, smol = _HUGE, cvmol = _HUGE, cpmol = _HUGE, w = _HUGE,
            q = _HUGE, mm = _HUGE, p_kPa = _HUGE, hjt = _HUGE;
     int ierr = 0;

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5294,6 +5294,114 @@ TEST_CASE("Qmass input: REFPROP mixture update clears cached state", "[Qmass][RE
     }
 }
 
+TEST_CASE("Qmass input: REFPROP pure fluid takes the molar path", "[Qmass][REFPROP]") {
+    // For a pure or pseudo-pure fluid Qmass IS Qmolar -- no conversion is defined,
+    // so update() is supposed to rewrite the Qmass pair to its molar sibling via
+    // mass_to_molar_inputs() and run the ordinary switch.  The dispatch guard tested
+    // REFPROPMixtureBackend's own mole_fractions member, which every success branch
+    // of set_REFPROP_fluids resize(ncmax)'s to 20 -- so "size() > 1" was never false
+    // and pure fluids took AbstractState::update_Qmass_pair's TOMS748 solve on
+    // Qmolar instead, returning a Q one ULP off the value the caller passed in.
+    //
+    // The comparisons below are deliberately exact, not Approx: on this path nothing
+    // may touch the numbers at all, so any difference is a routing bug, not noise.
+    //
+    // Several fluids on purpose.  Qmass() is recomputed lazily from _Q through the
+    // lever rule, and whether that rounds back to the input depends on the molar
+    // mass -- Water happens to round favourably where CO2 and Nitrogen do not, so a
+    // single-fluid test would pass on luck rather than on the pure-fluid shortcut.
+    const std::vector<std::string> fluids = {"Water", "CO2", "Nitrogen"};
+    std::shared_ptr<CoolProp::AbstractState> probe;
+    try {
+        probe.reset(CoolProp::AbstractState::factory("REFPROP", "Water"));
+    } catch (...) {
+        WARN("REFPROP not available; skipping");
+        return;
+    }
+
+    SECTION("Q and Qmass survive the pure-fluid Qmass flash untouched") {
+        for (const auto& fluid : fluids) {
+            auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("REFPROP", fluid));
+            const double T = 0.8 * AS->T_critical();
+            for (double q : {0.0, 0.25, 0.5, 0.75, 1.0}) {
+                CAPTURE(fluid, q, T);
+                AS->update(CoolProp::QmassT_INPUTS, q, T);
+                CHECK(AS->Q() == q);
+                CHECK(AS->Qmass() == q);
+            }
+        }
+    }
+
+    SECTION("QmassT and QT reach the same state for a pure fluid") {
+        for (const auto& fluid : fluids) {
+            auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("REFPROP", fluid));
+            auto ASm = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("REFPROP", fluid));
+            const double T = 0.8 * AS->T_critical();
+            for (double q : {0.0, 0.25, 0.5, 0.75, 1.0}) {
+                CAPTURE(fluid, q, T);
+                AS->update(CoolProp::QT_INPUTS, q, T);
+                ASm->update(CoolProp::QmassT_INPUTS, q, T);
+                CHECK(ASm->p() == AS->p());
+                CHECK(ASm->rhomolar() == AS->rhomolar());
+                CHECK(ASm->hmolar() == AS->hmolar());
+                CHECK(ASm->smolar() == AS->smolar());
+                CHECK(ASm->Q() == AS->Q());
+                CHECK(ASm->phase() == AS->phase());
+            }
+        }
+    }
+
+    SECTION("PQmass and PQ reach the same state for a pure fluid") {
+        for (const auto& fluid : fluids) {
+            auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("REFPROP", fluid));
+            auto ASm = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("REFPROP", fluid));
+            AS->update(CoolProp::QT_INPUTS, 0.0, 0.8 * AS->T_critical());
+            const double p_sat = AS->p();
+            for (double q : {0.0, 0.25, 1.0}) {
+                CAPTURE(fluid, q, p_sat);
+                AS->update(CoolProp::PQ_INPUTS, p_sat, q);
+                ASm->update(CoolProp::PQmass_INPUTS, p_sat, q);
+                CHECK(ASm->T() == AS->T());
+                CHECK(ASm->rhomolar() == AS->rhomolar());
+                CHECK(ASm->hmolar() == AS->hmolar());
+                CHECK(ASm->Q() == AS->Q());
+            }
+        }
+    }
+
+    SECTION("out-of-range Qmass is still rejected on the pure path") {
+        // AbstractState::update_Qmass_pair validates Qmass in [0,1] before it
+        // iterates.  The pure-fluid rewrite skips that function entirely, so the
+        // check has to survive independently -- REFPROP will not do it for us:
+        // DQFL2 happily extrapolates a quality above 1 and hands back a state whose
+        // Q() says 1.05 and phase() says gas, while Qmass() on that same state
+        // throws "requires a two-phase state".
+        //
+        // Match on this guard's own message, not merely on ValueError.  REFPROP
+        // rejects most of these by itself -- QmassT via TQFLSH error 19, and the
+        // density pairs at -0.05 and 1.5 via DQFL2 "2-phase iteration did not
+        // converge", a misleading diagnostic for what is really an invalid input.
+        // Only the +1.05 density cases actually die when the guard is deleted, so
+        // a bare CHECK_THROWS_AS would leave most of this section passing on
+        // REFPROP's behaviour rather than on ours, and would go silently vacuous
+        // if REFPROP ever tightened DQFL2's input validation.
+        const auto out_of_range = Catch::Matchers::ContainsSubstring("Qmass out of range");
+        for (const auto& fluid : fluids) {
+            auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("REFPROP", fluid));
+            const double T = 0.8 * AS->T_critical();
+            AS->update(CoolProp::QT_INPUTS, 0.5, T);
+            const double rhomolar = AS->rhomolar(), rhomass = AS->rhomass();
+            // The guard runs before clear(), so the state survives each expected throw.
+            for (double q : {-0.05, 1.05, 1.5, std::numeric_limits<double>::quiet_NaN()}) {
+                CAPTURE(fluid, q);
+                CHECK_THROWS_WITH(AS->update(CoolProp::DmolarQmass_INPUTS, rhomolar, q), out_of_range);
+                CHECK_THROWS_WITH(AS->update(CoolProp::DmassQmass_INPUTS, rhomass, q), out_of_range);
+                CHECK_THROWS_WITH(AS->update(CoolProp::QmassT_INPUTS, q, T), out_of_range);
+            }
+        }
+    }
+}
+
 TEST_CASE("Qmass edge cases: bubble/dew, out-of-range, single-phase", "[Qmass][edge]") {
     auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "R32&R125"));
     AS->set_mole_fractions({0.5, 0.5});


### PR DESCRIPTION
## What

`REFPROPMixtureBackend::update()` gated its mass-quality dispatch on

```cpp
if (CoolProp::is_Qmass_pair(input_pair) && mole_fractions.size() > 1)
```

with a comment promising that pure / pseudo-pure fluids instead take the `mass_to_molar_inputs` path. `mole_fractions` is the backend's own REFPROP argument buffer, and every success branch of `set_REFPROP_fluids` does `resize(ncmax)` on it — so `size() > 1` was never false, the guard excluded nothing, and pure fluids took the mixture path the comment said they would not. `update()` never called `mass_to_molar_inputs` at all.

The gate now tests `get_mole_fractions()`, which is sized `Ncomp`: 1 for a pure fluid, 2 for `R410A.MIX`, 3 for `R407C.MIX`, and 0 when the composition was never set. Size 1 rewrites the pair to its molar sibling and falls through to the switch; anything else keeps `update_Qmass_pair`, so an unset composition still reports "Mole fractions not yet set".

## Why it mattered

Numerically the pure path was *almost* right, because `Qmass == Qmolar` for a single component. Almost — it round-tripped the caller's quality through the TOMS748 solve:

```
QmassT_INPUTS at Q = 0.25  ->  Q() == 0.25000000000000006
```

Everything else — `p`, `rho`, `h`, `s`, `phase`, transport — was already bit-identical to the molar path, which is why this never surfaced as a numbers bug.

## Three things the rewrite had to carry with it

All three came out of adversarial review, and each was reproduced before being fixed:

1. **The `[0,1]` range check lived inside `update_Qmass_pair`**, so the pure path dropped it and REFPROP became the only validator. `DQFL2` does not refuse a quality above 1 — pure-fluid `DmassQmass` at `Qmass=1.05` returned a state reading `Q()=1.05` and `phase()=gas`, on which `Qmass()` then threw "requires a two-phase state". The pair→molar mapping is now shared (`qmass_pair_mapping`) and the check is a helper both paths call.

2. **`calc_Qmass()` recomputed Qmass through the lever rule**, an identity on paper but not in floating point. With `_Qmass` no longer cached, pure-fluid `Qmass()` stopped round-tripping: CO2 at 0.75 → `0.75000000000000011`, Nitrogen → `0.74999999999999989`, roughly one molar mass in seven. Now short-circuits to `_Q` for a single component, as the `Q==0/1` endpoints already did.

3. **`REFPROPMixtureBackend::calc_phase_molar_masses()` has the identical dead guard**, so its pure-fluid `{mm, mm}` shortcut never ran either. Without it a pure fluid calls `WMOLdll` on the liquid and vapor composition arrays, which are all-zero until a two-phase flash populates them.

## Two effects reach beyond REFPROP

Both are improvements and both were measured, but they are observable outside the backend this PR is named for:

- The range predicate is now `!(q >= 0 && q <= 1)` rather than `q < 0 || q > 1`, so **NaN is rejected** (pure REFPROP `QmassT` with NaN previously returned `Q()=nan` silently). For **HEOS, Cubics and PCSAFT mixtures** it also replaces a `boost::wrapexcept<std::domain_error>` leaked out of `toms748_solve` with a `CoolProp::ValueError`. `catch (CoolProp::ValueError&)` did not previously catch those; now it does.
- The `calc_Qmass()` short-circuit is in the base class, so **HEOS, Cubics, PCSAFT and Tabular pure fluids** get the same exact round-trip. Mixture results on every backend are byte-identical to before.

## Notes on the tests

The comparisons are exact `==`, not `Approx`, on purpose: on the pure path nothing may touch the numbers, so any difference is a routing bug rather than noise. Two deliberate choices behind that:

- **Water, CO2 and Nitrogen, not just Water.** Whether the lever rule rounds back to the input is molar-mass dependent. A Water-only test passed on luck — CO2 and Nitrogen are what actually kill the mutant.
- **The out-of-range section matches on the guard's own message**, not on `ValueError`. REFPROP rejects most of those inputs by itself (`TQFLSH error 19`; `DQFL2 error 226`), so a bare `CHECK_THROWS_AS` left 21 of 27 assertions passing on REFPROP's behaviour instead of ours, and would have gone silently vacuous if REFPROP ever tightened `DQFL2`'s input validation. Deleting the guard now fails all 36.

## Verification

- Full `~[slow]` suite with REFPROP 10 loaded: **191,296 assertions in 518 test cases, all pass**
- `[Qmass],[REFPROP],[refprop]`: 1337 assertions, 26 cases
- Mutation-tested both new guards: removing the range check fails 36/36 of the out-of-range assertions; removing the `calc_Qmass` short-circuit fails exactly the CO2 and Nitrogen cases and nothing for Water
- `./dev/ci/preflight.sh`: format, build, tests, semgrep pass. cppcheck and clang-tidy fail on pre-existing whole-file findings — zero findings inside any hunk of this diff, and the cppcheck `syntaxError` reproduces on pristine `master`

## Follow-up filed

`bd` **CoolProp-nn6b** — the same fail-open is still live in `CubicBackend` and `PCSAFTBackend`, which rewrite the pair the same way without calling the new check. `SRK::Propane` at `Qmass = 1.05` silently succeeds today. Pre-existing, not a regression from this PR, and now one call away from being fixed. That issue also records that the same user error raises `ValueError` on the REFPROP pure path but `OutOfRangeError` on the HEOS pure path — unrelated sibling types, worth unifying deliberately rather than by accident.

## AI assistance

Implemented by Claude Opus 5 under my direction, following the project's TDD and pre-PR review workflow: failing test first for each defect, then the fix, then an adversarial review subagent whose findings were reproduced independently before being addressed, then a re-review of the delta. I verified the REFPROP behaviour locally against REFPROP 10 and reviewed the final diff.

Closes `bd` CoolProp-4a16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
