### PR TITLE
fix(flash): stop two mixture flashes returning a state nobody asked for (#3346)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2388,6 +2388,8 @@ if(COOLPROP_CATCH_MODULE)
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-PXFlash.cpp")
   list(APPEND APP_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-MixtureSaturationTrivial.cpp")
+  list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-CubicAlpha.cpp")
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-CubicU.cpp")

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -943,12 +943,26 @@ void FlashRoutines::QS_flash_with_guesses(HelmholtzEOSMixtureBackend& HEOS, cons
  */
 static void check_not_trivial_solution(double rho_liq, double rho_vap, double T, double p, const char* who) {
     if (!ValidNumber(rho_liq) || !ValidNumber(rho_vap) || rho_liq <= 0 || rho_vap <= 0) {
-        return;  // not our failure to diagnose; the callers' own checks apply
+        throw ValueError(format("%s returned saturation densities that are not usable numbers "
+                                "(rhomolar %g and %g mol/m3)",
+                                who, rho_liq, rho_vap));
     }
-    // Genuine saturation pairs stay orders above this even within a kelvin of
-    // the critical point; a collapsed pair comes in around 1e-6 relative.
+    // Signed, not absolute: the saturated liquid is the denser phase by
+    // definition, so an inverted pair is a bubble/dew root swap and is no more
+    // an answer than a collapsed one.  Matches _phases_are_distinct() in
+    // wrappers/Python/CoolProp/Plots/Common.py, which uses the same constant.
+    //
+    // Genuine saturation pairs stay far above this: across the predefined
+    // blends the closest approach on the converged branch is 0.087 (R463A at
+    // Q=0.5), because the solvers stop converging well before the two phases
+    // get close.  Collapsed pairs are not so tidily separated -- they run from
+    // 1e-10 up to a few times 1e-3 -- so this catches the bulk of them rather
+    // than all: a pair just above the threshold with a latent heat of a few
+    // J/kg is still returned.  Tightening it is not the answer, since that
+    // would start eating into the genuine branch; a latent-heat test would
+    // discriminate better and is worth adding separately.
     const double rtol = 1e-4;
-    if (std::abs(rho_liq - rho_vap) <= rtol * std::max(rho_liq, rho_vap)) {
+    if (rho_liq - rho_vap <= rtol * std::max(rho_liq, rho_vap)) {
         throw ValueError(format("%s converged on the trivial solution: the saturated liquid and vapour "
                                 "are the same state (rhomolar %g and %g mol/m3 at T=%g K, p=%g Pa), so this "
                                 "is not a saturation point",
@@ -1465,6 +1479,9 @@ void FlashRoutines::PQ_flash_with_guesses(HelmholtzEOSMixtureBackend& HEOS, cons
         throw ValueError(format("Quality must be 0 or 1"));
     }
 
+    if (!HEOS.is_pure_or_pseudopure) {
+        check_not_trivial_solution(IO.rhomolar_liq, IO.rhomolar_vap, IO.T, IO.p, "PQ_flash_with_guesses");
+    }
     // Load the other outputs
     HEOS._phase = iphase_twophase;
     HEOS._rhomolar = 1 / (HEOS._Q / IO.rhomolar_vap + (1 - HEOS._Q) / IO.rhomolar_liq);
@@ -1497,6 +1514,9 @@ void FlashRoutines::QT_flash_with_guesses(HelmholtzEOSMixtureBackend& HEOS, cons
         throw ValueError(format("Quality must be 0 or 1"));
     }
 
+    if (!HEOS.is_pure_or_pseudopure) {
+        check_not_trivial_solution(IO.rhomolar_liq, IO.rhomolar_vap, IO.T, IO.p, "QT_flash_with_guesses");
+    }
     // Load the other outputs
     HEOS._p = IO.p;
     HEOS._phase = iphase_twophase;
@@ -4247,7 +4267,19 @@ void FlashRoutines::DHSU_T_flash(HelmholtzEOSMixtureBackend& HEOS, parameters ot
             {
                 const auto resid_dhsu = static_cast<double>(HEOS.keyed_output(other) - value);
                 const double scale_dhsu = std::abs(static_cast<double>(value)) + 1.0;
-                if (!ValidNumber(resid_dhsu) || std::abs(resid_dhsu) > 1e-6 * scale_dhsu) {
+                // Density gets a looser tolerance than H/S/U, because the P-sweep
+                // parameterises by pressure and inside the dome of a narrow-boiling
+                // mixture drho/dP is enormous -- R502.mix has a bubble-to-dew
+                // pressure window of about 1e-10 Pa at 213 K.  TOMS748 converging P
+                // to 40 bits there still leaves ~1e-5 relative in rho, which is the
+                // conditioning of the parameterisation and not a failure to solve.
+                // Measured across the R502/R404A/R508B domes the two populations are
+                // four orders apart: conditioning noise tops out near 1e-5 relative,
+                // while the states this check exists to catch are wrong by 1e-2 to
+                // 20+ relative.  1e-6 would reject 19 of 23 correct two-phase points
+                // on the R502 dome at 195 K.
+                const double rtol_dhsu = (other == iDmolar) ? 1e-4 : 1e-6;
+                if (!ValidNumber(resid_dhsu) || std::abs(resid_dhsu) > rtol_dhsu * scale_dhsu) {
                     throw ValueError(format("DHSU_T_flash for mixture did not converge to the specification: residual %g "
                                             "(target %s=%g) at T=%g K -- the (T,p) flash is misclassifying the phase for this mixture",
                                             resid_dhsu, get_parameter_information(other, "short").c_str(), static_cast<double>(value),

--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -919,6 +919,43 @@ void FlashRoutines::QS_flash_with_guesses(HelmholtzEOSMixtureBackend& HEOS, cons
     HEOS._phase = iphase_twophase;
 }
 
+/// Reject the trivial solution from a mixture saturation flash.
+/**
+ * Successive substitution and the Newton-Raphson saturation solver both
+ * converge when every K-value reaches unity, because the Rachford-Rice
+ * residual is then identically zero.  That solution is the two phases having
+ * become the same phase, which is not a saturation state: near the critical
+ * point of a mixture it is what the solvers land on, and they report success.
+ * On HEOS::R513A.mix at Q=0.5 the QT flash fails outright from 365 K to 367 K
+ * and then returns rho_liq = rho_vap = 2408.7 mol/m3 at 367.433 K, 93 J/kg/K
+ * away in entropy from the last real point.
+ *
+ * The check lives here, at the flash boundary, rather than inside the solvers:
+ * the phase envelope tracer drives those same solvers deliberately up to and
+ * through the critical point, where the collapse is the answer it is looking
+ * for.
+ *
+ * @param rho_liq Molar density of the saturated liquid the solver returned
+ * @param rho_vap Molar density of the saturated vapour the solver returned
+ * @param T Temperature of the solved state, for the error message
+ * @param p Pressure of the solved state, for the error message
+ * @param who Name of the calling flash, for the error message
+ */
+static void check_not_trivial_solution(double rho_liq, double rho_vap, double T, double p, const char* who) {
+    if (!ValidNumber(rho_liq) || !ValidNumber(rho_vap) || rho_liq <= 0 || rho_vap <= 0) {
+        return;  // not our failure to diagnose; the callers' own checks apply
+    }
+    // Genuine saturation pairs stay orders above this even within a kelvin of
+    // the critical point; a collapsed pair comes in around 1e-6 relative.
+    const double rtol = 1e-4;
+    if (std::abs(rho_liq - rho_vap) <= rtol * std::max(rho_liq, rho_vap)) {
+        throw ValueError(format("%s converged on the trivial solution: the saturated liquid and vapour "
+                                "are the same state (rhomolar %g and %g mol/m3 at T=%g K, p=%g Pa), so this "
+                                "is not a saturation point",
+                                who, rho_liq, rho_vap, T, p));
+    }
+}
+
 void FlashRoutines::QT_flash(HelmholtzEOSMixtureBackend& HEOS) {
     CoolPropDbl T = HEOS._T;
     CoolPropDbl Q = HEOS._Q;
@@ -1075,6 +1112,9 @@ void FlashRoutines::QT_flash(HelmholtzEOSMixtureBackend& HEOS) {
 
             HEOS._p = IO.p;
             HEOS._rhomolar = 1 / (HEOS._Q / IO.rhomolar_vap + (1 - HEOS._Q) / IO.rhomolar_liq);
+        }
+        if (!HEOS.is_pure_or_pseudopure && HEOS.SatL && HEOS.SatV) {
+            check_not_trivial_solution(HEOS.SatL->rhomolar(), HEOS.SatV->rhomolar(), HEOS.SatL->T(), HEOS.SatV->p(), "QT_flash");
         }
         // Load the outputs
         HEOS._phase = iphase_twophase;
@@ -1392,6 +1432,9 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend& HEOS) {
             }
         }
 
+        if (!HEOS.is_pure_or_pseudopure && HEOS.SatL && HEOS.SatV) {
+            check_not_trivial_solution(HEOS.SatL->rhomolar(), HEOS.SatV->rhomolar(), HEOS.SatL->T(), HEOS.SatV->p(), "PQ_flash");
+        }
         // Load the outputs
         HEOS._phase = iphase_twophase;
         HEOS._p = HEOS.SatV->p();
@@ -4189,10 +4232,19 @@ void FlashRoutines::DHSU_T_flash(HelmholtzEOSMixtureBackend& HEOS, parameters ot
             // Verify the mixture result reproduces the requested property (#3148/#3192).  The
             // P-sweep + TOMS748 (and the fast-path density sweep) can return a state where
             // keyed_output(other) != value -- e.g. a discontinuity from a phase misclassification
-            // -- so without this check the flash could SILENTLY return a wrong state.  D+T is a
-            // direct evaluation and needs no check; H/S/U at fixed T solve for the state and must
-            // be verified.  Mirrors the HSU_P guard.
-            if (other != iDmolar) {
+            // -- so without this check the flash could SILENTLY return a wrong state.
+            // Mirrors the HSU_P guard.
+            //
+            // Density is included.  This check used to exclude it, reasoning that
+            // D+T is a direct evaluation and needs none -- true of the fast path,
+            // where update_DmolarT_direct is handed the requested density, but not
+            // of the P-sweep below it.  That sweep solves rho(P) = value through PT
+            // flashes, and rho(P) at fixed T is not monotonic, so it can settle on a
+            // state at a different density entirely: HEOS::R513A.mix at 288.853439 K
+            // returned 617.6 mol/m3 for a requested 1198.85 with h = -1.02e7 J/kg,
+            // while 1190 and 1210 round tripped exactly.  The check costs nothing
+            // when the fast path ran, since the residual is then identically zero.
+            {
                 const auto resid_dhsu = static_cast<double>(HEOS.keyed_output(other) - value);
                 const double scale_dhsu = std::abs(static_cast<double>(value)) + 1.0;
                 if (!ValidNumber(resid_dhsu) || std::abs(resid_dhsu) > 1e-6 * scale_dhsu) {

--- a/src/Tests/CoolProp-Tests-MixtureSaturationTrivial.cpp
+++ b/src/Tests/CoolProp-Tests-MixtureSaturationTrivial.cpp
@@ -25,6 +25,7 @@
 
 #    include <catch2/catch_all.hpp>
 #    include <catch2/catch_approx.hpp>
+#    include <catch2/matchers/catch_matchers_string.hpp>
 
 #    include "AbstractState.h"
 #    include "CoolProp.h"
@@ -50,21 +51,14 @@ TEST_CASE("QT_flash does not return the trivial solution for a mixture", "[mixsa
 
     SECTION("a collapsed pair is reported rather than returned") {
         // At these temperatures the solver used to return rho_liq == rho_vap to
-        // seven digits, which put the Q=0.5 line 93 J/kg/K out of place.
+        // seven digits, which put the Q=0.5 line 93 J/kg/K out of place.  The
+        // message is asserted, not merely the throw: without it this section
+        // would pass on any exception at all -- including one that had nothing
+        // to do with the trivial solution -- and it would pass just as happily
+        // if someone made the flash throw unconditionally for mixtures.
         for (double T : {367.4330, 368.0}) {
             CAPTURE(T);
-            bool threw = false;
-            try {
-                AS->update(QT_INPUTS, 0.5, T);
-            } catch (const std::exception&) {
-                threw = true;
-            }
-            if (!threw) {
-                // Converging here is fine, provided the two phases are distinct.
-                const double rho_liq = AS->saturated_liquid_keyed_output(iDmolar);
-                const double rho_vap = AS->saturated_vapor_keyed_output(iDmolar);
-                CHECK(std::abs(rho_liq - rho_vap) > 1e-4 * std::max(rho_liq, rho_vap));
-            }
+            REQUIRE_THROWS_WITH(AS->update(QT_INPUTS, 0.5, T), Catch::Matchers::ContainsSubstring("trivial solution"));
         }
     }
 }
@@ -73,23 +67,82 @@ TEST_CASE("DmassT_INPUTS returns the density it was given for a mixture", "[mixs
     std::shared_ptr<AbstractState> AS(AbstractState::factory("HEOS", "R513A.mix"));
     const double T = 288.853439;
 
+    // These four round trip and must keep doing so.
+    for (double rho : {1190.0, 1195.0, 1210.0, 1250.0}) {
+        CAPTURE(rho);
+        REQUIRE_NOTHROW(AS->update(DmassT_INPUTS, rho, T));
+        CHECK(AS->rhomass() == Catch::Approx(rho).epsilon(1e-9));
+        CHECK(AS->hmass() > 0.0);
+        CHECK(AS->hmass() < 1e6);
+    }
+
     // 1198.85 and 1200.0 used to come back as 617.6 and 1256.6 kg/m3, the first
-    // of them with h = -1.02e7 J/kg, while their neighbours round tripped exactly.
-    for (double rho : {1190.0, 1195.0, 1198.85, 1200.0, 1210.0}) {
+    // of them with h = -1.02e7 J/kg, while their neighbours round tripped
+    // exactly.  Refusing them is acceptable -- answering wrongly is not -- so
+    // assert the disjunction explicitly rather than skipping the check when the
+    // call throws, which would let a tolerance regression pass unnoticed.
+    for (double rho : {1198.85, 1200.0}) {
         CAPTURE(rho);
         bool threw = false;
         try {
             AS->update(DmassT_INPUTS, rho, T);
         } catch (const std::exception&) {
-            threw = true;  // refusing is acceptable; answering wrongly is not
+            threw = true;
         }
+        CHECK((threw || AS->rhomass() == Catch::Approx(rho).epsilon(1e-9)));
         if (!threw) {
-            CHECK(AS->rhomass() == Catch::Approx(rho).epsilon(1e-9));
-            // and the enthalpy has to be a compressed-liquid value, not -1e7
             CHECK(AS->hmass() > 0.0);
             CHECK(AS->hmass() < 1e6);
         }
     }
+}
+
+TEST_CASE("DmassT still answers inside the dome of a narrow-boiling mixture", "[mixsat]") {
+    // The convergence check applies a relative tolerance to a density the
+    // P-sweep obtained by solving rho(P) through PT flashes.  Inside a narrow
+    // dome drho/dP is enormous -- R502.mix spans bubble to dew in about 1e-10 Pa
+    // at 213 K -- so TOMS748 converging P to 40 bits still leaves ~1e-5 relative
+    // in rho.  That is the conditioning of the parameterisation, not a failure
+    // to solve, and a tolerance tight enough for H/S/U reads it as one: at 1e-6
+    // every density below threw, including all six of these.
+    std::shared_ptr<AbstractState> AS(AbstractState::factory("HEOS", "R502.mix"));
+    const double T = 213.2394;
+    for (double rho : {537.960, 1225.640, 1378.458, 1454.867, 1500.712, 1523.635}) {
+        CAPTURE(rho);
+        REQUIRE_NOTHROW(AS->update(DmassT_INPUTS, rho, T));
+        CHECK(AS->rhomass() == Catch::Approx(rho).epsilon(1e-4));
+    }
+}
+
+TEST_CASE("DmassT never answers with a density far from the one requested", "[mixsat]") {
+    // The complement of the test above: loosening the tolerance must not let a
+    // genuinely wrong state through.  Sweeping the R502 dome at 195 K, about
+    // half the points cannot be placed at all and throw -- that is the flash's
+    // own limitation and is acceptable -- but every point it *does* answer has
+    // to carry the density it was given.
+    std::shared_ptr<AbstractState> AS(AbstractState::factory("HEOS", "R502.mix"));
+    std::shared_ptr<AbstractState> sat(AbstractState::factory("HEOS", "R502.mix"));
+    const double T = 195.47;
+    sat->update(QT_INPUTS, 0.0, T);
+    const double rho_liq = sat->rhomass();
+    sat->update(QT_INPUTS, 1.0, T);
+    const double rho_vap = sat->rhomass();
+    REQUIRE(rho_liq > rho_vap * 10);
+
+    int answered = 0;
+    for (int i = 1; i < 24; ++i) {
+        const double rho = rho_vap + (rho_liq - rho_vap) * i / 24.0;
+        CAPTURE(rho);
+        try {
+            AS->update(DmassT_INPUTS, rho, T);
+        } catch (const std::exception&) {
+            continue;  // cannot place this point; refusing is the honest answer
+        }
+        ++answered;
+        CHECK(AS->rhomass() == Catch::Approx(rho).epsilon(1e-4));
+    }
+    CAPTURE(answered);
+    CHECK(answered > 4);  // it must not have simply rejected everything
 }
 
 TEST_CASE("the trivial-solution guard does not disturb phase envelope tracing", "[mixsat]") {

--- a/src/Tests/CoolProp-Tests-MixtureSaturationTrivial.cpp
+++ b/src/Tests/CoolProp-Tests-MixtureSaturationTrivial.cpp
@@ -1,0 +1,105 @@
+// Regression tests for two silent wrong answers from the mixture flash routines.
+//
+// Runs in the default suite (tag [mixsat], NOT [.]-hidden).  Run explicitly:
+//   ./CatchTestRunner "[mixsat]"
+//
+// Both were found while building the isoline tracer for the Python plotting
+// package (GH #3344, discussion #3269), where they surfaced as excursions and
+// gaps in mixture property plots.  Neither raised an error at the time: each
+// returned a plausible-looking state that was simply not the one asked for.
+//
+//  GH #3346 / bd CoolProp-mojf -- QT_flash and PQ_flash could converge on the
+//      trivial solution near the critical point of a mixture, returning a state
+//      whose saturated liquid and vapour are the same root.  Successive
+//      substitution and the Newton-Raphson saturation solver both satisfy their
+//      residual when every K-value reaches unity, and near the critical point
+//      that is where they land.
+//
+//  bd CoolProp-1gth -- DHSU_T_flash excluded density from its own
+//      "did this converge to what was asked for" check, on the reasoning that
+//      D+T is a direct evaluation.  True of the fast path, but the P-sweep
+//      fallback solves rho(P) = value through PT flashes and can settle on a
+//      different density entirely.
+
+#if defined(ENABLE_CATCH)
+
+#    include <catch2/catch_all.hpp>
+#    include <catch2/catch_approx.hpp>
+
+#    include "AbstractState.h"
+#    include "CoolProp.h"
+
+#    include <cmath>
+#    include <memory>
+
+using namespace CoolProp;
+
+TEST_CASE("QT_flash does not return the trivial solution for a mixture", "[mixsat]") {
+    std::shared_ptr<AbstractState> AS(AbstractState::factory("HEOS", "R513A.mix"));
+
+    SECTION("a genuine two-phase point is unaffected") {
+        // 364.05 K is comfortably below the critical region: the two phases are
+        // separated by a factor of about 2.6 in density.
+        REQUIRE_NOTHROW(AS->update(QT_INPUTS, 0.5, 364.0501));
+        const double rho_liq = AS->saturated_liquid_keyed_output(iDmolar);
+        const double rho_vap = AS->saturated_vapor_keyed_output(iDmolar);
+        CHECK(rho_liq > rho_vap * 1.5);
+        CHECK(AS->smass() == Catch::Approx(1581.676).epsilon(1e-4));
+    }
+
+    SECTION("a collapsed pair is reported rather than returned") {
+        // At these temperatures the solver used to return rho_liq == rho_vap to
+        // seven digits, which put the Q=0.5 line 93 J/kg/K out of place.
+        for (double T : {367.4330, 368.0}) {
+            CAPTURE(T);
+            bool threw = false;
+            try {
+                AS->update(QT_INPUTS, 0.5, T);
+            } catch (const std::exception&) {
+                threw = true;
+            }
+            if (!threw) {
+                // Converging here is fine, provided the two phases are distinct.
+                const double rho_liq = AS->saturated_liquid_keyed_output(iDmolar);
+                const double rho_vap = AS->saturated_vapor_keyed_output(iDmolar);
+                CHECK(std::abs(rho_liq - rho_vap) > 1e-4 * std::max(rho_liq, rho_vap));
+            }
+        }
+    }
+}
+
+TEST_CASE("DmassT_INPUTS returns the density it was given for a mixture", "[mixsat]") {
+    std::shared_ptr<AbstractState> AS(AbstractState::factory("HEOS", "R513A.mix"));
+    const double T = 288.853439;
+
+    // 1198.85 and 1200.0 used to come back as 617.6 and 1256.6 kg/m3, the first
+    // of them with h = -1.02e7 J/kg, while their neighbours round tripped exactly.
+    for (double rho : {1190.0, 1195.0, 1198.85, 1200.0, 1210.0}) {
+        CAPTURE(rho);
+        bool threw = false;
+        try {
+            AS->update(DmassT_INPUTS, rho, T);
+        } catch (const std::exception&) {
+            threw = true;  // refusing is acceptable; answering wrongly is not
+        }
+        if (!threw) {
+            CHECK(AS->rhomass() == Catch::Approx(rho).epsilon(1e-9));
+            // and the enthalpy has to be a compressed-liquid value, not -1e7
+            CHECK(AS->hmass() > 0.0);
+            CHECK(AS->hmass() < 1e6);
+        }
+    }
+}
+
+TEST_CASE("imposing the phase still gives the correct compressed liquid", "[mixsat]") {
+    // The EOS always had the right answer; the defect was in the free path's
+    // phase determination.  This pins the reference the fix is measured against.
+    std::shared_ptr<AbstractState> AS(AbstractState::factory("HEOS", "R513A.mix"));
+    AS->specify_phase(iphase_liquid);
+    AS->update(DmassT_INPUTS, 1198.85, 288.853439);
+    CHECK(AS->rhomass() == Catch::Approx(1198.85).epsilon(1e-9));
+    CHECK(AS->p() == Catch::Approx(6.4474e6).epsilon(1e-3));
+    CHECK(AS->hmass() == Catch::Approx(224455.0).epsilon(1e-3));
+}
+
+#endif

--- a/src/Tests/CoolProp-Tests-MixtureSaturationTrivial.cpp
+++ b/src/Tests/CoolProp-Tests-MixtureSaturationTrivial.cpp
@@ -31,6 +31,7 @@
 
 #    include <cmath>
 #    include <memory>
+#    include <string>
 
 using namespace CoolProp;
 
@@ -88,6 +89,21 @@ TEST_CASE("DmassT_INPUTS returns the density it was given for a mixture", "[mixs
             CHECK(AS->hmass() > 0.0);
             CHECK(AS->hmass() < 1e6);
         }
+    }
+}
+
+TEST_CASE("the trivial-solution guard does not disturb phase envelope tracing", "[mixsat]") {
+    // The guard sits at the QT/PQ flash boundary rather than inside the
+    // saturation solvers precisely because PhaseEnvelopeRoutines drives those
+    // same solvers up to and through the critical point, where the two phases
+    // collapsing together is the answer it is looking for.  If that reasoning
+    // were wrong, envelope construction would be the first thing to break.
+    for (std::string fluid :
+         {"R513A.mix", "R410A.mix", "R404A.mix", "R407C.mix", "Air.mix", "R454B.mix", "R448A.mix", "R441A.mix", "R504.mix", "R507A.mix"}) {
+        CAPTURE(fluid);
+        std::shared_ptr<AbstractState> AS(AbstractState::factory("HEOS", fluid));
+        REQUIRE_NOTHROW(AS->build_phase_envelope("none"));
+        CHECK(AS->get_phase_envelope_data().T.size() > 10);
     }
 }
 


### PR DESCRIPTION
Fixes two mixture flash routines that returned a state nobody asked for, without
raising. Both were found while building the isoline tracer in #3344 (discussion
#3269), where they showed up as the excursions and gaps in mixture property
plots that the reporter posted.

### GH #3346 — `QT_flash` / `PQ_flash` could return the trivial solution

Successive substitution and the Newton–Raphson saturation solver both satisfy
their residual when every K-value reaches unity, because the Rachford–Rice
residual is then identically zero. That solution is the two phases having become
one phase — not a saturation state — and near the critical point of a mixture it
is where they land.

On `HEOS::R513A.mix` at Q=0.5 the flash fails outright from 365 K to 367 K, then
"succeeds" at 367.433 K:

```
QT(0.5, 364.0501) -> s = 1581.676   rho_l = 6599.31  rho_v = 2555.52   gap = 6.1e-01
QT(0.5, 367.4330) -> s = 1674.520   rho_l = 2408.77  rho_v = 2408.76   gap = 3.8e-06
```

93 J/kg/K along in entropy from the last real point, where neighbouring steps are
about 1.7. No exception, no NaN.

**The check goes at the flash boundary, not inside the solvers.**
`PhaseEnvelopeRoutines` drives those same solvers deliberately up to and through
the critical point, where the collapse is the answer it is looking for — a guard
in the solver would break envelope construction. A test pins that reasoning: ten
predefined blends must still build an envelope, including R504 (whose envelope
stops 37 K short of its critical point) and R441A/R454B.

Threshold is a relative density gap of 1e-4. Measured across the predefined
blends at Q=0/Q=1, where the guard operates: the closest genuine approach is
0.176 (R507A, within 0.02 K of its envelope maximum), about 1700x above the cut,
while collapsed pairs come in around 1e-6.

### bd CoolProp-1gth — `DHSU_T_flash` excluded density from its own check

That routine ends with a "did this converge to what was asked for" guard, gated
`if (other != iDmolar)`. The comment justified the exclusion: *D+T is a direct
evaluation and needs no check*. True of the fast path, where
`update_DmolarT_direct` is handed the requested density — but not of the P-sweep
it falls into when the stability test rejects that path. The sweep solves
`rho(P) = value` through PT flashes, and `rho(P)` at fixed T is not monotonic, so
it can settle on a different density entirely:

```
rho_in = 1190.00  ->  rho_out = 1190.000   h =  224 100
rho_in = 1195.00  ->  rho_out = 1195.000   h =  224 290
rho_in = 1198.85  ->  rho_out =  617.588   h = -1.02e7     <-- 
rho_in = 1200.00  ->  rho_out = 1256.633   h =  229 031    <-- 
rho_in = 1210.00  ->  rho_out = 1210.000   h =  225 030
```

So the guard that exists to stop a silent wrong answer was switched off for the
input where a wrong answer is most detectable. It now covers density, which costs
nothing on the fast path since the residual is identically zero there.

`specify_phase(iphase_liquid)` always gave the right answer for those inputs
(rho = 1198.85, p = 6.447 MPa, h = 224 455, agreeing with a PT flash), so the EOS
was never at fault — only the free path's phase determination.

### The density tolerance, and what review changed

Reusing the H/S/U tolerance (1e-6 relative) for density regressed correct
answers, and adversarial review caught it. The P-sweep parameterises by
pressure, and inside the dome of a narrow-boiling mixture `drho/dP` is enormous
— `R502.mix` spans bubble to dew in about **1e-10 Pa** at 213 K — so TOMS748
converging P to 40 bits still leaves ~1e-5 relative in rho. That is the
conditioning of the parameterisation, not a failure to solve, and 1e-6 read it
as one: 19 of 23 correct two-phase points on the R502 dome at 195 K started
throwing.

Density now uses 1e-4. The two populations are four orders apart, so this is
not a fine-tuned constant:

| | relative error |
|---|---|
| states that round trip (conditioning noise) | 4.8e-6 … 1.6e-5 |
| states the check exists to catch | 0.05 … 1.0 |

Both bounds are pinned by tests — one that the good states are answered, one
that no answered state carries a density far from the requested one.

### Verification

- New `[mixsat]` tests: 6 cases, 72 assertions. Against `origin/master` they
  fail 3 of 6 cases (15 assertions); against the first commit of this branch,
  2 of 6 — so they bind to both the original defects and the tolerance
  regression.
- Full suite `~[slow]`: **550 cases, 181 374 assertions, no failures.**
- Phase envelopes build for all ten blends tested.

### Notes for the reviewer

Both changes convert silent wrong answers into exceptions, so callers that
previously got *a* number will now see one. That is the intent, but it is the
main risk in this diff and worth a look at `PT_flash_mixtures`, the `DHSU_T_flash`
P-sweep (which calls `update(PT_INPUTS, ...)` in a loop), and `CoolPropPlot.cpp`.

`PQ_flash_with_guesses` and `QT_flash_with_guesses` **are** guarded, added after
review. They drive the same solver, are publicly reachable through
`update_with_guesses`, and bd CoolProp-mojf is exactly that defect — the Python
isoline tracer documents avoiding those functions outright because "near the
critical point it converges on a state that is not the bubble or dew point and
reports no error while doing so".

Two things review found that are **recorded rather than fixed**:

- The 1e-4 trivial-solution threshold catches the bulk of collapsed pairs, not
  all of them. They run from 1e-10 up to a few times 1e-3, so a pair just above
  the cut — `R407C.mix` at Q=0.5, 373.9 K, 11.5 K above `T_reducing`, with a
  latent heat of 10.9 J/kg where a real one is ~200 000 — is still returned.
  Tightening is not the answer (the genuine branch reaches 0.087). A latent-heat
  test would discriminate far better and deserves its own change.
- The density check cannot see fast-path errors, by construction: when
  `update_DmolarT_direct` runs, the residual is bit-exactly zero. `R513A.mix` at
  the same 288.85 K returns `p = 6.67e8 Pa, h = -5.85e6 J/kg` for
  rho = 700 kg/m3, where the truth is two-phase at 539 kPa — `is_stable()`
  accepting a vdW-loop root. Pre-existing and untouched here.

Preflight is green except cppcheck and clang-tidy, both of which fire on the
file rather than the diff: zero clang-tidy findings fall inside the changed line
ranges (922–958, 1116–1118, 1435–1437, 4235–4247), and the cppcheck
`syntaxError` reproduces identically on master's copy of the file. Tracked as
CoolProp-ikfi.

Once this lands, the workarounds added to the Python plotting layer in #3344
(`_phases_are_distinct` and the imposed-phase evaluation in `_check_clone`) can
come out.

### Verified by the human

- [ ] the 1e-4 threshold is right for the near-critical mixtures you care about
- [ ] converting these to exceptions is the behaviour you want, vs. clamping or
      warning

bd CoolProp-1gth, CoolProp-mojf

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mixture saturation calculations near critical points by rejecting invalid collapsed solutions.
  * Improved density-based mixture calculations to better preserve requested density values and correctly handle two-phase states.
  * Preserved correct behavior for phase-envelope tracing and compressed-liquid calculations.

* **Tests**
  * Added regression coverage for mixture saturation and density flash calculations, including critical-point and narrow-boiling mixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->