### PR TITLE
Add 'C2H6' alias for Ethane

### DIFF
--- a/dev/fluids/Ethane.json
+++ b/dev/fluids/Ethane.json
@@ -4306,7 +4306,8 @@
       "ethane",
       "ETHANE",
       "R170",
-      "n-C2H6"
+      "n-C2H6",
+      "C2H6"
     ],
     "CAS": "74-84-0",
     "CHEMSPIDER_ID": 6084,


### PR DESCRIPTION
CoolProp currently accepts `n-C2H6` but not `C2H6` as an alias for Ethane. Since C2H6 unambiguously identifies Ethane and analogous formula aliases such as CH4 and C3H8 are already supported, this adds C2H6 to the Ethane alias list.

No thermophysical data or model behavior is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added “C2H6” as an alternative name for the Ethane fluid, improving recognition when using its chemical formula.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->