### PR TITLE
build: route compiles through ccache so worktrees stop rebuilding from scratch

### DIFF
--- a/.github/workflows/dev_checks.yml
+++ b/.github/workflows/dev_checks.yml
@@ -602,10 +602,17 @@ jobs:
       # gate that can quietly lose coverage as the cache warms up across
       # runs, without ever failing the job. See ccache.dev/manual, "Using
       # ccache with other tools" / GitHub codeql issues #9882, #19447.
+      #
+      # -DCOOLPROP_USE_CCACHE=OFF is what enforces that. CMakeLists.txt now
+      # auto-enables ccache whenever find_program locates it, so merely
+      # omitting a launcher flag no longer keeps it out: the protection would
+      # rest on ccache being absent from the runner image's PATH, and would
+      # break silently the day that changes. Opt out explicitly instead.
       - name: Configure CPP
         if: ${{ matrix.language == 'cpp' }}
         run: cmake
                -DCOOLPROP_MY_MAIN=dev/ci/main.cpp
+               -DCOOLPROP_USE_CCACHE=OFF
                -B ${{github.workspace}}/build
                -S .
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,86 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(CheckIncludeFileCXX)
 
+#######################################
+#          COMPILER CACHE             #
+#-------------------------------------#
+
+# Route compiles through ccache when it is available.  A fresh git worktree
+# otherwise recompiles the entire library from scratch -- measured at 3m47s for
+# the Catch runner tree plus 4m02s for the shared-library tree, on sources
+# byte-identical to the ones the main checkout already built (bd CoolProp-tl0w).
+#
+# This MUST sit above the dependencies.cmake include below.  CMAKE_<LANG>_-
+# COMPILER_LAUNCHER is consumed when a target is created, and that include adds
+# every CPM package -- Catch2 alone is 106 of the Catch runner tree's 205
+# objects.  Setting the launcher after project() (line ~219) left those 106
+# compiling uncached, which measured as 99/205 objects covered.
+#
+# CCACHE_BASEDIR is load-bearing, not a tuning knob.  CoolProp's compile lines
+# bake in absolute paths: every -I into the source tree, the CPM _deps includes
+# under the build dir, and the input file itself.  Those strings differ per
+# worktree, so without base_dir every object in a new worktree misses and ccache
+# buys nothing.  Pointing base_dir at the source root makes ccache rewrite
+# absolute paths beneath it to CWD-relative form before hashing; since a
+# worktree's build dir sits inside the worktree exactly as the main checkout's
+# does, the rewritten command lines coincide and the cache is shared.
+#
+# What base_dir does NOT do is reach inside a -D macro value, and CatchTestRunner
+# carries -DCOOLPROP_ALL_FLUIDS_JSON_PATH="<source dir>/dev/all_fluids.json" on
+# all 99 of its objects (CMakeLists.txt, target_compile_definitions below).  That
+# costs far less than it looks like it should, because ccache's preprocessor mode
+# excludes -D from the command-line hash -- a define's effect is already present
+# in the preprocessed text -- so only a TU that actually expands the macro fails
+# to share.  Measured on a fresh cache populated from an unrelated path:
+#
+#   cacheable calls  205 / 205      direct hits         106  (Catch2; no -D)
+#   hits             204 / 205      preprocessed hits    98  (-D present, unused)
+#   misses             1 / 205      the one TU that expands the macro
+#
+# The other limit is ccache's hash_dir, which defaults true and folds the working
+# directory into the hash whenever -g is present.  Debug / RelWithDebInfo /
+# sanitizer trees therefore do NOT share across worktrees; the numbers above are
+# Release, and only -g-free builds get them.
+#
+# `cmake -E env` rather than a bare `env` so the launcher stays portable.
+#
+# Only the Makefile and Ninja generators honour <LANG>_COMPILER_LAUNCHER, so
+# Visual Studio and Xcode are excluded -- wiring it there is a silent no-op that
+# reads as support.  (CoolProp documents `cmake -G Xcode` for the iOS wrapper,
+# and already special-cases Xcode further down, so this is a live path.)
+# MSVC itself is NOT excluded: this runs before project(), so the MSVC variable
+# is not populated yet and cannot be tested here.  ccache has supported cl.exe
+# since 4.6 under Ninja and Makefiles, though MSVC's default /Zi debug format is
+# uncacheable (/Z7 is required); opt out with -DCOOLPROP_USE_CCACHE=OFF.
+#
+# A launcher the caller already supplied (distcc, sccache, a CI wrapper) is
+# honoured rather than overwritten.  Both the -D form and the environment-
+# variable form are checked: CMake itself initializes the cache variable from
+# the environment, but only during project(), which is ~200 lines below here --
+# so testing the variable alone would silently discard an env-set launcher.
+# Either language being pre-set defers the whole block, so a caller who sets
+# only CXX does not end up with a mismatched C launcher.
+option(COOLPROP_USE_CCACHE "Route compiles through ccache when available" ON)
+
+if(COOLPROP_USE_CCACHE
+   AND NOT CMAKE_GENERATOR MATCHES "Visual Studio|Xcode"
+   AND NOT CMAKE_C_COMPILER_LAUNCHER
+   AND NOT CMAKE_CXX_COMPILER_LAUNCHER
+   AND NOT DEFINED ENV{CMAKE_C_COMPILER_LAUNCHER}
+   AND NOT DEFINED ENV{CMAKE_CXX_COMPILER_LAUNCHER})
+  find_program(COOLPROP_CCACHE_PROGRAM ccache)
+  if(COOLPROP_CCACHE_PROGRAM)
+    set(_coolprop_ccache_launcher
+        "${CMAKE_COMMAND}" -E env "CCACHE_BASEDIR=${CMAKE_CURRENT_SOURCE_DIR}"
+        "${COOLPROP_CCACHE_PROGRAM}")
+    set(CMAKE_C_COMPILER_LAUNCHER ${_coolprop_ccache_launcher})
+    set(CMAKE_CXX_COMPILER_LAUNCHER ${_coolprop_ccache_launcher})
+    message(STATUS "ccache enabled: ${COOLPROP_CCACHE_PROGRAM} (CCACHE_BASEDIR=${CMAKE_CURRENT_SOURCE_DIR})")
+  else()
+    message(STATUS "ccache not found; compiling without a compiler cache")
+  endif()
+endif()
+
 # Dependency management via CPM.cmake (replaces git submodules).
 # Set CPM_SOURCE_CACHE (e.g. ~/.cache/CPM) to share downloads across worktrees.
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/CPM.cmake")


### PR DESCRIPTION
A fresh git worktree recompiled the whole library before `preflight.sh` could run a single check. Measured on an 8-core M-series Mac: **3m47s** for the Catch runner tree plus **4m02s** for the shared-library tree, on sources byte-identical to the ones the main checkout had already built. ccache 4.13.6 was installed the whole time and doing nothing — an empty 0.0/5.0 GiB cache, and no `CMAKE_<LANG>_COMPILER_LAUNCHER` in any `CMakeCache.txt`.

This came out of a broader investigation into why preflight is slow for trivial changes (`bd CoolProp-8fta`); ccache was the largest single number in it.

## Result

Measured on a **fresh cache populated entirely from an unrelated path**, then built in a different worktree:

| | |
|---|---|
| cacheable calls | 205 / 205 (100%) |
| hits | **204 / 205 (99.51%)** — 106 direct, 98 preprocessed |
| compile time | 3m47s → **18.1s** (12.5×) |

## Three things that are load-bearing, none of which show up if you only check that the "ccache enabled" line prints

**The block must sit above the `cmake/dependencies.cmake` include, not next to `project()`.** `CMAKE_<LANG>_COMPILER_LAUNCHER` is consumed when a target is created, and that include — which adds every CPM package — runs 207 lines *before* `project()`. My first attempt set the launcher after `project()` and covered only **99 of 205 objects**: Catch2's 106 compiled straight through the bare compiler while the status line cheerfully said ccache was on. Only counting objects exposed it.

**`CCACHE_BASEDIR` is what makes the cache shareable at all**, since the compile lines bake in absolute `-I` paths, `_deps` includes and input-file paths that differ per worktree. It does *not* rewrite `-D` values, and `CatchTestRunner` carries an absolute `COOLPROP_ALL_FLUIDS_JSON_PATH` on all 99 of its objects. That costs exactly one object: ccache's preprocessor mode drops `-D` from the command-line hash (the define's effect is already in the preprocessed text), so only the single TU that actually expands the macro fails to share. Hence the 106/98/1 split. An earlier version of this description claimed base_dir rewrote the `-D`; that was wrong and is corrected in the comment.

**`hash_dir` defaults true**, folding the working directory into the hash whenever `-g` is present. Debug / RelWithDebInfo / sanitizer trees therefore do **not** share across worktrees. The numbers above are Release, and the comment says so.

## Guards, and what defeats each

- **Visual Studio and Xcode generators excluded** — neither honours the launcher property, so wiring it there is a silent no-op that reads as support. CoolProp documents `cmake -G Xcode` for the iOS wrapper.
- **A caller-supplied launcher is honoured, in both the `-D` and environment-variable forms.** CMake initializes the cache variable from the environment only during `project()`, 200 lines below this block, so checking the variable alone silently discarded an env-set distcc/sccache wrapper. Verified: `CMAKE_CXX_COMPILER_LAUNCHER=sccache` now defers correctly.
- **MSVC cannot be tested at this point in the file** (the variable isn't populated until `project()`). ccache has supported `cl.exe` since 4.6 under Ninja and Makefiles, though MSVC's default `/Zi` is uncacheable (`/Z7` required). `-DCOOLPROP_USE_CCACHE=OFF` opts out.
- **The CodeQL job now passes `-DCOOLPROP_USE_CCACHE=OFF` explicitly.** It deliberately avoids ccache because a cache hit means the real compiler never runs and its extractor silently drops that TU. With ccache auto-enabled, *omitting* a launcher flag no longer keeps it out — the protection would have rested on ccache being absent from the runner image's PATH. This was a blocking review finding.

`compile_commands.json` excludes the launcher, so clang-tidy, cppcheck and editor LSPs are unaffected. The IWYU job was checked too: CMake routes it through `cmake -E __run_co_compile`, where IWYU runs before the launcher, so a cache hit cannot drop a TU from its report.

## Verification

- Cached-binary correctness verified rather than assumed: `CatchTestRunner "~[slow]"` exits **0** — 544 cases, 514 passed / 30 skipped, **181302 assertions, 0 failures**.
- `./dev/ci/preflight.sh`: **4 passed / 0 failed / 6 skipped**, plus again via the pre-push hook.
- Two adversarial review passes per CLAUDE.md. The first returned 3 blocking findings (CodeQL fail-open, env-var launcher discarded, and a challenge to the headline number); all are addressed above. The second reviewed the delta and returned no blocking findings, independently reproducing the 106/98/1 mechanism.

**Human verification pending: Ian has not independently reproduced these results.**

## Filed, not fixed here

- `bd CoolProp-rinx` (P2) — the CodeQL opt-out is a bare `-D`; if the option is ever renamed CMake downgrades it to a warning and the job silently re-acquires ccache. Also: deferral prints nothing (an empty env var defers and yields no launcher — fail-closed, but undiagnosable), and a stale `find_program` cache entry turns "ccache uninstalled" into a hard build break.
- `bd CoolProp-8fta` (P1) — the rest of the preflight cost: `install-headers` is 47.7s of *serial* `-fsyntax-only` calls (parallelising is ~42s back), four gates run unconditionally regardless of the diff, and clang-tidy analyses whole files at 30s each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)