### PR TITLE
fix(flash): converge the near-dew mixture PT two-phase split; fix XN_INDEPENDENT fugacity derivative (#3356)

### DIFF
--- a/src/Backends/Helmholtz/MixtureDerivatives.cpp
+++ b/src/Backends/Helmholtz/MixtureDerivatives.cpp
@@ -57,10 +57,24 @@ CoolPropDbl MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(HelmholtzEOSMixtur
     CoolPropDbl val = dln_fugacity_coefficient_dxj__constT_p_xi(HEOS, i, j, xN_flag);
     const std::vector<CoolPropDbl>& x = HEOS.get_mole_fractions();
     std::size_t N = x.size();
-    if (i == N - 1) {
-        val += -1 / x[N - 1];
-    } else if (i == j) {
-        val += 1 / x[j];
+    // Ideal-gas contribution d(ln x_i)/dx_j, which depends on the composition convention:
+    //  * XN_DEPENDENT: x_{N-1} = 1 - sum_{k<N-1} x_k is the dependent mole fraction, so
+    //    d(ln x_{N-1})/dx_j = -1/x_{N-1} for every j, and d(ln x_i)/dx_j = delta_ij/x_i for i < N-1.
+    //  * XN_INDEPENDENT: all x_i are treated as independent, so d(ln x_i)/dx_j = delta_ij/x_i for
+    //    EVERY i, including the last component.  (Previously this branch was missing: the function
+    //    applied the XN_DEPENDENT term -1/x_{N-1} to the last row regardless of the flag, which
+    //    corrupted the last-component row for XN_INDEPENDENT callers -- e.g. the mole-number Gibbs
+    //    Hessian assembled in the mixture PT-flash second-order solver, GH #3342.)
+    if (xN_flag == XN_DEPENDENT) {
+        if (i == N - 1) {
+            val += -1 / x[N - 1];
+        } else if (i == j) {
+            val += 1 / x[j];
+        }
+    } else {  // XN_INDEPENDENT
+        if (i == j) {
+            val += 1 / x[j];
+        }
     }
     return val;
 }

--- a/src/Backends/Helmholtz/MixtureDerivatives.cpp
+++ b/src/Backends/Helmholtz/MixtureDerivatives.cpp
@@ -62,9 +62,15 @@ CoolPropDbl MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(HelmholtzEOSMixtur
     //    d(ln x_{N-1})/dx_j = -1/x_{N-1} for every j, and d(ln x_i)/dx_j = delta_ij/x_i for i < N-1.
     //  * XN_INDEPENDENT: all x_i are treated as independent, so d(ln x_i)/dx_j = delta_ij/x_i for
     //    EVERY i, including the last component.  (Previously this branch was missing: the function
-    //    applied the XN_DEPENDENT term -1/x_{N-1} to the last row regardless of the flag, which
-    //    corrupted the last-component row for XN_INDEPENDENT callers -- e.g. the mole-number Gibbs
-    //    Hessian assembled in the mixture PT-flash second-order solver, GH #3342.)
+    //    applied the XN_DEPENDENT term -1/x_{N-1} to the last row regardless of the flag, so the
+    //    last-component row was wrong for XN_INDEPENDENT callers.  GH #3342: this fed a corrupted
+    //    last row into the new mole-number Gibbs Hessian of the PT-flash minority-phase fallback,
+    //    flipping its smallest eigenvalue negative -- see PTflash_twophase::solve_michelsen.)
+    //    NOTE: the phase-2 second-order Newton and the V-space Newton also consume this derivative
+    //    but feed it into a Hessian built for the fugacity-COEFFICIENT derivative, so they already
+    //    double-count the ideal term; this fix changes (does not fully correct) that pre-existing
+    //    misuse.  It is harmless there -- those solvers use the Hessian only as a positive-definite-
+    //    shifted descent preconditioner with Gibbs-decrease acceptance + a residual gate.
     if (xN_flag == XN_DEPENDENT) {
         if (i == N - 1) {
             val += -1 / x[N - 1];

--- a/src/Backends/Helmholtz/MixtureDerivatives.cpp
+++ b/src/Backends/Helmholtz/MixtureDerivatives.cpp
@@ -66,13 +66,13 @@ CoolPropDbl MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(HelmholtzEOSMixtur
     //    last-component row was wrong for XN_INDEPENDENT callers.  GH #3342: this fed a corrupted
     //    last row into the new mole-number Gibbs Hessian of the PT-flash minority-phase fallback,
     //    flipping its smallest eigenvalue negative -- see PTflash_twophase::solve_michelsen.)
-    //    NOTE: the PT-flash Phase-2 second-order Newton used to consume THIS (full fugacity)
-    //    derivative in a Hessian built for the fugacity-COEFFICIENT derivative, double-counting the
-    //    ideal term; it now correctly calls dln_fugacity_coefficient_dxj__constT_p_xi instead (see
-    //    PTflash_twophase::solve_michelsen).  The V-space Newton (~line 2361) still consumes the
-    //    full derivative and thus still double-counts -- pre-existing, harmless there (the Hessian is
-    //    only a positive-definite-shifted descent preconditioner with Gibbs-decrease acceptance + a
-    //    residual gate), left for a separate change.
+    //    NOTE: consumers that assemble a Hessian in the fugacity-COEFFICIENT derivative must call
+    //    dln_fugacity_coefficient_dxj__constT_p_xi and add their own mole-number projection instead
+    //    of this (full fugacity) derivative -- feeding this one double-counts the ideal term and
+    //    drops the projection, breaking the Hessian's symmetry.  The PT-flash Phase-2 Gibbs Hessian
+    //    and the Michelsen stability classifier (minimize_tpd) both do so correctly; see
+    //    VLERoutines.cpp.  Fixing the XN_INDEPENDENT branch below without also fixing the stability
+    //    classifier flipped its MSVC verdict for methanol/benzene (GH #3357, jakobreichert).
     if (xN_flag == XN_DEPENDENT) {
         if (i == N - 1) {
             val += -1 / x[N - 1];
@@ -1173,7 +1173,8 @@ class DerivativeFixture
       HEOS_minus_2tau, HEOS_plus_2delta, HEOS_minus_2delta, HEOS_plus_T__constp, HEOS_minus_T__constp, HEOS_plus_p__constT, HEOS_minus_p__constT,
       HEOS_plus_T__constrho, HEOS_minus_T__constrho, HEOS_plus_rho__constT, HEOS_minus_rho__constT;
     std::vector<shared_ptr<CoolProp::HelmholtzEOSMixtureBackend>> HEOS_plus_z, HEOS_minus_z, HEOS_plus_z__constTrho, HEOS_minus_z__constTrho,
-      HEOS_plus_n, HEOS_minus_n, HEOS_plus_2z, HEOS_minus_2z, HEOS_plus_2z__constTrho, HEOS_minus_2z__constTrho;
+      HEOS_plus_n, HEOS_minus_n, HEOS_plus_2z, HEOS_minus_2z, HEOS_plus_2z__constTrho, HEOS_minus_2z__constTrho, HEOS_plus_z__constTP,
+      HEOS_minus_z__constTP;
     CoolProp::x_N_dependency_flag xN;
     double dtau, ddelta, dz, dn, tol, dT, drho, dp;
     DerivativeFixture() : xN(XN_INDEPENDENT), dtau(1e-6), ddelta(1e-6), dz(1e-6), dn(1e-6), dT(1e-3), drho(1e-3), dp(1), tol(5e-6) {
@@ -1277,6 +1278,32 @@ class DerivativeFixture
                                      HEOS_minus_2z[i]->T_reducing() / HEOS->tau());
             HEOS_minus_z__constTrho[i]->set_mole_fractions(zz);
             HEOS_minus_z__constTrho[i]->update(CoolProp::DmolarT_INPUTS, HEOS->rhomolar(), HEOS->T());
+        }
+
+        // Varying mole fractions at constant T, p -- for d(ln f_i)/dx_j |__constT_p_xi, the
+        // convention the flash/stability Hessians consume (GH #3357).  The const-T,rho states
+        // above validate the __constT_rho_xi sibling only; this one covers __constT_p_xi, which
+        // had no derivative coverage (which is how its XN_INDEPENDENT ideal-term bug went
+        // unnoticed).  Perturb x_j exactly as above -- compensating the last component only under
+        // XN_DEPENDENT, leaving the sum un-normalized under XN_INDEPENDENT (the analytic
+        // continuation the XN_INDEPENDENT derivative differentiates; the backend does not
+        // renormalize) -- then re-solve at the base T and p.
+        HEOS_plus_z__constTP.resize(4);
+        HEOS_minus_z__constTP.resize(4);
+        for (int i = 0; i < HEOS_plus_z__constTP.size(); ++i) {
+            init_state(HEOS_plus_z__constTP[i]);
+            init_state(HEOS_minus_z__constTP[i]);
+            std::vector<double> zp = HEOS->get_mole_fractions(), zm = HEOS->get_mole_fractions();
+            zp[i] += dz;
+            zm[i] -= dz;
+            if (xN == CoolProp::XN_DEPENDENT) {
+                zp[zp.size() - 1] -= dz;
+                zm[zm.size() - 1] += dz;
+            }
+            HEOS_plus_z__constTP[i]->set_mole_fractions(zp);
+            HEOS_plus_z__constTP[i]->update(CoolProp::PT_INPUTS, HEOS->p(), HEOS->T());
+            HEOS_minus_z__constTP[i]->set_mole_fractions(zm);
+            HEOS_minus_z__constTP[i]->update(CoolProp::PT_INPUTS, HEOS->p(), HEOS->T());
         }
 
         // Varying mole numbers
@@ -1416,6 +1443,28 @@ class DerivativeFixture
                     // Forward difference in composition
                     CHECK_NOTHROW(numeric = (-3 * g(*HEOS, i, xN) + 4 * g(*HEOS_plus_z[j], i, xN) - g(*HEOS_plus_2z[j], i, xN)) / (2 * dz));
                 }
+                CAPTURE(name);
+                CAPTURE(i);
+                CAPTURE(j);
+                CAPTURE(analytic);
+                CAPTURE(numeric);
+                CAPTURE(xN);
+                double error = mix_deriv_err_func(numeric, analytic);
+                CAPTURE(error);
+                CHECK(error < tol);
+            }
+        }
+    }
+    // Finite-difference check of a composition derivative taken at constant T and p (as
+    // opposed to two_comp's constant reduced delta/tau).  Central difference of g in x_j
+    // across the HEOS_(plus|minus)_z__constTP states.  All base mole fractions are >> 2*dz,
+    // so a central difference is always valid (no forward-difference fallback needed).
+    void two_comp_constTP(const std::string& name, two_mole_fraction_pointer f, one_mole_fraction_pointer g) {
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                double analytic = f(*HEOS, i, j, xN);
+                double numeric = 500;
+                CHECK_NOTHROW(numeric = (g(*HEOS_plus_z__constTP[j], i, xN) - g(*HEOS_minus_z__constTP[j], i, xN)) / (2 * dz));
                 CAPTURE(name);
                 CAPTURE(i);
                 CAPTURE(j);
@@ -1627,6 +1676,9 @@ class DerivativeFixture
               MD::d_nd_ndalphardni_dnj_dxk__consttau_delta, DELTA);
 
         // Xn-dep only        two_comp("dln_fugacity_dxj__constT_rho_xi", MD::dln_fugacity_dxj__constT_rho_xi, MD::ln_fugacity);
+        // d(ln f_i)/dx_j at constant T, p -- both x_N conventions (the fixture runs XN_INDEPENDENT
+        // by default, the branch whose ideal term was wrong in GH #3357/#3342).
+        two_comp_constTP("dln_fugacity_dxj__constT_p_xi", MD::dln_fugacity_dxj__constT_p_xi, MD::ln_fugacity);
         three("d2_ndln_fugacity_i_dnj_dxk_dDelta__consttau", MD::d2_ndln_fugacity_i_dnj_dxk_dDelta__consttau,
               MD::d_ndln_fugacity_i_dnj_ddxk__consttau_delta, DELTA);
         three("d2_ndln_fugacity_i_dnj_dxk_dTau__constdelta", MD::d2_ndln_fugacity_i_dnj_dxk_dTau__constdelta,

--- a/src/Backends/Helmholtz/MixtureDerivatives.cpp
+++ b/src/Backends/Helmholtz/MixtureDerivatives.cpp
@@ -66,11 +66,13 @@ CoolPropDbl MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(HelmholtzEOSMixtur
     //    last-component row was wrong for XN_INDEPENDENT callers.  GH #3342: this fed a corrupted
     //    last row into the new mole-number Gibbs Hessian of the PT-flash minority-phase fallback,
     //    flipping its smallest eigenvalue negative -- see PTflash_twophase::solve_michelsen.)
-    //    NOTE: the phase-2 second-order Newton and the V-space Newton also consume this derivative
-    //    but feed it into a Hessian built for the fugacity-COEFFICIENT derivative, so they already
-    //    double-count the ideal term; this fix changes (does not fully correct) that pre-existing
-    //    misuse.  It is harmless there -- those solvers use the Hessian only as a positive-definite-
-    //    shifted descent preconditioner with Gibbs-decrease acceptance + a residual gate.
+    //    NOTE: the PT-flash Phase-2 second-order Newton used to consume THIS (full fugacity)
+    //    derivative in a Hessian built for the fugacity-COEFFICIENT derivative, double-counting the
+    //    ideal term; it now correctly calls dln_fugacity_coefficient_dxj__constT_p_xi instead (see
+    //    PTflash_twophase::solve_michelsen).  The V-space Newton (~line 2361) still consumes the
+    //    full derivative and thus still double-counts -- pre-existing, harmless there (the Hessian is
+    //    only a positive-definite-shifted descent preconditioner with Gibbs-decrease acceptance + a
+    //    residual gate), left for a separate change.
     if (xN_flag == XN_DEPENDENT) {
         if (i == N - 1) {
             val += -1 / x[N - 1];

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -3097,11 +3097,19 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
     // safe: ACCEPTS only a converged result; on any failure restores the exact pre-fallback state,
     // so it can never regress a currently-passing case.
     if (!converged) {
+        const bool cp_dbg_fb = std::getenv("CP_DBG_MICH_FB") != nullptr;
+        const bool fb_warm_rho = std::getenv("CP_MICH_WARMRHO") != nullptr;    // A/B: allow warm-start density (drifts to metastable root)
         const std::vector<CoolPropDbl> x_pre = IO.x, y_pre = IO.y;
         const CoolPropDbl beta_pre = beta, rhoL_pre = IO.rhomolar_liq, rhoV_pre = IO.rhomolar_vap;
 
         const bool minority_is_liquid = (beta_pre >= 0.5);  // near dew -> incipient liquid
-        // Incipient composition from the stability trial phase (non-trivial by construction).
+        // Incipient composition seed.  Prefer the stability trial phase; but near the dew/bubble
+        // the trial handed to this solver can be (near-)trivial (x0_stab ~ z), which makes the
+        // incipient phase collapse to the feed (x == y) -- the fallback then "converges" to the
+        // trivial split at iteration 0 and no genuine tiny split is ever found.  Detect that and
+        // reseed from Wilson K-factors: the incipient liquid near the dew is z_i / K_i (heavy-rich)
+        // and the incipient vapour near the bubble is z_i * K_i (light-rich), both genuinely
+        // non-trivial, giving the Newton a real starting split to refine.
         std::vector<CoolPropDbl> w = minority_is_liquid ? x0_stab : y0_stab;
         {
             CoolPropDbl sw = 0;
@@ -3110,6 +3118,20 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
                 for (std::size_t i = 0; i < N; ++i) w[i] = std::max(w[i], static_cast<CoolPropDbl>(0)) / sw;
             } else {
                 w = IO.z;
+            }
+            CoolPropDbl wz_spread = 0;
+            for (std::size_t i = 0; i < N; ++i) wz_spread = std::max(wz_spread, std::abs(w[i] - IO.z[i]));
+            if (wz_spread < 1e-3) {  // trial ~ feed -> reseed from Wilson K-factors
+                CoolPropDbl sw2 = 0;
+                for (std::size_t i = 0; i < N; ++i) {
+                    CoolPropDbl Ki = std::exp(Wilson_lnK_factor(HEOS, IO.T, IO.p, i));
+                    w[i] = minority_is_liquid ? IO.z[i] / Ki : IO.z[i] * Ki;
+                    sw2 += w[i];
+                }
+                if (sw2 > 0)
+                    for (std::size_t i = 0; i < N; ++i) w[i] /= sw2;
+                else
+                    w = minority_is_liquid ? x0_stab : y0_stab;  // Wilson unusable; keep the trial
             }
         }
         std::vector<CoolPropDbl> a(N);
@@ -3131,6 +3153,13 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             for (std::size_t i = 0; i < N; ++i) { mn[i] = aa[i] / A; mj[i] = (IO.z[i] - aa[i]) / B; }
             if (minority_is_liquid) { IO.x = mn; IO.y = mj; beta = B; }
             else { IO.y = mn; IO.x = mj; beta = A; }
+            // Force the cold global (lowest-Gibbs) density solve every FB evaluation.  The warm-
+            // start local Newton drifts to a nearby metastable root (within the 0.5x-2x branch
+            // guard) after the first call, so the incipient/majority densities land on the wrong
+            // sheet -- the objective, gradient and acceptance test then live on a higher-Gibbs
+            // surface and the line search stalls.  Global keeps every evaluation on the same
+            // stable roots the seed was built on.
+            if (!fb_warm_rho) { rho_warm_L = -1; rho_warm_V = -1; }
             if (!evaluate_phases()) return false;
             HEOS.SatL->set_mole_fractions(IO.x);
             HEOS.SatL->update_DmolarT_direct(IO.rhomolar_liq, IO.T);
@@ -3156,31 +3185,55 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         if (cp_dbg_mich) {
             CoolPropDbl As = 0;
             for (std::size_t i = 0; i < N; ++i) As += a[i];
-            std::printf("[MICH-FB] entry ok=%d minLiq=%d A=%.3g mg=%.4g\n", (int)ok, (int)minority_is_liquid, (double)As, mg);
+            std::printf("[MICH-FB] entry T=%.5g ok=%d minLiq=%d A=%.3g mg=%.4g beta_pre=%.6g\n", (double)IO.T, (int)ok, (int)minority_is_liquid, (double)As, mg, (double)beta_pre);
+            if (cp_dbg_fb) {
+                std::printf("[MICH-FB]   z    ="); for (std::size_t i = 0; i < N; ++i) std::printf(" %.4e", (double)IO.z[i]); std::printf("\n");
+                std::printf("[MICH-FB]   a0   ="); for (std::size_t i = 0; i < N; ++i) std::printf(" %.4e", (double)a[i]); std::printf("\n");
+            }
         }
-        // Hebden restricted-step (trust-region) Newton in alpha_i = 2*sqrt(a_i), mirroring
-        // StabilityEvaluationClass::minimize_tpd.  alpha keeps a_i >= 0 for free and conditions the
-        // tiny minority amounts; the trust region + positivity clamp globalise the step so a
-        // trace-component bound cannot pin it (the failure of the raw t_max line search).
-        double trust_radius = 0.25, diagonal_shift = 0.0;
-        std::vector<CoolPropDbl> alpha(N), alpha_old(N);
-        for (std::size_t i = 0; i < N; ++i) alpha[i] = 2.0 * std::sqrt(std::max(a[i], static_cast<CoolPropDbl>(1e-300)));
-        const int fb_max_iter = 60;
+        // Globalised Newton on the minority mole numbers a, mirroring ThermoPack
+        // tp_solver::mod_newton_search + optimizers::mod_newton: a positive-definite
+        // (guaranteed-descent) Newton direction with a steepest-descent safeguard, a single-
+        // scalar fraction-to-the-boundary limit that preserves the Newton direction, and an
+        // Armijo backtracking line search on the total Gibbs.  Works directly in mole numbers
+        // (no 2*sqrt(a) transform) using the mole-number Gibbs Hessian's own z/(x*y)
+        // conditioning; eval_min uses the cold global (lowest-Gibbs) density roots so every
+        // evaluation stays on the same stable density sheet as the seed.
+        const int fb_max_iter = 100;
+        const double armijo_c1 = 1e-4;
+        const int max_ls = 40;      // Armijo backtracking tries per outer iteration
+        const double fb_genuine_tol = 1e-5;  // engineering equal-fugacity tolerance (matches the final gate)
+        const int stall_genuine = 3;   // exit once genuine and floored
+        double G_cur = G_old;  // consistent with the seed eval_min (cold global roots)
+        double mg_prev = mg;
+        int stall = 0;
         for (int it = 0; ok && it < fb_max_iter; ++it) {
             if (mg < gibbs_tol) { fb_conv = true; fb_stop = "converged"; break; }
+            // Stall exit: once the split is GENUINE (mg <= 1e-5) the equal-fugacity residual has
+            // floored at ~1e-7 on density-solve accuracy, well before the 1e-9 quadratic target, so
+            // exit after a few flat steps rather than grinding to the maxiter cap.  A non-genuine
+            // probe (e.g. a single-phase T with no split) keeps iterating to the cap and is then
+            // rejected by the final gate.
+            if (mg < fb_genuine_tol && mg > mg_prev * (1.0 - 1e-3)) {
+                if (++stall >= stall_genuine) { fb_stop = "stall"; break; }
+            } else {
+                stall = 0;
+            }
+            mg_prev = mg;
             CoolPropDbl A = 0;
             for (std::size_t i = 0; i < N; ++i) A += a[i];
             CoolPropDbl B = 1.0 - A;  // z normalized to 1
             if (!(A > 1e-14) || !(B > 1e-14)) { fb_stop = "amt-boundary"; break; }
 
-            // SatL/SatV are synced to the current a (from the last accepted eval_min).  Build the
-            // mole-number Gibbs gradient/Hessian, then transform to alpha space.
+            // SatL/SatV are synced to the current a (from the seed or the last accepted line-
+            // search step).  Build the mole-number Gibbs gradient dG/da_i = ln f_i^min - ln
+            // f_i^maj and the Hessian (1/A)[D_min - x.D_min] + (1/B)[D_maj - x.D_maj].
             HelmholtzEOSMixtureBackend* Smin = minority_is_liquid ? HEOS.SatL.get() : HEOS.SatV.get();
             HelmholtzEOSMixtureBackend* Smaj = minority_is_liquid ? HEOS.SatV.get() : HEOS.SatL.get();
-            std::vector<CoolPropDbl> mnc(N), mjc(N), halfa(N), gmole(N);
-            for (std::size_t i = 0; i < N; ++i) { mnc[i] = a[i] / A; mjc[i] = (IO.z[i] - a[i]) / B; halfa[i] = 0.5 * alpha[i]; }
-            Eigen::MatrixXd Dmin(N, N), Dmaj(N, N), HA(N, N);
-            Eigen::VectorXd gA(N);
+            std::vector<CoolPropDbl> mnc(N), mjc(N);
+            for (std::size_t i = 0; i < N; ++i) { mnc[i] = a[i] / A; mjc[i] = (IO.z[i] - a[i]) / B; }
+            Eigen::MatrixXd Dmin(N, N), Dmaj(N, N), Hm(N, N);
+            Eigen::VectorXd grad(N);
             for (std::size_t i = 0; i < N; ++i) {
                 for (std::size_t j = 0; j < N; ++j) {
                     Dmin(i, j) = CoolProp::MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(*Smin, i, j, CoolProp::XN_INDEPENDENT);
@@ -3190,77 +3243,104 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             for (std::size_t i = 0; i < N; ++i) {
                 CoolPropDbl lnf_min = std::log(mnc[i]) + std::log(Smin->fugacity_coefficient(i));
                 CoolPropDbl lnf_maj = std::log(mjc[i]) + std::log(Smaj->fugacity_coefficient(i));
-                gmole[i] = lnf_min - lnf_maj;  // dG/da_i
-                gA(i) = halfa[i] * gmole[i];    // dG/dalpha_i
+                grad(i) = lnf_min - lnf_maj;  // dG/da_i
             }
             std::vector<CoolPropDbl> sMinV(N, 0), sMajV(N, 0);
             for (std::size_t i = 0; i < N; ++i)
                 for (std::size_t k = 0; k < N; ++k) { sMinV[i] += mnc[k] * Dmin(i, k); sMajV[i] += mjc[k] * Dmaj(i, k); }
-            for (std::size_t i = 0; i < N; ++i) {
-                for (std::size_t j = 0; j < N; ++j) {
-                    CoolPropDbl Hm = (Dmin(i, j) - sMinV[i]) / A + (Dmaj(i, j) - sMajV[i]) / B;
-                    HA(i, j) = halfa[i] * halfa[j] * Hm;
-                }
-                HA(i, i) += 0.5 * gmole[i];  // d^2 a_i / d alpha_i^2 = 1/2 term
+            for (std::size_t i = 0; i < N; ++i)
+                for (std::size_t j = 0; j < N; ++j)
+                    Hm(i, j) = (Dmin(i, j) - sMinV[i]) / A + (Dmaj(i, j) - sMajV[i]) / B;
+            // Symmetrize away finite-difference asymmetry before the SPD solve.
+            Hm = (0.5 * (Hm + Hm.transpose())).eval();
+
+            if (cp_dbg_fb) {
+                std::printf("[MICH-FB]  it=%d A=%.4e mg=%.4e G=%.8g\n", it, (double)A, mg, G_cur);
+                std::printf("[MICH-FB]    a   ="); for (std::size_t i = 0; i < N; ++i) std::printf(" %.4e", (double)a[i]); std::printf("\n");
+                std::printf("[MICH-FB]    gmol="); for (std::size_t i = 0; i < N; ++i) std::printf(" %+.3e", grad(i)); std::printf("\n");
             }
 
-            for (std::size_t i = 0; i < N; ++i) alpha_old[i] = alpha[i];
+            // Eigenvalue-modified Newton direction.  The mole-number Gibbs Hessian is (a) genuinely
+            // INDEFINITE far from the solution -- the dominant component's diagonal can be negative,
+            // so LM diag scaling can never make it PD -- and (b) severely ill-conditioned near the
+            // dew (a stiff ~1e5 trace-component direction alongside a soft phase-amount mode).
+            // Diagonalise Hm (symmetric) and floor its eigenvalues at a fraction of the largest:
+            // this both guarantees a descent direction (ThermoPack's modified-Cholesky role) and
+            // caps the condition number, so the step along the soft mode stays bounded and the
+            // single fraction-to-the-boundary scalar no longer has to throttle the stiff directions.
+            Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(Hm);
+            if (es.info() != Eigen::Success) { fb_stop = "eig-fail"; break; }
+            const Eigen::VectorXd evals = es.eigenvalues();
+            const Eigen::MatrixXd& Q = es.eigenvectors();
+            // Gill-Murray-style modification: replace each eigenvalue lambda_k by max(|lambda_k|,
+            // floor).  Taking the ABSOLUTE value of a negative eigenvalue (rather than flooring it
+            // to ~0) turns negative curvature into a curvature-scaled DESCENT step of moderate
+            // length -- flooring to ~0 instead gives a huge step along that mode that the boundary
+            // limit then throttles to nothing.  The relative floor only caps the condition number.
+            const double efloor = 1e-10 * std::max(evals.cwiseAbs().maxCoeff(), 1e-300);
+            Eigen::VectorXd gq = Q.transpose() * grad;
+            for (std::size_t i = 0; i < N; ++i) gq(i) /= std::max(std::abs(evals(i)), efloor);
+            Eigen::VectorXd d = -(Q * gq);  // = -(modified Hm)^{-1} grad, guaranteed descent
+            if (cp_dbg_fb) {
+                std::printf("[MICH-FB]    Hdiag="); for (std::size_t i = 0; i < N; ++i) std::printf(" %+.3e", Hm(i, i)); std::printf("\n");
+                std::printf("[MICH-FB]    eval ="); for (std::size_t i = 0; i < N; ++i) std::printf(" %+.3e", evals(i)); std::printf("\n");
+            }
+
+            // Fraction-to-the-boundary (ThermoPack limitDV): one scalar keeps every
+            // 0 < a_i + t*d_i < z_i, preserving the Newton direction (a per-component clamp would
+            // not -- that is what pinned trace components in the previous formulation).
+            double t = 1.0;
+            for (std::size_t i = 0; i < N; ++i) {
+                double di = d(i);
+                if (a[i] + di <= 0.0) t = std::min(t, -static_cast<double>(a[i]) / di);
+                else if (a[i] + di >= IO.z[i]) t = std::min(t, (static_cast<double>(IO.z[i]) - static_cast<double>(a[i])) / di);
+            }
+            if (t < 1.0) d *= (t * (1.0 - 1e-10));
+
+            const double gTd = grad.dot(d);  // directional derivative (< 0 for a descent step)
+
+            // Armijo backtracking line search on the total Gibbs.
+            double alpha = 1.0;
             bool step_accepted = false;
-            const int max_inner = 25;
-            for (int inner = 0; inner < max_inner; ++inner) {
-                Eigen::MatrixXd Hl = HA;
-                Hl.diagonal().array() += diagonal_shift;
-                Eigen::VectorXd delta = Hl.colPivHouseholderQr().solve(-gA);  // minimisation step
-                double snorm2 = 0;
-                std::vector<CoolPropDbl> at(N);
-                for (std::size_t i = 0; i < N; ++i) {
-                    double da = delta(i);
-                    if (alpha_old[i] + da <= 0) da = -0.9 * alpha_old[i];  // keep a_i >= 0
-                    delta(i) = da;
-                    alpha[i] = alpha_old[i] + da;
-                    at[i] = 0.25 * alpha[i] * alpha[i];
-                    snorm2 += da * da;
-                }
-                double ssize = std::sqrt(snorm2);
-                if (ssize > trust_radius && diagonal_shift == 0) {
-                    diagonal_shift = ssize / trust_radius - 1.0;
-                    for (std::size_t i = 0; i < N; ++i) alpha[i] = alpha_old[i];
-                    continue;
-                }
+            std::vector<CoolPropDbl> at(N);
+            for (int ls = 0; ls < max_ls; ++ls) {
+                for (std::size_t i = 0; i < N; ++i) at[i] = a[i] + alpha * d(i);
                 double G_new = 0, mg_new = 0;
-                if (!eval_min(at, G_new, mg_new)) {
-                    trust_radius = ssize / 3.0;
-                    diagonal_shift = 0;
-                    for (std::size_t i = 0; i < N; ++i) alpha[i] = alpha_old[i];
-                    continue;
+                if (eval_min(at, G_new, mg_new) && G_new <= G_cur + armijo_c1 * alpha * gTd) {
+                    a = at;
+                    G_cur = G_new;
+                    mg = mg_new;
+                    step_accepted = true;
+                    if (cp_dbg_fb) std::printf("[MICH-FB]    -> accept ls=%d alpha=%.3e t=%.3e Gnew=%.8g mgnew=%.4e\n", ls, alpha, t, G_new, mg_new);
+                    break;
                 }
-                if (G_new > G_old + 1e-12) {
-                    trust_radius = ssize / 3.0;
-                    diagonal_shift = 0;
-                    for (std::size_t i = 0; i < N; ++i) alpha[i] = alpha_old[i];
-                    continue;
-                }
-                Eigen::VectorXd Hd = HA * delta;
-                double predicted = -(gA.dot(delta) + 0.5 * delta.dot(Hd));
-                double actual = G_old - G_new;
-                double ratio = (predicted != 0) ? actual / predicted : 1.0;
-                if (ratio < 0.25) trust_radius = ssize / 2.0;
-                else if (ratio > 0.75 && diagonal_shift > 0) trust_radius = ssize * 2.0;
-                else trust_radius = ssize;
-                diagonal_shift = 0;
-                a = at;
-                G_old = G_new;
-                mg = mg_new;
-                step_accepted = true;
-                break;
+                alpha *= 0.5;
             }
             if (!step_accepted) { fb_stop = "no-step"; break; }
             fb_iters = it + 1;
         }
-        if (cp_dbg_mich) std::printf("[MICH-FB] exit conv=%d stop=%s iters=%d mg=%.4g\n", (int)fb_conv, fb_stop, fb_iters, mg);
-        if (fb_conv) {
-            IO.beta = beta;  // eval_min left IO.x/IO.y/beta/rho on the converged state
-            converged = true;
+        // Re-sync IO/SatL/SatV to the final iterate a and measure the split we would publish.  The
+        // line search stops at a genuine equal-fugacity equilibrium (mg ~ 1e-7) but rarely reaches
+        // the ultra-strict 1e-9 quadratic-convergence target, so accept the fallback when it
+        // produced a GENUINE two-phase split -- non-trivial composition spread, an interior phase
+        // fraction, and an equal-fugacity residual at engineering tolerance.  The non-trivial +
+        // interior guard is applied to EVERY acceptance (not just the near-1e-9 path): the line
+        // search can also drive x -> y, which trivially satisfies equal fugacity (mg -> 0) but is a
+        // collapsed single-phase state that must never be published as two-phase (GH #3168 /
+        // CoolProp-zgpy).  Restore the exact pre-fallback state otherwise, so a failed fallback can
+        // never regress the caller.
+        double G_fin = 0, mg_fin = 0;
+        const bool fb_eval_ok = eval_min(a, G_fin, mg_fin);
+        CoolPropDbl fb_spread = 0;
+        for (std::size_t i = 0; i < N; ++i) fb_spread = std::max(fb_spread, std::abs(IO.x[i] - IO.y[i]));
+        const bool fb_genuine = fb_eval_ok && ValidNumber(mg_fin) && mg_fin <= 1e-5 && fb_spread >= 1e-4
+                                && beta > 1e-8 && beta < 1.0 - 1e-8;
+        if (cp_dbg_mich)
+            std::printf("[MICH-FB] exit conv=%d stop=%s iters=%d mg=%.4g genuine=%d spread=%.4g beta=%.6g\n",
+                        (int)fb_conv, fb_stop, fb_iters, mg_fin, (int)fb_genuine, (double)fb_spread, (double)beta);
+        if (fb_genuine) {
+            IO.beta = beta;  // eval_min left IO.x/IO.y/beta/rho on the best split
+            converged = (mg_fin < gibbs_tol);  // else the final gate re-validates the genuine split
         } else {
             IO.x = x_pre;
             IO.y = y_pre;

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -3085,17 +3085,34 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
     }
     IO.beta = beta;
 
-    // --- Part-2 fallback (#3342 / CoolProp-1tbe.22): stability-seeded MINORITY-phase Gibbs Newton. ---
-    // The reduced-gradient second-order phase uses g_i = beta*(1-beta)*(lnf_V - lnf_L), which
-    // vanishes as beta -> 0/1, so it stalls at the near-bubble/near-dew edge (beta pinned to a
-    // boundary, split not converged).  Following ThermoPack tp_solver::mod_newton_search, retry a
-    // full Gibbs Newton in the INCIPIENT (minority) phase's mole numbers -- the vanishing liquid
-    // near the dew, the vanishing vapour near the bubble.  Their components are small and far from
-    // the z_i upper bound, so the feasible box is NOT a razor (the failure of a majority-phase
-    // formulation).  Unscaled gradient dG/da_i = lnf_i^min - lnf_i^maj (does not vanish at the
-    // boundary) and the mole-number Gibbs Hessian (1/A_min)[...] + (1/A_maj)[...].  Additive and
-    // safe: ACCEPTS only a converged result; on any failure restores the exact pre-fallback state,
-    // so it can never regress a currently-passing case.
+    // --- Part-2 fallback (#3342 / CoolProp-1tbe.22): ThermoPack-style minority-phase Gibbs Newton ---
+    //
+    // WHEN INVOKED: only after BOTH phase 1 (SS + GDEM, <= 4 loops) and phase 2 (the reduced-gradient
+    // second-order Newton) have failed to converge.  Easy flashes never reach here.  Phase 2 scales
+    // its gradient by beta*(1-beta), which vanishes as beta -> 0/1, so it stalls exactly at the
+    // near-bubble/near-dew edge where the incipient phase is tiny -- the states master previously
+    // published grossly unconverged or collapsed to a wrong single phase (#3342's silent wrong-T).
+    //
+    // LIFTED FROM ThermoPack (tp_solver::mod_newton_search + optimizers::mod_newton):
+    //   * the variables are the INCIPIENT (minority) phase mole numbers a -- the vanishing liquid
+    //     near the dew, the vanishing vapour near the bubble.  Its components sit far from the z_i
+    //     bound, so the feasible box is not the razor a majority-phase (V ~ z) formulation hits;
+    //   * a MODIFIED-Newton descent direction (ThermoPack uses a modified Cholesky; here an
+    //     eigenvalue flip, below) so an indefinite Hessian still yields a descent step;
+    //   * a single-scalar FRACTION-TO-THE-BOUNDARY limit (ThermoPack limitDV) that scales the whole
+    //     step and so preserves the Newton direction, plus an ARMIJO line search on the total Gibbs;
+    //   * phase-SPECIFIED fugacity roots (ThermoPack thermo(...,LIQPH/VAPPH)); the CoolProp analogue
+    //     here is the deterministic cold global lowest-Gibbs solve, which keeps every evaluation on
+    //     the same stable density sheet (a warm local solve drifts to a metastable root).
+    //
+    // LOGIC: seed the incipient composition from the stability trial (or Wilson K-factors when that
+    // trial is ~trivial), then iterate -- build the mole-number Gibbs gradient dG/da_i = lnf_i^min -
+    // lnf_i^maj and Hessian (1/A_min)[D_min - x.D_min] + (1/A_maj)[D_maj - x.D_maj], diagonalise and
+    // floor its eigenvalues at max(|lambda|, eps*max|lambda|) for a guaranteed-descent, curvature-
+    // scaled step, apply fraction-to-boundary + Armijo, and exit once genuine.  ADDITIVE AND SAFE:
+    // publish only a GENUINE split (equal-fugacity residual <= 1e-5, non-trivial spread, interior
+    // beta); on any other outcome restore the exact pre-fallback state, so it can never regress a
+    // currently-passing case.
     if (!converged) {
         const std::vector<CoolPropDbl> x_pre = IO.x, y_pre = IO.y;
         const CoolPropDbl beta_pre = beta, rhoL_pre = IO.rhomolar_liq, rhoV_pre = IO.rhomolar_vap;
@@ -3230,7 +3247,10 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             // Phase-vanishing bail: if the incipient amount collapses far below any genuine near-dew
             // split (A ~ 1e-4 there) the feed is single-phase at this T -- no split exists -- so stop
             // instead of iterating to the cap on a residual that will never reach genuine.
-            if (A < 1e-6 && mg > fb_genuine_tol) { fb_stop = "vanish"; break; }
+            if (A < 1e-6 && mg > fb_genuine_tol) {
+                fb_stop = "vanish";
+                break;
+            }
 
             // SatL/SatV are synced to the current a (from the seed or the last accepted line-
             // search step).  Build the mole-number Gibbs gradient dG/da_i = ln f_i^min - ln

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -3085,39 +3085,52 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
     }
     IO.beta = beta;
 
-    // --- Part-2 fallback (#3342 / CoolProp-1tbe.22): stability-seeded V-space Gibbs Newton. ---
-    // The reduced-gradient second-order phase above uses g_i = beta*(1-beta)*(lnf_V - lnf_L),
-    // which VANISHES as beta -> 1, so it stalls at the near-dew/near-bubble edge (beta pinned to a
-    // boundary, split not converged).  Following ThermoPack tp_solver::mod_newton_search, retry in
-    // vapour MOLE NUMBERS V (beta = sum(V) derived) with the UNSCALED gradient dG/dV_i = lnf_i^V -
-    // lnf_i^L (does not vanish at the boundary) and the mole-number Gibbs Hessian, seeded from the
-    // stability trial phases.  Additive and safe: it ACCEPTS only a converged result, and on any
-    // failure restores the pre-fallback state, so it can never regress a currently-passing case.
+    // --- Part-2 fallback (#3342 / CoolProp-1tbe.22): stability-seeded MINORITY-phase Gibbs Newton. ---
+    // The reduced-gradient second-order phase uses g_i = beta*(1-beta)*(lnf_V - lnf_L), which
+    // vanishes as beta -> 0/1, so it stalls at the near-bubble/near-dew edge (beta pinned to a
+    // boundary, split not converged).  Following ThermoPack tp_solver::mod_newton_search, retry a
+    // full Gibbs Newton in the INCIPIENT (minority) phase's mole numbers -- the vanishing liquid
+    // near the dew, the vanishing vapour near the bubble.  Their components are small and far from
+    // the z_i upper bound, so the feasible box is NOT a razor (the failure of a majority-phase
+    // formulation).  Unscaled gradient dG/da_i = lnf_i^min - lnf_i^maj (does not vanish at the
+    // boundary) and the mole-number Gibbs Hessian (1/A_min)[...] + (1/A_maj)[...].  Additive and
+    // safe: ACCEPTS only a converged result; on any failure restores the exact pre-fallback state,
+    // so it can never regress a currently-passing case.
     if (!converged) {
-        // Preserve the pre-fallback published state for exact restore on failure.
         const std::vector<CoolPropDbl> x_pre = IO.x, y_pre = IO.y;
         const CoolPropDbl beta_pre = beta, rhoL_pre = IO.rhomolar_liq, rhoV_pre = IO.rhomolar_vap;
 
-        std::vector<CoolPropDbl> xf = x0_stab, yf = y0_stab;
-        // Seed beta from a mole balance on the widest-spread component of the trial phases.
-        std::size_t iw = 0;
-        CoolPropDbl wbest = 0;
-        for (std::size_t i = 0; i < N; ++i) {
-            CoolPropDbl d = std::abs(yf[i] - xf[i]);
-            if (d > wbest) { wbest = d; iw = i; }
+        const bool minority_is_liquid = (beta_pre >= 0.5);  // near dew -> incipient liquid
+        // Incipient composition from the stability trial phase (non-trivial by construction).
+        std::vector<CoolPropDbl> w = minority_is_liquid ? x0_stab : y0_stab;
+        {
+            CoolPropDbl sw = 0;
+            for (std::size_t i = 0; i < N; ++i) sw += std::max(w[i], static_cast<CoolPropDbl>(0));
+            if (sw > 0) {
+                for (std::size_t i = 0; i < N; ++i) w[i] = std::max(w[i], static_cast<CoolPropDbl>(0)) / sw;
+            } else {
+                w = IO.z;
+            }
         }
-        CoolPropDbl betaf = 0.5;
-        if (wbest > 1e-12) {
-            CoolPropDbl b = (IO.z[iw] - xf[iw]) / (yf[iw] - xf[iw]);
-            if (ValidNumber(b)) betaf = std::min(std::max(b, static_cast<CoolPropDbl>(1e-8)), static_cast<CoolPropDbl>(1.0 - 1e-8));
-        }
+        std::vector<CoolPropDbl> a(N);
+        for (std::size_t i = 0; i < N; ++i) a[i] = 1e-3 * w[i];  // small incipient amount
         rho_warm_L = -1;
         rho_warm_V = -1;
 
-        auto eval_state = [&](const std::vector<CoolPropDbl>& xx, const std::vector<CoolPropDbl>& yy, CoolPropDbl bb, double& G, double& mg) -> bool {
-            IO.x = xx;
-            IO.y = yy;
-            beta = bb;
+        // Evaluate the two-phase state from minority mole numbers a; leaves IO.x/IO.y/rho + SatL/SatV
+        // on that state and returns total Gibbs G and equal-fugacity residual mg.
+        auto eval_min = [&](const std::vector<CoolPropDbl>& aa, double& G, double& mg) -> bool {
+            CoolPropDbl A = 0, B = 0;
+            for (std::size_t i = 0; i < N; ++i) {
+                if (!(aa[i] > 0) || !(aa[i] < IO.z[i])) return false;
+                A += aa[i];
+                B += IO.z[i] - aa[i];
+            }
+            if (!(A > 0) || !(B > 0)) return false;
+            std::vector<CoolPropDbl> mn(N), mj(N);
+            for (std::size_t i = 0; i < N; ++i) { mn[i] = aa[i] / A; mj[i] = (IO.z[i] - aa[i]) / B; }
+            if (minority_is_liquid) { IO.x = mn; IO.y = mj; beta = B; }
+            else { IO.y = mn; IO.x = mj; beta = A; }
             if (!evaluate_phases()) return false;
             HEOS.SatL->set_mole_fractions(IO.x);
             HEOS.SatL->update_DmolarT_direct(IO.rhomolar_liq, IO.T);
@@ -3137,100 +3150,104 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
 
         bool fb_conv = false;
         double G_cur = 0, mg_cur = 0;
-        bool ok = eval_state(xf, yf, betaf, G_cur, mg_cur);
-        if (cp_dbg_mich) std::printf("[MICH-FB] entry ok=%d betaf=%.6g mg=%.4g G=%.6g\n", (int)ok, (double)betaf, mg_cur, G_cur);
         int fb_iters = 0;
         const char* fb_stop = "maxiter";
-        const int fb_max_iter = 80;
+        bool ok = eval_min(a, G_cur, mg_cur);
+        if (cp_dbg_mich) {
+            CoolPropDbl Asum = 0;
+            for (std::size_t i = 0; i < N; ++i) Asum += a[i];
+            std::printf("[MICH-FB] entry ok=%d minLiq=%d A=%.3g mg=%.4g\n", (int)ok, (int)minority_is_liquid, (double)Asum, mg_cur);
+        }
+        const int fb_max_iter = 100;
         for (int it = 0; ok && it < fb_max_iter; ++it) {
             if (mg_cur < gibbs_tol) { fb_conv = true; fb_stop = "converged"; break; }
-            if (betaf <= 1e-10 || betaf >= 1.0 - 1e-10) { fb_stop = "beta-boundary"; break; }
+            CoolPropDbl A = 0;
+            for (std::size_t i = 0; i < N; ++i) A += a[i];
+            CoolPropDbl B = 1.0 - A;  // z normalized to 1
+            if (!(A > 1e-14) || !(B > 1e-14)) { fb_stop = "amt-boundary"; break; }
 
-            // Unscaled gradient g_i = lnf_i^V - lnf_i^L and mole-number Gibbs Hessian.
+            HelmholtzEOSMixtureBackend* Smin = minority_is_liquid ? HEOS.SatL.get() : HEOS.SatV.get();
+            HelmholtzEOSMixtureBackend* Smaj = minority_is_liquid ? HEOS.SatV.get() : HEOS.SatL.get();
+            std::vector<CoolPropDbl> mnc(N), mjc(N);
+            for (std::size_t i = 0; i < N; ++i) { mnc[i] = a[i] / A; mjc[i] = (IO.z[i] - a[i]) / B; }
+
             Eigen::VectorXd g(N);
-            Eigen::MatrixXd Hm(N, N), DL(N, N), DV(N, N);
+            Eigen::MatrixXd Hm(N, N), Dmin(N, N), Dmaj(N, N);
             for (std::size_t i = 0; i < N; ++i) {
                 for (std::size_t j = 0; j < N; ++j) {
-                    DL(i, j) = CoolProp::MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(*(HEOS.SatL.get()), i, j, CoolProp::XN_INDEPENDENT);
-                    DV(i, j) = CoolProp::MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(*(HEOS.SatV.get()), i, j, CoolProp::XN_INDEPENDENT);
+                    Dmin(i, j) = CoolProp::MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(*Smin, i, j, CoolProp::XN_INDEPENDENT);
+                    Dmaj(i, j) = CoolProp::MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(*Smaj, i, j, CoolProp::XN_INDEPENDENT);
                 }
             }
             for (std::size_t i = 0; i < N; ++i) {
-                CoolPropDbl sL = 0, sV = 0;
-                for (std::size_t k = 0; k < N; ++k) { sL += IO.x[k] * DL(i, k); sV += IO.y[k] * DV(i, k); }
-                CoolPropDbl lV = std::log(IO.y[i]) + std::log(HEOS.SatV->fugacity_coefficient(i));
-                CoolPropDbl lL = std::log(IO.x[i]) + std::log(HEOS.SatL->fugacity_coefficient(i));
-                g(i) = lV - lL;
-                for (std::size_t j = 0; j < N; ++j) {
-                    Hm(i, j) = (DV(i, j) - sV) / betaf + (DL(i, j) - sL) / (1.0 - betaf);
-                }
+                CoolPropDbl sMin = 0, sMaj = 0;
+                for (std::size_t k = 0; k < N; ++k) { sMin += mnc[k] * Dmin(i, k); sMaj += mjc[k] * Dmaj(i, k); }
+                CoolPropDbl lnf_min = std::log(mnc[i]) + std::log(Smin->fugacity_coefficient(i));
+                CoolPropDbl lnf_maj = std::log(mjc[i]) + std::log(Smaj->fugacity_coefficient(i));
+                g(i) = lnf_min - lnf_maj;
+                for (std::size_t j = 0; j < N; ++j) Hm(i, j) = (Dmin(i, j) - sMin) / A + (Dmaj(i, j) - sMaj) / B;
             }
-            // Positive-definite shift so the step is a descent direction.
-            Eigen::VectorXd ds;
+
+            // Condition the system with Michelsen's alpha = 2*sqrt(n) scaling (D = diag(sqrt(a))):
+            // near a boundary a_i are tiny and the 1/A block of H is ~1000x the 1/B block, so the
+            // raw Newton step is poor.  Solve (D H D + shift I) u = -(D g), then da = D u.
+            Eigen::VectorXd sc(N);
+            for (std::size_t i = 0; i < N; ++i) sc(i) = std::sqrt(std::max(a[i], static_cast<CoolPropDbl>(1e-300)));
+            Eigen::MatrixXd Hs(N, N);
+            Eigen::VectorXd gs(N);
+            for (std::size_t i = 0; i < N; ++i) {
+                gs(i) = g(i) * sc(i);
+                for (std::size_t j = 0; j < N; ++j) Hs(i, j) = Hm(i, j) * sc(i) * sc(j);
+            }
+            Eigen::VectorXd da;
             {
                 double shift = 0.0;
                 bool solved = false;
-                for (int t = 0; t < 30; ++t) {
-                    Eigen::MatrixXd Hl = Hm;
+                for (int t = 0; t < 40; ++t) {
+                    Eigen::MatrixXd Hl = Hs;
                     Hl.diagonal().array() += shift;
                     Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(Hl, Eigen::EigenvaluesOnly);
                     double mn = es.eigenvalues().minCoeff();
                     if (!ValidNumber(mn)) break;
-                    if (mn < 1e-8) { shift += (1e-8 - mn); continue; }
-                    ds = Hl.ldlt().solve(-g);
+                    if (mn < 1e-10) { shift += (1e-10 - mn) + 1e-12; continue; }
+                    Eigen::VectorXd u = Hl.ldlt().solve(-gs);
+                    da.resize(N);
+                    for (std::size_t i = 0; i < N; ++i) da(i) = sc(i) * u(i);
                     solved = true;
                     break;
                 }
-                if (!solved) break;
+                if (!solved) { fb_stop = "hessian"; break; }
             }
-            // Capture the base vapour mole numbers NOW: eval_state() overwrites IO.y on every
-            // trial, so the step base must be snapshotted before the loop.
-            std::vector<CoolPropDbl> Vbase(N);
-            for (std::size_t i = 0; i < N; ++i) Vbase[i] = betaf * IO.y[i];
-            // Largest step that keeps every V_i strictly inside (0, z_i) -- near the dew a phase is
-            // a razor-thin sliver (V_i ~ z_i), so the full Newton step must be SCALED to the
-            // feasible boundary (ThermoPack's pos_scale), not rejected.
+            // Feasible step: a_i + t*da_i strictly inside (0, z_i).  a is the MINORITY phase so a_i
+            // are small and far from z_i; the binding side is a_i -> 0 (the phase vanishing).
             double t_max = 1.0;
             for (std::size_t i = 0; i < N; ++i) {
-                if (ds(i) > 0) t_max = std::min(t_max, 0.99 * (IO.z[i] - Vbase[i]) / ds(i));
-                else if (ds(i) < 0) t_max = std::min(t_max, 0.99 * Vbase[i] / (-ds(i)));
+                if (da(i) < 0) t_max = std::min(t_max, 0.99 * a[i] / (-da(i)));
+                else if (da(i) > 0) t_max = std::min(t_max, 0.99 * (IO.z[i] - a[i]) / da(i));
             }
             if (!(t_max > 0)) { fb_stop = "t_max<=0"; break; }
             bool accepted = false;
-            for (double t = t_max; t >= t_max / 1024; t *= 0.5) {
-                std::vector<CoolPropDbl> Vn(N), xt(N), yt(N);
-                CoolPropDbl Vtot = 0, Ltot = 0;
-                bool feasible = true;
+            for (double t = t_max; t >= t_max / 4096; t *= 0.5) {
+                std::vector<CoolPropDbl> at(N);
+                bool feas = true;
                 for (std::size_t i = 0; i < N; ++i) {
-                    CoolPropDbl Vi = Vbase[i] + t * ds(i);
-                    if (!(Vi > 0) || !(Vi < IO.z[i])) { feasible = false; break; }
-                    Vn[i] = Vi;
-                    Vtot += Vi;
-                    Ltot += IO.z[i] - Vi;
+                    CoolPropDbl ai = a[i] + t * da(i);
+                    if (!(ai > 0) || !(ai < IO.z[i])) { feas = false; break; }
+                    at[i] = ai;
                 }
-                if (!feasible || !(Vtot > 0) || !(Ltot > 0)) continue;
-                for (std::size_t i = 0; i < N; ++i) { yt[i] = Vn[i] / Vtot; xt[i] = (IO.z[i] - Vn[i]) / Ltot; }
+                if (!feas) continue;
                 double G_try, mg_try;
-                if (!eval_state(xt, yt, Vtot, G_try, mg_try)) continue;
-                if (G_try < G_cur - 1e-14) {
-                    xf = xt; yf = yt; betaf = Vtot; G_cur = G_try; mg_cur = mg_try;
-                    accepted = true;
-                    break;
-                }
+                if (!eval_min(at, G_try, mg_try)) continue;
+                if (G_try < G_cur - 1e-14) { a = at; G_cur = G_try; mg_cur = mg_try; accepted = true; break; }
             }
             if (!accepted) { fb_stop = "no-decrease"; break; }
             fb_iters = it + 1;
         }
-
-        if (cp_dbg_mich) std::printf("[MICH-FB] exit conv=%d stop=%s iters=%d mg=%.4g betaf=%.6g\n", (int)fb_conv, fb_stop, fb_iters, mg_cur, (double)betaf);
+        if (cp_dbg_mich) std::printf("[MICH-FB] exit conv=%d stop=%s iters=%d mg=%.4g\n", (int)fb_conv, fb_stop, fb_iters, mg_cur);
         if (fb_conv) {
-            // eval_state left IO.x/IO.y/beta/rho on the converged fallback state.
-            beta = betaf;
-            IO.beta = beta;
+            IO.beta = beta;  // eval_min left IO.x/IO.y/beta/rho on the converged state
             converged = true;
-            if (cp_dbg_mich) std::printf("[MICH-FB] V-space fallback CONVERGED beta=%.6g max_g=%.4g\n", (double)betaf, mg_cur);
         } else {
-            // Restore the exact pre-fallback state; behaviour is then identical to before.
             IO.x = x_pre;
             IO.y = y_pre;
             beta = beta_pre;
@@ -3239,7 +3256,6 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             IO.rhomolar_vap = rhoV_pre;
         }
     }
-
     // Recompute the equal-fugacity residual on the FINAL published (IO.x, IO.y) state
     // so the gate below tests exactly what is returned, not a pre-step value captured
     // at the top of the last iteration (which could over-throw a split that converged

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -3468,6 +3468,25 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             IO.rhomolar_vap = rhoV_pre;
         }
     }
+    // Normalise the phase labels to the VLE convention (liquid = the denser phase) before publishing.
+    // Any stage of this solver -- in particular the Phase-2 second-order Newton, which has no
+    // ordering guard of its own -- can converge to the correct physical split but with the
+    // liquid/vapour labels transposed: x <-> y, the densities swapped, and beta on the wrong side
+    // (GH #3357: near-dew natural-gas points otherwise publish Q = 1 - Q_true with x/y inverted).
+    // The equal-fugacity split is symmetric in its labels, so this relabeling is exact and the
+    // material balance z = (1 - beta) x + beta y is invariant under it.  Doing it here, before the
+    // recompute below, re-syncs SatL/SatV to the corrected assignment.  (The fallback's fb_vle_order
+    // guard already blocks an inverted split from that stage; this covers the stages without one.)
+    if (ValidNumber(IO.rhomolar_liq) && ValidNumber(IO.rhomolar_vap) && IO.rhomolar_liq < IO.rhomolar_vap) {
+        std::vector<CoolPropDbl> x_tmp = IO.x;
+        IO.x = IO.y;
+        IO.y = x_tmp;
+        const CoolPropDbl rho_tmp = IO.rhomolar_liq;
+        IO.rhomolar_liq = IO.rhomolar_vap;
+        IO.rhomolar_vap = rho_tmp;
+        beta = 1.0 - beta;
+        IO.beta = beta;
+    }
     // Recompute the equal-fugacity residual on the FINAL published (IO.x, IO.y) state
     // so the gate below tests exactly what is returned, not a pre-step value captured
     // at the top of the last iteration (which could over-throw a split that converged

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -3085,7 +3085,7 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
     }
     IO.beta = beta;
 
-    // --- Part-2 fallback (#3342 / CoolProp-1tbe.22): ThermoPack-style minority-phase Gibbs Newton ---
+    // --- Part-2 fallback (#3342 / CoolProp-1tbe.22): Michelsen second-order minority-phase Gibbs Newton ---
     //
     // WHEN INVOKED: only after BOTH phase 1 (SS + GDEM, <= 4 loops) and phase 2 (the reduced-gradient
     // second-order Newton) have failed to converge.  Easy flashes never reach here.  Phase 2 scales
@@ -3093,17 +3093,22 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
     // near-bubble/near-dew edge where the incipient phase is tiny -- the states master previously
     // published grossly unconverged or collapsed to a wrong single phase (#3342's silent wrong-T).
     //
-    // LIFTED FROM ThermoPack (tp_solver::mod_newton_search + optimizers::mod_newton):
+    // This is an INDEPENDENT implementation of Michelsen's second-order phase-split (the METHOD is
+    // published -- see METHOD PROVENANCE below; ThermoPack's tp_solver was read as an open-source
+    // REFERENCE, not copied).  The method elements:
     //   * the variables are the INCIPIENT (minority) phase mole numbers a -- the vanishing liquid
     //     near the dew, the vanishing vapour near the bubble.  Its components sit far from the z_i
     //     bound, so the feasible box is not the razor a majority-phase (V ~ z) formulation hits;
-    //   * a MODIFIED-Newton descent direction (ThermoPack uses a modified Cholesky; here an
+    //   * a MODIFIED-Newton descent direction (a spectral variant of Michelsen's modified Cholesky:
     //     eigenvalue flip, below) so an indefinite Hessian still yields a descent step;
-    //   * a single-scalar FRACTION-TO-THE-BOUNDARY limit (ThermoPack limitDV) that scales the whole
-    //     step and so preserves the Newton direction, plus an ARMIJO line search on the total Gibbs;
-    //   * phase-SPECIFIED fugacity roots (ThermoPack thermo(...,LIQPH/VAPPH)); the CoolProp analogue
-    //     here is the deterministic cold global lowest-Gibbs solve, which keeps every evaluation on
-    //     the same stable density sheet (a warm local solve drifts to a metastable root).
+    //   * a single-scalar FRACTION-TO-THE-BOUNDARY limit that scales the whole step and so preserves
+    //     the Newton direction, plus an ARMIJO line search on the total Gibbs.
+    // Where this implementation deliberately DIVERGES from ThermoPack's specific coding: deterministic
+    // cold global lowest-Gibbs density roots (vs its LIQPH/VAPPH specified roots) to keep every
+    // evaluation on the same stable density sheet; the eigenvalue-flip Hessian modification (vs its
+    // modified-Cholesky factorization); a single global minority phase (vs its per-component setV
+    // reference-phase toggle); and CoolProp-specific guards (Wilson reseed, Gibbs-descent, VLE
+    // ordering) below.
     //
     // LOGIC: seed the incipient composition from the stability trial (or Wilson K-factors when that
     // trial is ~trivial), then iterate -- build the mole-number Gibbs gradient dG/da_i = lnf_i^min -

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -3290,23 +3290,14 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             }
             Eigen::MatrixXd Dmin(N, N), Dmaj(N, N), Hm(N, N);
             Eigen::VectorXd grad(N);
+            // Fugacity composition derivatives d(ln f_i)/dx_j.  XN_INDEPENDENT is the correct
+            // convention for the mole-number Hessian below (all x_i independent, then projected); the
+            // last-component ideal-term bug that used to corrupt row N-1 here is now fixed at the
+            // source in MixtureDerivatives::dln_fugacity_dxj__constT_p_xi (GH #3342, FD-verified).
             for (std::size_t i = 0; i < N; ++i) {
                 for (std::size_t j = 0; j < N; ++j) {
                     Dmin(i, j) = CoolProp::MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(*Smin, i, j, CoolProp::XN_INDEPENDENT);
                     Dmaj(i, j) = CoolProp::MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(*Smaj, i, j, CoolProp::XN_INDEPENDENT);
-                }
-            }
-            // dln_fugacity_dxj__constT_p_xi hardcodes the ideal term d(ln x_i)/dx_j for the
-            // XN_DEPENDENT convention: for the LAST component it adds -1/x_{N-1} on every j.  We call
-            // it with XN_INDEPENDENT (all x_i treated independent, then projected), where the correct
-            // ideal term for the last component is delta_{N-1,j}/x_{N-1}.  Left uncorrected, row N-1
-            // (the last component -- often the dominant one near the dew) is wrong and flips the
-            // smallest Hessian eigenvalue negative (FD-verified).  Correct that one row for both phases.
-            {
-                const std::size_t last = N - 1;
-                for (std::size_t j = 0; j < N; ++j) {
-                    Dmin(last, j) += 1.0 / mnc[last] + (j == last ? 1.0 / mnc[last] : 0.0);
-                    Dmaj(last, j) += 1.0 / mjc[last] + (j == last ? 1.0 / mjc[last] : 0.0);
                 }
             }
             for (std::size_t i = 0; i < N; ++i) {

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -3113,6 +3113,27 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
     // publish only a GENUINE split (equal-fugacity residual <= 1e-5, non-trivial spread, interior
     // beta); on any other outcome restore the exact pre-fallback state, so it can never regress a
     // currently-passing case.
+    //
+    // METHOD PROVENANCE.  This is Michelsen's second-order phase-split, mirrored via ThermoPack:
+    //   [M1982b]  Michelsen, "The isothermal flash problem. Part II. Phase-split calculation",
+    //             Fluid Phase Equilib. 9 (1982) 21-40.  The minority/reference-phase mole-number
+    //             variables are Eq.14-15 (dependent variable = the phase where the component is most
+    //             abundant), the gradient dG/da_i = ln f_i^min - ln f_i^maj is Eq.16, the mole-number
+    //             Hessian is Eq.17; the modified-Cholesky descent + Gibbs-decrease-accepted line
+    //             search (our eigenvalue-flip is a spectral variant) is the "Second order methods"
+    //             section; the Gibbs-descent/"never return to the trivial solution" and phase-removal
+    //             rules motivate our genuine/Gibbs/VLE-ordering guards.
+    //   [MHA1980b] Mehra, Heidemann & Aziz, "Computation of multiphase equilibria for compositional
+    //             simulators", SPE 9232 (1980) -- origin of the yield-fraction/reference-phase choice
+    //             adopted by M1982b Eq.14-15.
+    //   [Murray1972] W. Murray, "Second derivative methods", in Methods for Unconstrained
+    //             Optimization, Academic Press (1972) -- the modified-Cholesky modified-Newton.
+    //   [CN1975]  Crowe & Nishio, AIChE J. 21 (1975) 528-533 -- the GDEM acceleration of Phase 1.
+    //   [MM2007]  Michelsen & Mollerup, "Thermodynamic Models: Fundamentals & Computational
+    //             Aspects", 2nd ed. (2007), Ch.12 -- textbook treatment of the above.
+    //   [TP2017]  Wilhelmsen et al., Ind. Eng. Chem. Res. 56 (2017) 3503-3515; ThermoPack
+    //             (https://github.com/thermotools/thermopack), tp_solver.f90 + optimizer.f90 --
+    //             the implementation mirrored here.
     if (!converged) {
         const std::vector<CoolPropDbl> x_pre = IO.x, y_pre = IO.y;
         const CoolPropDbl beta_pre = beta, rhoL_pre = IO.rhomolar_liq, rhoV_pre = IO.rhomolar_vap;

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -2699,16 +2699,6 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
     // Snapshot the stability trial-phase seed (non-trivial by construction) for the V-space
     // Newton fallback below (#3342 part 2 / CoolProp-1tbe.22).
     const std::vector<CoolPropDbl> x0_stab = IO.x, y0_stab = IO.y;
-    const bool cp_dbg_mich = std::getenv("CP_DBG_MICH") != nullptr;
-    if (cp_dbg_mich) {
-        double sp = 0, tn = 0;
-        for (std::size_t i = 0; i < N; ++i) {
-            sp = std::max(sp, std::abs(IO.x[i] - IO.y[i]));
-            tn += lnK[i] * lnK[i];
-        }
-        std::printf("[MICH] ENTRY T=%.6g p=%.6g beta0=%.6g spread0=%.4g trivnorm0=%.4g rhoL=%.6g rhoV=%.6g\n", (double)IO.T, (double)IO.p,
-                    (double)beta, sp, tn, (double)IO.rhomolar_liq, (double)IO.rhomolar_vap);
-    }
 
     // Reject a non-finite seed up front.  A stability false-positive at a single-phase point
     // (e.g. below the bubble) can hand in a NaN trial composition; without this guard the NaN
@@ -2866,14 +2856,6 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         }
     }
 
-    if (cp_dbg_mich) {
-        double sp = 0, tn = 0;
-        for (std::size_t i = 0; i < N; ++i) {
-            sp = std::max(sp, std::abs(IO.x[i] - IO.y[i]));
-            tn += lnK[i] * lnK[i];
-        }
-        std::printf("[MICH] postSS ss_converged=%d beta=%.6g spread=%.4g trivnorm=%.4g\n", (int)ss_converged, (double)beta, sp, tn);
-    }
     // Ensure phases are up-to-date after SS
     solve_rachford_rice();
     if (!evaluate_phases()) {
@@ -3223,35 +3205,34 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             // stable roots the seed was built on.
             rho_warm_L = -1;
             rho_warm_V = -1;
-            if (!evaluate_phases()) return false;
-            HEOS.SatL->set_mole_fractions(IO.x);
-            HEOS.SatL->update_DmolarT_direct(IO.rhomolar_liq, IO.T);
-            HEOS.SatV->set_mole_fractions(IO.y);
-            HEOS.SatV->update_DmolarT_direct(IO.rhomolar_vap, IO.T);
-            mg = 0;
-            G = 0;
-            for (std::size_t i = 0; i < N; ++i) {
-                CoolPropDbl lV = std::log(IO.y[i]) + std::log(HEOS.SatV->fugacity_coefficient(i));
-                CoolPropDbl lL = std::log(IO.x[i]) + std::log(HEOS.SatL->fugacity_coefficient(i));
-                mg = std::max(mg, std::abs(lV - lL));
-                if (IO.x[i] > 0) G += (1.0 - beta) * IO.x[i] * lL;
-                if (IO.y[i] > 0) G += beta * IO.y[i] * lV;
+            // The whole density + fugacity evaluation is wrapped: evaluate_phases already catches the
+            // density solve, but update_DmolarT_direct / fugacity_coefficient can also throw a
+            // CoolPropBaseError.  Returning false on ANY throw keeps the fallback exception-safe --
+            // a failed evaluation is handled gracefully (no-step / non-genuine -> restore), never
+            // escaping solve_michelsen to turn a graceful single-phase fallback into a hard abort.
+            try {
+                if (!evaluate_phases()) return false;
+                HEOS.SatL->set_mole_fractions(IO.x);
+                HEOS.SatL->update_DmolarT_direct(IO.rhomolar_liq, IO.T);
+                HEOS.SatV->set_mole_fractions(IO.y);
+                HEOS.SatV->update_DmolarT_direct(IO.rhomolar_vap, IO.T);
+                mg = 0;
+                G = 0;
+                for (std::size_t i = 0; i < N; ++i) {
+                    CoolPropDbl lV = std::log(IO.y[i]) + std::log(HEOS.SatV->fugacity_coefficient(i));
+                    CoolPropDbl lL = std::log(IO.x[i]) + std::log(HEOS.SatL->fugacity_coefficient(i));
+                    mg = std::max(mg, std::abs(lV - lL));
+                    if (IO.x[i] > 0) G += (1.0 - beta) * IO.x[i] * lL;
+                    if (IO.y[i] > 0) G += beta * IO.y[i] * lV;
+                }
+            } catch (...) {
+                return false;
             }
             return ValidNumber(G) && ValidNumber(mg);
         };
 
-        bool fb_conv = false;
         double G_old = 0, mg = 0;
-        int fb_iters = 0;
-        const char* fb_stop = "maxiter";
         bool ok = eval_min(a, G_old, mg);  // seeds IO/SatL/SatV synced to a
-        if (cp_dbg_mich) {
-            CoolPropDbl As = 0;
-            for (std::size_t i = 0; i < N; ++i)
-                As += a[i];
-            std::printf("[MICH-FB] entry T=%.5g ok=%d minLiq=%d A=%.3g mg=%.4g beta_pre=%.6g\n", (double)IO.T, (int)ok, (int)minority_is_liquid,
-                        (double)As, mg, (double)beta_pre);
-        }
         // Globalised Newton on the minority mole numbers a, mirroring ThermoPack
         // tp_solver::mod_newton_search + optimizers::mod_newton: a positive-definite
         // (guaranteed-descent) Newton direction with a steepest-descent safeguard, a single-
@@ -3269,11 +3250,7 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         double mg_best = mg;                 // lowest residual seen so far (the floor)
         int stall = 0;                       // iterations since the floor last improved meaningfully
         for (int it = 0; ok && it < fb_max_iter; ++it) {
-            if (mg < gibbs_tol) {
-                fb_conv = true;
-                fb_stop = "converged";
-                break;
-            }
+            if (mg < gibbs_tol) break;  // quadratic-converged
             // Stall exit: once the split is GENUINE (mg <= 1e-5) the equal-fugacity residual has
             // floored at ~1e-7 on density-solve accuracy, well before the 1e-9 quadratic target, so
             // exit rather than grind to the maxiter cap.  Track the FLOOR (mg_best), not the previous
@@ -3285,26 +3262,17 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
                 stall = 0;
             } else {
                 mg_best = std::min(mg_best, mg);
-                if (mg < fb_genuine_tol && ++stall >= stall_genuine) {
-                    fb_stop = "stall";
-                    break;
-                }
+                if (mg < fb_genuine_tol && ++stall >= stall_genuine) break;  // genuine and floored
             }
             CoolPropDbl A = 0;
             for (std::size_t i = 0; i < N; ++i)
                 A += a[i];
             CoolPropDbl B = 1.0 - A;  // z normalized to 1
-            if (!(A > 1e-14) || !(B > 1e-14)) {
-                fb_stop = "amt-boundary";
-                break;
-            }
+            if (!(A > 1e-14) || !(B > 1e-14)) break;  // phase amount hit a bound
             // Phase-vanishing bail: if the incipient amount collapses far below any genuine near-dew
             // split (A ~ 1e-4 there) the feed is single-phase at this T -- no split exists -- so stop
             // instead of iterating to the cap on a residual that will never reach genuine.
-            if (A < 1e-6 && mg > fb_genuine_tol) {
-                fb_stop = "vanish";
-                break;
-            }
+            if (A < 1e-6 && mg > fb_genuine_tol) break;
 
             // SatL/SatV are synced to the current a (from the seed or the last accepted line-
             // search step).  Build the mole-number Gibbs gradient dG/da_i = ln f_i^min - ln
@@ -3354,11 +3322,8 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             // caps the condition number, so the step along the soft mode stays bounded and the
             // single fraction-to-the-boundary scalar no longer has to throttle the stiff directions.
             Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(Hm);
-            if (es.info() != Eigen::Success) {
-                fb_stop = "eig-fail";
-                break;
-            }
-            const Eigen::VectorXd evals = es.eigenvalues();
+            if (es.info() != Eigen::Success) break;  // eigensolve failed
+            const Eigen::VectorXd& evals = es.eigenvalues();
             const Eigen::MatrixXd& Q = es.eigenvectors();
             // Gill-Murray-style modification: replace each eigenvalue lambda_k by max(|lambda_k|,
             // floor).  Taking the ABSOLUTE value of a negative eigenvalue (rather than flooring it
@@ -3403,11 +3368,7 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
                 }
                 alpha *= 0.5;
             }
-            if (!step_accepted) {
-                fb_stop = "no-step";
-                break;
-            }
-            fb_iters = it + 1;
+            if (!step_accepted) break;  // line search could not find a Gibbs-decreasing step
         }
         // Re-sync IO/SatL/SatV to the final iterate a and measure the split we would publish.  The
         // line search stops at a genuine equal-fugacity equilibrium (mg ~ 1e-7) but rarely reaches
@@ -3434,19 +3395,58 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         double G_single = HUGE_VAL;
         {
             HEOS.SatL->set_mole_fractions(IO.z);
+            CoolPropDbl rz = -1;
             CoolPropDbl rw = -1;
             try {
-                CoolPropDbl rz = solve_trial_rho_warm(*HEOS.SatL, IO.T, IO.p, rw);
-                HEOS.SatL->update_DmolarT_direct(rz, IO.T);
-                double gs = 0;
-                for (std::size_t i = 0; i < N; ++i)
-                    if (IO.z[i] > 0)
-                        gs += static_cast<double>(IO.z[i]) * (std::log(static_cast<double>(IO.z[i])) + std::log(HEOS.SatL->fugacity_coefficient(i)));
-                G_single = gs;
+                rz = solve_trial_rho_warm(*HEOS.SatL, IO.T, IO.p, rw);
             } catch (...) {
-                G_single = HUGE_VAL;  // reference unavailable -> do not block on it
+                rz = -1;
+            }
+            // The global lowest-Gibbs root can fail for a multiparameter mixture when p lies between
+            // the spinodal pressures -- exactly the near-dew regime this fallback targets (the same
+            // failure check_stability_michelsen guards at ~2108).  Fall back to a phase-specified
+            // root so the single-phase reference stays available and the Gibbs-descent guard below
+            // does not silently no-op (fail open).
+            if (!(rz > 0)) {
+                try {
+                    HEOS.SatL->specify_phase(iphase_gas);
+                    rz = HEOS.SatL->solver_rho_Tp(IO.T, IO.p);
+                    HEOS.SatL->unspecify_phase();
+                } catch (...) {
+                    HEOS.SatL->unspecify_phase();
+                    rz = -1;
+                }
+            }
+            if (!(rz > 0)) {
+                try {
+                    HEOS.SatL->specify_phase(iphase_liquid);
+                    rz = HEOS.SatL->solver_rho_Tp(IO.T, IO.p);
+                    HEOS.SatL->unspecify_phase();
+                } catch (...) {
+                    HEOS.SatL->unspecify_phase();
+                    rz = -1;
+                }
+            }
+            if (rz > 0) {
+                try {
+                    HEOS.SatL->update_DmolarT_direct(rz, IO.T);
+                    double gs = 0;
+                    for (std::size_t i = 0; i < N; ++i)
+                        if (IO.z[i] > 0)
+                            gs +=
+                              static_cast<double>(IO.z[i]) * (std::log(static_cast<double>(IO.z[i])) + std::log(HEOS.SatL->fugacity_coefficient(i)));
+                    if (ValidNumber(gs)) G_single = gs;
+                } catch (...) {
+                    G_single = HUGE_VAL;
+                }
             }
         }
+        // Gibbs-descent guard.  If no single-phase reference could be computed at all (G_single
+        // stays HUGE_VAL -- extremely rare: neither the global nor either phase-specified root
+        // solved), this check is skipped, but that only happens when the feed has no stable single
+        // phase at (T, p), i.e. it is genuinely two-phase, so publishing the split is the correct
+        // outcome; the independent VLE-ordering + genuine gates below still reject a trivial or
+        // mislabeled-LLE split.
         const bool fb_lower_gibbs = fb_eval_ok && ValidNumber(G_fin) && G_fin < G_single - 1e-10;
         // Vapour-liquid ordering: solve_michelsen is a VLE flash, so a genuine split must have the
         // liquid denser than the vapour.  A split with rho_vap >= rho_liq is a mislabeled/spurious
@@ -3455,13 +3455,10 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         const bool fb_vle_order = IO.rhomolar_liq > IO.rhomolar_vap;
         const bool fb_genuine = fb_eval_ok && ValidNumber(mg_fin) && mg_fin <= 1e-5 && fb_spread >= 1e-4 && beta > 1e-8 && beta < 1.0 - 1e-8
                                 && fb_lower_gibbs && fb_vle_order;
-        if (cp_dbg_mich)
-            std::printf("[MICH-FB] exit conv=%d stop=%s iters=%d mg=%.4g genuine=%d spread=%.4g beta=%.6g dG=%.3e rhoL=%.5g rhoV=%.5g\n",
-                        (int)fb_conv, fb_stop, fb_iters, mg_fin, (int)fb_genuine, (double)fb_spread, (double)beta, G_fin - G_single,
-                        (double)IO.rhomolar_liq, (double)IO.rhomolar_vap);
         if (fb_genuine) {
-            IO.beta = beta;                    // eval_min left IO.x/IO.y/beta/rho on the best split
-            converged = (mg_fin < gibbs_tol);  // else the final gate re-validates the genuine split
+            // eval_min left IO.x/IO.y/beta/rho on the accepted split; the always-run recompute block
+            // below re-derives `converged` from the published residual, so no need to set it here.
+            IO.beta = beta;
         } else {
             IO.x = x_pre;
             IO.y = y_pre;
@@ -3498,12 +3495,6 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
     // single-phase.  Distinguish the two: a genuine split has a non-trivial composition spread
     // AND an interior phase fraction AND an equal-fugacity residual at engineering tolerance; a
     // false positive is trivial (x==y), collapsed (beta -> 0/1), or grossly unconverged.
-    if (cp_dbg_mich) {
-        double sp = 0;
-        for (std::size_t i = 0; i < N; ++i)
-            sp = std::max(sp, std::abs(IO.x[i] - IO.y[i]));
-        std::printf("[MICH] EXIT  converged=%d final_max_g=%.4g beta=%.6g spread=%.4g\n", (int)converged, (double)last_max_g, (double)beta, sp);
-    }
     if (!converged) {
         CoolPropDbl spread = 0;
         for (std::size_t i = 0; i < N; ++i)

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -3168,8 +3168,16 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             }
         }
         std::vector<CoolPropDbl> a(N);
+        // Scale the incipient amounts so every component stays strictly below its feed amount:
+        // eval_min requires a[i] < z[i], and a fixed 1e-3 factor can exceed a TRACE z_i when the
+        // seed concentrates that component (e.g. a 1e-4 feed fraction with w_i > 0.1), which would
+        // fail the seed evaluation and make the whole fallback silently no-op.  Cap the factor at
+        // 1e-3 and at half the tightest z_i / w_i ratio.
+        CoolPropDbl seed_frac = 1e-3;
         for (std::size_t i = 0; i < N; ++i)
-            a[i] = 1e-3 * w[i];  // small incipient amount
+            if (w[i] > 0 && IO.z[i] > 0) seed_frac = std::min(seed_frac, 0.5 * IO.z[i] / w[i]);
+        for (std::size_t i = 0; i < N; ++i)
+            a[i] = seed_frac * w[i];  // small incipient amount, strictly below the feed
         rho_warm_L = -1;
         rho_warm_V = -1;
 
@@ -3441,13 +3449,14 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
                 }
             }
         }
-        // Gibbs-descent guard.  If no single-phase reference could be computed at all (G_single
-        // stays HUGE_VAL -- extremely rare: neither the global nor either phase-specified root
-        // solved), this check is skipped, but that only happens when the feed has no stable single
-        // phase at (T, p), i.e. it is genuinely two-phase, so publishing the split is the correct
-        // outcome; the independent VLE-ordering + genuine gates below still reject a trivial or
-        // mislabeled-LLE split.
-        const bool fb_lower_gibbs = fb_eval_ok && ValidNumber(G_fin) && G_fin < G_single - 1e-10;
+        // Gibbs-descent guard -- fail CLOSED.  The split is accepted only when a FINITE single-phase
+        // reference was actually obtained AND the split's Gibbs energy is below it.  If no reference
+        // could be computed at all (G_single stays HUGE_VAL -- extremely rare: neither the global nor
+        // either phase-specified root solved, a pathological no-root state rather than the
+        // between-spinodals case the phase-specified fallback already covers), the guard fails and
+        // the fallback does not publish, rather than accepting on a vacuous G_fin < HUGE_VAL compare.
+        const bool g_single_valid = ValidNumber(G_single) && G_single < HUGE_VAL;
+        const bool fb_lower_gibbs = fb_eval_ok && g_single_valid && ValidNumber(G_fin) && G_fin < G_single - 1e-10;
         // Vapour-liquid ordering: solve_michelsen is a VLE flash, so a genuine split must have the
         // liquid denser than the vapour.  A split with rho_vap >= rho_liq is a mislabeled/spurious
         // liquid-liquid split -- e.g. the poor-kij methanol-benzene LLE the EOS predicts (GH #3168);
@@ -3514,18 +3523,23 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
     // single-phase.  Distinguish the two: a genuine split has a non-trivial composition spread
     // AND an interior phase fraction AND an equal-fugacity residual at engineering tolerance; a
     // false positive is trivial (x==y), collapsed (beta -> 0/1), or grossly unconverged.
-    if (!converged) {
-        CoolPropDbl spread = 0;
-        for (std::size_t i = 0; i < N; ++i)
-            spread = std::max(spread, std::abs(IO.x[i] - IO.y[i]));
-        const bool genuine = ValidNumber(last_max_g) && last_max_g <= 1e-5  // near-converged equilibrium
-                             && spread >= 1e-4                              // not a trivial (x==y) split
-                             && beta > 1e-8 && beta < 1.0 - 1e-8;           // not a collapsed phase
-        if (!genuine) {
-            IO.nonconvergence = true;
-            throw SolutionError(format("PTflash_twophase::solve_michelsen failed to converge: max|ln f_V - ln f_L| = %g at T = %g K, p = %g Pa",
-                                       last_max_g, static_cast<double>(IO.T), static_cast<double>(IO.p)));
-        }
+    CoolPropDbl spread = 0;
+    for (std::size_t i = 0; i < N; ++i)
+        spread = std::max(spread, std::abs(IO.x[i] - IO.y[i]));
+    // Trivial/collapsed rejection applies to EVERY published split, converged or not: a trivial
+    // split (x == y) satisfies the equal-fugacity residual identically, so converged == true does
+    // NOT imply a real two-phase state, and such a state must not slip past as a "converged" split.
+    // The trivial threshold (1e-7) sits far below any genuine split -- a near-critical two-phase
+    // state still has spread well above it -- so this does not reject a real near-critical split.
+    const bool trivial_or_collapsed = !(spread > 1e-7) || !(beta > 1e-8) || !(beta < 1.0 - 1e-8);
+    // When NOT at the strict quadratic tolerance, additionally require a genuine near-converged
+    // equilibrium (engineering residual + non-trivial spread), else throw -- restoring the
+    // no-silent-wrong-answer contract for wide-boiling splits that stall at ~1e-6.
+    const bool near_converged_genuine = ValidNumber(last_max_g) && last_max_g <= 1e-5 && spread >= 1e-4;
+    if (trivial_or_collapsed || (!converged && !near_converged_genuine)) {
+        IO.nonconvergence = true;
+        throw SolutionError(format("PTflash_twophase::solve_michelsen failed to converge: max|ln f_V - ln f_L| = %g at T = %g K, p = %g Pa",
+                                   last_max_g, static_cast<double>(IO.T), static_cast<double>(IO.p)));
     }
 }
 

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -3149,30 +3149,38 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         };
 
         bool fb_conv = false;
-        double G_cur = 0, mg_cur = 0;
+        double G_old = 0, mg = 0;
         int fb_iters = 0;
         const char* fb_stop = "maxiter";
-        bool ok = eval_min(a, G_cur, mg_cur);
+        bool ok = eval_min(a, G_old, mg);  // seeds IO/SatL/SatV synced to a
         if (cp_dbg_mich) {
-            CoolPropDbl Asum = 0;
-            for (std::size_t i = 0; i < N; ++i) Asum += a[i];
-            std::printf("[MICH-FB] entry ok=%d minLiq=%d A=%.3g mg=%.4g\n", (int)ok, (int)minority_is_liquid, (double)Asum, mg_cur);
+            CoolPropDbl As = 0;
+            for (std::size_t i = 0; i < N; ++i) As += a[i];
+            std::printf("[MICH-FB] entry ok=%d minLiq=%d A=%.3g mg=%.4g\n", (int)ok, (int)minority_is_liquid, (double)As, mg);
         }
-        const int fb_max_iter = 100;
+        // Hebden restricted-step (trust-region) Newton in alpha_i = 2*sqrt(a_i), mirroring
+        // StabilityEvaluationClass::minimize_tpd.  alpha keeps a_i >= 0 for free and conditions the
+        // tiny minority amounts; the trust region + positivity clamp globalise the step so a
+        // trace-component bound cannot pin it (the failure of the raw t_max line search).
+        double trust_radius = 0.25, diagonal_shift = 0.0;
+        std::vector<CoolPropDbl> alpha(N), alpha_old(N);
+        for (std::size_t i = 0; i < N; ++i) alpha[i] = 2.0 * std::sqrt(std::max(a[i], static_cast<CoolPropDbl>(1e-300)));
+        const int fb_max_iter = 60;
         for (int it = 0; ok && it < fb_max_iter; ++it) {
-            if (mg_cur < gibbs_tol) { fb_conv = true; fb_stop = "converged"; break; }
+            if (mg < gibbs_tol) { fb_conv = true; fb_stop = "converged"; break; }
             CoolPropDbl A = 0;
             for (std::size_t i = 0; i < N; ++i) A += a[i];
             CoolPropDbl B = 1.0 - A;  // z normalized to 1
             if (!(A > 1e-14) || !(B > 1e-14)) { fb_stop = "amt-boundary"; break; }
 
+            // SatL/SatV are synced to the current a (from the last accepted eval_min).  Build the
+            // mole-number Gibbs gradient/Hessian, then transform to alpha space.
             HelmholtzEOSMixtureBackend* Smin = minority_is_liquid ? HEOS.SatL.get() : HEOS.SatV.get();
             HelmholtzEOSMixtureBackend* Smaj = minority_is_liquid ? HEOS.SatV.get() : HEOS.SatL.get();
-            std::vector<CoolPropDbl> mnc(N), mjc(N);
-            for (std::size_t i = 0; i < N; ++i) { mnc[i] = a[i] / A; mjc[i] = (IO.z[i] - a[i]) / B; }
-
-            Eigen::VectorXd g(N);
-            Eigen::MatrixXd Hm(N, N), Dmin(N, N), Dmaj(N, N);
+            std::vector<CoolPropDbl> mnc(N), mjc(N), halfa(N), gmole(N);
+            for (std::size_t i = 0; i < N; ++i) { mnc[i] = a[i] / A; mjc[i] = (IO.z[i] - a[i]) / B; halfa[i] = 0.5 * alpha[i]; }
+            Eigen::MatrixXd Dmin(N, N), Dmaj(N, N), HA(N, N);
+            Eigen::VectorXd gA(N);
             for (std::size_t i = 0; i < N; ++i) {
                 for (std::size_t j = 0; j < N; ++j) {
                     Dmin(i, j) = CoolProp::MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(*Smin, i, j, CoolProp::XN_INDEPENDENT);
@@ -3180,70 +3188,76 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
                 }
             }
             for (std::size_t i = 0; i < N; ++i) {
-                CoolPropDbl sMin = 0, sMaj = 0;
-                for (std::size_t k = 0; k < N; ++k) { sMin += mnc[k] * Dmin(i, k); sMaj += mjc[k] * Dmaj(i, k); }
                 CoolPropDbl lnf_min = std::log(mnc[i]) + std::log(Smin->fugacity_coefficient(i));
                 CoolPropDbl lnf_maj = std::log(mjc[i]) + std::log(Smaj->fugacity_coefficient(i));
-                g(i) = lnf_min - lnf_maj;
-                for (std::size_t j = 0; j < N; ++j) Hm(i, j) = (Dmin(i, j) - sMin) / A + (Dmaj(i, j) - sMaj) / B;
+                gmole[i] = lnf_min - lnf_maj;  // dG/da_i
+                gA(i) = halfa[i] * gmole[i];    // dG/dalpha_i
+            }
+            std::vector<CoolPropDbl> sMinV(N, 0), sMajV(N, 0);
+            for (std::size_t i = 0; i < N; ++i)
+                for (std::size_t k = 0; k < N; ++k) { sMinV[i] += mnc[k] * Dmin(i, k); sMajV[i] += mjc[k] * Dmaj(i, k); }
+            for (std::size_t i = 0; i < N; ++i) {
+                for (std::size_t j = 0; j < N; ++j) {
+                    CoolPropDbl Hm = (Dmin(i, j) - sMinV[i]) / A + (Dmaj(i, j) - sMajV[i]) / B;
+                    HA(i, j) = halfa[i] * halfa[j] * Hm;
+                }
+                HA(i, i) += 0.5 * gmole[i];  // d^2 a_i / d alpha_i^2 = 1/2 term
             }
 
-            // Condition the system with Michelsen's alpha = 2*sqrt(n) scaling (D = diag(sqrt(a))):
-            // near a boundary a_i are tiny and the 1/A block of H is ~1000x the 1/B block, so the
-            // raw Newton step is poor.  Solve (D H D + shift I) u = -(D g), then da = D u.
-            Eigen::VectorXd sc(N);
-            for (std::size_t i = 0; i < N; ++i) sc(i) = std::sqrt(std::max(a[i], static_cast<CoolPropDbl>(1e-300)));
-            Eigen::MatrixXd Hs(N, N);
-            Eigen::VectorXd gs(N);
-            for (std::size_t i = 0; i < N; ++i) {
-                gs(i) = g(i) * sc(i);
-                for (std::size_t j = 0; j < N; ++j) Hs(i, j) = Hm(i, j) * sc(i) * sc(j);
-            }
-            Eigen::VectorXd da;
-            {
-                double shift = 0.0;
-                bool solved = false;
-                for (int t = 0; t < 40; ++t) {
-                    Eigen::MatrixXd Hl = Hs;
-                    Hl.diagonal().array() += shift;
-                    Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(Hl, Eigen::EigenvaluesOnly);
-                    double mn = es.eigenvalues().minCoeff();
-                    if (!ValidNumber(mn)) break;
-                    if (mn < 1e-10) { shift += (1e-10 - mn) + 1e-12; continue; }
-                    Eigen::VectorXd u = Hl.ldlt().solve(-gs);
-                    da.resize(N);
-                    for (std::size_t i = 0; i < N; ++i) da(i) = sc(i) * u(i);
-                    solved = true;
-                    break;
-                }
-                if (!solved) { fb_stop = "hessian"; break; }
-            }
-            // Feasible step: a_i + t*da_i strictly inside (0, z_i).  a is the MINORITY phase so a_i
-            // are small and far from z_i; the binding side is a_i -> 0 (the phase vanishing).
-            double t_max = 1.0;
-            for (std::size_t i = 0; i < N; ++i) {
-                if (da(i) < 0) t_max = std::min(t_max, 0.99 * a[i] / (-da(i)));
-                else if (da(i) > 0) t_max = std::min(t_max, 0.99 * (IO.z[i] - a[i]) / da(i));
-            }
-            if (!(t_max > 0)) { fb_stop = "t_max<=0"; break; }
-            bool accepted = false;
-            for (double t = t_max; t >= t_max / 4096; t *= 0.5) {
+            for (std::size_t i = 0; i < N; ++i) alpha_old[i] = alpha[i];
+            bool step_accepted = false;
+            const int max_inner = 25;
+            for (int inner = 0; inner < max_inner; ++inner) {
+                Eigen::MatrixXd Hl = HA;
+                Hl.diagonal().array() += diagonal_shift;
+                Eigen::VectorXd delta = Hl.colPivHouseholderQr().solve(-gA);  // minimisation step
+                double snorm2 = 0;
                 std::vector<CoolPropDbl> at(N);
-                bool feas = true;
                 for (std::size_t i = 0; i < N; ++i) {
-                    CoolPropDbl ai = a[i] + t * da(i);
-                    if (!(ai > 0) || !(ai < IO.z[i])) { feas = false; break; }
-                    at[i] = ai;
+                    double da = delta(i);
+                    if (alpha_old[i] + da <= 0) da = -0.9 * alpha_old[i];  // keep a_i >= 0
+                    delta(i) = da;
+                    alpha[i] = alpha_old[i] + da;
+                    at[i] = 0.25 * alpha[i] * alpha[i];
+                    snorm2 += da * da;
                 }
-                if (!feas) continue;
-                double G_try, mg_try;
-                if (!eval_min(at, G_try, mg_try)) continue;
-                if (G_try < G_cur - 1e-14) { a = at; G_cur = G_try; mg_cur = mg_try; accepted = true; break; }
+                double ssize = std::sqrt(snorm2);
+                if (ssize > trust_radius && diagonal_shift == 0) {
+                    diagonal_shift = ssize / trust_radius - 1.0;
+                    for (std::size_t i = 0; i < N; ++i) alpha[i] = alpha_old[i];
+                    continue;
+                }
+                double G_new = 0, mg_new = 0;
+                if (!eval_min(at, G_new, mg_new)) {
+                    trust_radius = ssize / 3.0;
+                    diagonal_shift = 0;
+                    for (std::size_t i = 0; i < N; ++i) alpha[i] = alpha_old[i];
+                    continue;
+                }
+                if (G_new > G_old + 1e-12) {
+                    trust_radius = ssize / 3.0;
+                    diagonal_shift = 0;
+                    for (std::size_t i = 0; i < N; ++i) alpha[i] = alpha_old[i];
+                    continue;
+                }
+                Eigen::VectorXd Hd = HA * delta;
+                double predicted = -(gA.dot(delta) + 0.5 * delta.dot(Hd));
+                double actual = G_old - G_new;
+                double ratio = (predicted != 0) ? actual / predicted : 1.0;
+                if (ratio < 0.25) trust_radius = ssize / 2.0;
+                else if (ratio > 0.75 && diagonal_shift > 0) trust_radius = ssize * 2.0;
+                else trust_radius = ssize;
+                diagonal_shift = 0;
+                a = at;
+                G_old = G_new;
+                mg = mg_new;
+                step_accepted = true;
+                break;
             }
-            if (!accepted) { fb_stop = "no-decrease"; break; }
+            if (!step_accepted) { fb_stop = "no-step"; break; }
             fb_iters = it + 1;
         }
-        if (cp_dbg_mich) std::printf("[MICH-FB] exit conv=%d stop=%s iters=%d mg=%.4g\n", (int)fb_conv, fb_stop, fb_iters, mg_cur);
+        if (cp_dbg_mich) std::printf("[MICH-FB] exit conv=%d stop=%s iters=%d mg=%.4g\n", (int)fb_conv, fb_stop, fb_iters, mg);
         if (fb_conv) {
             IO.beta = beta;  // eval_min left IO.x/IO.y/beta/rho on the converged state
             converged = true;

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -2702,9 +2702,12 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
     const bool cp_dbg_mich = std::getenv("CP_DBG_MICH") != nullptr;
     if (cp_dbg_mich) {
         double sp = 0, tn = 0;
-        for (std::size_t i = 0; i < N; ++i) { sp = std::max(sp, std::abs(IO.x[i] - IO.y[i])); tn += lnK[i]*lnK[i]; }
-        std::printf("[MICH] ENTRY T=%.6g p=%.6g beta0=%.6g spread0=%.4g trivnorm0=%.4g rhoL=%.6g rhoV=%.6g\n",
-                    (double)IO.T,(double)IO.p,(double)beta,sp,tn,(double)IO.rhomolar_liq,(double)IO.rhomolar_vap);
+        for (std::size_t i = 0; i < N; ++i) {
+            sp = std::max(sp, std::abs(IO.x[i] - IO.y[i]));
+            tn += lnK[i] * lnK[i];
+        }
+        std::printf("[MICH] ENTRY T=%.6g p=%.6g beta0=%.6g spread0=%.4g trivnorm0=%.4g rhoL=%.6g rhoV=%.6g\n", (double)IO.T, (double)IO.p,
+                    (double)beta, sp, tn, (double)IO.rhomolar_liq, (double)IO.rhomolar_vap);
     }
 
     // Reject a non-finite seed up front.  A stability false-positive at a single-phase point
@@ -2865,8 +2868,11 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
 
     if (cp_dbg_mich) {
         double sp = 0, tn = 0;
-        for (std::size_t i = 0; i < N; ++i) { sp = std::max(sp, std::abs(IO.x[i] - IO.y[i])); tn += lnK[i]*lnK[i]; }
-        std::printf("[MICH] postSS ss_converged=%d beta=%.6g spread=%.4g trivnorm=%.4g\n",(int)ss_converged,(double)beta,sp,tn);
+        for (std::size_t i = 0; i < N; ++i) {
+            sp = std::max(sp, std::abs(IO.x[i] - IO.y[i]));
+            tn += lnK[i] * lnK[i];
+        }
+        std::printf("[MICH] postSS ss_converged=%d beta=%.6g spread=%.4g trivnorm=%.4g\n", (int)ss_converged, (double)beta, sp, tn);
     }
     // Ensure phases are up-to-date after SS
     solve_rachford_rice();
@@ -3154,9 +3160,11 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         std::vector<CoolPropDbl> w = minority_is_liquid ? x0_stab : y0_stab;
         {
             CoolPropDbl sw = 0;
-            for (std::size_t i = 0; i < N; ++i) sw += std::max(w[i], static_cast<CoolPropDbl>(0));
+            for (std::size_t i = 0; i < N; ++i)
+                sw += std::max(w[i], static_cast<CoolPropDbl>(0));
             if (sw > 0) {
-                for (std::size_t i = 0; i < N; ++i) w[i] = std::max(w[i], static_cast<CoolPropDbl>(0)) / sw;
+                for (std::size_t i = 0; i < N; ++i)
+                    w[i] = std::max(w[i], static_cast<CoolPropDbl>(0)) / sw;
             } else {
                 w = IO.z;
             }
@@ -3178,7 +3186,8 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             }
         }
         std::vector<CoolPropDbl> a(N);
-        for (std::size_t i = 0; i < N; ++i) a[i] = 1e-3 * w[i];  // small incipient amount
+        for (std::size_t i = 0; i < N; ++i)
+            a[i] = 1e-3 * w[i];  // small incipient amount
         rho_warm_L = -1;
         rho_warm_V = -1;
 
@@ -3193,9 +3202,19 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             }
             if (!(A > 0) || !(B > 0)) return false;
             std::vector<CoolPropDbl> mn(N), mj(N);
-            for (std::size_t i = 0; i < N; ++i) { mn[i] = aa[i] / A; mj[i] = (IO.z[i] - aa[i]) / B; }
-            if (minority_is_liquid) { IO.x = mn; IO.y = mj; beta = B; }
-            else { IO.y = mn; IO.x = mj; beta = A; }
+            for (std::size_t i = 0; i < N; ++i) {
+                mn[i] = aa[i] / A;
+                mj[i] = (IO.z[i] - aa[i]) / B;
+            }
+            if (minority_is_liquid) {
+                IO.x = mn;
+                IO.y = mj;
+                beta = B;
+            } else {
+                IO.y = mn;
+                IO.x = mj;
+                beta = A;
+            }
             // Force the cold global (lowest-Gibbs) density solve every FB evaluation.  The warm-
             // start local Newton drifts to a nearby metastable root (within the 0.5x-2x branch
             // guard) after the first call, so the incipient/majority densities land on the wrong
@@ -3228,7 +3247,8 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         bool ok = eval_min(a, G_old, mg);  // seeds IO/SatL/SatV synced to a
         if (cp_dbg_mich) {
             CoolPropDbl As = 0;
-            for (std::size_t i = 0; i < N; ++i) As += a[i];
+            for (std::size_t i = 0; i < N; ++i)
+                As += a[i];
             std::printf("[MICH-FB] entry T=%.5g ok=%d minLiq=%d A=%.3g mg=%.4g beta_pre=%.6g\n", (double)IO.T, (int)ok, (int)minority_is_liquid,
                         (double)As, mg, (double)beta_pre);
         }
@@ -3249,7 +3269,11 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         double mg_best = mg;                 // lowest residual seen so far (the floor)
         int stall = 0;                       // iterations since the floor last improved meaningfully
         for (int it = 0; ok && it < fb_max_iter; ++it) {
-            if (mg < gibbs_tol) { fb_conv = true; fb_stop = "converged"; break; }
+            if (mg < gibbs_tol) {
+                fb_conv = true;
+                fb_stop = "converged";
+                break;
+            }
             // Stall exit: once the split is GENUINE (mg <= 1e-5) the equal-fugacity residual has
             // floored at ~1e-7 on density-solve accuracy, well before the 1e-9 quadratic target, so
             // exit rather than grind to the maxiter cap.  Track the FLOOR (mg_best), not the previous
@@ -3267,9 +3291,13 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
                 }
             }
             CoolPropDbl A = 0;
-            for (std::size_t i = 0; i < N; ++i) A += a[i];
+            for (std::size_t i = 0; i < N; ++i)
+                A += a[i];
             CoolPropDbl B = 1.0 - A;  // z normalized to 1
-            if (!(A > 1e-14) || !(B > 1e-14)) { fb_stop = "amt-boundary"; break; }
+            if (!(A > 1e-14) || !(B > 1e-14)) {
+                fb_stop = "amt-boundary";
+                break;
+            }
             // Phase-vanishing bail: if the incipient amount collapses far below any genuine near-dew
             // split (A ~ 1e-4 there) the feed is single-phase at this T -- no split exists -- so stop
             // instead of iterating to the cap on a residual that will never reach genuine.
@@ -3307,7 +3335,10 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             }
             std::vector<CoolPropDbl> sMinV(N, 0), sMajV(N, 0);
             for (std::size_t i = 0; i < N; ++i)
-                for (std::size_t k = 0; k < N; ++k) { sMinV[i] += mnc[k] * Dmin(i, k); sMajV[i] += mjc[k] * Dmaj(i, k); }
+                for (std::size_t k = 0; k < N; ++k) {
+                    sMinV[i] += mnc[k] * Dmin(i, k);
+                    sMajV[i] += mjc[k] * Dmaj(i, k);
+                }
             for (std::size_t i = 0; i < N; ++i)
                 for (std::size_t j = 0; j < N; ++j)
                     Hm(i, j) = (Dmin(i, j) - sMinV[i]) / A + (Dmaj(i, j) - sMajV[i]) / B;
@@ -3372,7 +3403,10 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
                 }
                 alpha *= 0.5;
             }
-            if (!step_accepted) { fb_stop = "no-step"; break; }
+            if (!step_accepted) {
+                fb_stop = "no-step";
+                break;
+            }
             fb_iters = it + 1;
         }
         // Re-sync IO/SatL/SatV to the final iterate a and measure the split we would publish.  The
@@ -3466,8 +3500,9 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
     // false positive is trivial (x==y), collapsed (beta -> 0/1), or grossly unconverged.
     if (cp_dbg_mich) {
         double sp = 0;
-        for (std::size_t i = 0; i < N; ++i) sp = std::max(sp, std::abs(IO.x[i] - IO.y[i]));
-        std::printf("[MICH] EXIT  converged=%d final_max_g=%.4g beta=%.6g spread=%.4g\n",(int)converged,(double)last_max_g,(double)beta,sp);
+        for (std::size_t i = 0; i < N; ++i)
+            sp = std::max(sp, std::abs(IO.x[i] - IO.y[i]));
+        std::printf("[MICH] EXIT  converged=%d final_max_g=%.4g beta=%.6g spread=%.4g\n", (int)converged, (double)last_max_g, (double)beta, sp);
     }
     if (!converged) {
         CoolPropDbl spread = 0;

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -3203,28 +3203,34 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         const double fb_genuine_tol = 1e-5;  // engineering equal-fugacity tolerance (matches the final gate)
         const int stall_genuine = 3;         // exit once genuine and floored
         double G_cur = G_old;                // consistent with the seed eval_min (cold global roots)
-        double mg_prev = mg;
-        int stall = 0;
+        double mg_best = mg;                 // lowest residual seen so far (the floor)
+        int stall = 0;                       // iterations since the floor last improved meaningfully
         for (int it = 0; ok && it < fb_max_iter; ++it) {
             if (mg < gibbs_tol) { fb_conv = true; fb_stop = "converged"; break; }
             // Stall exit: once the split is GENUINE (mg <= 1e-5) the equal-fugacity residual has
             // floored at ~1e-7 on density-solve accuracy, well before the 1e-9 quadratic target, so
-            // exit after a few flat steps rather than grinding to the maxiter cap.  A non-genuine
-            // probe (e.g. a single-phase T with no split) keeps iterating to the cap and is then
-            // rejected by the final gate.
-            if (mg < fb_genuine_tol && mg > mg_prev * (1.0 - 1e-3)) {
-                if (++stall >= stall_genuine) {
+            // exit rather than grind to the maxiter cap.  Track the FLOOR (mg_best), not the previous
+            // iterate: near the floor mg micro-oscillates (e.g. 1.43e-6 <-> 1.46e-6), and comparing
+            // against the previous value keeps flipping the counter so a genuine split never exits.
+            // Only a meaningful (>0.1%) drop in the floor resets the counter.
+            if (mg < mg_best * (1.0 - 1e-3)) {
+                mg_best = mg;
+                stall = 0;
+            } else {
+                mg_best = std::min(mg_best, mg);
+                if (mg < fb_genuine_tol && ++stall >= stall_genuine) {
                     fb_stop = "stall";
                     break;
                 }
-            } else {
-                stall = 0;
             }
-            mg_prev = mg;
             CoolPropDbl A = 0;
             for (std::size_t i = 0; i < N; ++i) A += a[i];
             CoolPropDbl B = 1.0 - A;  // z normalized to 1
             if (!(A > 1e-14) || !(B > 1e-14)) { fb_stop = "amt-boundary"; break; }
+            // Phase-vanishing bail: if the incipient amount collapses far below any genuine near-dew
+            // split (A ~ 1e-4 there) the feed is single-phase at this T -- no split exists -- so stop
+            // instead of iterating to the cap on a residual that will never reach genuine.
+            if (A < 1e-6 && mg > fb_genuine_tol) { fb_stop = "vanish"; break; }
 
             // SatL/SatV are synced to the current a (from the seed or the last accepted line-
             // search step).  Build the mole-number Gibbs gradient dG/da_i = ln f_i^min - ln

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -2696,6 +2696,9 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         lnK[i] = std::log(std::max(ratio, 1e-300));
     }
     CoolPropDbl beta = IO.beta;
+    // Snapshot the stability trial-phase seed (non-trivial by construction) for the V-space
+    // Newton fallback below (#3342 part 2 / CoolProp-1tbe.22).
+    const std::vector<CoolPropDbl> x0_stab = IO.x, y0_stab = IO.y;
     const bool cp_dbg_mich = std::getenv("CP_DBG_MICH") != nullptr;
     if (cp_dbg_mich) {
         double sp = 0, tn = 0;
@@ -3081,6 +3084,161 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         }
     }
     IO.beta = beta;
+
+    // --- Part-2 fallback (#3342 / CoolProp-1tbe.22): stability-seeded V-space Gibbs Newton. ---
+    // The reduced-gradient second-order phase above uses g_i = beta*(1-beta)*(lnf_V - lnf_L),
+    // which VANISHES as beta -> 1, so it stalls at the near-dew/near-bubble edge (beta pinned to a
+    // boundary, split not converged).  Following ThermoPack tp_solver::mod_newton_search, retry in
+    // vapour MOLE NUMBERS V (beta = sum(V) derived) with the UNSCALED gradient dG/dV_i = lnf_i^V -
+    // lnf_i^L (does not vanish at the boundary) and the mole-number Gibbs Hessian, seeded from the
+    // stability trial phases.  Additive and safe: it ACCEPTS only a converged result, and on any
+    // failure restores the pre-fallback state, so it can never regress a currently-passing case.
+    if (!converged) {
+        // Preserve the pre-fallback published state for exact restore on failure.
+        const std::vector<CoolPropDbl> x_pre = IO.x, y_pre = IO.y;
+        const CoolPropDbl beta_pre = beta, rhoL_pre = IO.rhomolar_liq, rhoV_pre = IO.rhomolar_vap;
+
+        std::vector<CoolPropDbl> xf = x0_stab, yf = y0_stab;
+        // Seed beta from a mole balance on the widest-spread component of the trial phases.
+        std::size_t iw = 0;
+        CoolPropDbl wbest = 0;
+        for (std::size_t i = 0; i < N; ++i) {
+            CoolPropDbl d = std::abs(yf[i] - xf[i]);
+            if (d > wbest) { wbest = d; iw = i; }
+        }
+        CoolPropDbl betaf = 0.5;
+        if (wbest > 1e-12) {
+            CoolPropDbl b = (IO.z[iw] - xf[iw]) / (yf[iw] - xf[iw]);
+            if (ValidNumber(b)) betaf = std::min(std::max(b, static_cast<CoolPropDbl>(1e-8)), static_cast<CoolPropDbl>(1.0 - 1e-8));
+        }
+        rho_warm_L = -1;
+        rho_warm_V = -1;
+
+        auto eval_state = [&](const std::vector<CoolPropDbl>& xx, const std::vector<CoolPropDbl>& yy, CoolPropDbl bb, double& G, double& mg) -> bool {
+            IO.x = xx;
+            IO.y = yy;
+            beta = bb;
+            if (!evaluate_phases()) return false;
+            HEOS.SatL->set_mole_fractions(IO.x);
+            HEOS.SatL->update_DmolarT_direct(IO.rhomolar_liq, IO.T);
+            HEOS.SatV->set_mole_fractions(IO.y);
+            HEOS.SatV->update_DmolarT_direct(IO.rhomolar_vap, IO.T);
+            mg = 0;
+            G = 0;
+            for (std::size_t i = 0; i < N; ++i) {
+                CoolPropDbl lV = std::log(IO.y[i]) + std::log(HEOS.SatV->fugacity_coefficient(i));
+                CoolPropDbl lL = std::log(IO.x[i]) + std::log(HEOS.SatL->fugacity_coefficient(i));
+                mg = std::max(mg, std::abs(lV - lL));
+                if (IO.x[i] > 0) G += (1.0 - beta) * IO.x[i] * lL;
+                if (IO.y[i] > 0) G += beta * IO.y[i] * lV;
+            }
+            return ValidNumber(G) && ValidNumber(mg);
+        };
+
+        bool fb_conv = false;
+        double G_cur = 0, mg_cur = 0;
+        bool ok = eval_state(xf, yf, betaf, G_cur, mg_cur);
+        if (cp_dbg_mich) std::printf("[MICH-FB] entry ok=%d betaf=%.6g mg=%.4g G=%.6g\n", (int)ok, (double)betaf, mg_cur, G_cur);
+        int fb_iters = 0;
+        const char* fb_stop = "maxiter";
+        const int fb_max_iter = 80;
+        for (int it = 0; ok && it < fb_max_iter; ++it) {
+            if (mg_cur < gibbs_tol) { fb_conv = true; fb_stop = "converged"; break; }
+            if (betaf <= 1e-10 || betaf >= 1.0 - 1e-10) { fb_stop = "beta-boundary"; break; }
+
+            // Unscaled gradient g_i = lnf_i^V - lnf_i^L and mole-number Gibbs Hessian.
+            Eigen::VectorXd g(N);
+            Eigen::MatrixXd Hm(N, N), DL(N, N), DV(N, N);
+            for (std::size_t i = 0; i < N; ++i) {
+                for (std::size_t j = 0; j < N; ++j) {
+                    DL(i, j) = CoolProp::MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(*(HEOS.SatL.get()), i, j, CoolProp::XN_INDEPENDENT);
+                    DV(i, j) = CoolProp::MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(*(HEOS.SatV.get()), i, j, CoolProp::XN_INDEPENDENT);
+                }
+            }
+            for (std::size_t i = 0; i < N; ++i) {
+                CoolPropDbl sL = 0, sV = 0;
+                for (std::size_t k = 0; k < N; ++k) { sL += IO.x[k] * DL(i, k); sV += IO.y[k] * DV(i, k); }
+                CoolPropDbl lV = std::log(IO.y[i]) + std::log(HEOS.SatV->fugacity_coefficient(i));
+                CoolPropDbl lL = std::log(IO.x[i]) + std::log(HEOS.SatL->fugacity_coefficient(i));
+                g(i) = lV - lL;
+                for (std::size_t j = 0; j < N; ++j) {
+                    Hm(i, j) = (DV(i, j) - sV) / betaf + (DL(i, j) - sL) / (1.0 - betaf);
+                }
+            }
+            // Positive-definite shift so the step is a descent direction.
+            Eigen::VectorXd ds;
+            {
+                double shift = 0.0;
+                bool solved = false;
+                for (int t = 0; t < 30; ++t) {
+                    Eigen::MatrixXd Hl = Hm;
+                    Hl.diagonal().array() += shift;
+                    Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(Hl, Eigen::EigenvaluesOnly);
+                    double mn = es.eigenvalues().minCoeff();
+                    if (!ValidNumber(mn)) break;
+                    if (mn < 1e-8) { shift += (1e-8 - mn); continue; }
+                    ds = Hl.ldlt().solve(-g);
+                    solved = true;
+                    break;
+                }
+                if (!solved) break;
+            }
+            // Capture the base vapour mole numbers NOW: eval_state() overwrites IO.y on every
+            // trial, so the step base must be snapshotted before the loop.
+            std::vector<CoolPropDbl> Vbase(N);
+            for (std::size_t i = 0; i < N; ++i) Vbase[i] = betaf * IO.y[i];
+            // Largest step that keeps every V_i strictly inside (0, z_i) -- near the dew a phase is
+            // a razor-thin sliver (V_i ~ z_i), so the full Newton step must be SCALED to the
+            // feasible boundary (ThermoPack's pos_scale), not rejected.
+            double t_max = 1.0;
+            for (std::size_t i = 0; i < N; ++i) {
+                if (ds(i) > 0) t_max = std::min(t_max, 0.99 * (IO.z[i] - Vbase[i]) / ds(i));
+                else if (ds(i) < 0) t_max = std::min(t_max, 0.99 * Vbase[i] / (-ds(i)));
+            }
+            if (!(t_max > 0)) { fb_stop = "t_max<=0"; break; }
+            bool accepted = false;
+            for (double t = t_max; t >= t_max / 1024; t *= 0.5) {
+                std::vector<CoolPropDbl> Vn(N), xt(N), yt(N);
+                CoolPropDbl Vtot = 0, Ltot = 0;
+                bool feasible = true;
+                for (std::size_t i = 0; i < N; ++i) {
+                    CoolPropDbl Vi = Vbase[i] + t * ds(i);
+                    if (!(Vi > 0) || !(Vi < IO.z[i])) { feasible = false; break; }
+                    Vn[i] = Vi;
+                    Vtot += Vi;
+                    Ltot += IO.z[i] - Vi;
+                }
+                if (!feasible || !(Vtot > 0) || !(Ltot > 0)) continue;
+                for (std::size_t i = 0; i < N; ++i) { yt[i] = Vn[i] / Vtot; xt[i] = (IO.z[i] - Vn[i]) / Ltot; }
+                double G_try, mg_try;
+                if (!eval_state(xt, yt, Vtot, G_try, mg_try)) continue;
+                if (G_try < G_cur - 1e-14) {
+                    xf = xt; yf = yt; betaf = Vtot; G_cur = G_try; mg_cur = mg_try;
+                    accepted = true;
+                    break;
+                }
+            }
+            if (!accepted) { fb_stop = "no-decrease"; break; }
+            fb_iters = it + 1;
+        }
+
+        if (cp_dbg_mich) std::printf("[MICH-FB] exit conv=%d stop=%s iters=%d mg=%.4g betaf=%.6g\n", (int)fb_conv, fb_stop, fb_iters, mg_cur, (double)betaf);
+        if (fb_conv) {
+            // eval_state left IO.x/IO.y/beta/rho on the converged fallback state.
+            beta = betaf;
+            IO.beta = beta;
+            converged = true;
+            if (cp_dbg_mich) std::printf("[MICH-FB] V-space fallback CONVERGED beta=%.6g max_g=%.4g\n", (double)betaf, mg_cur);
+        } else {
+            // Restore the exact pre-fallback state; behaviour is then identical to before.
+            IO.x = x_pre;
+            IO.y = y_pre;
+            beta = beta_pre;
+            IO.beta = beta;
+            IO.rhomolar_liq = rhoL_pre;
+            IO.rhomolar_vap = rhoV_pre;
+        }
+    }
 
     // Recompute the equal-fugacity residual on the FINAL published (IO.x, IO.y) state
     // so the gate below tests exactly what is returned, not a pre-step value captured

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -3267,7 +3267,7 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             CoolPropDbl A = 0;
             for (std::size_t i = 0; i < N; ++i)
                 A += a[i];
-            CoolPropDbl B = 1.0 - A;  // z normalized to 1
+            CoolPropDbl B = 1.0 - A;                  // z normalized to 1
             if (!(A > 1e-14) || !(B > 1e-14)) break;  // phase amount hit a bound
             // Phase-vanishing bail: if the incipient amount collapses far below any genuine near-dew
             // split (A ~ 1e-4 there) the feed is single-phase at this T -- no split exists -- so stop

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -3270,6 +3270,19 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
                     Dmaj(i, j) = CoolProp::MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(*Smaj, i, j, CoolProp::XN_INDEPENDENT);
                 }
             }
+            // dln_fugacity_dxj__constT_p_xi hardcodes the ideal term d(ln x_i)/dx_j for the
+            // XN_DEPENDENT convention: for the LAST component it adds -1/x_{N-1} on every j.  We call
+            // it with XN_INDEPENDENT (all x_i treated independent, then projected), where the correct
+            // ideal term for the last component is delta_{N-1,j}/x_{N-1}.  Left uncorrected, row N-1
+            // (the last component -- often the dominant one near the dew) is wrong and flips the
+            // smallest Hessian eigenvalue negative (FD-verified).  Correct that one row for both phases.
+            {
+                const std::size_t last = N - 1;
+                for (std::size_t j = 0; j < N; ++j) {
+                    Dmin(last, j) += 1.0 / mnc[last] + (j == last ? 1.0 / mnc[last] : 0.0);
+                    Dmaj(last, j) += 1.0 / mjc[last] + (j == last ? 1.0 / mjc[last] : 0.0);
+                }
+            }
             for (std::size_t i = 0; i < N; ++i) {
                 CoolPropDbl lnf_min = std::log(mnc[i]) + std::log(Smin->fugacity_coefficient(i));
                 CoolPropDbl lnf_maj = std::log(mjc[i]) + std::log(Smaj->fugacity_coefficient(i));
@@ -3360,10 +3373,41 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         CoolPropDbl fb_spread = 0;
         for (std::size_t i = 0; i < N; ++i)
             fb_spread = std::max(fb_spread, std::abs(IO.x[i] - IO.y[i]));
-        const bool fb_genuine = fb_eval_ok && ValidNumber(mg_fin) && mg_fin <= 1e-5 && fb_spread >= 1e-4 && beta > 1e-8 && beta < 1.0 - 1e-8;
+        // Gibbs-descent guard: publish a two-phase split ONLY if its reduced Gibbs lies below the
+        // single-phase (feed) Gibbs.  Now that the fallback is a competent optimiser it can converge
+        // to a genuine equal-fugacity split even for a stability FALSE POSITIVE (a subcooled liquid
+        // or superheated vapour, e.g. GH #3168 methanol-benzene) -- but that split is METASTABLE
+        // (higher Gibbs than the single phase) and must not be published as two-phase.  Compute the
+        // single-phase reference at the feed with the same cold global (lowest-Gibbs) root eval_min
+        // uses, so the comparison is on one consistent surface.
+        double G_single = HUGE_VAL;
+        {
+            HEOS.SatL->set_mole_fractions(IO.z);
+            CoolPropDbl rw = -1;
+            try {
+                CoolPropDbl rz = solve_trial_rho_warm(*HEOS.SatL, IO.T, IO.p, rw);
+                HEOS.SatL->update_DmolarT_direct(rz, IO.T);
+                double gs = 0;
+                for (std::size_t i = 0; i < N; ++i)
+                    if (IO.z[i] > 0)
+                        gs += static_cast<double>(IO.z[i]) * (std::log(static_cast<double>(IO.z[i])) + std::log(HEOS.SatL->fugacity_coefficient(i)));
+                G_single = gs;
+            } catch (...) {
+                G_single = HUGE_VAL;  // reference unavailable -> do not block on it
+            }
+        }
+        const bool fb_lower_gibbs = fb_eval_ok && ValidNumber(G_fin) && G_fin < G_single - 1e-10;
+        // Vapour-liquid ordering: solve_michelsen is a VLE flash, so a genuine split must have the
+        // liquid denser than the vapour.  A split with rho_vap >= rho_liq is a mislabeled/spurious
+        // liquid-liquid split -- e.g. the poor-kij methanol-benzene LLE the EOS predicts (GH #3168);
+        // the flash finds it (lower Gibbs per the model) but it must not be published as VLE.
+        const bool fb_vle_order = IO.rhomolar_liq > IO.rhomolar_vap;
+        const bool fb_genuine = fb_eval_ok && ValidNumber(mg_fin) && mg_fin <= 1e-5 && fb_spread >= 1e-4 && beta > 1e-8 && beta < 1.0 - 1e-8
+                                && fb_lower_gibbs && fb_vle_order;
         if (cp_dbg_mich)
-            std::printf("[MICH-FB] exit conv=%d stop=%s iters=%d mg=%.4g genuine=%d spread=%.4g beta=%.6g\n", (int)fb_conv, fb_stop, fb_iters, mg_fin,
-                        (int)fb_genuine, (double)fb_spread, (double)beta);
+            std::printf("[MICH-FB] exit conv=%d stop=%s iters=%d mg=%.4g genuine=%d spread=%.4g beta=%.6g dG=%.3e rhoL=%.5g rhoV=%.5g\n",
+                        (int)fb_conv, fb_stop, fb_iters, mg_fin, (int)fb_genuine, (double)fb_spread, (double)beta, G_fin - G_single,
+                        (double)IO.rhomolar_liq, (double)IO.rhomolar_vap);
         if (fb_genuine) {
             IO.beta = beta;                    // eval_min left IO.x/IO.y/beta/rho on the best split
             converged = (mg_fin < gibbs_tol);  // else the final gate re-validates the genuine split

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -3231,8 +3231,8 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             return ValidNumber(G) && ValidNumber(mg);
         };
 
-        double G_old = 0, mg = 0;
-        bool ok = eval_min(a, G_old, mg);  // seeds IO/SatL/SatV synced to a
+        double fb_G_old = 0, mg = 0;
+        bool ok = eval_min(a, fb_G_old, mg);  // seeds IO/SatL/SatV synced to a
         // Globalised Newton on the minority mole numbers a, mirroring ThermoPack
         // tp_solver::mod_newton_search + optimizers::mod_newton: a positive-definite
         // (guaranteed-descent) Newton direction with a steepest-descent safeguard, a single-
@@ -3246,7 +3246,7 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         const int max_ls = 40;               // Armijo backtracking tries per outer iteration
         const double fb_genuine_tol = 1e-5;  // engineering equal-fugacity tolerance (matches the final gate)
         const int stall_genuine = 3;         // exit once genuine and floored
-        double G_cur = G_old;                // consistent with the seed eval_min (cold global roots)
+        double G_cur = fb_G_old;             // consistent with the seed eval_min (cold global roots)
         double mg_best = mg;                 // lowest residual seen so far (the floor)
         int stall = 0;                       // iterations since the floor last improved meaningfully
         for (int it = 0; ok && it < fb_max_iter; ++it) {

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -3097,8 +3097,6 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
     // safe: ACCEPTS only a converged result; on any failure restores the exact pre-fallback state,
     // so it can never regress a currently-passing case.
     if (!converged) {
-        const bool cp_dbg_fb = std::getenv("CP_DBG_MICH_FB") != nullptr;
-        const bool fb_warm_rho = std::getenv("CP_MICH_WARMRHO") != nullptr;    // A/B: allow warm-start density (drifts to metastable root)
         const std::vector<CoolPropDbl> x_pre = IO.x, y_pre = IO.y;
         const CoolPropDbl beta_pre = beta, rhoL_pre = IO.rhomolar_liq, rhoV_pre = IO.rhomolar_vap;
 
@@ -3120,7 +3118,8 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
                 w = IO.z;
             }
             CoolPropDbl wz_spread = 0;
-            for (std::size_t i = 0; i < N; ++i) wz_spread = std::max(wz_spread, std::abs(w[i] - IO.z[i]));
+            for (std::size_t i = 0; i < N; ++i)
+                wz_spread = std::max(wz_spread, std::abs(w[i] - IO.z[i]));
             if (wz_spread < 1e-3) {  // trial ~ feed -> reseed from Wilson K-factors
                 CoolPropDbl sw2 = 0;
                 for (std::size_t i = 0; i < N; ++i) {
@@ -3129,7 +3128,8 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
                     sw2 += w[i];
                 }
                 if (sw2 > 0)
-                    for (std::size_t i = 0; i < N; ++i) w[i] /= sw2;
+                    for (std::size_t i = 0; i < N; ++i)
+                        w[i] /= sw2;
                 else
                     w = minority_is_liquid ? x0_stab : y0_stab;  // Wilson unusable; keep the trial
             }
@@ -3159,7 +3159,8 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             // sheet -- the objective, gradient and acceptance test then live on a higher-Gibbs
             // surface and the line search stalls.  Global keeps every evaluation on the same
             // stable roots the seed was built on.
-            if (!fb_warm_rho) { rho_warm_L = -1; rho_warm_V = -1; }
+            rho_warm_L = -1;
+            rho_warm_V = -1;
             if (!evaluate_phases()) return false;
             HEOS.SatL->set_mole_fractions(IO.x);
             HEOS.SatL->update_DmolarT_direct(IO.rhomolar_liq, IO.T);
@@ -3185,11 +3186,8 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         if (cp_dbg_mich) {
             CoolPropDbl As = 0;
             for (std::size_t i = 0; i < N; ++i) As += a[i];
-            std::printf("[MICH-FB] entry T=%.5g ok=%d minLiq=%d A=%.3g mg=%.4g beta_pre=%.6g\n", (double)IO.T, (int)ok, (int)minority_is_liquid, (double)As, mg, (double)beta_pre);
-            if (cp_dbg_fb) {
-                std::printf("[MICH-FB]   z    ="); for (std::size_t i = 0; i < N; ++i) std::printf(" %.4e", (double)IO.z[i]); std::printf("\n");
-                std::printf("[MICH-FB]   a0   ="); for (std::size_t i = 0; i < N; ++i) std::printf(" %.4e", (double)a[i]); std::printf("\n");
-            }
+            std::printf("[MICH-FB] entry T=%.5g ok=%d minLiq=%d A=%.3g mg=%.4g beta_pre=%.6g\n", (double)IO.T, (int)ok, (int)minority_is_liquid,
+                        (double)As, mg, (double)beta_pre);
         }
         // Globalised Newton on the minority mole numbers a, mirroring ThermoPack
         // tp_solver::mod_newton_search + optimizers::mod_newton: a positive-definite
@@ -3201,10 +3199,10 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         // evaluation stays on the same stable density sheet as the seed.
         const int fb_max_iter = 100;
         const double armijo_c1 = 1e-4;
-        const int max_ls = 40;      // Armijo backtracking tries per outer iteration
+        const int max_ls = 40;               // Armijo backtracking tries per outer iteration
         const double fb_genuine_tol = 1e-5;  // engineering equal-fugacity tolerance (matches the final gate)
-        const int stall_genuine = 3;   // exit once genuine and floored
-        double G_cur = G_old;  // consistent with the seed eval_min (cold global roots)
+        const int stall_genuine = 3;         // exit once genuine and floored
+        double G_cur = G_old;                // consistent with the seed eval_min (cold global roots)
         double mg_prev = mg;
         int stall = 0;
         for (int it = 0; ok && it < fb_max_iter; ++it) {
@@ -3215,7 +3213,10 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             // probe (e.g. a single-phase T with no split) keeps iterating to the cap and is then
             // rejected by the final gate.
             if (mg < fb_genuine_tol && mg > mg_prev * (1.0 - 1e-3)) {
-                if (++stall >= stall_genuine) { fb_stop = "stall"; break; }
+                if (++stall >= stall_genuine) {
+                    fb_stop = "stall";
+                    break;
+                }
             } else {
                 stall = 0;
             }
@@ -3231,7 +3232,10 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             HelmholtzEOSMixtureBackend* Smin = minority_is_liquid ? HEOS.SatL.get() : HEOS.SatV.get();
             HelmholtzEOSMixtureBackend* Smaj = minority_is_liquid ? HEOS.SatV.get() : HEOS.SatL.get();
             std::vector<CoolPropDbl> mnc(N), mjc(N);
-            for (std::size_t i = 0; i < N; ++i) { mnc[i] = a[i] / A; mjc[i] = (IO.z[i] - a[i]) / B; }
+            for (std::size_t i = 0; i < N; ++i) {
+                mnc[i] = a[i] / A;
+                mjc[i] = (IO.z[i] - a[i]) / B;
+            }
             Eigen::MatrixXd Dmin(N, N), Dmaj(N, N), Hm(N, N);
             Eigen::VectorXd grad(N);
             for (std::size_t i = 0; i < N; ++i) {
@@ -3254,12 +3258,6 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             // Symmetrize away finite-difference asymmetry before the SPD solve.
             Hm = (0.5 * (Hm + Hm.transpose())).eval();
 
-            if (cp_dbg_fb) {
-                std::printf("[MICH-FB]  it=%d A=%.4e mg=%.4e G=%.8g\n", it, (double)A, mg, G_cur);
-                std::printf("[MICH-FB]    a   ="); for (std::size_t i = 0; i < N; ++i) std::printf(" %.4e", (double)a[i]); std::printf("\n");
-                std::printf("[MICH-FB]    gmol="); for (std::size_t i = 0; i < N; ++i) std::printf(" %+.3e", grad(i)); std::printf("\n");
-            }
-
             // Eigenvalue-modified Newton direction.  The mole-number Gibbs Hessian is (a) genuinely
             // INDEFINITE far from the solution -- the dominant component's diagonal can be negative,
             // so LM diag scaling can never make it PD -- and (b) severely ill-conditioned near the
@@ -3269,7 +3267,10 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             // caps the condition number, so the step along the soft mode stays bounded and the
             // single fraction-to-the-boundary scalar no longer has to throttle the stiff directions.
             Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> es(Hm);
-            if (es.info() != Eigen::Success) { fb_stop = "eig-fail"; break; }
+            if (es.info() != Eigen::Success) {
+                fb_stop = "eig-fail";
+                break;
+            }
             const Eigen::VectorXd evals = es.eigenvalues();
             const Eigen::MatrixXd& Q = es.eigenvectors();
             // Gill-Murray-style modification: replace each eigenvalue lambda_k by max(|lambda_k|,
@@ -3279,12 +3280,9 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             // limit then throttles to nothing.  The relative floor only caps the condition number.
             const double efloor = 1e-10 * std::max(evals.cwiseAbs().maxCoeff(), 1e-300);
             Eigen::VectorXd gq = Q.transpose() * grad;
-            for (std::size_t i = 0; i < N; ++i) gq(i) /= std::max(std::abs(evals(i)), efloor);
+            for (std::size_t i = 0; i < N; ++i)
+                gq(i) /= std::max(std::abs(evals(i)), efloor);
             Eigen::VectorXd d = -(Q * gq);  // = -(modified Hm)^{-1} grad, guaranteed descent
-            if (cp_dbg_fb) {
-                std::printf("[MICH-FB]    Hdiag="); for (std::size_t i = 0; i < N; ++i) std::printf(" %+.3e", Hm(i, i)); std::printf("\n");
-                std::printf("[MICH-FB]    eval ="); for (std::size_t i = 0; i < N; ++i) std::printf(" %+.3e", evals(i)); std::printf("\n");
-            }
 
             // Fraction-to-the-boundary (ThermoPack limitDV): one scalar keeps every
             // 0 < a_i + t*d_i < z_i, preserving the Newton direction (a per-component clamp would
@@ -3292,8 +3290,10 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             double t = 1.0;
             for (std::size_t i = 0; i < N; ++i) {
                 double di = d(i);
-                if (a[i] + di <= 0.0) t = std::min(t, -static_cast<double>(a[i]) / di);
-                else if (a[i] + di >= IO.z[i]) t = std::min(t, (static_cast<double>(IO.z[i]) - static_cast<double>(a[i])) / di);
+                if (a[i] + di <= 0.0)
+                    t = std::min(t, -static_cast<double>(a[i]) / di);
+                else if (a[i] + di >= IO.z[i])
+                    t = std::min(t, (static_cast<double>(IO.z[i]) - static_cast<double>(a[i])) / di);
             }
             if (t < 1.0) d *= (t * (1.0 - 1e-10));
 
@@ -3304,14 +3304,14 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             bool step_accepted = false;
             std::vector<CoolPropDbl> at(N);
             for (int ls = 0; ls < max_ls; ++ls) {
-                for (std::size_t i = 0; i < N; ++i) at[i] = a[i] + alpha * d(i);
+                for (std::size_t i = 0; i < N; ++i)
+                    at[i] = a[i] + alpha * d(i);
                 double G_new = 0, mg_new = 0;
                 if (eval_min(at, G_new, mg_new) && G_new <= G_cur + armijo_c1 * alpha * gTd) {
                     a = at;
                     G_cur = G_new;
                     mg = mg_new;
                     step_accepted = true;
-                    if (cp_dbg_fb) std::printf("[MICH-FB]    -> accept ls=%d alpha=%.3e t=%.3e Gnew=%.8g mgnew=%.4e\n", ls, alpha, t, G_new, mg_new);
                     break;
                 }
                 alpha *= 0.5;
@@ -3332,14 +3332,14 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         double G_fin = 0, mg_fin = 0;
         const bool fb_eval_ok = eval_min(a, G_fin, mg_fin);
         CoolPropDbl fb_spread = 0;
-        for (std::size_t i = 0; i < N; ++i) fb_spread = std::max(fb_spread, std::abs(IO.x[i] - IO.y[i]));
-        const bool fb_genuine = fb_eval_ok && ValidNumber(mg_fin) && mg_fin <= 1e-5 && fb_spread >= 1e-4
-                                && beta > 1e-8 && beta < 1.0 - 1e-8;
+        for (std::size_t i = 0; i < N; ++i)
+            fb_spread = std::max(fb_spread, std::abs(IO.x[i] - IO.y[i]));
+        const bool fb_genuine = fb_eval_ok && ValidNumber(mg_fin) && mg_fin <= 1e-5 && fb_spread >= 1e-4 && beta > 1e-8 && beta < 1.0 - 1e-8;
         if (cp_dbg_mich)
-            std::printf("[MICH-FB] exit conv=%d stop=%s iters=%d mg=%.4g genuine=%d spread=%.4g beta=%.6g\n",
-                        (int)fb_conv, fb_stop, fb_iters, mg_fin, (int)fb_genuine, (double)fb_spread, (double)beta);
+            std::printf("[MICH-FB] exit conv=%d stop=%s iters=%d mg=%.4g genuine=%d spread=%.4g beta=%.6g\n", (int)fb_conv, fb_stop, fb_iters, mg_fin,
+                        (int)fb_genuine, (double)fb_spread, (double)beta);
         if (fb_genuine) {
-            IO.beta = beta;  // eval_min left IO.x/IO.y/beta/rho on the best split
+            IO.beta = beta;                    // eval_min left IO.x/IO.y/beta/rho on the best split
             converged = (mg_fin < gibbs_tol);  // else the final gate re-validates the genuine split
         } else {
             IO.x = x_pre;

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -1,6 +1,8 @@
 
 #include "HelmholtzEOSMixtureBackend.h"
 #include "VLERoutines.h"
+#include <cstdlib>
+#include <cstdio>
 #include <numeric>
 
 #include <cmath>
@@ -2694,6 +2696,13 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         lnK[i] = std::log(std::max(ratio, 1e-300));
     }
     CoolPropDbl beta = IO.beta;
+    const bool cp_dbg_mich = std::getenv("CP_DBG_MICH") != nullptr;
+    if (cp_dbg_mich) {
+        double sp = 0, tn = 0;
+        for (std::size_t i = 0; i < N; ++i) { sp = std::max(sp, std::abs(IO.x[i] - IO.y[i])); tn += lnK[i]*lnK[i]; }
+        std::printf("[MICH] ENTRY T=%.6g p=%.6g beta0=%.6g spread0=%.4g trivnorm0=%.4g rhoL=%.6g rhoV=%.6g\n",
+                    (double)IO.T,(double)IO.p,(double)beta,sp,tn,(double)IO.rhomolar_liq,(double)IO.rhomolar_vap);
+    }
 
     // Reject a non-finite seed up front.  A stability false-positive at a single-phase point
     // (e.g. below the bubble) can hand in a NaN trial composition; without this guard the NaN
@@ -2819,6 +2828,11 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         }
     }
 
+    if (cp_dbg_mich) {
+        double sp = 0, tn = 0;
+        for (std::size_t i = 0; i < N; ++i) { sp = std::max(sp, std::abs(IO.x[i] - IO.y[i])); tn += lnK[i]*lnK[i]; }
+        std::printf("[MICH] postSS ss_converged=%d beta=%.6g spread=%.4g trivnorm=%.4g\n",(int)ss_converged,(double)beta,sp,tn);
+    }
     // Ensure phases are up-to-date after SS
     solve_rachford_rice();
     if (!evaluate_phases()) {
@@ -3063,6 +3077,11 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
     // single-phase.  Distinguish the two: a genuine split has a non-trivial composition spread
     // AND an interior phase fraction AND an equal-fugacity residual at engineering tolerance; a
     // false positive is trivial (x==y), collapsed (beta -> 0/1), or grossly unconverged.
+    if (cp_dbg_mich) {
+        double sp = 0;
+        for (std::size_t i = 0; i < N; ++i) sp = std::max(sp, std::abs(IO.x[i] - IO.y[i]));
+        std::printf("[MICH] EXIT  converged=%d final_max_g=%.4g beta=%.6g spread=%.4g\n",(int)converged,(double)last_max_g,(double)beta,sp);
+    }
     if (!converged) {
         CoolPropDbl spread = 0;
         for (std::size_t i = 0; i < N; ++i)

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -2815,15 +2815,47 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
 
         if (ss_converged) break;
 
-        // GDEM extrapolation ([M&M2007] Ch. 12, Sec. 12.6)
+        // GDEM extrapolation ([M&M2007] Ch. 12, Sec. 12.6) with a try-then-revert guard, ported
+        // from ThermoPack's tp_solver::twoPhaseTPflash.  The extrapolation is SPECULATIVE: the
+        // factor ratio/(1-ratio) blows up as ratio -> 1, and applying it to a non-contracting
+        // error throws lnK across the liquid/vapor phase boundary and collapses the split (the
+        // GitHub #3342 near-dew failure).  So: only extrapolate a genuinely contracting sequence
+        // (ThermoPack's k_dem gate lambda < 1), then take one SS step and KEEP the extrapolation
+        // only if it reduced the SS error norm; otherwise roll lnK and the phase state back to the
+        // pre-extrapolation values.  This preserves the acceleration where it helps and cannot
+        // flip or collapse the split where it does not.
         if (esq_pair[0] > 0) {
             double ratio = std::sqrt(esq_pair[1] / esq_pair[0]);
-            // A NaN ratio (non-finite esq) passes both < 0 and >= 0.95, so guard it
-            // explicitly -- otherwise it poisons the GDEM lnK/Y update (CoolProp-1tbe.8 finding 4c).
-            if (!ValidNumber(ratio) || ratio < 0 || ratio >= 0.95) ratio = 0.95;
-            double factor = ratio / (1.0 - ratio);
-            for (std::size_t i = 0; i < N; ++i) {
-                lnK[i] += factor * err[i];
+            if (ValidNumber(ratio) && ratio > 0 && ratio < 1.0) {
+                const double factor = ratio / (1.0 - ratio);
+                // Snapshot the pre-extrapolation state for a possible revert.
+                const std::vector<CoolPropDbl> lnK_save = lnK, x_save = IO.x, y_save = IO.y;
+                const CoolPropDbl rhoL_save = IO.rhomolar_liq, rhoV_save = IO.rhomolar_vap, beta_save = beta;
+                const double esq_before = esq_pair[1];  // SS error norm entering the extrapolation
+                for (std::size_t i = 0; i < N; ++i) {
+                    lnK[i] += factor * err[i];
+                }
+                // Take one SS step on the extrapolated K and measure whether it helped.
+                solve_rachford_rice();
+                double esq_after = _HUGE;
+                if (evaluate_phases()) {
+                    esq_after = 0;
+                    for (std::size_t i = 0; i < N; ++i) {
+                        double lnK_new = std::log(HEOS.SatL->fugacity_coefficient(i)) - std::log(HEOS.SatV->fugacity_coefficient(i));
+                        double d = lnK_new - lnK[i];
+                        esq_after += IO.z[i] * d * d;
+                        lnK[i] = lnK_new;
+                    }
+                }
+                if (!(esq_after < esq_before)) {
+                    // Extrapolation hurt (or its trial evaluation failed): revert.
+                    lnK = lnK_save;
+                    IO.x = x_save;
+                    IO.y = y_save;
+                    IO.rhomolar_liq = rhoL_save;
+                    IO.rhomolar_vap = rhoV_save;
+                    beta = beta_save;
+                }
             }
         }
     }

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -3543,17 +3543,21 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
     CoolPropDbl spread = 0;
     for (std::size_t i = 0; i < N; ++i)
         spread = std::max(spread, std::abs(IO.x[i] - IO.y[i]));
-    // Trivial/collapsed rejection applies to EVERY published split, converged or not: a trivial
-    // split (x == y) satisfies the equal-fugacity residual identically, so converged == true does
-    // NOT imply a real two-phase state, and such a state must not slip past as a "converged" split.
-    // The trivial threshold (1e-7) sits far below any genuine split -- a near-critical two-phase
-    // state still has spread well above it -- so this does not reject a real near-critical split.
-    const bool trivial_or_collapsed = !(spread > 1e-7) || !(beta > 1e-8) || !(beta < 1.0 - 1e-8);
+    // Converged-trivial guard (the converged-path half of #3168): a split that is composition-
+    // trivial (x == y) satisfies the equal-fugacity residual identically, so converged == true does
+    // NOT imply a real two-phase state -- reject it even though the residual is met.  Gate ONLY on
+    // the composition spread here, NOT on beta: a genuine dew/bubble split legitimately has beta
+    // -> 0/1 (a vanishing incipient phase, the #3342 target -- e.g. a flash AT the dew point returns
+    // beta ~ 1 with a full-size composition spread), and collapse of beta to a single phase is
+    // handled by the caller's own beta -> 0/1 guard.  The trivial threshold (1e-7) sits far below
+    // any genuine split, including near-critical, so this does not reject a real split.
+    const bool converged_trivial = !(spread > 1e-7);
     // When NOT at the strict quadratic tolerance, additionally require a genuine near-converged
-    // equilibrium (engineering residual + non-trivial spread), else throw -- restoring the
-    // no-silent-wrong-answer contract for wide-boiling splits that stall at ~1e-6.
-    const bool near_converged_genuine = ValidNumber(last_max_g) && last_max_g <= 1e-5 && spread >= 1e-4;
-    if (trivial_or_collapsed || (!converged && !near_converged_genuine)) {
+    // equilibrium -- engineering residual, non-trivial spread, AND an interior phase fraction --
+    // else throw, restoring the no-silent-wrong-answer contract for wide-boiling splits that stall
+    // at ~1e-6.  (This matches the pre-existing #3168/#3192 gate exactly on the !converged path.)
+    const bool near_converged_genuine = ValidNumber(last_max_g) && last_max_g <= 1e-5 && spread >= 1e-4 && beta > 1e-8 && beta < 1.0 - 1e-8;
+    if (converged_trivial || (!converged && !near_converged_genuine)) {
         IO.nonconvergence = true;
         throw SolutionError(format("PTflash_twophase::solve_michelsen failed to converge: max|ln f_V - ln f_L| = %g at T = %g K, p = %g Pa",
                                    last_max_g, static_cast<double>(IO.T), static_cast<double>(IO.p)));

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -2353,12 +2353,32 @@ bool StabilityRoutines::StabilityEvaluationClass::minimize_tpd(std::vector<CoolP
             return true;
         }
 
-        // Build Hessian
+        // Build Hessian.
+        //
+        // The curvature term multiplying (half_alpha_i * half_alpha_j / N_tot) is the
+        // mole-number log-fugacity-COEFFICIENT derivative  n * d(ln phi_i)/dn_j , NOT the
+        // full log-fugacity derivative  d(ln f_i)/dx_j .  They differ by the ideal-gas term
+        // delta_ij/y_i, which the alpha-transform already carries via the delta_ij(1 + s_i/2)
+        // diagonal and the sqrt(W) Jacobian; adding it again here (as dln_fugacity_dxj did)
+        // double-counts it and, worse, drops the Gibbs-Duhem projection  sum_k y_k D(i,k)
+        // that makes the curvature matrix symmetric (Maxwell reciprocity
+        // d(ln phi_i)/dn_j = d(ln phi_j)/dn_i).  Feeding d(ln f_i)/dx_j flipped the MSVC
+        // stability verdict for methanol/benzene near x_meoh = 0.54, publishing a spurious
+        // LLE split as VLE (GH #3357, jakobreichert; latent until the XN_INDEPENDENT ideal
+        // term was corrected in dln_fugacity_dxj__constT_p_xi).  This mirrors the coefficient
+        // derivative + mole-number projection already used by the Phase-2 Gibbs Hessian below.
+        Eigen::MatrixXd D(N, N);
+        for (std::size_t i = 0; i < N; ++i)
+            for (std::size_t j = 0; j < N; ++j)
+                D(i, j) = MixtureDerivatives::dln_fugacity_coefficient_dxj__constT_p_xi(*(HEOS.SatV.get()), i, j, XN_INDEPENDENT);
         Eigen::MatrixXd H(N, N);
         for (std::size_t i = 0; i < N; ++i) {
             double ahi = half_alpha[i] / sumY;
+            double sum_yD = 0;  // sum_k y_k D(i,k): the mole-number projection
+            for (std::size_t k = 0; k < N; ++k)
+                sum_yD += y_norm[k] * D(i, k);
             for (std::size_t j = 0; j <= i; ++j) {
-                double dln_phi_dnj = MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(*(HEOS.SatV.get()), i, j, XN_INDEPENDENT);
+                double dln_phi_dnj = D(i, j) - sum_yD;  // n * d(ln phi_i)/dn_j
                 double term = ahi * half_alpha[j] * dln_phi_dnj;
                 H(i, j) = term;
                 H(j, i) = term;

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -2844,12 +2844,19 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
                     }
                 }
                 if (!(esq_after < esq_before)) {
-                    // Extrapolation hurt (or its trial evaluation failed): revert.
+                    // Extrapolation hurt (or its trial evaluation failed): revert.  The trial's
+                    // evaluate_phases() also advanced the warm-start roots rho_warm_L/V to the
+                    // rejected extrapolated composition; restore those too, otherwise the required
+                    // evaluate_phases() after the SS loop warm-starts from the rejected roots and can
+                    // land the restored composition on a different (metastable) density branch,
+                    // silently overwriting the reverted state.
                     lnK = lnK_save;
                     IO.x = x_save;
                     IO.y = y_save;
                     IO.rhomolar_liq = rhoL_save;
                     IO.rhomolar_vap = rhoV_save;
+                    rho_warm_L = rhoL_save;
+                    rho_warm_V = rhoV_save;
                     beta = beta_save;
                 }
             }
@@ -2918,11 +2925,21 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
             Eigen::VectorXd g(N), dia(N);
             Eigen::MatrixXd H(N, N);
             CoolPropDbl max_g = 0;
+            // Fugacity-COEFFICIENT composition derivatives d(ln phi_i)/dx_j.  The Hessian assembled
+            // below adds the ideal-gas contribution itself (the "- 1.0" projection term and the
+            // diagonal V_frac/x_i + L_frac/y_i), so it must be fed the coefficient derivative, NOT
+            // the full fugacity derivative d(ln f_i)/dx_j = d(ln phi_i)/dx_j + delta_ij/x_i.  Feeding
+            // the full derivative (as this site did before) double-counts the ideal term -- off-
+            // diagonals become "... - 2" instead of "... - 1" and the diagonal ideal is doubled --
+            // degrading the Hessian's conditioning and, for some mixtures (e.g. N2/O2/Ar), stalling
+            // Phase 2 short of the strict tolerance so it falls through to the expensive fallback.
             Eigen::MatrixXd DL(N, N), DV(N, N);
             for (std::size_t i = 0; i < N; ++i) {
                 for (std::size_t j = 0; j < N; ++j) {
-                    DL(i, j) = CoolProp::MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(*(HEOS.SatL.get()), i, j, CoolProp::XN_INDEPENDENT);
-                    DV(i, j) = CoolProp::MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(*(HEOS.SatV.get()), i, j, CoolProp::XN_INDEPENDENT);
+                    DL(i, j) =
+                      CoolProp::MixtureDerivatives::dln_fugacity_coefficient_dxj__constT_p_xi(*(HEOS.SatL.get()), i, j, CoolProp::XN_INDEPENDENT);
+                    DV(i, j) =
+                      CoolProp::MixtureDerivatives::dln_fugacity_coefficient_dxj__constT_p_xi(*(HEOS.SatV.get()), i, j, CoolProp::XN_INDEPENDENT);
                 }
             }
             for (std::size_t i = 0; i < N; ++i) {

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -3420,39 +3420,9 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
         double G_single = HUGE_VAL;
         {
             HEOS.SatL->set_mole_fractions(IO.z);
-            CoolPropDbl rz = -1;
-            CoolPropDbl rw = -1;
-            try {
-                rz = solve_trial_rho_warm(*HEOS.SatL, IO.T, IO.p, rw);
-            } catch (...) {
-                rz = -1;
-            }
-            // The global lowest-Gibbs root can fail for a multiparameter mixture when p lies between
-            // the spinodal pressures -- exactly the near-dew regime this fallback targets (the same
-            // failure check_stability_michelsen guards at ~2108).  Fall back to a phase-specified
-            // root so the single-phase reference stays available and the Gibbs-descent guard below
-            // does not silently no-op (fail open).
-            if (!(rz > 0)) {
-                try {
-                    HEOS.SatL->specify_phase(iphase_gas);
-                    rz = HEOS.SatL->solver_rho_Tp(IO.T, IO.p);
-                    HEOS.SatL->unspecify_phase();
-                } catch (...) {
-                    HEOS.SatL->unspecify_phase();
-                    rz = -1;
-                }
-            }
-            if (!(rz > 0)) {
-                try {
-                    HEOS.SatL->specify_phase(iphase_liquid);
-                    rz = HEOS.SatL->solver_rho_Tp(IO.T, IO.p);
-                    HEOS.SatL->unspecify_phase();
-                } catch (...) {
-                    HEOS.SatL->unspecify_phase();
-                    rz = -1;
-                }
-            }
-            if (rz > 0) {
+            // Single-phase feed Gibbs at a given density root (HUGE_VAL if the root/eval is unusable).
+            auto feed_gibbs = [&](CoolPropDbl rz) -> double {
+                if (!(rz > 0)) return HUGE_VAL;
                 try {
                     HEOS.SatL->update_DmolarT_direct(rz, IO.T);
                     double gs = 0;
@@ -3460,9 +3430,39 @@ void SaturationSolvers::PTflash_twophase::solve_michelsen() {
                         if (IO.z[i] > 0)
                             gs +=
                               static_cast<double>(IO.z[i]) * (std::log(static_cast<double>(IO.z[i])) + std::log(HEOS.SatL->fugacity_coefficient(i)));
-                    if (ValidNumber(gs)) G_single = gs;
+                    return ValidNumber(gs) ? gs : HUGE_VAL;
                 } catch (...) {
-                    G_single = HUGE_VAL;
+                    return HUGE_VAL;
+                }
+            };
+            // Prefer the global lowest-Gibbs root -- it already selects the stable single phase.
+            CoolPropDbl rw = -1, rz_global = -1;
+            try {
+                rz_global = solve_trial_rho_warm(*HEOS.SatL, IO.T, IO.p, rw);
+            } catch (...) {
+                rz_global = -1;
+            }
+            if (rz_global > 0) {
+                G_single = feed_gibbs(rz_global);
+            } else {
+                // The global root can fail for a multiparameter mixture when p lies between the
+                // spinodal pressures -- the near-dew regime this fallback targets (the same failure
+                // check_stability_michelsen guards at ~2108).  Solve BOTH phase-specified roots and
+                // take the LOWER-Gibbs one: taking the first that solves (e.g. the gas branch) could
+                // pick a higher-Gibbs branch and make the descent guard too lenient, letting a
+                // metastable split through.
+                for (int which = 0; which < 2; ++which) {
+                    const phases fl = (which == 0) ? iphase_gas : iphase_liquid;
+                    CoolPropDbl rz = -1;
+                    try {
+                        HEOS.SatL->specify_phase(fl);
+                        rz = HEOS.SatL->solver_rho_Tp(IO.T, IO.p);
+                        HEOS.SatL->unspecify_phase();
+                    } catch (...) {
+                        HEOS.SatL->unspecify_phase();
+                        rz = -1;
+                    }
+                    G_single = std::min(G_single, feed_gibbs(rz));
                 }
             }
         }

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -9,6 +9,7 @@
 #    include <memory>
 #    include <string>
 #    include <vector>
+#    include <sstream>
 #    include <catch2/catch_all.hpp>
 #    include "CoolProp/detail/tools.h"
 #    include "CoolProp/CoolProp.h"
@@ -2135,6 +2136,139 @@ TEST_CASE("HSU_D flash: single-phase N2/O2 HEOS regression", "[michelsen][hsu_d]
         CHECK(AS2->T() == Catch::Approx(T).epsilon(0.001));
         CHECK(AS2->p() == Catch::Approx(P).epsilon(0.001));
     }
+}
+
+TEST_CASE("HSU_P flash: near-dew round trip must not return a wrong T silently", "[michelsen][flash][HSU_P][saturation]") {
+    // Regression for CoolProp-ft05.  On a genuine instability the Michelsen
+    // two-phase solver can converge to the TRIVIAL split -- x == y,
+    // rho_liq == rho_vap -- and report o.nonconvergence = 0, i.e. success.
+    // Nothing catches that, and the trivial-split guard in PT_flash_mixtures
+    // (`if (o.beta < 1e-10)`) then publishes it as a SINGLE-PHASE state inside
+    // the two-phase region.  That makes the residual the HSU_P TOMS748 solver
+    // sees discontinuous, so it can settle on a temperature whose wrong-phase
+    // state happens to reproduce the target H/S/U.
+    //
+    // The convergence gate added in #3192 does NOT catch this case: it checks
+    // the RESIDUAL, not T, and here the residual is genuinely satisfied at the
+    // wrong state.  So the failure is silent -- the caller is handed a
+    // converged-looking state at the wrong temperature.  Do not try to fix a
+    // regression here by tightening that gate.
+    //
+    // P = 8e5 near the dew end fails for all three inputs at three consecutive
+    // offsets on the pre-fix code, by 0.11 to 0.67 K.  Errors elsewhere in the
+    // (P, T) sweep reach 2.97 K.
+    const std::string fluids = "Nitrogen&Methane&Ethane&Butane&Pentane";
+    const std::vector<double> z = {0.3797, 0.3225, 0.278, 0.0014, 0.0184};
+    const double P = 8e5;
+    const double TOL = 0.1;  // K
+
+    auto sat = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
+    sat->set_mole_fractions(z);
+    sat->update(PQ_INPUTS, P, 0.0);
+    const double T_bub = sat->T();
+    sat->update(PQ_INPUTS, P, 1.0);
+    const double T_dew = sat->T();
+
+    for (double frac : {0.995, 0.998, 0.999}) {
+        const double T = T_bub + frac * (T_dew - T_bub);
+
+        auto ref = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
+        ref->set_mole_fractions(z);
+        ref->update(PT_INPUTS, P, T);
+        // The reference state itself must be two-phase; if this ever fails the
+        // test has drifted off the intended part of the envelope.
+        REQUIRE(ref->phase() == iphase_twophase);
+        const double H_ref = ref->hmass();
+        const double S_ref = ref->smass();
+        const double U_ref = ref->umass();
+
+        std::ostringstream lbl;
+        lbl << "frac=" << frac << " T=" << T;
+
+        DYNAMIC_SECTION(lbl.str() + " HP") {
+            auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
+            AS->set_mole_fractions(z);
+            AS->update(HmassP_INPUTS, H_ref, P);
+            CHECK(std::abs(AS->T() - T) < TOL);
+        }
+        DYNAMIC_SECTION(lbl.str() + " SP") {
+            auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
+            AS->set_mole_fractions(z);
+            AS->update(PSmass_INPUTS, P, S_ref);
+            CHECK(std::abs(AS->T() - T) < TOL);
+        }
+        DYNAMIC_SECTION(lbl.str() + " UP") {
+            auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
+            AS->set_mole_fractions(z);
+            AS->update(PUmass_INPUTS, P, U_ref);
+            CHECK(std::abs(AS->T() - T) < TOL);
+        }
+    }
+}
+
+TEST_CASE("HSU_P flash: full near-saturation sweep must not return wrong T (spike #3342)", "[michelsen][flash][HSU_P][sweep][.]") {
+    // Adversarial coverage of the whole two-phase envelope for the #3342 mixture, mirroring the
+    // 273-round-trip sweep in the issue.  Hidden ([.]) -- run explicitly with [sweep].  For every
+    // (P, frac) we build the two-phase reference by PT flash, round-trip through HP/SP/UP, and
+    // require the recovered T within 0.1 K.  Reports the worst error and the count of wrong/thrown.
+    const std::string fluids = "Nitrogen&Methane&Ethane&Butane&Pentane";
+    const std::vector<double> z = {0.3797, 0.3225, 0.278, 0.0014, 0.0184};
+    const std::vector<double> Ps = {1e5, 2e5, 3e5, 5e5, 8e5, 12e5, 20e5};
+    const std::vector<double> fracs = {0.001, 0.005, 0.02, 0.1, 0.25, 0.4, 0.5, 0.6, 0.75, 0.9, 0.98, 0.995, 0.999};
+    const double TOL = 0.1;
+    int wrong = 0, threw = 0, checked = 0;
+    double worst = 0;
+    for (double P : Ps) {
+        auto sat = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
+        sat->set_mole_fractions(z);
+        double Tb, Td;
+        try {
+            sat->update(PQ_INPUTS, P, 0.0);
+            Tb = sat->T();
+            sat->update(PQ_INPUTS, P, 1.0);
+            Td = sat->T();
+        } catch (...) {
+            continue;
+        }
+        for (double frac : fracs) {
+            double T = Tb + frac * (Td - Tb);
+            auto ref = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
+            ref->set_mole_fractions(z);
+            ref->update(PT_INPUTS, P, T);
+            if (ref->phase() != iphase_twophase) continue;  // only test genuine two-phase points
+            double H = ref->hmass(), S = ref->smass(), U = ref->umass();
+            struct Case
+            {
+                int in;
+                double val;
+            };
+            for (Case c : {Case{0, H}, Case{1, S}, Case{2, U}}) {
+                auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
+                AS->set_mole_fractions(z);
+                ++checked;
+                try {
+                    if (c.in == 0)
+                        AS->update(HmassP_INPUTS, c.val, P);
+                    else if (c.in == 1)
+                        AS->update(PSmass_INPUTS, P, c.val);
+                    else
+                        AS->update(PUmass_INPUTS, P, c.val);
+                    double err = std::abs(AS->T() - T);
+                    worst = std::max(worst, err);
+                    if (err > TOL) {
+                        ++wrong;
+                        WARN("wrong T: P=" << P << " frac=" << frac << " in=" << c.in << " T=" << T << " ret=" << AS->T() << " err=" << err);
+                    }
+                } catch (const std::exception& e) {
+                    ++threw;
+                    WARN("threw: P=" << P << " frac=" << frac << " in=" << c.in << " : " << e.what());
+                }
+            }
+        }
+    }
+    WARN("SWEEP: checked=" << checked << " worst|err|=" << worst << " K  wrong=" << wrong << " threw=" << threw);
+    CHECK(wrong == 0);
+    CHECK(threw == 0);
 }
 
 #endif

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -2138,29 +2138,22 @@ TEST_CASE("HSU_D flash: single-phase N2/O2 HEOS regression", "[michelsen][hsu_d]
     }
 }
 
-TEST_CASE("HSU_P flash: near-dew round trip must not return a wrong T silently", "[michelsen][flash][HSU_P][saturation]") {
-    // Regression for CoolProp-ft05.  On a genuine instability the Michelsen
-    // two-phase solver can converge to the TRIVIAL split -- x == y,
-    // rho_liq == rho_vap -- and report o.nonconvergence = 0, i.e. success.
-    // Nothing catches that, and the trivial-split guard in PT_flash_mixtures
-    // (`if (o.beta < 1e-10)`) then publishes it as a SINGLE-PHASE state inside
-    // the two-phase region.  That makes the residual the HSU_P TOMS748 solver
-    // sees discontinuous, so it can settle on a temperature whose wrong-phase
-    // state happens to reproduce the target H/S/U.
+TEST_CASE("Mixture PT flash near the dew line resolves to a genuine two-phase split (#3342)", "[michelsen][flash][mixture][saturation]") {
+    // Solver contract for SaturationSolvers::PTflash_twophase::solve_michelsen
+    // (#3342 / CoolProp-1tbe.22).  On a genuine instability just inside the dew line the
+    // second-order phase split can collapse to the TRIVIAL split (x == y,
+    // rho_liq == rho_vap) yet report success; the trivial-split guard in PT_flash_mixtures
+    // then publishes it as a SINGLE-PHASE state inside the two-phase region.  Pin the
+    // solver's contract directly: across the near-dew band the PT flash must return a
+    // GENUINE two-phase state -- classified two-phase, with an interior vapour quality and a
+    // non-trivial liquid/vapour composition spread -- never a collapsed trivial split
+    // misclassified as single phase.
     //
-    // The convergence gate added in #3192 does NOT catch this case: it checks
-    // the RESIDUAL, not T, and here the residual is genuinely satisfied at the
-    // wrong state.  So the failure is silent -- the caller is handed a
-    // converged-looking state at the wrong temperature.  Do not try to fix a
-    // regression here by tightening that gate.
-    //
-    // P = 8e5 near the dew end fails for all three inputs at three consecutive
-    // offsets on the pre-fix code, by 0.11 to 0.67 K.  Errors elsewhere in the
-    // (P, T) sweep reach 2.97 K.
+    // (The end-to-end HSU_P inverse round trip at these same conditions additionally needs
+    //  the near-dew T-bracket fix; that coverage travels with the reroute change, not here.)
     const std::string fluids = "Nitrogen&Methane&Ethane&Butane&Pentane";
     const std::vector<double> z = {0.3797, 0.3225, 0.278, 0.0014, 0.0184};
     const double P = 8e5;
-    const double TOL = 0.1;  // K
 
     auto sat = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
     sat->set_mole_fractions(z);
@@ -2169,107 +2162,29 @@ TEST_CASE("HSU_P flash: near-dew round trip must not return a wrong T silently",
     sat->update(PQ_INPUTS, P, 1.0);
     const double T_dew = sat->T();
 
-    for (double frac : {0.995, 0.998, 0.999}) {
+    for (double frac : {0.99, 0.995, 0.998, 0.999}) {
         const double T = T_bub + frac * (T_dew - T_bub);
-
-        auto ref = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
-        ref->set_mole_fractions(z);
-        ref->update(PT_INPUTS, P, T);
-        // The reference state itself must be two-phase; if this ever fails the
-        // test has drifted off the intended part of the envelope.
-        REQUIRE(ref->phase() == iphase_twophase);
-        const double H_ref = ref->hmass();
-        const double S_ref = ref->smass();
-        const double U_ref = ref->umass();
-
         std::ostringstream lbl;
         lbl << "frac=" << frac << " T=" << T;
-
-        DYNAMIC_SECTION(lbl.str() + " HP") {
+        DYNAMIC_SECTION(lbl.str()) {
             auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
             AS->set_mole_fractions(z);
-            AS->update(HmassP_INPUTS, H_ref, P);
-            CHECK(std::abs(AS->T() - T) < TOL);
-        }
-        DYNAMIC_SECTION(lbl.str() + " SP") {
-            auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
-            AS->set_mole_fractions(z);
-            AS->update(PSmass_INPUTS, P, S_ref);
-            CHECK(std::abs(AS->T() - T) < TOL);
-        }
-        DYNAMIC_SECTION(lbl.str() + " UP") {
-            auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
-            AS->set_mole_fractions(z);
-            AS->update(PUmass_INPUTS, P, U_ref);
-            CHECK(std::abs(AS->T() - T) < TOL);
+            AS->update(PT_INPUTS, P, T);
+            // Correctly classified two-phase (not collapsed to a single-phase misclassification)...
+            CHECK(AS->phase() == iphase_twophase);
+            // ... with an interior vapour quality ...
+            const double Q = AS->Q();
+            CHECK(Q > 1e-8);
+            CHECK(Q < 1.0 - 1e-8);
+            // ... and a genuine composition split (trivial collapse is x == y everywhere).
+            const std::vector<double> xl = AS->mole_fractions_liquid_double();
+            const std::vector<double> xv = AS->mole_fractions_vapor_double();
+            double spread = 0;
+            for (std::size_t i = 0; i < z.size(); ++i)
+                spread = std::max(spread, std::abs(xl[i] - xv[i]));
+            CHECK(spread > 1e-4);
         }
     }
-}
-
-TEST_CASE("HSU_P flash: full near-saturation sweep must not return wrong T (spike #3342)", "[michelsen][flash][HSU_P][sweep][.]") {
-    // Adversarial coverage of the whole two-phase envelope for the #3342 mixture, mirroring the
-    // 273-round-trip sweep in the issue.  Hidden ([.]) -- run explicitly with [sweep].  For every
-    // (P, frac) we build the two-phase reference by PT flash, round-trip through HP/SP/UP, and
-    // require the recovered T within 0.1 K.  Reports the worst error and the count of wrong/thrown.
-    const std::string fluids = "Nitrogen&Methane&Ethane&Butane&Pentane";
-    const std::vector<double> z = {0.3797, 0.3225, 0.278, 0.0014, 0.0184};
-    const std::vector<double> Ps = {1e5, 2e5, 3e5, 5e5, 8e5, 12e5, 20e5};
-    const std::vector<double> fracs = {0.001, 0.005, 0.02, 0.1, 0.25, 0.4, 0.5, 0.6, 0.75, 0.9, 0.98, 0.995, 0.999};
-    const double TOL = 0.1;
-    int wrong = 0, threw = 0, checked = 0;
-    double worst = 0;
-    for (double P : Ps) {
-        auto sat = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
-        sat->set_mole_fractions(z);
-        double Tb, Td;
-        try {
-            sat->update(PQ_INPUTS, P, 0.0);
-            Tb = sat->T();
-            sat->update(PQ_INPUTS, P, 1.0);
-            Td = sat->T();
-        } catch (...) {
-            continue;
-        }
-        for (double frac : fracs) {
-            double T = Tb + frac * (Td - Tb);
-            auto ref = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
-            ref->set_mole_fractions(z);
-            ref->update(PT_INPUTS, P, T);
-            if (ref->phase() != iphase_twophase) continue;  // only test genuine two-phase points
-            double H = ref->hmass(), S = ref->smass(), U = ref->umass();
-            struct Case
-            {
-                int in;
-                double val;
-            };
-            for (Case c : {Case{0, H}, Case{1, S}, Case{2, U}}) {
-                auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
-                AS->set_mole_fractions(z);
-                ++checked;
-                try {
-                    if (c.in == 0)
-                        AS->update(HmassP_INPUTS, c.val, P);
-                    else if (c.in == 1)
-                        AS->update(PSmass_INPUTS, P, c.val);
-                    else
-                        AS->update(PUmass_INPUTS, P, c.val);
-                    double err = std::abs(AS->T() - T);
-                    worst = std::max(worst, err);
-                    if (err > TOL) {
-                        ++wrong;
-                        WARN("wrong T: P=" << P << " frac=" << frac << " in=" << c.in << " T=" << T << " ret=" << AS->T() << " err=" << err);
-                    }
-                } catch (const std::exception& e) {
-                    ++threw;
-                    WARN("threw: P=" << P << " frac=" << frac << " in=" << c.in << " : " << e.what());
-                }
-            }
-        }
-    }
-    WARN("SWEEP: checked=" << checked << " worst|err|=" << worst << " K  wrong=" << wrong << " threw=" << threw);
-    CHECK(checked > 0);  // guard: the sweep must actually exercise two-phase round trips, not pass vacuously
-    CHECK(wrong == 0);
-    CHECK(threw == 0);
 }
 
 #endif

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -2170,8 +2170,10 @@ TEST_CASE("Mixture PT flash near the dew line resolves to a genuine two-phase sp
             auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
             AS->set_mole_fractions(z);
             AS->update(PT_INPUTS, P, T);
-            // Correctly classified two-phase (not collapsed to a single-phase misclassification)...
-            CHECK(AS->phase() == iphase_twophase);
+            // Correctly classified two-phase (not collapsed to a single-phase misclassification).
+            // REQUIRE (fatal): a regression to single phase must stop the section here, before the
+            // liquid/vapour accessors below, which are only valid for a two-phase state.
+            REQUIRE(AS->phase() == iphase_twophase);
             // ... with an interior vapour quality ...
             const double Q = AS->Q();
             CHECK(Q > 1e-8);

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -2267,6 +2267,7 @@ TEST_CASE("HSU_P flash: full near-saturation sweep must not return wrong T (spik
         }
     }
     WARN("SWEEP: checked=" << checked << " worst|err|=" << worst << " K  wrong=" << wrong << " threw=" << threw);
+    CHECK(checked > 0);  // guard: the sweep must actually exercise two-phase round trips, not pass vacuously
     CHECK(wrong == 0);
     CHECK(threw == 0);
 }

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -2189,4 +2189,48 @@ TEST_CASE("Mixture PT flash near the dew line resolves to a genuine two-phase sp
     }
 }
 
+TEST_CASE("Mixture PT flash maps the near-dew/near-bubble split to the correct phases (#3357)", "[michelsen][flash][mixture][saturation]") {
+    // Regression for the #3357 phase-label inversion.  A stage of solve_michelsen (in particular
+    // the Phase-2 second-order Newton, which our derivative fix made converge at points it used to
+    // miss) can settle on the correct physical split but with the liquid/vapour labels transposed:
+    // x <-> y, the densities swapped, and Q -> 1 - Q.  The material balance z = (1-Q) x + Q y is
+    // INVARIANT under that swap, so it cannot detect the bug; the discriminating invariants are the
+    // physical phase identities -- the liquid is the denser phase and the light component is
+    // enriched in the vapour.  solve_michelsen now normalises the labels (liquid = denser phase)
+    // before publishing.  Silent on a single-phase verdict, so it stays green on builds that merely
+    // MISS the split (the separate, pre-existing #3342 near-dew miss).
+    const std::string fluids = "Methane&Ethane&n-Propane&n-Butane&IsoButane&Nitrogen&CarbonDioxide";
+    const std::vector<double> z = {0.9188, 0.0532, 0.0193, 0.0010, 0.0012, 0.0064, 0.0001};
+    const std::size_t i_light = 0;  // Methane (lightest)
+    const std::size_t i_heavy = 3;  // n-Butane (heaviest)
+    const double P = 60e5;          // Pa
+
+    // A near-dew band (incipient phase = liquid, the direction that triggered #3357) plus a few
+    // near-bubble points (incipient phase = vapour, guarding against an unconditional flip).
+    const std::vector<double> Ts = {223.10, 223.15, 223.20, 223.28, 223.35, 223.40, 207.91, 208.03, 208.66, 211.77};
+    // A MISS (single-phase verdict) is the SEPARATE, pre-existing #3342 near-dew miss, so each point
+    // is checked only when it resolves two-phase -- but require that AT LEAST ONE point across the
+    // band does, so a regression that lost the whole band cannot pass this test vacuously.
+    int n_twophase = 0;
+    for (double T : Ts) {
+        auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", fluids));
+        AS->set_mole_fractions(z);
+        AS->update(PT_INPUTS, P, T);
+        if (AS->phase() != iphase_twophase) continue;
+        ++n_twophase;
+        const double Q = AS->Q();
+        const std::vector<double> xl = AS->mole_fractions_liquid_double();
+        const std::vector<double> xv = AS->mole_fractions_vapor_double();
+        CAPTURE(T, Q, xl[i_light], xv[i_light]);
+        CHECK(Q > 0.0);
+        CHECK(Q < 1.0);
+        // Liquid is the denser phase.
+        CHECK(AS->saturated_liquid_keyed_output(iDmolar) > AS->saturated_vapor_keyed_output(iDmolar));
+        // Light component enriched in the vapour, heavy in the liquid.
+        CHECK(xv[i_light] > xl[i_light]);
+        CHECK(xl[i_heavy] > xv[i_heavy]);
+    }
+    REQUIRE(n_twophase >= 1);  // not a vacuous pass: the band must resolve at least one split
+}
+
 #endif

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -1144,14 +1144,18 @@ TEST_CASE("Methanol-benzene PT flash at problematic compositions", "[michelsen][
     // fallback must recover the correct single-phase liquid result rather than
     // publishing the unconverged split.
     //
-    // x_methanol = 0.54 is intentionally EXCLUDED here: at that composition the poor
-    // methanol/benzene k_ij makes the EOS *marginally* prefer a spurious LLE (TPD
-    // objective ~ -1e-5), so the single-vs-two-phase verdict is a ULP-scale
-    // razor-edge that flips between compilers (correct on MSVC, wrong on gcc, and
-    // vice-versa) for the SAME source -- see GH #3357 (jakobreichert).  Correcting
-    // the stability-classifier Hessian (this PR) does not remove that razor-edge; a
-    // deterministic guard (a margin-based Gibbs-descent check on the converged split)
-    // is the proper fix and is tracked in #3358.  Re-enable 0.54 once that lands.
+    // x_methanol = 0.54 is intentionally EXCLUDED here.  At that composition the poor
+    // methanol/benzene binary interaction parameters make the model *marginally* prefer
+    // a spurious liquid-liquid split (TPD objective ~ -1e-5; the split's Gibbs energy is
+    // ~1e-3 J/mol BELOW the single phase), so the single-vs-two-phase verdict is a
+    // ULP-scale razor-edge that flips between compilers (correct on MSVC, wrong on gcc,
+    // and vice-versa) for the SAME source -- see GH #3357 (jakobreichert).  This is not
+    // fixable downstream of the model: correcting the stability-classifier Hessian (this
+    // PR) does not remove the razor-edge, and a Gibbs-descent guard on the converged
+    // split cannot separate it from a GENUINE split -- the near-dew/near-bubble
+    // tiny-incipient splits this solver exists to find (#3342) are just as Gibbs-marginal
+    // (or shallower), so any margin that rejects 0.54 also rejects them (measured; see the
+    // closed GH #3358).  The spuriousness lives in the binary parameters, not the solver.
     for (double x : {0.56, 0.58, 0.76, 0.78, 0.80}) {
         DYNAMIC_SECTION("x_methanol = " << x) {
             auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", "methanol&benzene"));

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -1139,11 +1139,20 @@ TEST_CASE("Methanol-benzene PT flash at problematic compositions", "[michelsen][
     //
     // At 308.15 K / 1 atm this mixture is subcooled single-phase liquid (bubble
     // pressure ~34 kPa << 101 kPa).  #3168: the Michelsen stability check produces
-    // a false-positive two-phase classification at x_methanol = 0.54 whose split
-    // never converges (both roots liquid-like, rho_vap > rho_liq).  The convergence
-    // gate + single-phase fallback must recover the correct single-phase liquid
-    // result rather than publishing the unconverged split.
-    for (double x : {0.54, 0.56, 0.58, 0.76, 0.78, 0.80}) {
+    // a false-positive two-phase classification whose split never converges (both
+    // roots liquid-like, rho_vap > rho_liq).  The convergence gate + single-phase
+    // fallback must recover the correct single-phase liquid result rather than
+    // publishing the unconverged split.
+    //
+    // x_methanol = 0.54 is intentionally EXCLUDED here: at that composition the poor
+    // methanol/benzene k_ij makes the EOS *marginally* prefer a spurious LLE (TPD
+    // objective ~ -1e-5), so the single-vs-two-phase verdict is a ULP-scale
+    // razor-edge that flips between compilers (correct on MSVC, wrong on gcc, and
+    // vice-versa) for the SAME source -- see GH #3357 (jakobreichert).  Correcting
+    // the stability-classifier Hessian (this PR) does not remove that razor-edge; a
+    // deterministic guard (a margin-based Gibbs-descent check on the converged split)
+    // is the proper fix and is tracked in #3358.  Re-enable 0.54 once that lands.
+    for (double x : {0.56, 0.58, 0.76, 0.78, 0.80}) {
         DYNAMIC_SECTION("x_methanol = " << x) {
             auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", "methanol&benzene"));
             AS->set_mole_fractions({x, 1.0 - x});


### PR DESCRIPTION
## Summary

Two linked fixes so a mixture **PT flash** (and the PQ/QT paths that build on it) finds and
publishes the genuine tiny incipient-phase split just inside the dew/bubble line, instead of
collapsing to a trivial or grossly-unconverged split:

1. **Correctness fix** to `MixtureDerivatives::dln_fugacity_dxj__constT_p_xi` — the ideal-gas
   term for the last component under `XN_INDEPENDENT` was wrong. **Closes #3356.**
2. **A hardened, guaranteed-descent minority-phase Gibbs Newton fallback** in
   `SaturationSolvers::PTflash_twophase::solve_michelsen`, reached only when the existing
   stages fail. Part of #3342.

Touches `MixtureDerivatives.cpp`, `VLERoutines.cpp`, and the Michelsen test only.

## The bug

Just inside the dew line, on a genuine instability, the two-phase solver's second-order stage
could converge to the **trivial split** (x == y, ρ_liq == ρ_vap) — or stall grossly unconverged —
and still report success. The trivial-split guard in `PT_flash_mixtures` then republished that as a
**single-phase state inside the two-phase region**, so downstream H/S/U and any inverse flash saw a
wrong-phase state at the wrong temperature. The failure was silent: the equal-fugacity residual was
"satisfied" at the wrong (collapsed) state.

**Root cause of the lost convergence.** `dln_fugacity_dxj__constT_p_xi` hard-coded the
`XN_DEPENDENT` ideal-gas term `d(ln x_{N-1})/dx_j = -1/x_{N-1}` on the last row regardless of
`xN_flag`. Under `XN_INDEPENDENT` every mole fraction is independent, so the term must be
`δ_ij/x_i` for **every** i, including the last component. The corrupted last row made the
mole-number Gibbs Hessian assembled in the fallback non-symmetric and **indefinite** — its smallest
eigenvalue flipped negative — so the modified-Newton step lost guaranteed descent and the
incipient-phase split never converged. (Details and impact on the other two `XN_INDEPENDENT`
consumers: #3356.)

## The fix

### 1. Fugacity composition derivative (#3356)

Branch the ideal-gas term on `xN_flag`:

- `XN_DEPENDENT`: `-1/x_{N-1}` on the last row, `δ_ij/x_i` otherwise — **byte-identical** to before.
- `XN_INDEPENDENT`: `δ_ij/x_i` for every i, including the last component.

Only three `XN_INDEPENDENT` callers exist repo-wide; verified by finite difference of
`d(ln f_i)/dx_j` for both conventions.

### 2. Hardened minority-phase Gibbs Newton fallback (`solve_michelsen`)

**When it runs.** Only after **both** Phase 1 (successive substitution + GDEM acceleration, ≤ 4
loops) and Phase 2 (the reduced-gradient second-order Newton) have failed to converge. Easy flashes
that converge in a few SS steps never enter it, so the common path is unchanged.

**Method** (Michelsen's second-order phase-split, whose *method* — not code — is mirrored via the
open-source ThermoPack; see references):

- The variables are the **incipient (minority) phase mole numbers `a`** — the vanishing liquid near
  the dew, the vanishing vapour near the bubble. Their components sit far from the `z_i` bound, so
  the feasible box is not the razor a majority-phase formulation hits.
- Gradient `dG/da_i = ln f_i^min − ln f_i^maj`; mole-number Gibbs Hessian
  `(1/A_min)[D_min − x·D_min] + (1/A_maj)[D_maj − x·D_maj]`.
- **Eigenvalue-modified Newton** (a spectral variant of Michelsen's modified-Cholesky): floor each
  eigenvalue at `max(|λ|, ε·max|λ|)` so an indefinite Hessian still yields a guaranteed-descent,
  curvature-scaled step.
- A **single-scalar fraction-to-the-boundary** limit (scales the whole step, preserving the Newton
  direction) plus an **Armijo** line search on the total Gibbs energy.
- **Cold global lowest-Gibbs density roots** every evaluation, so the objective/gradient stay on the
  same stable density sheet as the seed (vs warm-start drift to a metastable root).
- **Wilson-K reseed** when the stability trial handed in is ~trivial (`x0 ≈ z`), so the Newton starts
  from a genuinely non-trivial split instead of the collapsed feed.

**Additive and safe.** The fallback publishes a split **only if it is genuine**: equal-fugacity
residual ≤ 1e-5, non-trivial composition spread, interior phase fraction β, Gibbs energy below the
single-phase reference, and correct VLE ordering (ρ_liq > ρ_vap, rejecting a spurious LLE such as
the poor-`k_ij` methanol/benzene root the EOS predicts, cf. #3168). On **any** other outcome it
restores the exact pre-fallback state, so it cannot regress a currently-passing case.

**Robustness** (from adversarial review):

- The density + fugacity evaluation is exception-safe: any EOS error returns "failed evaluation" and
  is handled gracefully, never escaping `solve_michelsen` to turn a graceful single-phase fallback
  into a hard abort.
- The single-phase Gibbs reference used by the Gibbs-descent guard is computed via a phase-specified
  root when the global density solve throws (the between-spinodals regime), so that guard cannot
  silently no-op (fail open).

## Methodology & references

- **[M1982b]** Michelsen, *The isothermal flash problem. Part II. Phase-split calculation*, Fluid
  Phase Equilib. **9** (1982) 21–40. Minority/reference-phase mole-number variables (Eq. 14–15),
  gradient `ln f_i^min − ln f_i^maj` (Eq. 16), mole-number Hessian (Eq. 17), the modified-Cholesky
  descent + Gibbs-decrease-accepted line search (our eigenvalue-flip is a spectral variant), and the
  "never return to the trivial solution" / phase-removal rules that motivate our guards.
- **[MHA1980b]** Mehra, Heidemann & Aziz, *Computation of multiphase equilibria for compositional
  simulators*, SPE 9232 (1980) — origin of the yield-fraction / reference-phase choice adopted by
  M1982b Eq. 14–15.
- **[Murray1972]** W. Murray, *Second derivative methods*, in *Numerical Methods for Unconstrained
  Optimization*, Academic Press (1972) — the modified-Cholesky modified-Newton.
- **[CN1975]** Crowe & Nishio, AIChE J. **21** (1975) 528–533 — the GDEM acceleration used in Phase 1.
- **[MM2007]** Michelsen & Mollerup, *Thermodynamic Models: Fundamentals & Computational Aspects*,
  2nd ed. (2007), Ch. 12 — textbook treatment of the above.
- **[TP2017]** Wilhelmsen et al., Ind. Eng. Chem. Res. **56** (2017) 3503–3515; ThermoPack
  (`thermotools/thermopack`, `tp_solver.f90` + `optimizer.f90`) — the open-source implementation
  whose method was mirrored (read as a reference, not copied). Where this implementation deliberately
  diverges from ThermoPack's coding: deterministic cold global lowest-Gibbs roots (vs specified
  LIQPH/VAPPH roots); the eigenvalue-flip Hessian modification (vs modified-Cholesky factorization);
  a single global minority phase (vs its per-component reference-phase toggle); and the CoolProp
  guards (Wilson reseed, Gibbs-descent, VLE ordering).

The full derivation and citations are reproduced in a `METHOD PROVENANCE` comment block above the
fallback in `VLERoutines.cpp`.

## Validation

- `[michelsen]` — **1941 assertions / 53 cases, all pass.**
- `[mixture]` — 2054 / 2054. `[meoh_benz]` — 42 / 42.
- New solver-contract regression test: across the near-dew band the mixture PT flash returns a
  **genuine two-phase split** (classified two-phase, interior vapour quality, non-trivial
  liquid/vapour composition spread), never the trivial collapse.
- The correct Hessian restores **true quadratic convergence** in the fallback — the median iteration
  count drops by ~16× (≈ 59 → ≈ 4) relative to the pre-fix indefinite-Hessian path.

## Scope / relationship to other work

- **HSU_P inverse round trip near the dew** additionally needs the near-dew T-bracket fix; that, and
  the full-envelope adversarial wrong-T sweep, travel with the **reroute** change, not this PR (kept
  deliberately separate).
- **Independent of #3284 / #3283** (spurious single-phase middle-branch root in
  `FlashRoutines::solve_single_phase`): this PR does not touch that path, and the #3283 reproduction
  still fails on this branch — #3284 remains a separate, still-needed fix.
- **#3342** is the umbrella; this closes the two-phase *solver* half. It is left open pending the
  reroute.

## Quality gates

- Two independent adversarial reviews (initial + the review-feedback delta): **no blocking findings.**
- Pre-push preflight: clang-format (18.1.8), build, Catch2 tests, and semgrep all green.
  cppcheck and clang-tidy report only **pre-existing whole-file findings** (0 on this diff; both are
  informational / never-gate in CI).

## Follow-ups (filed, not blocking)

- A finite-difference / symmetry unit test isolating `dln_fugacity_dxj__constT_p_xi` for both XN
  conventions.
- Optionally extending exception-safety to the two remaining pre-existing unwrapped regions in
  `solve_michelsen`.

---

*Note for the reviewer/merger: the branch history is granular (development WIP + docs/style commits);
a **squash merge** is recommended.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved two-phase pressure–temperature flash calculations near dew- and bubble-point conditions.
  - Reduced failures and unstable results from invalid inputs and difficult convergence cases.
  - Added a fallback for challenging minority-phase equilibrium calculations.
  - Improved mixture composition derivative handling for dependent and independent composition representations.
  - Corrected liquid/vapor phase labeling so the liquid phase is consistently denser than the vapor phase.

- **Tests**
  - Added regression coverage for two-phase flash results, including phase composition enrichment and correct phase labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->