### PR TITLE
perf(Plots): trace isolines instead of flashing every point cold (#3269)

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -396,6 +396,10 @@ jobs:
             fi
             uv pip install "$WHL"   # broken/incompatible wheel -> hard fail via set -e
             uv pip install mypy || echo "::warning::mypy unavailable on $PY; test_stub mypy check will skip"
+            # CoolProp.Plots imports matplotlib at module scope, so without it
+            # the whole Plots suite (test_derivatives_plots, test_isoline_tracer)
+            # silently importorskips (CoolProp-dgxi).
+            uv pip install matplotlib || echo "::warning::matplotlib unavailable on $PY; Plots tests will skip"
             python -c "import sys; print('Python', sys.version.split()[0])"
             pytest wrappers/Python/pytest -q
             ran=$((ran + 1))

--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -366,6 +366,7 @@ jobs:
           # single cp312-abi3 wheel (the crux of abi3 -- it must work on each).
           ran=0
           ran_abi3=0   # legs that ran the cp312-abi3 wheel (3.12/3.13/3.14)
+          ran_mpl=0    # legs where matplotlib installed, i.e. the Plots suite ran
           for PY in 3.9 3.10 3.11 3.12 3.13 3.14; do
             is_abi3=0
             case "$PY" in
@@ -398,8 +399,17 @@ jobs:
             uv pip install mypy || echo "::warning::mypy unavailable on $PY; test_stub mypy check will skip"
             # CoolProp.Plots imports matplotlib at module scope, so without it
             # the whole Plots suite (test_derivatives_plots, test_isoline_tracer)
-            # silently importorskips (CoolProp-dgxi).
-            uv pip install matplotlib || echo "::warning::matplotlib unavailable on $PY; Plots tests will skip"
+            # silently importorskips (CoolProp-dgxi).  Per-leg this is a warning,
+            # because a brand-new interpreter can genuinely lack a matplotlib
+            # wheel -- but if it is missing on EVERY leg the suite reverts to
+            # zero coverage and the job would still be green, which is the exact
+            # condition this install exists to remove.  Counted and asserted
+            # below, the same way the abi3 wheel is.
+            if uv pip install matplotlib; then
+              ran_mpl=$((ran_mpl + 1))
+            else
+              echo "::warning::matplotlib unavailable on $PY; Plots tests will skip on this leg"
+            fi
             python -c "import sys; print('Python', sys.version.split()[0])"
             pytest wrappers/Python/pytest -q
             ran=$((ran + 1))
@@ -412,6 +422,7 @@ jobs:
           # actually be exercised on at least one of them, else a broken abi3 wheel
           # could green the job on the 3.9-3.11 per-version legs alone (CoolProp-1tbe.12).
           test "$ran_abi3" -gt 0 || { echo "::error::the cp312-abi3 wheel ran on NO interpreter (3.12/3.13/3.14) -- it is the v8 crux and must be tested"; exit 1; }
+          test "$ran_mpl" -gt 0 || { echo "::error::matplotlib installed on NO interpreter -- the whole Plots suite importorskipped and this job proves nothing about it"; exit 1; }
 
       - name: PDSim cimport contract (compile + run against the abi3 wheel)
         shell: bash

--- a/wrappers/Python/CoolProp/Plots/Common.py
+++ b/wrappers/Python/CoolProp/Plots/Common.py
@@ -491,6 +491,31 @@ def _phases_are_distinct(state):
     return (rho_liq - rho_vap) > _TRIVIAL_SOLUTION_RTOL * max(rho_liq, rho_vap)
 
 
+def _model_key(state):
+    """Everything about a state that changes what the EOS computes
+
+    Anything cached per fluid has to be keyed on this rather than on the fluid
+    name, because two states can name the same mixture at the same composition
+    and still be different models.  A departure function installed with
+    ``set_binary_interaction_string`` cannot be read back from Python and so
+    cannot appear here; :func:`IsoLineTracer._check_clone` is what refuses to
+    trace in that case.
+    """
+    fluids = tuple(state.fluid_names())
+    interactions = ()
+    if len(fluids) > 1:
+        values = []
+        for i in range(len(fluids)):
+            for j in range(i + 1, len(fluids)):
+                for name in _BINARY_INTERACTION_KEYS:
+                    try:
+                        values.append(state.get_binary_interaction_double(i, j, name))
+                    except Exception:
+                        values.append(None)  # key absent for this backend
+        interactions = tuple(values)
+    return (state.backend_name(), fluids, tuple(state.get_mole_fractions()), interactions)
+
+
 def _clone_state(state):
     """Return a fresh AbstractState with the same backend, fluids and model"""
     fluids = state.fluid_names()
@@ -571,11 +596,15 @@ class IsoLineTracer(object):
     LIQUID = -1
     VAPOUR = 1
 
-    #: Critical temperatures keyed by fluid, for the blends whose phase
+    #: Critical temperatures keyed by fluid *model*, for the blends whose phase
     #: envelope does not reach the critical point and where locating it costs
     #: seconds to minutes.  Unlike the envelope, this lookup has no side effect
     #: on the state that produced it, so caching it cannot make one tracer
-    #: behave differently from the next.
+    #: behave differently from the next.  The key has to carry the binary
+    #: interaction parameters, not just the fluids and composition: they move
+    #: the critical point, and a shared limit that came out too low would send
+    #: :func:`_check_outside_the_dome` down its no-dome path over a range where
+    #: there is one.
     _CRITICAL_T = {}
 
     @classmethod
@@ -865,8 +894,7 @@ class IsoLineTracer(object):
         # An envelope that stopped early does not bound the dome.  The critical
         # point can be located directly, which is slow enough to be worth
         # avoiding whenever the envelope already answered.
-        key = (self._sat.backend_name(), tuple(self._sat.fluid_names()),
-               tuple(self._sat.get_mole_fractions()))
+        key = _model_key(self._sat)
         if key not in self._CRITICAL_T:
             if len(self._CRITICAL_T) > 64:  # a plotting session, not a cache
                 self._CRITICAL_T.clear()

--- a/wrappers/Python/CoolProp/Plots/Common.py
+++ b/wrappers/Python/CoolProp/Plots/Common.py
@@ -464,10 +464,17 @@ _BINARY_INTERACTION_KEYS = ('betaT', 'gammaT', 'betaV', 'gammaV', 'Fij', 'kij')
 
 #: A two-phase state whose two phases differ in density by less than this,
 #: relatively, is the trivial solution: the VLE solver collapsed both phases
-#: onto the same root rather than converging on a saturation state.  Measured
-#: over Q sweeps of eight fluids, genuine states bottom out at 3.4e-3 (Air,
-#: right at its critical point) while collapsed ones come in at ~1e-6, so this
-#: sits about thirty times clear of both.
+#: onto the same root rather than converging on a saturation state.
+#:
+#: Calibrated where it is load-bearing, which is the Q=0 and Q=1 calls the
+#: bracket and the dome check make: across the predefined blends, genuine
+#: saturation pairs there stay above 1.8e-3 and collapsed ones fall below
+#: 1e-7, so this sits orders clear of both.  At intermediate quality the
+#: separation is looser -- Air, R441A, R448A and R407C all return pairs a
+#: little above this threshold at temperatures beyond their critical point --
+#: and `calc_sat_range` will draw those.  Both error directions are safe for
+#: the tracer: a rejected genuine pair costs a fallback flash, and an accepted
+#: collapsed one still has to get past the density comparison that follows.
 _TRIVIAL_SOLUTION_RTOL = 1e-4
 
 

--- a/wrappers/Python/CoolProp/Plots/Common.py
+++ b/wrappers/Python/CoolProp/Plots/Common.py
@@ -454,6 +454,719 @@ class Base2DObject(object, metaclass=ABCMeta):
         return sat_min, sat_max
 
 
+#: Binary interaction parameters that have to be carried onto a cloned state.
+#: Rebuilding from the fluid names alone gets the defaults, so a state the
+#: caller customised with set_binary_interaction_double or
+#: apply_simple_mixing_rule would otherwise be traced with a different fluid
+#: model than it is flashed with.
+_BINARY_INTERACTION_KEYS = ('betaT', 'gammaT', 'betaV', 'gammaV', 'Fij', 'kij')
+
+
+def _clone_state(state):
+    """Return a fresh AbstractState with the same backend, fluids and model"""
+    fluids = state.fluid_names()
+    new_state = AbstractState(state.backend_name(), '&'.join(fluids))
+    if len(fluids) > 1:
+        new_state.set_mole_fractions(state.get_mole_fractions())
+        for i in range(len(fluids)):
+            for j in range(i + 1, len(fluids)):
+                for key in _BINARY_INTERACTION_KEYS:
+                    try:
+                        value = state.get_binary_interaction_double(i, j, key)
+                    except Exception:
+                        continue
+                    new_state.set_binary_interaction_double(i, j, key, value)
+    return new_state
+
+
+class IsoLineTracer(object):
+    """Walk along an isoline, warm-starting every point from the previous one.
+
+    :func:`IsoLine.calc_range` evaluates an isoline at consecutive points, so
+    the solution at one point is an excellent initial guess for the next one.
+    That turns each point into a much cheaper problem than the cold
+    two-dimensional flash it replaces:
+
+    * A single-phase point is solved as a two-by-two Newton iteration in
+      ``(T, rhomolar)``.  Every property is an explicit function of
+      ``(T, rhomolar)`` for a Helmholtz-energy EOS, so the iteration needs no
+      flash at all, only ``DmolarT_INPUTS`` updates on a state whose phase has
+      been imposed.  Imposing the phase skips the saturation call that
+      dominates a mixture update and, just as importantly, keeps the iterates
+      on the single-phase root instead of snapping to a two-phase solution.
+    * A two-phase point is bracketed by the two saturation states at the
+      constant temperature or pressure of the input pair, and the vapour
+      quality between them is found by a bracketed one-dimensional solve.
+
+    The tracer needs temperature or pressure among the two inputs -- see
+    :func:`supports` -- because that is what lets it bracket the saturation
+    curve.  Every point it cannot bracket, on either side, raises so that the
+    caller falls back to a plain :func:`AbstractState.update` call: a
+    phase-imposed Newton iteration will happily return the metastable
+    extension of the EOS inside the dome, and only the bracket rules that out.
+    """
+
+    #: The Newton iteration has settled once the relative step in both T and
+    #: rhomolar is this small.  That alone is not convergence -- see
+    #: RESIDUAL_RTOL -- but it is what stops the iteration.
+    NEWTON_RTOL = 1e-10
+    #: Residual accepted at that point, relative to how much the property
+    #: varies over the iteration variables.
+    RESIDUAL_RTOL = 1e-9
+    NEWTON_ITMAX = 30
+    #: A single Newton step may not move T or rhomolar by more than this
+    #: fraction of their current value.
+    NEWTON_TRUST = 0.25
+    #: Bracketed solve for the vapour quality of a two-phase point.
+    QUALITY_XTOL = 1e-12
+    QUALITY_RTOL = 1e-8
+    QUALITY_ITMAX = 60
+    #: A saturation bracket narrower than this (relative) cannot resolve a
+    #: quality: a pure fluid at fixed T brackets p by psat on both sides, and
+    #: an azeotropic mixture is barely better.  Such a point is single-phase
+    #: as far as the tracer is concerned.
+    BRACKET_RTOL = 1e-8
+    #: How far outside the saturation densities a converged single-phase root
+    #: may sit before it is rejected as the wrong branch.
+    BRANCH_RTOL = 1e-6
+
+    #: The reported extent of the two-phase region is a traced curve, so its
+    #: end is not exactly the cricondenbar (or cricondentherm).  A point is
+    #: only called supercritical this far beyond it.
+    DOME_MARGIN = 1.05
+    #: A phase envelope that ends with its two densities still this far apart
+    #: did not run to the critical point, so where its dome ends is unknown
+    #: and has to be found the expensive way.
+    ENVELOPE_CLOSED_RTOL = 0.35
+
+    LIQUID = -1
+    VAPOUR = 1
+
+    @classmethod
+    def supports(cls, index1, index2):
+        """Whether an isoline with these two inputs can be traced
+
+        The tracer needs temperature or pressure among the inputs, because
+        that is what lets it put a saturation bracket around a point and so
+        tell a two-phase state from a single-phase one.  Without it the Newton
+        iteration would run on a phase-imposed state with nothing to stop it
+        returning the metastable extension of the EOS inside the dome -- a
+        plausible-looking answer that is simply wrong.  ``HmassSmass_INPUTS``
+        and ``DmassSmass_INPUTS`` are the pairs this rules out.
+        """
+        return CoolProp.iT in (index1, index2) or CoolProp.iP in (index1, index2)
+
+    def __init__(self, state, index1, index2, iso_index):
+        """
+        Parameters
+        ----------
+        state : CoolProp.AbstractState
+            The state the isoline belongs to; it is cloned, never modified.
+        index1, index2 : int
+            Parameter indices of the two inputs, in the order the input pair
+            expects them.
+        iso_index : int
+            Parameter index the isoline holds constant.
+        """
+        if index1 == index2:
+            raise ValueError("The two inputs of an isoline cannot be the same property.")
+        if not self.supports(index1, index2):
+            raise ValueError("An isoline whose inputs include neither temperature "
+                             "nor pressure cannot be traced.")
+        self._i1 = index1
+        self._i2 = index2
+        self._sat = _clone_state(state)
+        self._sp = _clone_state(state)
+        self._check_clone(state)
+        # Not every backend honours an imposed phase; the tracer is still
+        # correct without it, just slower and less robust, so fail soft.
+        try:
+            self._sp.specify_phase(CoolProp.iphase_gas)
+        except Exception:
+            pass
+        # Using the isoline's own constant as the saturation variable makes the
+        # bracket constant along the whole line, so it is computed only once.
+        if iso_index in (CoolProp.iT, CoolProp.iP) and iso_index in (index1, index2):
+            self._sat_index = iso_index
+        elif CoolProp.iT in (index1, index2):
+            self._sat_index = CoolProp.iT
+        else:
+            self._sat_index = CoolProp.iP
+        self._eos_bounds = self._find_eos_bounds()
+        envelope_bounds, self._saturation_bounds = self._find_saturation_bounds()
+        self._dome_limit = envelope_bounds.get(self._sat_index)
+        self._dome_T_limit, self._dome_p_limit = self._find_dome_limits()
+        self._sat_value = None
+        self._bracket = None
+        self._bracket_failure = None
+        self._T = np.nan
+        self._rhomolar = np.nan
+        self._side = None
+        self._out = None
+
+    def _check_clone(self, state):
+        """Refuse to trace if the clone is not the caller's fluid model
+
+        The numeric binary interaction parameters are copied across, but a
+        departure function installed with ``set_binary_interaction_string``
+        cannot be read back from Python at all, so the clone would quietly
+        fall back on the default one and the isoline would mix two models --
+        traced points from the defaults, flashed points from the caller's.
+        Pressure at a given ``(T, rhomolar)`` is a direct function of the
+        model, so one comparison settles it.  A caller whose state is
+        two-phase or has never been updated gives nothing to compare against,
+        and then this cannot help.
+        """
+        try:
+            if state.Q() >= 0.0:
+                return
+            T, rhomolar, expected = state.T(), state.rhomolar(), state.p()
+        except Exception:
+            return
+        if not (np.isfinite(T) and np.isfinite(rhomolar) and np.isfinite(expected)):
+            return
+        self._sp.update(CoolProp.DmolarT_INPUTS, rhomolar, T)
+        got = self._sp.p()
+        if abs(got - expected) > 1e-9 * max(abs(expected), abs(got)):
+            raise ValueError("The traced copy of this state does not reproduce it; "
+                             "the fluid model cannot be cloned.")
+
+    @property
+    def state(self):
+        """The state holding the most recently traced point
+
+        Note that its ``phase()`` reports the phase the tracer imposed on it,
+        not one it determined; ``Q()`` is meaningful, ``phase()`` is not.
+        """
+        if self._out is None:
+            raise ValueError("No point has been traced yet.")
+        return self._out
+
+    def keyed_output(self, key):
+        return self.state.keyed_output(key)
+
+    def set_guess(self, state):
+        """Adopt a state the caller solved itself as the warm start
+
+        A two-phase state says nothing about the single-phase root the Newton
+        iteration follows, so it is ignored.  Both ``phase()`` and ``Q()`` are
+        consulted: the caller's state is shared and may have had a phase
+        imposed on it, in which case ``phase()`` reports that rather than what
+        was found.
+        """
+        try:
+            if state.phase() == CoolProp.iphase_twophase:
+                return
+            quality = state.Q()
+            # phase() reports whatever the caller imposed on the shared state,
+            # so do not rely on it alone.
+            if np.isfinite(quality) and 0.0 <= quality <= 1.0:
+                return
+            T, rhomolar = state.T(), state.rhomolar()
+        except Exception:
+            return
+        if np.isfinite(T) and np.isfinite(rhomolar) and T > 0.0 and rhomolar > 0.0:
+            self._T = T
+            self._rhomolar = rhomolar
+            self._side = None
+
+    def update(self, value1, value2):
+        """Trace the state with ``index1 == value1`` and ``index2 == value2``
+
+        Raises if the point could not be traced.  The warm start survives,
+        because it holds the last point that *did* converge and that is still
+        the best guess available for the next one -- dropping it on every
+        failure lets a single awkward point strand the whole rest of the line
+        in a region where there is no saturation state to restart from.
+        """
+        try:
+            self._out = None
+            targets = {self._i1: value1, self._i2: value2}
+            bracket = self._get_bracket(targets)
+            if bracket is not None and bracket['two_phase']:
+                self._solve_quality(bracket)
+            else:
+                self._solve_single_phase(targets, bracket)
+        except Exception:
+            self._out = None
+            raise
+
+    # -------------------------------------------------------------------
+    # Saturation bracket
+    # -------------------------------------------------------------------
+    def _find_eos_bounds(self):
+        """The range the equation of state is actually valid over
+
+        Cheap -- these are trivial parameters -- and used twice: to keep a
+        diverged phase envelope from setting a meaningless bound, and to stop
+        the Newton iteration reporting a root far outside the fitted range.
+        With the phase imposed there is nothing else to stop it: an isochore
+        on R504 will happily extrapolate to tens of thousands of kelvin and
+        report finite numbers there.
+        """
+        bounds = {}
+        for index, key in ((CoolProp.iT, CoolProp.iT_max), (CoolProp.iP, CoolProp.iP_max)):
+            try:
+                value = self._sp.trivial_keyed_output(key)
+            except Exception:
+                continue
+            if np.isfinite(value) and value > 0.0:
+                bounds[index] = value
+        try:
+            value = self._sp.trivial_keyed_output(CoolProp.iT_min)
+            if np.isfinite(value) and value > 0.0:
+                bounds['T_min'] = value
+        except Exception:
+            pass
+        return bounds
+
+    def _find_saturation_bounds(self):
+        """Two bounds on how far the two-phase region reaches, in T and in p
+
+        They answer different questions and must not be conflated.
+
+        The *inner* one is the phase envelope's own extent.  It decides what a
+        failed saturation call means: beyond it there is probably no dome, so
+        the point is traced without a bracket -- and then checked against the
+        saturation densities at its own temperature by
+        :func:`_check_outside_the_dome`, which is what actually makes that
+        safe.  Being merely probable is therefore fine, and keeping it tight
+        is what keeps the fallback rate down.
+
+        The *outer* one also takes in the largest critical point among the
+        components, and decides whether a saturation state the solver returned
+        can be believed.  Beyond the cricondenbar the mixture PQ and QT
+        solvers do not fail: they return a state that reports the requested
+        pressure and quality exactly and sits hundreds of kelvin from the
+        dome.  This one has to be generous, because the envelope trace stops
+        short of the real cricondentherm for several predefined blends --
+        R504 by about 20 K -- and those genuine dome states must not be thrown
+        away as solver noise.
+
+        Building the envelope is also what makes the saturation calls on
+        ``self._sat`` converge in the first place -- the mixture PQ and QT
+        flashes take their guesses from it -- so this is deliberately done on
+        that object and deliberately not cached between tracers.  Caching it
+        made the first isoline of a fluid behave differently from the rest.
+        """
+        envelope = {}
+        try:
+            self._sat.build_phase_envelope("none")
+            data = self._sat.get_phase_envelope_data()
+            envelope = {CoolProp.iT: max(data.T), CoolProp.iP: max(data.p)}
+        except Exception:
+            pass
+        outer = dict(envelope)
+        try:
+            for index, name in ((CoolProp.iT, 'Tcrit'), (CoolProp.iP, 'pcrit')):
+                critical = max(PropsSI(name, fluid) for fluid in self._sat.fluid_names())
+                outer[index] = max(outer.get(index, 0.0), critical)
+        except Exception:
+            pass
+        def clean(candidate):
+            bounds = {}
+            for index, value in candidate.items():
+                if not (np.isfinite(value) and value > 0.0):
+                    continue
+                # A phase envelope can diverge rather than fail -- CO2/nitrogen
+                # traces one out to 18000 K -- and an unclamped bound from it
+                # makes every plausibility test below a tautology.
+                limit = self._eos_bounds.get(index)
+                bounds[index] = min(value, limit) if limit is not None else value
+            return {k: v * self.DOME_MARGIN for k, v in bounds.items()}
+        return clean(envelope), clean(outer)
+
+    def _find_dome_limits(self):
+        """The temperature, and pressure, above which there is certainly no dome
+
+        This one has to be right rather than generous: it is what decides
+        whether a saturation call that could not answer counts as "there is no
+        dome here" or as "this point cannot be checked, hand it back".  Too
+        high and every supercritical point pays for a flash; too low and roots
+        inside the dome are accepted unexamined.
+
+        A phase envelope that ran to the critical point ends with its liquid
+        and vapour densities converging, and then its own maximum temperature
+        is the answer for free.  One that stopped early -- R504's ends with
+        them still a factor of six apart, 37 K below the real critical point
+        -- says nothing, and the critical point has to be located directly,
+        which is slow enough to be worth avoiding for every other fluid.
+        """
+        try:
+            data = self._sat.get_phase_envelope_data()
+            temperatures = np.asarray(data.T, dtype=float)
+            hot = int(np.argmax(temperatures))
+            rho_liq = float(np.asarray(data.rhomolar_liq, dtype=float)[hot])
+            rho_vap = float(np.asarray(data.rhomolar_vap, dtype=float)[hot])
+            closed = abs(rho_liq - rho_vap) <= self.ENVELOPE_CLOSED_RTOL * max(rho_liq, rho_vap)
+            if closed:
+                # The trace covered the whole dome, so its own extremes are the
+                # cricondentherm and the cricondenbar.
+                return (temperatures[hot] * self.DOME_MARGIN,
+                        float(np.max(np.asarray(data.p, dtype=float))) * self.DOME_MARGIN)
+        except Exception:
+            pass
+        # An envelope that stopped early bounds neither.  The critical point can
+        # be located directly, which is slow enough to be worth avoiding when
+        # the envelope already answered, and gives the temperature only: the
+        # cricondenbar can lie above the critical pressure, so no pressure
+        # bound is claimed here and pressure simply stops short-circuiting.
+        try:
+            stable = [point.T for point in self._sat.all_critical_points() if point.stable]
+            if stable:
+                return max(stable) * self.DOME_MARGIN, None
+        except Exception:
+            pass
+        return self._saturation_bounds.get(CoolProp.iT), None
+
+    def _is_plausible_saturation(self, T, p):
+        """Whether a state the saturation solver returned can be on the dome"""
+        for index, value in ((CoolProp.iT, T), (CoolProp.iP, p)):
+            bound = self._saturation_bounds.get(index)
+            if bound is not None and not value <= bound:
+                return False
+        return True
+
+    def _saturation_endpoint(self, sat_value, quality):
+        """Move ``self._sat`` onto the saturation curve
+
+        These deliberately do not go through ``update_with_guesses``.  Seeding
+        the saturation solver from the previous point is about twice as fast,
+        but near the critical point it converges on a state that is not the
+        bubble or dew point and reports no error while doing so, and every
+        branch decision below is built on this bracket.  The saturation calls
+        are a small part of the cost of a traced isoline anyway.
+        """
+        if self._sat_index == CoolProp.iT:
+            self._sat.update(CoolProp.QT_INPUTS, quality, sat_value)
+        else:
+            self._sat.update(CoolProp.PQ_INPUTS, sat_value, quality)
+
+    def _get_bracket(self, targets):
+        """Bracket the target property between its saturated liquid and vapour values
+
+        Returns a dict describing the bracket and whether the point falls
+        inside it, or ``None`` if the point is beyond the dome entirely, where
+        an unbracketed single-phase root is safe because there is no second
+        root to confuse it with.  Raises if the dome should be there and could
+        not be found, so that the caller flashes the point instead.
+        """
+        sat_value = targets[self._sat_index]
+        target_index = self._i2 if self._sat_index == self._i1 else self._i1
+        target = targets[target_index]
+
+        if self._sat_value is None or sat_value != self._sat_value:
+            # Record the outcome and the value it belongs to together.  Storing
+            # the value first and letting the build raise past it would leave
+            # the previous outcome -- None, meaning "no dome, nothing to
+            # check" -- cached against the new value, and since an isoline in T
+            # or p has the same saturation value at every point, one failed
+            # build would disable the branch check for the whole line.
+            bracket, failure = None, None
+            try:
+                bracket = self._build_bracket(sat_value, target_index)
+            except Exception as e:
+                failure = str(e)
+            self._sat_value = sat_value
+            self._bracket = bracket
+            self._bracket_failure = failure
+        if self._bracket_failure is not None:
+            raise ValueError(self._bracket_failure)
+        if self._bracket is None:
+            # Above the dome; a single-phase root here needs no checking
+            # because there is no other root to be confused with.
+            return None
+
+        bracket = dict(self._bracket)
+        v_liq, v_vap = bracket['liq'][0], bracket['vap'][0]
+        bracket['target'] = target
+        bracket['two_phase'] = (not bracket['degenerate']
+                                and min(v_liq, v_vap) < target < max(v_liq, v_vap))
+        # Which single-phase branch the point sits on.  Following the bracket
+        # rather than the previous point is what keeps the iteration on the
+        # correct root where an isoline crosses the saturation curve.  The
+        # midpoint and the slope are used rather than the two bracket values
+        # because for an azeotropic mixture the bubble and dew values can
+        # agree to within round-off, and then their order is noise: R513A's
+        # bubble and dew pressures come within 1.4e-9 relative of each other
+        # near 305 K, below BRACKET_RTOL.
+        slope = bracket['slope']
+        if bracket['two_phase']:
+            bracket['side'] = None
+        elif slope is not None:
+            bracket['side'] = self.LIQUID if (target - 0.5 * (v_liq + v_vap)) * slope > 0 \
+                else self.VAPOUR
+        elif not bracket['degenerate']:
+            # No slope, but a bracket this wide still separates the branches
+            bracket['side'] = self.LIQUID if (target - v_liq) * (v_liq - v_vap) > 0 \
+                else self.VAPOUR
+        else:
+            raise ValueError("Cannot tell which side of the saturation curve "
+                             "this point is on.")
+        return bracket
+
+    def _build_bracket(self, sat_value, target_index):
+        """Saturation states at ``sat_value``, or None if there is no dome there
+
+        Raises rather than returning None when the dome should exist but could
+        not be found: an unbracketed point is only safe where there is nothing
+        to bracket, and everywhere else the caller has to flash it instead.
+        """
+        # The bracket is attempted even beyond the reported extent of the dome,
+        # because that extent is only a lower bound and a saturation state
+        # that really does exist is better evidence than the limit.  A call
+        # that fails, or that returns a state the envelope says cannot be on
+        # the dome, then falls back on the limit to decide whether it came up
+        # empty for want of a dome or for want of a solver.
+        ends = {}
+        try:
+            for name, quality in (('liq', 0.0), ('vap', 1.0)):
+                self._saturation_endpoint(sat_value, quality)
+                ends[name] = (self._sat.keyed_output(target_index),
+                              self._sat.T(), self._sat.rhomolar())
+                if not self._is_plausible_saturation(self._sat.T(), self._sat.p()):
+                    raise ValueError(
+                        "The saturation solver returned a state at T={0:g} K, "
+                        "p={1:g} Pa, beyond any possible dome.".format(
+                            self._sat.T(), self._sat.p()))
+        except Exception:
+            if self._dome_limit is not None and sat_value > self._dome_limit:
+                return None
+            raise
+        v_liq, v_vap = ends['liq'][0], ends['vap'][0]
+        if not (np.isfinite(v_liq) and np.isfinite(v_vap)):
+            raise ValueError("The saturation states are not finite.")
+        # A saturation solver that converged on the wrong branch would make
+        # every branch decision below meaningless, so check the one thing that
+        # always holds: the saturated liquid is the denser one.
+        if not ends['liq'][2] > ends['vap'][2]:
+            raise ValueError("The saturation states are not on their own branches.")
+        degenerate = abs(v_vap - v_liq) <= self.BRACKET_RTOL * max(abs(v_liq), abs(v_vap), 1e-30)
+        return {'target_index': target_index, 'liq': ends['liq'], 'vap': ends['vap'],
+                'degenerate': degenerate,
+                'slope': self._branch_slope(target_index, ends['liq'])}
+
+    def _branch_slope(self, target_index, liquid_end):
+        """Sign of the target property along density at the saturated liquid
+
+        A point whose target property lies on the same side of the saturation
+        curve as this slope points sits on the liquid branch.  Returns None if
+        the derivative is unavailable, in which case the branch is left to the
+        previous point.
+        """
+        try:
+            self._sp.update(CoolProp.DmolarT_INPUTS, liquid_end[2], liquid_end[1])
+            slope = self._sp.first_partial_deriv(target_index, CoolProp.iDmolar, self._sat_index)
+        except Exception:
+            return None
+        if not np.isfinite(slope) or slope == 0.0:
+            return None
+        return slope
+
+    # -------------------------------------------------------------------
+    # Two-phase point: solve for the vapour quality
+    # -------------------------------------------------------------------
+    def _quality_residual(self, quality, bracket):
+        if self._sat_index == CoolProp.iT:
+            self._sat.update(CoolProp.QT_INPUTS, quality, self._sat_value)
+        else:
+            self._sat.update(CoolProp.PQ_INPUTS, self._sat_value, quality)
+        return self._sat.keyed_output(bracket['target_index']) - bracket['target']
+
+    def _solve_quality(self, bracket):
+        """Regula falsi (Illinois) on the vapour quality between the saturation states"""
+        target = bracket['target']
+        a, fa = 0.0, bracket['liq'][0] - target
+        b, fb = 1.0, bracket['vap'][0] - target
+        width = abs(fb - fa)
+        if fa * fb > 0.0:
+            raise ValueError("The saturation bracket does not contain the target.")
+        for _ in range(self.QUALITY_ITMAX):
+            quality = b - fb * (b - a) / (fb - fa)
+            # The endpoints are already known and a regula falsi can creep onto
+            # them, so keep every trial strictly inside the bracket.
+            lo, hi = min(a, b), max(a, b)
+            if not np.isfinite(quality) or not lo < quality < hi:
+                quality = 0.5 * (lo + hi)
+            fq = self._quality_residual(quality, bracket)
+            if fq * fb < 0.0:
+                a, fa = b, fb
+            else:
+                fa *= 0.5  # Illinois: stops the retained endpoint from stalling
+            b, fb = quality, fq
+            if fq == 0.0 or abs(b - a) < self.QUALITY_XTOL:
+                break
+        else:
+            raise ValueError("The quality solver did not converge.")
+        # A bracket built on a bad saturation state can be wide enough to
+        # appear to contain a target the two-phase region never reaches, and
+        # then the iteration runs out of interval with the residual intact.
+        if abs(fb) > self.QUALITY_RTOL * width:
+            raise ValueError("The quality solver ran out of bracket with the "
+                             "residual unresolved.")
+        self._out = self._sat
+        # A two-phase point says nothing about the single-phase root.
+        self._T = np.nan
+        self._rhomolar = np.nan
+        self._side = None
+
+    # -------------------------------------------------------------------
+    # Single-phase point: Newton iteration in (T, rhomolar)
+    # -------------------------------------------------------------------
+    def _seed(self, bracket):
+        """Pick the initial (T, rhomolar), preferring the previous point"""
+        side = None if bracket is None else bracket['side']
+        if np.isfinite(self._T) and np.isfinite(self._rhomolar) \
+                and (side is None or self._side is None or side == self._side):
+            return self._T, self._rhomolar
+        if bracket is not None:
+            end = bracket['liq'] if side == self.LIQUID else bracket['vap']
+            return end[1], end[2]
+        raise ValueError("No initial guess is available for the Newton iteration.")
+
+    def _solve_single_phase(self, targets, bracket):
+        T, rhomolar = self._seed(bracket)
+        i1, i2, state = self._i1, self._i2, self._sp
+        v1, v2 = targets[i1], targets[i2]
+        for _ in range(self.NEWTON_ITMAX):
+            state.update(CoolProp.DmolarT_INPUTS, rhomolar, T)
+            f1 = state.keyed_output(i1) - v1
+            f2 = state.keyed_output(i2) - v2
+            J11 = state.first_partial_deriv(i1, CoolProp.iT, CoolProp.iDmolar)
+            J12 = state.first_partial_deriv(i1, CoolProp.iDmolar, CoolProp.iT)
+            J21 = state.first_partial_deriv(i2, CoolProp.iT, CoolProp.iDmolar)
+            J22 = state.first_partial_deriv(i2, CoolProp.iDmolar, CoolProp.iT)
+            det = J11 * J22 - J12 * J21
+            if not np.isfinite(det) or det == 0.0:
+                raise ValueError("The Newton iteration hit a singular Jacobian.")
+            dT = (J12 * f2 - J22 * f1) / det
+            dD = (J21 * f1 - J11 * f2) / det
+            if not (np.isfinite(dT) and np.isfinite(dD)):
+                raise ValueError("The Newton iteration produced a non-finite step.")
+            if abs(dT) <= self.NEWTON_RTOL * T and abs(dD) <= self.NEWTON_RTOL * rhomolar:
+                # A small step is not by itself a small residual: where the
+                # Jacobian is large -- cv near the critical point, say -- the
+                # iteration can stall with the residual intact.  Scale each
+                # residual by how much its property moves over the iteration
+                # variables, which is finite and non-zero even for an enthalpy
+                # that happens to sit near its reference value.
+                scale1 = abs(J11) * T + abs(J12) * rhomolar
+                scale2 = abs(J21) * T + abs(J22) * rhomolar
+                if not (np.isfinite(scale1) and np.isfinite(scale2)):
+                    raise ValueError("The residual cannot be scaled at this point.")
+                if abs(f1) > self.RESIDUAL_RTOL * scale1 \
+                        or abs(f2) > self.RESIDUAL_RTOL * scale2:
+                    raise ValueError("The Newton iteration stalled with the "
+                                     "residual unresolved.")
+                self._check_in_range(T)
+                side = None if bracket is None else bracket['side']
+                self._check_branch(bracket, side, T, rhomolar)
+                self._T, self._rhomolar = T, rhomolar
+                self._side = side
+                self._out = state
+                return
+            damp = 1.0
+            if abs(dT) > self.NEWTON_TRUST * T:
+                damp = min(damp, self.NEWTON_TRUST * T / abs(dT))
+            if abs(dD) > self.NEWTON_TRUST * rhomolar:
+                damp = min(damp, self.NEWTON_TRUST * rhomolar / abs(dD))
+            T += damp * dT
+            rhomolar += damp * dD
+            if not (T > 0.0 and rhomolar > 0.0):
+                raise ValueError("The Newton iteration left the physical domain.")
+        raise ValueError("The Newton iteration did not converge.")
+
+    #: How far past the equation of state's stated temperature range a root
+    #: may sit.  Deliberately loose: this is not a validity check.  CoolProp
+    #: answers a PT flash well outside the fitted range and so would the
+    #: fallback this hands back to, so a tighter bound would only make traced
+    #: and flashed points on the same isoline obey different rules.  What it
+    #: catches is an iteration that has run away entirely -- an R504 isochore
+    #: reaching four hundred times the maximum temperature.
+    RANGE_FACTOR = 2.0
+
+    def _check_in_range(self, T):
+        """Reject a root the Newton iteration has run away with"""
+        upper = self._eos_bounds.get(CoolProp.iT)
+        lower = self._eos_bounds.get('T_min')
+        if (upper is not None and T > upper * self.RANGE_FACTOR) \
+                or (lower is not None and T < lower / self.RANGE_FACTOR):
+            raise ValueError("The Newton iteration converged at T={0:g} K, far "
+                             "outside the range of the equation of state.".format(T))
+
+    def _check_branch(self, bracket, side, T, rhomolar):
+        """Reject a root that ended up inside the two-phase dome
+
+        With a bracket this is a comparison against the two saturation
+        densities at the constant temperature (or pressure) it was built at: a
+        liquid root is denser than the saturated liquid, a vapour root thinner
+        than the saturated vapour, and a root that is neither is metastable or
+        unstable and goes back to the caller to flash.
+
+        Without one the point was taken to be beyond the dome, and that is
+        checked here rather than assumed.  The reported extent of the phase
+        envelope is not reliable enough to assume it: for several predefined
+        blends the envelope trace stops well short of the real cricondentherm
+        -- R504 by about 20 K -- and every point in between would otherwise be
+        accepted unexamined, which is exactly where the dome is.
+        """
+        if bracket is None:
+            return self._check_outside_the_dome(T, rhomolar)
+        if side is None:
+            return
+        if side == self.LIQUID:
+            limit = bracket['liq'][2]
+            wrong = rhomolar < limit * (1.0 - self.BRANCH_RTOL)
+        else:
+            limit = bracket['vap'][2]
+            wrong = rhomolar > limit * (1.0 + self.BRANCH_RTOL)
+        if wrong:
+            raise ValueError("The Newton iteration converged on the wrong side "
+                             "of the saturation curve.")
+
+    def _check_outside_the_dome(self, T, rhomolar):
+        """Confirm there is no two-phase region around this root
+
+        A saturation call that succeeds here gives the two densities to
+        compare against directly.  One that fails is not the reassurance it
+        looks like: when the isoline is indexed by temperature this is the
+        same call, at the same temperature, that :func:`_build_bracket`
+        already gave up on, so it can add nothing.  Treating that as "no dome"
+        left a band of about ten kelvin on R504 -- between where the
+        saturation solver stops converging and the real critical point at
+        335.5 K, which its phase envelope stops 37 K short of -- in which
+        roots inside the dome were accepted unexamined.  So a failure only
+        counts as an answer above the temperature where a dome could exist at
+        all; below it the point goes back to the caller to flash.
+        """
+        if self._dome_T_limit is not None and T > self._dome_T_limit:
+            return          # above the critical point; there is no dome to be in
+        if self._sat_index == CoolProp.iP and self._dome_p_limit is not None \
+                and self._sat_value is not None and self._sat_value > self._dome_p_limit:
+            return          # above the cricondenbar; this isobar has no dome
+        undecided = None
+        try:
+            self._sat.update(CoolProp.QT_INPUTS, 0.0, T)
+            rho_liq, p_liq = self._sat.rhomolar(), self._sat.p()
+            self._sat.update(CoolProp.QT_INPUTS, 1.0, T)
+            rho_vap, p_vap = self._sat.rhomolar(), self._sat.p()
+        except Exception:
+            undecided = "the saturation solver did not converge"
+        if undecided is None and not self._is_plausible_saturation(T, max(p_liq, p_vap)):
+            undecided = "the saturation solver left the dome behind"
+        if undecided is None and not rho_liq > rho_vap:
+            undecided = "the saturation states are not on their own branches"
+        if undecided is not None:
+            bound = self._dome_T_limit
+            if bound is None or T <= bound:
+                raise ValueError("This root cannot be shown to be outside the "
+                                 "two-phase dome: {0}.".format(undecided))
+            return          # above any possible dome, so there is none to be in
+        if rho_vap < rhomolar < rho_liq:
+            raise ValueError("The Newton iteration converged inside the "
+                             "two-phase dome.")
+
+
 class IsoLine(Base2DObject):
     """An object that holds the functions to calculate a line of
     a constant property in the dimensions of a property plot. This
@@ -474,16 +1187,29 @@ class IsoLine(Base2DObject):
     # valid entries.
     VALID_REQ = 5.0 / 100.0
 
-    def __init__(self, i_index, x_index, y_index, value=0.0, state=None):
+    def __init__(self, i_index, x_index, y_index, value=0.0, state=None, tracing=True):
         super().__init__(x_index, y_index, state)
         self._i_index = _get_index(i_index)
         if value is not None: self.value = value
         else: self._value = None
         self._x = None
         self._y = None
+        self._tracing = bool(tracing)
 
     @property
     def i_index(self): return self._i_index
+
+    @property
+    def tracing(self):
+        """Whether :class:`IsoLineTracer` is used to walk along the isoline
+
+        Set this to False to calculate every point with an independent flash,
+        which is much slower but does not depend on the neighbouring points.
+        """
+        return self._tracing
+
+    @tracing.setter
+    def tracing(self, value): self._tracing = bool(value)
 
     @property
     def value(self): return self._value
@@ -625,37 +1351,40 @@ class IsoLine(Base2DObject):
 
         vals[2] = np.empty_like(vals[0])
         err = False
-        guesses = CoolProp.CoolProp.PyGuessesStructure()
-        # Only use the guesses for selected inputs
-        if pair == CoolProp.HmolarP_INPUTS \
-          or pair == CoolProp.HmassP_INPUTS:
-            # or pair == CoolProp.HmassSmass_INPUTS \
-            # or pair == CoolProp.HmolarSmolar_INPUTS \
-            # or pair == CoolProp.PSmass_INPUTS \
-            # or pair == CoolProp.PSmolar_INPUTS:
-            use_guesses = True
-        else:
-            use_guesses = False
-        for index, _ in np.ndenumerate(vals[0]):
+        # Consecutive points of an isoline are close together, so each one can
+        # be warm-started from the last instead of being flashed cold.  For a
+        # mixture that is orders of magnitude faster and, because the iteration
+        # never has to find the region on its own, far less likely to leave a
+        # gap in the line.  Anything the tracer will not take is flashed.
+        tracer = None
+        if self.tracing and IsoLineTracer.supports(idxs[0], idxs[1]):
             try:
-                if use_guesses:
-                    if np.isfinite(guesses.rhomolar):
-                        self.state.update_with_guesses(pair, vals[0][index], vals[1][index], guesses)
-                    else:
-                        self.state.update(pair, vals[0][index], vals[1][index])
-                    guesses.rhomolar = self.state.rhomolar()
-                    guesses.T = self.state.T()
-                else:
-                    self.state.update(pair, vals[0][index], vals[1][index])
-                vals[2][index] = self.state.keyed_output(idxs[2])
+                tracer = IsoLineTracer(self.state, idxs[0], idxs[1], self.i_index)
             except Exception as e:
                 warnings.warn(
-                  "An error occurred for inputs {0:f}, {1:f} with index {2:s}: {3:s}".format(vals[0][index], vals[1][index], str(index), str(e)),
+                  "Could not set up the isoline tracer, falling back to flash calculations: {0:s}".format(str(e)),
                   UserWarning)
-                vals[2][index] = np.nan
-                guesses.rhomolar = np.nan
-                guesses.T = np.nan
-                err = True
+        for index, _ in np.ndenumerate(vals[0]):
+            traced = False
+            if tracer is not None:
+                try:
+                    tracer.update(vals[0][index], vals[1][index])
+                    vals[2][index] = tracer.keyed_output(idxs[2])
+                    traced = np.isfinite(vals[2][index])
+                except Exception:
+                    traced = False
+            if not traced:
+                try:
+                    self.state.update(pair, vals[0][index], vals[1][index])
+                    vals[2][index] = self.state.keyed_output(idxs[2])
+                    if tracer is not None:
+                        tracer.set_guess(self.state)
+                except Exception as e:
+                    warnings.warn(
+                      "An error occurred for inputs {0:f}, {1:f} with index {2:s}: {3:s}".format(vals[0][index], vals[1][index], str(index), str(e)),
+                      UserWarning)
+                    vals[2][index] = np.nan
+                    err = True
 
         for i, v in enumerate(idxs):
             if v == self.x_index: self.x = vals[i]

--- a/wrappers/Python/CoolProp/Plots/Common.py
+++ b/wrappers/Python/CoolProp/Plots/Common.py
@@ -612,7 +612,7 @@ class IsoLineTracer(object):
         try:
             self._sp.specify_phase(CoolProp.iphase_gas)
         except Exception:
-            pass
+            pass  # backend without an imposed phase; correctness does not depend on it
         # Using the isoline's own constant as the saturation variable makes the
         # bracket constant along the whole line, so it is computed only once.
         if iso_index in (CoolProp.iT, CoolProp.iP) and iso_index in (index1, index2):
@@ -642,16 +642,24 @@ class IsoLineTracer(object):
         fall back on the default one and the isoline would mix two models --
         traced points from the defaults, flashed points from the caller's.
         Pressure at a given ``(T, rhomolar)`` is a direct function of the
-        model, so one comparison settles it.  A caller whose state is
-        two-phase or has never been updated gives nothing to compare against,
-        and then this cannot help.
+        model, so one comparison settles it.
+
+        The one case this cannot cover: a caller whose state is two-phase or
+        has never been updated gives nothing to compare against, and a
+        departure function is invisible either way, so a mixture customised
+        that way and handed over in that state would be traced with the
+        default model while its fallback points were flashed with the
+        caller's.  Everything reachable through ``set_binary_interaction_double``
+        and ``apply_simple_mixing_rule`` is copied outright and unaffected,
+        and ``PropertyPlot`` leaves its state single-phase, so the probe does
+        run on the path that matters.
         """
         try:
             if state.Q() >= 0.0:
                 return
             T, rhomolar, expected = state.T(), state.rhomolar(), state.p()
         except Exception:
-            return
+            return  # nothing to compare the clone against; see the docstring
         if not (np.isfinite(T) and np.isfinite(rhomolar) and np.isfinite(expected)):
             return
         self._sp.update(CoolProp.DmolarT_INPUTS, rhomolar, T)
@@ -672,6 +680,7 @@ class IsoLineTracer(object):
         return self._out
 
     def keyed_output(self, key):
+        """Read a property of the most recently traced point"""
         return self.state.keyed_output(key)
 
     def set_guess(self, state):
@@ -693,7 +702,7 @@ class IsoLineTracer(object):
                 return
             T, rhomolar = state.T(), state.rhomolar()
         except Exception:
-            return
+            return  # unusable state; keep whatever warm start we already had
         if np.isfinite(T) and np.isfinite(rhomolar) and T > 0.0 and rhomolar > 0.0:
             self._T = T
             self._rhomolar = rhomolar
@@ -746,7 +755,7 @@ class IsoLineTracer(object):
             if np.isfinite(value) and value > 0.0:
                 bounds['T_min'] = value
         except Exception:
-            pass
+            pass  # no lower limit published; the runaway guard uses the upper one
         return bounds
 
     def _find_saturation_bounds(self):
@@ -784,15 +793,16 @@ class IsoLineTracer(object):
             data = self._sat.get_phase_envelope_data()
             envelope = {CoolProp.iT: max(data.T), CoolProp.iP: max(data.p)}
         except Exception:
-            pass
+            pass  # no envelope: every point must be bracketed or handed back
         outer = dict(envelope)
         try:
             for index, name in ((CoolProp.iT, 'Tcrit'), (CoolProp.iP, 'pcrit')):
                 critical = max(PropsSI(name, fluid) for fluid in self._sat.fluid_names())
                 outer[index] = max(outer.get(index, 0.0), critical)
         except Exception:
-            pass
+            pass  # no component critical data; the envelope alone has to do
         def clean(candidate):
+            """Drop unusable bounds, clamp to the EOS range, apply the margin"""
             bounds = {}
             for index, value in candidate.items():
                 if not (np.isfinite(value) and value > 0.0):
@@ -834,7 +844,7 @@ class IsoLineTracer(object):
                 return (temperatures[hot] * self.DOME_MARGIN,
                         float(np.max(np.asarray(data.p, dtype=float))) * self.DOME_MARGIN)
         except Exception:
-            pass
+            pass  # envelope unusable; fall through to locating the critical point
         # An envelope that stopped early bounds neither.  The critical point can
         # be located directly, which is slow enough to be worth avoiding when
         # the envelope already answered, and gives the temperature only: the
@@ -845,7 +855,7 @@ class IsoLineTracer(object):
             if stable:
                 return max(stable) * self.DOME_MARGIN, None
         except Exception:
-            pass
+            pass  # critical point not locatable; fall back on the outer bound
         return self._saturation_bounds.get(CoolProp.iT), None
 
     def _is_plausible_saturation(self, T, p):
@@ -996,6 +1006,7 @@ class IsoLineTracer(object):
     # Two-phase point: solve for the vapour quality
     # -------------------------------------------------------------------
     def _quality_residual(self, quality, bracket):
+        """How far the two-phase state at this quality is from the target"""
         if self._sat_index == CoolProp.iT:
             self._sat.update(CoolProp.QT_INPUTS, quality, self._sat_value)
         else:
@@ -1054,6 +1065,11 @@ class IsoLineTracer(object):
         raise ValueError("No initial guess is available for the Newton iteration.")
 
     def _solve_single_phase(self, targets, bracket):
+        """Newton iteration in (T, rhomolar) onto both target properties
+
+        Raises unless it settles on a root that is checked, in range, and on
+        the side of the saturation curve the bracket says it should be.
+        """
         T, rhomolar = self._seed(bracket)
         i1, i2, state = self._i1, self._i2, self._sp
         v1, v2 = targets[i1], targets[i2]
@@ -1140,7 +1156,8 @@ class IsoLineTracer(object):
         accepted unexamined, which is exactly where the dome is.
         """
         if bracket is None:
-            return self._check_outside_the_dome(T, rhomolar)
+            self._check_outside_the_dome(T, rhomolar)
+            return
         if side is None:
             return
         if side == self.LIQUID:
@@ -1238,7 +1255,9 @@ class IsoLine(Base2DObject):
         return self._tracing
 
     @tracing.setter
-    def tracing(self, value): self._tracing = bool(value)
+    def tracing(self, value):
+        """Turn isoline tracing on or off for this line"""
+        self._tracing = bool(value)
 
     @property
     def value(self): return self._value

--- a/wrappers/Python/CoolProp/Plots/Common.py
+++ b/wrappers/Python/CoolProp/Plots/Common.py
@@ -462,6 +462,35 @@ class Base2DObject(object, metaclass=ABCMeta):
 _BINARY_INTERACTION_KEYS = ('betaT', 'gammaT', 'betaV', 'gammaV', 'Fij', 'kij')
 
 
+#: A two-phase state whose two phases differ in density by less than this,
+#: relatively, is the trivial solution: the VLE solver collapsed both phases
+#: onto the same root rather than converging on a saturation state.  Measured
+#: over Q sweeps of eight fluids, genuine states bottom out at 3.4e-3 (Air,
+#: right at its critical point) while collapsed ones come in at ~1e-6, so this
+#: sits about thirty times clear of both.
+_TRIVIAL_SOLUTION_RTOL = 1e-4
+
+
+def _phases_are_distinct(state):
+    """Whether a two-phase state really has two phases
+
+    Near the critical point the mixture QT and PQ solvers can return the
+    trivial solution, reporting the requested quality and a state whose
+    saturated liquid and vapour are the same root.  The result is a plausible
+    looking point that is nowhere near the one asked for -- on an R513A Q=0.5
+    line it puts the last point 93 J/kg/K along in entropy, which is the jag
+    at the top of the dome.
+    """
+    try:
+        rho_liq = state.saturated_liquid_keyed_output(CoolProp.iDmolar)
+        rho_vap = state.saturated_vapor_keyed_output(CoolProp.iDmolar)
+    except Exception:
+        return True         # nothing to check against; the caller's other tests apply
+    if not (np.isfinite(rho_liq) and np.isfinite(rho_vap)) or rho_liq <= 0.0 or rho_vap <= 0.0:
+        return False
+    return (rho_liq - rho_vap) > _TRIVIAL_SOLUTION_RTOL * max(rho_liq, rho_vap)
+
+
 def _clone_state(state):
     """Return a fresh AbstractState with the same backend, fluids and model"""
     fluids = state.fluid_names()
@@ -936,10 +965,10 @@ class IsoLineTracer(object):
         v_liq, v_vap = ends['liq'][0], ends['vap'][0]
         if not (np.isfinite(v_liq) and np.isfinite(v_vap)):
             raise ValueError("The saturation states are not finite.")
-        # A saturation solver that converged on the wrong branch would make
-        # every branch decision below meaningless, so check the one thing that
-        # always holds: the saturated liquid is the denser one.
-        if not ends['liq'][2] > ends['vap'][2]:
+        # A saturation solver that converged on the wrong branch, or onto the
+        # trivial solution with both phases at one density, would make every
+        # branch decision below meaningless.
+        if not ends['liq'][2] > ends['vap'][2] * (1.0 + _TRIVIAL_SOLUTION_RTOL):
             raise ValueError("The saturation states are not on their own branches.")
         degenerate = abs(v_vap - v_liq) <= self.BRACKET_RTOL * max(abs(v_liq), abs(v_vap), 1e-30)
         return {'target_index': target_index, 'liq': ends['liq'], 'vap': ends['vap'],
@@ -1304,6 +1333,10 @@ class IsoLine(Base2DObject):
         for index, _ in np.ndenumerate(one):
             try:
                 self.state.update(pair, one[index], two[index])
+                if not _phases_are_distinct(self.state):
+                    raise ValueError(
+                      "The saturation solver returned the trivial solution, with both "
+                      "phases at the same density.")
                 X[index] = self.state.keyed_output(self._x_index)
                 Y[index] = self.state.keyed_output(self._y_index)
             except Exception as e:

--- a/wrappers/Python/CoolProp/Plots/Common.py
+++ b/wrappers/Python/CoolProp/Plots/Common.py
@@ -571,6 +571,13 @@ class IsoLineTracer(object):
     LIQUID = -1
     VAPOUR = 1
 
+    #: Critical temperatures keyed by fluid, for the blends whose phase
+    #: envelope does not reach the critical point and where locating it costs
+    #: seconds to minutes.  Unlike the envelope, this lookup has no side effect
+    #: on the state that produced it, so caching it cannot make one tracer
+    #: behave differently from the next.
+    _CRITICAL_T = {}
+
     @classmethod
     def supports(cls, index1, index2):
         """Whether an isoline with these two inputs can be traced
@@ -624,7 +631,7 @@ class IsoLineTracer(object):
         self._eos_bounds = self._find_eos_bounds()
         envelope_bounds, self._saturation_bounds = self._find_saturation_bounds()
         self._dome_limit = envelope_bounds.get(self._sat_index)
-        self._dome_T_limit, self._dome_p_limit = self._find_dome_limits()
+        self._dome_T_limit = self._find_dome_temperature_limit()
         self._sat_value = None
         self._bracket = None
         self._bracket_failure = None
@@ -815,8 +822,19 @@ class IsoLineTracer(object):
             return {k: v * self.DOME_MARGIN for k, v in bounds.items()}
         return clean(envelope), clean(outer)
 
-    def _find_dome_limits(self):
-        """The temperature, and pressure, above which there is certainly no dome
+    def _find_dome_temperature_limit(self):
+        """The temperature above which there is certainly no two-phase region
+
+        Temperature only, deliberately.  A pressure bound looks like it should
+        be just as usable -- above the cricondenbar no two-phase state exists
+        at that pressure -- but it does not answer the question this is for.
+        What has to be decided is whether the ``(T, rhomolar)`` the Newton
+        iteration landed on is the stable root at *its own* temperature, and
+        the EOS pressure along the metastable branch inside the dome runs well
+        above the cricondenbar, so a root there satisfies a high-pressure
+        isobar perfectly while sitting between the saturation densities.
+        Short-circuiting on pressure shipped 69 such roots on a default
+        R441A T-s plot, 8.7 % out in temperature.
 
         This one has to be right rather than generous: it is what decides
         whether a saturation call that could not answer counts as "there is no
@@ -841,22 +859,29 @@ class IsoLineTracer(object):
             if closed:
                 # The trace covered the whole dome, so its own extremes are the
                 # cricondentherm and the cricondenbar.
-                return (temperatures[hot] * self.DOME_MARGIN,
-                        float(np.max(np.asarray(data.p, dtype=float))) * self.DOME_MARGIN)
+                return temperatures[hot] * self.DOME_MARGIN
         except Exception:
             pass  # envelope unusable; fall through to locating the critical point
-        # An envelope that stopped early bounds neither.  The critical point can
-        # be located directly, which is slow enough to be worth avoiding when
-        # the envelope already answered, and gives the temperature only: the
-        # cricondenbar can lie above the critical pressure, so no pressure
-        # bound is claimed here and pressure simply stops short-circuiting.
-        try:
-            stable = [point.T for point in self._sat.all_critical_points() if point.stable]
-            if stable:
-                return max(stable) * self.DOME_MARGIN, None
-        except Exception:
-            pass  # critical point not locatable; fall back on the outer bound
-        return self._saturation_bounds.get(CoolProp.iT), None
+        # An envelope that stopped early does not bound the dome.  The critical
+        # point can be located directly, which is slow enough to be worth
+        # avoiding whenever the envelope already answered.
+        key = (self._sat.backend_name(), tuple(self._sat.fluid_names()),
+               tuple(self._sat.get_mole_fractions()))
+        if key not in self._CRITICAL_T:
+            if len(self._CRITICAL_T) > 64:  # a plotting session, not a cache
+                self._CRITICAL_T.clear()
+            critical = None
+            try:
+                stable = [point.T for point in self._sat.all_critical_points() if point.stable]
+                if stable:
+                    critical = max(stable)
+            except Exception:
+                pass  # critical point not locatable; fall back on the outer bound
+            self._CRITICAL_T[key] = critical
+        critical = self._CRITICAL_T[key]
+        if critical is not None:
+            return critical * self.DOME_MARGIN
+        return self._saturation_bounds.get(CoolProp.iT)
 
     def _is_plausible_saturation(self, T, p):
         """Whether a state the saturation solver returned can be on the dome"""
@@ -1187,9 +1212,6 @@ class IsoLineTracer(object):
         """
         if self._dome_T_limit is not None and T > self._dome_T_limit:
             return          # above the critical point; there is no dome to be in
-        if self._sat_index == CoolProp.iP and self._dome_p_limit is not None \
-                and self._sat_value is not None and self._sat_value > self._dome_p_limit:
-            return          # above the cricondenbar; this isobar has no dome
         undecided = None
         try:
             self._sat.update(CoolProp.QT_INPUTS, 0.0, T)

--- a/wrappers/Python/CoolProp/Plots/Common.py
+++ b/wrappers/Python/CoolProp/Plots/Common.py
@@ -1200,7 +1200,10 @@ class IsoLineTracer(object):
             undecided = "the saturation solver did not converge"
         if undecided is None and not self._is_plausible_saturation(T, max(p_liq, p_vap)):
             undecided = "the saturation solver left the dome behind"
-        if undecided is None and not rho_liq > rho_vap:
+        if undecided is None and not _phases_are_distinct(self._sat):
+            # Same trivial solution the bracket has to reject: a positive but
+            # vanishing density gap is the solver collapsing both phases, not
+            # a narrow dome, and it would let a root inside one through.
             undecided = "the saturation states are not on their own branches"
         if undecided is not None:
             bound = self._dome_T_limit

--- a/wrappers/Python/CoolProp/Plots/Plots.py
+++ b/wrappers/Python/CoolProp/Plots/Plots.py
@@ -114,17 +114,20 @@ class PropertyPlot(BasePlot):
             output = np.unique(output)
         return output
 
-    def calc_isolines(self, iso_type=None, iso_range=None, num=15, rounding=False, points=250):
+    def calc_isolines(self, iso_type=None, iso_range=None, num=15, rounding=False, points=250, tracing=True):
         """Calculate lines with constant values of type 'iso_type' in terms of x and y as
         defined by the plot object. 'iso_range' either is a collection of values or
         simply the minimum and maximum value between which 'num' lines get calculated.
         The 'rounding' parameter can be used to generate prettier labels if needed.
+        Pass tracing=False to calculate every point with an independent flash
+        instead of walking along the isoline; that is much slower and leaves
+        more gaps, but it does not depend on the neighbouring points.
         """
 
         if iso_type is None or iso_type == 'all':
             for i_type in IsoLine.XY_SWITCH:
                 if IsoLine.XY_SWITCH[i_type].get(self.y_index * 10 + self.x_index, None) is not None:
-                    self.calc_isolines(i_type, None, num, rounding, points)
+                    self.calc_isolines(i_type, None, num, rounding, points, tracing)
             return
 
         if iso_range is None:
@@ -157,7 +160,7 @@ class PropertyPlot(BasePlot):
 
         lines = self.isolines.get(iso_type, [])
         for i in range(num):
-            lines.append(IsoLine(iso_type, self._x_index, self._y_index, value=dim.to_SI(iso_range[i]), state=self._state))
+            lines.append(IsoLine(iso_type, self._x_index, self._y_index, value=dim.to_SI(iso_range[i]), state=self._state, tracing=tracing))
             lines[-1].calc_range(ixrange, iyrange)
             lines[-1].sanitize_data()
         self.isolines[iso_type] = lines

--- a/wrappers/Python/pytest/test_isoline_tracer.py
+++ b/wrappers/Python/pytest/test_isoline_tracer.py
@@ -491,6 +491,78 @@ class TestFluidModelIsCarriedOver:
         assert _relerr(tracer.keyed_output(CoolProp.iHmass), state.hmass()) < 1e-9
 
 
+class TestCollapsedPairInTheUnbracketedCheck:
+    """The no-bracket path must reject a collapsed saturation pair too
+
+    `_check_outside_the_dome` compares a root against the saturation densities
+    at its own temperature.  A bare ``rho_liq > rho_vap`` is satisfied by the
+    VLE solver's trivial solution -- both phases converged onto one root, which
+    CoolProp really does return near the critical point of a mixture (on R513A
+    at Q=0.5, 367.433 K, it reports rho_liq and rho_vap equal to seven digits)
+    -- and a root between two densities that are the same number is every root.
+
+    The pair is injected rather than provoked: that state is reachable at
+    intermediate quality but not through the Q=0 and Q=1 calls this path makes,
+    where the solver raises instead.  What is under test is this module's
+    handling of such a pair, not CoolProp's production of one.
+    """
+
+    class _CollapsedSaturation:
+        """Minimal stand-in for the tracer's saturation state object"""
+
+        def __init__(self, rho_liq, rho_vap, p):
+            self._rho = {0.0: rho_liq, 1.0: rho_vap}
+            self._rho_liq, self._rho_vap, self._p = rho_liq, rho_vap, p
+            self._q = 0.0
+
+        def update(self, pair, quality, value):
+            """Accept the QT call and remember which end was asked for"""
+            self._q = quality
+
+        def rhomolar(self):
+            """Bulk density of the end most recently asked for"""
+            return self._rho[self._q]
+
+        def p(self):
+            """Pressure, well inside any plausible bound"""
+            return self._p
+
+        def saturated_liquid_keyed_output(self, key):
+            """Saturated liquid density, as the trivial solution reports it"""
+            return self._rho_liq
+
+        def saturated_vapor_keyed_output(self, key):
+            """Saturated vapour density, indistinguishable from the liquid"""
+            return self._rho_vap
+
+    def test_a_collapsed_pair_cannot_certify_a_root(self, Common):
+        """Densities that agree to seven digits decide nothing
+
+        The dangerous root is the one *outside* the collapsed pair, not inside
+        it.  A root between two nearly-equal numbers is caught either way; a
+        root anywhere else is "outside the dome" according to a bare
+        ``rho_liq > rho_vap``, and that is every root the Newton can reach.
+        """
+        tracer = Common.IsoLineTracer(AbstractState("HEOS", "R513A.mix"),
+                                      CoolProp.iP, CoolProp.iSmass, CoolProp.iP)
+        T = 300.0
+        assert tracer._dome_T_limit is None or T <= tracer._dome_T_limit, \
+            "the test temperature has to be one where a dome could exist"
+        rho_liq, rho_vap = 2408.7702, 2408.7601        # gap 4.2e-6, as observed
+        tracer._sat = self._CollapsedSaturation(rho_liq, rho_vap, 3.4e6)
+        with pytest.raises(ValueError):
+            tracer._check_outside_the_dome(T, 5000.0)      # nowhere near the pair
+        with pytest.raises(ValueError):
+            tracer._check_outside_the_dome(T, 0.5 * (rho_liq + rho_vap))
+
+        # and a pair that really is separated still decides normally
+        tracer._sat = self._CollapsedSaturation(11395.8, 2175.9, 3.4e6)
+        with pytest.raises(ValueError):
+            tracer._check_outside_the_dome(T, 5000.0)      # between them
+        tracer._check_outside_the_dome(T, 14000.0)         # denser than liquid
+        tracer._check_outside_the_dome(T, 100.0)           # thinner than vapour
+
+
 class TestPressureIsNotAProxyForTheDome:
     """A pressure above the cricondenbar does not make a root safe
 

--- a/wrappers/Python/pytest/test_isoline_tracer.py
+++ b/wrappers/Python/pytest/test_isoline_tracer.py
@@ -1,0 +1,501 @@
+"""Coverage for CoolProp.Plots.Common.IsoLineTracer (bd CoolProp-dgxi).
+
+The tracer walks along an isoline instead of flashing every point cold, which
+is what makes a mixture property plot finish in seconds rather than minutes
+(GH discussion #3269).  What these tests pin down is that the speed does not
+cost correctness, and in particular the three ways it could:
+
+* the traced point has to be the same state the flash would have found;
+* the tracer has to stay on the right side of the saturation curve -- which
+  for a near-azeotropic blend cannot be decided from the bubble and dew values
+  of the swept property, because they agree to within round-off;
+* an isoline the tracer cannot bracket has to be flashed, not traced.  A
+  phase-imposed Newton iteration converges happily on the metastable extension
+  of the EOS inside the two-phase dome, and the answer looks entirely
+  self-consistent, so nothing downstream would notice.
+
+``CoolProp.Plots.Common`` imports matplotlib, so everything here skips without
+it.
+"""
+import pytest
+
+import CoolProp
+from CoolProp import AbstractState
+
+
+@pytest.fixture(scope="module")
+def Common():
+    pytest.importorskip("matplotlib")
+    import matplotlib
+    matplotlib.use("Agg")
+    from CoolProp.Plots import Common
+    return Common
+
+
+def _tracer(Common, backend, fluid, index1, index2, iso_index):
+    return Common.IsoLineTracer(AbstractState(backend, fluid), index1, index2, iso_index)
+
+
+def _reconstruct(backend, fluid, state, mole_fractions=None):
+    """Rebuild a traced state from (T, Q) or (T, rho) on a fresh object
+
+    Neither route uses a two-dimensional flash, so this checks the solvers the
+    tracer used to get there.  The single-phase route imposes the phase
+    because the free ``DmassT`` path on a mixture can return a state at a
+    different density than it was given (bd CoolProp-1gth).
+
+    Note what this deliberately does *not* prove: re-evaluating the same
+    ``(T, rho)`` reproduces a metastable root just as faithfully as a stable
+    one, so a root that should have been two-phase reconstructs perfectly.
+    Checking for that needs the saturation densities at the point's own
+    temperature -- see TestBranchSelection and TestUnbracketableInputs.
+    """
+    fresh = AbstractState(backend, fluid)
+    if mole_fractions is not None:
+        fresh.set_mole_fractions(mole_fractions)
+    Q = state.Q()
+    if 0.0 <= Q <= 1.0:
+        fresh.update(CoolProp.QT_INPUTS, Q, state.T())
+    else:
+        fresh.specify_phase(CoolProp.iphase_gas)
+        fresh.update(CoolProp.DmassT_INPUTS, state.rhomass(), state.T())
+    return fresh
+
+
+def _relerr(a, b):
+    return abs(a - b) / max(abs(a), abs(b), 1e-8)
+
+
+def _isoline(Common, fluid, graph, iso_type, value, points, tracing=True):
+    """Calculate one isoline the way PropertyPlot.calc_isolines does"""
+    from CoolProp.Plots import PropertyPlot
+    import numpy as np
+    plot = PropertyPlot(fluid, graph, unit_system='SI', tp_limits='ACHP')
+    limits = plot._get_axis_limits()
+    xvals = plot.generate_ranges(plot._x_index, limits[0], limits[1], points)
+    yvals = plot.generate_ranges(plot._y_index, limits[2], limits[3], points)
+    line = Common.IsoLine(iso_type, plot._x_index, plot._y_index,
+                          value=value, state=plot._state, tracing=tracing)
+    line.calc_range(xvals, yvals)
+    return np.asarray(line.x), np.asarray(line.y)
+
+
+class TestSinglePhase:
+    def test_isentrope_matches_the_flash(self, Common):
+        """A traced superheated isentrope reproduces the PSmass flash"""
+        smass = 7000.0  # J/kg/K, superheated steam
+        tracer = _tracer(Common, "HEOS", "Water", CoolProp.iP, CoolProp.iSmass, CoolProp.iSmass)
+        flash = AbstractState("HEOS", "Water")
+        for p in [1e5, 3e5, 1e6, 3e6, 1e7]:
+            tracer.update(p, smass)
+            flash.update(CoolProp.PSmass_INPUTS, p, smass)
+            assert _relerr(tracer.keyed_output(CoolProp.iHmass), flash.hmass()) < 1e-9
+            assert _relerr(tracer.keyed_output(CoolProp.iT), flash.T()) < 1e-9
+
+    def test_traced_state_reconstructs(self, Common):
+        """Every traced point rebuilds to itself from (T, rho) alone"""
+        tracer = _tracer(Common, "HEOS", "R134a", CoolProp.iP, CoolProp.iSmass, CoolProp.iSmass)
+        smass = 1900.0
+        for p in [5e4, 1e5, 2e5, 5e5, 1e6]:
+            tracer.update(p, smass)
+            fresh = _reconstruct("HEOS", "R134a", tracer.state)
+            assert _relerr(fresh.smass(), smass) < 1e-8
+            assert _relerr(fresh.p(), p) < 1e-8
+
+
+class TestTwoPhase:
+    def test_quality_solve_on_a_wide_glide_mixture(self, Common):
+        """Inside the dome the tracer solves for the quality, not a density root"""
+        fluid = "Methane&Ethane"
+        state = AbstractState("HEOS", fluid)
+        state.set_mole_fractions([0.6, 0.4])
+        sat = AbstractState("HEOS", fluid)
+        sat.set_mole_fractions([0.6, 0.4])
+        p = 2e6
+        sat.update(CoolProp.PQ_INPUTS, p, 0.0)
+        s_liq = sat.smass()
+        sat.update(CoolProp.PQ_INPUTS, p, 1.0)
+        s_vap = sat.smass()
+        assert s_vap - s_liq > 1.0, "the test needs a real two-phase span"
+
+        tracer = Common.IsoLineTracer(state, CoolProp.iP, CoolProp.iSmass, CoolProp.iP)
+        for frac in [0.2, 0.5, 0.8]:
+            smass = s_liq + frac * (s_vap - s_liq)
+            tracer.update(p, smass)
+            assert 0.0 < tracer.state.Q() < 1.0
+            assert _relerr(tracer.keyed_output(CoolProp.iSmass), smass) < 1e-8
+            assert _relerr(tracer.keyed_output(CoolProp.iP), p) < 1e-8
+            fresh = _reconstruct("HEOS", fluid, tracer.state, [0.6, 0.4])
+            assert _relerr(fresh.smass(), smass) < 1e-8
+            assert _relerr(fresh.p(), p) < 1e-8
+
+
+class TestBranchSelection:
+    def test_near_azeotrope_isotherm_crosses_to_the_liquid(self, Common):
+        """R513A brackets p by psat on both sides; the branch must not be guessed
+
+        Near 305 K the bubble and dew pressures of this blend come within
+        1.4e-9 relative of each other, which is inside BRACKET_RTOL, so the
+        bracket reads as degenerate and its two values cannot say which side
+        of the saturation curve a point is on.  The branch has to come from
+        the slope of p along density instead.  Pick the temperature carefully:
+        a few degrees away the gap is 1e-6 or wider and the value comparison
+        would carry the test on its own.
+        """
+        T = 305.0
+        state = AbstractState("HEOS", "R513A.mix")
+        sat = AbstractState("HEOS", "R513A.mix")
+        sat.update(CoolProp.QT_INPUTS, 0.0, T)
+        psat = sat.p()
+        tracer = Common.IsoLineTracer(state, CoolProp.iP, CoolProp.iT, CoolProp.iT)
+        flash = AbstractState("HEOS", "R513A.mix")
+        for p, expect_liquid in [(0.5 * psat, False), (0.9 * psat, False),
+                                 (1.1 * psat, True), (2.0 * psat, True)]:
+            tracer.update(p, T)
+            rho = tracer.state.rhomass()
+            sat.update(CoolProp.QT_INPUTS, 1.0 if not expect_liquid else 0.0, T)
+            if expect_liquid:
+                assert rho > sat.rhomass() * (1.0 - 1e-6), "expected the liquid branch at p={0}".format(p)
+            else:
+                assert rho < sat.rhomass() * (1.0 + 1e-6), "expected the vapour branch at p={0}".format(p)
+            flash.update(CoolProp.PT_INPUTS, p, T)
+            assert _relerr(tracer.keyed_output(CoolProp.iHmass), flash.hmass()) < 1e-8
+
+    def test_the_slope_is_what_decides_the_branch_there(self, Common):
+        """Without the derivative probe the same points cannot be placed
+
+        This is what stops the previous test passing for the wrong reason: at
+        a temperature where the bracket is not degenerate, the value order
+        alone would do the job and the slope would be dead weight.
+        """
+        T = 305.0
+        state = AbstractState("HEOS", "R513A.mix")
+        sat = AbstractState("HEOS", "R513A.mix")
+        sat.update(CoolProp.QT_INPUTS, 0.0, T)
+        psat = sat.p()
+        tracer = Common.IsoLineTracer(state, CoolProp.iP, CoolProp.iT, CoolProp.iT)
+        tracer._branch_slope = lambda *args: None
+        for p in [0.5 * psat, 0.9 * psat, 1.1 * psat, 2.0 * psat]:
+            with pytest.raises(ValueError):
+                tracer.update(p, T)
+
+    def test_wrong_branch_is_handed_back(self, Common):
+        """A root inside the dome is rejected rather than reported"""
+        state = AbstractState("HEOS", "Water")
+        tracer = Common.IsoLineTracer(state, CoolProp.iP, CoolProp.iT, CoolProp.iT)
+        sat = AbstractState("HEOS", "Water")
+        sat.update(CoolProp.QT_INPUTS, 0.0, 400.0)
+        rho_liq = sat.rhomolar()
+        sat.update(CoolProp.QT_INPUTS, 1.0, 400.0)
+        rho_vap = sat.rhomolar()
+        bracket = {'liq': (sat.p(), 400.0, rho_liq), 'vap': (sat.p(), 400.0, rho_vap)}
+        mid = 0.5 * (rho_liq + rho_vap)
+        with pytest.raises(ValueError):
+            tracer._check_branch(bracket, tracer.LIQUID, 400.0, mid)
+        with pytest.raises(ValueError):
+            tracer._check_branch(bracket, tracer.VAPOUR, 400.0, mid)
+        # the saturation densities themselves are on their own branch
+        tracer._check_branch(bracket, tracer.LIQUID, 400.0, rho_liq)
+        tracer._check_branch(bracket, tracer.VAPOUR, 400.0, rho_vap)
+
+    def test_an_undecidable_unbracketed_root_is_handed_back(self, Common):
+        """A dome check that cannot answer is not the same as "no dome"
+
+        For an isoline indexed by temperature, the check runs the very call at
+        the very temperature that building the bracket already failed on, so
+        it can add nothing.  Reading that as "beyond the dome" left a band on
+        R504 -- above where its saturation solver converges, below its real
+        critical point at 335.5 K, which its phase envelope stops 37 K short
+        of -- where roots inside the dome were accepted unexamined.
+        """
+        tracer = Common.IsoLineTracer(AbstractState("HEOS", "R504.mix"),
+                                      CoolProp.iP, CoolProp.iT, CoolProp.iT)
+        sat = AbstractState("HEOS", "R504.mix")
+        undecidable = []
+        for T in (325.0, 330.0, 334.0):
+            try:
+                sat.update(CoolProp.QT_INPUTS, 0.0, T)
+            except Exception:
+                undecidable.append(T)
+        assert undecidable, "this fluid is meant to defeat the saturation solver here"
+        assert tracer._dome_T_limit > max(undecidable), \
+            "the band has to be below the temperature where a dome can still exist"
+        for T in undecidable:
+            with pytest.raises(ValueError):
+                tracer._check_outside_the_dome(T, 5000.0)
+        # and well above the critical point there really is no dome, cheaply
+        tracer._check_outside_the_dome(tracer._dome_T_limit * 1.5, 5000.0)
+
+    def test_an_unbracketed_root_is_still_checked(self, Common):
+        """Without a bracket the dome is checked at the root's own temperature
+
+        The reported extent of the phase envelope is not enough on its own:
+        for R504 the trace stops about 20 K short of the real cricondentherm,
+        and points in between used to be accepted unexamined -- inside the
+        dome, as it turns out.
+        """
+        tracer = Common.IsoLineTracer(AbstractState("HEOS", "R504.mix"),
+                                      CoolProp.iP, CoolProp.iSmass, CoolProp.iP)
+        sat = AbstractState("HEOS", "R504.mix")
+        T = 314.54                       # beyond the envelope, inside the dome
+        sat.update(CoolProp.QT_INPUTS, 0.0, T); rho_liq = sat.rhomolar()
+        sat.update(CoolProp.QT_INPUTS, 1.0, T); rho_vap = sat.rhomolar()
+        assert rho_liq > rho_vap
+        with pytest.raises(ValueError):
+            tracer._check_branch(None, None, T, 0.5 * (rho_liq + rho_vap))
+        # and a root that really is outside passes
+        tracer._check_branch(None, None, T, rho_liq * 1.05)
+        tracer._check_branch(None, None, T, rho_vap * 0.95)
+
+
+class TestIsoLineIntegration:
+    def test_tracing_is_on_by_default_and_switching_it_off_reaches_the_flash(self, Common):
+        """The flag has to change what calc_range does, not just its own value"""
+        import numpy as np
+        line = Common.IsoLine(CoolProp.iT, CoolProp.iHmass, CoolProp.iP, value=300.0,
+                              state=AbstractState("HEOS", "Water"))
+        assert line.tracing is True
+        line.tracing = False
+        assert line.tracing is False
+
+        calls = []
+        original = Common.IsoLineTracer.update
+
+        def counting(self, v1, v2):
+            calls.append(1)
+            return original(self, v1, v2)
+
+        Common.IsoLineTracer.update = counting
+        try:
+            args = (Common, 'HEOS::Water', 'PH', CoolProp.iSmass, 7000.0, 20)
+            off_x, off_y = _isoline(*args, tracing=False)
+            assert calls == [], "tracing=False still went through the tracer"
+            on_x, on_y = _isoline(*args, tracing=True)
+            assert calls, "tracing=True never reached the tracer"
+        finally:
+            Common.IsoLineTracer.update = original
+        both = np.isfinite(off_x) & np.isfinite(off_y)
+        assert both.any()
+        assert np.allclose(on_x[both], off_x[both], rtol=1e-7)
+        assert np.allclose(on_y[both], off_y[both], rtol=1e-7)
+
+
+class TestUnbracketableInputs:
+    """An isoline whose inputs are neither T nor p must not be traced
+
+    A phase-imposed Newton iteration has nothing to stop it converging on the
+    metastable extension of the EOS inside the two-phase dome, and without T
+    or p among the inputs there is no saturation bracket to rule that out.
+    Constant-enthalpy lines on a T-s diagram are the case that bites: they are
+    ordinary plot furniture and they cross the dome.
+    """
+
+    def test_supports_requires_temperature_or_pressure(self, Common):
+        assert Common.IsoLineTracer.supports(CoolProp.iP, CoolProp.iSmass)
+        assert Common.IsoLineTracer.supports(CoolProp.iHmass, CoolProp.iT)
+        assert not Common.IsoLineTracer.supports(CoolProp.iHmass, CoolProp.iSmass)
+        assert not Common.IsoLineTracer.supports(CoolProp.iDmass, CoolProp.iSmass)
+
+    def test_constructor_refuses_an_unbracketable_pair(self, Common):
+        with pytest.raises(ValueError):
+            Common.IsoLineTracer(AbstractState("HEOS", "Water"),
+                                 CoolProp.iHmass, CoolProp.iSmass, CoolProp.iHmass)
+
+    def test_constant_enthalpy_on_a_ts_diagram_matches_the_flash(self, Common):
+        """Every point of this line is flashed, so it must equal the flash"""
+        import numpy as np
+        value = 1.86222e6
+        state = AbstractState("HEOS", "Water")
+        line = Common.IsoLine(CoolProp.iHmass, CoolProp.iSmass, CoolProp.iT,
+                              value=value, state=state)
+        _, _, _, pair = line.get_update_pair()
+        assert pair == CoolProp.HmassSmass_INPUTS
+        svals = np.linspace(4000.0, 7000.0, 40)
+        line.calc_range(svals, None)
+        flash = AbstractState("HEOS", "Water")
+        checked = 0
+        for smass, T in zip(svals, line.y):
+            if not np.isfinite(T):
+                continue
+            flash.update(CoolProp.HmassSmass_INPUTS, value, smass)
+            assert _relerr(T, flash.T()) < 1e-6, (
+                "traced {0} K where the flash gives {1} K at Q={2}".format(T, flash.T(), flash.Q()))
+            checked += 1
+        assert checked > 20, "the line has to actually cross the region of interest"
+
+
+class TestNoMetastableRoots:
+    """No point the tracer calls single phase may sit inside the dome
+
+    This is the check that a reconstruction from (T, rho) cannot make: the
+    metastable root re-evaluates to itself perfectly.  Only the saturation
+    densities at the point's own temperature can tell the two apart.
+    """
+
+    @pytest.mark.parametrize("fluid,graph,iso_type,value", [
+        ("HEOS::Water", 'PH', CoolProp.iSmass, 6000.0),
+        ("HEOS::Water", 'TS', CoolProp.iP, 5.0e5),
+        ("HEOS::R513A.mix", 'PH', CoolProp.iSmass, 1750.0),
+        ("HEOS::R513A.mix", 'PH', CoolProp.iT, 300.0),
+    ])
+    def test_traced_points_are_outside_the_dome(self, Common, fluid, graph, iso_type, value):
+        from CoolProp.Plots import PropertyPlot
+        import numpy as np
+        backend, name = fluid.split("::")
+        plot = PropertyPlot(fluid, graph, unit_system='SI', tp_limits='ACHP')
+        limits = plot._get_axis_limits()
+        xvals = plot.generate_ranges(plot._x_index, limits[0], limits[1], 60)
+        yvals = plot.generate_ranges(plot._y_index, limits[2], limits[3], 60)
+        line = Common.IsoLine(iso_type, plot._x_index, plot._y_index,
+                              value=value, state=plot._state)
+        ipos, xpos, ypos, _ = line.get_update_pair()
+        keys = [v for (_, v) in sorted(zip([ipos, xpos, ypos],
+                                           [iso_type, plot._x_index, plot._y_index]))]
+        vals = [v for (_, v) in sorted(zip([ipos, xpos, ypos],
+                                           [np.array(value), xvals, yvals]))]
+        if vals[0].size < vals[1].size:
+            vals[0] = np.resize(vals[0], vals[1].shape)
+        elif vals[1].size < vals[0].size:
+            vals[1] = np.resize(vals[1], vals[0].shape)
+
+        tracer = Common.IsoLineTracer(plot._state, keys[0], keys[1], iso_type)
+        sat = AbstractState(backend, name)
+        checked = 0
+        for v0, v1 in zip(vals[0], vals[1]):
+            try:
+                tracer.update(v0, v1)
+            except Exception:
+                continue
+            state = tracer.state
+            if 0.0 <= state.Q() <= 1.0:
+                continue                       # solved as two phase, which is fine
+            T, rho = state.T(), state.rhomass()
+            try:
+                sat.update(CoolProp.QT_INPUTS, 0.0, T); rho_liq = sat.rhomass()
+                sat.update(CoolProp.QT_INPUTS, 1.0, T); rho_vap = sat.rhomass()
+            except Exception:
+                continue                       # no dome at this T to be inside of
+            checked += 1
+            assert not rho_vap * (1.0 + 1e-6) < rho < rho_liq * (1.0 - 1e-6), (
+                "traced a single-phase root at rho={0} inside the dome "
+                "({1} .. {2}) at T={3}".format(rho, rho_vap, rho_liq, T))
+        assert checked >= 5, "the sweep never reached a temperature that has a dome"
+
+
+class TestBracketIsNotSilentlySkipped:
+    """A bracket that could not be built must never read as "no bracket needed"
+
+    ``_get_bracket`` returns None for a point beyond the dome, where an
+    unchecked single-phase root is safe, and raises everywhere else.  Two ways
+    that distinction has been lost, both of which left whole isolines traced
+    with the branch check disabled:
+
+    * recording the saturation value before the build, so that a build which
+      raised left the *previous* outcome (None) cached against the new value.
+      An isoline in T or p has one saturation value for its whole length, so a
+      single failure disabled the check for every remaining point;
+    * caching the phase envelope between tracers.  Building it is what makes
+      the mixture saturation flashes on that state converge, so the first
+      isoline of a fluid bracketed and the rest did not.
+    """
+
+    def test_a_failed_build_keeps_failing_instead_of_going_unchecked(self, Common):
+        tracer = Common.IsoLineTracer(AbstractState("HEOS", "R513A.mix"),
+                                      CoolProp.iP, CoolProp.iSmass, CoolProp.iP)
+        p, smass = 1.0e6, 1750.0
+        tracer.update(p, smass)                 # works, and caches a real bracket
+        assert tracer._bracket is not None
+
+        def always_fails(sat_value, target_index):
+            raise ValueError("saturation solver gave up")
+
+        tracer._build_bracket = always_fails
+        tracer._sat_value = None                # force one rebuild, which fails
+        for _ in range(3):                      # same saturation value each time
+            with pytest.raises(ValueError):
+                tracer.update(p, smass)
+            assert tracer._bracket is None
+            assert tracer._bracket_failure is not None
+
+    @pytest.mark.parametrize("attempt", [1, 2, 3])
+    def test_every_tracer_for_a_fluid_brackets_the_same(self, Common, attempt):
+        """The Nth tracer in a process must behave like the first
+
+        3.4 MPa is below R513A's cricondenbar but high enough that PQ_INPUTS
+        needs the phase envelope to converge, which is exactly where a cached
+        envelope used to leave later isolines unbracketed.
+        """
+        from CoolProp.Plots import PropertyPlot
+        import numpy as np
+        plot = PropertyPlot('HEOS::R513A.mix', 'TS', unit_system='SI', tp_limits='ACHP')
+        limits = plot._get_axis_limits()
+        svals = plot.generate_ranges(plot._x_index, limits[0], limits[1], 40)
+        pressure = 3.4e6
+        flash = AbstractState("HEOS", "R513A.mix")
+        for _ in range(attempt):                # burn N-1 tracers first
+            tracer = Common.IsoLineTracer(plot._state, CoolProp.iP, CoolProp.iSmass, CoolProp.iP)
+        unchecked = compared = 0
+        for smass in svals:
+            try:
+                tracer.update(pressure, smass)
+            except Exception:
+                continue
+            if tracer._bracket is None:
+                unchecked += 1
+                continue
+            try:
+                flash.update(CoolProp.PSmass_INPUTS, pressure, smass)
+            except Exception:
+                continue           # the flash cannot do this point; that is the premise
+            compared += 1
+            assert _relerr(tracer.state.T(), flash.T()) < 1e-6
+        assert unchecked == 0, "{0} points traced without a saturation bracket".format(unchecked)
+        assert compared > 20
+
+
+class TestFluidModelIsCarriedOver:
+    def test_custom_binary_interaction_parameters_reach_the_tracer(self, Common):
+        """The tracer clones the state; a modified kij must come with it
+
+        Otherwise one isoline mixes two fluid models -- traced points from the
+        defaults, flashed points from the caller's parameters.
+        """
+        state = AbstractState("HEOS", "R1234yf&R134a")
+        state.set_mole_fractions([0.5, 0.5])
+        state.set_binary_interaction_double(0, 1, "betaT", 1.05)
+        default = AbstractState("HEOS", "R1234yf&R134a")
+        default.set_mole_fractions([0.5, 0.5])
+
+        p, T = 1.0e6, 320.0
+        state.update(CoolProp.PT_INPUTS, p, T)
+        default.update(CoolProp.PT_INPUTS, p, T)
+        assert _relerr(state.hmass(), default.hmass()) > 1e-9, \
+            "the modified parameter has to actually change the answer"
+
+        tracer = Common.IsoLineTracer(state, CoolProp.iP, CoolProp.iT, CoolProp.iT)
+        tracer.update(p, T)
+        assert _relerr(tracer.keyed_output(CoolProp.iHmass), state.hmass()) < 1e-9
+
+
+class TestGapFilling:
+    def test_mixture_isentrope_has_far_fewer_gaps(self, Common):
+        """Flashing an R513A isentrope cold leaves holes in it; tracing mostly does not
+
+        Not zero: a handful of near-critical points cannot be bracketed and
+        cannot be flashed either, and those are handed on as non-finite rather
+        than guessed at.  The point is the order of magnitude.
+        """
+        import numpy as np
+        args = (Common, 'HEOS::R513A.mix', 'PH', CoolProp.iSmass, 1950.0, 40)
+        x, y = _isoline(*args, tracing=True)
+        xf, yf = _isoline(*args, tracing=False)
+        traced_holes = int(np.sum(~np.isfinite(x) | ~np.isfinite(y)))
+        flashed_holes = int(np.sum(~np.isfinite(xf) | ~np.isfinite(yf)))
+        assert flashed_holes > 0, "this line is meant to be one the cold flash cannot do"
+        assert traced_holes * 3 < flashed_holes, (
+            "tracing left {0} holes against the flash's {1}".format(traced_holes, flashed_holes))
+        # and where both landed, they agree
+        both = (np.isfinite(xf) & np.isfinite(yf) & np.isfinite(x) & np.isfinite(y))
+        assert both.sum() > 20
+        assert np.allclose(x[both], xf[both], rtol=1e-7)
+        assert np.allclose(y[both], yf[both], rtol=1e-7)

--- a/wrappers/Python/pytest/test_isoline_tracer.py
+++ b/wrappers/Python/pytest/test_isoline_tracer.py
@@ -242,8 +242,10 @@ class TestBranchSelection:
                                       CoolProp.iP, CoolProp.iSmass, CoolProp.iP)
         sat = AbstractState("HEOS", "R504.mix")
         T = 314.54                       # beyond the envelope, inside the dome
-        sat.update(CoolProp.QT_INPUTS, 0.0, T); rho_liq = sat.rhomolar()
-        sat.update(CoolProp.QT_INPUTS, 1.0, T); rho_vap = sat.rhomolar()
+        sat.update(CoolProp.QT_INPUTS, 0.0, T)
+        rho_liq = sat.rhomolar()
+        sat.update(CoolProp.QT_INPUTS, 1.0, T)
+        rho_vap = sat.rhomolar()
         assert rho_liq > rho_vap
         with pytest.raises(ValueError):
             tracer._check_branch(None, None, T, 0.5 * (rho_liq + rho_vap))
@@ -373,14 +375,16 @@ class TestNoMetastableRoots:
             try:
                 tracer.update(v0, v1)
             except Exception:
-                continue
+                continue        # this point has no dome to be inside of
             state = tracer.state
             if 0.0 <= state.Q() <= 1.0:
                 continue                       # solved as two phase, which is fine
             T, rho = state.T(), state.rhomass()
             try:
-                sat.update(CoolProp.QT_INPUTS, 0.0, T); rho_liq = sat.rhomass()
-                sat.update(CoolProp.QT_INPUTS, 1.0, T); rho_vap = sat.rhomass()
+                sat.update(CoolProp.QT_INPUTS, 0.0, T)
+                rho_liq = sat.rhomass()
+                sat.update(CoolProp.QT_INPUTS, 1.0, T)
+                rho_vap = sat.rhomass()
             except Exception:
                 continue                       # no dome at this T to be inside of
             checked += 1
@@ -449,7 +453,7 @@ class TestBracketIsNotSilentlySkipped:
             try:
                 tracer.update(pressure, smass)
             except Exception:
-                continue
+                continue        # this point has no dome to be inside of
             if tracer._bracket is None:
                 unchecked += 1
                 continue
@@ -515,24 +519,29 @@ class TestPressureIsNotAProxyForTheDome:
         for smass in svals:
             try:
                 tracer.update(pressure, smass)
-            except Exception:
+            except ValueError:
+                # the tracer handed this point back; prime it from the flash the
+                # way calc_range does, and if that fails too the point is simply
+                # one neither can place
                 try:
                     shared.update(CoolProp.PSmass_INPUTS, pressure, smass)
-                    tracer.set_guess(shared)
-                except Exception:
-                    pass
+                except ValueError:
+                    continue        # neither route can place this point
+                tracer.set_guess(shared)
                 continue
             state = tracer.state
             if 0.0 <= state.Q() <= 1.0:
                 continue
             T, rho = state.T(), state.rhomolar()
             try:
-                sat.update(CoolProp.QT_INPUTS, 0.0, T); rho_liq = sat.rhomolar()
-                sat.update(CoolProp.QT_INPUTS, 1.0, T); rho_vap = sat.rhomolar()
-            except Exception:
-                continue
+                sat.update(CoolProp.QT_INPUTS, 0.0, T)
+                rho_liq = sat.rhomolar()
+                sat.update(CoolProp.QT_INPUTS, 1.0, T)
+                rho_vap = sat.rhomolar()
+            except ValueError:
+                continue        # no dome at this T, so nothing to be inside of
             if not rho_liq > rho_vap * 1.0001:
-                continue
+                continue        # collapsed pair: cannot decide, not a failure
             checked += 1
             assert not rho_vap < rho < rho_liq, (
                 "traced rho={0} at T={1} sits inside the dome ({2} .. {3}) on an "

--- a/wrappers/Python/pytest/test_isoline_tracer.py
+++ b/wrappers/Python/pytest/test_isoline_tracer.py
@@ -487,6 +487,59 @@ class TestFluidModelIsCarriedOver:
         assert _relerr(tracer.keyed_output(CoolProp.iHmass), state.hmass()) < 1e-9
 
 
+class TestPressureIsNotAProxyForTheDome:
+    """A pressure above the cricondenbar does not make a root safe
+
+    It is tempting: above the cricondenbar no two-phase state exists at that
+    pressure, so an isobar there looks like it needs no dome check.  But the
+    question is whether the (T, rhomolar) the Newton landed on is the stable
+    root at *its own* temperature, and the EOS pressure along the metastable
+    branch inside the dome runs well above the cricondenbar -- so such a root
+    satisfies the isobar exactly while sitting between the saturation
+    densities.  Short-circuiting on pressure put 69 of these on a default
+    R441A T-s plot, 8.7 % out in temperature.
+    """
+
+    def test_high_pressure_isobar_has_no_roots_inside_the_dome(self, Common):
+        """The check has to run even where the isobar cannot be two-phase"""
+        from CoolProp.Plots import PropertyPlot
+        import numpy as np
+        plot = PropertyPlot('HEOS::R441A.mix', 'TS')
+        limits = plot._get_axis_limits()
+        svals = plot.generate_ranges(plot._x_index, limits[0], limits[1], 120)
+        pressure = 1.0109e7                      # above R441A's cricondenbar
+        tracer = Common.IsoLineTracer(plot._state, CoolProp.iP, CoolProp.iSmass, CoolProp.iP)
+        sat = AbstractState("HEOS", "R441A.mix")
+        shared = AbstractState("HEOS", "R441A.mix")
+        checked = 0
+        for smass in svals:
+            try:
+                tracer.update(pressure, smass)
+            except Exception:
+                try:
+                    shared.update(CoolProp.PSmass_INPUTS, pressure, smass)
+                    tracer.set_guess(shared)
+                except Exception:
+                    pass
+                continue
+            state = tracer.state
+            if 0.0 <= state.Q() <= 1.0:
+                continue
+            T, rho = state.T(), state.rhomolar()
+            try:
+                sat.update(CoolProp.QT_INPUTS, 0.0, T); rho_liq = sat.rhomolar()
+                sat.update(CoolProp.QT_INPUTS, 1.0, T); rho_vap = sat.rhomolar()
+            except Exception:
+                continue
+            if not rho_liq > rho_vap * 1.0001:
+                continue
+            checked += 1
+            assert not rho_vap < rho < rho_liq, (
+                "traced rho={0} at T={1} sits inside the dome ({2} .. {3}) on an "
+                "isobar above the cricondenbar".format(rho, T, rho_vap, rho_liq))
+        assert checked > 20, "the sweep has to reach temperatures that have a dome"
+
+
 class TestGapFilling:
     def test_mixture_isentrope_has_far_fewer_gaps(self, Common):
         """Flashing an R513A isentrope cold leaves holes in it; tracing mostly does not

--- a/wrappers/Python/pytest/test_isoline_tracer.py
+++ b/wrappers/Python/pytest/test_isoline_tracer.py
@@ -20,11 +20,13 @@ it.
 import pytest
 
 import CoolProp
-from CoolProp import AbstractState
+
+AbstractState = CoolProp.AbstractState
 
 
 @pytest.fixture(scope="module")
 def Common():
+    """The worktree's CoolProp.Plots.Common, or skip if matplotlib is absent"""
     pytest.importorskip("matplotlib")
     import matplotlib
     matplotlib.use("Agg")
@@ -33,6 +35,7 @@ def Common():
 
 
 def _tracer(Common, backend, fluid, index1, index2, iso_index):
+    """Build a tracer on a fresh state of this fluid"""
     return Common.IsoLineTracer(AbstractState(backend, fluid), index1, index2, iso_index)
 
 
@@ -63,6 +66,7 @@ def _reconstruct(backend, fluid, state, mole_fractions=None):
 
 
 def _relerr(a, b):
+    """Relative difference, safe when either value is near zero"""
     return abs(a - b) / max(abs(a), abs(b), 1e-8)
 
 
@@ -262,6 +266,7 @@ class TestIsoLineIntegration:
         original = Common.IsoLineTracer.update
 
         def counting(self, v1, v2):
+            """Record that the tracer was reached, then behave normally"""
             calls.append(1)
             return original(self, v1, v2)
 
@@ -291,12 +296,14 @@ class TestUnbracketableInputs:
     """
 
     def test_supports_requires_temperature_or_pressure(self, Common):
+        """Only pairs that can be bracketed are accepted"""
         assert Common.IsoLineTracer.supports(CoolProp.iP, CoolProp.iSmass)
         assert Common.IsoLineTracer.supports(CoolProp.iHmass, CoolProp.iT)
         assert not Common.IsoLineTracer.supports(CoolProp.iHmass, CoolProp.iSmass)
         assert not Common.IsoLineTracer.supports(CoolProp.iDmass, CoolProp.iSmass)
 
     def test_constructor_refuses_an_unbracketable_pair(self, Common):
+        """supports() is enforced, not merely advisory"""
         with pytest.raises(ValueError):
             Common.IsoLineTracer(AbstractState("HEOS", "Water"),
                                  CoolProp.iHmass, CoolProp.iSmass, CoolProp.iHmass)
@@ -339,6 +346,7 @@ class TestNoMetastableRoots:
         ("HEOS::R513A.mix", 'PH', CoolProp.iT, 300.0),
     ])
     def test_traced_points_are_outside_the_dome(self, Common, fluid, graph, iso_type, value):
+        """Every single-phase root sits outside the saturation densities at its own T"""
         from CoolProp.Plots import PropertyPlot
         import numpy as np
         backend, name = fluid.split("::")
@@ -400,6 +408,7 @@ class TestBracketIsNotSilentlySkipped:
     """
 
     def test_a_failed_build_keeps_failing_instead_of_going_unchecked(self, Common):
+        """A cached bracket failure must keep raising, not read as no-dome"""
         tracer = Common.IsoLineTracer(AbstractState("HEOS", "R513A.mix"),
                                       CoolProp.iP, CoolProp.iSmass, CoolProp.iP)
         p, smass = 1.0e6, 1750.0
@@ -407,6 +416,7 @@ class TestBracketIsNotSilentlySkipped:
         assert tracer._bracket is not None
 
         def always_fails(sat_value, target_index):
+            """Stand in for a saturation solver that will not converge"""
             raise ValueError("saturation solver gave up")
 
         tracer._build_bracket = always_fails


### PR DESCRIPTION
Fixes the property plots in GH discussion #3269: reproducing the reporter's
two R513A figures took 255 s and 367 s and left 662 and 865 non-finite
points behind. They now take 10.4 s and 5.5 s, with 14 and 0.

<img width="704" height="528" alt="cmp_Water_PH_before" src="https://github.com/user-attachments/assets/1cd8ab5b-288a-4f00-841c-aa79e90f2a22" />
<img width="704" height="528" alt="cmp_Water_PH_after" src="https://github.com/user-attachments/assets/38a1b210-4c76-47cc-8fcb-ca3c6debbfad" />

<img width="704" height="528" alt="cmp_R513A mix_PH_before" src="https://github.com/user-attachments/assets/9daeed1a-b71a-4eca-a7c6-b5a125599f6c" />
<img width="704" height="528" alt="cmp_R513A mix_PH_after" src="https://github.com/user-attachments/assets/f0c8975c-4f69-4aab-9586-b4544b6e0166" />

<img width="704" height="528" alt="cmp_R513A mix_TS_before" src="https://github.com/user-attachments/assets/594bcaff-fa22-41a5-8d7e-81c40884efad" />
<img width="704" height="528" alt="cmp_R513A mix_TS_after" src="https://github.com/user-attachments/assets/7722aca0-6b72-4d15-99b8-de85a668fd55" />




### What was wrong

`IsoLine.calc_range` ran an independent, cold two-dimensional flash per
point. For a mixture those are slow (tens of milliseconds for
`PSmass_INPUTS` on R513A) and a good fraction fail outright, which is the
ragged compressed-liquid corner the reporter posted. The one place that
already tried to reuse guess values was dead code: it called
`update_with_guesses` with `HmolarP_INPUTS`/`HmassP_INPUTS`, which HEOS does
not support, so it threw on every point and NaN'd it.

### What this does

Points on an isoline are consecutive, so the previous solution is an
excellent initial guess. A single-phase point becomes a 2x2 Newton
iteration in `(T, rhomolar)` with the analytic Jacobian from
`first_partial_deriv`, on a state with the phase imposed — every property is
an explicit function of `(T, rhomolar)` for a Helmholtz EOS, so no flash is
involved, and imposing the phase both skips the saturation call that
dominates a mixture `DmolarT_INPUTS` update (1.4 us vs 640 us) and pins the
iteration to the single-phase root. A two-phase point is bracketed by the
saturation states at the constant T or p of the pair and solved for vapour
quality by an Illinois regula falsi.

|                          | before            | after        |
|--------------------------|-------------------|--------------|
| R513A p-h                | 255 s / 662 gaps  | 10.4 s / 14  |
| R513A T-s                | 367 s / 865 gaps  | 5.5 s / 0    |
| Water (both figures)     | 0.80 s / 124 gaps | 0.63 s / 0   |
| R134a (both figures)     | 0.49 s / 3 gaps   | 0.63 s / 0   |

Pure fluids are level on time and strictly cleaner. Anything the tracer
cannot do is flashed exactly as before: median 0 % of points, mean 1.9 %.



### Why most of the diff is guards, not the Newton

A phase-imposed Newton iteration converges just as happily on the metastable
extension of the EOS inside the two-phase dome, and the answer is entirely
self-consistent, so nothing downstream would notice. Five review rounds
found four separate ways that happened; each guard below exists because it
was caught returning wrong numbers:

- isolines whose inputs include neither T nor p cannot be bracketed at all
  and are not traced (`IsoLineTracer.supports`). Constant-enthalpy lines on
  a T-s diagram are the case that bit: 29 of 60 points wrong, up to 24 %
  off, on a Water line.
- a bracket that cannot be built where a dome should be hands the point
  back, and that outcome is cached with the saturation value it belongs to.
  Recording the value first left the previous "no dome here" cached against
  the new one, and a T or p isoline has one saturation value along its whole
  length, so a single failed build disabled the check for the entire line.
- an unbracketed root is checked against the saturation densities at its own
  temperature. A saturation call that fails there is not reassurance — for a
  T-indexed isoline it is the same call at the same temperature the bracket
  already failed on — so it only counts as an answer above the temperature
  where a dome can still exist. Treating it as "no dome" put four points of
  an R504 isotherm inside the dome, 36 % out in enthalpy, on points master
  gets right.
- the branch is chosen from the sign of the target property along density at
  the saturated liquid, not from the order of the two bracket values: R513A's
  bubble and dew pressures come within 1.4e-9 relative near 305 K, so that
  order is numerical noise.

The dome's temperature bound has to be exact or every supercritical point
pays for a flash. A phase envelope that ran to the critical point ends with
its liquid and vapour densities converging, and then its own extremes are
the cricondentherm and cricondenbar for free; one that stopped early says
nothing — R504's ends with them a factor of six apart, 37 K below its real
critical point — and the critical point is located directly instead.

### Verification

A harness that drives the tracer the way `calc_range` does, priming
included, checking every traced point against cold saturation densities at
its own temperature. Seven plot types, every traceable isoline type, for
R504, R513A, R454B, R410A, Air, Water, R134a and CO2 — **142 903 traced
points, none inside the two-phase dome**. The harness cannot decide about
1105 of them because the cold saturation call it checks with fails there
too; all of those were bracketed points that the tracer had itself checked
against the saturation states at their isoline's own constant, so no point
goes unexamined by both.

22 new tests in `wrappers/Python/pytest/test_isoline_tracer.py`, each of the
four defects above pinned by one that fails against the code before its fix.
The CI pytest leg now installs matplotlib, without which these and the
existing `test_derivatives_plots.py` Plots tests silently `importorskip`.

### Two CoolProp bugs found while validating this

Filed separately, not fixed here:

- mixture `DmassT_INPUTS` can return a state at a different density than it
  was given, and reports single-phase at a density provably inside the dome
  (R513A at 0.757 kg/m3, 173 K, where the saturated vapour is 0.061 and the
  saturated liquid 1501 kg/m3).
- `PQ_flash_with_guesses` silently converges on a non-saturation state near
  the critical point. The saturation calls here deliberately avoid it.

Where the tracer and a cold flash disagree, the flash is the one that is
wrong in every case examined.

### Scope

Python `Plots` only — no C++, no C API, no other wrappers. `CoolPropPlot.cpp`
has the identical cold-flash loop and is untouched; per #2463 the Python
implementation is the reference the C++ one is generated from, so the fix
belongs here first. Follow-up issue filed for the C++ port, which also notes
that `dev/scripts/generate_Plot_test_data.py` would now generate a test file
the unchanged C++ fails (values agree to 8e-10, but the NaN pattern differs
in 3 places on the R134a grid it pins).

### Verified by the human

- [ ] R513A p-h and T-s figures before/after
- [ ] the trade-off in `_check_outside_the_dome`: correctness over gap-filling
      in the near-critical band where CoolProp's saturation solver will not
      converge

bd CoolProp-dgxi

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved isoline generation with intelligent point-to-point tracing for smoother, more reliable results.
  * Added an option to enable or disable tracing during isoline calculations.
  * Preserved fluid models and custom mixture settings throughout isoline calculations.

* **Bug Fixes**
  * Improved handling of single-phase and two-phase regions, difficult mixtures, and unbracketable isolines.
  * Reduced gaps and incorrect branch selection in plotted isolines.
  * Prevented invalid near-critical or collapsed saturation solutions from being accepted.

* **Tests**
  * Expanded coverage for isoline tracing, phase transitions, mixture behavior, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->