### PR TITLE
fix(python): silence nanobind leak warnings at shutdown

### DIFF
--- a/src/nanobind_interface.cxx
+++ b/src/nanobind_interface.cxx
@@ -1225,6 +1225,11 @@ void init_CoolProp(nb::module_& m) {
 
 #    if defined(COOLPROP_NANOBIND_MODULE)
 NB_MODULE(CoolProp, m) {
+    // Leak "warnings" at interpreter shutdown are benign here (the objects are
+    // reclaimed by the OS at process exit) but confuse end users. nanobind's
+    // documentation recommends disabling them for wheels shipped to end users.
+    // See: https://nanobind.readthedocs.io/en/latest/refleaks.html
+    nb::set_leak_warnings(false);
     init_CoolProp(m);
     // Export the State C-ABI table so the frozen Cython `State` shim can forward
     // through it (PDSim cimport compatibility without a Cython AbstractState).


### PR DESCRIPTION
## Summary

Closes #3354.

Since the migration to nanobind in 8.0.0, every Python import prints benign leak warnings at interpreter shutdown:

```
nanobind: leaked 1 instances!
nanobind: leaked 3 types!
 - leaked type "CoolProp.CoolProp.AbstractState"
nanobind: leaked 173 functions!
```

The objects are reclaimed by the OS at process exit, so these are harmless — but they pollute stderr and are regularly reported as bugs by end users.

## Change

A single line in `NB_MODULE` (`src/nanobind_interface.cxx`):

```cpp
nb::set_leak_warnings(false);
```

This follows the [nanobind documentation](https://nanobind.readthedocs.io/en/latest/refleaks.html), which recommends disabling these warnings for wheels shipped to end users:

> "Some projects choose to activate leak warnings for internal builds but disable them for wheels uploaded to PyPI, as they can be confusing to end users."

## Notes

- No functional change; only suppresses the shutdown warning output.
- `nb::set_leak_warnings(bool)` is declared in `nanobind/nb_misc.h` and available in the nanobind version already used by the build.
- As discussed in #3354, @ibell indicated a PR would be welcome and the approach looks good.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed nanobind leak warnings during module initialization to reduce unnecessary warning messages when loading the module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->