### PR TITLE
fix(fluids): stop leaking orphan names and stop swallowing load failures

### DIFF
--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.cpp
@@ -52,12 +52,35 @@ void load() {
     // Let a CBOR-decode failure propagate (it did, as a parse error, before this
     // migration): under std::call_once a thrown load() leaves the once-flag unset
     // so the error surfaces and a later call can retry, rather than silently
-    // leaving the global library empty. add_many keeps its original catch.
+    // leaving the global library empty.
     nlohmann::json dd = cpjson::from_cbor(gall_fluids_CBORData, gall_fluids_CBORSize);
+    // add_many is likewise left to throw.  It used to be wrapped in a handler
+    // that printed to stdout and returned, but add_many has no per-fluid try, so
+    // one bad fluid aborted the loop and every fluid after it in load order
+    // silently vanished -- the library came up truncated, with a stdout line as
+    // the only signal and no error state anywhere. Users saw an arbitrary subset
+    // of fluids reported as unknown.  The same data reaches add_fluids_as_JSON
+    // through a path that has always thrown, so the two entry points used to
+    // disagree about what a malformed fluid means.  This is shipped, CI-verified
+    // data: a throw here means the build is broken, and failing loudly at first
+    // use beats a silently partial library.
+    //
+    // The retry story differs from the from_cbor line above, which is why this
+    // is not a bare call.  from_cbor leaves no state behind, so a rethrow is
+    // simply retried.  add_many mutates the library in place and is NOT
+    // transactional: a mid-array failure leaves every fluid before it
+    // registered.  Since a thrown load() leaves the std::call_once flag unset,
+    // the next library access re-runs load() -- which would meet its own
+    // half-finished first attempt and throw "already in library" for fluid 0,
+    // naming the wrong fluid and pointing at OVERWRITE_FLUIDS instead of the
+    // real parse error.  Wrappers surface the most recent error, so that
+    // misleading message is the one users would actually see.  Resetting first
+    // makes every attempt report the same, true cause.
     try {
         library.add_many(dd);
-    } catch (std::exception& e) {
-        std::cout << e.what() << '\n';
+    } catch (...) {
+        library = JSONFluidLibrary();
+        throw;
     }
 }
 
@@ -162,9 +185,17 @@ void JSONFluidLibrary::add_one(const nlohmann::json& fluid_json) {
     // Parse out Fluid name
     fluid.name = fluid_json.at("INFO").at("NAME").get<std::string>();
 
-    // Push the fluid name onto the name_vector used for returning the full list of library fluids
-    // If it is found that this fluid already exists in the library, it will be popped back off below.
-    name_vector.push_back(fluid.name);
+    // name_vector is deliberately NOT appended here.  It backs
+    // get_global_param_string("fluids_list"), and anything parsed below can
+    // throw, so publishing the name up-front left it permanently listed for a
+    // fluid that has no entry in string_to_index_map or fluid_map -- an orphan
+    // that makes AbstractState::factory("HEOS", <name>) throw for a name the
+    // library itself advertises.  The append now happens at the end of the try,
+    // once the fluid is genuinely in the library.
+    //
+    // Popping in the catch instead would be wrong: the duplicate-fluid branch
+    // below throws *after* it would have popped, so the handler would remove
+    // some other fluid's name and turn a leak into corruption.
 
     try {
         // CAS number
@@ -314,8 +345,7 @@ void JSONFluidLibrary::add_one(const nlohmann::json& fluid_json) {
         bool fluid_exists = false;  // Initialize flag for doing replace instead of add
 
         if (index != fluid_map.size()) {               // Fluid already in list if index was reset to something < fluid_map.size()
-            fluid_exists = true;                       //   Set the flag for replace
-            name_vector.pop_back();                    //   Pop duplicate name off the back of the name vector; otherwise it keeps growing!
+            fluid_exists = true;                       //   Set the flag for replace; the name is already in name_vector
             if (!get_config_bool(OVERWRITE_FLUIDS)) {  // Throw exception if replacing fluids is not allowed
                 throw ValueError(format("Cannot load fluid [%s:%s] because it is already in library; index = [%i] of [%i]; Consider enabling the "
                                         "config boolean variable OVERWRITE_FLUIDS",
@@ -363,6 +393,13 @@ void JSONFluidLibrary::add_one(const nlohmann::json& fluid_json) {
 
             // Add uppercase alias for EES compatibility
             string_to_index_map[upper(alias)] = index;
+        }
+
+        // Everything that can throw is behind us, so the fluid is now genuinely
+        // in the library and its name can be advertised.  Skipped when
+        // overwriting, because the name is already there from the first load.
+        if (!fluid_exists) {
+            name_vector.push_back(fluid.name);
         }
 
         //If Debug level set >5 print fluid name and total size of fluid_map

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.h
@@ -359,9 +359,9 @@ class JSONFluidLibrary
         //
         // Throwing here aborts add_one for the whole fluid: EOS, ancillaries
         // and transport all become unavailable over an optional
-        // thermochemical annotation, and the failed add strands the fluid's
-        // name in fluids_list with no string_to_index_map entry (bd
-        // CoolProp-dwuu).  Nothing requires these keys -- there is no HEOS
+        // thermochemical annotation.  (It used to also strand the fluid's name
+        // in fluids_list, bd CoolProp-dwuu; that is fixed, but the rest of this
+        // reasoning stands on its own.)  Nothing requires these keys -- there is no HEOS
         // fluid schema at all (dev/validate_fluid_schemas.py covers
         // pcsaft/cubics/mixtures only) -- so a third-party fluid registered
         // through add_fluids_as_JSON with a partial block loads today and

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5707,6 +5707,114 @@ TEST_CASE("User-fluid schema validation rejects malformed PCSAFT/cubic payloads"
     }
 }
 
+// JSONFluidLibrary::add_one used to append the fluid name to name_vector -- the
+// vector behind get_global_param_string("fluids_list") -- before parsing
+// anything else.  Any failure after that point left the name advertised in
+// fluids_list with no entry in string_to_index_map or fluid_map, so
+// AbstractState::factory("HEOS", <name>) threw for a name the library itself
+// listed.  The library is process-wide with no unregister, so the orphan
+// persisted for the rest of the process: measured, 2 of 3 --order rand seeds
+// then broke the [formation] test, the only one that walks the whole list.
+//
+// This test is only safe to write BECAUSE of that fix.  It deliberately fails an
+// add, which under the old code would have poisoned every later test in the
+// binary -- which is why the guard tests for parse_rhosr_viscosity could not be
+// added at the time and had to be deferred to this fix.
+TEST_CASE("A failed HEOS add leaves no orphan in fluids_list", "[fluids_list],[add_one]") {
+    using nlohmann::json;
+
+    const std::string before = CoolProp::get_global_param_string("fluids_list");
+    const std::string probe_name = "CatchRuntimeOrphanProbe";
+    REQUIRE(before.find(probe_name) == std::string::npos);
+
+    SECTION("a fluid that throws mid-parse is not advertised") {
+        // Enough INFO for add_one to read the name, then nothing else: it throws
+        // on the missing CAS member, which is the first thing inside the try.
+        json bad = json::object();
+        bad["INFO"] = json::object();
+        bad["INFO"]["NAME"] = probe_name;
+
+        CHECK_THROWS_AS(CoolProp::add_fluids_as_JSON("HEOS", json::array({bad}).dump()), CoolProp::ValueError);
+
+        const std::string after = CoolProp::get_global_param_string("fluids_list");
+        CHECK(after.find(probe_name) == std::string::npos);
+        // Exact, not just "probe absent": a leak of any other name would also be
+        // a regression, and the list is otherwise immutable here.
+        CHECK(after == before);
+    }
+
+    SECTION("the whole list still constructs afterwards") {
+        // The orphan's real damage was downstream -- an unconstructible name in
+        // fluids_list. Walk the list the way the [formation] test does.
+        for (const auto& fluid : strsplit(CoolProp::get_global_param_string("fluids_list"), ',')) {
+            CAPTURE(fluid);
+            REQUIRE_NOTHROW(std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", fluid)));
+        }
+    }
+
+    SECTION("add_many is not transactional: a mid-list failure keeps what came before") {
+        // This is the mechanism that made the old load() come up truncated.
+        // add_many has no per-fluid try, so a bad entry aborts the loop and
+        // everything after it is never added.  load() used to swallow that into
+        // a stdout line, so the library came up partial with no error state.
+        // The semantics are pinned here through the public path, since the
+        // static load's copy cannot be reached from the test suite.
+        //
+        // R134a is the donor because it carries no INFO.STANDARD_STATE, so the
+        // exact ATcT count in the [formation] test is unperturbed by the clone
+        // that this section leaves permanently registered.
+        json donor = json::parse(CoolProp::get_fluid_param_string("R134a", "JSON"))[0];
+        auto clone = [&](const std::string& name, const std::string& CAS) {
+            json fluid = donor;
+            fluid["INFO"]["NAME"] = name;
+            fluid["INFO"]["CAS"] = CAS;
+            fluid["INFO"]["ALIASES"] = json::array();
+            fluid["INFO"]["REFPROP_NAME"] = "N/A";
+            return fluid;
+        };
+        const std::string before_name = "CatchRuntimeTruncBefore";
+        const std::string after_name = "CatchRuntimeTruncAfter";
+
+        json bad = json::object();
+        bad["INFO"] = json::object();
+        bad["INFO"]["NAME"] = "CatchRuntimeTruncBad";
+
+        json doc = json::array();
+        doc.push_back(clone(before_name, "999-99-70"));
+        doc.push_back(bad);
+        doc.push_back(clone(after_name, "999-99-71"));
+
+        CHECK_THROWS_AS(CoolProp::add_fluids_as_JSON("HEOS", doc.dump()), CoolProp::ValueError);
+
+        const std::string list = CoolProp::get_global_param_string("fluids_list");
+        // Entries before the failure are kept.  This assertion DOCUMENTS current
+        // behaviour rather than requiring it: making add_many transactional
+        // would be a defensible improvement and would flip this check.  The two
+        // == npos assertions below are the ones carrying regression signal.
+        CHECK(list.find(before_name) != std::string::npos);
+        CHECK_NOTHROW(CoolProp::PropsSI("T", "P", 101325, "Q", 0, before_name));
+        // ...everything after it is dropped, and — the point of the fix — the
+        // one that failed is not advertised either.
+        CHECK(list.find(after_name) == std::string::npos);
+        CHECK(list.find("CatchRuntimeTruncBad") == std::string::npos);
+    }
+
+    SECTION("a rejected duplicate does not disturb the list either") {
+        // The duplicate branch pops nothing now, but it throws AFTER the point
+        // where the old code had already popped -- so a naive "pop in the catch"
+        // fix would have removed a DIFFERENT fluid's name here.  This is the
+        // case that makes that fix wrong, and it is why the append moved to the
+        // end of the try instead.
+        REQUIRE(CoolProp::get_config_bool(OVERWRITE_FLUIDS) == false);
+        json water = json::parse(CoolProp::get_fluid_param_string("Water", "JSON"));
+
+        const std::string list_before = CoolProp::get_global_param_string("fluids_list");
+        CHECK_THROWS_AS(CoolProp::add_fluids_as_JSON("HEOS", water.dump()), CoolProp::ValueError);
+        CHECK(CoolProp::get_global_param_string("fluids_list") == list_before);
+        CHECK_NOTHROW(CoolProp::PropsSI("T", "P", 101325, "Q", 0, "Water"));
+    }
+}
+
 TEST_CASE("Water TS_INPUTS flash near 631-634 K is smooth (no spike to 6e13 Pa)", "[water_flash][2079]") {
     // Issue #2079: previously CP.PropsSI('P','T',T,'S',6763.617,'Water')
     // for T in {631, 632, 633, 634} returned ~6e13 Pa (vs ~3.1 MPa
@@ -7677,9 +7785,10 @@ TEST_CASE("Standard molar enthalpy of formation from ATcT", "[formation][Helmhol
     }
     SECTION("a block in the wrong units is declined without killing the fluid") {
         // parse_standard_state is protected on a non-final class, so a
-        // subclass reaches it directly -- no add_fluids_as_JSON, no failed
-        // add_one, and therefore none of the process-wide fluids_list
-        // poisoning (bd CoolProp-dwuu) that made this look untestable.
+        // subclass reaches it directly -- no add_fluids_as_JSON and no failed
+        // add_one.  That mattered when a failed add poisoned fluids_list
+        // process-wide (bd CoolProp-dwuu); that is fixed now, but reaching the
+        // parser directly is still the tighter test.
         struct Probe : public CoolProp::JSONFluidLibrary
         {
             using CoolProp::JSONFluidLibrary::parse_standard_state;
@@ -7730,24 +7839,15 @@ TEST_CASE("Standard molar enthalpy of formation from ATcT", "[formation][Helmhol
         std::vector<std::string> fluids = strsplit(CoolProp::get_global_param_string("fluids_list"), ',');
         std::size_t checked = 0;
         for (auto& fluid : fluids) {
+            // Every name in fluids_list must construct.  This used to swallow a
+            // ValueError and continue, because add_one appended the name before
+            // its try block, so any failed HEOS add permanently left an orphan
+            // here and broke this loop under --order rand.  add_one now appends
+            // only on success, so an unconstructible name is a real defect
+            // again and is allowed to fail the test rather than be skipped.
             shared_ptr<CoolProp::AbstractState> AS;
-            try {
-                AS.reset(CoolProp::AbstractState::factory("HEOS", fluid));
-            } catch (const CoolProp::ValueError&) {
-                // A name in fluids_list that will not construct is an orphan
-                // left behind by a failed add_one: name_vector is appended
-                // before add_one's try block and never popped in its catch, so
-                // any test that fails a HEOS add permanently leaves its name in
-                // get_global_param_string("fluids_list") with no entry in
-                // string_to_index_map.  Measured: with such a name present, 2
-                // of 3 --order rand seeds failed here on the factory call.  No
-                // test does that today, but this loop is the only one that
-                // walks the whole list, so it should not be the thing that
-                // breaks when one does.  This cannot hide a real regression:
-                // if a fluid that HAS a value stops constructing, the exact
-                // count below drops below 76 and fails.
-                continue;
-            }
+            CAPTURE(fluid);
+            REQUIRE_NOTHROW(AS.reset(CoolProp::AbstractState::factory("HEOS", fluid)));
             double value = 0;
             try {
                 value = AS->keyed_output(CoolProp::iHmolar_formation);


### PR DESCRIPTION
Closes `CoolProp-dwuu` and `CoolProp-anpw`. Two defects in `JSONFluidLibrary`
with the same shape: a failure that leaves the library in a state it reports as
healthy.

## 1. A failed add advertised a fluid that does not exist

`add_one` appended `fluid.name` to `name_vector` — the vector behind
`get_global_param_string("fluids_list")` — **before** parsing anything else.
Anything that threw after that point left the name listed forever with no entry
in `string_to_index_map` or `fluid_map`, so
`AbstractState::factory("HEOS", name)` threw for a name the library itself
advertised. The library is process-wide with no unregister, so one bad add
poisoned the rest of the process.

The append now happens at the end of the `try`, once the fluid is genuinely in
the library, and only when it is not an overwrite.

**The obvious fix is wrong.** Popping in the `catch` would corrupt rather than
repair: the duplicate-fluid branch pops the name and *then* throws when
`OVERWRITE_FLUIDS` is off, so the handler would run on an already-popped vector
and remove some other fluid's name. Appending late has no such ordering hazard,
and lets the duplicate branch drop its manual pop entirely. There is a test for
that case.

## 2. The static load swallowed failures and came up truncated

`load()` wrapped `library.add_many(dd)` in a handler that printed to
`std::cout` and returned. `add_many` has no per-fluid `try`, so one bad fluid
aborted the loop and every fluid after it silently vanished — a partial library,
no error state, a stdout line as the only signal. The same data through
`add_fluids_as_JSON` has always thrown, so the two entry points disagreed about
what a malformed fluid means.

`add_many` now propagates — but **not** as a bare call, and the difference
matters. Unlike the `from_cbor` line above it, `add_many` mutates the library in
place and is not transactional, so a mid-array failure leaves earlier fluids
registered. A thrown `load()` leaves the `std::call_once` flag unset, so the
next access re-runs `load()`, meets its own half-finished first attempt, and
throws *"already in library"* for fluid 0 — naming the wrong fluid and pointing
at `OVERWRITE_FLUIDS` instead of the real parse error. Wrappers surface the most
recent error, so that misleading message is the one users would actually see.

Measured by injecting a malformed fluid into the embedded CBOR and running the
suite:

| | what the suite reports |
|---|---|
| propagate bare | 66× `Unable to load fluid [D4] … already in library`; the true cause never appears |
| propagate after reset | 66× `Unable to load fluid [R410A] … does not have CAS member` |

So the handler resets the library before rethrowing. Every attempt now reports
the same true cause.

## Testing

The new `[fluids_list]` case fails before the change, and its failure mode *is*
the bug: Catch2 re-enters a `TEST_CASE` per `SECTION`, so the orphan left by the
first section is already present when the second begins, and the guard at the
top reports the probe name at offset 1254 of `fluids_list`. The case also walks
the whole list calling `factory()` on every name, covers the rejected-duplicate
path that makes the pop-in-catch fix wrong, and pins `add_many`'s
non-transactional semantics through the public path.

**That test could not have been written before this commit** — failing an add
was precisely what poisoned process-wide state, which is why the
`parse_rhosr_viscosity` guards were deferred out of #3339. They are now
unblocked.

Because the orphan class is gone, the `[formation]` sweep's fail-open guard
loses its reason to exist: it caught `ValueError` from `factory()` and skipped
the name, with a comment describing this very bug in the present tense. An
unconstructible name is a real defect again, so that guard is now
`REQUIRE_NOTHROW`. Two other comments that described the bug as current are
corrected the same way.

`load()`'s own path has **no automated test** — reaching it needs a malformed
fluid inside the embedded CBOR, which the suite cannot produce. The mechanism it
depends on is covered and the retry behaviour was verified by the injection
above, but the handler itself is a deletion whose effect is visible by
inspection. Stating that rather than implying coverage it does not have.

Full `~[slow]`: 521 cases, 177,502 assertions, 0 failures.

## Known, pre-existing, not fixed here

Under `--order rand` the suite has one failure: `Check PC-SAFT interaction
parameter functions` registers a Water/AceticAcid `kij` unguarded where three
sibling tests wrap the identical call in a try/catch idempotence guard. It is
byte-identical on `master` and reproduces at seeds 11 and 33 with only
`[pcsaft_binary_interaction],[pcsaft_bubble_pressure]` in the filter. Filed
separately.

Review also found that `PCSAFTLibrary.cpp` still carries the identical
swallow-and-truncate defect fixed here, plus a schema-validation failure
discarded unless `get_debug_level() > 0`. Filed separately rather than bundled,
to keep this diff to one library.

Written by Claude Opus 5, reviewed adversarially with the fixes re-reviewed
after the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fluid-library initialization for safer, more reliable concurrent use.
  - Failed fluid registrations now cleanly report errors without leaving invalid or orphaned fluid names behind.
  - Duplicate fluid registrations no longer alter the existing fluid list.
  - Batch registrations preserve successfully added fluids while removing entries affected by later failures.
  - Clarified handling of incomplete standard-state thermochemical data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->