### PR TITLE
fix: reject non-finite vapor quality; initialize EquationOfState scalars

### DIFF
--- a/include/CoolProp/CoolPropFluid.h
+++ b/include/CoolProp/CoolPropFluid.h
@@ -438,12 +438,38 @@ class EquationOfState
       max_sat_T,         ///< The state at the maximum saturation temperature for pseudo-pure
       max_sat_p;         ///< The state at the maximum saturation pressure for pseudo-pure
     EOSLimits limits;    ///< Limits on the EOS
-    double R_u,          ///< The universal gas constant used for this EOS (usually, but not always, 8.314472 J/mol/K)
-      molar_mass,        ///< The molar mass in kg/mol (note NOT kg/kmol)
-      acentric,          ///< The acentric factor \f$ \omega = -log_{10}\left(\frac{p_s(T/T_c=0.7)}{p_c}\right)-1\f$
-      Ttriple,           ///< Triple point temperature (K)
-      ptriple;           ///< Triple point pressure (Pa)
-    bool pseudo_pure;    ///< Is a pseudo-pure fluid (true) or pure fluid (false)
+    /// Every scalar below carries a default because EquationOfState is built by
+    /// DEFAULT-initialization in two places -- `EquationOfState E;` in FluidLibrary's
+    /// parse_EOS, and the same in its -SRK / -PengRobinson else branch -- each
+    /// followed by push_back(E), which copies whatever the stack happened to hold.
+    /// parse_EOS then overwrites everything from JSON, so it is UB but benign; the
+    /// cubic branch does not, and that one was user-visible: PropsSI("M", ...) on
+    /// HEOS::R1233ZD(E)-SRK, the only cubic-library fluid with no multiparameter
+    /// sibling and so the only one taking that branch, returned 1.5e-313 with an
+    /// empty error string.
+    ///
+    /// The values are 0, NOT _HUGE, and that is load-bearing.  Adding initializers
+    /// also changes the VALUE-initialized path -- AbstractCubicBackend::
+    /// set_alpha0_from_components builds its components with EOSVector.emplace_back(),
+    /// which zero-initialized them before and now runs this constructor instead.
+    /// Zero reproduces what those components used to get.  _HUGE does not: it makes
+    /// the (T > Tc && T > Ttriple) supercritical branch of FlashRoutines::
+    /// DHSU_T_flash unreachable, so every supercritical T+H/S/U flash on a cubic
+    /// throws "we don't support T below Ttriple [inf K]".  GERGBackend.cpp documents
+    /// the same hazard and picks Ttriple = 0 for the same reason.
+    double R_u = 0,    ///< The universal gas constant used for this EOS (usually, but not always, 8.314472 J/mol/K)
+      molar_mass = 0,  ///< The molar mass in kg/mol (note NOT kg/kmol)
+      acentric = 0,    ///< The acentric factor \f$ \omega = -log_{10}\left(\frac{p_s(T/T_c=0.7)}{p_c}\right)-1\f$
+      Ttriple = 0,     ///< Triple point temperature (K)
+      ptriple = 0;     ///< Triple point pressure (Pa)
+    /// Is a pseudo-pure fluid (true) or pure fluid (false).
+    /// Initialized here because only two places ever assign it -- FluidLibrary
+    /// (from HEOS JSON) and GERGBackend -- while cubic components are synthesised
+    /// in set_alpha0_from_components without touching it.  Every read on a cubic
+    /// backend was therefore an indeterminate read, including is_pure() and the
+    /// pseudo_pure branches in HelmholtzEOSMixtureBackend and FlashRoutines that
+    /// cubics inherit.
+    bool pseudo_pure = false;
     ResidualHelmholtzContainer alphar;  ///< The residual Helmholtz energy
     IdealHelmholtzContainer alpha0;     ///< The ideal Helmholtz energy
     std::string BibTeX_EOS,             ///< The bibtex key for the equation of state

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -573,7 +573,24 @@ bool FlashRoutines::sat_superanc_path_applies(HelmholtzEOSMixtureBackend& HEOS) 
     return std::abs(Q) < Q_BOUNDARY_TOL || std::abs(Q - 1) < Q_BOUNDARY_TOL;
 }
 
+namespace {
+/// Reject a vapor quality outside [0,1], NaN included, before any flash consumes it.
+///
+/// The public update() switches check this too, but they are not the only doors into
+/// these routines: update_HmolarQ_with_guessT and direct FlashRoutines calls arrive
+/// unchecked.  HQ_flash's own gate, std::abs(Q - 1) > 1e-10, is false for NaN, so a
+/// NaN quality was accepted as if it were exactly 1, missed the superancillary gate
+/// (false for NaN as well) and faulted inside saturation_PHSU_pure.
+void reject_non_finite_Q(CoolProp::HelmholtzEOSMixtureBackend& HEOS, const char* who) {
+    const double Q = HEOS.Q();  // CoolPropDbl is double; no cast needed
+    if (!is_in_closed_range(0.0, 1.0, Q)) {
+        throw CoolProp::OutOfRangeError(format("%s: input vapor quality [Q] must be between 0 and 1, got %g", who, Q));
+    }
+}
+}  // namespace
+
 void FlashRoutines::DQ_flash(HelmholtzEOSMixtureBackend& HEOS) {
+    reject_non_finite_Q(HEOS, "DQ_flash");
     if (!HEOS.is_pure_or_pseudopure) {
         throw NotImplementedError("DQ_flash not ready for mixtures");
     }
@@ -612,6 +629,7 @@ void FlashRoutines::DQ_flash(HelmholtzEOSMixtureBackend& HEOS) {
     HEOS._phase = iphase_twophase;
 }
 void FlashRoutines::HQ_flash(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl Tguess) {
+    reject_non_finite_Q(HEOS, "HQ_flash");
     if (!HEOS.is_pure_or_pseudopure) {
         throw NotImplementedError("HQ_flash not ready for mixtures");
     }
@@ -645,6 +663,7 @@ void FlashRoutines::HQ_flash(HelmholtzEOSMixtureBackend& HEOS, CoolPropDbl Tgues
     HEOS._phase = iphase_twophase;
 }
 void FlashRoutines::QS_flash(HelmholtzEOSMixtureBackend& HEOS) {
+    reject_non_finite_Q(HEOS, "QS_flash");
     if (!HEOS.is_pure_or_pseudopure) {
         throw NotImplementedError("QS_flash not ready for mixtures");
     }
@@ -896,6 +915,7 @@ void FlashRoutines::QS_flash_with_guesses(HelmholtzEOSMixtureBackend& HEOS, cons
 }
 
 void FlashRoutines::QT_flash(HelmholtzEOSMixtureBackend& HEOS) {
+    reject_non_finite_Q(HEOS, "QT_flash");
     CoolPropDbl T = HEOS._T;
     CoolPropDbl Q = HEOS._Q;
     if (HEOS.is_pure_or_pseudopure) {
@@ -1165,6 +1185,7 @@ void get_Henrys_coeffs_FP(const std::string& CAS, double& A, double& B, double& 
     }
 }
 void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend& HEOS) {
+    reject_non_finite_Q(HEOS, "PQ_flash");
     if (HEOS.is_pure_or_pseudopure) {
 
         if (get_config_bool(ENABLE_SUPERANCILLARIES) && HEOS.is_pure()) {

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.h
@@ -1397,6 +1397,10 @@ class JSONFluidLibrary
                         CoolPropFluid fluid;
                         fluid.CAS = vals.CAS;
                         EquationOfState E;
+                        // Populate the scalars this branch needs; without molar_mass
+                        // every mass-basis query on the fluid is silently wrong,
+                        // because it feeds all of mass_to_molar_inputs.
+                        E.molar_mass = vals.molemass;
                         E.acentric = vals.acentric;
                         E.sat_min_liquid.T = _HUGE;
                         E.sat_min_liquid.p = _HUGE;

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -1591,31 +1591,36 @@ void HelmholtzEOSMixtureBackend::update(CoolProp::input_pairs input_pair, double
         // SatV pointers from a prior valid update plus the new bad _Q
         // and return a meaningless extrapolated value (#2195).
         case QT_INPUTS:
-            if ((value1 < 0) || (value1 > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
+            if (!is_in_closed_range(0.0, 1.0, static_cast<double>(value1)))
+                throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             _Q = value1;
             _T = value2;
             FlashRoutines::QT_flash(*this);
             break;
         case PQ_INPUTS:
-            if ((value2 < 0) || (value2 > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
+            if (!is_in_closed_range(0.0, 1.0, static_cast<double>(value2)))
+                throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             _p = value1;
             _Q = value2;
             FlashRoutines::PQ_flash(*this);
             break;
         case QSmolar_INPUTS:
-            if ((value1 < 0) || (value1 > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
+            if (!is_in_closed_range(0.0, 1.0, static_cast<double>(value1)))
+                throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             _Q = value1;
             _smolar = value2;
             FlashRoutines::QS_flash(*this);
             break;
         case HmolarQ_INPUTS:
-            if ((value2 < 0) || (value2 > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
+            if (!is_in_closed_range(0.0, 1.0, static_cast<double>(value2)))
+                throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             _hmolar = value1;
             _Q = value2;
             FlashRoutines::HQ_flash(*this);
             break;
         case DmolarQ_INPUTS:
-            if ((value2 < 0) || (value2 > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
+            if (!is_in_closed_range(0.0, 1.0, static_cast<double>(value2)))
+                throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             _rhomolar = value1;
             _Q = value2;
             FlashRoutines::DQ_flash(*this);
@@ -1670,19 +1675,22 @@ void HelmholtzEOSMixtureBackend::update_with_guesses(CoolProp::input_pairs input
         case DmolarQ_INPUTS:
             _rhomolar = value1;
             _Q = value2;
-            if ((_Q < 0) || (_Q > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
+            if (!is_in_closed_range(0.0, 1.0, static_cast<double>(_Q)))
+                throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             FlashRoutines::DQ_flash_with_guesses(*this, guesses);
             break;
         case HmolarQ_INPUTS:
             _hmolar = value1;
             _Q = value2;
-            if ((_Q < 0) || (_Q > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
+            if (!is_in_closed_range(0.0, 1.0, static_cast<double>(_Q)))
+                throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             FlashRoutines::HQ_flash_with_guesses(*this, guesses);
             break;
         case QSmolar_INPUTS:
             _Q = value1;
             _smolar = value2;
-            if ((_Q < 0) || (_Q > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
+            if (!is_in_closed_range(0.0, 1.0, static_cast<double>(_Q)))
+                throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             FlashRoutines::QS_flash_with_guesses(*this, guesses);
             break;
         default:

--- a/src/Backends/IF97/IF97Backend.h
+++ b/src/Backends/IF97/IF97Backend.h
@@ -199,14 +199,16 @@ class IF97Backend : public AbstractState
             case PQ_INPUTS:
                 _p = value1;
                 _Q = value2;
-                if ((_Q < 0) || (_Q > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
+                if (!is_in_closed_range(0.0, 1.0, static_cast<double>(_Q)))
+                    throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
                 _T = IF97::Tsat97(_p);  // ...will throw exception if _P not on saturation curve
                 _phase = iphase_twophase;
                 break;
             case QT_INPUTS:
                 _Q = value1;
                 _T = value2;
-                if ((_Q < 0) || (_Q > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
+                if (!is_in_closed_range(0.0, 1.0, static_cast<double>(_Q)))
+                    throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
                 _p = IF97::psat97(_T);  // ...will throw exception if _P not on saturation curve
                 _phase = iphase_twophase;
                 break;

--- a/src/Backends/PCSAFT/PCSAFTBackend.cpp
+++ b/src/Backends/PCSAFT/PCSAFTBackend.cpp
@@ -1748,11 +1748,12 @@ void PCSAFTBackend::update(CoolProp::input_pairs input_pair, double value1, doub
         // Pure / pseudo-pure falls through to mass_to_molar_inputs below, which
         // rewrites the pair to its molar sibling without looking at the quality.
         // Unlike the cubic backend, PCSAFT is not fully open here: the QT_INPUTS
-        // and PQ_INPUTS cases downstream do reject a finite out-of-range quality
-        // with OutOfRangeError.  They do NOT reject NaN -- their guard is
-        // (v < 0) || (v > 1), which is false for NaN -- so a NaN quality reached
-        // the flash and surfaced as "solution could not be found".  Validating
-        // here closes that and makes the diagnostic match the other backends.
+        // and PQ_INPUTS cases downstream reject an out-of-range quality with
+        // OutOfRangeError.  Until those guards were rewritten to is_in_closed_range
+        // they were (v < 0) || (v > 1), which is false for NaN, so a NaN quality
+        // reached the flash and surfaced as "solution could not be found".  Both
+        // layers now refuse it; validating here keeps the diagnostic a Qmass one
+        // and matches the other backends.
         check_Qmass_pair_range(input_pair, value1, value2);
     }
 
@@ -1815,7 +1816,8 @@ void PCSAFTBackend::update(CoolProp::input_pairs input_pair, double value1, doub
             SatL->_T = value2;
             SatV->_T = value2;
             _phase = iphase_twophase;
-            if ((_Q < 0) || (_Q > 1)) throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
+            if (!is_in_closed_range(0.0, 1.0, static_cast<double>(_Q)))
+                throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             if (water_present) {
                 components[water_idx].calc_water_sigma(_T);
                 SatL->components[water_idx].calc_water_sigma(_T);
@@ -1835,7 +1837,7 @@ void PCSAFTBackend::update(CoolProp::input_pairs input_pair, double value1, doub
             SatL->_Q = value2;
             SatV->_Q = value2;
             _phase = iphase_twophase;
-            if ((_Q < 0) || (_Q > 1)) {
+            if (!is_in_closed_range(0.0, 1.0, static_cast<double>(_Q))) {
                 throw CoolProp::OutOfRangeError("Input vapor quality [Q] must be between 0 and 1");
             }
             flash_PQ(*this);

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5689,6 +5689,117 @@ TEST_CASE("Qmass range check: cubic and PCSAFT pure fluids reject out-of-range q
     }
 }
 
+TEST_CASE("Non-finite vapor quality is rejected rather than flashed", "[quality][nonfinite]") {
+    // Every quality guard in the library was written (Q < 0) || (Q > 1).  That is
+    // false for NaN, so a NaN quality walked straight past all of them into the
+    // flash routines.  Infinities were caught only incidentally, because inf > 1.
+    //
+    // The consequences ranged from a misleading diagnostic to a hard crash:
+    // HEOS::Propane with HmolarQ_INPUTS at hmolar = 20000 and Q = NaN SEGFAULTED
+    // inside HQ_flash (exit 139).  The value of hmolar mattered -- at 10000 the
+    // same call merely threw "p is not a valid number" -- which is why this test
+    // pins the enthalpy that actually crashed.
+    //
+    // Mixtures were already covered for the Qmass pairs by check_Qmass_pair_range
+    // (#3336); this is the molar side and the pure-fluid side.
+    const double qnan = std::numeric_limits<double>::quiet_NaN();
+    const double qinf = std::numeric_limits<double>::infinity();
+    const auto between_0_and_1 = Catch::Matchers::ContainsSubstring("must be between 0 and 1");
+
+    SECTION("HEOS pure fluid, update()") {
+        auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Propane"));
+        for (double q : {qnan, qinf, -qinf}) {
+            CAPTURE(q);
+            CHECK_THROWS_WITH(AS->update(CoolProp::QT_INPUTS, q, 300.0), between_0_and_1);
+            CHECK_THROWS_WITH(AS->update(CoolProp::PQ_INPUTS, 5e5, q), between_0_and_1);
+            CHECK_THROWS_WITH(AS->update(CoolProp::QSmolar_INPUTS, q, 100.0), between_0_and_1);
+            CHECK_THROWS_WITH(AS->update(CoolProp::DmolarQ_INPUTS, 1e3, q), between_0_and_1);
+            // hmolar = 20000 is the value that crashed; 10000 did not.
+            CHECK_THROWS_WITH(AS->update(CoolProp::HmolarQ_INPUTS, 2e4, q), between_0_and_1);
+            CHECK_THROWS_WITH(AS->update(CoolProp::HmolarQ_INPUTS, 1e4, q), between_0_and_1);
+        }
+    }
+
+    SECTION("HEOS pure fluid, update_with_guesses()") {
+        auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Propane"));
+        CoolProp::GuessesStructure guesses;
+        guesses.T = 300.0;
+        guesses.p = 5e5;
+        for (double q : {qnan, qinf}) {
+            CAPTURE(q);
+            CHECK_THROWS_WITH(AS->update_with_guesses(CoolProp::DmolarQ_INPUTS, 1e3, q, guesses), between_0_and_1);
+            CHECK_THROWS_WITH(AS->update_with_guesses(CoolProp::HmolarQ_INPUTS, 2e4, q, guesses), between_0_and_1);
+            CHECK_THROWS_WITH(AS->update_with_guesses(CoolProp::QSmolar_INPUTS, q, 100.0, guesses), between_0_and_1);
+        }
+    }
+
+    SECTION("IF97 and PCSAFT carry the same guard") {
+        auto IF = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("IF97", "Water"));
+        auto PC = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("PCSAFT", "METHANE"));
+        for (double q : {qnan, qinf}) {
+            CAPTURE(q);
+            CHECK_THROWS_WITH(IF->update(CoolProp::QT_INPUTS, q, 400.0), between_0_and_1);
+            CHECK_THROWS_WITH(IF->update(CoolProp::PQ_INPUTS, 5e5, q), between_0_and_1);
+            CHECK_THROWS_WITH(PC->update(CoolProp::QT_INPUTS, q, 150.0), between_0_and_1);
+            CHECK_THROWS_WITH(PC->update(CoolProp::PQ_INPUTS, 1e6, q), between_0_and_1);
+        }
+    }
+
+    SECTION("valid boundary qualities still flash") {
+        // Guard against a fix that over-rejects: 0 and 1 are legal.
+        auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Propane"));
+        for (double q : {0.0, 0.5, 1.0}) {
+            CAPTURE(q);
+            CHECK_NOTHROW(AS->update(CoolProp::QT_INPUTS, q, 300.0));
+            CHECK(AS->Q() == q);
+        }
+    }
+}
+
+TEST_CASE("Flash routines reject a non-finite quality themselves", "[quality][nonfinite]") {
+    // Guarding only at update()'s switch is the wrong altitude.  The quality
+    // reaches the flash routines by other doors, and HQ_flash's own gate,
+    //     if (std::abs(HEOS.Q() - 1) > 1e-10) throw ...
+    // is false for NaN -- so a NaN quality was accepted AS IF it were exactly 1,
+    // fell past the superancillary gate (also false for NaN) into
+    // saturation_PHSU_pure, and faulted.
+    //
+    // update_HmolarQ_with_guessT is such a door: a public HelmholtzEOSMixtureBackend
+    // entry point with no quality check at all.  It has no in-tree callers, which is
+    // exactly why it is the right regression test -- it reaches HQ_flash without
+    // passing through anything this commit's sibling touched.  Before the guard moved
+    // into the flash routines, this call SIGSEGVed (exit 139).
+    auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Propane"));
+    auto* HEOS = dynamic_cast<CoolProp::HelmholtzEOSMixtureBackend*>(AS.get());
+    REQUIRE(HEOS != nullptr);
+    const double qnan = std::numeric_limits<double>::quiet_NaN();
+
+    SECTION("update_HmolarQ_with_guessT does not crash on NaN quality") {
+        CHECK_THROWS_AS(HEOS->update_HmolarQ_with_guessT(2e4, qnan, 300.0), CoolProp::CoolPropBaseError);
+    }
+
+    SECTION("a valid unity quality still works through the same entry point") {
+        // Flash first so hmolar() is a real saturated-vapor enthalpy; the entry point
+        // is only meaningful for Q = 1, which is what its own gate enforces.
+        auto AS2 = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Propane"));
+        auto* H2 = dynamic_cast<CoolProp::HelmholtzEOSMixtureBackend*>(AS2.get());
+        REQUIRE(H2 != nullptr);
+        H2->update(CoolProp::QT_INPUTS, 1.0, 300.0);
+        const double h_sat_vap = H2->hmolar();
+        // It may still fail for an unrelated, pre-existing reason -- propane's
+        // saturated-vapor enthalpy at 300 K has two T-roots (GitHub #2773) -- but it
+        // must not be turned away by the range check this commit adds.
+        try {
+            H2->update_HmolarQ_with_guessT(h_sat_vap, 1.0, 300.0);
+        } catch (const std::exception& e) {
+            CHECK_THAT(std::string(e.what()), !Catch::Matchers::ContainsSubstring("must be between 0 and 1"));
+        }
+        // And the ordinary route for a boundary quality is untouched.
+        CHECK_NOTHROW(H2->update(CoolProp::QT_INPUTS, 1.0, 300.0));
+        CHECK_NOTHROW(H2->update(CoolProp::QT_INPUTS, 0.0, 300.0));
+    }
+}
+
 TEST_CASE("User-fluid schema validation rejects malformed PCSAFT/cubic payloads", "[json_validation]") {
     // --- Cubic (SRK) ---
     // 1. Structurally invalid JSON must throw unconditionally.

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -5800,6 +5800,82 @@ TEST_CASE("Flash routines reject a non-finite quality themselves", "[quality][no
     }
 }
 
+TEST_CASE("EquationOfState::pseudo_pure is initialized", "[cubic][uninitialized]") {
+    // EquationOfState had no user-declared constructor and declared its scalars
+    // (`bool pseudo_pure;`, R_u, molar_mass, acentric, Ttriple, ptriple) with no
+    // initializers.
+    //
+    // NOTE on the mechanism, because the obvious explanation is wrong: the bug was
+    // NOT in components built with EOSVector.emplace_back().  emplace_back() with no
+    // arguments performs VALUE-initialization, and since the class had no
+    // user-provided default constructor that zero-initialized the whole object
+    // first.  The sites that bit are the two DEFAULT-initializations in FluidLibrary
+    // -- `EquationOfState E;` in parse_EOS, and the same in the -SRK /
+    // -PengRobinson else branch -- both followed by push_back(E), which copies
+    // whatever the stack happened to hold.
+    //
+    // That distinction is why the defaults are 0 and not _HUGE: adding initializers
+    // makes the constructor non-trivial, so the value-initialized components now run
+    // it too.  Zero is what they used to get; _HUGE would have handed them an
+    // infinite Ttriple and broken every supercritical cubic flash.
+    //
+    // On this toolchain the indeterminate read of pseudo_pure happened to yield
+    // false, i.e. the right answer, so a black-box check through the backend cannot
+    // distinguish fixed from broken.  Constructing the object over deliberately
+    // poisoned storage can: without the initializer the member reads back as the
+    // poison.  For a case that WAS user-visible, see the molar-mass test below.
+    SECTION("default construction defines the member, whatever the storage held") {
+        alignas(CoolProp::EquationOfState) unsigned char buf[sizeof(CoolProp::EquationOfState)];
+        std::memset(buf, 0xFF, sizeof(buf));
+        // Default-initialization (no parentheses).  `EquationOfState()` would be
+        // VALUE-initialization, which zeroes the whole object and would mask the
+        // very thing under test.
+        auto* eos = new (static_cast<void*>(buf)) CoolProp::EquationOfState;
+        // Copy the object representation out rather than reading the member.
+        // Reading an indeterminate bool is itself UB, and an optimizing compiler
+        // may fold the comparison away -- an earlier version of this test read the
+        // member directly and passed against the unfixed code at -O1 for exactly
+        // that reason.  memcpy from the member's address reads bytes, which is
+        // well-defined, so this is deterministic at any optimization level.
+        unsigned char raw = 0;
+        std::memcpy(&raw, &eos->pseudo_pure, sizeof(raw));
+        eos->~EquationOfState();
+        CHECK(raw == 0u);
+    }
+
+    SECTION("cubic backends report themselves as pure") {
+        for (const char* backend : {"SRK", "PR"}) {
+            CAPTURE(backend);
+            auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory(backend, "Propane"));
+            CHECK(AS->fluid_param_string("pure") == "true");
+        }
+    }
+}
+
+TEST_CASE("Cubic-library-only fluids report a real molar mass", "[cubic][uninitialized]") {
+    // FluidLibrary's -SRK / -PengRobinson else branch builds its EquationOfState by
+    // default-initialization and then assigned only acentric, sat_min_liquid and
+    // reduce -- leaving R_u, molar_mass, Ttriple, ptriple, pseudo_pure and limits
+    // indeterminate, and copying them in via push_back.  (That branch now also
+    // assigns molar_mass, which is what this test pins.)
+    //
+    // R1233ZD(E) is the one cubic-library fluid with no multiparameter sibling, so
+    // it is the fluid that actually takes that branch.  PropsSI("M", ...) on it
+    // returned 1.5e-313 -- with an EMPTY error string, so nothing anywhere reported
+    // a problem.  molar_mass feeds every conversion in mass_to_molar_inputs, which
+    // makes every mass-basis query on that fluid silently wrong.
+    const double M = CoolProp::PropsSI("M", "T", 300.0, "P", 101325.0, "HEOS::R1233ZD(E)-SRK");
+    CAPTURE(M);
+    // Deliberately NOT asserting on get_global_param_string("errstring") here: it is a
+    // read-then-cleared process global that ANY earlier failing PropsSI in the binary
+    // can set, which makes such an assertion order-dependent (it fails under
+    // --order rand on some seeds).  The M check below is the real one -- the C++
+    // PropsSI returns _HUGE rather than throwing, so a regression shows up as inf.
+    // 0.1304944 kg/mol is the "molemass" this fluid carries in
+    // dev/cubics/all_cubic_fluids.json -- the value the branch should be reading.
+    CHECK(M == Catch::Approx(0.1304944).epsilon(1e-9));
+}
+
 TEST_CASE("User-fluid schema validation rejects malformed PCSAFT/cubic payloads", "[json_validation]") {
     // --- Cubic (SRK) ---
     // 1. Structurally invalid JSON must throw unconditionally.


### PR DESCRIPTION
Two related hardening fixes, one commit each, individually bisectable. Both came out of the review of #3340; both turned out to be worse than the issues that spawned them.

## 1 — Non-finite vapor quality (`bd` CoolProp-uedc)

Every quality guard in the library was written `if ((Q < 0) || (Q > 1))`, which is **false for NaN**. A NaN quality walked past all of them into the flash routines. Infinities were caught, but only incidentally, because `inf > 1`.

On `HEOS::Propane`:

| input | before |
|---|---|
| `HmolarQ_INPUTS`, hmolar = 20000, Q = NaN | **SIGSEGV (exit 139)** |
| `HmolarQ_INPUTS`, hmolar = 10000, Q = NaN | `"p is not a valid number"` |
| `DmolarQ_INPUTS`, Q = NaN | `"Brent's method f(b) is NAN"` |
| `QT_INPUTS` / `PQ_INPUTS`, Q = NaN | `"rhomolar is not a valid number"` |

The crash is enthalpy-dependent, which is why it is easy to miss.

Twelve guards become `is_in_closed_range(0.0, 1.0, Q)` — the existing helper in `numerics.h`, NaN-correct by construction.

**That alone does not fix the crash, which is the part worth reading twice.** `update()` is not the only door, and `HQ_flash` has its own NaN-blind gate — `std::abs(Q - 1) > 1e-10`, false for NaN — so NaN was accepted *as if it were exactly 1*, missed the superancillary gate (also false for NaN) and faulted inside `saturation_PHSU_pure`. `update_HmolarQ_with_guessT` is a public entry point with no quality check at all and **still segfaulted with all twelve guards in place**. So the check also goes where it belongs: `reject_non_finite_Q` at the top of `DQ_flash`, `HQ_flash`, `QS_flash`, `QT_flash` and `PQ_flash`. The regression test drives `update_HmolarQ_with_guessT` precisely because it bypasses everything the twelve cover.

## 2 — Uninitialized `EquationOfState` scalars (`bd` CoolProp-9h53)

The mechanism is not the obvious one, and my first attempt got it wrong. Components built with `EOSVector.emplace_back()` were never broken — that is **value**-initialization, which zero-initializes first. The sites that bite are the two **default**-initializations in `FluidLibrary`, each followed by `push_back(E)`.

`parse_EOS` overwrites everything from JSON, so it's UB but benign. The cubic-library branch does not, and that one was user-visible:

```
PropsSI("M", "T", 300, "P", 101325, "HEOS::R1233ZD(E)-SRK")
  ->  1.5039619940288733e-313      errstring: ""
```

`R1233ZD(E)` is the only cubic-library fluid with no multiparameter sibling, so it's the only one reaching that branch. `molar_mass` feeds every conversion in `mass_to_molar_inputs`, making every mass-basis query on it silently wrong — with an empty error string, so nothing reported it. It now returns the real `0.1304944 kg/mol`.

### The defaults are `0`, not `_HUGE`, and that is load-bearing

Adding initializers makes the constructor non-trivial, so the **value**-initialized components run it too. Zero is exactly what they used to get. An earlier revision of this PR used `_HUGE` and **regressed every cubic backend** — an infinite `Ttriple` makes the `(T > Tc && T > Ttriple)` supercritical branch of `DHSU_T_flash` unreachable:

```
PropsSI("Dmolar","T",500,"Hmolar",30000,"SRK::Propane")
  15954.550158568756   ->   throws "we don't support T [500 K] below Ttriple [inf K]"
```

**Nothing in the test suite covered it** — 535 cases green with the regression in place. `GERGBackend.cpp` already documents this exact hazard and picks `Ttriple = 0` for the same reason.

## Verification

- Full `~[slow]` with REFPROP 10: **191,918 assertions in 535 test cases**
- Both commits independently build and pass `~[slow]`
- Cubic values confirmed byte-identical to master after the `_HUGE` → `0` correction
- `./dev/ci/preflight.sh`: cppcheck and clang-tidy fail on pre-existing whole-file findings; **zero findings inside any of the 21 hunks**, checked programmatically. The cppcheck `syntaxError` in `FlashRoutines.cpp` reproduces on pristine master

## Scope: what is deliberately NOT here

Filed rather than fixed, to keep each commit to one concern:

- `bd` **CoolProp-jvkr** (P1) — the cubic backends' own switch has **no quality check at all**: `SRK::Propane` at `Q = 5.0` returns `rho = 102.182`, `p = 1.0087e6`, no error. Silent plausible-but-wrong output, which is worse than the crash this PR fixes. Also SVDSBTL, INCOMP, PhaseEnvelopeRoutines, and IF97 clamping NaN through `std::min/max`.
- `bd` **CoolProp-k21q** (P2) — REFPROP absorbs NaN quality and returns a plausible number with an empty errstring; and `update_with_guesses`'s PQ/QT arms fail closed but with an inconsistent message.
- `bd` **CoolProp-mvga** (P3) — PCSAFT's `QT_INPUTS` guard runs after `SatL`/`SatV`/`_phase` are already written.
- `bd` **CoolProp-dag6** (P3) — the suite has pre-existing order-dependent failures under `--order rand` (ATcT count, REFPROP in-file tests). Worth fixing because the noise makes a genuinely order-dependent *new* test indistinguishable — one was caught by hand during this review.

## AI assistance

Implemented by Claude Opus 5 under my direction. Two rounds of adversarial subagent review; every finding was reproduced independently before being acted on. That process caught, among other things, that my first fix did not fix the crash, and that my second fix introduced the cubic regression above — both of which the test suite passed. I verified the behaviour locally against REFPROP 10 and reviewed the final diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected molar-mass results for fluids using cubic equation-of-state backends.
  * Ensured cubic backends report consistent purity and fluid properties.
  * Improved validation of vapor-quality inputs, including NaN, infinite, and out-of-range values, with clear range errors.
  * Prevented invalid quality inputs from reaching flash calculations.
* **Tests**
  * Added regression coverage for vapor-quality validation and cubic-backend fluid properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->