### PR TITLE
fix(transport): rhosr-CS viscosity ignored x_crossover from the fluid file

### DIFF
--- a/src/Backends/Helmholtz/TransportRoutines.cpp
+++ b/src/Backends/Helmholtz/TransportRoutines.cpp
@@ -1274,8 +1274,11 @@ CoolPropDbl TransportRoutines::viscosity_rhosr(HelmholtzEOSMixtureBackend& HEOS)
     // Calculate x
     double x = HEOS.rhomolar() * HEOS.gas_constant() * (HEOS.tau() * HEOS.dalphar_dTau() - HEOS.alphar()) / data.rhosr_critical;
 
-    // Crossover variable
-    double psi_liq = 1 / (1 + exp(-100.0 * (x - 2)));
+    // Crossover variable.  The switch location comes from the fluid file
+    // (x_crossover); the sharpness is a fixed constant of the correlation and is
+    // deliberately not exposed as data.
+    const double crossover_sharpness = 100.0;
+    double psi_liq = 1 / (1 + exp(-crossover_sharpness * (x - data.x_crossover)));
 
     // Evaluated using Horner's method
     const std::vector<double>&cL = data.c_liq, cV = data.c_vap;

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -665,6 +665,71 @@ TEST_CASE("R1233zd(E) has a viscosity model (#3330)", "[viscosity],[transport],[
     }
 }
 
+// The rho*s_r correlation blends a liquid and a vapor branch with a logistic
+// switch centred on x_crossover, which every rhosr-CS fluid file carries as
+// data.  TransportRoutines::viscosity_rhosr used to hardcode the centre as the
+// literal 2 and never read the parsed field, so editing x_crossover in a fluid
+// file silently did nothing.  All eight rhosr-CS fluids happen to set it to 2,
+// so nothing was numerically wrong -- the field was simply inert, which is the
+// worse kind of bug: it fails only for whoever next tries to use it.
+//
+// Clone R1233zd(E) twice, changing nothing but x_crossover, and evaluate at a
+// state whose x sits between the two values.  Before the fix both clones return
+// bit-identical viscosity; after it they must diverge, because the switch has
+// moved from "fully liquid branch" to "fully vapor branch" at that state.
+TEST_CASE("rhosr-CS viscosity honours x_crossover from the fluid file", "[viscosity],[transport],[rhosr]") {
+    using nlohmann::json;
+
+    json arr = json::parse(CoolProp::get_fluid_param_string("R1233zd(E)", "JSON"));
+    REQUIRE(arr.is_array());
+    REQUIRE(arr.size() == 1);
+
+    // Guard the premise: this test is meaningless if the block stops being
+    // rhosr-CS, or if the shipped switch location ever moves off 2.
+    REQUIRE(arr[0]["TRANSPORT"]["viscosity"].at("type").get<std::string>() == "rhosr-CS");
+    REQUIRE(arr[0]["TRANSPORT"]["viscosity"].at("x_crossover").get<double>() == 2);
+
+    auto register_clone = [&](const std::string& name, const std::string& CAS, double x_crossover) {
+        json fluid = arr[0];
+        fluid["INFO"]["NAME"] = name;
+        fluid["INFO"]["CAS"] = CAS;
+        fluid["INFO"]["ALIASES"] = json::array();
+        fluid["INFO"]["REFPROP_NAME"] = "N/A";
+        for (const char* key : {"INCHI_KEY", "INCHI_STRING", "SMILES", "CHEMSPIDER_ID", "2DPNG_URL"}) {
+            fluid["INFO"].erase(key);
+        }
+        fluid["TRANSPORT"]["viscosity"]["x_crossover"] = x_crossover;
+        json doc = json::array();
+        doc.push_back(fluid);
+        // add_fluids_as_JSON returns a literal true on the HEOS branch and
+        // signals failure only by throwing, so assert on the throw.
+        REQUIRE_NOTHROW(CoolProp::add_fluids_as_JSON("HEOS", doc.dump()));
+    };
+
+    register_clone("R1233zdE_XC_SHIPPED", "999-99-80", 2.0);
+    register_clone("R1233zdE_XC_MOVED", "999-99-81", 12.0);
+
+    // x = rho*s_r/rhosr_critical is 9.00 here, i.e. between the two crossover
+    // values, and the state is single-phase (supercritical liquid).
+    const double T = 300.0, rhomolar = 10000.0;
+
+    const double shipped = CoolProp::PropsSI("V", "T", T, "Dmolar", rhomolar, "R1233zd(E)");
+    const double clone_same = CoolProp::PropsSI("V", "T", T, "Dmolar", rhomolar, "R1233zdE_XC_SHIPPED");
+    const double clone_moved = CoolProp::PropsSI("V", "T", T, "Dmolar", rhomolar, "R1233zdE_XC_MOVED");
+    CAPTURE(shipped, clone_same, clone_moved);
+
+    REQUIRE(ValidNumber(shipped));
+    REQUIRE(ValidNumber(clone_same));
+    REQUIRE(ValidNumber(clone_moved));
+
+    // Round-tripping the fluid through JSON must not perturb the answer.
+    CHECK(std::abs(clone_same / shipped - 1) < 1e-14);
+
+    // The point of the test: moving the switch must move the result.  This
+    // failed before the fix, when the two clones agreed exactly.
+    CHECK(std::abs(clone_moved / shipped - 1) > 0.01);
+}
+
 static CoolProp::input_pairs inputs[] = {
   CoolProp::DmolarT_INPUTS,
   //CoolProp::SmolarT_INPUTS,


### PR DESCRIPTION
The `rhosr-CS` viscosity correlation blends a liquid and a vapor branch with a
logistic switch centred on `x_crossover`. Every one of the eight `rhosr-CS`
fluid files carries that centre as data, `parse_rhosr_viscosity` reads it into
`ViscosityRhoSrVariables::x_crossover` — and nothing ever read it back.
`TransportRoutines::viscosity_rhosr` hardcoded the centre as the literal `2`.

## No shipped number changes

All eight fluids (R1233zd(E), R1234yf, R1234ze(E), R124, R152A, R22, R245fa,
R32) carry `x_crossover` as the JSON integer `2`, which converts to a double
that is exactly `2.0`, so `x - data.x_crossover` is bit-identical to `x - 2`.

That is what makes it worth fixing rather than leaving. The field looks live,
its presence in eight fluid files implies it means something, and it silently
does nothing. It fails only for whoever next edits it, and it fails quietly.

The switch *sharpness* stays hardcoded at `100.0` — a constant of the
correlation rather than fluid data, carried by no fluid file. It is now named
instead of being a bare literal.

## Test

Clone R1233zd(E) twice through `add_fluids_as_JSON`, altering nothing but
`x_crossover` (2 vs 12), and evaluate at `T = 300 K, ρ = 10000 mol/m³` — where
`x = ρ·s_r/rhosr_critical` is 9.00, between the two switch locations, and single
phase.

Before the fix the two clones agree to the bit:

```
CHECK( std::abs(clone_moved / shipped - 1) > 0.01 )
with expansion:
  0.0 > 0.01
```

After it they differ by a factor of 2605. The test also pins that the shipped
fluid is unchanged by the JSON round-trip (1e-14) and `REQUIRE`s its premises —
that the block is still `rhosr-CS` and the shipped `x_crossover` is still 2 — so
it degrades to a clear failure rather than a false pass if the data moves.

## Deliberately not included

Validation of `c_liq`/`c_vap` arity and of a zero `rhosr_critical` — both one
line from the line fixed here, both real (`viscosity_rhosr` indexes `[0..3]`
unconditionally and divides by `rhosr_critical`). A throwing guard there cannot
be given a negative test today: `FluidLibrary.cpp` appends to `name_vector`
before `add_one`'s `try`, so any rejected fluid permanently strands its name in
`fluids_list`, and 12+ test sites walk that list calling `factory()` on every
name. Shipping an untested throw inside a commit whose other half closes a gate
hole would be the wrong trade. Filed instead, blocked on the orphan fix.

## Verification

Full `~[slow]`: 519 cases, 177,207 assertions, 0 failures — byte-identical to
the pre-change baseline. CI runs the whole suite (`~[slow]` in
`dev_checks.yml`, everything in `test_catch2.yml`), so the new test is gated
there.

Note for local runs: `dev/ci/preflight.sh` maps `src/Backends/Helmholtz/` to
`[Helmholtz],[REFPROP]`, which selects no transport, viscosity or conductivity
test at all — so a local preflight on this diff exercises none of the changed
code. That is a preflight-scope issue only, not a CI coverage gap, and it is
being handled separately.

`cppcheck` and `clang-tidy` were skipped locally. Being precise about what that
means: `clang-tidy` ran and produced 80 signal findings, none in the added
lines. `cppcheck` bails out of `CoolProp-Tests.cpp` at line 332 with a
`syntaxError` and never reaches the new test, so "no findings there" is vacuous
rather than reassuring. Both fail identically on `origin/master`'s copies of the
same files.

Written by Claude Opus 5, reviewed adversarially before and after the
post-review changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
