### PR TITLE
fix(headers): include <cstring> for the memset in CacheArray::clear()

### DIFF
--- a/include/CoolProp/detail/CachedElement.h
+++ b/include/CoolProp/detail/CachedElement.h
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstring>  // memset, used by CacheArray::clear()
 #include "CoolProp/detail/tools.h"
 #include "CoolProp/DataStructures.h"
 #include "CoolProp/numerics/numerics.h"
@@ -154,8 +155,8 @@ class CacheArray
 
    public:
     void clear() {
-        memset(m_values.data(), 0, sizeof(m_values));
-        memset(m_cached.data(), false, sizeof(m_cached));
+        std::memset(m_values.data(), 0, sizeof(m_values));
+        std::memset(m_cached.data(), false, sizeof(m_cached));
     }
     auto factory(std::size_t i) {
         return CacheArrayElement<double>(m_values[i], m_cached[i]);


### PR DESCRIPTION
The **Installed-header hygiene gate** has been failing on `master` since #3360 — ten installed headers no longer compile standalone. All ten reduce to one missing include.

## Cause

`CacheArray::clear()` calls `memset` (`CachedElement.h:157-158`), but the header includes only `<algorithm>`, `<array>` and CoolProp's own headers. libc++ pulls `<cstring>` in transitively, so macOS builds and the gate run locally never noticed; libstdc++ does not, so GCC fails with `'memset' was not declared in this scope`.

It stayed dormant because `clear()` is a member of a class template — only instantiated when called, and nothing in the installed header chain called it. #3360 added `AbstractState::clear_cached_properties()`, which does `cache.clear()` inline in the header, forcing instantiation of `CacheArray<80>::clear()` in every translation unit that includes `AbstractState.h`. The other nine failures are simply headers that include `AbstractState.h`, directly or transitively:

```
AbstractState.h                      CoolProp/sbtl/SVDSurfaceFactory.h
CoolProp/AbstractState.h             CoolProp/sbtl/SatBoundaryFactory.h
CoolProp/fluids/IdealCurves.h        CoolProp/sbtl/SaturationSurrogate.h
CoolProp/plotting/CoolPropPlot.h     CoolProp/sbtl/SurfaceSpec.h
CoolPropPlot.h                       IdealCurves.h
```

## Fix

Add `<cstring>`, and qualify the calls as `std::memset` — the form `<cstring>` actually guarantees (placing these names in the global namespace is permitted but not required).

## Verification

The failure does not reproduce on macOS, so this was verified on Linux rather than reasoned about. Every installed header compiled standalone under `gcc:13` with the gate's own flags (`-std=c++17 -fsyntax-only -DNO_FMTLIB -DCOOLPROP_NO_DEPRECATED_HEADER_WARNINGS`, Eigen-only on the include path):

| | result |
|---|---|
| before | 93 installed headers checked, **10 failing** — the same ten CI names |
| after | 93 installed headers checked, **0 failing** |

`./dev/ci/check-installed-headers.sh build_shared` also passes locally on macOS both before and after, which is why the gate is Linux-only in effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Follow-ups found while reviewing this, deliberately *not* in this PR

Both are pre-existing and neither blocks the CI fix; filed separately so this stays a one-line unbreak.

* `CacheArray::clear()` zeroes to `0.0`, while the member initializer and both other `clear()` overloads use `_HUGE` — the two ways of resetting a cache entry disagree about the sentinel. **Not currently reachable**: `pt()` does return the raw value with no `is_cached` gate, and `FlashRoutines.cpp:456` reads `_TLanc` through it, but the `clear_cached_properties()` call is in `PT_flash` while that read is in `DP_flash`, which calls `p_phase_determination_pure_or_pseudopure()` first — and that writes `_TLanc` on both of its paths. So the cleared value can never be observed. Cosmetic today, a trap for any future `pt()` read not preceded by a write. (CoolProp-rqrk, P4.)
* `dev/ci/check-installed-headers.sh` compiles with the *host* `c++`. On macOS that is libc++, which supplies `memset` transitively — which is exactly why this bug reached `master` green locally and red on Linux. The gate's verdict is stdlib-specific.
