### PR TITLE
feat(REFPROP): expose HEATFRMdll through HFORMATION

### DIFF
--- a/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.cpp
@@ -1018,6 +1018,33 @@ CoolPropDbl REFPROPMixtureBackend::calc_dipole_moment() {
         throw ValueError(format("dipole moment is only available for pure fluids"));
     }
 };
+CoolPropDbl REFPROPMixtureBackend::calc_Hmolar_formation() {
+    this->check_loaded_fluid();
+    this->check_status();
+
+    if (HEATFRMdll == nullptr) {
+        throw ValueError("HEATFRMdll function is not available in your version of REFPROP. Please upgrade");
+    }
+
+    // HEATFRMdll defines the standard state as the ideal gas at 298.15 K.
+    // Density is part of the legacy signature but is not used by REFPROP.
+    double T = 298.15;
+    double D_mol_L = 0.0;
+    double hformation_J_mol = NAN;
+    int ierr = 0;
+    std::array<char, errormessagelength + 1> herr{};
+    HEATFRMdll(&T, &D_mol_L, mole_fractions.data(), &hformation_J_mol, &ierr, herr.data(), errormessagelength);
+
+    // HEATFRMdll documents only ierr == 0 as success. In particular, missing
+    // heating-value data must not be exposed as a plausible zero or NaN.
+    if (ierr != 0) {
+        throw ValueError(format("REFPROP HEATFRMdll failed with error code %d: %s", ierr, herr.data()));
+    }
+    if (!ValidNumber(hformation_J_mol)) {
+        throw ValueError("REFPROP HEATFRMdll returned an invalid standard molar enthalpy of formation");
+    }
+    return static_cast<CoolPropDbl>(hformation_J_mol);
+}
 CoolPropDbl REFPROPMixtureBackend::calc_gas_constant() {
     this->check_loaded_fluid();
     double Rmix = 0;

--- a/src/Backends/REFPROP/REFPROPMixtureBackend.h
+++ b/src/Backends/REFPROP/REFPROPMixtureBackend.h
@@ -285,6 +285,7 @@ class REFPROPMixtureBackend : public AbstractState
     CoolPropDbl calc_acentric_factor() override;
     CoolPropDbl calc_gas_constant() override;
     CoolPropDbl calc_dipole_moment() override;
+    CoolPropDbl calc_Hmolar_formation() override;
 
     /// Calculate the "true" critical point where dp/drho|T and d2p/drho2|T are zero
     void calc_true_critical_point(double& T, double& rho) override;

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -7756,4 +7756,40 @@ TEST_CASE("Standard molar enthalpy of formation from ATcT", "[formation][Helmhol
     }
 }
 
+TEST_CASE("Standard molar enthalpy of formation from REFPROP", "[formation][REFPROP]") {
+    CoolProp::Skip_if_No_REFPROP();
+    using Catch::Approx;
+
+    SECTION("pure-fluid value is available without a state update") {
+        shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("REFPROP", "Methane"));
+        const double hformation = AS->keyed_output(CoolProp::iHmolar_formation);
+        CHECK(ValidNumber(hformation));
+        // Broad enough for REFPROP data revisions, narrow enough to catch a
+        // J/mol-to-kJ/mol conversion error.
+        CHECK(hformation > -1e5);
+        CHECK(hformation < -5e4);
+
+        AS->update(CoolProp::PT_INPUTS, 101325.0, 300.0);
+        CHECK(AS->keyed_output(CoolProp::iHmolar_formation) == Approx(hformation).margin(1e-12));
+        CHECK(CoolProp::PropsSI("HFORMATION", "", 0, "", 0, "REFPROP::Methane") == Approx(hformation).margin(1e-12));
+    }
+
+    SECTION("mixture value uses the current mole fractions") {
+        shared_ptr<CoolProp::AbstractState> methane(CoolProp::AbstractState::factory("REFPROP", "Methane"));
+        shared_ptr<CoolProp::AbstractState> ethane(CoolProp::AbstractState::factory("REFPROP", "Ethane"));
+        const double h_methane = methane->keyed_output(CoolProp::iHmolar_formation);
+        const double h_ethane = ethane->keyed_output(CoolProp::iHmolar_formation);
+
+        shared_ptr<CoolProp::AbstractState> mixture(CoolProp::AbstractState::factory("REFPROP", "Methane&Ethane"));
+        const std::vector<double> z{0.7, 0.3};
+        mixture->set_mole_fractions(z);
+        CHECK(mixture->keyed_output(CoolProp::iHmolar_formation) == Approx(z[0] * h_methane + z[1] * h_ethane).epsilon(1e-12).margin(1e-6));
+    }
+
+    SECTION("unset mixture composition is rejected") {
+        shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("REFPROP", "Methane&Ethane"));
+        CHECK_THROWS_WITH(AS->keyed_output(CoolProp::iHmolar_formation), Catch::Matchers::ContainsSubstring("Mole fractions not yet set"));
+    }
+}
+
 #endif


### PR DESCRIPTION
### Description of the Change

PR #3309 added the `HFORMATION` parameter for HEOS using ATcT data. This PR implements the same public parameter for the REFPROP backend by forwarding REFPROP's native [`HEATFRMdll`](https://refprop-docs.readthedocs.io/en/latest/DLL/legacy.html#f/HEATFRMdll) call from `REFPROPMixtureBackend`.

The implementation ensures that the selected REFPROP fluid and composition are loaded, passes the active mole fractions to REFPROP, and returns `hFrm` unchanged in J/mol. A missing `HEATFRMdll` symbol, any non-zero REFPROP error, or a non-finite result raises a descriptive `ValueError` instead of returning a sentinel value. `HEATFRMdll` documents only zero as success, so this path deliberately fails closed rather than applying the configurable general REFPROP error threshold to missing formation data.

Because `REFPROPBackend` derives from `REFPROPMixtureBackend`, the implementation covers both pure fluids and REFPROP mixtures.

This is deliberately backend-specific. It does not change the ATcT values used by HEOS, does not use REFPROP to validate or populate HEOS data, and does not change the current HEOS mixture behavior. Values returned by `REFPROP::...` may therefore differ from `HEOS::...`.

### Benefits

- Makes the existing `HFORMATION` property available for REFPROP pure fluids and mixtures through the standard CoolProp API.
- Preserves the coverage and composition handling of the installed REFPROP backend.
- Allows downstream integrations to obtain the formation-reference contribution without calling the REFPROP DLL directly.
- Fails explicitly when the installed REFPROP library cannot provide a value.

### Possible Drawbacks

REFPROP derives `HEATFRMdll` from its stored heating-value data, so its provenance, coverage, and numerical result differ from the ATcT-backed HEOS value and can depend on the installed REFPROP version. Some fluids or mixtures may therefore throw a REFPROP error. An older REFPROP DLL without `HEATFRMdll` also produces a clear upgrade error. CoolProp does not add or redistribute any REFPROP data with this change.

### Verification Process

- Configured and built `CatchTestRunner` with Visual Studio 2022 x64. The local upstream-master build used `CMAKE_POLICY_DEFAULT_CMP0091=NEW` and `CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL` to keep CoolProp and Catch2 on the same MSVC runtime.
- Ran `[formation][REFPROP]` against the locally installed REFPROP DLL: all 7 assertions passed.
- Ran the complete `[formation]` filter in random order with seed 1360: all 101 assertions in 2 test cases passed.
- Verified a pure-fluid result before any state update, state independence after a PT update, and access through `PropsSI`.
- Verified that a 0.7 methane / 0.3 ethane mixture matches the mole-fraction-weighted native REFPROP pure-fluid values.
- Verified that an unset mixture composition throws before `HEATFRMdll` is called.
- Added a methane magnitude range that rejects J/mol-versus-kJ/mol conversion errors while allowing REFPROP data revisions.
- Ran clang-format over the changed ranges and `git diff --cached --check` with no whitespace errors.

### Applicable Issues

Related to #1360. Follow-up to #3309.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for calculating standard molar enthalpy of formation for REFPROP fluids and mixtures.
  * Available through standard property queries, including `HFORMATION`.

* **Bug Fixes**
  * Added validation for unavailable REFPROP functionality, invalid results, unloaded fluids, and unset mixture compositions.

* **Tests**
  * Added coverage for pure fluids, mixtures, state updates, and invalid composition handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->