### PR TITLE
docs(changelog): record the p,T and entropy-input density solve improvements

### DIFF
--- a/Web/coolprop/changelog.rst
+++ b/Web/coolprop/changelog.rst
@@ -132,7 +132,42 @@ Highlights:
   ``include/CoolProp/DataStructures.h`` are appended at the end of their enums
   and are ABI-safe.
 
+Performance:
+
+* **The p,T flash stops recomputing derivatives it already has**, and the
+  supercritical-liquid branch, which solved without derivatives at all, now tries a
+  derivative method before its bracketed fallback.  ``Householder4`` was doing six
+  full derivative evaluations per solve where two suffice.  Compressed water goes
+  from 11.96 to 4.97 microseconds, against REFPROP's 4.45
+  (`#3360 <https://github.com/CoolProp/CoolProp/pull/3360>`_).
+
+* **Entropy-input density solves invert on a logarithmic density axis.**  ``s ~
+  -R*ln(rho)``, so the residual is nearly straight in ``ln(rho)`` where the bracket
+  spans 13 to 18 decades of density.  ``SmolarT`` is 2.4x faster at low pressure
+  (Water 51.18 to 20.96 microseconds per point) and slower at high pressure (Water
+  22.31 to 24.33), the log path running a 1e-12 tolerance rather than 1e-9.  Entropy
+  only — ``h`` and ``u`` have no ideal-gas logarithm and stay on the linear axis.
+  Together the two changes take a 137-fluid flash-consistency sweep from 3614
+  inconsistent points to 2185
+  (`#3362 <https://github.com/CoolProp/CoolProp/pull/3362>`_).
+
 Bug fixes:
+
+* **Low-density entropy flashes returned wrong densities.**  ``SmolarT`` resolved
+  absolute density on a bracket spanning up to 18 decades, so at ``rho = 1e-8``
+  mol/m^3 the answer was off by 6.1e-2 relative; it is now 4e-16 to 1e-12 across
+  twelve decades, and the ``SmolarT`` panel of the 137-fluid sweep falls from 1446
+  inconsistent points to 439
+  (`#3362 <https://github.com/CoolProp/CoolProp/pull/3362>`_).
+
+* **The p,T flash did not return the pressure it was given.**  Each density-residual
+  evaluation overwrote ``p`` with the equation of state's pressure at the trial
+  density, so ``PropsSI("P", "P", p, "T", T, fluid)`` came back 7.4e-10 relative
+  away from ``p`` for supercritical nitrogen.  It is now restored exactly, on the
+  **pure-fluid** path (`#3360 <https://github.com/CoolProp/CoolProp/pull/3360>`_).
+  Properties read after a pure-fluid p,T update are now evaluated at the converged
+  density rather than the previous iterate, so bit-exact baselines move in the last
+  digits.
 
 * **R1233zd(E) viscosity works again, with refit constants.**  v8.0.0 replaced
   this fluid's equation of state with the Akasaka & Lemmon (JPCRD 2022)


### PR DESCRIPTION
Stacked on #3362.  Changelog only — no code.

Adds 8.0.1 entries for the two flash changes, split across **Performance** and **Bug fixes** because each is both:

- #3360 — recomputed derivatives it already had (compressed water 11.96 → 4.97 µs, REFPROP 4.45), *and* did not return the pressure it was given (7.4e-10 for supercritical nitrogen).
- #3362 — entropy solves move to a log density axis (2.4× faster at low pressure, slower at high), *and* low-density `SmolarT` was off by 6.1e-2 relative at ρ = 1e-8.

Filing either purely as a performance note would bury the half a user searches for.

A review of the first draft caught four places where it read better than its sources, all now fixed: it paired a *before* from one benchmark with an *after* from another (`11.96 → 7.10`; the table's own after is 4.97), quoted only the favourable half of the `SmolarT` timings, used a sweep baseline no release has (3192 is post-#3360; against 8.0.0 it is 3614 → 2185), and omitted that values move — `PT_flash` now evaluates properties at the converged density, so bit-exact baselines shift in the last digits.

`docutils` parses `changelog.rst` with the same nine error-level messages before and after (Sphinx-only roles, none in this addition).  Docs-only, so no test run.  Merge after #3362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved calculation speed for pressure–temperature and entropy-based density calculations.

* **Bug Fixes**
  * Corrected inaccurate densities returned for low-density entropy calculations.
  * Fixed an issue where requested pressure values could be replaced during pure-fluid calculations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->