### PR TITLE
feat(cubics): Péneloux volume translation: repair the pure-fluid path, extend it to mixtures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2473,6 +2473,10 @@ if(COOLPROP_CATCH_MODULE)
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-CubicU.cpp")
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-CubicEntropy.cpp")
+  list(APPEND
+       APP_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-CubicVolumeTranslation.cpp"
+  )
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-NeonMelting.cpp")
   list(APPEND APP_SOURCES

--- a/CoolPropBibTeXLibrary.bib
+++ b/CoolPropBibTeXLibrary.bib
@@ -545,6 +545,37 @@
   Year                     = {2016}
 }
 
+@Article{Peneloux-FPE-1982,
+  Title                    = {{A consistent correction for Redlich-Kwong-Soave volumes}},
+  Author                   = {P{\'e}neloux, A. and Rauzy, E. and Fr{\`e}ze, R.},
+  Journal                  = {Fluid Phase Equilib.},
+  Year                     = {1982},
+  Number                   = {1},
+  Pages                    = {7-23},
+  Volume                   = {8},
+  Doi                      = {10.1016/0378-3812(82)80002-2}
+}
+
+@Article{Jaubert-FPE-2016,
+  Title                    = {{Note on the properties altered by application of a P{\'e}neloux-type volume translation to an equation of state}},
+  Author                   = {Jaubert, Jean-No{\"e}l and Privat, Romain and Le Guennec, Yohann and Coniglio, Lucie},
+  Journal                  = {Fluid Phase Equilib.},
+  Year                     = {2016},
+  Pages                    = {88-95},
+  Volume                   = {419},
+  Doi                      = {10.1016/j.fluid.2016.03.012}
+}
+
+@Article{Privat-FPE-2016,
+  Title                    = {{Incorporation of a volume translation in an equation of state for fluid mixtures: which combining rule? which effect on properties of mixing?}},
+  Author                   = {Privat, Romain and Jaubert, Jean-No{\"e}l and Le Guennec, Yohann},
+  Journal                  = {Fluid Phase Equilib.},
+  Year                     = {2016},
+  Pages                    = {414-420},
+  Volume                   = {427},
+  Doi                      = {10.1016/j.fluid.2016.07.035}
+}
+
 @Article{Bell-IECR-2014,
   Title                    = {{Pure and Pseudo-pure Fluid Thermophysical Property Evaluation and the Open-Source Thermophysical Property Library CoolProp}},
   Author                   = {Bell, Ian H. and Wronski, Jorrit and Quoilin, Sylvain and Lemort, Vincent},

--- a/Web/coolprop/Cubics.rst
+++ b/Web/coolprop/Cubics.rst
@@ -272,46 +272,58 @@ which collapses to the linear form above -- so there is no :math:`c_{ij}` to fit
 What changes and what does not
 ------------------------------
 
-A constant translation is *not* a fudge factor applied to one output; it changes some properties by
-an exactly predictable amount and leaves others untouched.  The table below follows Jaubert et al.
-:cite:`Jaubert-FPE-2016` and Privat et al. :cite:`Privat-FPE-2016` and is pinned by the test suite 
-at round-off level.
+A constant translation is *not* a fudge factor applied to one output; at fixed :math:`T`, :math:`p`
+and composition it changes some properties by an exactly predictable amount and leaves others
+untouched.  The table below follows Jaubert et al. :cite:`Jaubert-FPE-2016` and Privat et al.
+:cite:`Privat-FPE-2016` and additionally includes the Joule-Thomson coefficient :math:`\mu_{\mathrm{JT}}`.
 
-=====================================================  =============================================
-Quantity                                               Effect of the translation
-=====================================================  =============================================
-:math:`v`                                              :math:`v - c_m(\mathbf{z})`
-:math:`h`, :math:`g`                                   shifted by :math:`-p\,c_m(\mathbf{z})`
-:math:`\mu_i`                                          shifted by :math:`-p\,c_i`, using the
-                                                       **pure-component** :math:`c_i`
-:math:`\ln \varphi_i`                                  shifted by :math:`-p\,c_i/(RT)`, the same
-                                                       pure-component :math:`c_i`
-:math:`B` (second virial coefficient)                  :math:`B - c_m(\mathbf{z})`
-:math:`s`, :math:`u`, :math:`a`, :math:`c_p`,          **unchanged**
-:math:`c_v`
-:math:`-(\partial v/\partial p)_T`,                    **unchanged**
-:math:`(\partial v/\partial T)_p`
-:math:`p^{\mathrm{sat}}`, :math:`p_{\mathrm{bub}}`,    **unchanged**
-:math:`p_{\mathrm{dew}}`, :math:`K_i`, phase
-compositions
-:math:`w` (speed of sound)                             **changes** (:math:`w^2 \propto v^2`)
-:math:`\Delta_{\mathrm{vap}} S`,                       **unchanged**
-:math:`\Delta_{\mathrm{vap}} U`,
-:math:`\Delta_{\mathrm{vap}} A`,
-:math:`\Delta_{\mathrm{vap}} c_p`,
-:math:`\Delta_{\mathrm{vap}} c_v`
-:math:`\Delta_{\mathrm{vap}} V`,                       unchanged for a pure fluid; for a mixture
-:math:`\Delta_{\mathrm{vap}} H`                        shifted by
-                                                       :math:`-[c_m(\mathbf{y})-c_m(\mathbf{x})]`
-                                                       and
-                                                       :math:`-p[c_m(\mathbf{y})-c_m(\mathbf{x})]`
-=====================================================  =============================================
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
 
-Two consequences are worth spelling out.  Because :math:`\ln \varphi_i` shifts by the same amount in
+   * - Quantity
+     - Effect of the translation
+   * - :math:`v`
+     - shifted by :math:`- c_m(\mathbf{z})`
+   * - :math:`h`, :math:`g`
+     - shifted by :math:`-p\,c_m(\mathbf{z})`
+   * - :math:`\mu_i`
+     - shifted by :math:`-p\,c_i`, using the pure-component :math:`c_i`
+   * - :math:`\ln \varphi_i`
+     - shifted by :math:`-p\,c_i/(RT)`, the same pure-component :math:`c_i`
+   * - :math:`B` (second virial coefficient)
+     - :math:`B - c_m(\mathbf{z})`
+   * - :math:`Z = pv/(RT)`
+     - shifted by :math:`-p\,c_m(\mathbf{z})/(RT)`
+   * - :math:`\mu_{\mathrm{JT}} = (\partial T/\partial p)_h`
+     - | shifted by :math:`+c_m(\mathbf{z})/c_p` 
+       | due to :math:`\mu_{\mathrm{JT}} = [T(\partial v/\partial T)_p - v]/c_p`
+   * - :math:`w` (speed of sound)
+     - changes (:math:`w^2 \propto v^2`)
+   * - :math:`s`, :math:`u`, :math:`a`, :math:`c_p`, :math:`c_v`
+     - **unchanged**
+   * - :math:`-(\partial v/\partial p)_T`,
+       :math:`(\partial v/\partial T)_p`
+     - **unchanged**
+   * - :math:`p^{\mathrm{sat}}`, :math:`p_{\mathrm{bub}}`,
+       :math:`p_{\mathrm{dew}}`, :math:`K_i`, :math:`\mathbf{x}`, :math:`\mathbf{y}`
+     - **unchanged**
+   * - :math:`\Delta_{\mathrm{vap}} S`, :math:`\Delta_{\mathrm{vap}} U`,
+       :math:`\Delta_{\mathrm{vap}} A`, :math:`\Delta_{\mathrm{vap}} c_p`,
+       :math:`\Delta_{\mathrm{vap}} c_v`
+     - **unchanged**
+   * - :math:`\Delta_{\mathrm{vap}} V`, :math:`\Delta_{\mathrm{vap}} H`
+     - unchanged for a pure fluid; for a mixture shifted by
+       :math:`-[c_m(\mathbf{y})-c_m(\mathbf{x})]` and
+       :math:`-p[c_m(\mathbf{y})-c_m(\mathbf{x})]`
+
+Anything containing :math:`v` explicitly changes, unless two such quantities are subtracted at the same 
+composition, which is why all :math:`\Delta_{\mathrm{vap}}` rows survive for a pure fluid. 
+Because :math:`\ln \varphi_i` shifts by the same amount in
 both phases at the same :math:`(T,p)`, the shift cancels in the equifugacity condition: **VLE is
-invariant for arbitrary, unequal** :math:`c_i`, not merely for equal ones.  And because the two
-coexisting phases have different compositions, :math:`\Delta_{\mathrm{vap}} V` and
-:math:`\Delta_{\mathrm{vap}} H` are the one place a mixture behaves differently from a pure fluid.
+invariant for arbitrary** :math:`c_i`.  And because the two coexisting phases have different compositions, 
+:math:`\Delta_{\mathrm{vap}} V` and :math:`\Delta_{\mathrm{vap}} H` are the one place a mixture behaves 
+differently from a pure fluid.
 
 .. warning:: CoolProp implements a **temperature-independent** :math:`c` only.  A :math:`c(T)` would
              break most of the "unchanged" rows above -- it perturbs :math:`s`, :math:`u`,
@@ -321,11 +333,22 @@ coexisting phases have different compositions, :math:`\Delta_{\mathrm{vap}} V` a
 Setting the translation
 -----------------------
 
-:math:`c` is a per-component fluid parameter, in m\ :sup:`3`/mol, reached through
+:math:`c` is a per-component fluid parameter, in m\ :sup:`3`/mol and is :math:`0` by default 
+(no volume translation).  It can be set and retrieved with
 :cpapi:`set_fluid_parameter_double <CoolProp::AbstractState::set_fluid_parameter_double>` and
 :cpapi:`get_fluid_parameter_double <CoolProp::AbstractState::get_fluid_parameter_double>` under the
 names ``c``, ``cm`` or ``c_m``.  When setting, the spelling ``c_all`` broadcasts one value to
 every component; reading back always names a component, through ``c``/``cm``/``c_m``.
+
+.. ipython::
+
+    In [0]: import CoolProp.CoolProp as CP
+
+    In [0]: AS = CP.AbstractState("PR", "n-Propane")
+
+    In [0]: AS.set_fluid_parameter_double(0, "cm", -3.7e-6)
+
+    In [0]: AS.get_fluid_parameter_double(0, "cm")
 
 Setting a value that would drive :math:`b_i - c_i \le 0` raises a ``ValueError``, since past that
 point the repulsive pole moves through the liquid branch and the model returns finite nonsense
@@ -337,16 +360,6 @@ change is rolled back if it would invalidate a translation already in place.
              rule :math:`b_{ij} = ((b_i^{3/4} + b_j^{3/4})/2)^{4/3}` is sub-linear, so
              :math:`b_m \le \sum_i x_i b_i` while :math:`c_m` stays linear.  Per-component values
              that each pass can therefore still give :math:`b_m - c_m \le 0` at some compositions.
-
-.. ipython::
-
-    In [0]: import CoolProp.CoolProp as CP
-
-    In [0]: AS = CP.AbstractState("PR", "n-Propane")
-
-    In [0]: AS.set_fluid_parameter_double(0, "cm", -3.7e-6)
-
-    In [0]: AS.get_fluid_parameter_double(0, "cm")
 
 
 Adding your own fluids

--- a/Web/coolprop/Cubics.rst
+++ b/Web/coolprop/Cubics.rst
@@ -324,10 +324,19 @@ Setting the translation
 :math:`c` is a per-component fluid parameter, in m\ :sup:`3`/mol, reached through
 :cpapi:`set_fluid_parameter_double <CoolProp::AbstractState::set_fluid_parameter_double>` and
 :cpapi:`get_fluid_parameter_double <CoolProp::AbstractState::get_fluid_parameter_double>` under the
-names ``c``, ``cm`` or ``c_m``.  The spelling ``c_all`` broadcasts one value to every component.
+names ``c``, ``cm`` or ``c_m``.  When setting, the spelling ``c_all`` broadcasts one value to
+every component; reading back always names a component, through ``c``/``cm``/``c_m``.
+
 Setting a value that would drive :math:`b_i - c_i \le 0` raises a ``ValueError``, since past that
 point the repulsive pole moves through the liquid branch and the model returns finite nonsense
-rather than failing loudly.
+rather than failing loudly.  Because :math:`b_i = \Omega_b R T_{c,i}/p_{c,i}`, the covolume moves
+with the critical constants, so the same check runs when ``Tcrit`` or ``pcrit`` is set, and such a
+change is rolled back if it would invalidate a translation already in place.
+
+.. warning:: For VTPR the per-component condition is necessary but not sufficient.  Its combining
+             rule :math:`b_{ij} = ((b_i^{3/4} + b_j^{3/4})/2)^{4/3}` is sub-linear, so
+             :math:`b_m \le \sum_i x_i b_i` while :math:`c_m` stays linear.  Per-component values
+             that each pass can therefore still give :math:`b_m - c_m \le 0` at some compositions.
 
 .. ipython::
 

--- a/Web/coolprop/Cubics.rst
+++ b/Web/coolprop/Cubics.rst
@@ -246,6 +246,98 @@ Here we plot phase envelopes and critical points for an equimolar methane/ethane
     plt.tight_layout()
     plt.show()
 
+Volume Translation
+==================
+
+Cubic equations of state predict saturated liquid densities poorly with average deviations of about 
+16 % and 8 % for SRK and PR respectively :cite:`Jaubert-FPE-2016`.  The Péneloux correction :cite:`Peneloux-FPE-1982` 
+fixes this at almost no cost by shifting the molar volume by a constant:
+
+.. math::
+
+  v = v^{\mathrm{EOS}} - c
+
+Equivalently, the Helmholtz energy is evaluated at a shifted volume,
+:math:`a^{vs}(T,v) = a^{\mathrm{EOS}}(T,v+c)`, which is how it is implemented in CoolProp.  For a
+mixture the translation is composition dependent through the **linear** mixing rule
+
+.. math::
+
+  c_m(\mathbf{x}) = \sum_i x_i c_i
+
+This rule is not a choice.  Privat et al. :cite:`Privat-FPE-2016` show that requiring the translation
+to leave phase equilibria unchanged forces the arithmetic-mean combining rule for :math:`c_{ij}`,
+which collapses to the linear form above -- so there is no :math:`c_{ij}` to fit or store.
+
+What changes and what does not
+------------------------------
+
+A constant translation is *not* a fudge factor applied to one output; it changes some properties by
+an exactly predictable amount and leaves others untouched.  The table below follows Jaubert et al.
+:cite:`Jaubert-FPE-2016` and Privat et al. :cite:`Privat-FPE-2016` and is pinned by the test suite 
+at round-off level.
+
+=====================================================  =============================================
+Quantity                                               Effect of the translation
+=====================================================  =============================================
+:math:`v`                                              :math:`v - c_m(\mathbf{z})`
+:math:`h`, :math:`g`, :math:`\mu_i`                    shifted by :math:`-p\,c_m(\mathbf{z})`
+:math:`\ln \varphi_i`                                  shifted by :math:`-p\,c_i/(RT)`, using the
+                                                       **pure-component** :math:`c_i`
+:math:`B` (second virial coefficient)                  :math:`B - c_m(\mathbf{z})`
+:math:`s`, :math:`u`, :math:`a`, :math:`c_p`,          **unchanged**
+:math:`c_v`
+:math:`-(\partial v/\partial p)_T`,                    **unchanged**
+:math:`(\partial v/\partial T)_p`
+:math:`p^{\mathrm{sat}}`, :math:`p_{\mathrm{bub}}`,    **unchanged**
+:math:`p_{\mathrm{dew}}`, :math:`K_i`, phase
+compositions
+:math:`w` (speed of sound)                             **changes** (:math:`w^2 \propto v^2`)
+:math:`\Delta_{\mathrm{vap}} S`,                       **unchanged**
+:math:`\Delta_{\mathrm{vap}} U`,
+:math:`\Delta_{\mathrm{vap}} A`,
+:math:`\Delta_{\mathrm{vap}} c_p`,
+:math:`\Delta_{\mathrm{vap}} c_v`
+:math:`\Delta_{\mathrm{vap}} V`,                       unchanged for a pure fluid; for a mixture
+:math:`\Delta_{\mathrm{vap}} H`                        shifted by
+                                                       :math:`-[c_m(\mathbf{y})-c_m(\mathbf{x})]`
+                                                       and
+                                                       :math:`-p[c_m(\mathbf{y})-c_m(\mathbf{x})]`
+=====================================================  =============================================
+
+Two consequences are worth spelling out.  Because :math:`\ln \varphi_i` shifts by the same amount in
+both phases at the same :math:`(T,p)`, the shift cancels in the equifugacity condition: **VLE is
+invariant for arbitrary, unequal** :math:`c_i`, not merely for equal ones.  And because the two
+coexisting phases have different compositions, :math:`\Delta_{\mathrm{vap}} V` and
+:math:`\Delta_{\mathrm{vap}} H` are the one place a mixture behaves differently from a pure fluid.
+
+.. warning:: CoolProp implements a **temperature-independent** :math:`c` only.  A :math:`c(T)` would
+             break most of the "unchanged" rows above -- it perturbs :math:`s`, :math:`u`,
+             :math:`c_p` and :math:`c_v` as well, which is precisely why constant translations are
+             the standard choice.
+
+Setting the translation
+-----------------------
+
+:math:`c` is a per-component fluid parameter, in m\ :sup:`3`/mol, reached through
+:cpapi:`set_fluid_parameter_double <CoolProp::AbstractState::set_fluid_parameter_double>` and
+:cpapi:`get_fluid_parameter_double <CoolProp::AbstractState::get_fluid_parameter_double>` under the
+names ``c``, ``cm`` or ``c_m``.  The spelling ``c_all`` broadcasts one value to every component.
+Setting a value that would drive :math:`b_i - c_i \le 0` raises a ``ValueError``, since past that
+point the repulsive pole moves through the liquid branch and the model returns finite nonsense
+rather than failing loudly.
+
+.. ipython::
+
+    In [0]: import CoolProp.CoolProp as CP
+
+    In [0]: AS = CP.AbstractState("PR", "n-Propane")
+
+    In [0]: AS.set_fluid_parameter_double(0, "cm", -3.7e-6)
+
+    In [0]: AS.get_fluid_parameter_double(0, "cm")
+
+
 Adding your own fluids
 ======================
 

--- a/Web/coolprop/Cubics.rst
+++ b/Web/coolprop/Cubics.rst
@@ -281,9 +281,11 @@ at round-off level.
 Quantity                                               Effect of the translation
 =====================================================  =============================================
 :math:`v`                                              :math:`v - c_m(\mathbf{z})`
-:math:`h`, :math:`g`, :math:`\mu_i`                    shifted by :math:`-p\,c_m(\mathbf{z})`
-:math:`\ln \varphi_i`                                  shifted by :math:`-p\,c_i/(RT)`, using the
+:math:`h`, :math:`g`                                   shifted by :math:`-p\,c_m(\mathbf{z})`
+:math:`\mu_i`                                          shifted by :math:`-p\,c_i`, using the
                                                        **pure-component** :math:`c_i`
+:math:`\ln \varphi_i`                                  shifted by :math:`-p\,c_i/(RT)`, the same
+                                                       pure-component :math:`c_i`
 :math:`B` (second virial coefficient)                  :math:`B - c_m(\mathbf{z})`
 :math:`s`, :math:`u`, :math:`a`, :math:`c_p`,          **unchanged**
 :math:`c_v`

--- a/dev/ci/preflight.sh
+++ b/dev/ci/preflight.sh
@@ -310,7 +310,16 @@ else
         # is instantiated for PengRobinsonBackend and SRKBackend and finite-
         # differences the whole fugacity chain, so it is where a wrong
         # composition derivative shows up.
-        TAG_FILTER="[cubic],[volume_translation],[mixture_derivs2],[michelsen]"
+        #
+        # The last three are NOT optional and must not be trimmed: GeneralizedCubic
+        # is not reached only through the cubic backends.  HEOS embeds an
+        # AbstractCubic via ResidualHelmholtzGeneralizedCubic -- both from
+        # change_EOS(i,"SRK"/"Peng-Robinson") and from the "-SRK"/"-PengRobinson"
+        # fluid endings -- so alphar of an ordinary HEOS fluid can run straight
+        # through psi_minus/PI_12/A_term.  The tests covering that path carry none
+        # of the four tags above, and before this branch a Cubics change fell
+        # through to the whole "~[slow]" suite and picked them up for free.
+        TAG_FILTER="[cubic],[volume_translation],[mixture_derivs2],[michelsen],[change_EOS],[GERG],[json_validation]"
     else
         # Default: run everything fast (skip the [slow] long tests).
         TAG_FILTER="~[slow]"

--- a/dev/ci/preflight.sh
+++ b/dev/ci/preflight.sh
@@ -303,6 +303,14 @@ else
         # exclusion, so 6 [slow]-tagged cases are in scope — but they came in
         # with [REFPROP] already, not with this widening.
         TAG_FILTER="[Helmholtz],[REFPROP],[flash],[mixture]"
+    elif printf '%s\n' "$ALL_PATHS" | grep -qE "^src/Backends/Cubics/"; then
+        # Cubic backends touched.  [cubic] is the umbrella (every [cubic_*]
+        # test now carries it too — Catch2 tags are exact-match, not prefix).
+        # [mixture_derivs2] is the composition-derivative gate: DerivativeFixture
+        # is instantiated for PengRobinsonBackend and SRKBackend and finite-
+        # differences the whole fugacity chain, so it is where a wrong
+        # composition derivative shows up.
+        TAG_FILTER="[cubic],[volume_translation],[mixture_derivs2],[michelsen]"
     else
         # Default: run everything fast (skip the [slow] long tests).
         TAG_FILTER="~[slow]"

--- a/dev/ci/preflight.sh
+++ b/dev/ci/preflight.sh
@@ -311,15 +311,22 @@ else
         # differences the whole fugacity chain, so it is where a wrong
         # composition derivative shows up.
         #
-        # The last three are NOT optional and must not be trimmed: GeneralizedCubic
-        # is not reached only through the cubic backends.  HEOS embeds an
-        # AbstractCubic via ResidualHelmholtzGeneralizedCubic -- both from
-        # change_EOS(i,"SRK"/"Peng-Robinson") and from the "-SRK"/"-PengRobinson"
-        # fluid endings -- so alphar of an ordinary HEOS fluid can run straight
-        # through psi_minus/PI_12/A_term.  The tests covering that path carry none
-        # of the four tags above, and before this branch a Cubics change fell
-        # through to the whole "~[slow]" suite and picked them up for free.
-        TAG_FILTER="[cubic],[volume_translation],[mixture_derivs2],[michelsen],[change_EOS],[GERG],[json_validation]"
+        # [helmholtz] is NOT optional, and neither is it covered by the rest of
+        # this list: GeneralizedCubic is not reached only through the cubic
+        # backends.  HelmholtzConsistencyFixture builds a
+        # ResidualHelmholtzGeneralizedCubic over both SRK and PengRobinson and
+        # finite-differences all 14 derivatives, including the third- and
+        # fourth-order delta terms -- psi_minus/psi_plus cases 3 and 4, which feed
+        # d3alphar_ddelta3 / d4alphar_ddelta4 and hence the critical-point and
+        # stability routines.  Nothing else here reaches them: [mixture_derivs2]
+        # stops at d2alphar_dDelta2, and [change_EOS] only asserts that
+        # change_EOS(0,"SRK") does not throw -- it never evaluates a property
+        # afterwards, so it cannot see a wrong alphar.  Nor does anything in the
+        # suite evaluate a thermodynamic property through the "-SRK" /
+        # "-PengRobinson" fluid endings; the one test that names them reads molar
+        # mass.  [GERG] and [json_validation] stay for the cubic JSON payload and
+        # change_EOS surfaces they do cover.
+        TAG_FILTER="[cubic],[volume_translation],[mixture_derivs2],[michelsen],[change_EOS],[GERG],[json_validation],[helmholtz]"
     else
         # Default: run everything fast (skip the [slow] long tests).
         TAG_FILTER="~[slow]"

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -876,7 +876,7 @@ double CoolProp::AbstractCubicBackend::get_fluid_parameter_double(const size_t i
     if (i >= N) {
         throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N - 1));
     }
-    // Get the volume translation parrameter, currently applied to the whole fluid, not to components.
+    // The volume translation is per component; component i is returned, not a fluid-wide value.
     if (parameter == "c" || parameter == "cm" || parameter == "c_m") {
         return get_cubic()->get_cm(i);
     } else if (parameter == "Q" || parameter == "Qk" || parameter == "Q_k") {

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -147,7 +147,13 @@ void CoolProp::AbstractCubicBackend::get_linear_reducing_parameters(double& rhom
         T_r += mole_fractions[i] * Tc[i];
         // Curve fit from all the pure fluids in CoolProp (thanks to recommendation of A. Kazakov)
         double v_c_Lmol = 2.14107171795 * (Tc[i] / pc[i] * 1000) + 0.00773144012514;  // [L/mol]
-        v_r += mole_fractions[i] * v_c_Lmol / 1000.0;
+        // A volume translation leaves Tc alone but moves each component's critical volume by -c_i,
+        // so the linear volume average has to be taken on the translated volumes to stay consistent
+        // with calc_rhomolar_critical().
+        v_r += mole_fractions[i] * (v_c_Lmol / 1000.0 - cubic->get_cm(i));
+    }
+    if (!(v_r > 0)) {
+        throw ValueError(format("Volume translation is too large: the linear reducing molar volume (%g m^3/mol) is not positive", v_r));
     }
     rhomolar_r = 1 / v_r;
 }
@@ -167,8 +173,8 @@ bool CoolProp::AbstractCubicBackend::get_critical_is_terminated(double& delta, d
     // If the volume is less than the mixture covolume, stop.  The mixture covolume is the
     // smallest volume that is physically allowed for a cubic EOS -- and under a volume translation
     // that floor moves with it, to b_m - c_m.
-    double b = get_cubic()->bm_term(mole_fractions) - get_cubic()->cm_term();  // [m^3/mol]
-    double v = 1 / (delta * rhomolar_reducing());                              //[m^3/mol]
+    double b = get_cubic()->bm_term(mole_fractions) - get_cubic()->cm_term(mole_fractions);  // [m^3/mol]
+    double v = 1 / (delta * rhomolar_reducing());                                            //[m^3/mol]
     bool covolume_check = v < 1.1 * b;
 
     return covolume_check;
@@ -401,7 +407,7 @@ void CoolProp::AbstractCubicBackend::rho_Tp_cubic(CoolPropDbl T, CoolPropDbl p, 
     double R = cubic->get_R_u();
     double am = cubic->am_term(cubic->get_Tr() / T, mole_fractions, 0);
     double bm = cubic->bm_term(mole_fractions);
-    double cm = cubic->cm_term();
+    double cm = cubic->cm_term(mole_fractions);
 
     // Introducing new variables to simplify the equation:
     double d1 = cm - bm;
@@ -496,7 +502,7 @@ std::vector<double> CoolProp::AbstractCubicBackend::spinodal_densities() {
     // simply translates: there is no need to re-derive the quartic, only to map v = v_EOS - c_m on
     // the way out.  The v_EOS > b_m filter below is applied to the untranslated volumes, where it
     // belongs.
-    const double cm = cubic->cm_term();
+    const double cm = cubic->cm_term(x);
     std::vector<double> roots;
     for (double rho_eos : {rho0, rho1, rho2, rho3}) {
         if (!(rho_eos > 0) || !(1 / rho_eos > b)) {
@@ -768,7 +774,7 @@ void CoolProp::AbstractCubicBackend::copy_k(AbstractCubicBackend* donor) {
 }
 
 void CoolProp::AbstractCubicBackend::copy_cm(AbstractCubicBackend* donor) {
-    get_cubic()->set_cm(donor->get_cubic()->get_cm());
+    get_cubic()->set_cm_vector(donor->get_cubic()->get_cm_vector());
     for (auto& state : linked_states) {
         auto* ACB = static_cast<AbstractCubicBackend*>(state.get());
         ACB->copy_cm(this);
@@ -822,24 +828,35 @@ void CoolProp::AbstractCubicBackend::set_fluid_parameter_double(const size_t i, 
     if (i >= N) {
         throw ValueError(format("Index i [%d] is out of bounds. Must be between 0 and %d.", i, N - 1));
     }
-    // Set the volume translation parrameter, currently applied to the whole fluid, not to components.
-    if (parameter == "c" || parameter == "cm" || parameter == "c_m") {
+    // Volume translation.  "c"/"cm"/"c_m" set the i-th COMPONENT; "c_all" broadcasts to every
+    // component, which is what the parameter used to do unconditionally (the index was accepted and
+    // then ignored).  For a pure fluid the two are identical.
+    if (parameter == "c" || parameter == "cm" || parameter == "c_m" || parameter == "c_all") {
         // Reject a translation large enough to invert the repulsive branch, at set time.  Past the
         // pole the model does not fail loudly -- only quantities needing alpha^r itself go NaN,
         // while p, h and cp return finite nonsense -- so this has to be a precondition rather than
-        // something a caller is expected to notice downstream.  b_m is a mole-fraction average of
-        // the b0_ii, so the composition-independent worst case is the smallest of them.
+        // something a caller is expected to notice downstream.
+        //
+        // The mixture condition is b_m - c_m = sum_i x_i*(b0_ii - c_i) > 0, which is guaranteed for
+        // every composition if it holds component by component.  Checking per component is both
+        // tighter and independent of whether the mole fractions have been set yet.
         AbstractCubic* ac = get_cubic().get();
-        double bm_min = ac->b0_ii(0);
-        for (std::size_t j = 1; j < N; ++j) {
-            bm_min = std::min(bm_min, ac->b0_ii(j));
+        const bool broadcast = (parameter == "c_all");
+        for (std::size_t j = 0; j < N; ++j) {
+            if (!broadcast && j != i) {
+                continue;
+            }
+            if (!(ac->b0_ii(j) - value > 0)) {
+                throw ValueError(format("Volume translation c [%g m^3/mol] must be smaller than the covolume b [%g m^3/mol] of "
+                                        "component %d; b - c = %g is not positive",
+                                        value, ac->b0_ii(j), static_cast<int>(j), ac->b0_ii(j) - value));
+            }
         }
-        if (!(bm_min - value > 0)) {
-            throw ValueError(format("Volume translation c [%g m^3/mol] must be smaller than the smallest component covolume "
-                                    "b [%g m^3/mol]; b - c = %g is not positive",
-                                    value, bm_min, bm_min - value));
+        if (broadcast) {
+            ac->set_cm(value);
+        } else {
+            ac->set_cm(i, value);
         }
-        ac->set_cm(value);
     } else if (parameter == "Q" || parameter == "Qk" || parameter == "Q_k") {
         get_cubic()->set_Q_k(i, value);
     } else if (parameter == "Tcrit" || parameter == "Tc") {
@@ -861,7 +878,7 @@ double CoolProp::AbstractCubicBackend::get_fluid_parameter_double(const size_t i
     }
     // Get the volume translation parrameter, currently applied to the whole fluid, not to components.
     if (parameter == "c" || parameter == "cm" || parameter == "c_m") {
-        return get_cubic()->get_cm();
+        return get_cubic()->get_cm(i);
     } else if (parameter == "Q" || parameter == "Qk" || parameter == "Q_k") {
         return get_cubic()->get_Q_k(i);
     } else if (parameter == "Tcrit" || parameter == "Tc") {

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -165,9 +165,10 @@ void CoolProp::AbstractCubicBackend::get_critical_point_search_radii(double& R_d
 
 bool CoolProp::AbstractCubicBackend::get_critical_is_terminated(double& delta, double& tau) {
     // If the volume is less than the mixture covolume, stop.  The mixture covolume is the
-    // smallest volume that is physically allowed for a cubic EOS
-    double b = get_cubic()->bm_term(mole_fractions);  // [m^3/mol]
-    double v = 1 / (delta * rhomolar_reducing());     //[m^3/mol]
+    // smallest volume that is physically allowed for a cubic EOS -- and under a volume translation
+    // that floor moves with it, to b_m - c_m.
+    double b = get_cubic()->bm_term(mole_fractions) - get_cubic()->cm_term();  // [m^3/mol]
+    double v = 1 / (delta * rhomolar_reducing());                              //[m^3/mol]
     bool covolume_check = v < 1.1 * b;
 
     return covolume_check;
@@ -489,18 +490,23 @@ std::vector<double> CoolProp::AbstractCubicBackend::spinodal_densities() {
     double rho0 = NAN, rho1 = NAN, rho2 = NAN, rho3 = NAN;
     int Nsoln = 0;
     solve_quartic(crho4, crho3, crho2, crho1, crho0, Nsoln, rho0, rho1, rho2, rho3);
+
+    // The quartic above is that of the UNTRANSLATED cubic, so its roots are densities of the
+    // untranslated EOS.  Because -(dv/dP)_T is invariant under a Peneloux translation, the spinodal
+    // simply translates: there is no need to re-derive the quartic, only to map v = v_EOS - c_m on
+    // the way out.  The v_EOS > b_m filter below is applied to the untranslated volumes, where it
+    // belongs.
+    const double cm = cubic->cm_term();
     std::vector<double> roots;
-    if (rho0 > 0 && 1 / rho0 > b) {
-        roots.push_back(rho0);
-    }
-    if (rho1 > 0 && 1 / rho1 > b) {
-        roots.push_back(rho1);
-    }
-    if (rho2 > 0 && 1 / rho2 > b) {
-        roots.push_back(rho2);
-    }
-    if (rho3 > 0 && 1 / rho3 > b) {
-        roots.push_back(rho3);
+    for (double rho_eos : {rho0, rho1, rho2, rho3}) {
+        if (!(rho_eos > 0) || !(1 / rho_eos > b)) {
+            continue;
+        }
+        const double v = 1 / rho_eos - cm;
+        if (!(v > 0)) {
+            continue;
+        }
+        roots.push_back(1 / v);
     }
     return roots;
 }
@@ -518,8 +524,11 @@ void CoolProp::AbstractCubicBackend::saturation(CoolProp::input_pairs inputs) {
             static std::string errstr;
             double Ts = CoolProp::Secant(resid, Ts_est, -0.1, 1e-10, 100);
             _T = Ts;
-            rhoL = resid.deltaL * cubic->get_Tr();
-            rhoV = resid.deltaV * cubic->get_Tr();
+            // deltaL/deltaV are reduced densities (rho/rho_r), so the reducing DENSITY is what
+            // converts them back, not the reducing temperature.  This is currently masked because
+            // the standalone cubic backends never call set_Tr/set_rhor and both default to 1.0.
+            rhoL = resid.deltaL * cubic->get_rhor();
+            rhoV = resid.deltaV * cubic->get_rhor();
             this->SatL->update(DmolarT_INPUTS, rhoL, _T);
             this->SatV->update(DmolarT_INPUTS, rhoV, _T);
         } else {
@@ -556,8 +565,11 @@ void CoolProp::AbstractCubicBackend::saturation(CoolProp::input_pairs inputs) {
             }
 
             _p = ps;
-            rhoL = resid.deltaL * cubic->get_Tr();
-            rhoV = resid.deltaV * cubic->get_Tr();
+            // deltaL/deltaV are reduced densities (rho/rho_r), so the reducing DENSITY is what
+            // converts them back, not the reducing temperature.  This is currently masked because
+            // the standalone cubic backends never call set_Tr/set_rhor and both default to 1.0.
+            rhoL = resid.deltaL * cubic->get_rhor();
+            rhoV = resid.deltaV * cubic->get_rhor();
             this->SatL->update(DmolarT_INPUTS, rhoL, _T);
             this->SatV->update(DmolarT_INPUTS, rhoV, _T);
         } else {
@@ -755,8 +767,17 @@ void CoolProp::AbstractCubicBackend::copy_k(AbstractCubicBackend* donor) {
     }
 }
 
+void CoolProp::AbstractCubicBackend::copy_cm(AbstractCubicBackend* donor) {
+    get_cubic()->set_cm(donor->get_cubic()->get_cm());
+    for (auto& state : linked_states) {
+        auto* ACB = static_cast<AbstractCubicBackend*>(state.get());
+        ACB->copy_cm(this);
+    }
+}
+
 void CoolProp::AbstractCubicBackend::copy_internals(AbstractCubicBackend& donor) {
     this->copy_k(&donor);
+    this->copy_cm(&donor);
 
     this->components = donor.components;
     this->set_alpha_from_components();
@@ -803,7 +824,22 @@ void CoolProp::AbstractCubicBackend::set_fluid_parameter_double(const size_t i, 
     }
     // Set the volume translation parrameter, currently applied to the whole fluid, not to components.
     if (parameter == "c" || parameter == "cm" || parameter == "c_m") {
-        get_cubic()->set_cm(value);
+        // Reject a translation large enough to invert the repulsive branch, at set time.  Past the
+        // pole the model does not fail loudly -- only quantities needing alpha^r itself go NaN,
+        // while p, h and cp return finite nonsense -- so this has to be a precondition rather than
+        // something a caller is expected to notice downstream.  b_m is a mole-fraction average of
+        // the b0_ii, so the composition-independent worst case is the smallest of them.
+        AbstractCubic* ac = get_cubic().get();
+        double bm_min = ac->b0_ii(0);
+        for (std::size_t j = 1; j < N; ++j) {
+            bm_min = std::min(bm_min, ac->b0_ii(j));
+        }
+        if (!(bm_min - value > 0)) {
+            throw ValueError(format("Volume translation c [%g m^3/mol] must be smaller than the smallest component covolume "
+                                    "b [%g m^3/mol]; b - c = %g is not positive",
+                                    value, bm_min, bm_min - value));
+        }
+        ac->set_cm(value);
     } else if (parameter == "Q" || parameter == "Qk" || parameter == "Q_k") {
         get_cubic()->set_Q_k(i, value);
     } else if (parameter == "Tcrit" || parameter == "Tc") {
@@ -879,14 +915,12 @@ CoolPropDbl CoolProp::AbstractCubicBackend::calc_saturation_ancillary(parameters
 
     using namespace CubicSuperAncillary;
     if (param == iP) {
+        // A volume translation moves no pressure, so the p~ mapping needs no correction.
         double p_tilde = supercubic(eos_code, P_CODE, Ttilde);
         return p_tilde * am / (bm * bm);
     } else if (param == iDmolar) {
-        if (Q == 0) {
-            return supercubic(eos_code, RHOL_CODE, Ttilde) / bm;
-        } else {
-            return supercubic(eos_code, RHOV_CODE, Ttilde) / bm;
-        }
+        double rho_tilde = supercubic(eos_code, (Q == 0) ? RHOL_CODE : RHOV_CODE, Ttilde);
+        return untranslate_superanc_rho(rho_tilde, bm);
     } else {
         throw NotImplementedError(
           format("calc_saturation_ancillary: unsupported param=%s for cubic EOS", get_parameter_information(param, "short").c_str()));
@@ -913,8 +947,9 @@ void CoolProp::AbstractCubicBackend::update_QT_pure_superanc(CoolPropDbl Q, Cool
     double Ttilde = cubic->get_R_u() * T * bm / am;
 
     using namespace CubicSuperAncillary;
-    CoolPropDbl rhoL = supercubic(eos_code, RHOL_CODE, Ttilde) / bm;
-    CoolPropDbl rhoV = supercubic(eos_code, RHOV_CODE, Ttilde) / bm;
+    CoolPropDbl rhoL = untranslate_superanc_rho(supercubic(eos_code, RHOL_CODE, Ttilde), bm);
+    CoolPropDbl rhoV = untranslate_superanc_rho(supercubic(eos_code, RHOV_CODE, Ttilde), bm);
+    // A volume translation moves no pressure, so p~ needs no correction.
     CoolPropDbl p = supercubic(eos_code, P_CODE, Ttilde) * am / (bm * bm);
 
     clear();

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -837,9 +837,12 @@ void CoolProp::AbstractCubicBackend::set_fluid_parameter_double(const size_t i, 
         // while p, h and cp return finite nonsense -- so this has to be a precondition rather than
         // something a caller is expected to notice downstream.
         //
-        // The mixture condition is b_m - c_m = sum_i x_i*(b0_ii - c_i) > 0, which is guaranteed for
-        // every composition if it holds component by component.  Checking per component is both
-        // tighter and independent of whether the mole fractions have been set yet.
+        // For the base cubics b_m is linear in x, so b_m - c_m = sum_i x_i*(b0_ii - c_i) > 0 holds
+        // at every composition as soon as it holds component by component, and checking per
+        // component is both tighter and independent of whether the mole fractions have been set
+        // yet.  That implication does NOT carry to VTPR: its b_ij = ((b_i^(3/4) + b_j^(3/4))/2)^(4/3)
+        // is sub-linear, so b_m^VTPR <= sum_i x_i*b0_ii while c_m stays linear, and the per-component
+        // check is then necessary but not sufficient.
         AbstractCubic* ac = get_cubic().get();
         const bool broadcast = (parameter == "c_all");
         for (std::size_t j = 0; j < N; ++j) {

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -837,25 +837,18 @@ void CoolProp::AbstractCubicBackend::set_fluid_parameter_double(const size_t i, 
         // while p, h and cp return finite nonsense -- so this has to be a precondition rather than
         // something a caller is expected to notice downstream.
         //
+        // The b - c > 0 check lives in AbstractCubic::set_cm now, not here, so that every entry
+        // point gets it -- including set_cm_vector and the Tc/pc setters, which move the covolume
+        // underneath a translation already in place.
+        //
         // For the base cubics b_m is linear in x, so b_m - c_m = sum_i x_i*(b0_ii - c_i) > 0 holds
-        // at every composition as soon as it holds component by component, and checking per
-        // component is both tighter and independent of whether the mole fractions have been set
-        // yet.  That implication does NOT carry to VTPR: its b_ij = ((b_i^(3/4) + b_j^(3/4))/2)^(4/3)
-        // is sub-linear, so b_m^VTPR <= sum_i x_i*b0_ii while c_m stays linear, and the per-component
-        // check is then necessary but not sufficient.
+        // at every composition as soon as it holds component by component, and the per-component
+        // check is both tighter and independent of whether the mole fractions have been set yet.
+        // That implication does NOT carry to VTPR: its b_ij = ((b_i^(3/4) + b_j^(3/4))/2)^(4/3) is
+        // sub-linear, so b_m^VTPR <= sum_i x_i*b0_ii while c_m stays linear, and there the
+        // per-component check is necessary but not sufficient.
         AbstractCubic* ac = get_cubic().get();
-        const bool broadcast = (parameter == "c_all");
-        for (std::size_t j = 0; j < N; ++j) {
-            if (!broadcast && j != i) {
-                continue;
-            }
-            if (!(ac->b0_ii(j) - value > 0)) {
-                throw ValueError(format("Volume translation c [%g m^3/mol] must be smaller than the covolume b [%g m^3/mol] of "
-                                        "component %d; b - c = %g is not positive",
-                                        value, ac->b0_ii(j), static_cast<int>(j), ac->b0_ii(j) - value));
-            }
-        }
-        if (broadcast) {
+        if (parameter == "c_all") {
             ac->set_cm(value);
         } else {
             ac->set_cm(i, value);

--- a/src/Backends/Cubics/CubicBackend.cpp
+++ b/src/Backends/Cubics/CubicBackend.cpp
@@ -875,6 +875,14 @@ double CoolProp::AbstractCubicBackend::get_fluid_parameter_double(const size_t i
     // The volume translation is per component; component i is returned, not a fluid-wide value.
     if (parameter == "c" || parameter == "cm" || parameter == "c_m") {
         return get_cubic()->get_cm(i);
+    } else if (parameter == "c_all") {
+        // Deliberately not readable: "c_all" is a broadcast, and once the components can differ
+        // there is no single value to hand back.  It gets its own arm anyway, because it is the
+        // one spelling the setter accepts and this getter does not, so a generic round-trip
+        // caller lands here -- and the generic message below would send them looking for a typo
+        // rather than telling them which spelling to read.
+        throw ValueError(format("Parameter [c_all] is write-only: it broadcasts one value to every "
+                                "component. Read the translation back per component with \"c\", \"cm\" or \"c_m\"."));
     } else if (parameter == "Q" || parameter == "Qk" || parameter == "Q_k") {
         return get_cubic()->get_Q_k(i);
     } else if (parameter == "Tcrit" || parameter == "Tc") {

--- a/src/Backends/Cubics/CubicBackend.h
+++ b/src/Backends/Cubics/CubicBackend.h
@@ -137,7 +137,7 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
         // bound: a sufficiently negative c puts 0.9/b_m PAST the pole (where p, h and cp return
         // finite nonsense rather than NaN), and a positive c puts it BELOW real saturated-liquid
         // densities.
-        const double bmc = get_cubic()->bm_term(mole_fractions) - get_cubic()->cm_term();
+        const double bmc = get_cubic()->bm_term(mole_fractions) - get_cubic()->cm_term(mole_fractions);
         if (!(bmc > 0)) {
             throw ValueError(format("Volume translation is too large: b_m - c_m = %g m^3/mol must be positive", bmc));
         }
@@ -177,7 +177,7 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
             // Curve fit from all the pure fluids in CoolProp (thanks to recommendation of A. Kazakov)
             double v_c_Lmol = 2.14107171795 * (cubic->get_Tc()[0] / cubic->get_pc()[0] * 1000) + 0.00773144012514;  // [L/mol]
             // A volume translation leaves Tc and pc alone but moves the critical volume by -c.
-            const double v_c = v_c_Lmol / 1000.0 - get_cubic()->cm_term();  // [m^3/mol]
+            const double v_c = v_c_Lmol / 1000.0 - get_cubic()->cm_term(mole_fractions);  // [m^3/mol]
             if (!(v_c > 0)) {
                 throw ValueError(format("Volume translation is too large: the translated critical molar volume (%g m^3/mol) is not positive", v_c));
             }
@@ -372,7 +372,7 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
     /// a translated fluid is the untranslated one, which then misclassifies states in
     /// update_DmolarT().
     double untranslate_superanc_rho(double rho_tilde, double bm) {
-        const double v = bm / rho_tilde - get_cubic()->cm_term();
+        const double v = bm / rho_tilde - get_cubic()->cm_term(mole_fractions);
         if (!(v > 0)) {
             throw ValueError(format("Volume translation is too large: the translated saturation molar volume (%g m^3/mol) is not positive", v));
         }

--- a/src/Backends/Cubics/CubicBackend.h
+++ b/src/Backends/Cubics/CubicBackend.h
@@ -132,7 +132,16 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
         return reducing;
     };
     CoolPropDbl calc_rhomolar_max_bound() override {
-        return 0.9 / get_cubic()->bm_term(mole_fractions);
+        // The repulsive term -ln(1 - (b_m - c_m)*rho) has its pole at rho = 1/(b_m - c_m), not at
+        // 1/b_m.  Both signs of the translation occur in practice and both break the untranslated
+        // bound: a sufficiently negative c puts 0.9/b_m PAST the pole (where p, h and cp return
+        // finite nonsense rather than NaN), and a positive c puts it BELOW real saturated-liquid
+        // densities.
+        const double bmc = get_cubic()->bm_term(mole_fractions) - get_cubic()->cm_term();
+        if (!(bmc > 0)) {
+            throw ValueError(format("Volume translation is too large: b_m - c_m = %g m^3/mol must be positive", bmc));
+        }
+        return 0.9 / bmc;
     };
     CoolPropDbl calc_reduced_density() override {
         return _rhomolar / get_cubic()->get_rhor();
@@ -167,7 +176,12 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
         if (is_pure_or_pseudopure) {
             // Curve fit from all the pure fluids in CoolProp (thanks to recommendation of A. Kazakov)
             double v_c_Lmol = 2.14107171795 * (cubic->get_Tc()[0] / cubic->get_pc()[0] * 1000) + 0.00773144012514;  // [L/mol]
-            return 1 / (v_c_Lmol / 1000.0);
+            // A volume translation leaves Tc and pc alone but moves the critical volume by -c.
+            const double v_c = v_c_Lmol / 1000.0 - get_cubic()->cm_term();  // [m^3/mol]
+            if (!(v_c > 0)) {
+                throw ValueError(format("Volume translation is too large: the translated critical molar volume (%g m^3/mol) is not positive", v_c));
+            }
+            return 1 / v_c;
         } else {
             return HelmholtzEOSMixtureBackend::calc_rhomolar_critical();
         }
@@ -320,6 +334,14 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
     // Copy the entire kij matrix from another instance in one shot
     void copy_k(AbstractCubicBackend* donor);
 
+    /// Copy the volume-translation parameter from another instance.
+    ///
+    /// get_copy() constructs a brand-new AbstractCubic from Tc/pc/acentric/R_u, whose constructor
+    /// zeroes the translation.  copy_internals() replays only the kij matrix and the components
+    /// vector, so without this the copy silently reverts to an untranslated EOS -- which would leave
+    /// TPD_state, critical_state and transient_pure_state disagreeing with their parent.
+    void copy_cm(AbstractCubicBackend* donor);
+
     //
     void copy_all_alpha_functions(AbstractCubicBackend* donor);
 
@@ -339,6 +361,22 @@ class AbstractCubicBackend : public HelmholtzEOSMixtureBackend
     /// Derived classes (SRKBackend, PengRobinsonBackend) override this.
     virtual int get_superanc_eos_code() const {
         return CubicSuperAncillary::UNKNOWN_CODE;
+    }
+
+    /// Map a reduced superancillary density \f$\tilde\rho = \rho_{\rm EOS} b_m\f$ back to a real
+    /// molar density, applying the volume translation.
+    ///
+    /// The Chebyshev superancillary tables describe the UNTRANSLATED cubic, so the volume they
+    /// imply is \f$v_{\rm EOS} = b_m/\tilde\rho\f$ and the physical volume is
+    /// \f$v = v_{\rm EOS} - c_m\f$.  Without this correction every saturation density returned for
+    /// a translated fluid is the untranslated one, which then misclassifies states in
+    /// update_DmolarT().
+    double untranslate_superanc_rho(double rho_tilde, double bm) {
+        const double v = bm / rho_tilde - get_cubic()->cm_term();
+        if (!(v > 0)) {
+            throw ValueError(format("Volume translation is too large: the translated saturation molar volume (%g m^3/mol) is not positive", v));
+        }
+        return 1.0 / v;
     }
 
     CoolPropDbl calc_saturation_ancillary(parameters param, int Q, parameters given, double value) override;

--- a/src/Backends/Cubics/GeneralizedCubic.cpp
+++ b/src/Backends/Cubics/GeneralizedCubic.cpp
@@ -310,9 +310,22 @@ double AbstractCubic::d3_bm_term_dxidxjdxk(const std::vector<double>& x, std::si
     return 0;
 }
 
+void AbstractCubic::require_below_covolume(std::size_t i, double c) {
+    const double b = b0_ii(i);
+    // Negated rather than `b - c <= 0` so a NaN c is rejected instead of sliding through.
+    if (!(b - c > 0)) {
+        throw CoolProp::ValueError(format("Volume translation c [%g m^3/mol] must be smaller than the covolume b [%g m^3/mol] of "
+                                          "component %d; b - c = %g is not positive",
+                                          c, b, static_cast<int>(i), b - c));
+    }
+}
+
 double AbstractCubic::cm_term(const std::vector<double>& x) {
+    // Bounded by N, matching bm_term.  Ranging over x.size() instead would make bm_term(x) and
+    // cm_term(x) disagree about how many components there are whenever the two differ, and the
+    // difference b_m - c_m is exactly what the pole condition is built from.
     double summer = 0;
-    for (std::size_t i = 0; i < x.size(); ++i) {
+    for (int i = 0; i < N; ++i) {
         summer += x[i] * c_translation[i];
     }
     return summer;
@@ -326,13 +339,6 @@ double AbstractCubic::d_cm_term_dxi(const std::vector<double>& x, std::size_t i,
         return c_translation[i] - c_translation[N - 1];
     }
 }
-double AbstractCubic::d2_cm_term_dxidxj(const std::vector<double>& x, std::size_t i, std::size_t j, bool xN_independent) {
-    return 0;
-}
-double AbstractCubic::d3_cm_term_dxidxjdxk(const std::vector<double>& x, std::size_t i, std::size_t j, std::size_t k, bool xN_independent) {
-    return 0;
-}
-
 double AbstractCubic::aii_term(double tau, std::size_t i, std::size_t itau) {
     if (itau > 4) {
         // m_aii_cache[i] only stores derivatives for itau = 0..4 (see calc_all_terms()); higher

--- a/src/Backends/Cubics/GeneralizedCubic.cpp
+++ b/src/Backends/Cubics/GeneralizedCubic.cpp
@@ -605,7 +605,7 @@ double AbstractCubic::d3_PI_12_dxidxjdxk(double delta, const std::vector<double>
 double AbstractCubic::psi_plus(double delta, const std::vector<double>& x, std::size_t idelta) {
     switch (idelta) {
         case 0:
-            return A_term(delta, x) * c_term(x) / (Delta_1 - Delta_2);
+            return A_term(delta, x) * inv_bm_term(x) / (Delta_1 - Delta_2);
         case 1:
             return rho_r / PI_12(delta, x, 0);
         case 2: {
@@ -628,7 +628,8 @@ double AbstractCubic::psi_plus(double delta, const std::vector<double>& x, std::
 double AbstractCubic::d_psi_plus_dxi(double delta, const std::vector<double>& x, std::size_t idelta, std::size_t i, bool xN_independent) {
     double bracket = 0;
     if (idelta == 0) {
-        return (A_term(delta, x) * d_c_term_dxi(x, i, xN_independent) + c_term(x) * d_A_term_dxi(delta, x, i, xN_independent)) / (Delta_1 - Delta_2);
+        return (A_term(delta, x) * d_inv_bm_term_dxi(x, i, xN_independent) + inv_bm_term(x) * d_A_term_dxi(delta, x, i, xN_independent))
+               / (Delta_1 - Delta_2);
     }
     // All the terms with at least one delta derivative are multiplied by a common term of -rhor/PI12^2
     // So we just evaluate the bracketed term and then multiply by the common factor in the front
@@ -664,9 +665,9 @@ double AbstractCubic::d2_psi_plus_dxidxj(double delta, const std::vector<double>
     double bracket = 0;
     double PI12 = PI_12(delta, x, 0);
     if (idelta == 0) {
-        return (A_term(delta, x) * d2_c_term_dxidxj(x, i, j, xN_independent) + c_term(x) * d2_A_term_dxidxj(delta, x, i, j, xN_independent)
-                + d_A_term_dxi(delta, x, i, xN_independent) * d_c_term_dxi(x, j, xN_independent)
-                + d_A_term_dxi(delta, x, j, xN_independent) * d_c_term_dxi(x, i, xN_independent))
+        return (A_term(delta, x) * d2_inv_bm_term_dxidxj(x, i, j, xN_independent) + inv_bm_term(x) * d2_A_term_dxidxj(delta, x, i, j, xN_independent)
+                + d_A_term_dxi(delta, x, i, xN_independent) * d_inv_bm_term_dxi(x, j, xN_independent)
+                + d_A_term_dxi(delta, x, j, xN_independent) * d_inv_bm_term_dxi(x, i, xN_independent))
                / (Delta_1 - Delta_2);
     }
     // All the terms with at least one delta derivative have a common factor of -1/PI_12^2 out front
@@ -728,14 +729,14 @@ double AbstractCubic::d3_psi_plus_dxidxjdxk(double delta, const std::vector<doub
     double PI12 = PI_12(delta, x, 0);
     switch (idelta) {
         case 0:
-            return (A_term(delta, x) * d3_c_term_dxidxjdxk(x, i, j, k, xN_independent)
-                    + c_term(x) * d3_A_term_dxidxjdxk(delta, x, i, j, k, xN_independent)
-                    + d_A_term_dxi(delta, x, i, xN_independent) * d2_c_term_dxidxj(x, j, k, xN_independent)
-                    + d_A_term_dxi(delta, x, j, xN_independent) * d2_c_term_dxidxj(x, i, k, xN_independent)
-                    + d_A_term_dxi(delta, x, k, xN_independent) * d2_c_term_dxidxj(x, i, j, xN_independent)
-                    + d_c_term_dxi(x, i, xN_independent) * d2_A_term_dxidxj(delta, x, j, k, xN_independent)
-                    + d_c_term_dxi(x, j, xN_independent) * d2_A_term_dxidxj(delta, x, i, k, xN_independent)
-                    + d_c_term_dxi(x, k, xN_independent) * d2_A_term_dxidxj(delta, x, i, j, xN_independent))
+            return (A_term(delta, x) * d3_inv_bm_term_dxidxjdxk(x, i, j, k, xN_independent)
+                    + inv_bm_term(x) * d3_A_term_dxidxjdxk(delta, x, i, j, k, xN_independent)
+                    + d_A_term_dxi(delta, x, i, xN_independent) * d2_inv_bm_term_dxidxj(x, j, k, xN_independent)
+                    + d_A_term_dxi(delta, x, j, xN_independent) * d2_inv_bm_term_dxidxj(x, i, k, xN_independent)
+                    + d_A_term_dxi(delta, x, k, xN_independent) * d2_inv_bm_term_dxidxj(x, i, j, xN_independent)
+                    + d_inv_bm_term_dxi(x, i, xN_independent) * d2_A_term_dxidxj(delta, x, j, k, xN_independent)
+                    + d_inv_bm_term_dxi(x, j, xN_independent) * d2_A_term_dxidxj(delta, x, i, k, xN_independent)
+                    + d_inv_bm_term_dxi(x, k, xN_independent) * d2_A_term_dxidxj(delta, x, i, j, xN_independent))
                    / (Delta_1 - Delta_2);
         case 1:
             return -1 / pow(PI12, 2)

--- a/src/Backends/Cubics/GeneralizedCubic.cpp
+++ b/src/Backends/Cubics/GeneralizedCubic.cpp
@@ -380,6 +380,11 @@ double AbstractCubic::aij_term(double tau, std::size_t i, std::size_t j, std::si
     }
 }
 double AbstractCubic::psi_minus(double delta, const std::vector<double>& x, std::size_t itau, std::size_t idelta) {
+    // This early return -- and the absence of any tau derivatives in psi_plus -- IS the assumption
+    // that the volume translation is temperature-independent.  A c(T) would make psi_minus a
+    // function of tau and every one of these would need a chain-rule term.  That is deliberate:
+    // temperature-dependent translations cost the caloric invariances (s, u, cp, cv all move) and
+    // are documented to produce crossing isotherms and negative heat capacities.
     if (itau > 0) return 0.0;
     double bmc = bm_term(x) - cm_term();  // appears only in the form (b-c) in the equations
     double bracket = 1 - bmc * delta * rho_r;

--- a/src/Backends/Cubics/GeneralizedCubic.cpp
+++ b/src/Backends/Cubics/GeneralizedCubic.cpp
@@ -204,7 +204,7 @@ AbstractCubic::AbstractCubic(const std::vector<double>& Tc, std::vector<double> 
     Delta_1(Delta_1),
     Delta_2(Delta_2),
     N(static_cast<int>(Tc.size())),
-    cm(0.) {
+    c_translation(Tc.size(), 0.0) {
 
     k.resize(N, std::vector<double>(N, 0));
 
@@ -310,8 +310,27 @@ double AbstractCubic::d3_bm_term_dxidxjdxk(const std::vector<double>& x, std::si
     return 0;
 }
 
-double AbstractCubic::cm_term() {
-    return cm;
+double AbstractCubic::cm_term(const std::vector<double>& x) {
+    double summer = 0;
+    for (std::size_t i = 0; i < x.size(); ++i) {
+        summer += x[i] * c_translation[i];
+    }
+    return summer;
+}
+double AbstractCubic::d_cm_term_dxi(const std::vector<double>& x, std::size_t i, bool xN_independent) {
+    // Same x_N convention as d_bm_term_dxi -- both b_m and c_m are linear in x, so the chain rule
+    // through the dependent x_N applies to them identically.
+    if (xN_independent) {
+        return c_translation[i];
+    } else {
+        return c_translation[i] - c_translation[N - 1];
+    }
+}
+double AbstractCubic::d2_cm_term_dxidxj(const std::vector<double>& x, std::size_t i, std::size_t j, bool xN_independent) {
+    return 0;
+}
+double AbstractCubic::d3_cm_term_dxidxjdxk(const std::vector<double>& x, std::size_t i, std::size_t j, std::size_t k, bool xN_independent) {
+    return 0;
 }
 
 double AbstractCubic::aii_term(double tau, std::size_t i, std::size_t itau) {
@@ -386,7 +405,7 @@ double AbstractCubic::psi_minus(double delta, const std::vector<double>& x, std:
     // temperature-dependent translations cost the caloric invariances (s, u, cp, cv all move) and
     // are documented to produce crossing isotherms and negative heat capacities.
     if (itau > 0) return 0.0;
-    double bmc = bm_term(x) - cm_term();  // appears only in the form (b-c) in the equations
+    double bmc = bm_term(x) - cm_term(x);  // appears only in the form (b-c) in the equations
     double bracket = 1 - bmc * delta * rho_r;
 
     switch (idelta) {
@@ -413,8 +432,12 @@ double AbstractCubic::psi_minus(double delta, const std::vector<double>& x, std:
 double AbstractCubic::d_psi_minus_dxi(double delta, const std::vector<double>& x, std::size_t itau, std::size_t idelta, std::size_t i,
                                       bool xN_independent) {
     if (itau > 0) return 0.0;
-    double bmc = bm_term(x) - cm_term();  // appears only in the form (b-c) in the equations
-    double db_dxi = d_bm_term_dxi(x, i, xN_independent);
+    double bmc = bm_term(x) - cm_term(x);  // appears only in the form (b-c) in the equations
+    // psi_minus depends on x ONLY through B = b_m - c_m, so every composition derivative is a
+    // function of the B-derivatives.  With a composition-dependent c that means b_i -> b_i - c_i in
+    // the first-order slots; the second and third derivatives of c vanish under the linear rule, so
+    // the d2b/d3b terms carry through unchanged.
+    double db_dxi = d_bm_term_dxi(x, i, xN_independent) - d_cm_term_dxi(x, i, xN_independent);
     double bracket = 1 - bmc * delta * rho_r;
 
     switch (idelta) {
@@ -435,8 +458,9 @@ double AbstractCubic::d_psi_minus_dxi(double delta, const std::vector<double>& x
 double AbstractCubic::d2_psi_minus_dxidxj(double delta, const std::vector<double>& x, std::size_t itau, std::size_t idelta, std::size_t i,
                                           std::size_t j, bool xN_independent) {
     if (itau > 0) return 0.0;
-    double bmc = bm_term(x) - cm_term();  // appears only in the form (b-c) in the equations
-    double db_dxi = d_bm_term_dxi(x, i, xN_independent), db_dxj = d_bm_term_dxi(x, j, xN_independent),
+    double bmc = bm_term(x) - cm_term(x);  // appears only in the form (b-c) in the equations
+    double db_dxi = d_bm_term_dxi(x, i, xN_independent) - d_cm_term_dxi(x, i, xN_independent),
+           db_dxj = d_bm_term_dxi(x, j, xN_independent) - d_cm_term_dxi(x, j, xN_independent),
            d2b_dxidxj = d2_bm_term_dxidxj(x, i, j, xN_independent);
     double bracket = 1 - bmc * delta * rho_r;
 
@@ -461,8 +485,10 @@ double AbstractCubic::d2_psi_minus_dxidxj(double delta, const std::vector<double
 double AbstractCubic::d3_psi_minus_dxidxjdxk(double delta, const std::vector<double>& x, std::size_t itau, std::size_t idelta, std::size_t i,
                                              std::size_t j, std::size_t k, bool xN_independent) {
     if (itau > 0) return 0.0;
-    double bmc = bm_term(x) - cm_term();  // appears only in the form (b-c) in the equations
-    double db_dxi = d_bm_term_dxi(x, i, xN_independent), db_dxj = d_bm_term_dxi(x, j, xN_independent), db_dxk = d_bm_term_dxi(x, k, xN_independent),
+    double bmc = bm_term(x) - cm_term(x);  // appears only in the form (b-c) in the equations
+    double db_dxi = d_bm_term_dxi(x, i, xN_independent) - d_cm_term_dxi(x, i, xN_independent),
+           db_dxj = d_bm_term_dxi(x, j, xN_independent) - d_cm_term_dxi(x, j, xN_independent),
+           db_dxk = d_bm_term_dxi(x, k, xN_independent) - d_cm_term_dxi(x, k, xN_independent),
            d2b_dxidxj = d2_bm_term_dxidxj(x, i, j, xN_independent), d2b_dxidxk = d2_bm_term_dxidxj(x, i, k, xN_independent),
            d2b_dxjdxk = d2_bm_term_dxidxj(x, j, k, xN_independent), d3b_dxidxjdxk = d3_bm_term_dxidxjdxk(x, i, j, k, xN_independent);
     double bracket = 1 - bmc * delta * rho_r;
@@ -480,7 +506,7 @@ double AbstractCubic::d3_psi_minus_dxidxjdxk(double delta, const std::vector<dou
 }
 double AbstractCubic::PI_12(double delta, const std::vector<double>& x, std::size_t idelta) {
     double bm = bm_term(x);
-    double cm = cm_term();
+    double cm = cm_term(x);
     switch (idelta) {
         case 0:
             return (1 + (Delta_1 * bm + cm) * rho_r * delta) * (1 + (Delta_2 * bm + cm) * rho_r * delta);
@@ -498,15 +524,23 @@ double AbstractCubic::PI_12(double delta, const std::vector<double>& x, std::siz
 }
 double AbstractCubic::d_PI_12_dxi(double delta, const std::vector<double>& x, std::size_t idelta, std::size_t i, bool xN_independent) {
     double bm = bm_term(x);
-    double cm = cm_term();
+    double cm = cm_term(x);
     double db_dxi = d_bm_term_dxi(x, i, xN_independent);
+    double dc_dxi = d_cm_term_dxi(x, i, xN_independent);
+    // PI_12 = (1 + (D1*b + c)*rho)*(1 + (D2*b + c)*rho).  Grouping the composition derivative by
+    // powers of rho gives a linear part S1 and a quadratic part S2; the three idelta cases below
+    // are the same pair with different rho weights.  Setting c_i = 0 recovers the untranslated
+    // expressions exactly.
+    const double rho = delta * rho_r;
+    const double S1 = (Delta_1 + Delta_2) * db_dxi + 2 * dc_dxi;
+    const double S2 = 2 * Delta_1 * Delta_2 * bm * db_dxi + (Delta_1 + Delta_2) * (db_dxi * cm + bm * dc_dxi) + 2 * cm * dc_dxi;
     switch (idelta) {
         case 0:
-            return delta * rho_r * db_dxi * (2 * Delta_1 * Delta_2 * bm * delta * rho_r + (Delta_1 + Delta_2) * (1 + cm * delta * rho_r));
+            return rho * (S1 + rho * S2);
         case 1:
-            return rho_r * db_dxi * (4 * Delta_1 * Delta_2 * bm * delta * rho_r + (Delta_1 + Delta_2) * (1 + 2 * cm * delta * rho_r));
+            return rho_r * (S1 + 2 * rho * S2);
         case 2:
-            return 2 * pow(rho_r, 2) * (2 * Delta_1 * Delta_2 * bm + (Delta_1 + Delta_2) * cm) * db_dxi;
+            return 2 * pow(rho_r, 2) * S2;
         case 3:
             return 0;
         case 4:
@@ -518,21 +552,24 @@ double AbstractCubic::d_PI_12_dxi(double delta, const std::vector<double>& x, st
 double AbstractCubic::d2_PI_12_dxidxj(double delta, const std::vector<double>& x, std::size_t idelta, std::size_t i, std::size_t j,
                                       bool xN_independent) {
     double bm = bm_term(x);
-    double cm = cm_term();
+    double cm = cm_term(x);
     double db_dxi = d_bm_term_dxi(x, i, xN_independent), db_dxj = d_bm_term_dxi(x, j, xN_independent),
            d2b_dxidxj = d2_bm_term_dxidxj(x, i, j, xN_independent);
+    double dc_dxi = d_cm_term_dxi(x, i, xN_independent), dc_dxj = d_cm_term_dxi(x, j, xN_independent);
+    // Same S1/S2 grouping as d_PI_12_dxi, one order up.  The cross terms (b_i*c_j + b_j*c_i) and
+    // 2*c_i*c_j SURVIVE even though d2(c_m) is identically zero under the linear rule -- they come
+    // from the product structure of PI_12, not from a second derivative of c.
+    const double rho = delta * rho_r;
+    const double T1 = (Delta_1 + Delta_2) * d2b_dxidxj;
+    const double T2 = 2 * Delta_1 * Delta_2 * (db_dxi * db_dxj + bm * d2b_dxidxj)
+                      + (Delta_1 + Delta_2) * (d2b_dxidxj * cm + db_dxi * dc_dxj + db_dxj * dc_dxi) + 2 * dc_dxi * dc_dxj;
     switch (idelta) {
         case 0:
-            return delta * rho_r
-                   * (2 * Delta_1 * Delta_2 * delta * rho_r * db_dxi * db_dxj
-                      + (2 * Delta_1 * Delta_2 * bm * delta * rho_r + (Delta_1 + Delta_2) * (1 + cm * delta * rho_r)) * d2b_dxidxj);
+            return rho * (T1 + rho * T2);
         case 1:
-            return rho_r
-                   * (4 * Delta_1 * Delta_2 * delta * rho_r * db_dxi * db_dxj
-                      + (4 * Delta_1 * Delta_2 * bm * delta * rho_r + (Delta_1 + Delta_2) * (1 + 2 * cm * delta * rho_r)) * d2b_dxidxj);
+            return rho_r * (T1 + 2 * rho * T2);
         case 2:
-            return 2 * pow(rho_r, 2)
-                   * (2 * Delta_1 * Delta_2 * db_dxi * db_dxj + (2 * Delta_1 * Delta_2 * bm + (Delta_1 + Delta_2) * cm) * d2b_dxidxj);
+            return 2 * pow(rho_r, 2) * T2;
         case 3:
             return 0;
         case 4:
@@ -544,19 +581,23 @@ double AbstractCubic::d2_PI_12_dxidxj(double delta, const std::vector<double>& x
 double AbstractCubic::d3_PI_12_dxidxjdxk(double delta, const std::vector<double>& x, std::size_t idelta, std::size_t i, std::size_t j, std::size_t k,
                                          bool xN_independent) {
     double bm = bm_term(x);
-    double cm = cm_term();
+    double cm = cm_term(x);
     double db_dxi = d_bm_term_dxi(x, i, xN_independent), db_dxj = d_bm_term_dxi(x, j, xN_independent), db_dxk = d_bm_term_dxi(x, k, xN_independent),
            d2b_dxidxj = d2_bm_term_dxidxj(x, i, j, xN_independent), d2b_dxidxk = d2_bm_term_dxidxj(x, i, k, xN_independent),
            d2b_dxjdxk = d2_bm_term_dxidxj(x, j, k, xN_independent), d3b_dxidxjdxk = d3_bm_term_dxidxjdxk(x, i, j, k, xN_independent);
+    double dc_dxi = d_cm_term_dxi(x, i, xN_independent), dc_dxj = d_cm_term_dxi(x, j, xN_independent), dc_dxk = d_cm_term_dxi(x, k, xN_independent);
+    // The (D1+D2)*(b_ij*c_k + b_ik*c_j + b_jk*c_i) terms are nonzero only where d2_bm_term_dxidxj
+    // is -- that is, for VTPRCubic, whose covolume mixing rule is quadratic.  For AbstractCubic
+    // they vanish, so an error in them would hide everywhere except VTPR.
+    const double rho = delta * rho_r;
+    const double U1 = (Delta_1 + Delta_2) * d3b_dxidxjdxk;
+    const double U2 = 2 * Delta_1 * Delta_2 * (bm * d3b_dxidxjdxk + d2b_dxidxj * db_dxk + d2b_dxidxk * db_dxj + d2b_dxjdxk * db_dxi)
+                      + (Delta_1 + Delta_2) * (d3b_dxidxjdxk * cm + d2b_dxidxj * dc_dxk + d2b_dxidxk * dc_dxj + d2b_dxjdxk * dc_dxi);
     switch (idelta) {
         case 0:
-            return delta * rho_r
-                   * ((2 * Delta_1 * Delta_2 * bm * delta * rho_r + (Delta_1 + Delta_2) * (1 + cm * delta * rho_r)) * d3b_dxidxjdxk
-                      + 2 * Delta_1 * Delta_2 * delta * rho_r * (db_dxi * d2b_dxjdxk + db_dxj * d2b_dxidxk + db_dxk * d2b_dxidxj));
+            return rho * (U1 + rho * U2);
         case 1:
-            return rho_r
-                   * ((4. * Delta_1 * Delta_2 * bm * delta * rho_r + (Delta_1 + Delta_2) * (1 + 2 * cm * delta * rho_r)) * d3b_dxidxjdxk
-                      + 4 * Delta_1 * Delta_2 * delta * rho_r * (db_dxi * d2b_dxjdxk + db_dxj * d2b_dxidxk + db_dxk * d2b_dxidxj));
+            return rho_r * (U1 + 2 * rho * U2);
         default:
             throw -1;
     }

--- a/src/Backends/Cubics/GeneralizedCubic.h
+++ b/src/Backends/Cubics/GeneralizedCubic.h
@@ -264,6 +264,49 @@ class AbstractCubic
     }
 
     /**
+     * \brief Throw unless component i's volume translation stays strictly inside its covolume
+     *
+     * The repulsive pole sits at \f$v = b - c\f$, so \f$b - c \le 0\f$ inverts the repulsive
+     * branch -- and the model does NOT then fail loudly: only quantities needing \f$\alpha^r\f$
+     * itself go NaN, while p, h and c_p keep returning finite nonsense.  The invariant therefore
+     * has to be enforced at every mutator that can break it, which is why it lives here on the
+     * data rather than in one caller.  Note \f$b_{0,ii} \propto T_c/p_c\f$, so the Tc and pc
+     * setters break it just as surely as the c setters do.
+     */
+    void require_below_covolume(std::size_t i, double c);
+
+    /**
+     * \brief Refresh everything derived from Tc[i] or pc[i] after either has changed
+     *
+     * a0_ii depends on Tc[i]^2/pc[i] and Tr_over_Tci on T_r/Tc[i], so both are refreshed in the
+     * existing alpha function; b0_ii depends on Tc[i]/pc[i], so its cache entry is marked stale.
+     */
+    void refresh_after_critical_change(std::size_t i) {
+        alpha[i]->set_a0(a0_ii(i));
+        alpha[i]->set_Tr_over_Tci(T_r / Tc[i]);
+        if (i < m_b0_ii_cache.size()) {
+            m_b0_ii_cache_valid[i] = 0;
+        }
+        m_tau_cache = std::numeric_limits<double>::quiet_NaN();  // invalidate aii cache
+    }
+
+    /**
+     * \brief Undo a Tc/pc change that would have left the covolume at or below the translation
+     *
+     * `slot` is the member that was just written, passed by reference so the restore happens
+     * here rather than being duplicated at both call sites.
+     */
+    void rollback_critical_unless_translation_fits(std::size_t i, double previous, double& slot) {
+        try {
+            require_below_covolume(i, c_translation[i]);
+        } catch (...) {
+            slot = previous;
+            refresh_after_critical_change(i);
+            throw;
+        }
+    }
+
+    /**
      * \brief Set the critical temperature of the i-th component [K]
      *
      * Updates Tc[i], refreshes the alpha function's a0 and Tr/Tci ratio, and
@@ -271,16 +314,10 @@ class AbstractCubic
      * up the new value consistently.
      */
     void set_Tci(std::size_t i, double Tci) {
+        const double previous = Tc[i];
         Tc[i] = Tci;
-        // a0_ii depends on Tc[i]^2/pc[i], and Tr_over_Tci = T_r/Tc[i].
-        // Refresh both in the existing alpha function so its parameters stay consistent.
-        alpha[i]->set_a0(a0_ii(i));
-        alpha[i]->set_Tr_over_Tci(T_r / Tc[i]);
-        // b0_ii depends on Tc[i]/pc[i]; mark the affected entry as stale.
-        if (i < m_b0_ii_cache.size()) {
-            m_b0_ii_cache_valid[i] = 0;
-        }
-        m_tau_cache = std::numeric_limits<double>::quiet_NaN();  // invalidate aii cache
+        refresh_after_critical_change(i);
+        rollback_critical_unless_translation_fits(i, previous, Tc[i]);
     }
     /**
      * \brief Set the critical pressure of the i-th component [Pa]
@@ -289,14 +326,10 @@ class AbstractCubic
      * cache so that all subsequent evaluations pick up the new value consistently.
      */
     void set_pci(std::size_t i, double pci) {
+        const double previous = pc[i];
         pc[i] = pci;
-        // a0_ii depends on Tc[i]^2/pc[i]; refresh it in the existing alpha function.
-        alpha[i]->set_a0(a0_ii(i));
-        // b0_ii depends on Tc[i]/pc[i]; mark the affected entry as stale.
-        if (i < m_b0_ii_cache.size()) {
-            m_b0_ii_cache_valid[i] = 0;
-        }
-        m_tau_cache = std::numeric_limits<double>::quiet_NaN();  // invalidate aii cache
+        refresh_after_critical_change(i);
+        rollback_critical_unless_translation_fits(i, previous, pc[i]);
     }
     /// Set the three Mathias-Copeman constants in one shot for the component i of a mixture
     void set_C_MC(std::size_t i, double c1, double c2, double c3) {
@@ -410,13 +443,17 @@ class AbstractCubic
      * \param xN_independent True if \f$x_N\f$ is an independent variable, false otherwise
      */
     virtual double d_cm_term_dxi(const std::vector<double>& x, std::size_t i, bool xN_independent);
-    /// The second composition derivative of \f$c_{\rm m}\f$; identically zero for the linear rule
-    virtual double d2_cm_term_dxidxj(const std::vector<double>& x, std::size_t i, std::size_t j, bool xN_independent);
-    /// The third composition derivative of \f$c_{\rm m}\f$; identically zero for the linear rule
-    virtual double d3_cm_term_dxidxjdxk(const std::vector<double>& x, std::size_t i, std::size_t j, std::size_t k, bool xN_independent);
+    // No d2_cm_term_dxidxj / d3_cm_term_dxidxjdxk.  Under the linear rule c_m = sum_i x_i*c_i
+    // they are identically zero, and every consumer (d2_PI_12's T1, d3_PI_12's U2, L_term,
+    // L3_term, d2/d3_psi_minus) folds that zero in by hand.  Declaring them virtual would invite
+    // an override that those hardcoded zeros would then silently ignore.
 
-    /// Set the volume translation of every component to the same value
+    /// Set the volume translation of every component to the same value.  All-or-nothing: every
+    /// component is validated before any is written, so a rejected value leaves c untouched.
     void set_cm(double val) {
+        for (std::size_t i = 0; i < c_translation.size(); ++i) {
+            require_below_covolume(i, val);
+        }
         std::fill(c_translation.begin(), c_translation.end(), val);
     }
     /// Set the volume translation of the i-th component
@@ -424,6 +461,7 @@ class AbstractCubic
         if (i >= c_translation.size()) {
             throw CoolProp::ValueError("index out of range in set_cm");
         }
+        require_below_covolume(i, val);
         c_translation[i] = val;
     }
     /// Get the volume translation of the i-th component
@@ -437,10 +475,15 @@ class AbstractCubic
     const std::vector<double>& get_cm_vector() const {
         return c_translation;
     }
-    /// Set the whole vector of volume translations, for copy propagation
+    /// Set the whole vector of volume translations, for copy propagation.  Also the entry point
+    /// used directly on a bare AbstractCubic -- the HEOS "-SRK"/"-PengRobinson" fluids have no
+    /// backend wrapper to validate on their behalf -- so it checks rather than trusting the donor.
     void set_cm_vector(const std::vector<double>& c) {
         if (c.size() != c_translation.size()) {
             throw CoolProp::ValueError("size mismatch in set_cm_vector");
+        }
+        for (std::size_t i = 0; i < c.size(); ++i) {
+            require_below_covolume(i, c[i]);
         }
         c_translation = c;
     }

--- a/src/Backends/Cubics/GeneralizedCubic.h
+++ b/src/Backends/Cubics/GeneralizedCubic.h
@@ -399,6 +399,15 @@ class AbstractCubic
     double get_cm() {
         return cm;
     }
+    /**
+	* \brief The factor \f$1 + c_{\rm m}\rho\f$ common to every composition derivative of \f$A\f$
+	*
+	* Named rather than inlined at each of the three call sites so they cannot drift apart, and so
+	* that the one place the translation enters those derivatives is greppable.
+	*/
+    double one_plus_cm_rho(double delta) {
+        return 1.0 + cm_term() * delta * rho_r;
+    }
 
     /// Modify the surface parameter Q_k of the sub group sgi
     virtual void set_Q_k(const size_t sgi, const double value) {
@@ -671,7 +680,12 @@ class AbstractCubic
      */
     double d_A_term_dxi(double delta, const std::vector<double>& x, std::size_t i, bool xN_independent) {
         std::size_t idelta = 0;
-        return delta * rho_r * d_bm_term_dxi(x, i, xN_independent) * (Delta_1 - Delta_2) / PI_12(delta, x, idelta);
+        // The (1 + c_m*rho) factor is easy to miss because PI_12 in the denominator already carries
+        // c_m, which makes the expression look translation-aware when it is not.  Differentiating
+        // A = ln[(1 + (D1*b + c)*rho) / (1 + (D2*b + c)*rho)] gives
+        //     dA/dx_i = rho*(D1 - D2)*(1 + c*rho)*b_i / PI_12
+        // for a composition-independent c.  Omitting the factor is exact only at c = 0.
+        return delta * rho_r * d_bm_term_dxi(x, i, xN_independent) * (Delta_1 - Delta_2) * one_plus_cm_rho(delta) / PI_12(delta, x, idelta);
     };
     /**
      * \brief The second composition derivative of the term \f$A\f$ used in the pure composition partial derivatives of \f$\psi^{(+)}\f$
@@ -684,7 +698,9 @@ class AbstractCubic
     double d2_A_term_dxidxj(double delta, const std::vector<double>& x, std::size_t i, std::size_t j, bool xN_independent) {
         std::size_t idelta = 0;
         double PI12 = PI_12(delta, x, idelta);
-        return delta * rho_r * (Delta_1 - Delta_2) / pow(PI12, 2)
+        // Same missing (1 + c_m*rho) as in d_A_term_dxi; for a composition-independent c it is a
+        // common factor on both surviving terms.
+        return delta * rho_r * (Delta_1 - Delta_2) * one_plus_cm_rho(delta) / pow(PI12, 2)
                * (PI12 * d2_bm_term_dxidxj(x, i, j, xN_independent)
                   - d_PI_12_dxi(delta, x, 0, j, xN_independent) * d_bm_term_dxi(x, i, xN_independent));
     };
@@ -700,8 +716,8 @@ class AbstractCubic
     double d3_A_term_dxidxjdxk(double delta, const std::vector<double>& x, std::size_t i, std::size_t j, std::size_t k, bool xN_independent) {
         std::size_t idelta = 0;
         double PI12 = PI_12(delta, x, idelta);
-        // The leading factor
-        double lead = delta * rho_r * (Delta_1 - Delta_2) / pow(PI12, 3);
+        // The leading factor -- see d_A_term_dxi for the missing (1 + c_m*rho)
+        double lead = delta * rho_r * (Delta_1 - Delta_2) * one_plus_cm_rho(delta) / pow(PI12, 3);
         return lead
                * (-PI12
                     * (d_PI_12_dxi(delta, x, idelta, j, xN_independent) * d2_bm_term_dxidxj(x, i, k, xN_independent)

--- a/src/Backends/Cubics/GeneralizedCubic.h
+++ b/src/Backends/Cubics/GeneralizedCubic.h
@@ -481,7 +481,7 @@ class AbstractCubic
      * \param x The vector of mole fractions
      * \param idelta How many derivatives to take with respect to \f$\delta\f$
      *
-     * \f[ \Pi_{12} = (1+\Delta_1\bm\rhor \delta)(1+\Delta_2\bm\rhor \delta) \f]
+     * \f[ \Pi_{12} = (1+(\Delta_1 b_m + c_m)\rho_r \delta)(1+(\Delta_2 b_m + c_m)\rho_r \delta) \f]
      */
     double PI_12(double delta, const std::vector<double>& x, std::size_t idelta);
     /**
@@ -561,7 +561,7 @@ class AbstractCubic
      * \param x The vector of mole fractions
      * \param idelta How many derivatives to take with respect to \f$\delta\f$
      *
-     * \f[  \psi^{(+)} = \dfrac{\ln\left(\dfrac{\Delta_1\bm\rhor \delta+1}{\Delta_2\bm\rhor \delta+1}\right)}{\bm(\Delta_1-\Delta_2)}  \f]
+     * \f[  \psi^{(+)} = \dfrac{\ln\left(\dfrac{(\Delta_1 b_m + c_m)\rho_r \delta+1}{(\Delta_2 b_m + c_m)\rho_r \delta+1}\right)}{b_m(\Delta_1-\Delta_2)}  \f]
      */
     double psi_plus(double delta, const std::vector<double>& x, std::size_t idelta);
     /**
@@ -651,7 +651,7 @@ class AbstractCubic
      * \brief The term \f$A\f$ used in the pure composition partial derivatives of \f$\psi^{(+)}\f$
      *
      * \f[
-     * A = \log\left(\frac{\Delta_1\delta\rho_r b_m+1}{\Delta_2\delta\rho_r b+1}\right)
+     * A = \log\left(\frac{(\Delta_1 b_m + c_m)\delta\rho_r+1}{(\Delta_2 b_m + c_m)\delta\rho_r+1}\right)
      * \f]
      *
      * \param delta The reduced density \f$\delta = \frac{\rho}{\rho_c}\f$

--- a/src/Backends/Cubics/GeneralizedCubic.h
+++ b/src/Backends/Cubics/GeneralizedCubic.h
@@ -650,47 +650,49 @@ class AbstractCubic
     double d3_psi_plus_dxidxjdxk(double delta, const std::vector<double>& x, std::size_t idelta, std::size_t i, std::size_t j, std::size_t k,
                                  bool xN_independent);
 
-    /** \brief The term \f$c\f$ used in the pure composition partial derivatives of \f$\psi^{(+)}\f$
+    /** \brief The reciprocal covolume \f$1/b_{\rm m}\f$, a factor of \f$\psi^{(+)}\f$
      *
-     * \f$c\f$ is given by
      * \f[
-     * c = \frac{1}{b_m}
+     * \mathrm{inv\_bm} = \frac{1}{b_m}
      * \f]
+     *
+     * Formerly called c_term, which had nothing to do with the volume translation c and sat
+     * directly beside cm_term.
      * \param x The vector of mole fractions
      */
-    double c_term(const std::vector<double>& x) {
+    double inv_bm_term(const std::vector<double>& x) {
         return 1 / bm_term(x);
     };
     /**
-     * \brief The first composition derivative of the term \f$c\f$ used in the pure composition partial derivatives of \f$\psi^{(+)}\f$
+     * \brief The first composition derivative of \f$1/b_{\rm m}\f$ used in the pure composition partial derivatives of \f$\psi^{(+)}\f$
      * \param x The vector of mole fractions
      * \param i The first index
      * \param xN_independent True if \f$x_N\f$ is an independent variable, false otherwise (dependent on other \f$N-1\f$ mole fractions)
      */
-    double d_c_term_dxi(const std::vector<double>& x, std::size_t i, bool xN_independent) {
+    double d_inv_bm_term_dxi(const std::vector<double>& x, std::size_t i, bool xN_independent) {
         return -d_bm_term_dxi(x, i, xN_independent) / pow(bm_term(x), 2);
     };
     /**
-     * \brief The second composition derivative of the term \f$c\f$ used in the pure composition partial derivatives of \f$\psi^{(+)}\f$
+     * \brief The second composition derivative of \f$1/b_{\rm m}\f$ used in the pure composition partial derivatives of \f$\psi^{(+)}\f$
      * \param x The vector of mole fractions
      * \param i The first index
      * \param j The second index
      * \param xN_independent True if \f$x_N\f$ is an independent variable, false otherwise (dependent on other \f$N-1\f$ mole fractions)
      */
-    double d2_c_term_dxidxj(const std::vector<double>& x, std::size_t i, std::size_t j, bool xN_independent) {
+    double d2_inv_bm_term_dxidxj(const std::vector<double>& x, std::size_t i, std::size_t j, bool xN_independent) {
         double bm = bm_term(x);
         return (2 * d_bm_term_dxi(x, i, xN_independent) * d_bm_term_dxi(x, j, xN_independent) - bm * d2_bm_term_dxidxj(x, i, j, xN_independent))
                / pow(bm, 3);
     };
     /**
-     * \brief The third composition derivative of the term \f$c\f$ used in the pure composition partial derivatives of \f$\psi^{(+)}\f$
+     * \brief The third composition derivative of \f$1/b_{\rm m}\f$ used in the pure composition partial derivatives of \f$\psi^{(+)}\f$
      * \param x The vector of mole fractions
      * \param i The first index
      * \param j The second index
      * \param k The third index
      * \param xN_independent True if \f$x_N\f$ is an independent variable, false otherwise (dependent on other \f$N-1\f$ mole fractions)
      */
-    double d3_c_term_dxidxjdxk(const std::vector<double>& x, std::size_t i, std::size_t j, std::size_t k, bool xN_independent) {
+    double d3_inv_bm_term_dxidxjdxk(const std::vector<double>& x, std::size_t i, std::size_t j, std::size_t k, bool xN_independent) {
         double bm = bm_term(x);
         return 1 / pow(bm, 4)
                * (2 * bm

--- a/src/Backends/Cubics/GeneralizedCubic.h
+++ b/src/Backends/Cubics/GeneralizedCubic.h
@@ -11,6 +11,7 @@
 #ifndef CUBIC_H
 #define CUBIC_H
 
+#include <algorithm>
 #include <utility>
 #include <vector>
 #include <cmath>
@@ -114,17 +115,23 @@ class AbstractCubic
 {
 
    protected:
-    double rho_r,                                               ///< The reducing density to be used [mol/m3]
-      T_r;                                                      ///< The reducing temperature to be used [K]
-    std::vector<double> Tc,                                     ///< Vector of critical temperatures (in K)
-      pc,                                                       ///< Vector of critical pressures (in Pa)
-      acentric;                                                 ///< Vector of acentric factors (unitless)
-    double R_u;                                                 ///< The universal gas constant  in J/(mol*K)
-    double Delta_1,                                             ///< The first cubic constant
-      Delta_2;                                                  ///< The second cubic constant
-    int N;                                                      ///< Number of components in the mixture
-    std::vector<std::vector<double>> k;                         ///< The interaction parameters (k_ii = 0)
-    double cm;                                                  ///< The volume translation parameter
+    double rho_r,                        ///< The reducing density to be used [mol/m3]
+      T_r;                               ///< The reducing temperature to be used [K]
+    std::vector<double> Tc,              ///< Vector of critical temperatures (in K)
+      pc,                                ///< Vector of critical pressures (in Pa)
+      acentric;                          ///< Vector of acentric factors (unitless)
+    double R_u;                          ///< The universal gas constant  in J/(mol*K)
+    double Delta_1,                      ///< The first cubic constant
+      Delta_2;                           ///< The second cubic constant
+    int N;                               ///< Number of components in the mixture
+    std::vector<std::vector<double>> k;  ///< The interaction parameters (k_ii = 0)
+    /// The per-component volume translation parameters \f$c_i\f$ [m^3/mol].
+    ///
+    /// Deliberately NOT named `c`: AbstractCubicAlphaFunction already has a protected
+    /// `std::vector<double> c` for the Mathias-Copeman/Twu constants, and
+    /// AbstractCubicBackend::set_alpha_from_components binds a local `const std::vector<double>& c`
+    /// to the alpha coefficients.  A third `c` in the same neighbourhood is a shadowing trap.
+    std::vector<double> c_translation;
     std::vector<shared_ptr<AbstractCubicAlphaFunction>> alpha;  ///< The vector of alpha functions for the pure components
     /// Cache: aii_term values for the most recent tau.  Populated lazily by _ensure_aii_cache().
     mutable double m_tau_cache;
@@ -388,16 +395,54 @@ class AbstractCubic
      */
     virtual double d3_bm_term_dxidxjdxk(const std::vector<double>& x, std::size_t i, std::size_t j, std::size_t k, bool xN_independent);
     /**
-	* \brief The term \f$c_{\rm m}\f$ (volume translation)
+	* \brief The mixture volume translation \f$c_{\rm m} = \sum_i x_i c_i\f$
+	*
+	* The linear mixing rule is not a modelling choice.  Privat, Jaubert & Le Guennec, Fluid Phase
+	* Equilibria 427 (2016) 414-420 start from the general quadratic rule and show that only the
+	* arithmetic-mean combining rule preserves phase equilibria -- and that this choice degenerates
+	* the quadratic rule to the linear one.  So there is no \f$c_{ij}\f$ to store or expose.
+	* \param x The vector of mole fractions
 	*/
-    virtual double cm_term();
-    /// Set the volume translation parameter
+    virtual double cm_term(const std::vector<double>& x);
+    /** \brief The first composition derivative of \f$c_{\rm m}\f$
+     * \param x The vector of mole fractions
+     * \param i The first index
+     * \param xN_independent True if \f$x_N\f$ is an independent variable, false otherwise
+     */
+    virtual double d_cm_term_dxi(const std::vector<double>& x, std::size_t i, bool xN_independent);
+    /// The second composition derivative of \f$c_{\rm m}\f$; identically zero for the linear rule
+    virtual double d2_cm_term_dxidxj(const std::vector<double>& x, std::size_t i, std::size_t j, bool xN_independent);
+    /// The third composition derivative of \f$c_{\rm m}\f$; identically zero for the linear rule
+    virtual double d3_cm_term_dxidxjdxk(const std::vector<double>& x, std::size_t i, std::size_t j, std::size_t k, bool xN_independent);
+
+    /// Set the volume translation of every component to the same value
     void set_cm(double val) {
-        cm = val;
+        std::fill(c_translation.begin(), c_translation.end(), val);
     }
-    /// Get the volume translation parameter
-    double get_cm() {
-        return cm;
+    /// Set the volume translation of the i-th component
+    void set_cm(std::size_t i, double val) {
+        if (i >= c_translation.size()) {
+            throw CoolProp::ValueError("index out of range in set_cm");
+        }
+        c_translation[i] = val;
+    }
+    /// Get the volume translation of the i-th component
+    double get_cm(std::size_t i) const {
+        if (i >= c_translation.size()) {
+            throw CoolProp::ValueError("index out of range in get_cm");
+        }
+        return c_translation[i];
+    }
+    /// Get the whole vector of volume translations, for copy propagation
+    const std::vector<double>& get_cm_vector() const {
+        return c_translation;
+    }
+    /// Set the whole vector of volume translations, for copy propagation
+    void set_cm_vector(const std::vector<double>& c) {
+        if (c.size() != c_translation.size()) {
+            throw CoolProp::ValueError("size mismatch in set_cm_vector");
+        }
+        c_translation = c;
     }
     /**
 	* \brief The factor \f$1 + c_{\rm m}\rho\f$ common to every composition derivative of \f$A\f$
@@ -405,8 +450,8 @@ class AbstractCubic
 	* Named rather than inlined at each of the three call sites so they cannot drift apart, and so
 	* that the one place the translation enters those derivatives is greppable.
 	*/
-    double one_plus_cm_rho(double delta) {
-        return 1.0 + cm_term() * delta * rho_r;
+    double one_plus_cm_rho(double delta, const std::vector<double>& x) {
+        return 1.0 + cm_term(x) * delta * rho_r;
     }
 
     /// Modify the surface parameter Q_k of the sub group sgi
@@ -668,7 +713,7 @@ class AbstractCubic
      */
     double A_term(double delta, const std::vector<double>& x) {
         double bm = bm_term(x);
-        double cm = cm_term();
+        double cm = cm_term(x);
         return log((delta * rho_r * (Delta_1 * bm + cm) + 1) / (delta * rho_r * (Delta_2 * bm + cm) + 1));
     };
     /**
@@ -678,14 +723,39 @@ class AbstractCubic
      * \param i The first index
      * \param xN_independent True if \f$x_N\f$ is an independent variable, false otherwise (dependent on other \f$N-1\f$ mole fractions)
      */
+    /**
+     * \brief The building block \f$K_i\f$ of the composition derivatives of \f$A\f$
+     *
+     * Differentiating \f$A = \ln[(1 + (\Delta_1 b + c)\rho)/(1 + (\Delta_2 b + c)\rho)]\f$ gives
+     * \f$\partial A/\partial x_i = \rho(\Delta_1-\Delta_2) K_i / \Pi_{12}\f$ with
+     * \f$K_i = b_i(1 + c\rho) - b c_i \rho\f$.  The \f$(1 + c\rho)\f$ factor is easy to lose because
+     * \f$\Pi_{12}\f$ in the denominator already carries \f$c\f$, which makes the expression look
+     * translation-aware when it is not.
+     */
+    double K_term(double delta, const std::vector<double>& x, std::size_t i, bool xN_independent) {
+        return d_bm_term_dxi(x, i, xN_independent) * one_plus_cm_rho(delta, x) - bm_term(x) * d_cm_term_dxi(x, i, xN_independent) * delta * rho_r;
+    };
+    /// \brief \f$L_{ij} = \partial K_i/\partial x_j = b_{ij}(1+c\rho) + \rho(b_i c_j - b_j c_i)\f$
+    ///
+    /// Not symmetric in (i,j): the antisymmetric part is cancelled by the \f$-K_i \Pi_j\f$ term in
+    /// d2_A_term_dxidxj.  Do not "fix" it by symmetrising.
+    double L_term(double delta, const std::vector<double>& x, std::size_t i, std::size_t j, bool xN_independent) {
+        return d2_bm_term_dxidxj(x, i, j, xN_independent) * one_plus_cm_rho(delta, x)
+               + delta * rho_r
+                   * (d_bm_term_dxi(x, i, xN_independent) * d_cm_term_dxi(x, j, xN_independent)
+                      - d_bm_term_dxi(x, j, xN_independent) * d_cm_term_dxi(x, i, xN_independent));
+    };
+    /// \brief \f$L_{ijk} = \partial L_{ij}/\partial x_k\f$
+    double L3_term(double delta, const std::vector<double>& x, std::size_t i, std::size_t j, std::size_t k, bool xN_independent) {
+        return d3_bm_term_dxidxjdxk(x, i, j, k, xN_independent) * one_plus_cm_rho(delta, x)
+               + delta * rho_r
+                   * (d2_bm_term_dxidxj(x, i, j, xN_independent) * d_cm_term_dxi(x, k, xN_independent)
+                      + d2_bm_term_dxidxj(x, i, k, xN_independent) * d_cm_term_dxi(x, j, xN_independent)
+                      - d2_bm_term_dxidxj(x, j, k, xN_independent) * d_cm_term_dxi(x, i, xN_independent));
+    };
     double d_A_term_dxi(double delta, const std::vector<double>& x, std::size_t i, bool xN_independent) {
         std::size_t idelta = 0;
-        // The (1 + c_m*rho) factor is easy to miss because PI_12 in the denominator already carries
-        // c_m, which makes the expression look translation-aware when it is not.  Differentiating
-        // A = ln[(1 + (D1*b + c)*rho) / (1 + (D2*b + c)*rho)] gives
-        //     dA/dx_i = rho*(D1 - D2)*(1 + c*rho)*b_i / PI_12
-        // for a composition-independent c.  Omitting the factor is exact only at c = 0.
-        return delta * rho_r * d_bm_term_dxi(x, i, xN_independent) * (Delta_1 - Delta_2) * one_plus_cm_rho(delta) / PI_12(delta, x, idelta);
+        return delta * rho_r * (Delta_1 - Delta_2) * K_term(delta, x, i, xN_independent) / PI_12(delta, x, idelta);
     };
     /**
      * \brief The second composition derivative of the term \f$A\f$ used in the pure composition partial derivatives of \f$\psi^{(+)}\f$
@@ -698,11 +768,8 @@ class AbstractCubic
     double d2_A_term_dxidxj(double delta, const std::vector<double>& x, std::size_t i, std::size_t j, bool xN_independent) {
         std::size_t idelta = 0;
         double PI12 = PI_12(delta, x, idelta);
-        // Same missing (1 + c_m*rho) as in d_A_term_dxi; for a composition-independent c it is a
-        // common factor on both surviving terms.
-        return delta * rho_r * (Delta_1 - Delta_2) * one_plus_cm_rho(delta) / pow(PI12, 2)
-               * (PI12 * d2_bm_term_dxidxj(x, i, j, xN_independent)
-                  - d_PI_12_dxi(delta, x, 0, j, xN_independent) * d_bm_term_dxi(x, i, xN_independent));
+        return delta * rho_r * (Delta_1 - Delta_2) / pow(PI12, 2)
+               * (PI12 * L_term(delta, x, i, j, xN_independent) - d_PI_12_dxi(delta, x, 0, j, xN_independent) * K_term(delta, x, i, xN_independent));
     };
     /**
      * \brief The third composition derivative of the term \f$A\f$ used in the pure composition partial derivatives of \f$\psi^{(+)}\f$
@@ -716,16 +783,16 @@ class AbstractCubic
     double d3_A_term_dxidxjdxk(double delta, const std::vector<double>& x, std::size_t i, std::size_t j, std::size_t k, bool xN_independent) {
         std::size_t idelta = 0;
         double PI12 = PI_12(delta, x, idelta);
-        // The leading factor -- see d_A_term_dxi for the missing (1 + c_m*rho)
-        double lead = delta * rho_r * (Delta_1 - Delta_2) * one_plus_cm_rho(delta) / pow(PI12, 3);
+        // The leading factor
+        double lead = delta * rho_r * (Delta_1 - Delta_2) / pow(PI12, 3);
         return lead
                * (-PI12
-                    * (d_PI_12_dxi(delta, x, idelta, j, xN_independent) * d2_bm_term_dxidxj(x, i, k, xN_independent)
-                       + d_PI_12_dxi(delta, x, idelta, k, xN_independent) * d2_bm_term_dxidxj(x, i, j, xN_independent)
-                       + d_bm_term_dxi(x, i, xN_independent) * d2_PI_12_dxidxj(delta, x, idelta, j, k, xN_independent))
-                  + pow(PI12, 2) * d3_bm_term_dxidxjdxk(x, i, j, k, xN_independent)
+                    * (d_PI_12_dxi(delta, x, idelta, k, xN_independent) * L_term(delta, x, i, j, xN_independent)
+                       + d_PI_12_dxi(delta, x, idelta, j, xN_independent) * L_term(delta, x, i, k, xN_independent)
+                       + K_term(delta, x, i, xN_independent) * d2_PI_12_dxidxj(delta, x, idelta, j, k, xN_independent))
+                  + pow(PI12, 2) * L3_term(delta, x, i, j, k, xN_independent)
                   + 2 * d_PI_12_dxi(delta, x, idelta, j, xN_independent) * d_PI_12_dxi(delta, x, idelta, k, xN_independent)
-                      * d_bm_term_dxi(x, i, xN_independent));
+                      * K_term(delta, x, i, xN_independent));
     };
     // Allows to modify the unifac interaction parameters aij, bij and cij. Only for use with VTPR backend.
     virtual void set_interaction_parameter(const std::size_t mgi1, const std::size_t mgi2, const std::string& parameter, const double value) {

--- a/src/Backends/Cubics/VTPRBackend.h
+++ b/src/Backends/Cubics/VTPRBackend.h
@@ -65,6 +65,7 @@ class VTPRBackend : public PengRobinsonBackend
         AbstractCubicBackend* ACB =
           new VTPRBackend(calc_fluid_names(), cubic->get_Tc(), cubic->get_pc(), cubic->get_acentric(), cubic->get_R_u(), generate_SatL_and_SatV);
         ACB->copy_k(this);
+        ACB->copy_cm(this);
         ACB->copy_all_alpha_functions(this);
         return static_cast<HelmholtzEOSMixtureBackend*>(ACB);
     }

--- a/src/Backends/Cubics/VTPRCubic.h
+++ b/src/Backends/Cubics/VTPRCubic.h
@@ -207,7 +207,7 @@ class VTPRCubic : public PengRobinson
         // Common terms for all components
         double tau = get_Tr() / T;
         double b = bm_term(z);
-        double c = cm_term();
+        double c = cm_term(z);
         double R = get_R_u();
         std::vector<double> ln_phi;
         double bracket = log((v + c + (1 + sqrt(2.0)) * b) / (v + c + (1 - sqrt(2.0)) * b));

--- a/src/Backends/Cubics/VTPRCubic.h
+++ b/src/Backends/Cubics/VTPRCubic.h
@@ -217,7 +217,11 @@ class VTPRCubic : public PengRobinson
                 summer1 += z[j] * bij_term(i, j);
             }
             double a_i_over_b_i = aii_term(tau, i, 0) / b0_ii(i);
-            double c_i = 0;  // TODO: fix this, allow for volume translation
+            // Under the linear mixing rule d(n*c_m)/dn_i is exactly the pure-component c_i, which is
+            // the Peneloux shift on this component's fugacity coefficient:
+            // ln(phi_i) = ln(phi_i,untranslated) - P*c_i/(R*T).  The rest of the expression is
+            // already written in v + c = v_EOS, so this term is all that was missing.
+            double c_i = get_cm(i);
             double _ln_phi = (2 / b * summer1 - 1) * (p * (v + c) / (R * T) - 1) - p * c_i / (R * T) - log(p * (v + c - b) / (R * T))
                              - 1.0 / (2.0 * sqrt(2.0) * R * T) * (a_i_over_b_i + R * T * unifaq.ln_gamma_R(tau, i, 0) / -0.53087) * bracket;
             ln_phi.push_back(_ln_phi);

--- a/src/Tests/CoolProp-Tests-CubicAlpha.cpp
+++ b/src/Tests/CoolProp-Tests-CubicAlpha.cpp
@@ -15,7 +15,7 @@
 
 using namespace CoolProp;
 
-TEST_CASE("calc_all_terms matches term() for non-default alpha functions", "[cubic_alpha]") {
+TEST_CASE("calc_all_terms matches term() for non-default alpha functions", "[cubic][cubic_alpha]") {
     const std::vector<double> tau_vals = {0.5, 0.7, 1.0, 1.3, 2.0};
 
     SECTION("BasicMathiasCopemanAlphaFunction") {

--- a/src/Tests/CoolProp-Tests-CubicVolumeTranslation.cpp
+++ b/src/Tests/CoolProp-Tests-CubicVolumeTranslation.cpp
@@ -26,6 +26,7 @@ Run with:  ./CatchTestRunner "[volume_translation]"
 #    include <functional>
 #    include <memory>
 #    include <string>
+#    include <utility>
 #    include <vector>
 
 using namespace CoolProp;
@@ -229,7 +230,7 @@ TEST_CASE("Cubic volume translation: saturation invariances", "[cubic][volume_tr
                 return 1.0 / S.saturated_vapor_keyed_output(iDmolar) - 1.0 / S.saturated_liquid_keyed_output(iDmolar);
             };
             CHECK(close_to(dvap_v(*trn), dvap_v(*ref), 1e-9, 1e-18));
-            for (parameters key : {iHmolar, iSmolar, iUmolar, iCvmolar, iCpmolar}) {
+            for (parameters key : {iHmolar, iSmolar, iUmolar, iHelmholtzmolar, iCvmolar, iCpmolar}) {
                 CAPTURE(get_parameter_information(key, "short"));
                 CHECK(close_to(dvap(*trn, key), dvap(*ref, key), 1e-9, 1e-8));
             }
@@ -389,7 +390,63 @@ TEST_CASE("Cubic volume translation: survives get_copy", "[cubic][volume_transla
 
         // SatL/SatV of the clone must agree too, or a saturation call on the copy silently mixes a
         // translated parent with untranslated daughters.
-        CHECK(clone_cb->get_fluid_parameter_double(0, "cm") == Catch::Approx(c).epsilon(1e-15));
+        //
+        // That has to be checked THROUGH a saturation call.  Reading the clone's own cm back routes
+        // to the same storage the CHECK above already read, so it asserts nothing new -- deleting
+        // copy_cm's linked_states fan-out leaves such a test green.  Drive a QT flash instead:
+        // SatL/SatV are where saturation() puts its converged phases, so an untranslated daughter
+        // shows up immediately.  The density agrees even when it is broken (DmolarT imposes it), so
+        // compare the caloric properties, which are what actually diverge -- by ~11 % here.
+        const double T = 0.7 * trn->T_critical();
+        REQUIRE_NOTHROW(trn->update(QT_INPUTS, 0, T));
+        REQUIRE_NOTHROW(clone->update(QT_INPUTS, 0, T));
+        CHECK(close_to(clone->hmolar(), trn->hmolar(), 1e-9, 1e-6));
+        CHECK(close_to(clone->smolar(), trn->smolar(), 1e-9, 1e-6));
+        CHECK(close_to(clone->umolar(), trn->umolar(), 1e-9, 1e-6));
+        CHECK(close_to(clone->rhomolar(), trn->rhomolar(), 1e-9, 1e-6));
+        REQUIRE_NOTHROW(trn->update(QT_INPUTS, 1, T));
+        REQUIRE_NOTHROW(clone->update(QT_INPUTS, 1, T));
+        CHECK(close_to(clone->hmolar(), trn->hmolar(), 1e-9, 1e-6));
+        CHECK(close_to(clone->rhomolar(), trn->rhomolar(), 1e-9, 1e-6));
+    }
+}
+
+TEST_CASE("Cubic volume translation: the critical and reducing volumes move with c", "[cubic][volume_translation]") {
+    // Three more paths reason about volume and all had to learn about c, but none of them is
+    // reachable through an ordinary property call, so none was covered: reverting the translation in
+    // all three at once left the suite green.  They are exercised directly here.
+    for (const auto& backend : cubic_backends()) {
+        CAPTURE(backend);
+        const double b = covolume(backend, "n-Propane");
+        const double c = 0.15 * b;
+        ASptr ref = make_translated(backend, "n-Propane", 0.0);
+        ASptr trn = make_translated(backend, "n-Propane", c);
+
+        // calc_rhomolar_critical(): the Kazakov correlation returns an UNtranslated critical volume,
+        // so the translated one is exactly c smaller.  An identity, not an approximation.
+        CHECK(close_to(1.0 / trn->rhomolar_critical(), 1.0 / ref->rhomolar_critical() - c, 1e-12, 1e-20));
+
+        // get_linear_reducing_parameters(): the same shift, through the mole-fraction weighted
+        // average that the critical-point tracer starts from.  T_r must NOT move.
+        double rhor_ref = 0, Tr_ref = 0, rhor_trn = 0, Tr_trn = 0;
+        as_cubic(*ref).get_linear_reducing_parameters(rhor_ref, Tr_ref);
+        as_cubic(*trn).get_linear_reducing_parameters(rhor_trn, Tr_trn);
+        CHECK(close_to(1.0 / rhor_trn, 1.0 / rhor_ref - c, 1e-12, 1e-20));
+        CHECK(close_to(Tr_trn, Tr_ref, 1e-14, 0.0));
+
+        // get_critical_is_terminated(): the tracer stops when v < 1.1*(b_m - c_m), so the floor
+        // moves with the translation.  Probe just inside and just outside the TRANSLATED floor --
+        // the outside probe is the discriminating one, because a version still using the
+        // untranslated b_m would see 1.15*(b - c) as below its own (larger) 1.1*b threshold and
+        // terminate early.
+        auto& cb = as_cubic(*trn);
+        const double bmc = b - c;
+        for (const auto& probe : {std::make_pair(1.05, true), std::make_pair(1.15, false)}) {
+            const double v = probe.first * bmc;
+            double delta = 1.0 / (v * cb.rhomolar_reducing()), tau = 1.0;
+            CAPTURE(probe.first);
+            CHECK(cb.get_critical_is_terminated(delta, tau) == probe.second);
+        }
     }
 }
 
@@ -495,6 +552,11 @@ ASptr make_mixture(const std::string& backend, const std::vector<double>& z, con
     return AS;
 }
 
+/// The invariant column of the property-change-on-vaporisation row, each with the absolute
+/// tolerance floor appropriate to its own magnitude.
+const std::vector<std::pair<parameters, double>> kMixtureDvapInvariants{
+  {iSmolar, 1e-8}, {iUmolar, 1e-6}, {iHelmholtzmolar, 1e-6}, {iCpmolar, 1e-8}, {iCvmolar, 1e-8}};
+
 double cm_of(const std::vector<double>& z, const std::vector<double>& c) {
     double s = 0;
     for (std::size_t i = 0; i < z.size(); ++i) {
@@ -545,6 +607,25 @@ TEST_CASE("Cubic volume translation: mixture single-phase invariances", "[cubic]
                     CHECK(close_to(std::log(trn->fugacity_coefficient(i)), std::log(ref->fugacity_coefficient(i)) - p * c[i] / (R * T), 1e-8, 1e-10));
                 }
 
+                // mu_i is NOT shifted by -p*c_m, even though g is.  G shifts by -p*sum_i n_i*c_i,
+                // so mu_i = d(G)/dn_i picks up the PURE-component c_i -- the same c_i that ln(phi_i)
+                // carries, which is the consistency the two have to satisfy.  The distinction is
+                // invisible for a pure fluid, where mu = g and c_i = c_m.
+                for (std::size_t i = 0; i < z.size(); ++i) {
+                    CAPTURE(i);
+                    const double dmu = trn->chemical_potential(i) - ref->chemical_potential(i);
+                    CAPTURE(dmu);
+                    // Sharp enough to separate the two hypotheses: -p*c_i and -p*c_m differ by
+                    // 17 J/mol here at p = 2e7 Pa, and the floor is four orders below that.
+                    CAPTURE(-p * cm);
+                    CHECK(close_to(dmu, -p * c[i], 1e-6, 1e-4));
+                }
+
+                // The second virial coefficient carries the mixture translation too.  B is
+                // evaluated in the zero-density limit at the current tau, so it depends on T and
+                // the composition but not on the state's own density.
+                CHECK(close_to(trn->Bvirial(), ref->Bvirial() - cm, 1e-9, 1e-18));
+
                 CHECK(std::abs(trn->speed_sound() / ref->speed_sound() - 1.0) > 1e-6);
             }
         }
@@ -586,19 +667,56 @@ TEST_CASE("Cubic volume translation: mixture VLE is invariant for arbitrary c_i"
                 }
 
                 // Property changes on vaporisation.  S, U and A survive because the c-dependent
-                // parts cancel between h, P*v and T*s; V and H carry the composition difference in
-                // c_m, which is nonzero precisely because the c_i differ.
+                // parts cancel between h, P*v and T*s, and c_p and c_v survive because each phase's
+                // own value does; V and H carry the composition difference in c_m, which is nonzero
+                // precisely because the c_i differ.
                 const double dcm = cm_of(std::vector<double>(yr.begin(), yr.end()), c) - cm_of(std::vector<double>(xr.begin(), xr.end()), c);
                 CAPTURE(dcm);
                 const auto dvap = [](AbstractState& S, parameters key) {
                     return S.saturated_vapor_keyed_output(key) - S.saturated_liquid_keyed_output(key);
                 };
-                CHECK(close_to(dvap(*trn, iSmolar), dvap(*ref, iSmolar), 1e-6, 1e-8));
-                CHECK(close_to(dvap(*trn, iUmolar), dvap(*ref, iUmolar), 1e-6, 1e-6));
+                // The absolute floors are per property because these are differences of two
+                // large numbers: S and the heat capacities are O(10..100) J/mol/K, while U and A are
+                // O(1e4) J/mol and so carry ~1e-11 relative round-off of their own.
+                for (const auto& probe : kMixtureDvapInvariants) {
+                    CAPTURE(get_parameter_information(probe.first, "short"));
+                    CHECK(close_to(dvap(*trn, probe.first), dvap(*ref, probe.first), 1e-6, probe.second));
+                }
                 const double dV_ref = 1.0 / ref->saturated_vapor_keyed_output(iDmolar) - 1.0 / ref->saturated_liquid_keyed_output(iDmolar);
                 const double dV_trn = 1.0 / trn->saturated_vapor_keyed_output(iDmolar) - 1.0 / trn->saturated_liquid_keyed_output(iDmolar);
                 CHECK(close_to(dV_trn, dV_ref - dcm, 1e-6, 1e-15));
                 CHECK(close_to(dvap(*trn, iHmolar), dvap(*ref, iHmolar) - ref->p() * dcm, 1e-6, 1e-6));
+            }
+        }
+    }
+}
+
+TEST_CASE("Cubic volume translation: c_all broadcasts to every component", "[cubic][volume_translation][mixture]") {
+    // "c_all" is the spelling that keeps the pre-vectorisation behaviour, where the index was
+    // accepted and then ignored.  Nothing else exercises it, so a regression there would silently
+    // change what callers relying on those old fluid-wide semantics get back.
+    const std::vector<double> z{0.30, 0.35, 0.35};
+    const std::size_t N = mixture_c().size();
+
+    for (const auto& backend : cubic_backends()) {
+        CAPTURE(backend);
+        // Seeded with distinct per-component values, so a broadcast that reaches only one of them
+        // is visible rather than being masked by the components already agreeing.
+        ASptr AS = make_mixture(backend, z, mixture_c());
+        for (std::size_t i = 0; i < N; ++i) {
+            CAPTURE(i);
+            CHECK(AS->get_fluid_parameter_double(i, "cm") == Catch::Approx(mixture_c()[i]).epsilon(1e-15));
+        }
+
+        // The index is ignored for c_all, so naming a different one must give the same result.
+        for (std::size_t named = 0; named < N; ++named) {
+            const double broadcast = 1.25e-6 * static_cast<double>(named + 1);
+            CAPTURE(named);
+            CAPTURE(broadcast);
+            REQUIRE_NOTHROW(AS->set_fluid_parameter_double(named, "c_all", broadcast));
+            for (std::size_t i = 0; i < N; ++i) {
+                CAPTURE(i);
+                CHECK(AS->get_fluid_parameter_double(i, "cm") == Catch::Approx(broadcast).epsilon(1e-15));
             }
         }
     }

--- a/src/Tests/CoolProp-Tests-CubicVolumeTranslation.cpp
+++ b/src/Tests/CoolProp-Tests-CubicVolumeTranslation.cpp
@@ -222,15 +222,21 @@ TEST_CASE("Cubic volume translation: pure-fluid property invariances", "[cubic][
 TEST_CASE("Cubic volume translation: second virial coefficient shifts by -c", "[cubic][volume_translation]") {
     for (const auto& backend : cubic_backends()) {
         for (const auto& fluid : probe_fluids()) {
-            CAPTURE(backend);
-            CAPTURE(fluid);
-            const double c = 0.15 * covolume(backend, fluid);
-            ASptr ref = make_translated(backend, fluid, 0.0);
-            ASptr trn = make_translated(backend, fluid, c);
-            const double T = 1.25 * ref->T_critical();
-            ref->update(DmolarT_INPUTS, 1e-3, T);
-            trn->update(DmolarT_INPUTS, 1e-3, T);
-            CHECK(close_to(trn->Bvirial(), ref->Bvirial() - c, 1e-9, 1e-18));
+            const double b = covolume(backend, fluid);
+            // Both signs, for the same reason the single-phase suite sweeps both: the two are not
+            // mirror images through the code, and both occur in published parameter sets.
+            for (double frac : {0.15, -0.15}) {
+                CAPTURE(backend);
+                CAPTURE(fluid);
+                CAPTURE(frac);
+                const double c = frac * b;
+                ASptr ref = make_translated(backend, fluid, 0.0);
+                ASptr trn = make_translated(backend, fluid, c);
+                const double T = 1.25 * ref->T_critical();
+                ref->update(DmolarT_INPUTS, 1e-3, T);
+                trn->update(DmolarT_INPUTS, 1e-3, T);
+                CHECK(close_to(trn->Bvirial(), ref->Bvirial() - c, 1e-9, 1e-18));
+            }
         }
     }
 }
@@ -238,45 +244,57 @@ TEST_CASE("Cubic volume translation: second virial coefficient shifts by -c", "[
 TEST_CASE("Cubic volume translation: saturation invariances", "[cubic][volume_translation]") {
     for (const auto& backend : cubic_backends()) {
         for (const auto& fluid : probe_fluids()) {
-            CAPTURE(backend);
-            CAPTURE(fluid);
-            const double c = 0.15 * covolume(backend, fluid);
-            ASptr ref = make_translated(backend, fluid, 0.0);
-            ASptr trn = make_translated(backend, fluid, c);
+            const double b = covolume(backend, fluid);
+            // Both signs, and three reduced temperatures rather than one.  The property changes on
+            // vaporisation shrink as the two phases converge towards the critical point, so a
+            // single mid-dome temperature says nothing about whether the identities still hold
+            // where Dvap V and Dvap H are small and the cancellation is correspondingly delicate.
+            for (double frac : {0.15, -0.15}) {
+                for (double Tr : {0.65, 0.75, 0.85}) {
+                    CAPTURE(backend);
+                    CAPTURE(fluid);
+                    CAPTURE(frac);
+                    CAPTURE(Tr);
+                    const double c = frac * b;
+                    ASptr ref = make_translated(backend, fluid, 0.0);
+                    ASptr trn = make_translated(backend, fluid, c);
 
-            const double T = 0.75 * ref->T_critical();
-            REQUIRE_NOTHROW(ref->update(QT_INPUTS, 0, T));
-            REQUIRE_NOTHROW(trn->update(QT_INPUTS, 0, T));
+                    const double T = Tr * ref->T_critical();
+                    REQUIRE_NOTHROW(ref->update(QT_INPUTS, 0, T));
+                    REQUIRE_NOTHROW(trn->update(QT_INPUTS, 0, T));
 
-            // The vapour pressure is the headline invariance: it is what lets a translation be
-            // fitted to densities without disturbing anything that was fitted to VLE.
-            CHECK(close_to(trn->p(), ref->p(), 1e-10, 1e-6));
+                    // The vapour pressure is the headline invariance: it is what lets a translation
+                    // be fitted to densities without disturbing anything that was fitted to VLE.
+                    CHECK(close_to(trn->p(), ref->p(), 1e-10, 1e-6));
 
-            // Each saturated phase moves by the same -c, so for a PURE fluid every property change
-            // on vaporisation is invariant -- the volume change included.
-            const auto dvap = [](AbstractState& S, parameters key) {
-                return S.saturated_vapor_keyed_output(key) - S.saturated_liquid_keyed_output(key);
-            };
-            const auto dvap_v = [](AbstractState& S) {
-                return 1.0 / S.saturated_vapor_keyed_output(iDmolar) - 1.0 / S.saturated_liquid_keyed_output(iDmolar);
-            };
-            CHECK(close_to(dvap_v(*trn), dvap_v(*ref), 1e-9, 1e-18));
-            for (parameters key : {iHmolar, iSmolar, iUmolar, iHelmholtzmolar, iCvmolar, iCpmolar}) {
-                CAPTURE(get_parameter_information(key, "short"));
-                CHECK(close_to(dvap(*trn, key), dvap(*ref, key), 1e-9, 1e-8));
-            }
+                    // Each saturated phase moves by the same -c, so for a PURE fluid every property
+                    // change on vaporisation is invariant -- the volume change included.
+                    const auto dvap = [](AbstractState& S, parameters key) {
+                        return S.saturated_vapor_keyed_output(key) - S.saturated_liquid_keyed_output(key);
+                    };
+                    const auto dvap_v = [](AbstractState& S) {
+                        return 1.0 / S.saturated_vapor_keyed_output(iDmolar) - 1.0 / S.saturated_liquid_keyed_output(iDmolar);
+                    };
+                    CHECK(close_to(dvap_v(*trn), dvap_v(*ref), 1e-9, 1e-18));
+                    for (parameters key : {iHmolar, iSmolar, iUmolar, iHelmholtzmolar, iCvmolar, iCpmolar}) {
+                        CAPTURE(get_parameter_information(key, "short"));
+                        CHECK(close_to(dvap(*trn, key), dvap(*ref, key), 1e-9, 1e-8));
+                    }
 
-            // Each saturated phase individually: the volume shifts by -c.
-            //
-            // The corresponding h -> h - p*c identity is deliberately NOT asserted here.  SatL/SatV
-            // are set from (rho, T), so each carries its own converged pressure rather than a shared
-            // exact p, and the residual p mismatch feeds straight into h = u + p*v.  The identity is
-            // pinned rigorously in the single-phase test above, where p is an exact input.
-            for (int Q : {0, 1}) {
-                CAPTURE(Q);
-                const double vr = 1.0 / (Q == 0 ? ref->saturated_liquid_keyed_output(iDmolar) : ref->saturated_vapor_keyed_output(iDmolar));
-                const double vt = 1.0 / (Q == 0 ? trn->saturated_liquid_keyed_output(iDmolar) : trn->saturated_vapor_keyed_output(iDmolar));
-                CHECK(close_to(vt, vr - c, 1e-9, 1e-18));
+                    // Each saturated phase individually: the volume shifts by -c.
+                    //
+                    // The corresponding h -> h - p*c identity is deliberately NOT asserted here.
+                    // SatL/SatV are set from (rho, T), so each carries its own converged pressure
+                    // rather than a shared exact p, and the residual p mismatch feeds straight into
+                    // h = u + p*v.  The identity is pinned rigorously in the single-phase test
+                    // above, where p is an exact input.
+                    for (int Q : {0, 1}) {
+                        CAPTURE(Q);
+                        const double vr = 1.0 / (Q == 0 ? ref->saturated_liquid_keyed_output(iDmolar) : ref->saturated_vapor_keyed_output(iDmolar));
+                        const double vt = 1.0 / (Q == 0 ? trn->saturated_liquid_keyed_output(iDmolar) : trn->saturated_vapor_keyed_output(iDmolar));
+                        CHECK(close_to(vt, vr - c, 1e-9, 1e-18));
+                    }
+                }
             }
         }
     }

--- a/src/Tests/CoolProp-Tests-CubicVolumeTranslation.cpp
+++ b/src/Tests/CoolProp-Tests-CubicVolumeTranslation.cpp
@@ -482,12 +482,85 @@ TEST_CASE("Cubic volume translation: rejects a translation past the covolume", "
     }
 }
 
+TEST_CASE("Cubic volume translation: moving Tc or pc cannot strand c past the covolume", "[cubic][volume_translation]") {
+    // b = Omega_b*R*Tc/pc, so the covolume moves with the critical constants and "set c, then
+    // shrink b" reaches the same forbidden state that setting c too large does -- but by a path
+    // that used to be unguarded.  It fails silently rather than loudly: once b - c < 0, the
+    // bracket 1 - (b_m - c_m)*rho in psi_minus is greater than 1 for EVERY rho, so the log never
+    // goes NaN and p, h and c_p keep returning finite nonsense.  update_DmolarT does not consult
+    // calc_rhomolar_max_bound either, so nothing downstream catches it.
+    for (const auto& backend : cubic_backends()) {
+        CAPTURE(backend);
+        const double b = covolume(backend, "n-Propane");
+        const double c = 0.9 * b;
+
+        for (const std::string key : {std::string("Tcrit"), std::string("pcrit")}) {
+            CAPTURE(key);
+            ASptr AS = make_translated(backend, "n-Propane", c);
+            const double before = AS->get_fluid_parameter_double(0, key);
+            // b is proportional to Tc and inversely proportional to pc, so either of these halves
+            // the covolume and leaves b - c = -0.4*b.
+            const double bad = (key == "Tcrit") ? 0.5 * before : 2.0 * before;
+            CHECK_THROWS(AS->set_fluid_parameter_double(0, key, bad));
+
+            // Rejected is not enough -- it has to be rolled back.  set_Tci/set_pci write the
+            // member first and refresh the alpha function and the b0 cache from it, so a throw
+            // without a rollback would leave a state that is wrong in a different way.
+            CHECK(AS->get_fluid_parameter_double(0, key) == Catch::Approx(before).epsilon(1e-15));
+            CHECK(AS->get_fluid_parameter_double(0, "cm") == Catch::Approx(c).epsilon(1e-15));
+
+            // And the rolled-back state must still be usable, which it is not if the derived
+            // caches were left referring to the value that was rejected.
+            REQUIRE_NOTHROW(AS->update(QT_INPUTS, 0, 0.7 * AS->T_critical()));
+            CHECK(AS->p() > 0);
+            CHECK(1.0 / AS->rhomolar() > b - c);
+        }
+
+        // A move in the safe direction still goes through -- the guard must not have frozen Tc/pc.
+        ASptr ok = make_translated(backend, "n-Propane", 0.5 * b);
+        const double Tc0 = ok->get_fluid_parameter_double(0, "Tcrit");
+        REQUIRE_NOTHROW(ok->set_fluid_parameter_double(0, "Tcrit", 1.10 * Tc0));
+        CHECK(ok->get_fluid_parameter_double(0, "Tcrit") == Catch::Approx(1.10 * Tc0).epsilon(1e-12));
+    }
+}
+
+TEST_CASE("Cubic volume translation: the bare AbstractCubic setters enforce the pole condition", "[cubic][volume_translation]") {
+    // The backend is not the only way in.  HEOS embeds an AbstractCubic through
+    // ResidualHelmholtzGeneralizedCubic -- change_EOS(i, "SRK"/"Peng-Robinson") and the
+    // "-SRK"/"-PengRobinson" fluid endings -- and those objects have no AbstractCubicBackend
+    // wrapping them, so a check that lives only in set_fluid_parameter_double does not cover them.
+    const std::vector<double> Tc{369.89}, pc{4.2512e6}, acentric{0.1521};
+    const double R = 8.31446261815324;
+
+    for (const auto& backend : cubic_backends()) {
+        CAPTURE(backend);
+        std::shared_ptr<AbstractCubic> bare;
+        if (backend == "PR") {
+            bare = std::make_shared<PengRobinson>(Tc, pc, acentric, R);
+        } else {
+            bare = std::make_shared<SRK>(Tc, pc, acentric, R);
+        }
+        const double b = bare->b0_ii(0);
+        REQUIRE(b > 0);
+
+        CHECK_THROWS(bare->set_cm(0, b));
+        CHECK_THROWS(bare->set_cm(0, 1.5 * b));
+        CHECK_THROWS(bare->set_cm(b));  // the broadcast form
+        CHECK_THROWS(bare->set_cm_vector(std::vector<double>{b}));
+        // A rejected value must leave the translation untouched rather than half-applied.
+        CHECK(bare->get_cm(0) == Catch::Approx(0.0).margin(1e-300));
+
+        CHECK_NOTHROW(bare->set_cm_vector(std::vector<double>{0.5 * b}));
+        CHECK(bare->get_cm(0) == Catch::Approx(0.5 * b).epsilon(1e-15));
+    }
+}
+
 TEST_CASE("Cubic volume translation: set/get round-trip", "[cubic][volume_translation]") {
     for (const auto& backend : cubic_backends()) {
         CAPTURE(backend);
         const double c = 0.2 * covolume(backend, "n-Propane");
         ASptr AS(AbstractState::factory(backend, "n-Propane"));
-        CHECK(AS->get_fluid_parameter_double(0, "cm") == Catch::Approx(0.0));
+        CHECK(AS->get_fluid_parameter_double(0, "cm") == Catch::Approx(0.0).margin(1e-300));
         for (const char* alias : {"c", "cm", "c_m"}) {
             CAPTURE(alias);
             REQUIRE_NOTHROW(AS->set_fluid_parameter_double(0, alias, c));

--- a/src/Tests/CoolProp-Tests-CubicVolumeTranslation.cpp
+++ b/src/Tests/CoolProp-Tests-CubicVolumeTranslation.cpp
@@ -120,6 +120,36 @@ struct StatePoint
     double T, p;
 };
 
+/// The quantities that move because v enters them explicitly, asserted as the exact identities
+/// they are rather than merely as "different".
+///
+/// Each shift is known in closed form, so there is no reason to settle for an inequality: asserting
+/// only that one of these changed accepts a change of any wrong magnitude, which is what the
+/// weaker checks alongside these calls do on their own.
+void check_v_scaled_quantities(AbstractState& ref, AbstractState& trn, double c) {
+    const double v_ref = 1.0 / ref.rhomolar(), v_trn = 1.0 / trn.rhomolar();
+
+    // w^2 = -v^2*(dp/dv)_s/M with (dp/dv)_s invariant, so w scales with v EXACTLY.  Asserting only
+    // that w changed would accept a change of any wrong magnitude.
+    CHECK(close_to(trn.speed_sound() / ref.speed_sound(), v_trn / v_ref, 1e-9, 0.0));
+
+    // kappa_T and alpha_v are the invariant derivatives divided by v, so they scale as 1/v.  The
+    // documented rows are the bare derivatives; these are the normalised forms the public API
+    // actually returns, so both are worth pinning.
+    CHECK(close_to(trn.isothermal_compressibility() / ref.isothermal_compressibility(), v_ref / v_trn, 1e-9, 0.0));
+    CHECK(close_to(trn.isobaric_expansion_coefficient() / ref.isobaric_expansion_coefficient(), v_ref / v_trn, 1e-9, 0.0));
+
+    // mu_JT = (dT/dp)_h shifts by +c/c_p.
+    const double mu_ref = ref.first_partial_deriv(iT, iP, iHmolar);
+    const double mu_trn = trn.first_partial_deriv(iT, iP, iHmolar);
+    CAPTURE(mu_ref);
+    CAPTURE(mu_trn);
+    CHECK(close_to(mu_trn, mu_ref + c / ref.cpmolar(), 1e-8, 1e-18));
+
+    // Z = p*v/(RT) inherits the volume shift directly.
+    CHECK(close_to(trn.compressibility_factor(), ref.compressibility_factor() - ref.p() * c / (8.31446261815324 * ref.T()), 1e-9, 1e-14));
+}
+
 /// Derived rather than hardcoded: a fixed (T, p) that is liquid for propane can be supercritical for
 /// carbon dioxide, and a state that lands inside the dome makes the PT flash pick a phase rather
 /// than a root.
@@ -182,6 +212,7 @@ TEST_CASE("Cubic volume translation: pure-fluid property invariances", "[cubic][
                     CHECK(std::abs(trn->speed_sound() / ref->speed_sound() - 1.0) > 1e-6);
                     CHECK(std::abs(trn->isothermal_compressibility() / ref->isothermal_compressibility() - 1.0) > 1e-6);
                     CHECK(std::abs(trn->isobaric_expansion_coefficient() / ref->isobaric_expansion_coefficient() - 1.0) > 1e-6);
+                    check_v_scaled_quantities(*ref, *trn, c);
                 }
             }
         }
@@ -596,11 +627,12 @@ TEST_CASE("Cubic volume translation: spinodal translates", "[cubic][volume_trans
 // Mixtures
 //
 // The mixture column of the invariance table.  Two things differ from a pure fluid.  First the
-// shifts are in c_m(z) = sum_i x_i c_i, EXCEPT ln(phi_i), which shifts by the PURE-component c_i --
-// that is what makes the equifugacity condition cancel, and hence what makes VLE invariant for
-// ARBITRARY c_i and not merely for equal ones.  Second, the property changes on vaporisation split:
-// the two coexisting phases have different compositions, so c_m(y) != c_m(x) unless every c_i is
-// equal, and Dvap V and Dvap H inherit that difference while Dvap S, U and A do not.
+// shifts are in c_m(z) = sum_i x_i c_i, EXCEPT the partial molar pair mu_i and ln(phi_i), which
+// shift by the PURE-component c_i -- that is what makes the equifugacity condition cancel, and
+// hence what makes VLE invariant for ARBITRARY c_i and not merely for equal ones.  Second, the
+// property changes on vaporisation split: the two coexisting phases have different compositions, so
+// c_m(y) != c_m(x) unless every c_i is equal, and Dvap V and Dvap H inherit that difference while
+// Dvap S, U, A, c_p and c_v do not.
 // ============================================================================================
 
 namespace {
@@ -630,6 +662,40 @@ ASptr make_mixture(const std::string& backend, const std::vector<double>& z, con
 const std::vector<std::pair<parameters, double>> kMixtureDvapInvariants{
   {iSmolar, 1e-8}, {iUmolar, 1e-6}, {iHelmholtzmolar, 1e-6}, {iCpmolar, 1e-8}, {iCvmolar, 1e-8}};
 
+/// Single-phase mixture states, derived from the phase envelope rather than hardcoded.
+///
+/// A fixed 5 MPa at 320 K sat 0.51 % below SRK's dew pressure (5.0256 MPa; PR 5.0931 MPa, 1.86 %).
+/// That is closer than a routine tweak to a critical constant in the cubic JSON would move it, and
+/// crossing in is not a soft failure: calc_fugacity_coefficient throws outright for 0 < Q < 1, so
+/// the ln(phi_i) assertions would abort the whole case rather than fail informatively.
+std::vector<StatePoint> mixture_single_phase_points(const std::string& backend, const std::vector<double>& z) {
+    ASptr AS(AbstractState::factory(backend, kMixture));
+    AS->set_mole_fractions(std::vector<CoolPropDbl>(z.begin(), z.end()));
+
+    std::vector<StatePoint> pts;
+    for (double T : {320.0, 450.0}) {
+        double p_dew = -1, p_bub = -1;
+        try {
+            AS->update(QT_INPUTS, 1, T);
+            p_dew = AS->p();
+            AS->update(QT_INPUTS, 0, T);
+            p_bub = AS->p();
+        } catch (...) {
+            // No envelope at this T: the mixture is supercritical there, so every pressure is
+            // single-phase and the absolute fallbacks below cannot land inside a dome.
+        }
+        if (p_dew > 0 && p_bub > 0) {
+            REQUIRE(p_bub > p_dew);
+            pts.push_back({"vapour, 40 % below the dew line", T, 0.6 * p_dew});
+            pts.push_back({"liquid, 3x the bubble pressure", T, 3.0 * p_bub});
+        } else {
+            pts.push_back({"supercritical", T, 5e6});
+            pts.push_back({"supercritical, dense", T, 2e7});
+        }
+    }
+    return pts;
+}
+
 double cm_of(const std::vector<double>& z, const std::vector<double>& c) {
     double s = 0;
     for (std::size_t i = 0; i < z.size(); ++i) {
@@ -651,10 +717,12 @@ TEST_CASE("Cubic volume translation: mixture single-phase invariances", "[cubic]
         ASptr ref = make_mixture(backend, z, {0.0, 0.0, 0.0});
         ASptr trn = make_mixture(backend, z, c);
 
-        // A single-phase state well away from the dome, so the PT flash returns a root rather than
-        // a phase split whose composition would differ between the two runs.
-        for (double T : {320.0, 450.0}) {
-            for (double p : {5e6, 2e7}) {
+        // Single-phase states, so the PT flash returns a root rather than a phase split whose
+        // composition would differ between the two runs.
+        for (const auto& pt : mixture_single_phase_points(backend, z)) {
+            {
+                const double T = pt.T, p = pt.p;
+                CAPTURE(pt.label);
                 CAPTURE(T);
                 CAPTURE(p);
                 REQUIRE_NOTHROW(ref->update(PT_INPUTS, p, T));
@@ -700,6 +768,7 @@ TEST_CASE("Cubic volume translation: mixture single-phase invariances", "[cubic]
                 CHECK(close_to(trn->Bvirial(), ref->Bvirial() - cm, 1e-9, 1e-18));
 
                 CHECK(std::abs(trn->speed_sound() / ref->speed_sound() - 1.0) > 1e-6);
+                check_v_scaled_quantities(*ref, *trn, cm);
             }
         }
     }
@@ -758,7 +827,14 @@ TEST_CASE("Cubic volume translation: mixture VLE is invariant for arbitrary c_i"
                 const double dV_ref = 1.0 / ref->saturated_vapor_keyed_output(iDmolar) - 1.0 / ref->saturated_liquid_keyed_output(iDmolar);
                 const double dV_trn = 1.0 / trn->saturated_vapor_keyed_output(iDmolar) - 1.0 / trn->saturated_liquid_keyed_output(iDmolar);
                 CHECK(close_to(dV_trn, dV_ref - dcm, 1e-6, 1e-15));
-                CHECK(close_to(dvap(*trn, iHmolar), dvap(*ref, iHmolar) - ref->p() * dcm, 1e-6, 1e-6));
+                // Tolerance tied to the SHIFT, not to Dvap H.  The shift is p*dcm ~ 0.27 J/mol at the
+                // 220 K dew point while Dvap H is ~1.4e4 J/mol, so a relative test on the latter
+                // accepted a 5 % error in the former.  The measured residual across all four
+                // (backend, T, Q) points is <= 1.4e-10 J/mol, so this still clears the numerical
+                // floor by four orders while pinning the shift itself to 1e-5 relative.
+                const double dH_shift = ref->p() * dcm;
+                CAPTURE(dH_shift);
+                CHECK(close_to(dvap(*trn, iHmolar), dvap(*ref, iHmolar) - dH_shift, 0.0, 1e-5 * std::abs(dH_shift) + 1e-8));
             }
         }
     }

--- a/src/Tests/CoolProp-Tests-CubicVolumeTranslation.cpp
+++ b/src/Tests/CoolProp-Tests-CubicVolumeTranslation.cpp
@@ -385,7 +385,7 @@ TEST_CASE("Cubic volume translation: survives get_copy", "[cubic][volume_transla
         std::shared_ptr<HelmholtzEOSMixtureBackend> clone(cb.get_copy(true));
         auto* clone_cb = dynamic_cast<AbstractCubicBackend*>(clone.get());
         REQUIRE(clone_cb != nullptr);
-        CHECK(clone_cb->get_cubic()->get_cm() == Catch::Approx(c).epsilon(1e-15));
+        CHECK(clone_cb->get_cubic()->get_cm(0) == Catch::Approx(c).epsilon(1e-15));
 
         // SatL/SatV of the clone must agree too, or a saturation call on the copy silently mixes a
         // translated parent with untranslated daughters.
@@ -463,6 +463,148 @@ TEST_CASE("Cubic volume translation: spinodal translates", "[cubic][volume_trans
 }
 
 // ============================================================================================
+// Mixtures
+//
+// The mixture column of the invariance table.  Two things differ from a pure fluid.  First the
+// shifts are in c_m(z) = sum_i x_i c_i, EXCEPT ln(phi_i), which shifts by the PURE-component c_i --
+// that is what makes the equifugacity condition cancel, and hence what makes VLE invariant for
+// ARBITRARY c_i and not merely for equal ones.  Second, the property changes on vaporisation split:
+// the two coexisting phases have different compositions, so c_m(y) != c_m(x) unless every c_i is
+// equal, and Dvap V and Dvap H inherit that difference while Dvap S, U and A do not.
+// ============================================================================================
+
+namespace {
+
+const char* kMixture = "Methane&Ethane&n-Propane";
+
+/// Distinct per-component translations with mixed signs -- the case that a scalar c cannot express
+/// and that only a correct dc_m/dx_i chain gets right.  Well inside methane's covolume (~2.7e-5).
+const std::vector<double>& mixture_c() {
+    static const std::vector<double> v{2.5e-6, -1.5e-6, 4.0e-6};
+    return v;
+}
+
+ASptr make_mixture(const std::string& backend, const std::vector<double>& z, const std::vector<double>& c) {
+    ASptr AS(AbstractState::factory(backend, kMixture));
+    for (std::size_t i = 0; i < c.size(); ++i) {
+        if (c[i] != 0.0) {
+            AS->set_fluid_parameter_double(i, "cm", c[i]);
+        }
+    }
+    AS->set_mole_fractions(std::vector<CoolPropDbl>(z.begin(), z.end()));
+    return AS;
+}
+
+double cm_of(const std::vector<double>& z, const std::vector<double>& c) {
+    double s = 0;
+    for (std::size_t i = 0; i < z.size(); ++i) {
+        s += z[i] * c[i];
+    }
+    return s;
+}
+
+}  // namespace
+
+TEST_CASE("Cubic volume translation: mixture single-phase invariances", "[cubic][volume_translation][mixture]") {
+    const std::vector<double> z{0.30, 0.35, 0.35};
+    const std::vector<double> c = mixture_c();
+    const double cm = cm_of(z, c);
+    const double R = 8.31446261815324;
+
+    for (const auto& backend : cubic_backends()) {
+        CAPTURE(backend);
+        ASptr ref = make_mixture(backend, z, {0.0, 0.0, 0.0});
+        ASptr trn = make_mixture(backend, z, c);
+
+        // A single-phase state well away from the dome, so the PT flash returns a root rather than
+        // a phase split whose composition would differ between the two runs.
+        for (double T : {320.0, 450.0}) {
+            for (double p : {5e6, 2e7}) {
+                CAPTURE(T);
+                CAPTURE(p);
+                REQUIRE_NOTHROW(ref->update(PT_INPUTS, p, T));
+                REQUIRE_NOTHROW(trn->update(PT_INPUTS, p, T));
+
+                CHECK(close_to(1.0 / trn->rhomolar(), 1.0 / ref->rhomolar() - cm, 1e-9, 1e-18));
+                CHECK(close_to(trn->hmolar(), ref->hmolar() - p * cm, 1e-9, 1e-8));
+                CHECK(close_to(trn->gibbsmolar(), ref->gibbsmolar() - p * cm, 1e-9, 1e-8));
+                CHECK(close_to(trn->smolar(), ref->smolar(), 1e-9, 1e-10));
+                CHECK(close_to(trn->umolar(), ref->umolar(), 1e-9, 1e-8));
+                CHECK(close_to(trn->helmholtzmolar(), ref->helmholtzmolar(), 1e-9, 1e-8));
+                CHECK(close_to(trn->cpmolar(), ref->cpmolar(), 1e-9, 1e-10));
+                CHECK(close_to(trn->cvmolar(), ref->cvmolar(), 1e-9, 1e-10));
+                CHECK(
+                  close_to(trn->isothermal_compressibility() / trn->rhomolar(), ref->isothermal_compressibility() / ref->rhomolar(), 1e-9, 1e-25));
+                CHECK(close_to(trn->isobaric_expansion_coefficient() / trn->rhomolar(), ref->isobaric_expansion_coefficient() / ref->rhomolar(), 1e-9,
+                               1e-20));
+
+                // The one that needs the PURE-component c_i, not c_m -- and the one that the
+                // d_A_term_dxi defect got wrong.
+                for (std::size_t i = 0; i < z.size(); ++i) {
+                    CAPTURE(i);
+                    CHECK(close_to(std::log(trn->fugacity_coefficient(i)), std::log(ref->fugacity_coefficient(i)) - p * c[i] / (R * T), 1e-8, 1e-10));
+                }
+
+                CHECK(std::abs(trn->speed_sound() / ref->speed_sound() - 1.0) > 1e-6);
+            }
+        }
+    }
+}
+
+TEST_CASE("Cubic volume translation: mixture VLE is invariant for arbitrary c_i", "[cubic][volume_translation][mixture]") {
+    // The headline mixture result.  ln(phi_i) shifts by -P*c_i/(RT), which is the SAME in both
+    // phases at the same (T, P), so it cancels in the equifugacity condition regardless of whether
+    // the c_i are equal.  Bubble and dew pressures and all K-values must therefore be untouched.
+    //
+    // This is the case that fails on the unfixed A_term derivatives: with c = 1e-5 on a
+    // methane/n-decane pair the bubble pressure moved from 10.20 MPa to 6.87 MPa.
+    const std::vector<double> z{0.30, 0.35, 0.35};
+    const std::vector<double> c = mixture_c();
+
+    for (const auto& backend : cubic_backends()) {
+        CAPTURE(backend);
+        for (double T : {220.0, 250.0}) {
+            CAPTURE(T);
+            for (int Q : {0, 1}) {
+                CAPTURE(Q);
+                ASptr ref = make_mixture(backend, z, {0.0, 0.0, 0.0});
+                ASptr trn = make_mixture(backend, z, c);
+                REQUIRE_NOTHROW(ref->update(QT_INPUTS, Q, T));
+                REQUIRE_NOTHROW(trn->update(QT_INPUTS, Q, T));
+
+                CHECK(close_to(trn->p(), ref->p(), 1e-6, 1.0));
+
+                const std::vector<CoolPropDbl> xr = ref->mole_fractions_liquid(), yr = ref->mole_fractions_vapor();
+                const std::vector<CoolPropDbl> xt = trn->mole_fractions_liquid(), yt = trn->mole_fractions_vapor();
+                REQUIRE(xr.size() == xt.size());
+                for (std::size_t i = 0; i < xr.size(); ++i) {
+                    CAPTURE(i);
+                    CHECK(close_to(xt[i], xr[i], 1e-6, 1e-9));
+                    CHECK(close_to(yt[i], yr[i], 1e-6, 1e-9));
+                    // K-values are what a flash actually consumes.
+                    CHECK(close_to(yt[i] / xt[i], yr[i] / xr[i], 1e-6, 1e-9));
+                }
+
+                // Property changes on vaporisation.  S, U and A survive because the c-dependent
+                // parts cancel between h, P*v and T*s; V and H carry the composition difference in
+                // c_m, which is nonzero precisely because the c_i differ.
+                const double dcm = cm_of(std::vector<double>(yr.begin(), yr.end()), c) - cm_of(std::vector<double>(xr.begin(), xr.end()), c);
+                CAPTURE(dcm);
+                const auto dvap = [](AbstractState& S, parameters key) {
+                    return S.saturated_vapor_keyed_output(key) - S.saturated_liquid_keyed_output(key);
+                };
+                CHECK(close_to(dvap(*trn, iSmolar), dvap(*ref, iSmolar), 1e-6, 1e-8));
+                CHECK(close_to(dvap(*trn, iUmolar), dvap(*ref, iUmolar), 1e-6, 1e-6));
+                const double dV_ref = 1.0 / ref->saturated_vapor_keyed_output(iDmolar) - 1.0 / ref->saturated_liquid_keyed_output(iDmolar);
+                const double dV_trn = 1.0 / trn->saturated_vapor_keyed_output(iDmolar) - 1.0 / trn->saturated_liquid_keyed_output(iDmolar);
+                CHECK(close_to(dV_trn, dV_ref - dcm, 1e-6, 1e-15));
+                CHECK(close_to(dvap(*trn, iHmolar), dvap(*ref, iHmolar) - ref->p() * dcm, 1e-6, 1e-6));
+            }
+        }
+    }
+}
+
+// ============================================================================================
 // Composition derivatives
 //
 // These operate on a bare AbstractCubic rather than through a backend, for two reasons: the
@@ -486,7 +628,7 @@ struct CompDerivCase
     double tau = 1.0 / 250.0;
 };
 
-CompDerivCase make_comp_case(const std::string& which, double cm) {
+CompDerivCase make_comp_case(const std::string& which, const std::vector<double>& cvec) {
     const std::vector<double> Tc{190.564, 305.322, 369.89};
     const std::vector<double> pc{4.5992e6, 4.8722e6, 4.2512e6};
     const std::vector<double> acentric{0.01142, 0.0995, 0.1521};
@@ -497,8 +639,21 @@ CompDerivCase make_comp_case(const std::string& which, double cm) {
     } else {
         c.cubic = std::make_shared<SRK>(Tc, pc, acentric, R);
     }
-    c.cubic->set_cm(cm);
+    c.cubic->set_cm_vector(cvec);
     return c;
+}
+
+/// The translations to sweep.  The uniform vector reproduces what a single scalar c used to mean;
+/// the mixed one is the case that actually exercises dc_m/dx_i, and it deliberately mixes signs
+/// because both occur in the real parameter sets.  The smallest covolume here is methane's, about
+/// 2.7e-5 m^3/mol, so all of these stay well inside the pole.
+const std::vector<std::vector<double>>& comp_deriv_translations() {
+    static const std::vector<std::vector<double>> v{
+      {0.0, 0.0, 0.0},      // control: must pass before and after the fix
+      {3e-6, 3e-6, 3e-6},   // uniform
+      {2e-6, -1e-6, 5e-6},  // genuinely per-component, mixed signs
+    };
+    return v;
 }
 
 /// Central difference of f with respect to x_i, honouring the same x_N convention the analytic
@@ -531,10 +686,12 @@ TEST_CASE("Cubic composition derivatives carry the volume translation", "[cubic]
     for (const auto& which : cubic_backends()) {
         CAPTURE(which);
         // c = 0 must pass both before and after the fix -- it is the control that proves the
-        // harness itself is sound.  The nonzero case is the reproduction.
-        for (double cm : {0.0, 3e-6}) {
-            CAPTURE(cm);
-            CompDerivCase cs = make_comp_case(which, cm);
+        // harness itself is sound.  The nonzero vectors are the reproduction.
+        for (const auto& cvec : comp_deriv_translations()) {
+            CAPTURE(cvec[0]);
+            CAPTURE(cvec[1]);
+            CAPTURE(cvec[2]);
+            CompDerivCase cs = make_comp_case(which, cvec);
             AbstractCubic& C = *cs.cubic;
             const std::vector<double>& x = cs.x;
             const double d = cs.delta, tau = cs.tau;

--- a/src/Tests/CoolProp-Tests-CubicVolumeTranslation.cpp
+++ b/src/Tests/CoolProp-Tests-CubicVolumeTranslation.cpp
@@ -1,0 +1,465 @@
+/*
+Regression guards for the Peneloux volume translation in the cubic backends.
+
+A temperature-independent volume translation v -> v - c is a change of variable, not a new model, so
+almost every property either stays *exactly* the same or moves by an amount that is known in closed
+form.  Jaubert, Privat, Le Guennec & Coniglio, Fluid Phase Equilibria 419 (2016) 88-95 tabulate
+which is which; those identities are exact, which makes them unusually good regression guards.
+
+Before this file there was no coverage of `cm` anywhere in the suite, and four code paths that
+reason directly about volume silently ignored it: the Chebyshev superancillary (which made
+update(DmolarT) hand back a NEGATIVE pressure for a state inside the dome), the maximum-density
+bound, the spinodal, and the critical density.  `cm` also did not survive get_copy().
+
+Run with:  ./CatchTestRunner "[volume_translation]"
+*/
+
+#if defined(ENABLE_CATCH)
+#    include <catch2/catch_all.hpp>
+
+#    include "CoolProp/AbstractState.h"
+#    include "CoolProp/DataStructures.h"
+#    include "../Backends/Cubics/CubicBackend.h"
+#    include "../Backends/Cubics/GeneralizedCubic.h"
+
+#    include <cmath>
+#    include <functional>
+#    include <memory>
+#    include <string>
+#    include <vector>
+
+using namespace CoolProp;
+
+namespace {
+
+using ASptr = std::shared_ptr<AbstractState>;
+
+/// The backends that carry a superancillary and are exercised throughout this file.
+const std::vector<std::string>& cubic_backends() {
+    static const std::vector<std::string> v{"SRK", "PR"};
+    return v;
+}
+
+/// A small, chemically varied set that all have a reference EOS available.
+const std::vector<std::string>& probe_fluids() {
+    static const std::vector<std::string> v{"n-Propane", "Water", "CarbonDioxide"};
+    return v;
+}
+
+AbstractCubicBackend& as_cubic(AbstractState& AS) {
+    auto* cb = dynamic_cast<AbstractCubicBackend*>(&AS);
+    REQUIRE(cb != nullptr);
+    return *cb;
+}
+
+/// The pure-fluid covolume, which sets the scale for a safe translation: the repulsive pole sits at
+/// v = b - c, so |c| is always chosen as a modest fraction of b rather than as an absolute number
+/// that might be fine for propane and past the pole for water.
+double covolume(const std::string& backend, const std::string& fluid) {
+    ASptr AS(AbstractState::factory(backend, fluid));
+    return as_cubic(*AS).get_cubic()->bm_term(std::vector<double>(1, 1.0));
+}
+
+ASptr make_translated(const std::string& backend, const std::string& fluid, double c) {
+    ASptr AS(AbstractState::factory(backend, fluid));
+    if (c != 0.0) {
+        AS->set_fluid_parameter_double(0, "cm", c);
+    }
+    return AS;
+}
+
+/// |got - ref| against a relative tolerance with an absolute floor.  Energies and entropies carry an
+/// arbitrary reference state and can legitimately sit near zero, where a pure relative test degrades
+/// into a division by nothing.
+bool close_to(double got, double ref, double rtol, double afloor) {
+    return std::abs(got - ref) <= rtol * std::abs(ref) + afloor;
+}
+
+struct Probe
+{
+    const char* name;
+    std::function<double(AbstractState&)> get;
+    /// Expected value minus untranslated value.  Invariant properties return 0.
+    std::function<double(double p, double T, double c)> shift;
+    double afloor;  ///< absolute tolerance floor, in the property's own units
+};
+
+/// The invariance table of Jaubert et al. (2016), as executable assertions.
+const std::vector<Probe>& pure_fluid_probes() {
+    static const double R = 8.31446261815324;
+    static const std::vector<Probe> v{
+      // -- properties that move by a known amount ------------------------------------------------
+      {"v", [](AbstractState& S) { return 1.0 / S.rhomolar(); }, [](double, double, double c) { return -c; }, 1e-18},
+      {"h", [](AbstractState& S) { return S.hmolar(); }, [](double p, double, double c) { return -p * c; }, 1e-9},
+      {"g", [](AbstractState& S) { return S.gibbsmolar(); }, [](double p, double, double c) { return -p * c; }, 1e-9},
+      {"ln(phi)", [](AbstractState& S) { return std::log(S.fugacity_coefficient(0)); }, [](double p, double T, double c) { return -p * c / (R * T); },
+       1e-12},
+      // -- properties that must not move at all --------------------------------------------------
+      {"s", [](AbstractState& S) { return S.smolar(); }, [](double, double, double) { return 0.0; }, 1e-10},
+      {"u", [](AbstractState& S) { return S.umolar(); }, [](double, double, double) { return 0.0; }, 1e-8},
+      {"a", [](AbstractState& S) { return S.helmholtzmolar(); }, [](double, double, double) { return 0.0; }, 1e-8},
+      {"cp", [](AbstractState& S) { return S.cpmolar(); }, [](double, double, double) { return 0.0; }, 1e-10},
+      {"cv", [](AbstractState& S) { return S.cvmolar(); }, [](double, double, double) { return 0.0; }, 1e-10},
+      // Jaubert et al. state these two as the PRODUCTS kappa_T*v and alpha_v*v rather than as the
+      // normalised compressibility and expansivity, and that is the sharp form: the derivatives
+      // -(dv/dP)_T and (dv/dT)_P are invariant, while dividing either by v does NOT survive,
+      // because v is exactly what moved.  Both are asserted -- invariance here, and the
+      // normalised pair is checked to genuinely change at the call site.
+      {"-(dv/dP)_T", [](AbstractState& S) { return S.isothermal_compressibility() / S.rhomolar(); }, [](double, double, double) { return 0.0; },
+       1e-25},
+      {"(dv/dT)_P", [](AbstractState& S) { return S.isobaric_expansion_coefficient() / S.rhomolar(); }, [](double, double, double) { return 0.0; },
+       1e-20},
+    };
+    return v;
+}
+
+struct StatePoint
+{
+    std::string label;
+    double T, p;
+};
+
+/// Derived rather than hardcoded: a fixed (T, p) that is liquid for propane can be supercritical for
+/// carbon dioxide, and a state that lands inside the dome makes the PT flash pick a phase rather
+/// than a root.
+std::vector<StatePoint> single_phase_points(AbstractState& AS) {
+    const double Tc = AS.T_critical(), pc = AS.p_critical();
+    const double T_sub = 0.75 * Tc;
+    AS.update(QT_INPUTS, 0, T_sub);
+    const double psat = AS.p();
+    return {
+      {"compressed liquid", T_sub, 3.0 * psat},
+      {"superheated vapour", T_sub, 0.4 * psat},
+      {"supercritical", 1.25 * Tc, 2.0 * pc},
+    };
+}
+
+}  // namespace
+
+TEST_CASE("Cubic volume translation: pure-fluid property invariances", "[cubic][volume_translation]") {
+    for (const auto& backend : cubic_backends()) {
+        for (const auto& fluid : probe_fluids()) {
+            CAPTURE(backend);
+            CAPTURE(fluid);
+            const double b = covolume(backend, fluid);
+
+            // Both signs matter: a positive c shrinks the volume and moves the repulsive pole to
+            // higher density, a negative c does the reverse.  Both occur in the real parameter sets.
+            for (double frac : {0.15, -0.15}) {
+                const double c = frac * b;
+                CAPTURE(c);
+
+                ASptr ref = make_translated(backend, fluid, 0.0);
+                ASptr trn = make_translated(backend, fluid, c);
+
+                for (const auto& pt : single_phase_points(*ref)) {
+                    CAPTURE(pt.label);
+                    CAPTURE(pt.T);
+                    CAPTURE(pt.p);
+                    REQUIRE_NOTHROW(ref->update(PT_INPUTS, pt.p, pt.T));
+                    REQUIRE_NOTHROW(trn->update(PT_INPUTS, pt.p, pt.T));
+
+                    for (const auto& probe : pure_fluid_probes()) {
+                        CAPTURE(probe.name);
+                        const double v0 = probe.get(*ref);
+                        const double v1 = probe.get(*trn);
+                        const double expected = v0 + probe.shift(pt.p, pt.T, c);
+                        CAPTURE(v0);
+                        CAPTURE(v1);
+                        CAPTURE(expected);
+                        // 1e-9 relative is loose enough for the two independent density solves and
+                        // far tighter than any of the defects this guards, which are O(1) relative.
+                        CHECK(close_to(v1, expected, 1e-9, probe.afloor));
+                    }
+
+                    // Quantities that must genuinely MOVE.  Without these a suite made only of
+                    // invariances would pass with the translation silently disabled.
+                    //
+                    // w^2 scales with v^2; the normalised compressibility and expansivity are the
+                    // invariant derivatives above divided by v, so they inherit the shift even
+                    // though their numerators do not.
+                    CHECK(std::abs(trn->speed_sound() / ref->speed_sound() - 1.0) > 1e-6);
+                    CHECK(std::abs(trn->isothermal_compressibility() / ref->isothermal_compressibility() - 1.0) > 1e-6);
+                    CHECK(std::abs(trn->isobaric_expansion_coefficient() / ref->isobaric_expansion_coefficient() - 1.0) > 1e-6);
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("Cubic volume translation: second virial coefficient shifts by -c", "[cubic][volume_translation]") {
+    for (const auto& backend : cubic_backends()) {
+        for (const auto& fluid : probe_fluids()) {
+            CAPTURE(backend);
+            CAPTURE(fluid);
+            const double c = 0.15 * covolume(backend, fluid);
+            ASptr ref = make_translated(backend, fluid, 0.0);
+            ASptr trn = make_translated(backend, fluid, c);
+            const double T = 1.25 * ref->T_critical();
+            ref->update(DmolarT_INPUTS, 1e-3, T);
+            trn->update(DmolarT_INPUTS, 1e-3, T);
+            CHECK(close_to(trn->Bvirial(), ref->Bvirial() - c, 1e-9, 1e-18));
+        }
+    }
+}
+
+TEST_CASE("Cubic volume translation: saturation invariances", "[cubic][volume_translation]") {
+    for (const auto& backend : cubic_backends()) {
+        for (const auto& fluid : probe_fluids()) {
+            CAPTURE(backend);
+            CAPTURE(fluid);
+            const double c = 0.15 * covolume(backend, fluid);
+            ASptr ref = make_translated(backend, fluid, 0.0);
+            ASptr trn = make_translated(backend, fluid, c);
+
+            const double T = 0.75 * ref->T_critical();
+            REQUIRE_NOTHROW(ref->update(QT_INPUTS, 0, T));
+            REQUIRE_NOTHROW(trn->update(QT_INPUTS, 0, T));
+
+            // The vapour pressure is the headline invariance: it is what lets a translation be
+            // fitted to densities without disturbing anything that was fitted to VLE.
+            CHECK(close_to(trn->p(), ref->p(), 1e-10, 1e-6));
+
+            // Each saturated phase moves by the same -c, so for a PURE fluid every property change
+            // on vaporisation is invariant -- the volume change included.
+            const auto dvap = [](AbstractState& S, parameters key) {
+                return S.saturated_vapor_keyed_output(key) - S.saturated_liquid_keyed_output(key);
+            };
+            const auto dvap_v = [](AbstractState& S) {
+                return 1.0 / S.saturated_vapor_keyed_output(iDmolar) - 1.0 / S.saturated_liquid_keyed_output(iDmolar);
+            };
+            CHECK(close_to(dvap_v(*trn), dvap_v(*ref), 1e-9, 1e-18));
+            for (parameters key : {iHmolar, iSmolar, iUmolar, iCvmolar, iCpmolar}) {
+                CAPTURE(get_parameter_information(key, "short"));
+                CHECK(close_to(dvap(*trn, key), dvap(*ref, key), 1e-9, 1e-8));
+            }
+
+            // Each saturated phase individually: the volume shifts by -c.
+            //
+            // The corresponding h -> h - p*c identity is deliberately NOT asserted here.  SatL/SatV
+            // are set from (rho, T), so each carries its own converged pressure rather than a shared
+            // exact p, and the residual p mismatch feeds straight into h = u + p*v.  The identity is
+            // pinned rigorously in the single-phase test above, where p is an exact input.
+            for (int Q : {0, 1}) {
+                CAPTURE(Q);
+                const double vr = 1.0 / (Q == 0 ? ref->saturated_liquid_keyed_output(iDmolar) : ref->saturated_vapor_keyed_output(iDmolar));
+                const double vt = 1.0 / (Q == 0 ? trn->saturated_liquid_keyed_output(iDmolar) : trn->saturated_vapor_keyed_output(iDmolar));
+                CHECK(close_to(vt, vr - c, 1e-9, 1e-18));
+            }
+        }
+    }
+}
+
+TEST_CASE("Cubic volume translation: superancillary returns translated densities", "[cubic][volume_translation]") {
+    for (const auto& backend : cubic_backends()) {
+        for (const auto& fluid : probe_fluids()) {
+            CAPTURE(backend);
+            CAPTURE(fluid);
+            const double c = 0.15 * covolume(backend, fluid);
+            ASptr ref = make_translated(backend, fluid, 0.0);
+            ASptr trn = make_translated(backend, fluid, c);
+            auto& cb_ref = as_cubic(*ref);
+            auto& cb_trn = as_cubic(*trn);
+
+            const double T = 0.75 * trn->T_critical();
+
+            const double rhoL_ref = cb_ref.calc_saturation_ancillary(iDmolar, 0, iT, T);
+            const double rhoV_ref = cb_ref.calc_saturation_ancillary(iDmolar, 1, iT, T);
+            const double rhoL_anc = cb_trn.calc_saturation_ancillary(iDmolar, 0, iT, T);
+            const double rhoV_anc = cb_trn.calc_saturation_ancillary(iDmolar, 1, iT, T);
+            const double p_anc = cb_trn.calc_saturation_ancillary(iP, 0, iT, T);
+            CAPTURE(rhoL_anc);
+            CAPTURE(rhoV_anc);
+
+            // The sharp assertion, and the one that fails without the un-translation: the reduced
+            // argument Ttilde = R*T*bm/am carries no c, so both calls hit the SAME point of the same
+            // Chebyshev expansion.  The two volumes must therefore differ by exactly -c, with no
+            // approximation error to hide behind.
+            CHECK(close_to(1.0 / rhoL_anc, 1.0 / rhoL_ref - c, 1e-12, 1e-20));
+            CHECK(close_to(1.0 / rhoV_anc, 1.0 / rhoV_ref - c, 1e-12, 1e-20));
+            // ... and the pressure carries no translation at all.
+            CHECK(close_to(p_anc, cb_ref.calc_saturation_ancillary(iP, 0, iT, T), 1e-12, 0.0));
+
+            // Separately, the translated ancillary must still track the translated EOS flash to the
+            // superancillary's own accuracy.  1e-3 is the figure the existing [cubic_superanc] test
+            // documents; this check is about the un-translation being applied, not about the
+            // Chebyshev fit being exact.
+            trn->update(QT_INPUTS, 0, T);
+            CHECK(close_to(rhoL_anc, trn->saturated_liquid_keyed_output(iDmolar), 1e-3, 0.0));
+            CHECK(close_to(rhoV_anc, trn->saturated_vapor_keyed_output(iDmolar), 1e-3, 0.0));
+            CHECK(close_to(p_anc, trn->p(), 1e-3, 0.0));
+        }
+    }
+}
+
+TEST_CASE("Cubic volume translation: DmolarT across the dome", "[cubic][volume_translation]") {
+    // The sharp case.  With the untranslated superancillary bracketing the dome, a density that is
+    // really inside the two-phase region was reported as single-phase liquid with a NEGATIVE
+    // pressure -- a point on the unstable branch of the isotherm returned as if it were physical.
+    for (const auto& backend : cubic_backends()) {
+        for (const auto& fluid : probe_fluids()) {
+            CAPTURE(backend);
+            CAPTURE(fluid);
+            const double c = 0.15 * covolume(backend, fluid);
+            ASptr ref = make_translated(backend, fluid, 0.0);
+            ASptr trn = make_translated(backend, fluid, c);
+            auto& cb = as_cubic(*trn);
+
+            const double T = 0.8 * trn->T_critical();
+
+            // Part 0 -- the narrow band where the defect actually lived.
+            //
+            // A translated saturated liquid volume is exactly c smaller than the untranslated one,
+            // so ANY volume strictly between them is inside the translated dome and outside the
+            // untranslated one.  That band is only a fraction of a percent of the dome wide -- for
+            // propane at c = 0.15*b it is frac < 0.004 -- so a uniform sweep steps straight over it.
+            // Aim at it directly: the midpoint is the state that came back as single-phase liquid
+            // at negative pressure.
+            ref->update(QT_INPUTS, 0, T);
+            const double vL_untranslated = 1.0 / ref->rhomolar();
+            const double rho_band = 1.0 / (vL_untranslated - 0.5 * c);
+            CAPTURE(vL_untranslated);
+            CAPTURE(rho_band);
+            REQUIRE_NOTHROW(trn->update(DmolarT_INPUTS, rho_band, T));
+            CHECK(trn->phase() == iphase_twophase);
+            CHECK(trn->p() > 0);
+            CHECK(trn->Q() > 0);
+            CHECK(trn->Q() < 1);
+
+            // Part 1 -- the regression guard, and it must be driven from the TRUE dome.
+            //
+            // The defect was that update_DmolarT bracketed with the UNTRANSLATED superancillary.
+            // For a positive c the translated liquid branch sits at higher density than the
+            // untranslated one, so a band of genuinely two-phase states fell outside the bracket
+            // and came back as single-phase liquid with a NEGATIVE pressure -- a point on the
+            // unstable branch of the isotherm, returned as if it were physical.  Sweeping the dome
+            // taken from the iterative flash is what exposes that; sweeping the ancillary's own
+            // dome would be self-consistent either way and would guard nothing.
+            trn->update(QT_INPUTS, 0, T);
+            const double vL_true = 1.0 / trn->rhomolar();
+            const double psat_true = trn->p();
+            trn->update(QT_INPUTS, 1, T);
+            const double vV_true = 1.0 / trn->rhomolar();
+            REQUIRE(vV_true > vL_true);
+
+            for (double frac : {0.05, 0.25, 0.5, 0.75, 0.95}) {
+                const double rho = 1.0 / (vL_true + frac * (vV_true - vL_true));
+                CAPTURE(frac);
+                CAPTURE(rho);
+                REQUIRE_NOTHROW(trn->update(DmolarT_INPUTS, rho, T));
+                CHECK(trn->phase() == iphase_twophase);
+                CHECK(trn->p() > 0);
+                CHECK(trn->Q() > 0);
+                CHECK(trn->Q() < 1);
+                // The dome is bracketed with the ancillary, so the pressure it reports is the
+                // ancillary's psat -- agreement with the flash is bounded by the ~1e-3 the
+                // superancillary is documented to achieve, not by solver precision.
+                CHECK(close_to(trn->p(), psat_true, 1e-3, 0.0));
+            }
+
+            // Part 2 -- the lever rule itself, on the densities update_DmolarT actually uses, so
+            // the ancillary's approximation error does not leak into the expected quality.
+            const double rhoL_anc = cb.calc_saturation_ancillary(iDmolar, 0, iT, T);
+            const double rhoV_anc = cb.calc_saturation_ancillary(iDmolar, 1, iT, T);
+            for (double frac : {0.25, 0.5, 0.75}) {
+                const double rho = 1.0 / (1.0 / rhoL_anc + frac * (1.0 / rhoV_anc - 1.0 / rhoL_anc));
+                CAPTURE(frac);
+                REQUIRE_NOTHROW(trn->update(DmolarT_INPUTS, rho, T));
+                const double Q_expected = (rhoV_anc * (rhoL_anc - rho)) / (rho * (rhoL_anc - rhoV_anc));
+                CHECK(close_to(trn->Q(), Q_expected, 1e-9, 1e-12));
+            }
+        }
+    }
+}
+
+TEST_CASE("Cubic volume translation: survives get_copy", "[cubic][volume_translation]") {
+    // get_copy() builds a brand-new AbstractCubic, whose constructor zeroes the translation, and
+    // copy_internals() replays only the kij matrix and the components vector.  Without copy_cm()
+    // the TPD, critical and transient states silently run an untranslated EOS.
+    for (const auto& backend : cubic_backends()) {
+        CAPTURE(backend);
+        const double c = 0.15 * covolume(backend, "n-Propane");
+        ASptr trn = make_translated(backend, "n-Propane", c);
+        auto& cb = as_cubic(*trn);
+
+        std::shared_ptr<HelmholtzEOSMixtureBackend> clone(cb.get_copy(true));
+        auto* clone_cb = dynamic_cast<AbstractCubicBackend*>(clone.get());
+        REQUIRE(clone_cb != nullptr);
+        CHECK(clone_cb->get_cubic()->get_cm() == Catch::Approx(c).epsilon(1e-15));
+
+        // SatL/SatV of the clone must agree too, or a saturation call on the copy silently mixes a
+        // translated parent with untranslated daughters.
+        CHECK(clone_cb->get_fluid_parameter_double(0, "cm") == Catch::Approx(c).epsilon(1e-15));
+    }
+}
+
+TEST_CASE("Cubic volume translation: density bound tracks the pole", "[cubic][volume_translation]") {
+    for (const auto& backend : cubic_backends()) {
+        CAPTURE(backend);
+        const double b = covolume(backend, "n-Propane");
+        for (double frac : {0.0, 0.3, -0.3}) {
+            const double c = frac * b;
+            CAPTURE(c);
+            ASptr AS = make_translated(backend, "n-Propane", c);
+            auto& cb = as_cubic(*AS);
+            const double pole = 1.0 / (b - c);
+            // The bound must stay strictly inside the pole for BOTH signs.  With the untranslated
+            // 0.9/b_m, a sufficiently negative c put the bound past the pole, where alpha^r takes
+            // the log of a negative number but p, h and cp still return finite nonsense.
+            CHECK(cb.calc_rhomolar_max_bound() < pole);
+            CHECK(cb.calc_rhomolar_max_bound() == Catch::Approx(0.9 * pole).epsilon(1e-12));
+        }
+    }
+}
+
+TEST_CASE("Cubic volume translation: rejects a translation past the covolume", "[cubic][volume_translation]") {
+    for (const auto& backend : cubic_backends()) {
+        CAPTURE(backend);
+        const double b = covolume(backend, "n-Propane");
+        ASptr AS(AbstractState::factory(backend, "n-Propane"));
+        // b - c <= 0 inverts the repulsive branch; it has to be rejected at set time because the
+        // model does not fail loudly afterwards.
+        CHECK_THROWS(AS->set_fluid_parameter_double(0, "cm", b));
+        CHECK_THROWS(AS->set_fluid_parameter_double(0, "cm", 1.5 * b));
+        CHECK_NOTHROW(AS->set_fluid_parameter_double(0, "cm", 0.9 * b));
+    }
+}
+
+TEST_CASE("Cubic volume translation: set/get round-trip", "[cubic][volume_translation]") {
+    for (const auto& backend : cubic_backends()) {
+        CAPTURE(backend);
+        const double c = 0.2 * covolume(backend, "n-Propane");
+        ASptr AS(AbstractState::factory(backend, "n-Propane"));
+        CHECK(AS->get_fluid_parameter_double(0, "cm") == Catch::Approx(0.0));
+        for (const char* alias : {"c", "cm", "c_m"}) {
+            CAPTURE(alias);
+            REQUIRE_NOTHROW(AS->set_fluid_parameter_double(0, alias, c));
+            CHECK(AS->get_fluid_parameter_double(0, alias) == Catch::Approx(c).epsilon(1e-15));
+        }
+    }
+}
+
+TEST_CASE("Cubic volume translation: spinodal translates", "[cubic][volume_translation]") {
+    for (const auto& backend : cubic_backends()) {
+        CAPTURE(backend);
+        const double c = 0.15 * covolume(backend, "n-Propane");
+        ASptr ref = make_translated(backend, "n-Propane", 0.0);
+        ASptr trn = make_translated(backend, "n-Propane", c);
+        const double T = 0.8 * ref->T_critical();
+        ref->update(QT_INPUTS, 0, T);
+        trn->update(QT_INPUTS, 0, T);
+
+        const std::vector<double> s0 = as_cubic(*ref).spinodal_densities();
+        const std::vector<double> s1 = as_cubic(*trn).spinodal_densities();
+        REQUIRE(s0.size() == s1.size());
+        REQUIRE(!s0.empty());
+        // -(dv/dP)_T is invariant under the translation, so the spinodal does not need re-deriving:
+        // it simply moves with the volume.
+        for (std::size_t i = 0; i < s0.size(); ++i) {
+            CAPTURE(i);
+            CHECK(close_to(1.0 / s1[i], 1.0 / s0[i] - c, 1e-9, 1e-18));
+        }
+    }
+}
+
+#endif

--- a/src/Tests/CoolProp-Tests-CubicVolumeTranslation.cpp
+++ b/src/Tests/CoolProp-Tests-CubicVolumeTranslation.cpp
@@ -462,4 +462,170 @@ TEST_CASE("Cubic volume translation: spinodal translates", "[cubic][volume_trans
     }
 }
 
+// ============================================================================================
+// Composition derivatives
+//
+// These operate on a bare AbstractCubic rather than through a backend, for two reasons: the
+// composition-derivative chain is pure algebra that needs no state object around it, and doing it
+// this way keeps the check independent of get_copy()/linked_states plumbing.
+//
+// The reference is a central difference of the *value* function.  For second derivatives the
+// reference is a central difference of the *analytic first* derivative -- nesting two finite
+// differences would lose far more precision than the defect being hunted.
+// ============================================================================================
+
+namespace {
+
+/// A three-component methane/ethane/propane mixture: enough to make every composition index
+/// distinct and to give b_m a real spread.
+struct CompDerivCase
+{
+    std::shared_ptr<AbstractCubic> cubic;
+    std::vector<double> x{0.3, 0.35, 0.35};
+    double delta = 5000.0;  ///< rho_r defaults to 1, so delta IS the molar density [mol/m^3]
+    double tau = 1.0 / 250.0;
+};
+
+CompDerivCase make_comp_case(const std::string& which, double cm) {
+    const std::vector<double> Tc{190.564, 305.322, 369.89};
+    const std::vector<double> pc{4.5992e6, 4.8722e6, 4.2512e6};
+    const std::vector<double> acentric{0.01142, 0.0995, 0.1521};
+    const double R = 8.31446261815324;
+    CompDerivCase c;
+    if (which == "PR") {
+        c.cubic = std::make_shared<PengRobinson>(Tc, pc, acentric, R);
+    } else {
+        c.cubic = std::make_shared<SRK>(Tc, pc, acentric, R);
+    }
+    c.cubic->set_cm(cm);
+    return c;
+}
+
+/// Central difference of f with respect to x_i, honouring the same x_N convention the analytic
+/// derivatives use: when x_N is dependent, perturbing x_i has to be compensated in x_N.
+double fd_dxi(const std::function<double(const std::vector<double>&)>& f, const std::vector<double>& x, std::size_t i, bool xN_independent,
+              double dz) {
+    std::vector<double> xp = x, xm = x;
+    xp[i] += dz;
+    xm[i] -= dz;
+    if (!xN_independent) {
+        xp[xp.size() - 1] -= dz;
+        xm[xm.size() - 1] += dz;
+    }
+    return (f(xp) - f(xm)) / (2 * dz);
+}
+
+/// Relative error, falling back to absolute when the analytic value is ~0.
+double deriv_err(double numeric, double analytic) {
+    return (std::abs(analytic) > 1e-12) ? std::abs(numeric / analytic - 1) : std::abs(numeric - analytic);
+}
+
+}  // namespace
+
+TEST_CASE("Cubic composition derivatives carry the volume translation", "[cubic][volume_translation][cubic_compderiv]") {
+    // 1e-6 sits comfortably above the floor of a central difference on well-scaled quantities and
+    // five orders below the defect it guards: dropping the (1 + c*rho) factor from d_A_term_dxi is
+    // a 2.4 % error at c = 5e-6 and 9.1 % at c = 2e-5.
+    const double dz = 1e-7, tol = 1e-6;
+
+    for (const auto& which : cubic_backends()) {
+        CAPTURE(which);
+        // c = 0 must pass both before and after the fix -- it is the control that proves the
+        // harness itself is sound.  The nonzero case is the reproduction.
+        for (double cm : {0.0, 3e-6}) {
+            CAPTURE(cm);
+            CompDerivCase cs = make_comp_case(which, cm);
+            AbstractCubic& C = *cs.cubic;
+            const std::vector<double>& x = cs.x;
+            const double d = cs.delta, tau = cs.tau;
+
+            for (bool xNi : {true, false}) {
+                CAPTURE(xNi);
+                for (std::size_t i = 0; i < x.size(); ++i) {
+                    CAPTURE(i);
+
+                    // b_m carries no translation, so this is a second control.
+                    CHECK(deriv_err(fd_dxi([&](const std::vector<double>& z) { return C.bm_term(z); }, x, i, xNi, dz), C.d_bm_term_dxi(x, i, xNi))
+                          < tol);
+
+                    // psi_minus depends on x only through (b_m - c_m).
+                    for (std::size_t id = 0; id <= 4; ++id) {
+                        CAPTURE(id);
+                        CHECK(deriv_err(fd_dxi([&](const std::vector<double>& z) { return C.psi_minus(d, z, 0, id); }, x, i, xNi, dz),
+                                        C.d_psi_minus_dxi(d, x, 0, id, i, xNi))
+                              < tol);
+                    }
+
+                    // PI_12 carries c_m in both factors.
+                    for (std::size_t id = 0; id <= 2; ++id) {
+                        CAPTURE(id);
+                        CHECK(deriv_err(fd_dxi([&](const std::vector<double>& z) { return C.PI_12(d, z, id); }, x, i, xNi, dz),
+                                        C.d_PI_12_dxi(d, x, id, i, xNi))
+                              < tol);
+                    }
+
+                    // A_term -- the one that drops (1 + c_m*rho).
+                    CHECK(deriv_err(fd_dxi([&](const std::vector<double>& z) { return C.A_term(d, z); }, x, i, xNi, dz), C.d_A_term_dxi(d, x, i, xNi))
+                          < tol);
+
+                    for (std::size_t id = 0; id <= 4; ++id) {
+                        CAPTURE(id);
+                        CHECK(deriv_err(fd_dxi([&](const std::vector<double>& z) { return C.psi_plus(d, z, id); }, x, i, xNi, dz),
+                                        C.d_psi_plus_dxi(d, x, id, i, xNi))
+                              < tol);
+                    }
+
+                    // alphar closes the loop: it is what the backend actually consumes.
+                    for (std::size_t it = 0; it <= 1; ++it) {
+                        for (std::size_t id = 0; id <= 2; ++id) {
+                            CAPTURE(it);
+                            CAPTURE(id);
+                            CHECK(deriv_err(fd_dxi([&](const std::vector<double>& z) { return C.alphar(tau, d, z, it, id); }, x, i, xNi, dz),
+                                            C.d_alphar_dxi(tau, d, x, it, id, i, xNi))
+                                  < tol);
+                        }
+                    }
+
+                    // Second derivative of A, referenced against the VALUE function via a
+                    // second-order central difference.
+                    //
+                    // This is deliberately independent of d_A_term_dxi.  Differencing the analytic
+                    // first derivative -- which the loop below does, at much better precision --
+                    // cannot see an error that is a common multiplicative factor on both orders,
+                    // and that is exactly the shape of the missing (1 + c*rho): with only that
+                    // check, d2_A_term_dxidxj passed against the unfixed code.
+                    {
+                        const double h = 1e-4;
+                        std::vector<double> xp = x, xm = x;
+                        xp[i] += h;
+                        xm[i] -= h;
+                        if (!xNi) {
+                            xp[xp.size() - 1] -= h;
+                            xm[xm.size() - 1] += h;
+                        }
+                        const double d2_num = (C.A_term(d, xp) - 2 * C.A_term(d, x) + C.A_term(d, xm)) / (h * h);
+                        // A second difference loses about half the available digits, so 1e-4
+                        // relative -- still two orders below the 1.5 % defect at this c and rho.
+                        CHECK(deriv_err(d2_num, C.d2_A_term_dxidxj(d, x, i, i, xNi)) < 1e-4);
+                    }
+
+                    // Second derivatives, referenced against the analytic first derivative.
+                    for (std::size_t j = 0; j < x.size(); ++j) {
+                        CAPTURE(j);
+                        CHECK(deriv_err(fd_dxi([&](const std::vector<double>& z) { return C.d_A_term_dxi(d, z, i, xNi); }, x, j, xNi, dz),
+                                        C.d2_A_term_dxidxj(d, x, i, j, xNi))
+                              < tol);
+                        CHECK(deriv_err(fd_dxi([&](const std::vector<double>& z) { return C.d_PI_12_dxi(d, z, 0, i, xNi); }, x, j, xNi, dz),
+                                        C.d2_PI_12_dxidxj(d, x, 0, i, j, xNi))
+                              < tol);
+                        CHECK(deriv_err(fd_dxi([&](const std::vector<double>& z) { return C.d_psi_minus_dxi(d, z, 0, 0, i, xNi); }, x, j, xNi, dz),
+                                        C.d2_psi_minus_dxidxj(d, x, 0, 0, i, j, xNi))
+                              < tol);
+                    }
+                }
+            }
+        }
+    }
+}
+
 #endif

--- a/src/Tests/CoolProp-Tests-CubicVolumeTranslation.cpp
+++ b/src/Tests/CoolProp-Tests-CubicVolumeTranslation.cpp
@@ -966,7 +966,7 @@ TEST_CASE("Cubic composition derivatives carry the volume translation", "[cubic]
     // 1e-6 sits comfortably above the floor of a central difference on well-scaled quantities and
     // five orders below the defect it guards: dropping the (1 + c*rho) factor from d_A_term_dxi is
     // a 2.4 % error at c = 5e-6 and 9.1 % at c = 2e-5.
-    const double dz = 1e-7, tol = 1e-6;
+    const double dz = 1e-7, dz3 = 1e-5, tol = 1e-6;
 
     for (const auto& which : cubic_backends()) {
         CAPTURE(which);
@@ -1063,6 +1063,51 @@ TEST_CASE("Cubic composition derivatives carry the volume translation", "[cubic]
                         CHECK(deriv_err(fd_dxi([&](const std::vector<double>& z) { return C.d_psi_minus_dxi(d, z, 0, 0, i, xNi); }, x, j, xNi, dz),
                                         C.d2_psi_minus_dxidxj(d, x, 0, 0, i, j, xNi))
                               < tol);
+
+                        // Third derivatives, referenced against the analytic second.
+                        //
+                        // These use a LARGER step than the orders above.  Differencing a second
+                        // derivative to reach a third subtracts two numbers that already agree to
+                        // most of their digits, so roundoff dominates far sooner: sweeping the step
+                        // for d3_psi_plus_dxidxjdxk (magnitude ~73) gives a relative error of
+                        // 1.4e-9 at dz3 = 1e-5 but 1.9e-6 at 1e-7 and 1.0e-4 at 1e-9 -- the error
+                        // GROWS as the step shrinks, which is cancellation, not truncation.  1e-7
+                        // is comfortable for the first and second orders and two-to-one over
+                        // tolerance here, so the third order gets its own step.
+                        //
+                        // Nothing else in the suite reaches these with a nonzero translation:
+                        // [mixture_derivs2] does run d3alphardxidxjdxk for PengRobinsonBackend and
+                        // SRKBackend, but at the default c = 0, where every term this branch added
+                        // vanishes identically.  And it is not a VTPR-only path -- for plain PR/SRK
+                        // d2b and d3b are zero, yet d3_A_term_dxidxjdxk still carries live c
+                        // dependence through K_term and d2_PI_12_dxidxj, which feeds
+                        // MixtureDerivatives::d3alphardxidxjdxk and hence the critical-point tracer
+                        // and the stability analysis for a translated mixture.
+                        //
+                        // One caveat on d3_PI_12: its U1 and U2 are built entirely from d2b and
+                        // d3b, so for PR/SRK it is structurally zero and so is the difference it is
+                        // compared against.  That assertion is therefore a zero-check here rather
+                        // than a value-check -- it cannot see a wrong coefficient, but it does
+                        // catch a SPURIOUS term (adding 2*c_i*c_j*c_k to U2 fails 124 assertions).
+                        // The value-checking work for PR/SRK is done by the other three.
+                        for (std::size_t k = 0; k < x.size(); ++k) {
+                            CAPTURE(k);
+                            CHECK(deriv_err(fd_dxi([&](const std::vector<double>& z) { return C.d2_A_term_dxidxj(d, z, i, j, xNi); }, x, k, xNi, dz3),
+                                            C.d3_A_term_dxidxjdxk(d, x, i, j, k, xNi))
+                                  < tol);
+                            CHECK(
+                              deriv_err(fd_dxi([&](const std::vector<double>& z) { return C.d2_PI_12_dxidxj(d, z, 0, i, j, xNi); }, x, k, xNi, dz3),
+                                        C.d3_PI_12_dxidxjdxk(d, x, 0, i, j, k, xNi))
+                              < tol);
+                            CHECK(deriv_err(fd_dxi([&](const std::vector<double>& z) { return C.d2_psi_minus_dxidxj(d, z, 0, 0, i, j, xNi); }, x, k,
+                                                   xNi, dz3),
+                                            C.d3_psi_minus_dxidxjdxk(d, x, 0, 0, i, j, k, xNi))
+                                  < tol);
+                            CHECK(deriv_err(
+                                    fd_dxi([&](const std::vector<double>& z) { return C.d2_psi_plus_dxidxj(d, z, 0, i, j, xNi); }, x, k, xNi, dz3),
+                                    C.d3_psi_plus_dxidxjdxk(d, x, 0, i, j, k, xNi))
+                                  < tol);
+                        }
                     }
                 }
             }

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -4630,7 +4630,7 @@ TEST_CASE("REFPROP melting_line honors iP_min/iT_min/iP_max/iT_max sentinels", "
 }
 
 // Tests for cubic EOS superancillaries (#2739)
-TEST_CASE("Cubic superancillary saturation_ancillary accuracy vs EOS flash", "[cubic_superanc][2739]") {
+TEST_CASE("Cubic superancillary saturation_ancillary accuracy vs EOS flash", "[cubic][cubic_superanc][2739]") {
     for (const auto& backend : std::vector<std::string>{"PR", "SRK"}) {
         CAPTURE(backend);
         std::shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory(backend, "Propane"));
@@ -4688,7 +4688,7 @@ TEST_CASE("Cubic superancillary saturation_ancillary accuracy vs EOS flash", "[c
     }
 }
 
-TEST_CASE("Cubic superancillary update_QT_pure_superanc", "[cubic_superanc][2739]") {
+TEST_CASE("Cubic superancillary update_QT_pure_superanc", "[cubic][cubic_superanc][2739]") {
     for (const auto& backend : std::vector<std::string>{"PR", "SRK"}) {
         CAPTURE(backend);
         std::shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory(backend, "Propane"));
@@ -4722,7 +4722,7 @@ TEST_CASE("Cubic superancillary update_QT_pure_superanc", "[cubic_superanc][2739
     }
 }
 
-TEST_CASE("Cubic pure-fluid DmolarT/DmassT round-trip vs PT", "[cubic_DmolarT][2673]") {
+TEST_CASE("Cubic pure-fluid DmolarT/DmassT round-trip vs PT", "[cubic][cubic_DmolarT][2673]") {
     for (const auto& backend : std::vector<std::string>{"PR", "SRK"}) {
         CAPTURE(backend);
         std::shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory(backend, "nButane"));
@@ -4794,7 +4794,7 @@ TEST_CASE("Cubic pure-fluid DmolarT/DmassT round-trip vs PT", "[cubic_DmolarT][2
 // Tests for set_fluid_parameter_double("Tcrit"/"pcrit") on cubic backends
 // ============================================================================
 
-TEST_CASE("Cubic set/get Tc and pc via set_fluid_parameter_double", "[cubic_Tcpc]") {
+TEST_CASE("Cubic set/get Tc and pc via set_fluid_parameter_double", "[cubic][cubic_Tcpc]") {
     // Use PR backend with propane as a representative pure fluid
     std::shared_ptr<CoolProp::AbstractState> AS(CoolProp::AbstractState::factory("PR", "Propane"));
     AbstractCubicBackend* raw = dynamic_cast<AbstractCubicBackend*>(AS.get());

--- a/wrappers/Julia/CoolProp.jl
+++ b/wrappers/Julia/CoolProp.jl
@@ -1056,7 +1056,7 @@ end
 """
     AbstractState_set_fluid_parameter_double(handle::Clong, i::Integer, parameter::AbstractString, value::Real)
 
-Set some fluid parameter (ie volume translation for cubic). Currently applied to the whole fluid not to components.
+Set some fluid parameter (ie volume translation for cubic). Applied to component `i`; use the name "c_all" to broadcast one value to every component.
 
 # Arguments
 * `handle`: The integer handle for the state class stored in memory


### PR DESCRIPTION
### Description of the change

The cubic backends already carried a volume-translation parameter (`AbstractCubic::cm`), and the
residual Helmholtz energy that consumes it was correct. Two separate things were not: several code
paths around it had never learned about `c`, and mixtures were never supported at all.

This PR treats those separately and pins the fixes with an extensive test suite. 
`c` still defaults to zero, so untranslated `PR`/`SRK` results are unchanged.

#### Part 1 — Fixes to pure-fluid translation

Setting `c` on a pure fluid was supported for the most part, but these paths ignored it:

| Path | Symptom with a nonzero `c` |
|---|---|
| Chebyshev superancillary | `update(DmolarT)` bracketed the dome with untranslated densities, so a genuinely two-phase state was returned as single-phase liquid at **negative pressure** |
| `calc_rhomolar_max_bound` | returned `0.9/b_m` instead of `0.9/(b_m - c_m)`, so the bound could sit past the repulsive pole (both signs of `c` reach this) |
| `spinodal_densities` | untranslated |
| `calc_rhomolar_critical` | untranslated |
| `get_linear_reducing_parameters` | untranslated |
| `get_copy()` / `copy_internals` | `c` was dropped, so `SatL`/`SatV`, `TPD_state`, `critical_state` and `transient_pure_state` silently ran an untranslated EoS |

Plus one missing precondition: `b - c > 0` was never checked. The
covolume also moves when `Tcrit`/`pcrit` change, so the check now lives on the data in
`AbstractCubic` and covers every mutator, rolling back a Tc/pc change that would invalidate a
translation already in place.

#### Part 2 — Mixture support

Previously `cm` was a single scalar and `set_fluid_parameter_double` bound-checked the component
index and then ignored it. Now:

- **Per-component c** with the linear mixing rule $c_\mathrm{m}(x) = \sum x_i c_i$, which is the 
  only mixing rule that preserves phase equilibria according to Privat et al. (2016), plus the
  $\partial c_\mathrm{m}/\partial x_i$ derivative family.
- `set_fluid_parameter_double(i, "c"|"cm"|"c_m", value)` **honours the index**. `c_all` preserves the
  old fluid-wide behaviour.
- **One prerequisite bug fix**: `d_A_term_dxi` and its 2nd/3rd-order siblings dropped a factor
  `(1 + c_m·ρ)`. This was wrong before this PR and reachable by setting the old scalar `cm` on a
  mixture.
- `VTPRCubic::ln_fugacity_coefficient` uses the real per-component $c_i$ in place of a `TODO`.

### Benefits

- Six pure-fluid paths that returned wrong answers with a nonzero `c` now return right ones.
- Mixtures can use volume translation at all.
- Out-of-range translations are rejected at set time, instead of silently producing finite but
  meaningless `p`, `h` and `c_p`.
- First test coverage of `cm` anywhere in the suite.

### Possible Drawbacks

- **Semantic change.** The component index is now honoured, so a mixture caller doing
  `set_fluid_parameter_double(0, "cm", value)` previously translated every component and now 
  translates only the first.  `c_all` restores the old meaning.
- **New throw sites.** $b - c \leq 0$ is rejected, `Tcrit`/`pcrit` changes can now be rejected, and
  `calc_rhomolar_max_bound` / `get_linear_reducing_parameters` throw where they previously
  returned. Intended, but a behaviour change.
- **VTPR is under-guarded.** Its combining rule $b_{ij} = ((b_i^{3/4} + b_j^{3/4})/2)^{4/3}$ is sub-linear,
  so $b_\mathrm{m} \leq \sum x_i b_i$ while `c_m` stays linear; the per-component check is necessary but not
  sufficient there. Documented, not enforced.
- **Coverage gaps that cannot be closed here.** VTPR has no test anywhere in the repo (it needs
  `VTPR_UNIFAC_PATH` and UNIFAC data), so its $\ln \phi_i$ term and its distinct `get_copy()` are
  unpinned.

### Verification

**Invariance table.** A constant translation is a change of variable,
so at fixed $(T, p, x)$ every property either stays exactly the same or moves by an amount known
in closed form (see Jaubert et al. 2016, Privat et al. 2016 and the new Volume Translation section 
in `Web\coolprop\Cubics.rst`). Both directions are asserted and run for `PR` and `SRK`, both signs 
of `c`, across compressed liquid, superheated vapour and supercritical states, and across the 
saturation dome.

**The other test cases** guard what the table cannot reach. Six pin paths that are invisible to
an ordinary property call — superancillary un-translation, `DmolarT` phase classification across the
dome, `get_copy` propagation to `SatL`/`SatV`, the critical and reducing volumes, the density bound
against the pole, and the spinodal — while three pin the `b - c > 0` precondition at each of its
mutators, two cover the set/get API including the `c_all` broadcast, and one finite-differences the
whole composition-derivative chain against its analytic form for both `x_N` conventions.

**Tag consolidation.** `[cubic]` was an orphan: `[cubic_alpha]`, `[cubic_superanc]`,
`[cubic_DmolarT]` and `[cubic_Tcpc]` carried no umbrella tag, so no single filter selected the
cubic tests. Those five cases now carry `[cubic]`, which is what makes the preflight gate meaningful.

**Numbers.**
- `[volume_translation]` — 3194 assertions across 17 cases.
- `[cubic],[volume_translation],[mixture_derivs2],[michelsen],[change_EOS],[GERG],[json_validation]`
  — 149 cases, 32 549/32 551 assertions. The one failure is
  `HSU_P flash: near saturation 5-component N2-HC`, a pre-existing `HEOS`-only flash failure that
  touches no cubic backend and reproduces on the merge base.

**Default behaviour unchanged.** Every existing test passes with `c` defaulting to zero.

### Applicable issues
Closes #2111 (was closed as "not planned" in cleanup)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Peneloux volume translation support for cubic equations of state, including pure fluids and mixtures.
  * Added per-component translation parameters, mixture broadcasting, aliases, and validation for incompatible volume and critical-property combinations.
  * Updated density, saturation, fugacity, spinodal, and critical-volume calculations to account for translation.

* **Documentation**
  * Added comprehensive volume-translation guidance, API usage, limitations, and references.

* **Bug Fixes**
  * Ensured copied cubic and VTPR states preserve volume-translation settings.

* **Tests**
  * Added extensive regression coverage for translation behavior and derivatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->