### PR TITLE
Mathcad Wrapper C++17 Compliance

### DIFF
--- a/wrappers/MathCAD/CoolPropMathcad.cpp
+++ b/wrappers/MathCAD/CoolPropMathcad.cpp
@@ -68,7 +68,7 @@ enum EC
 
 // table of error messages
 // As of Mathcad Prime 10, these are now actually returned as Custom Error: messages
-char* CPErrorMessageTable[NUMBER_OF_ERRORS] = {"Argument must be real",
+const char* CPErrorMessageTable[NUMBER_OF_ERRORS] = {"Argument must be real",
                                                "Insufficient Memory",
                                                "Interrupted",
                                                "Only one column allowed in input array",
@@ -857,59 +857,59 @@ static LRESULT CP_set_mixture_binary_pair_data(LPMCSTRING Msg,          // outpu
 // ********************************************************************************************************
 
 FUNCTIONINFO PropsParam = {
-  "get_global_param_string",                                 // Name by which Mathcad will recognize the function
-  "Name of the parameter to retrieve",                       // Description of input parameters
-  "Returns the value of the requested CoolProps parameter",  // description of the function for the Insert Function dialog box
-  (LPCFUNCTION)CP_get_global_param_string,                   // Pointer to the function code.
-  MC_STRING,                                                 // Returns a Mathcad string
-  1,                                                         // Number of arguments
-  {MC_STRING}                                                // Argument types
+  const_cast<char*>("get_global_param_string"),                                 // Name by which Mathcad will recognize the function
+  const_cast<char*>("Name of the parameter to retrieve"),                       // Description of input parameters
+  const_cast<char*>("Returns the value of the requested CoolProps parameter"),  // description of the function for the Insert Function dialog box
+  (LPCFUNCTION)CP_get_global_param_string,                                      // Pointer to the function code.
+  MC_STRING,                                                                    // Returns a Mathcad string
+  1,                                                                            // Number of arguments
+  {MC_STRING}                                                                   // Argument types
 };
 
 FUNCTIONINFO FluidParam = {
-  "get_fluid_param_string",                                  // Name by which Mathcad will recognize the function
-  "Fluid, Name of the parameter to retrieve",                // Description of input parameters
-  "Returns the value of the requested CoolProps parameter",  // description of the function for the Insert Function dialog box
-  (LPCFUNCTION)CP_get_fluid_param_string,                    // Pointer to the function code.
-  MC_STRING,                                                 // Returns a Mathcad string
-  2,                                                         // Number of arguments
-  {MC_STRING, MC_STRING}                                     // Argument types
+  const_cast<char*>("get_fluid_param_string"),                                  // Name by which Mathcad will recognize the function
+  const_cast<char*>("Fluid, Name of the parameter to retrieve"),                // Description of input parameters
+  const_cast<char*>("Returns the value of the requested CoolProps parameter"),  // description of the function for the Insert Function dialog box
+  (LPCFUNCTION)CP_get_fluid_param_string,                                       // Pointer to the function code.
+  MC_STRING,                                                                    // Returns a Mathcad string
+  2,                                                                            // Number of arguments
+  {MC_STRING, MC_STRING}                                                        // Argument types
 };
 
 FUNCTIONINFO RefState = {
-  "set_reference_state",                                           // Name by which Mathcad will recognize the function
-  "Fluid, Reference State String",                                 // Description of input parameters
-  "Sets the reference state to either IIR, ASHRAE, NBP, or DEF.",  // description of the function for the Insert Function dialog box
-  (LPCFUNCTION)CP_set_reference_state,                             // Pointer to the function code.
-  COMPLEX_SCALAR,                                                  // Returns a Mathcad complex scalar
-  2,                                                               // Number of arguments
-  {MC_STRING, MC_STRING}                                           // Argument types
+  const_cast<char*>("set_reference_state"),                                           // Name by which Mathcad will recognize the function
+  const_cast<char*>("Fluid, Reference State String"),                                 // Description of input parameters
+  const_cast<char*>("Sets the reference state to either IIR, ASHRAE, NBP, or DEF."),  // description of the function for the Insert Function dialog box
+  (LPCFUNCTION)CP_set_reference_state,                                                // Pointer to the function code.
+  COMPLEX_SCALAR,                                                                     // Returns a Mathcad complex scalar
+  2,                                                                                  // Number of arguments
+  {MC_STRING, MC_STRING}                                                              // Argument types
 };
 
 FUNCTIONINFO Props1SI = {
-  "Props1SI",                                                                                     // Name by which Mathcad will recognize the function
-  "Fluid, Property Name",                                                                         // Description of input parameters
-  "Returns a fluid-specific parameter, where the parameter is not dependent on the fluid state",  // Description of the function for the Insert Function dialog box
-  (LPCFUNCTION)CP_Props1SI,                                                                       // Pointer to the function code.
-  COMPLEX_SCALAR,                                                                                 // Returns a Mathcad complex scalar
-  2,                                                                                              // Number of arguments
-  {MC_STRING, MC_STRING}                                                                          // Argument types
+  const_cast<char*>("Props1SI"),                                                                                     // Name by which Mathcad will recognize the function
+  const_cast<char*>("Fluid, Property Name"),                                                                         // Description of input parameters
+  const_cast<char*>("Returns a fluid-specific parameter, where the parameter is not dependent on the fluid state"),  // Description of the function for the Insert Function dialog box
+  (LPCFUNCTION)CP_Props1SI,                                                                                          // Pointer to the function code.
+  COMPLEX_SCALAR,                                                                                                    // Returns a Mathcad complex scalar
+  2,                                                                                                                 // Number of arguments
+  {MC_STRING, MC_STRING}                                                                                             // Argument types
 };
 
 FUNCTIONINFO PropsSI = {
-  "PropsSI",                                                                                  // Name by which Mathcad will recognize the function
-  "Output Name, Input Name 1, Input Property 1, Input Name 2, Input Property 2, Fluid Name",  // Description of input parameters
-  "Returns a fluid-specific parameter, where the parameter is dependent on the fluid state",  // Description of the function for the Insert Function dialog box
-  (LPCFUNCTION)CP_PropsSI,                                                                    // Pointer to the function code.
-  COMPLEX_SCALAR,                                                                             // Returns a Mathcad complex scalar
-  6,                                                                                          // Number of arguments
-  {MC_STRING, MC_STRING, COMPLEX_SCALAR, MC_STRING, COMPLEX_SCALAR, MC_STRING}                // Argument types
+  const_cast<char*>("PropsSI"),                                                                                  // Name by which Mathcad will recognize the function
+  const_cast<char*>("Output Name, Input Name 1, Input Property 1, Input Name 2, Input Property 2, Fluid Name"),  // Description of input parameters
+  const_cast<char*>("Returns a fluid-specific parameter, where the parameter is dependent on the fluid state"),  // Description of the function for the Insert Function dialog box
+  (LPCFUNCTION)CP_PropsSI,                                                                                       // Pointer to the function code.
+  COMPLEX_SCALAR,                                                                                                // Returns a Mathcad complex scalar
+  6,                                                                                                             // Number of arguments
+  {MC_STRING, MC_STRING, COMPLEX_SCALAR, MC_STRING, COMPLEX_SCALAR, MC_STRING}                                   // Argument types
 };
 
 FUNCTIONINFO PropsSImulti = {
-  "PropsSImulti",  //                                                         // Name by which Mathcad will recognize the function
-  "Output Name, Input Name 1, Input Property 1 (Array), Input Name 2, Input Property 2 (Array), Fluid Name",  // Description of input parameters
-  "Returns a range of fluid-specific parameters, where the parameters are dependent on the state ranges defined by the input property arrays",  // Description of the function for the Insert Function dialog box
+  const_cast<char*>("PropsSImulti"),                                                                                                              // Name by which Mathcad will recognize the function
+  const_cast<char*>("Output Name, Input Name 1, Input Property 1 (Array), Input Name 2, Input Property 2 (Array), Fluid Name"),                    // Description of input parameters
+  const_cast<char*>("Returns a range of fluid-specific parameters, where the parameters are dependent on the state ranges defined by the input property arrays"),  // Description of the function for the Insert Function dialog box
   (LPCFUNCTION)CP_PropsSImulti,                                               // Pointer to the function code.
   COMPLEX_ARRAY,                                                              // Returns a Mathcad complex array
   6,                                                                          // Number of arguments
@@ -917,73 +917,73 @@ FUNCTIONINFO PropsSImulti = {
 };
 
 FUNCTIONINFO PhaseSI = {
-  "PhaseSI",                                                                     // Name by which Mathcad will recognize the function
-  "Input Name 1, Input Property 1, Input Name 2, Input Property 2, Fluid Name",  // Description of input parameters
-  "Returns the fluid phase, dependent on the fluid state",                       // Description of the function for the Insert Function dialog box
-  (LPCFUNCTION)CP_PhaseSI,                                                       // Pointer to the function code.
-  MC_STRING,                                                                     // Returns a Mathcad String
-  5,                                                                             // Number of arguments
-  {MC_STRING, COMPLEX_SCALAR, MC_STRING, COMPLEX_SCALAR, MC_STRING}              // Argument types
+  const_cast<char*>("PhaseSI"),                                                                     // Name by which Mathcad will recognize the function
+  const_cast<char*>("Input Name 1, Input Property 1, Input Name 2, Input Property 2, Fluid Name"),  // Description of input parameters
+  const_cast<char*>("Returns the fluid phase, dependent on the fluid state"),                       // Description of the function for the Insert Function dialog box
+  (LPCFUNCTION)CP_PhaseSI,                                                                          // Pointer to the function code.
+  MC_STRING,                                                                                        // Returns a Mathcad String
+  5,                                                                                                // Number of arguments
+  {MC_STRING, COMPLEX_SCALAR, MC_STRING, COMPLEX_SCALAR, MC_STRING}                                 // Argument types
 };
 
 FUNCTIONINFO HAPropsSI = {
-  "HAPropsSI",  // Name by which Mathcad will recognize the function
-  "Output Name, Input Name 1, Input Property 1, Input Name 2, Input Property 2, Input Name 3, Input Property 3",  // Description of input parameters
-  "Returns a parameter of humid air, where the parameter is dependent on the fluid state",  // Description of the function for the Insert Function dialog box
-  (LPCFUNCTION)CP_HAPropsSI,                                                                // Pointer to the function code.
-  COMPLEX_SCALAR,                                                                           // Returns a Mathcad complex scalar
-  7,                                                                                        // Number of arguments
-  {MC_STRING, MC_STRING, COMPLEX_SCALAR, MC_STRING, COMPLEX_SCALAR, MC_STRING, COMPLEX_SCALAR}  // Argument types
+  const_cast<char*>("HAPropsSI"),  // Name by which Mathcad will recognize the function
+  const_cast<char*>("Output Name, Input Name 1, Input Property 1, Input Name 2, Input Property 2, Input Name 3, Input Property 3"),  // Description of input parameters
+  const_cast<char*>("Returns a parameter of humid air, where the parameter is dependent on the fluid state"),  // Description of the function for the Insert Function dialog box
+  (LPCFUNCTION)CP_HAPropsSI,                                                                                   // Pointer to the function code.
+  COMPLEX_SCALAR,                                                                                              // Returns a Mathcad complex scalar
+  7,                                                                                                           // Number of arguments
+  {MC_STRING, MC_STRING, COMPLEX_SCALAR, MC_STRING, COMPLEX_SCALAR, MC_STRING, COMPLEX_SCALAR}                 // Argument types
 };
 
 FUNCTIONINFO GetMixtureData = {
-  "get_mixture_binary_pair_data",                            // Name by which Mathcad will recognize the function
-  "CAS 1, CAS 2, Name of the parameter to retrieve",         // Description of input parameters
-  "Returns the value of the requested CoolProps parameter",  // description of the function for the Insert Function dialog box
-  (LPCFUNCTION)CP_get_mixture_binary_pair_data,              // Pointer to the function code.
-  MC_STRING,                                                 // Returns a Mathcad string
-  3,                                                         // Number of arguments
-  {MC_STRING, MC_STRING, MC_STRING}                          // Argument types
+  const_cast<char*>("get_mixture_binary_pair_data"),                            // Name by which Mathcad will recognize the function
+  const_cast<char*>("CAS 1, CAS 2, Name of the parameter to retrieve"),         // Description of input parameters
+  const_cast<char*>("Returns the value of the requested CoolProps parameter"),  // description of the function for the Insert Function dialog box
+  (LPCFUNCTION)CP_get_mixture_binary_pair_data,                                 // Pointer to the function code.
+  MC_STRING,                                                                    // Returns a Mathcad string
+  3,                                                                            // Number of arguments
+  {MC_STRING, MC_STRING, MC_STRING}                                             // Argument types
 };
 
 FUNCTIONINFO ApplyMixingRule = {
-  "apply_simple_mixing_rule",                   // Name by which Mathcad will recognize the function
-  "CAS 1, CAS 2, Mixing Rule",                  // Description of input parameters
-  "Sets a simple mixing rule for binary pair",  // description of the function for the Insert Function dialog box
-  (LPCFUNCTION)CP_apply_simple_mixing_rule,     // Pointer to the function code.
-  MC_STRING,                                    // Returns a Mathcad string
-  3,                                            // Number of arguments
-  {MC_STRING, MC_STRING, MC_STRING}             // Argument types
+  const_cast<char*>("apply_simple_mixing_rule"),                   // Name by which Mathcad will recognize the function
+  const_cast<char*>("CAS 1, CAS 2, Mixing Rule"),                  // Description of input parameters
+  const_cast<char*>("Sets a simple mixing rule for binary pair"),  // description of the function for the Insert Function dialog box
+  (LPCFUNCTION)CP_apply_simple_mixing_rule,                        // Pointer to the function code.
+  MC_STRING,                                                       // Returns a Mathcad string
+  3,                                                               // Number of arguments
+  {MC_STRING, MC_STRING, MC_STRING}                                // Argument types
 };
 
 FUNCTIONINFO SetMixtureData = {
-  "set_mixture_binary_pair_data",                             // Name by which Mathcad will recognize the function
-  "CAS 1, CAS 2, Parameter Name, Parameter value",            // Description of input parameters
-  "Sets the value of the specified binary mixing parameter",  // description of the function for the Insert Function dialog box
-  (LPCFUNCTION)CP_set_mixture_binary_pair_data,               // Pointer to the function code.
-  MC_STRING,                                                  // Returns a Mathcad string
-  4,                                                          // Number of arguments
-  {MC_STRING, MC_STRING, MC_STRING, COMPLEX_SCALAR}           // Argument types
+  const_cast<char*>("set_mixture_binary_pair_data"),                             // Name by which Mathcad will recognize the function
+  const_cast<char*>("CAS 1, CAS 2, Parameter Name, Parameter value"),            // Description of input parameters
+  const_cast<char*>("Sets the value of the specified binary mixing parameter"),  // description of the function for the Insert Function dialog box
+  (LPCFUNCTION)CP_set_mixture_binary_pair_data,                                  // Pointer to the function code.
+  MC_STRING,                                                                     // Returns a Mathcad string
+  4,                                                                             // Number of arguments
+  {MC_STRING, MC_STRING, MC_STRING, COMPLEX_SCALAR}                              // Argument types
 };
 
 FUNCTIONINFO GetPredefFluids = {
-  "get_predefined_mixture_fluids",                                      // Name by which Mathcad will recognize the function
-  "MixtureName",                                                        // Description of input parameters
-  "Returns semicolon-delimited fluid names in the predefined mixture",  // description of the function for the Insert Function dialog box
-  (LPCFUNCTION)CP_get_predefined_mixture_fluids,                        // Pointer to the function code.
-  MC_STRING,                                                            // Returns a Mathcad string
-  1,                                                                    // Number of arguments
-  {MC_STRING}                                                           // Argument types
+  const_cast<char*>("get_predefined_mixture_fluids"),                                      // Name by which Mathcad will recognize the function
+  const_cast<char*>("MixtureName"),                                                        // Description of input parameters
+  const_cast<char*>("Returns semicolon-delimited fluid names in the predefined mixture"),  // description of the function for the Insert Function dialog box
+  (LPCFUNCTION)CP_get_predefined_mixture_fluids,                                           // Pointer to the function code.
+  MC_STRING,                                                                               // Returns a Mathcad string
+  1,                                                                                       // Number of arguments
+  {MC_STRING}                                                                              // Argument types
 };
 
 FUNCTIONINFO GetPredefMoleFracs = {
-  "get_predefined_mixture_fractions",                                      // Name by which Mathcad will recognize the function
-  "MixtureName",                                                           // Description of input parameters
-  "Returns a column vector of mole fractions for the predefined mixture",  // description of the function for the Insert Function dialog box
-  (LPCFUNCTION)CP_get_predefined_mixture_mole_fractions,                   // Pointer to the function code.
-  COMPLEX_ARRAY,                                                           // Returns a Mathcad complex array
-  1,                                                                       // Number of arguments
-  {MC_STRING}                                                              // Argument types
+  const_cast<char*>("get_predefined_mixture_fractions"),                                      // Name by which Mathcad will recognize the function
+  const_cast<char*>("MixtureName"),                                                           // Description of input parameters
+  const_cast<char*>("Returns a column vector of mole fractions for the predefined mixture"),  // description of the function for the Insert Function dialog box
+  (LPCFUNCTION)CP_get_predefined_mixture_mole_fractions,                                      // Pointer to the function code.
+  COMPLEX_ARRAY,                                                                              // Returns a Mathcad complex array
+  1,                                                                                          // Number of arguments
+  {MC_STRING}                                                                                 // Argument types
 };
 
 // ************************************************************************************
@@ -1009,7 +1009,7 @@ extern "C" BOOL WINAPI DllEntryPoint(HINSTANCE hDLL, DWORD dwReason, LPVOID lpRe
             if (!_CRT_INIT(hDLL, dwReason, lpReserved)) return FALSE;
 
             // Register the error message table
-            if (!CreateUserErrorMessageTable(hDLL, NUMBER_OF_ERRORS, CPErrorMessageTable)) break;
+            if (!CreateUserErrorMessageTable(hDLL, NUMBER_OF_ERRORS, const_cast<char**>(CPErrorMessageTable))) break;
 
             // ...and if the errors register OK, go ahead and register user function
             CreateUserFunction(hDLL, &PropsParam);
@@ -1033,7 +1033,6 @@ extern "C" BOOL WINAPI DllEntryPoint(HINSTANCE hDLL, DWORD dwReason, LPVOID lpRe
         case DLL_PROCESS_DETACH:
 
             if (!_CRT_INIT(hDLL, dwReason, lpReserved)) {
-                Sleep(1000);  // Attempt to keep CRT_INIT from detaching before all threads are closed
                 return FALSE;
             }
             break;

--- a/wrappers/MathCAD/CoolPropMathcad.cpp
+++ b/wrappers/MathCAD/CoolPropMathcad.cpp
@@ -1,6 +1,7 @@
 // CoolPropMathcad.cpp : Defines the exported functions for the DLL Add-in.
 //
 
+#include <limits>
 #include <string>
 #include <cstring>
 
@@ -149,8 +150,7 @@ static LRESULT AllocateToMathcadArray(LPCOMPLEXARRAY dest, const std::vector<std
 
 // Helper: Get IEEE 754 double precision NaN value for returning in case of errors in array outputs
 static double get_nan() {
-    unsigned long long nan_pattern = 0xFFF8000000000000ULL;
-    return *(double*)&nan_pattern;
+    return std::numeric_limits<double>::quiet_NaN();
 }
 
 // Helper: check that a complex scalar input is Real and return proper Mathcad error


### PR DESCRIPTION
## What
C++11-compliance and correctness fixes to the Mathcad wrapper (`wrappers/MathCAD/CoolPropMathcad.cpp`): replace a non-portable NaN construction with `std::numeric_limits`, and remove implicit string-literal → `char*` conversions the Mathcad SDK's `FUNCTIONINFO`/error-table structs were relying on.

## Why
- `get_nan()` built quiet NaN by reinterpret-casting a `long long` bit pattern through a pointer (`*(double*)&nan_pattern`), which violates strict aliasing and is UB in C++. `std::numeric_limits<double>::quiet_NaN()` gives the same IEEE 754 NaN portably and without the cast.  NaN values are returned to Mathcad by `PropsSImulti()` for all cases in the array that fail; the user can then locate the offending call parameters and/or filter them out in Mathcad.
- The Mathcad SDK's `FUNCTIONINFO` entries and `CPErrorMessageTable` take `char*` for name/description/message fields, but were being initialized directly from string literals (`const char*`). That's rejected under C++11 and later but was relying on the ; the fix wraps each literal in `const_cast<char*>(...)` (and marks the table itself `const char*`) so the wrapper builds cleanly under stricter/current compiler settings.  By default, MSVC keeps the old, non-conforming behavior: it silently allows string-literal → char*  initialization unless flags are set for strict compliance.  However, this is not guaranteed for future versions of MSVC.
- Also drops a `Sleep(1000)` in `DLL_PROCESS_DETACH` that was there as a speculative workaround for a CRT_INIT/thread-detach race in Legacy Mathcad.  Microsoft's Windows documentation explicitly prohibits this pattern, which could cause unexpected results.

## Changes
- `wrappers/MathCAD/CoolPropMathcad.cpp`:
  - `get_nan()` now returns `std::numeric_limits<double>::quiet_NaN()` instead of type-punning a bit pattern (added `#include <limits>`).
  - `CPErrorMessageTable` changed from `char*[]` to `const char*[]`; call site casts back to `char**` only where the SDK's `CreateUserErrorMessageTable` signature requires it.
  - All `FUNCTIONINFO` literal fields (function names, argument descriptions, insert-function-dialog descriptions) wrapped in `const_cast<char*>(...)`.
  - Removed the `Sleep(1000)` call in the `DLL_PROCESS_DETACH` branch of `DllEntryPoint`.

## AI Disclosure
Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>
Claude provided the C++17 modernization suggestions and generated the proper syntax for the const_cast of the string literals.  Claude also flagged the legacy `Sleep(1000)` call in the `DLL_PROCESS_DETACH` branch of `DllEntryPoint` during an independent code review. 

## Testing
- Manual build verification and testing for the Mathcad wrapper. Verification worksheets show no regressions.  The NaN functionality is unaffected, error message registration is unchanged, and the DLL detaches properly when Mathcad Prime shuts down without leaving any rogue Mathcad processes running.

🤖 Co-authored-by: [Claude Code](https://claude.com/claude-code) Sonnet 5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of error messages and special numeric values in the MathCAD integration.
  * Updated compatibility behavior for registered function metadata.
  * Streamlined shutdown behavior for the MathCAD component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->