### PR TITLE
ci: parallelise the installed-header self-containedness sweep (47.7s -> 11.5s)

### DIFF
--- a/dev/ci/check-installed-headers.sh
+++ b/dev/ci/check-installed-headers.sh
@@ -111,21 +111,161 @@ if [ -z "$INC_ROOT" ] || [ ! -d "$INC_ROOT" ]; then
 fi
 SC_LOG=/tmp/installed-headers-selfcontained.log
 : >"$SC_LOG"
-SC_FAIL=0
-while IFS= read -r hdr; do
-    rel="${hdr#"$INC_ROOT"/}"
-    if ! printf '#include "%s"\n' "$rel" | "$CXX_BIN" -std=c++17 -fsyntax-only \
-            -DNO_FMTLIB -DCOOLPROP_NO_DEPRECATED_HEADER_WARNINGS \
-            -I"$INC_ROOT" -I"$EIGEN_DIR" -x c++ - >>"$SC_LOG" 2>&1; then
-        echo "FAIL: installed header is not self-contained: $rel" >&2
-        SC_FAIL=$((SC_FAIL + 1))
-    fi
-done < <(find "$INC_ROOT" -name '*.h')
+
+# The sweep is ~93 INDEPENDENT -fsyntax-only invocations, so it parallelises
+# cleanly across cores.  Serially it was 47.7 s -- the single largest item in
+# ./dev/ci/preflight.sh's 122 s floor, and ~1000x the 0.05 s that `cmake
+# --install` itself costs (bd CoolProp-5vun).
+SC_JOBS="${COOLPROP_HEADER_CHECK_JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)}"
+# Clamp the auto-detected value.  getconf reports HOST cores, not a container's
+# cgroup quota, and a syntax-only TU peaks around 180 MB here -- so on a large
+# machine an unbounded -P invites the OOM killer, which takes cc1plus rather than
+# the bash child.  The child would then see a non-zero compiler status and report
+# "installed header is not self-contained", i.e. a false regression rather than
+# an infrastructure error.  8 keeps nearly all the speedup (the sweep is only ~93
+# items); an explicit COOLPROP_HEADER_CHECK_JOBS is honoured as given -- including
+# 0, which xargs reads as "unbounded" and which therefore re-opens the very OOM
+# case the clamp exists to prevent.  That is the point of an override, but set it
+# deliberately.
+if [ -z "${COOLPROP_HEADER_CHECK_JOBS:-}" ] && [ "$SC_JOBS" -gt 8 ] 2>/dev/null; then
+    SC_JOBS=8
+fi
+SC_TMP="$(mktemp -d)"
+# Supersede the earlier trap so the scratch dir is cleaned up too.  Both paths
+# are quoted; PREFIX and SC_TMP are mktemp output, but the quoting is what keeps
+# a future edit from turning this into an unbounded rm.
+trap 'rm -rf "$PREFIX" "$SC_TMP"' EXIT
+
+SC_TOTAL="$(find "$INC_ROOT" -name '*.h' | grep -c . || true)"
+[ -n "$SC_TOTAL" ] || SC_TOTAL=0
+if [ "$SC_TOTAL" -eq 0 ]; then
+    echo "FAIL: no *.h found under the installed include root ($INC_ROOT) -- the self-containedness sweep would verify nothing." >&2
+    exit 1
+fi
+
+export CXX_BIN INC_ROOT EIGEN_DIR SC_TMP
+
+# One header per child.  Each child writes to its OWN files: two parallel
+# writers appending to a single log interleave mid-line, which would corrupt the
+# very diagnostics this gate prints.  A child records `ok.` or `fail.` either
+# way and exits 0, so xargs' own status stays reserved for infrastructure failure
+# (couldn't spawn, bad interpreter) rather than a compile result.  The one
+# deviation is safe: if the marker path itself cannot be written (ENAMETOOLONG on
+# a pathologically deep header) the child exits non-zero and surfaces through
+# xargs as exactly that kind of infrastructure failure, and the count guard below
+# catches it independently.
+#
+# -print0/-0 keeps a path containing spaces as one argument.  The command is
+# passed inline rather than via `export -f`: exported bash functions do not
+# survive a version mismatch between the parent shell and the `bash` on PATH.
+SC_XARGS_RC=0
+find "$INC_ROOT" -name '*.h' -print0 \
+    | xargs -0 -P "$SC_JOBS" -n1 bash -c '
+        # SHELLOPTS is not exported, so this child does NOT inherit the parent'"'"'s
+        # pipefail.  Without it a failing printf would hand the compiler an empty
+        # translation unit, which exits 0 -- recording a header as self-contained
+        # without ever having compiled it.
+        set -o pipefail
+        hdr="$1"
+        rel="${hdr#"$INC_ROOT"/}"
+        # Percent-encoding, and the % must be escaped BEFORE / is mapped onto
+        # it -- that ordering is what makes this reversible, so two distinct
+        # headers cannot land on one marker file and silently lose a result.
+        # Mapping every separator onto _ is not injective (a plain tr collides
+        # "a/b.h" with "a_b.h"); neither is doubling _ first, which still
+        # collides "a_/b.h" with "a/_b.h" -- both become "a___b.h".
+        slug="$(printf "%s" "$rel" | sed "s/%/%25/g; s#/#%2F#g")"
+        if printf "#include \"%s\"\n" "$rel" | "$CXX_BIN" -std=c++17 -fsyntax-only \
+                -DNO_FMTLIB -DCOOLPROP_NO_DEPRECATED_HEADER_WARNINGS \
+                -I"$INC_ROOT" -I"$EIGEN_DIR" -x c++ - >"$SC_TMP/out.$slug" 2>&1; then
+            printf "%s\n" "$rel" >"$SC_TMP/ok.$slug"
+        else
+            printf "%s\n" "$rel" >"$SC_TMP/fail.$slug"
+        fi
+    ' _ || SC_XARGS_RC=$?
+if [ "$SC_XARGS_RC" -ne 0 ]; then
+    echo "FAIL: the parallel header sweep could not run (xargs exit $SC_XARGS_RC) -- treating as a failure rather than a pass." >&2
+    exit 1
+fi
+
+# Collect the per-header compiler output in a stable, deterministic order.  It is
+# sorted by encoded header path -- NOT the directory order find happened to yield
+# when this ran serially -- so the log is reproducible run to run.  LC_ALL=C is
+# what makes that true ACROSS environments: the default collation ignores
+# punctuation, so a C-locale CI runner and a UTF-8 local shell would otherwise
+# order the same slugs differently.
+find "$SC_TMP" -name 'out.*' | LC_ALL=C sort | while IFS= read -r out; do
+    cat "$out" >>"$SC_LOG"
+done
+
+# Parentheses around the -o alternation are belt-and-braces: with only -name
+# predicates here both forms behave identically, but they keep the grouping
+# explicit so adding another test (say -type f) later cannot silently bind to
+# one branch only.
+SC_CHECKED="$(find "$SC_TMP" \( -name 'ok.*' -o -name 'fail.*' \) | grep -c . || true)"
+[ -n "$SC_CHECKED" ] || SC_CHECKED=0
+SC_FAIL="$(find "$SC_TMP" -name 'fail.*' | grep -c . || true)"
+[ -n "$SC_FAIL" ] || SC_FAIL=0
+
+# Fail-closed guard with no serial equivalent: a child killed before it wrote
+# either marker (OOM, SIGKILL) leaves no failure behind, so counting only
+# `fail.` markers would report a clean pass over a sweep that never finished.
+# Every header found must have produced exactly one result.
+if [ "$SC_CHECKED" -ne "$SC_TOTAL" ]; then
+    echo "FAIL: the header sweep recorded $SC_CHECKED result(s) for $SC_TOTAL header(s) -- some check did not complete, so this is not a pass." >&2
+    exit 1
+fi
+
+# The success line below names shared_library/CoolPropLib.h as *the* header
+# outside the sweep.  Assert that rather than trusting it: if an install rule
+# ever ships another header outside INC_ROOT, the message would understate the
+# gap -- the same overstatement this change just fixed in the other direction.
+#
+# Compare the IDENTITY of the unswept set, not merely its size.  A count-only
+# check ("exactly one header is unswept") passes unchanged if CoolPropLib.h stops
+# being installed and some different header takes its place outside the sweep:
+# the total still differs by one, the gate still goes green, and the success line
+# then names a file that is no longer the exemption.  Enumerating the paths is
+# what makes the claim true rather than merely arithmetically consistent.
+#
+# A mismatch is a hard failure, which also means the gate stops asserting a stale
+# exemption once the sweep widens to cover CoolPropLib.h (bd CoolProp-1n5g).
+# Identity is asserted on the FILE NAME, not the full installed path.  What the
+# gate needs to know is "the one header we do not compile is still CoolPropLib.h,
+# not some other header that quietly stopped being swept".  Pinning the whole
+# relative path would additionally hard-code one install layout, so a change to
+# the install prefix or directory structure would fail the gate for a reason that
+# has nothing to do with header coverage.  The full path is printed either way,
+# so a layout change is still visible in the log.
+SC_UNSWEPT_EXPECTED="CoolPropLib.h"
+find "$PREFIX" -name '*.h' ! -path "$INC_ROOT/*" | LC_ALL=C sort >"$SC_TMP/unswept"
+# -printf '%P' would be tidier but is GNU-only; strip the prefix in the shell so
+# this keeps working under BSD/macOS find.
+SC_UNSWEPT_REL="$(while IFS= read -r h; do printf '%s\n' "${h#"$PREFIX"/}"; done <"$SC_TMP/unswept")"
+SC_UNSWEPT_N="$(printf '%s' "$SC_UNSWEPT_REL" | grep -c . || true)"
+[ -n "$SC_UNSWEPT_N" ] || SC_UNSWEPT_N=0
+if [ "$SC_UNSWEPT_N" -ne 1 ] || [ "${SC_UNSWEPT_REL##*/}" != "$SC_UNSWEPT_EXPECTED" ]; then
+    echo "FAIL: expected exactly one installed *.h outside the include root, named '$SC_UNSWEPT_EXPECTED'; found $SC_UNSWEPT_N:" >&2
+    printf '%s\n' "${SC_UNSWEPT_REL:-(none)}" | sed 's/^/        /' >&2
+    echo "      Either a header is newly shipped outside the swept tree -- in which case it is going unchecked -- or the sweep has widened and this assertion plus the success message need updating (bd CoolProp-1n5g)." >&2
+    exit 1
+fi
+SC_UNSWEPT_SHOWN="$SC_UNSWEPT_REL"
+
 if [ "$SC_FAIL" -ne 0 ]; then
+    find "$SC_TMP" -name 'fail.*' | LC_ALL=C sort | while IFS= read -r marker; do
+        echo "FAIL: installed header is not self-contained: $(cat "$marker")" >&2
+    done
     echo "FAIL: $SC_FAIL installed header(s) do not compile standalone (see $SC_LOG)." >&2
     echo "      A shipped header that #includes a non-installed header (internal or third-party)" >&2
     echo "      is broken for downstream consumers." >&2
     exit 1
 fi
 
-echo "OK: internal json/msgpack headers not installed; no shipped header pulls nlohmann/valijson/msgpack/boost; all ${NHEADERS} installed headers compile standalone (-DNO_FMTLIB, Eigen-only on the path) from ${BUILD_DIR}"
+# ${SC_TOTAL}, not ${NHEADERS}: the sweep compiles the headers under the include
+# root, while NHEADERS counts every *.h in the install prefix.  The difference is
+# exactly one file -- the top-level shared_library/CoolPropLib.h, the single-
+# include C/DLL API header, which sits outside INC_ROOT and is therefore NOT
+# swept (bd CoolProp-1n5g).  Claiming NHEADERS here overstated the
+# check by that one header.
+echo "OK: internal json/msgpack headers not installed; no shipped header pulls nlohmann/valijson/msgpack/boost; all ${SC_TOTAL} headers under the include root compile standalone (of ${NHEADERS} installed *.h; ${SC_UNSWEPT_SHOWN} is not swept) with -DNO_FMTLIB, Eigen-only on the path, from ${BUILD_DIR}"


### PR DESCRIPTION
Assertion 3 of `dev/ci/check-installed-headers.sh` compiles every installed header as its own translation unit to prove it is self-contained. It did so in a serial `while read` loop — 93 sequential `c++ -fsyntax-only` invocations — and that was **47.7 s, the single largest item in preflight's 122 s floor**. `cmake --install` itself is 0.05 s; the loop was the entire cost.

**Measured after: 11.5 s at 588% CPU (4.1×).** From `bd CoolProp-8fta`, the preflight-performance investigation.

The checks are independent, so the mechanism is just `xargs -P` across cores. The work is in not losing a failure along the way.

## Going parallel creates three ways to lose a failure that the serial loop could not have

- **Interleaved output.** Parallel writers appending to one log corrupt lines mid-write, garbling the diagnostics the gate prints. Each child writes its own files; the log is reassembled in `LC_ALL=C sort` order afterwards.
- **A child that vanishes.** If one is killed (OOM, SIGKILL) before recording anything, counting only failure markers reports a clean pass over a sweep that never finished. Every header found must now produce exactly one result. `xargs`' own exit status is a second layer, kept meaningful by having children record their result in a file and exit 0, so a non-zero `xargs` status means infrastructure failure rather than a compile result.
- **A child shell without `pipefail`.** `SHELLOPTS` is not exported, so the child does **not** inherit the parent's `set -o pipefail`. A failing `printf` would hand the compiler an empty translation unit, which exits 0 — recording a header as self-contained without ever compiling it. The child now sets `pipefail` itself. The reviewer confirmed this by stripping the line and reproducing the false pass.

## Two things caught in review that I had wrong

**Marker filenames were not injective**, though the code comment claimed they were. Mapping every separator to `_` collides `a/b.h` with `a_b.h`; my first fix (doubling `_` first) still collides `a_/b.h` with `a/_b.h` — both become `a___b.h`. Now percent-encoded, escaping `%` before mapping `/` onto it; that ordering is the load-bearing part. Verified over 7381 adversarial strings, zero collisions. A collision was fail-closed, but reported as "check did not complete" rather than the truth.

**The success line overstated the check.** It claimed all `${NHEADERS}` installed headers compile standalone. Only the 93 under the include root are ever fed to the compiler; the 94th is the top-level `shared_library/CoolPropLib.h`. The message now reports both, and a new assertion fails if that difference is ever anything but 1 — so a future install rule shipping a second unswept header cannot silently go unchecked.

`-P` is clamped to 8 when auto-detected: `getconf` reports host cores rather than a container's cgroup quota, and a syntax-only TU peaks near 180 MB, so unbounded parallelism invites the OOM killer — which takes `cc1plus`, not the bash child, making the gate report "header is not self-contained", a false regression rather than an infra error. `COOLPROP_HEADER_CHECK_JOBS` overrides without the clamp.

## Verification

Fail injection against the real install tree, because a faster gate that cannot fail is worth nothing:

| case | result |
|---|---|
| one bad header among 93 | exit 1, exactly 1 reported |
| every header bad | exit 1, 93 reported |
| child SIGKILLed mid-run | exit 1, no false pass |
| invalid job count | exit 1 |
| missing build dir | exit 2 |

`./dev/ci/preflight.sh`: **4 passed / 0 failed / 6 skipped.** Two adversarial review passes per CLAUDE.md; the second returned no blocking findings and independently reproduced the timing, the injectivity result and the `pipefail` false pass.

**Human verification pending: Ian has not independently reproduced these results.**

## Expect the Installed-header hygiene gate to be RED on this PR

It is red **on master already** — `bd CoolProp-ac2t`, raised to P1. Identical 10 failures at `c8521e810` (job 101493170860) and `85fc178d5` (job 101510523959), before this branch existed. Seven distinct headers fail on Linux/libstdc++ while passing on macOS/libc++, because libc++ pulls `<cmath>` in transitively and libstdc++ does not. That issue had *predicted* this exact mechanism and named `IdealCurves.h` and `sbtl/SurfaceSpec.h` among the latent cases; two of the failures are those. Not caused by, and not fixed by, this PR.

Chasing it exposed something this PR arguably should address: the script writes compiler output to `/tmp/installed-headers-selfcontained.log`, which CI neither prints nor uploads, so a run says *which* headers failed but never *why*. Establishing that the failure was pre-existing needed a diff of two master runs where one line of stderr would have sufficed. Left out to keep this PR to one concern; noted on `CoolProp-ac2t`.

## Filed, not fixed here

- `bd CoolProp-1n5g` (P2) — the sweep skips `shared_library/CoolPropLib.h`, the 922-line C/DLL API header downstream consumers actually include. Pre-existing; this change only made it visible by reporting the true count. It compiles standalone today.
- `bd CoolProp-ac2t` (P1) — the stdlib-specific gate above.
- `bd CoolProp-8fta` (P1) — the rest of preflight's floor: four gates that run regardless of the diff, and whole-file clang-tidy at 30 s each.

Independent of #3369 (ccache); either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved installed-header compilation checks for more reliable validation.
  - Added parallel processing with controlled concurrency to speed up verification.
  - Improved diagnostic reporting with consistent results and clearer failure details.
  - Added safeguards to detect incomplete checks and ensure all installed headers are accounted for.
  - Enhanced reporting to distinguish validated headers from the total installed-header count.
  - Added validation for the installed include location and expected public header layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->