### PR TITLE
fix(cubics,pcsaft): apply the Qmass [0,1] check on the pure-fluid path

### DIFF
--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -329,9 +329,17 @@ void CoolProp::AbstractCubicBackend::update(CoolProp::input_pairs input_pair, do
     // before delegating to the molar-pair flash. The inherited HEOS override of
     // calc_phase_molar_masses (using SatL/SatV->mole_fractions and components[i].molar_mass())
     // works for cubic backends since they share the same SatL/SatV machinery.
-    if (CoolProp::is_Qmass_pair(input_pair) && mole_fractions.size() > 1) {
-        update_Qmass_pair(input_pair, value1, value2);
-        return;
+    if (CoolProp::is_Qmass_pair(input_pair)) {
+        if (mole_fractions.size() > 1) {
+            update_Qmass_pair(input_pair, value1, value2);
+            return;
+        }
+        // Pure / pseudo-pure falls through to mass_to_molar_inputs below, which
+        // rewrites the pair to its molar sibling without looking at the quality.
+        // update_Qmass_pair's [0,1] check is the only one there is, so apply it
+        // here or nothing does: Qmass = 1.05 and 1.5 previously flashed happily
+        // and returned a state reading Q() = 1.05 with phase = 6.
+        check_Qmass_pair_range(input_pair, value1, value2);
     }
 
     CoolPropDbl ld_value1 = value1, ld_value2 = value2;

--- a/src/Backends/PCSAFT/PCSAFTBackend.cpp
+++ b/src/Backends/PCSAFT/PCSAFTBackend.cpp
@@ -1740,9 +1740,20 @@ void PCSAFTBackend::update(CoolProp::input_pairs input_pair, double value1, doub
     // Mass-quality input pair on a true mixture: solve iteratively for Qmolar
     // before delegating to the molar-pair flash. Pure / pseudo-pure (size==1)
     // goes through mass_to_molar_inputs in the existing flow.
-    if (CoolProp::is_Qmass_pair(input_pair) && mole_fractions.size() > 1) {
-        update_Qmass_pair(input_pair, value1, value2);
-        return;
+    if (CoolProp::is_Qmass_pair(input_pair)) {
+        if (mole_fractions.size() > 1) {
+            update_Qmass_pair(input_pair, value1, value2);
+            return;
+        }
+        // Pure / pseudo-pure falls through to mass_to_molar_inputs below, which
+        // rewrites the pair to its molar sibling without looking at the quality.
+        // Unlike the cubic backend, PCSAFT is not fully open here: the QT_INPUTS
+        // and PQ_INPUTS cases downstream do reject a finite out-of-range quality
+        // with OutOfRangeError.  They do NOT reject NaN -- their guard is
+        // (v < 0) || (v > 1), which is false for NaN -- so a NaN quality reached
+        // the flash and surfaced as "solution could not be found".  Validating
+        // here closes that and makes the diagnostic match the other backends.
+        check_Qmass_pair_range(input_pair, value1, value2);
     }
 
     // Converting input to CoolPropDbl

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5582,6 +5582,64 @@ TEST_CASE("Qmass: SRK cubic mixture output works after Q-pair flash", "[Qmass][c
     CHECK(AS2->Q() == Catch::Approx(0.0).epsilon(1e-10));
 }
 
+TEST_CASE("Qmass range check: cubic and PCSAFT pure fluids reject out-of-range quality", "[Qmass][cubic][PCSAFT]") {
+    // CubicBackend::update() and PCSAFTBackend::update() gate the Qmass dispatch on
+    // mole_fractions.size() > 1 and otherwise fall through to mass_to_molar_inputs,
+    // which rewrites the pair to its molar sibling without validating the quality.
+    // AbstractState::update_Qmass_pair's [0,1] check therefore never ran on the pure
+    // path, and nothing downstream caught it: SRK::Propane at Qmass = 1.05 returned
+    // a state reading Q() = 1.05 with phase = 6 instead of throwing.
+    //
+    // The same fail-open #3336 closed for REFPROP, using the helper added there.
+    // Match on the message rather than merely on ValueError: a bare CHECK_THROWS_AS
+    // would also be satisfied by an unrelated flash failure further downstream, and
+    // would leave the test passing if this guard were removed.
+    const auto out_of_range = Catch::Matchers::ContainsSubstring("Qmass out of range");
+    struct BackendFluid
+    {
+        const char* backend;
+        const char* fluid;
+        double T;
+    };
+    const std::vector<BackendFluid> cases = {{"SRK", "Propane", 296.0}, {"PR", "Propane", 296.0}, {"PCSAFT", "METHANE", 150.0}};
+
+    for (const auto& c : cases) {
+        auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory(c.backend, c.fluid));
+        AS->update(CoolProp::QT_INPUTS, 0.5, c.T);
+        const double p_sat = AS->p();
+        for (double q : {-0.05, 1.05, 1.5, std::numeric_limits<double>::quiet_NaN()}) {
+            CAPTURE(c.backend, c.fluid, q);
+            CHECK_THROWS_WITH(AS->update(CoolProp::QmassT_INPUTS, q, c.T), out_of_range);
+            CHECK_THROWS_WITH(AS->update(CoolProp::PQmass_INPUTS, p_sat, q), out_of_range);
+        }
+        // In-range quality still flashes, and Qmass round-trips exactly on the pure
+        // path via the base-class calc_Qmass short-circuit added in #3336.
+        //
+        // 0.0 and 1.0 are the point of this loop, not filler: they are the boundary
+        // values of the new >= 0 && <= 1 predicate, and the only thing that would
+        // catch a future > 0 && < 1 typo.
+        //
+        // A fresh instance, because a flash that throws after clear() leaves PCSAFT
+        // unusable -- the out-of-range calls above poison AS, and every later flash
+        // on it fails with "solution could not be found" regardless of input.  That
+        // is a pre-existing PCSAFT state-handling issue, not something this guard
+        // touches, but it does mean these assertions need their own object.
+        // QmassT only: PCSAFT's PQ flash cannot converge for METHANE at this p_sat
+        // at any quality, which is likewise separate from the range check.
+        auto ASin = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory(c.backend, c.fluid));
+        for (double q : {0.0, 0.25, 0.5, 0.75, 1.0}) {
+            CAPTURE(c.backend, c.fluid, q);
+            ASin->update(CoolProp::QmassT_INPUTS, q, c.T);
+            // Exact, not Approx: on the pure path the backend stores _Q verbatim and
+            // calc_Qmass short-circuits to it, so nothing rounds.  If a backend ever
+            // recomputes _Q through the lever rule this becomes a ULP flake, and that
+            // is the change we would want to hear about.
+            CHECK(ASin->Q() == q);
+            CHECK(ASin->Qmass() == q);
+        }
+    }
+}
+
 TEST_CASE("User-fluid schema validation rejects malformed PCSAFT/cubic payloads", "[json_validation]") {
     // --- Cubic (SRK) ---
     // 1. Structurally invalid JSON must throw unconditionally.


### PR DESCRIPTION
## What

`CubicBackend::update()` and `PCSAFTBackend::update()` gate their Qmass dispatch on `mole_fractions.size() > 1` and otherwise fall through to `mass_to_molar_inputs`, which rewrites the pair to its molar sibling without looking at the quality. `AbstractState::update_Qmass_pair`'s `[0,1]` check is the only validation there is, and the pure path skipped it.

This is the same fail-open #3336 closed for REFPROP, in two backends that reach the rewrite the same way. It calls `check_Qmass_pair_range` — the helper #3336 added for exactly this.

## The two backends were open to different degrees

**Cubics were wide open.** Measured on `SRK::Propane` and `PR::Propane` at 296 K before the fix:

| `Qmass` | behaviour on master |
|---|---|
| `-0.05` | throws `"rhomolar is less than zero"` |
| `1.05` | **no throw** — `Q() = 1.05`, `phase = 6` |
| `1.5` | **no throw** — `Q() = 1.5`, `phase = 6` |
| `NaN` | throws `"rhomolar is not a valid number"` |

The invalid inputs that were caught at all were caught by a density check several layers down, reporting a cause unrelated to what the caller did wrong. The two that weren't caught returned a state that reads back as a converged single-phase result.

**PCSAFT was narrower.** Its `QT_INPUTS`/`PQ_INPUTS` cases do reject a finite out-of-range quality with `OutOfRangeError`, so only **NaN** was getting through — their guard is `(v < 0) || (v > 1)`, which is false for NaN. I'd initially written the code comment claiming PCSAFT was as open as cubics; review caught that and it's corrected.

**HEOS is unaffected for finite values** — it gates on `!is_pure()`, so pseudo-pures take `update_Qmass_pair` and true pures are caught downstream.

## Notes on the tests

The assertions match on the guard's own message rather than on `ValueError`, because most of these inputs already threw *something*. A bare `CHECK_THROWS_AS` would have passed on master for cubic `-0.05` and `NaN` and for every finite PCSAFT case — and would keep passing if this guard were deleted.

Mutation-tested two ways:
- Disabling the guard fails **24 of 54** assertions.
- Narrowing the predicate to `> 0 && < 1` is caught by the `q = 0.0` and `q = 1.0` cases. Those are in the loop for that reason, not as filler — an earlier revision omitted them and that mutant survived.

The in-range assertions use their own `AbstractState`. A flash that throws after `clear()` leaves PCSAFT unusable, so the out-of-range calls poison the object and every later flash on it fails regardless of input. That's a pre-existing PCSAFT state-handling issue rather than anything this guard touches, but it's why the object isn't reused — and it's what misled an earlier revision of this PR into believing PCSAFT couldn't flash saturation endpoints at all. It can, on a fresh state.

## Flagged trade-off: exception type

`OutOfRangeError` and `ValueError` are *siblings* (`CoolPropError<eOutOfRange>` and `CoolPropError<eValue>`), not parent/child. So a caller catching `CoolProp::OutOfRangeError` for out-of-range quality now sees `ValueError` for PCSAFT pure `QmassT`/`PQmass` and for cubic pure `QmassSmolar`/`HmassQmass`/`DmolarQmass`. No in-tree catch site keys on `OutOfRangeError`, and the wrappers catch `CoolPropBaseError`/`std::exception`, so this is API-surface only. #3336 made the same trade for REFPROP. Worth knowing before it surprises a downstream user.

## Verification

- Full `~[slow]` suite with REFPROP 10 loaded: **191,358 assertions in 520 test cases, all pass**
- Both mutants killed, as above
- `./dev/ci/preflight.sh`: format, build, tests, semgrep pass. cppcheck and clang-tidy fail on pre-existing whole-file findings (`CubicBackend.h:40`, `CoolProp-Tests.cpp:332`) — zero findings inside any hunk of this diff

## Follow-ups filed

Both pre-existing, both found by the review of this change, neither fixed here:

- `bd` **CoolProp-uedc** (P1) — HEOS's `(v<0)||(v>1)` guards don't reject NaN, and `HmolarQ_INPUTS` with `Q = NaN` **segfaults** (exit 139). It reproduces through the plain molar pair too, so the root cause is `HQ_flash`, not the Qmass layer. Cubics throw instead of crashing. P1 because it's a crash.
- `bd` **CoolProp-9h53** (P2) — `EquationOfState::pseudo_pure` has no initializer and is never assigned for cubic components, so `is_pure()` reads an indeterminate bool on cubic backends. This is why these two backends gate on `mole_fractions.size() > 1` rather than `!is_pure()` like HEOS — worth recording before someone harmonises the gates without fixing it first.

## AI assistance

Implemented by Claude Opus 5 under my direction, following the project's TDD and pre-PR review workflow: failing test first, then the fix, then an adversarial review subagent whose findings I reproduced independently before acting on them. That review corrected two factual errors in my own comments (PCSAFT's actual coverage, and the false claim that PCSAFT can't flash endpoints) and restored the boundary test coverage. I verified the behaviour locally against REFPROP 10 and reviewed the final diff.

Closes `bd` CoolProp-nn6b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mass-based vapor quality inputs are now validated consistently for cubic and PCSAFT fluids.
  * Out-of-range or invalid quality values are rejected with a clear error.
  * Valid quality values continue to flash successfully and preserve accurate quality results.

* **Tests**
  * Added coverage for boundary, intermediate, out-of-range, and invalid quality inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->