### PR TITLE
docs: source-grounded assessment of REFPROP-vs-CoolProp functionality gaps

### DIFF
--- a/docs/superpowers/specs/2026-09-06-refprop-coolprop-functionality-gaps.md
+++ b/docs/superpowers/specs/2026-09-06-refprop-coolprop-functionality-gaps.md
@@ -1,7 +1,7 @@
 # REFPROP-vs-CoolProp functionality gaps
 
 **Date:** 2026-09-06
-**Issue:** CoolProp-it6e (epic), CoolProp-it6e.1 .. .8 (individual gaps)
+**Issue:** CoolProp-it6e (epic), CoolProp-it6e.1 .. .10 (individual gaps)
 **Status:** assessment complete; each gap needs its own design + plan before implementation
 
 ## Goal
@@ -11,50 +11,74 @@ REFPROP functionality* CoolProp's native `HEOS` backend does not provide, so
 that the roadmap argues from evidence and so that non-gaps stop being
 re-proposed.
 
-Every claim below is anchored to a file and line in this repository at
-`6de0bf8c5`.  Where a claim was checked and turned out to be **wrong**, it is
-recorded in "Rejected claims" rather than deleted — the point of the document
-is to stop the same wrong ideas recurring.
+Where a claim was checked and turned out to be **wrong**, it is recorded in
+"Rejected claims" rather than deleted — the point of the document is to stop
+the same wrong ideas recurring.
 
-## Scope
+## Method, and what it can and cannot support
 
-"Core functionality" means the property and equilibrium surface a library user
-calls.  Explicitly out of scope: the REFPROP GUI, the Excel add-in, table
-generation, and REFPROP's fitting tools.
+Two sides, anchored differently.  Read the distinction before quoting anything
+here, because it governs how much weight each claim carries.
 
-This document deliberately does **not** become an implementation plan.  It
-spans eight independent subsystems whose only common thread is "REFPROP has it";
-each needs its own design doc and its own plan, because the work in each is
-unrelated to the work in the others.  Bundling them into one plan would produce
-a plan nobody can execute.
+**CoolProp-side claims** are anchored to a file and line in this repository at
+`6de0bf8c5`.  They are checkable by anyone with the tree.
+
+**REFPROP-side claims** are claims about an external product and cannot be
+verified from CoolProp's own source.  Where the claim is about REFPROP's
+*exported API surface*, it is anchored to `REFPROP_lib.h` from the pinned
+`REFPROP-headers` dependency (`cmake/dependencies.cmake:70-73`, tag
+`b4faab1b73911c32c4b69c526c7e92f74edb67de`), which lists all 176 exported
+routines and is in-tree after a configure at
+`build_shared/_deps/refprop_headers-src/`.  That header proves a routine
+*exists* or does not.  It says nothing about what a routine *does* internally —
+so claims of the form "REFPROP's `TRNPRP` uses mixture ECS plus friction
+theory" rest on REFPROP's documentation and are marked as such below.
+
+**How the gap list was selected:** by scanning all 176 exported routines in that
+header for CoolProp counterparts, plus the mixture-model and flash coverage
+found by reading the HEOS backend.  A reader can therefore distinguish "not a
+gap" from "not considered": anything in the header not listed below was checked
+and found to have a counterpart.
 
 ## Rejected claims
 
 These were considered and are **not** gaps.  Recorded so they are not raised again.
 
-**Multiphase / VLLE / LLE / three-phase flash is NOT a REFPROP gap.**  REFPROP
-is two-phase VLE-only, exactly as CoolProp is.  CoolProp's VLE machinery
-(`src/Backends/Helmholtz/VLERoutines.cpp`) is structurally two-phase — bubble/dew
-plus a single Rachford-Rice split, with no phase-stability-driven phase-count
-determination — and REFPROP's flash routines make the same restriction.  Wanting
-VLLE is a legitimate goal, but it is a gap against `teqp` or a process
-simulator, not against REFPROP, and must not be justified by pointing at
-REFPROP.
+**Multiphase / VLLE / LLE / three-phase flash is NOT a REFPROP gap.**  Neither
+library does it.  On the REFPROP side, the header exports 34 `*FLSH`/`*FL1`/
+`*FL2` routines and no VLLE or three-phase routine of any name (searched for
+`VLLE`, `LLE`, `3PH`, `THREEPH`; zero hits).  On the CoolProp side,
+`src/Backends/Helmholtz/VLERoutines.cpp` is two-phase: bubble/dew plus a single
+Rachford-Rice split.  Wanting VLLE is a legitimate goal, but it is a gap
+against `teqp` or a process simulator, not against REFPROP, and must not be
+justified by pointing at REFPROP.
+
+*Correction to an earlier draft of this document:* that draft said CoolProp has
+"no phase-stability-driven phase-count determination".  **That is false.**
+Michelsen tangent-plane-distance stability analysis is implemented and
+load-bearing: `StabilityRoutines::StabilityEvaluationClass`
+(`VLERoutines.h:666`, `VLERoutines.cpp:2094` `check_stability_michelsen`,
+`:2288` `minimize_tpd`), and `PT_flash_mixtures` gates its split on it —
+`FlashRoutines.cpp:179-180` constructs the tester and sets
+`do_twophase = !stability_tester.is_stable()`.  It is used at five further
+sites.  The accurate statement is that the stability test is *binary* — it
+decides one phase versus two and cannot discover a third — not that there is
+none.
 
 **Solid-fluid equilibrium is NOT a REFPROP gap.**  REFPROP's `MELTT`/`MELTP`
-and `SUBLT`/`SUBLP` return correlated *boundary lines* for pure fluids.  They
-are not an SLE flash.  Neither library computes solid-fluid equilibrium, so
-"CO2 freeze-out in cryogenic mixtures" is not available from REFPROP either.
-What survives from this area is narrow and is recorded as gap 5 below.
+and `SUBLT`/`SUBLP` return correlated *boundary lines* for pure fluids; they are
+not an SLE flash, and the header exports no SLE routine.  So "CO2 freeze-out in
+cryogenic mixtures" is not available from REFPROP either.  What survives from
+this area is narrow and is gap 5.
 
 **Fugacity, chemical potential, virials, mixture critical points, phase
-envelopes, reference-state setting, and BIP get/set are all present natively.**
+envelopes, reference-state setting, and BIP get/set are present natively.**
 See `include/CoolProp/AbstractState.h` (`calc_fugacity`,
 `calc_fugacity_coefficient`, `calc_chemical_potential`, `calc_Bvirial`,
-`calc_Cvirial`), `HelmholtzEOSMixtureBackend.h`
-(`_calc_all_critical_points`, `calc_criticality_contour_values`), and
+`calc_Cvirial`), `HelmholtzEOSMixtureBackend.h` (`_calc_all_critical_points`,
+`calc_criticality_contour_values`), and
 `src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp`.  Cubics (SRK/PR) and PC-SAFT
-already cover the ground REFPROP's `PREOS` toggle addresses.
+cover the ground REFPROP's `PREOS` toggle addresses.
 
 ## The gaps
 
@@ -62,64 +86,65 @@ Ordered by impact, which is not the same as ordered by effort.
 
 ### 1. Mixture transport properties are a mole-fraction average, not a model — `CoolProp-it6e.1`, P1
 
-The largest predictive gap.  In
-`src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp`:
+The largest predictive gap.  In `HelmholtzEOSMixtureBackend.cpp`:
 
-- `calc_viscosity` (line 832) returns `exp(sum_i x_i * ln eta_i)` for mixtures,
+- `calc_viscosity` (:832) returns `exp(sum_i x_i * ln eta_i)` for mixtures,
   after `set_warning_string("Mixture model for viscosity is highly approximate")`.
-- `calc_conductivity` (line 1086) returns `sum_i x_i * lambda_i`, with the
-  matching warning.
+- `calc_conductivity` (:1086) returns `sum_i x_i * lambda_i`, same warning.
 
 Each per-component value is evaluated by constructing a fresh pure-fluid
 `HelmholtzEOSBackend` at the *mixture* `(rho, T)`, which is not a state the pure
-fluid is necessarily in.  There is no mixture critical enhancement at all.
+fluid is necessarily in.  There is no mixture critical enhancement.
 
 The underlying routines cannot help: `TransportRoutines.cpp` throws
 `"is only for pure and pseudo-pure"` in **15** distinct places, covering every
 dilute, initial-density, higher-order, friction-theory, Chung and critical
 contribution.
 
-REFPROP's `TRNPRPdll` runs a genuine mixture model — extended corresponding
-states with a mixture conformal-state solve, plus friction theory.  CoolProp has
-`viscosity_ECS`/`conductivity_ECS` declared in `TransportRoutines.h` (lines
-274, 278) with a conformal-state solver, but they are wired for pure fluids
-against a reference fluid, not for mixtures.
+CoolProp does have `viscosity_ECS`/`conductivity_ECS` (`TransportRoutines.h:274`,
+`:278`) with a conformal-state solver, but both index `HEOS.components[0]` and
+are reached only from the pure branch.  REFPROP exports `TRNPRPdll`
+(`REFPROP_lib.h:254`), which per REFPROP's documentation runs extended
+corresponding states with a mixture conformal-state solve plus friction theory.
 
 *Consequence:* for any real mixture, CoolProp's eta and lambda are not
-predictive.  The warning string is set, but a caller who does not read
+predictive.  The warning string is set, but a caller who never reads
 `get_warning_string()` gets a plausible-looking number with no accuracy claim
 behind it.
 
-*Effort:* large.  This is the multi-month item.  The existing ECS scaffolding is
-the natural starting point, so the first design question is whether the
-conformal-state solver generalises to mixtures or needs replacing.
+*Effort:* large — the multi-month item.  First design question: does the
+existing conformal-state solver generalise to mixtures, or must it be replaced?
 
 ### 2. Ammonia-water is absent entirely — `CoolProp-it6e.2`, P1
 
-`dev/mixtures/mixture_binary_pairs.json` contains 888 binary pairs and
-**no Ammonia/Water row**.  Verified programmatically, not by eye.  The
-consequence is not "inaccurate" — it is that the mixture cannot be constructed
-at all, so every absorption-cycle use case is a hard failure at `factory()`.
+`dev/mixtures/mixture_binary_pairs.json` holds 888 binary pairs and **no
+Ammonia/Water row** (checked by CAS `7664-41-7`/`7732-18-5` and by name).  The
+consequence is not inaccuracy — the mixture cannot be constructed at all:
+`set_mixture_parameters()` is called from the constructor
+(`HelmholtzEOSMixtureBackend.cpp:131`) and throws at `MixtureParameters.cpp:590`.
+So `AbstractState::factory("HEOS", "Ammonia&Water")` is a hard failure, and
+every absorption-cycle use case on the HEOS backend fails at construction.
+(`factory("REFPROP", ...)` works for a licensed user; this gap is HEOS-only.)
 
-REFPROP carries the dedicated Tillner-Roth & Friend Helmholtz model for this
-system, which is not expressible in CoolProp's three available departure-function
-forms (`Exponential`, `GERG-2008`, `Gaussian+Exponential`; 28 functions total in
-`dev/mixtures/mixture_departure_functions.json`).
+REFPROP carries the dedicated Tillner-Roth & Friend model for this system.
 
 *Design question to settle first:* fit a BIP row into the existing multi-fluid
 framework (cheap, approximate) versus implement TRF as a dedicated model
-(faithful, more work).  These have very different costs and the choice is not
-obvious.
+(faithful, more work).  Note the obstruction to (b) is **not** simply the set of
+available departure-function forms — it is TRF's composition dependence and its
+reducing function.  Establish the real obstruction during design rather than
+assuming this one.
 
-*Effort:* small if (a), medium if (b).  Highest impact-per-unit-effort on this
-list, and the recommended first target.
+*Effort:* small if (a), medium if (b).  Highest impact-per-unit-effort here, and
+the recommended first target.
 
 ### 3. Mixture surface tension throws — `CoolProp-it6e.3`, P2
 
 `HelmholtzEOSMixtureBackend.cpp:712` throws
 `NotImplementedError("surface tension not implemented for mixtures")`.
-REFPROP's `SURFTdll` handles mixtures.  A mixing rule must be chosen before any
-code is written; this is a modelling decision, not a plumbing one.
+REFPROP exports `SURFTdll` (`REFPROP_lib.h:238`), documented as handling
+mixtures.  A mixing rule must be chosen before any code is written; this is a
+modelling decision, not plumbing.
 
 *Effort:* medium, dominated by the model choice and its validation data.
 
@@ -128,106 +153,159 @@ code is written; this is a modelling decision, not a plumbing one.
 In `src/Backends/Helmholtz/FlashRoutines.cpp`, these throw
 `"not ready for mixtures"`:
 
-| Line | Routine |
-| ---- | ------- |
-| 510  | `DP_flash` |
-| 578  | `DQ_flash` |
-| 616  | `HQ_flash` |
-| 649  | `QS_flash` |
+| Line | Routine | REFPROP counterpart |
+| ---- | ------- | ------------------- |
+| 510  | `DP_flash` | `PDFLSHdll` (`REFPROP_lib.h:180`) |
+| 578  | `DQ_flash` | `DQFL2dll` (`:134`) |
+| 616  | `HQ_flash` | `SATHdll` (`:214`), saturation state from `h` with a `kph` code |
+| 649  | `QS_flash` | `SATSdll` (`:218`), likewise from `s` |
 
-REFPROP ships the complete matrix (`DEFLSH`, `DHFLSH`, `DSFLSH`, `PDFLSH`,
-`PEFLSH`, `TDFLSH`, `TEFLSH`, `DQFL2`, ...).
+Note there is **no** `HQFLSH` or `SQFLSH` in REFPROP — HQ and QS are served by
+the saturation routines, not by a flash.  An earlier draft claimed REFPROP
+"ships the complete matrix" and cited `DEFLSH`/`DHFLSH`/`DSFLSH`/`PEFLSH`/
+`TEFLSH`; those are real routines but they correspond to input pairs CoolProp
+already supports, so they were not evidence for these four.
+
+There are five `not ready for mixtures` throws in the file; the fifth (:728) is
+inside the superancillary helper `resolve_T_via_superancillary`, reachable only
+from DQ/HQ/QS and their `_with_guesses` variants, so the gap is four input
+pairs, not five.
 
 **Sequencing constraint:** `CoolProp-ft05` (P0 — mixture `HSU_P` flash returns
 wrong `T`, silently, on master) and `CoolProp-1gth` (P1 — `DmassT`/`DmolarT`
 can return a state at a different density than requested) are open defects in
-the mixture flash paths that *already exist*.  Adding four more input pairs on
-top of a base with known silent-wrong-answer bugs would multiply the surface
-area of those bugs.  Fix those first.
+mixture flash paths that *already exist*.  Adding four more input pairs onto a
+base with known silent-wrong-answer bugs multiplies their surface area.  Fix
+those first.
 
-*Effort:* medium per pair, and they share machinery.
+*Effort:* medium per pair; they share machinery.
 
 ### 5. No sublimation line, natively or by passthrough — `CoolProp-it6e.5`, P2
 
 Two separate absences:
 
-- **Native.** Zero occurrences of `sublim` in the Helmholtz backend.  The only
-  repo-wide hits are the humid-air ice line in `src/HumidAirProp.cpp` and
-  `SATT` `kph`-code comments in the REFPROP backend.  Melting *is* covered
-  (`src/Backends/Helmholtz/MeltingCaloric.cpp`).
+- **Native.** No general per-fluid sublimation ancillary.  There *is* one
+  hard-coded ice curve — `psub_Ice` (`src/Ice.cpp:36`, declared
+  `include/CoolProp/fluids/Ice.h:4`), reachable via
+  `HAProps_Aux("psub_Ice", ...)` (`src/HumidAirProp.cpp:2404`) — so this is a
+  missing *general facility*, not a total absence.  (An earlier draft argued
+  from "zero occurrences of `sublim`"; that grep misses `psub_Ice` entirely and
+  was weak evidence.  Melting, by contrast, is covered generally:
+  `src/Backends/Helmholtz/MeltingCaloric.cpp`.)
 - **Passthrough.** `src/Backends/REFPROP/REFPROPMixtureBackend.cpp` wraps
-  `MELTPdll` and `MELTTdll` but **not** `SUBLPdll`/`SUBLTdll`.  So even a user
-  who owns REFPROP cannot reach its sublimation curve through CoolProp.
+  `MELTPdll`/`MELTTdll` but **not** `SUBLPdll`/`SUBLTdll`
+  (`REFPROP_lib.h:236-237`).  Even a user who owns REFPROP cannot reach its
+  sublimation curve through CoolProp.
 
-Scope note, to prevent the rejected claim from creeping back: this is boundary
-*lines* only.  It is not SLE, and REFPROP does not offer SLE either.
+Scope note, so the rejected claim does not creep back: this is boundary *lines*
+only.  Not SLE; REFPROP has no SLE either.
 
-*Effort:* the passthrough is small and mirrors the existing melting-line
-wrapping exactly — it is the natural first commit.  The native pure-fluid
-ancillary is the larger piece and needs source correlations per fluid.
+*Effort:* medium, and larger than "just mirror the melting code" suggests —
+there is no sublimation API to mirror onto.  The melting passthrough hangs off
+`AbstractState::calc_melting_line` (`AbstractState.h:650`), `melting_line()`
+(`:1571`) and `has_melting_line()` (`:1564`); sublimation equivalents must all be
+created first.  That new-virtual-plus-parameter-plumbing work is the same shape
+as gap 6.
 
 ### 6. No dielectric constant — `CoolProp-it6e.6`, P3
 
-REFPROP exposes `DIELEC`.  CoolProp has no such property; the only `dielectric`
-matches under `src/` belong to PC-SAFT's internal electrolyte term
-(`src/Backends/PCSAFT/PCSAFTBackend.cpp`), which is not a general-purpose
-dielectric constant and is not exposed as a parameter.
+REFPROP exports `DIELECdll` (`REFPROP_lib.h:128`).  CoolProp has no such
+property; the only matches under `src/` belong to PC-SAFT's internal
+electrolyte term (`PCSAFTBackend.cpp`, `PCSAFTBackend.h:37`), which is neither a
+general-purpose dielectric constant nor exposed as a parameter.  Also searched
+`permittivity` and `epsilon_r`: no hits.
 
-Requires a new entry in `DataStructures`, the parameter plumbing, and per-fluid
-correlations — the last of which is the real cost.
+Requires a new `DataStructures` entry, parameter plumbing, and per-fluid
+correlations — the last being the real cost.
 
 *Effort:* medium, dominated by data collection.
 
 ### 7. No runtime model switching — `CoolProp-it6e.7`, P3
 
-REFPROP's `SETMOD` selects an alternate published EOS or transport model per
-fluid at runtime, and can disable the critical enhancement.  CoolProp binds
-exactly one EOS per fluid JSON.
+REFPROP's `SETMODdll` (`REFPROP_lib.h:227`) selects an alternate published EOS
+or transport model per fluid at runtime.
 
-This is more relevant than its P3 suggests, because it interacts with work
-already open: `CoolProp-9s9u` (REFPROP 10.1 viscosity correlations not
-implemented), `CoolProp-3bpg` (how to adopt the 2022 R-134a viscosity given its
-ECS reference role) and `CoolProp-f1ez` (nitrogen/argon viscosity supersession
-blocked by the conductivity coupling) are all cases where being able to select
-between an old and a new correlation would let both ship instead of forcing a
-choice.  Worth revisiting the priority if the supersession work stalls.
+**The gap is narrower than "CoolProp only has one model per fluid", and the work
+is in a different place than you would guess.**  23 of the 137 fluid JSONs
+already ship **two** EOS entries (Ammonia carries Gao-2020 *and*
+Tillner-Roth-1993; also D4, D5, Helium, HydrogenChloride, MD2M, MD3M, MD4M, …),
+and `parse_EOS_listing`
+(`src/Backends/Helmholtz/Fluids/FluidLibrary.h:527-531`) loads all of them into
+`EOSVector`.  What hard-codes the choice is the accessor:
+`include/CoolProp/CoolPropFluid.h:564` and `:567` return `EOSVector[0]`, and
+nothing anywhere indexes `EOSVector[i>0]`.  So the alternate models are already
+shipped and parsed; the missing piece is **selection plumbing above the loader**,
+not loader work.
 
-*Effort:* medium; mostly an architecture change to the fluid-loading path.
+This interacts with open work: `CoolProp-f1ez` (nitrogen/argon viscosity
+supersession blocked by the conductivity coupling) and `CoolProp-3bpg` (how to
+adopt the 2022 R-134a viscosity given its ECS reference role) are genuine
+forced-choice cases, and 3bpg's option (b) is literally per-fluid model pinning.
+`CoolProp-9s9u` is *not* such a case — its items are blocked on missing
+manuscript verification points and a NIST HTTP 503, which model switching does
+not address.  Worth revisiting this priority if the supersession work stalls.
+
+*Effort:* medium; a selection API plus a policy for what a selected model means
+downstream (notably for ECS reference fluids).
 
 ### 8. No BIP estimation fallback — `CoolProp-it6e.8`, P3
 
-CoolProp throws for any binary pair outside the 888-pair library unless the
-caller explicitly invokes
+CoolProp throws for a binary pair outside the 888-pair library unless the caller
+supplies parameters by one of three explicit routes:
 `apply_simple_mixing_rule(id1, id2, "linear" | "Lorentz-Berthelot")`
-(`src/Backends/Helmholtz/MixtureParameters.cpp:286`, rules at :241 and :251).
-REFPROP falls back to its own estimation schemes when a pair is missing from
+(`MixtureParameters.cpp:286`; rules at `:241`, `:251`),
+`set_interaction_parameters` with binary-pair JSON (`:396`), or
+`set_departure_functions` fed a REFPROP `HMX.BNC` dump
+(`parse_HMX_BNC`, `:646`).  What is missing is specifically an *estimation*
+scheme that fires automatically, as REFPROP's does when a pair is absent from
 `HMX.BNC`.
 
 **This is a difference in philosophy, not straightforwardly a defect.**
 CoolProp's fail-loud default means a user never silently receives an estimated
-number believing it to be a fitted one.  That is the better default and should
-be preserved.  The design question is therefore whether to offer an *opt-in*
-estimation mode, not whether to change the default.
+number believing it fitted.  That is the better default and should be preserved.
+The design question is whether to offer an *opt-in* estimation mode — not
+whether to change the default.
 
-*Effort:* small, but do not start it without agreeing the opt-in framing.
+*Effort:* small, but do not start without agreeing the opt-in framing.
+
+### 9. No choked-flow / critical-flow factor — `CoolProp-it6e.9`, P3
+
+REFPROP exports `CSTARdll` (critical flow factor, `REFPROP_lib.h:113`) and
+`MASSFLUXdll` (choked mass flux, `:170`).  CoolProp has neither: `grep -rin
+'cstar|choked|mass_flux'` over `src/` and `include/` returns nothing outside the
+GERG backend.  Relevant to relief-valve and nozzle sizing.
+
+*Effort:* medium; the thermodynamics is standard but needs an isentropic-choking
+solver.
+
+### 10. No AGA8 characterization — `CoolProp-it6e.10`, P3
+
+REFPROP exports `SETAGAdll`/`UNSETAGAdll` (`REFPROP_lib.h:222`) to switch a
+loaded mixture onto AGA8.  CoolProp carries AGA8 only as GERG *validation
+reference data* (`src/Backends/GERG/GERGReferenceValues.h`); there is no AGA8
+model a user can select.  Closely related to gap 7 — `SETAGA` is a special case
+of runtime model switching — so sequence them together.
+
+*Effort:* medium.
 
 ## Non-gap, for completeness
 
-CoolProp ships 137 pure-fluid JSONs (`dev/fluids/*.json`) against REFPROP 10's
-~147.  This is the smallest difference on the list and is a data-curation
-matter rather than a functionality gap.  No issue filed.
+CoolProp ships 137 pure-fluid JSONs (`dev/fluids/*.json`, matching 137 entries in
+`dev/all_fluids.json`) against REFPROP 10's roughly 147.  A data-curation matter
+rather than a functionality gap.  No issue filed.
 
 ## Recommended sequencing
 
-1. **`CoolProp-it6e.2` (ammonia-water)** first — highest impact per unit effort,
-   and it converts a hard `factory()` failure into a working mixture.
-2. **`CoolProp-it6e.5` REFPROP sublimation passthrough** — small, self-contained,
-   mirrors existing code, good warm-up commit.
-3. **`CoolProp-ft05` and `CoolProp-1gth`** (existing flash defects) before
-   **`CoolProp-it6e.4`** (new flash pairs).
-4. **`CoolProp-it6e.1` (mixture transport)** as its own project, once someone
-   can commit to it.  Do not start it as a side quest.
+1. **`CoolProp-it6e.2` (ammonia-water)** — highest impact per unit effort, and it
+   converts a hard `factory()` failure into a working mixture.
+2. **`CoolProp-ft05` and `CoolProp-1gth`** (existing mixture-flash defects)
+   before **`CoolProp-it6e.4`** (new flash pairs).
+3. **`CoolProp-it6e.7` and `.10` together** — selection plumbing, then AGA8 as
+   its first consumer.  Cheaper than their P3 suggests, because the alternate
+   EOS data is already parsed and sitting in `EOSVector`.
+4. **`CoolProp-it6e.1` (mixture transport)** as its own project, once someone can
+   commit to it.  Do not start it as a side quest.
 
-Gaps 3, 6, 7 and 8 are unblocked and can be picked up independently; each needs
-its own design doc first, because each turns on a modelling or architecture
-decision that this assessment deliberately does not make.
+Gaps 3, 5, 6, 8 and 9 are unblocked and can be picked up independently.  Each
+needs its own design doc first, because each turns on a modelling or
+architecture decision that this assessment deliberately does not make.

--- a/docs/superpowers/specs/2026-09-06-refprop-coolprop-functionality-gaps.md
+++ b/docs/superpowers/specs/2026-09-06-refprop-coolprop-functionality-gaps.md
@@ -1,0 +1,233 @@
+# REFPROP-vs-CoolProp functionality gaps
+
+**Date:** 2026-09-06
+**Issue:** CoolProp-it6e (epic), CoolProp-it6e.1 .. .8 (individual gaps)
+**Status:** assessment complete; each gap needs its own design + plan before implementation
+
+## Goal
+
+Establish, from the source rather than from folklore, which pieces of *core
+REFPROP functionality* CoolProp's native `HEOS` backend does not provide, so
+that the roadmap argues from evidence and so that non-gaps stop being
+re-proposed.
+
+Every claim below is anchored to a file and line in this repository at
+`6de0bf8c5`.  Where a claim was checked and turned out to be **wrong**, it is
+recorded in "Rejected claims" rather than deleted — the point of the document
+is to stop the same wrong ideas recurring.
+
+## Scope
+
+"Core functionality" means the property and equilibrium surface a library user
+calls.  Explicitly out of scope: the REFPROP GUI, the Excel add-in, table
+generation, and REFPROP's fitting tools.
+
+This document deliberately does **not** become an implementation plan.  It
+spans eight independent subsystems whose only common thread is "REFPROP has it";
+each needs its own design doc and its own plan, because the work in each is
+unrelated to the work in the others.  Bundling them into one plan would produce
+a plan nobody can execute.
+
+## Rejected claims
+
+These were considered and are **not** gaps.  Recorded so they are not raised again.
+
+**Multiphase / VLLE / LLE / three-phase flash is NOT a REFPROP gap.**  REFPROP
+is two-phase VLE-only, exactly as CoolProp is.  CoolProp's VLE machinery
+(`src/Backends/Helmholtz/VLERoutines.cpp`) is structurally two-phase — bubble/dew
+plus a single Rachford-Rice split, with no phase-stability-driven phase-count
+determination — and REFPROP's flash routines make the same restriction.  Wanting
+VLLE is a legitimate goal, but it is a gap against `teqp` or a process
+simulator, not against REFPROP, and must not be justified by pointing at
+REFPROP.
+
+**Solid-fluid equilibrium is NOT a REFPROP gap.**  REFPROP's `MELTT`/`MELTP`
+and `SUBLT`/`SUBLP` return correlated *boundary lines* for pure fluids.  They
+are not an SLE flash.  Neither library computes solid-fluid equilibrium, so
+"CO2 freeze-out in cryogenic mixtures" is not available from REFPROP either.
+What survives from this area is narrow and is recorded as gap 5 below.
+
+**Fugacity, chemical potential, virials, mixture critical points, phase
+envelopes, reference-state setting, and BIP get/set are all present natively.**
+See `include/CoolProp/AbstractState.h` (`calc_fugacity`,
+`calc_fugacity_coefficient`, `calc_chemical_potential`, `calc_Bvirial`,
+`calc_Cvirial`), `HelmholtzEOSMixtureBackend.h`
+(`_calc_all_critical_points`, `calc_criticality_contour_values`), and
+`src/Backends/Helmholtz/PhaseEnvelopeRoutines.cpp`.  Cubics (SRK/PR) and PC-SAFT
+already cover the ground REFPROP's `PREOS` toggle addresses.
+
+## The gaps
+
+Ordered by impact, which is not the same as ordered by effort.
+
+### 1. Mixture transport properties are a mole-fraction average, not a model — `CoolProp-it6e.1`, P1
+
+The largest predictive gap.  In
+`src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp`:
+
+- `calc_viscosity` (line 832) returns `exp(sum_i x_i * ln eta_i)` for mixtures,
+  after `set_warning_string("Mixture model for viscosity is highly approximate")`.
+- `calc_conductivity` (line 1086) returns `sum_i x_i * lambda_i`, with the
+  matching warning.
+
+Each per-component value is evaluated by constructing a fresh pure-fluid
+`HelmholtzEOSBackend` at the *mixture* `(rho, T)`, which is not a state the pure
+fluid is necessarily in.  There is no mixture critical enhancement at all.
+
+The underlying routines cannot help: `TransportRoutines.cpp` throws
+`"is only for pure and pseudo-pure"` in **15** distinct places, covering every
+dilute, initial-density, higher-order, friction-theory, Chung and critical
+contribution.
+
+REFPROP's `TRNPRPdll` runs a genuine mixture model — extended corresponding
+states with a mixture conformal-state solve, plus friction theory.  CoolProp has
+`viscosity_ECS`/`conductivity_ECS` declared in `TransportRoutines.h` (lines
+274, 278) with a conformal-state solver, but they are wired for pure fluids
+against a reference fluid, not for mixtures.
+
+*Consequence:* for any real mixture, CoolProp's eta and lambda are not
+predictive.  The warning string is set, but a caller who does not read
+`get_warning_string()` gets a plausible-looking number with no accuracy claim
+behind it.
+
+*Effort:* large.  This is the multi-month item.  The existing ECS scaffolding is
+the natural starting point, so the first design question is whether the
+conformal-state solver generalises to mixtures or needs replacing.
+
+### 2. Ammonia-water is absent entirely — `CoolProp-it6e.2`, P1
+
+`dev/mixtures/mixture_binary_pairs.json` contains 888 binary pairs and
+**no Ammonia/Water row**.  Verified programmatically, not by eye.  The
+consequence is not "inaccurate" — it is that the mixture cannot be constructed
+at all, so every absorption-cycle use case is a hard failure at `factory()`.
+
+REFPROP carries the dedicated Tillner-Roth & Friend Helmholtz model for this
+system, which is not expressible in CoolProp's three available departure-function
+forms (`Exponential`, `GERG-2008`, `Gaussian+Exponential`; 28 functions total in
+`dev/mixtures/mixture_departure_functions.json`).
+
+*Design question to settle first:* fit a BIP row into the existing multi-fluid
+framework (cheap, approximate) versus implement TRF as a dedicated model
+(faithful, more work).  These have very different costs and the choice is not
+obvious.
+
+*Effort:* small if (a), medium if (b).  Highest impact-per-unit-effort on this
+list, and the recommended first target.
+
+### 3. Mixture surface tension throws — `CoolProp-it6e.3`, P2
+
+`HelmholtzEOSMixtureBackend.cpp:712` throws
+`NotImplementedError("surface tension not implemented for mixtures")`.
+REFPROP's `SURFTdll` handles mixtures.  A mixing rule must be chosen before any
+code is written; this is a modelling decision, not a plumbing one.
+
+*Effort:* medium, dominated by the model choice and its validation data.
+
+### 4. Four mixture flash input pairs are unimplemented — `CoolProp-it6e.4`, P2
+
+In `src/Backends/Helmholtz/FlashRoutines.cpp`, these throw
+`"not ready for mixtures"`:
+
+| Line | Routine |
+| ---- | ------- |
+| 510  | `DP_flash` |
+| 578  | `DQ_flash` |
+| 616  | `HQ_flash` |
+| 649  | `QS_flash` |
+
+REFPROP ships the complete matrix (`DEFLSH`, `DHFLSH`, `DSFLSH`, `PDFLSH`,
+`PEFLSH`, `TDFLSH`, `TEFLSH`, `DQFL2`, ...).
+
+**Sequencing constraint:** `CoolProp-ft05` (P0 — mixture `HSU_P` flash returns
+wrong `T`, silently, on master) and `CoolProp-1gth` (P1 — `DmassT`/`DmolarT`
+can return a state at a different density than requested) are open defects in
+the mixture flash paths that *already exist*.  Adding four more input pairs on
+top of a base with known silent-wrong-answer bugs would multiply the surface
+area of those bugs.  Fix those first.
+
+*Effort:* medium per pair, and they share machinery.
+
+### 5. No sublimation line, natively or by passthrough — `CoolProp-it6e.5`, P2
+
+Two separate absences:
+
+- **Native.** Zero occurrences of `sublim` in the Helmholtz backend.  The only
+  repo-wide hits are the humid-air ice line in `src/HumidAirProp.cpp` and
+  `SATT` `kph`-code comments in the REFPROP backend.  Melting *is* covered
+  (`src/Backends/Helmholtz/MeltingCaloric.cpp`).
+- **Passthrough.** `src/Backends/REFPROP/REFPROPMixtureBackend.cpp` wraps
+  `MELTPdll` and `MELTTdll` but **not** `SUBLPdll`/`SUBLTdll`.  So even a user
+  who owns REFPROP cannot reach its sublimation curve through CoolProp.
+
+Scope note, to prevent the rejected claim from creeping back: this is boundary
+*lines* only.  It is not SLE, and REFPROP does not offer SLE either.
+
+*Effort:* the passthrough is small and mirrors the existing melting-line
+wrapping exactly — it is the natural first commit.  The native pure-fluid
+ancillary is the larger piece and needs source correlations per fluid.
+
+### 6. No dielectric constant — `CoolProp-it6e.6`, P3
+
+REFPROP exposes `DIELEC`.  CoolProp has no such property; the only `dielectric`
+matches under `src/` belong to PC-SAFT's internal electrolyte term
+(`src/Backends/PCSAFT/PCSAFTBackend.cpp`), which is not a general-purpose
+dielectric constant and is not exposed as a parameter.
+
+Requires a new entry in `DataStructures`, the parameter plumbing, and per-fluid
+correlations — the last of which is the real cost.
+
+*Effort:* medium, dominated by data collection.
+
+### 7. No runtime model switching — `CoolProp-it6e.7`, P3
+
+REFPROP's `SETMOD` selects an alternate published EOS or transport model per
+fluid at runtime, and can disable the critical enhancement.  CoolProp binds
+exactly one EOS per fluid JSON.
+
+This is more relevant than its P3 suggests, because it interacts with work
+already open: `CoolProp-9s9u` (REFPROP 10.1 viscosity correlations not
+implemented), `CoolProp-3bpg` (how to adopt the 2022 R-134a viscosity given its
+ECS reference role) and `CoolProp-f1ez` (nitrogen/argon viscosity supersession
+blocked by the conductivity coupling) are all cases where being able to select
+between an old and a new correlation would let both ship instead of forcing a
+choice.  Worth revisiting the priority if the supersession work stalls.
+
+*Effort:* medium; mostly an architecture change to the fluid-loading path.
+
+### 8. No BIP estimation fallback — `CoolProp-it6e.8`, P3
+
+CoolProp throws for any binary pair outside the 888-pair library unless the
+caller explicitly invokes
+`apply_simple_mixing_rule(id1, id2, "linear" | "Lorentz-Berthelot")`
+(`src/Backends/Helmholtz/MixtureParameters.cpp:286`, rules at :241 and :251).
+REFPROP falls back to its own estimation schemes when a pair is missing from
+`HMX.BNC`.
+
+**This is a difference in philosophy, not straightforwardly a defect.**
+CoolProp's fail-loud default means a user never silently receives an estimated
+number believing it to be a fitted one.  That is the better default and should
+be preserved.  The design question is therefore whether to offer an *opt-in*
+estimation mode, not whether to change the default.
+
+*Effort:* small, but do not start it without agreeing the opt-in framing.
+
+## Non-gap, for completeness
+
+CoolProp ships 137 pure-fluid JSONs (`dev/fluids/*.json`) against REFPROP 10's
+~147.  This is the smallest difference on the list and is a data-curation
+matter rather than a functionality gap.  No issue filed.
+
+## Recommended sequencing
+
+1. **`CoolProp-it6e.2` (ammonia-water)** first — highest impact per unit effort,
+   and it converts a hard `factory()` failure into a working mixture.
+2. **`CoolProp-it6e.5` REFPROP sublimation passthrough** — small, self-contained,
+   mirrors existing code, good warm-up commit.
+3. **`CoolProp-ft05` and `CoolProp-1gth`** (existing flash defects) before
+   **`CoolProp-it6e.4`** (new flash pairs).
+4. **`CoolProp-it6e.1` (mixture transport)** as its own project, once someone
+   can commit to it.  Do not start it as a side quest.
+
+Gaps 3, 6, 7 and 8 are unblocked and can be picked up independently; each needs
+its own design doc first, because each turns on a modelling or architecture
+decision that this assessment deliberately does not make.

--- a/docs/superpowers/specs/2026-09-06-refprop-coolprop-functionality-gaps.md
+++ b/docs/superpowers/specs/2026-09-06-refprop-coolprop-functionality-gaps.md
@@ -1,7 +1,7 @@
 # REFPROP-vs-CoolProp functionality gaps
 
 **Date:** 2026-09-06
-**Issue:** CoolProp-it6e (epic), CoolProp-it6e.1 .. .10 (individual gaps)
+**Issue:** CoolProp-it6e (epic), CoolProp-it6e.1 .. .12 (individual gaps)
 **Status:** assessment complete; each gap needs its own design + plan before implementation
 
 ## Goal
@@ -31,14 +31,21 @@ verified from CoolProp's own source.  Where the claim is about REFPROP's
 routines and is in-tree after a configure at
 `build_shared/_deps/refprop_headers-src/`.  That header proves a routine
 *exists* or does not.  It says nothing about what a routine *does* internally —
-so claims of the form "REFPROP's `TRNPRP` uses mixture ECS plus friction
-theory" rest on REFPROP's documentation and are marked as such below.
+so **every description below of what a REFPROP routine *does* — `TRNPRP` using
+mixture ECS plus friction theory, `SATH`/`SATS` taking a `kph` code, what
+`SETMOD` and `SETAGA` switch, REFPROP's estimation fallback, `MELTT`/`SUBLT`
+returning correlated lines — rests on REFPROP's documentation, not on anything
+checkable here.**  Treat those as the weaker half of this document.
 
 **How the gap list was selected:** by scanning all 176 exported routines in that
 header for CoolProp counterparts, plus the mixture-model and flash coverage
-found by reading the HEOS backend.  A reader can therefore distinguish "not a
-gap" from "not considered": anything in the header not listed below was checked
-and found to have a counterpart.
+found by reading the HEOS backend.  Routines mapping to a thermophysical
+property or a model-selection facility were checked individually; REFPROP's
+infrastructure and I/O routines (`SETPATH`, `ERRMSG`, `FLAGS`, `PASSCMN`,
+`HMXORDER`, `GETENUM`, ...) were excluded as having no meaningful CoolProp
+counterpart to look for.  The scan is **not** claimed to be exhaustive beyond
+that: it found gaps 9 through 12, which the first draft missed entirely, so a
+further pass may well find more.
 
 ## Rejected claims
 
@@ -60,8 +67,9 @@ load-bearing: `StabilityRoutines::StabilityEvaluationClass`
 (`VLERoutines.h:666`, `VLERoutines.cpp:2094` `check_stability_michelsen`,
 `:2288` `minimize_tpd`), and `PT_flash_mixtures` gates its split on it —
 `FlashRoutines.cpp:179-180` constructs the tester and sets
-`do_twophase = !stability_tester.is_stable()`.  It is used at five further
-sites.  The accurate statement is that the stability test is *binary* — it
+`do_twophase = !stability_tester.is_stable()`.  It is constructed at four further
+production sites (`HelmholtzEOSMixtureBackend.cpp:4356`; `FlashRoutines.cpp:2572`,
+`:3950`, `:4077`), plus test-only uses.  The accurate statement is that the stability test is *binary* — it
 decides one phase versus two and cannot discover a third — not that there is
 none.
 
@@ -212,8 +220,9 @@ as gap 6.
 REFPROP exports `DIELECdll` (`REFPROP_lib.h:128`).  CoolProp has no such
 property; the only matches under `src/` belong to PC-SAFT's internal
 electrolyte term (`PCSAFTBackend.cpp`, `PCSAFTBackend.h:37`), which is neither a
-general-purpose dielectric constant nor exposed as a parameter.  Also searched
-`permittivity` and `epsilon_r`: no hits.
+general-purpose dielectric constant nor exposed as a parameter.  Also searched `permittivity`
+(one hit, `PCSAFTBackend.h:20` `perm_vac`, vacuum permittivity — PC-SAFT
+internals again) and `epsilon_r` (no hits).
 
 Requires a new `DataStructures` entry, parameter plumbing, and per-fluid
 correlations — the last being the real cost.
@@ -232,8 +241,10 @@ Tillner-Roth-1993; also D4, D5, Helium, HydrogenChloride, MD2M, MD3M, MD4M, …)
 and `parse_EOS_listing`
 (`src/Backends/Helmholtz/Fluids/FluidLibrary.h:527-531`) loads all of them into
 `EOSVector`.  What hard-codes the choice is the accessor:
-`include/CoolProp/CoolPropFluid.h:564` and `:567` return `EOSVector[0]`, and
-nothing anywhere indexes `EOSVector[i>0]`.  So the alternate models are already
+`include/CoolProp/CoolPropFluid.h:564` and `:567` return `EOSVector[0]`, and no
+consumer ever selects among the entries — the only non-zero index in the tree is
+the loader's own back-insertion while parsing (`FluidLibrary.h:428`,
+`EOSVector.at(EOSVector.size() - 1)`).  So the alternate models are already
 shipped and parsed; the missing piece is **selection plumbing above the loader**,
 not loader work.
 
@@ -241,9 +252,12 @@ This interacts with open work: `CoolProp-f1ez` (nitrogen/argon viscosity
 supersession blocked by the conductivity coupling) and `CoolProp-3bpg` (how to
 adopt the 2022 R-134a viscosity given its ECS reference role) are genuine
 forced-choice cases, and 3bpg's option (b) is literally per-fluid model pinning.
-`CoolProp-9s9u` is *not* such a case — its items are blocked on missing
-manuscript verification points and a NIST HTTP 503, which model switching does
-not address.  Worth revisiting this priority if the supersession work stalls.
+`CoolProp-9s9u` is a mixed case and should not be cited whole: its nitrogen and
+argon items *are* the `f1ez` forced-choice case already counted above, while its
+remaining items (deuterium, three correlations blocked on a NIST HTTP 503, neon,
+heavy water) are blocked on missing manuscripts, a server outage, or a VS0
+rewrite — none of which model switching addresses.  Worth revisiting this
+priority if the supersession work stalls.
 
 *Effort:* medium; a selection API plus a policy for what a selected model means
 downstream (notably for ECS reference fluids).
@@ -271,9 +285,9 @@ whether to change the default.
 ### 9. No choked-flow / critical-flow factor — `CoolProp-it6e.9`, P3
 
 REFPROP exports `CSTARdll` (critical flow factor, `REFPROP_lib.h:113`) and
-`MASSFLUXdll` (choked mass flux, `:170`).  CoolProp has neither: `grep -rin
-'cstar|choked|mass_flux'` over `src/` and `include/` returns nothing outside the
-GERG backend.  Relevant to relief-valve and nozzle sizing.
+`MASSFLUXdll` (choked mass flux, `:170`).  CoolProp has neither: `grep -rin` for `cstar`, `choked`,
+`mass_flux` and `massflux` over `src/` and `include/` returns **zero** hits
+each.  Relevant to relief-valve and nozzle sizing.
 
 *Effort:* medium; the thermodynamics is standard but needs an isentropic-choking
 solver.
@@ -287,6 +301,28 @@ model a user can select.  Closely related to gap 7 — `SETAGA` is a special cas
 of runtime model switching — so sequence them together.
 
 *Effort:* medium.
+
+### 11. No gross/net heating value — `CoolProp-it6e.11`, P3
+
+REFPROP exports `HEATdll` (`REFPROP_lib.h:158`) for gross and net heating
+values.  CoolProp has no counterpart: `grep -rinE 'HHV|LHV|heating_value|
+combustion'` over `src/` and `include/` returns nothing.
+
+Do not confuse this with `HFORMATION`/`HEATFRMdll`, added in `2ce7b0a1a` — that
+is the standard enthalpy of *formation*, a different quantity.  Relevant to
+natural-gas custody transfer, so it pairs naturally with gap 10.
+
+*Effort:* small; it is a combination of formation enthalpies plus a
+stoichiometry table.
+
+### 12. No fourth virial coefficient — `CoolProp-it6e.12`, P4
+
+REFPROP's `VIRBCDdll` (`REFPROP_lib.h:262`) returns the second, third **and
+fourth** virial coefficients.  CoolProp exposes `iBvirial` and `iCvirial` only;
+`grep -rin 'Dvirial'` over `src/` and `include/` returns zero hits.
+
+*Effort:* small, but `D` is rarely used — listed for completeness of the virial
+surface rather than because anyone is asking.
 
 ## Non-gap, for completeness
 
@@ -306,6 +342,10 @@ rather than a functionality gap.  No issue filed.
 4. **`CoolProp-it6e.1` (mixture transport)** as its own project, once someone can
    commit to it.  Do not start it as a side quest.
 
-Gaps 3, 5, 6, 8 and 9 are unblocked and can be picked up independently.  Each
-needs its own design doc first, because each turns on a modelling or
-architecture decision that this assessment deliberately does not make.
+Gaps 3, 5, 6, 8, 9, 11 and 12 are unblocked and can be picked up independently.
+Gap 11 pairs naturally with gap 10 (both serve natural-gas work).  Gap 12 is
+listed for completeness and nobody should prioritise it.
+
+Each remaining gap needs its own design doc first, because each turns on a
+modelling or architecture decision that this assessment deliberately does not
+make.

--- a/docs/superpowers/specs/2026-09-06-refprop-coolprop-functionality-gaps.md
+++ b/docs/superpowers/specs/2026-09-06-refprop-coolprop-functionality-gaps.md
@@ -355,13 +355,19 @@ covered by gaps 1-12:
 | `RIEMdll`  | :206 | thermodynamic curvature |
 | `B12dll`   | :105 | interaction second virial for a binary |
 | `CV2PKdll` | :114 | two-phase isochoric heat capacity |
-| `VIRBCD12dll` | :263 | virial composition derivatives |
+| `VIRBCD12dll` | :263 | first and second temperature derivatives of the virials |
 | `VIRTAUdll`   | :267 | higher-order tau derivatives of the virials |
 | `FPVdll`   | :147 | supercompressibility factor (arguably subsumed by gap 10) |
 
 `grep -rin 'acoustic'` over `src/` and `include/` returns zero hits, and
-`include/CoolProp/DataStructures.h:156` onward carries only `iBvirial`,
-`iCvirial`, `idBvirial_dT`, `idCvirial_dT`.
+`include/CoolProp/DataStructures.h:156` onward carries exactly four virial
+entries — `iBvirial`, `iCvirial`, `idBvirial_dT`, `idCvirial_dT`.
+
+`VIRTAUdll`'s quantity is inferred from its name and signature: it is absent
+from the FORTRAN tree on this machine, which is an older release than the
+pinned header.  That skew is worth remembering generally — `VIRBCD12` takes 14
+arguments in the local source against 7 in the pinned header — so the FORTRAN
+route verifies *semantics*, not the pinned API's exact shape.
 
 *Effort:* not estimated.  Triage into real issues if anyone asks; nobody
 currently is.

--- a/docs/superpowers/specs/2026-09-06-refprop-coolprop-functionality-gaps.md
+++ b/docs/superpowers/specs/2026-09-06-refprop-coolprop-functionality-gaps.md
@@ -1,7 +1,7 @@
 # REFPROP-vs-CoolProp functionality gaps
 
 **Date:** 2026-09-06
-**Issue:** CoolProp-it6e (epic), CoolProp-it6e.1 .. .12 (individual gaps)
+**Issue:** CoolProp-it6e (epic), CoolProp-it6e.1 .. .13 (individual gaps)
 **Status:** assessment complete; each gap needs its own design + plan before implementation
 
 ## Goal
@@ -31,21 +31,34 @@ verified from CoolProp's own source.  Where the claim is about REFPROP's
 routines and is in-tree after a configure at
 `build_shared/_deps/refprop_headers-src/`.  That header proves a routine
 *exists* or does not.  It says nothing about what a routine *does* internally —
-so **every description below of what a REFPROP routine *does* — `TRNPRP` using
-mixture ECS plus friction theory, `SATH`/`SATS` taking a `kph` code, what
-`SETMOD` and `SETAGA` switch, REFPROP's estimation fallback, `MELTT`/`SUBLT`
-returning correlated lines — rests on REFPROP's documentation, not on anything
-checkable here.**  Treat those as the weaker half of this document.
+so **every
+description below of what a REFPROP routine *does* — `TRNPRP` using mixture ECS
+plus friction theory, `SATH`/`SATS` taking a `kph` code, what `SETMOD` and
+`SETAGA` switch, REFPROP's estimation fallback, `MELTT`/`SUBLT` returning
+correlated lines — rests on REFPROP's documentation rather than on this
+repository.**  Treat those as the weaker half of this document.
 
-**How the gap list was selected:** by scanning all 176 exported routines in that
-header for CoolProp counterparts, plus the mixture-model and flash coverage
-found by reading the HEOS backend.  Routines mapping to a thermophysical
-property or a model-selection facility were checked individually; REFPROP's
-infrastructure and I/O routines (`SETPATH`, `ERRMSG`, `FLAGS`, `PASSCMN`,
-`HMXORDER`, `GETENUM`, ...) were excluded as having no meaningful CoolProp
-counterpart to look for.  The scan is **not** claimed to be exhaustive beyond
-that: it found gaps 9 through 12, which the first draft missed entirely, so a
-further pass may well find more.
+One qualification: REFPROP's FORTRAN source is available to maintainers holding
+a license (on Ian's machine at `~/Code/gpgREFPROP/REFPROPungpg/FORTRAN/`), and
+the semantics of `HEAT`, `HEATFRM` and `VIRBCD` in gaps 11 and 12 *were* checked
+against it rather than against the documentation.  That route is open for any
+claim here that turns out to matter; it is not reproducible in CI, and no
+REFPROP source is quoted in this document.
+
+**How the gap list was selected:** every one of the 176 exported routines in that
+header was screened by name, plus the mixture-model and flash coverage found by
+reading the HEOS backend.  REFPROP's infrastructure and I/O routines
+(`SETPATH`, `ERRMSG`, `FLAGS`, `PASSCMN`, `HMXORDER`, `GETENUM`, ...) were then
+set aside as having no meaningful CoolProp counterpart to look for.  Of the
+property and model-selection routines that remained, those with a CoolProp
+counterpart were dropped, those worth acting on became gaps 1-12, and those
+with **no** counterpart but no current demand are named explicitly in gap 13
+rather than left implicit.
+
+Screening by name is weaker than reading each routine, and this document does
+not claim more: the first draft missed gaps 9 through 12 entirely, and gap 13
+exists because a review pass found property routines the second draft had
+silently cleared.  A further pass may well find more.
 
 ## Rejected claims
 
@@ -254,9 +267,10 @@ adopt the 2022 R-134a viscosity given its ECS reference role) are genuine
 forced-choice cases, and 3bpg's option (b) is literally per-fluid model pinning.
 `CoolProp-9s9u` is a mixed case and should not be cited whole: its nitrogen and
 argon items *are* the `f1ez` forced-choice case already counted above, while its
-remaining items (deuterium, three correlations blocked on a NIST HTTP 503, neon,
-heavy water) are blocked on missing manuscripts, a server outage, or a VS0
-rewrite — none of which model switching addresses.  Worth revisiting this
+remaining items are blocked on things model switching does not address:
+deuterium (no manuscript verification points exist at all), three correlations
+behind a NIST HTTP 503, neon (published 2026, no accessible copy yet — an access
+problem, not a missing manuscript), and heavy water (a VS0 rewrite).  Worth revisiting this
 priority if the supersession work stalls.
 
 *Effort:* medium; a selection API plus a policy for what a selected model means
@@ -321,8 +335,36 @@ REFPROP's `VIRBCDdll` (`REFPROP_lib.h:262`) returns the second, third **and
 fourth** virial coefficients.  CoolProp exposes `iBvirial` and `iCvirial` only;
 `grep -rin 'Dvirial'` over `src/` and `include/` returns zero hits.
 
+(`VIRBCD` also carries a fifth-virial output slot that the shipped code does not
+currently compute, so "fourth" is the right claim today but is a statement about
+this REFPROP version, not about the signature.)
+
 *Effort:* small, but `D` is rarely used — listed for completeness of the virial
 surface rather than because anyone is asking.
+
+### 13. Property routines with no counterpart and no current demand — `CoolProp-it6e.13`, P4
+
+Named rather than left implicit, so the selection methodology above is honest.
+Each maps to a thermophysical property, has zero trace in CoolProp, and is not
+covered by gaps 1-12:
+
+| Routine | `REFPROP_lib.h` | Quantity |
+| ------- | --------------- | -------- |
+| `VIRBAdll` | :261 | second *acoustic* virial coefficient |
+| `VIRCAdll` | :265 | third *acoustic* virial coefficient |
+| `RIEMdll`  | :206 | thermodynamic curvature |
+| `B12dll`   | :105 | interaction second virial for a binary |
+| `CV2PKdll` | :114 | two-phase isochoric heat capacity |
+| `VIRBCD12dll` | :263 | virial composition derivatives |
+| `VIRTAUdll`   | :267 | higher-order tau derivatives of the virials |
+| `FPVdll`   | :147 | supercompressibility factor (arguably subsumed by gap 10) |
+
+`grep -rin 'acoustic'` over `src/` and `include/` returns zero hits, and
+`include/CoolProp/DataStructures.h:156` onward carries only `iBvirial`,
+`iCvirial`, `idBvirial_dT`, `idCvirial_dT`.
+
+*Effort:* not estimated.  Triage into real issues if anyone asks; nobody
+currently is.
 
 ## Non-gap, for completeness
 
@@ -343,8 +385,9 @@ rather than a functionality gap.  No issue filed.
    commit to it.  Do not start it as a side quest.
 
 Gaps 3, 5, 6, 8, 9, 11 and 12 are unblocked and can be picked up independently.
-Gap 11 pairs naturally with gap 10 (both serve natural-gas work).  Gap 12 is
-listed for completeness and nobody should prioritise it.
+Gap 11 pairs naturally with gap 10 (both serve natural-gas work).  Gaps 12 and
+13 are recorded for completeness of the survey and nobody should prioritise
+them.
 
 Each remaining gap needs its own design doc first, because each turns on a
 modelling or architecture decision that this assessment deliberately does not


### PR DESCRIPTION
## What this is

A single new document, `docs/superpowers/specs/2026-09-06-refprop-coolprop-functionality-gaps.md`, recording which pieces of core REFPROP functionality CoolProp's native HEOS backend does not provide. No code changes.

Started from the question "what core REFPROP functionality isn't in CoolProp?" — the point of writing it down is that the answer kept being given from memory, and memory got it wrong twice in the course of producing this.

## The gaps (bd CoolProp-it6e, children .1–.13)

| # | Gap | Priority |
|---|-----|----------|
| 1 | Mixture transport is a mole-fraction average, not a model | P1 |
| 2 | Ammonia–water absent entirely — hard `factory()` failure | P1 |
| 3 | Mixture surface tension throws | P2 |
| 4 | Mixture flash pairs DP/DQ/HQ/QS unimplemented | P2 |
| 5 | No sublimation line, natively or by REFPROP passthrough | P2 |
| 6 | No dielectric constant | P3 |
| 7 | No runtime model switching | P3 |
| 8 | No BIP estimation fallback | P3 |
| 9 | No choked flow / critical flow factor | P3 |
| 10 | No AGA8 characterization | P3 |
| 11 | No gross/net heating value | P3 |
| 12 | No fourth virial coefficient | P4 |
| 13 | Named residue: property routines with no counterpart, no demand | P4 |

Highest impact-per-effort is #2: ammonia–water isn't in `mixture_binary_pairs.json` at all, so every absorption-cycle use case fails at construction rather than merely being inaccurate.

## Claims it rejects

Recorded rather than deleted, because these are the ones that keep recurring:

- **VLLE/LLE/three-phase flash is not a REFPROP gap.** REFPROP is two-phase VLE-only, as CoolProp is. The pinned `REFPROP_lib.h` exports 34 flash routines and zero VLLE routines of any name. Wanting VLLE is legitimate; justifying it by pointing at REFPROP is not.
- **Solid–fluid equilibrium is not a REFPROP gap.** `MELTT`/`SUBLT` return correlated boundary lines, not an SLE flash.
- An earlier draft claimed CoolProp has no phase-stability-driven phase-count determination. **False** — Michelsen TPD is implemented and gates `PT_flash_mixtures`. The accurate claim is that the test is binary and cannot discover a third phase.

## Method, and its limits

CoolProp-side claims are anchored to file and line at `6de0bf8c5`. REFPROP-side claims about the *exported API surface* are anchored to `REFPROP_lib.h` from the pinned `REFPROP-headers` dependency. Claims about what a REFPROP routine *does* rest on REFPROP's documentation, or on its FORTRAN source where a licensed maintainer checked it — the doc says which, and no REFPROP source is quoted.

The selection method is stated honestly as name-screening, which is weaker than reading each routine. Gap 13 exists because review passes found property routines earlier drafts had silently cleared.

## Verification

- `./dev/ci/preflight.sh`: 4 passed / 0 failed / 6 skipped (all skips are "no C/C++ files in diff") — run before each of the four commits.
- Four adversarial review rounds. Each found real errors, all fixed; the corrections are their own commits with the reasoning in the messages. Notable catches: "REFPROP ships the complete flash matrix" was wrong (there is no `HQFLSH` or `SQFLSH`); the methodology's completeness claim was falsified twice; `VIRBCD12` returns temperature derivatives, not composition derivatives.
- Human verified: nothing yet — this is a claim-dense document and the numbers deserve a skim, particularly the REFPROP-side semantics, which is the half I can least support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an assessment of functionality gaps between CoolProp’s native HEOS backend and REFPROP.
  * Documented 13 identified gaps, including mixture transport properties, ammonia-water support, additional flash inputs, sublimation lines, dielectric properties, and heating values.
  * Added priorities, supporting evidence, effort estimates, rejected claims, and recommended implementation sequencing.
  * Clarified several capabilities that are not considered gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->