### PR TITLE
perf(HEOS): reuse component backends for mixture transport

### DIFF
--- a/.github/workflows/gui_builder.yml
+++ b/.github/workflows/gui_builder.yml
@@ -193,16 +193,16 @@ jobs:
         uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Tauri auto-updater signing — when present, tauri-action signs the
-          # update artifacts and emits latest.json next to each platform
-          # bundle. Without these the build still succeeds; the updater
-          # plugin just won't accept the signatures, so updates won't work
-          # for that release. Activate by adding both repo secrets.
+          # Sign updater artifacts for pushes and releases. PR builds skip
+          # signing below because fork PRs cannot access these secrets.
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: wrappers/GUI
           tauriScript: npm run tauri
+          # Fork PRs have no signing secrets. Keep signing enabled for pushes
+          # and releases; PR bundles are only used for build and smoke tests.
+          args: ${{ github.event_name == 'pull_request' && '--no-sign' || '' }}
 
       # ─── Linux smoke tests ────────────────────────────────────────────────
       # 1) Forward-compat: install .deb in a clean ubuntu:26.04 container,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2496,6 +2496,8 @@ if(COOLPROP_CATCH_MODULE)
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-GERG.cpp")
   list(APPEND APP_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-Expression.cpp")
+  list(APPEND APP_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/src/Tests/CoolProp-Tests-MixtureTransport.cpp")
 
   # CATCH TEST, compile everything with catch and set test entry point
   add_executable(CatchTestRunner ${APP_SOURCES})

--- a/src/Backends/GERG/GERGBackend.cpp
+++ b/src/Backends/GERG/GERGBackend.cpp
@@ -64,31 +64,14 @@ void GERGMixtureBackend::set_components(const std::vector<CoolPropFluid>& comps,
     // with GERG-typed states.  Constructing them with
     // generate_SatL_and_SatV = false is what stops the recursion.
     //
-    // The PREVIOUS SatL/SatV (if any -- set_components is only called from
-    // constructors today, so on a freshly-constructed object there is
-    // nothing to remove) are erased from linked_states before being replaced,
-    // so calling set_components twice on one object does not leave the
-    // superseded SatL/SatV in linked_states, where sync_linked_states would
-    // keep writing to them forever.  This erases ONLY the two SatL/SatV
-    // entries -- by pointer identity, not by clearing the whole vector -- so
-    // TPD_state/critical_state/transient_pure_state (HelmholtzEOSMixtureBackend.h:85,93,101)
-    // are left untouched if they happen to already be linked.  An earlier
-    // version called linked_states.clear() unconditionally: harmless today
-    // because those three are only ever created lazily, long after
-    // construction, but a future caller of set_components on a live object
-    // would silently strand them (non-null members, never reachable through
-    // linked_states again) -- trading one latent hazard for another instead
-    // of fixing it.
-    linked_states.erase(std::remove_if(linked_states.begin(), linked_states.end(),
-                                       [this](const shared_ptr<HelmholtzEOSMixtureBackend>& s) { return s == SatL || s == SatV; }),
-                        linked_states.end());
-
-    SatL.reset(new GERGMixtureBackend(m_model, comps, false));
+    // The base setter has discarded the old helpers. Use its owned component
+    // copy: comps may have referred to one of those now-destroyed helpers.
+    SatL.reset(new GERGMixtureBackend(m_model, this->components, false));
     SatL->specify_phase(iphase_liquid);
     linked_states.push_back(SatL);
     SatL->clear();
 
-    SatV.reset(new GERGMixtureBackend(m_model, comps, false));
+    SatV.reset(new GERGMixtureBackend(m_model, this->components, false));
     SatV->specify_phase(iphase_gas);
     SatV->clear();
     linked_states.push_back(SatV);

--- a/src/Backends/Helmholtz/ExcessHEFunction.h
+++ b/src/Backends/Helmholtz/ExcessHEFunction.h
@@ -233,9 +233,10 @@ class ExcessTerm
     /// Resize the parts of this term
     void resize(std::size_t N) {
         this->N = N;
-        F.resize(N, std::vector<CoolPropDbl>(N, 0));
+        F.resize(N);
         DepartureFunctionMatrix.resize(N);
         for (std::size_t i = 0; i < N; ++i) {
+            F[i].resize(N, 0);
             DepartureFunctionMatrix[i].resize(N);
         }
     };

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -104,6 +104,7 @@ HelmholtzEOSMixtureBackend::HelmholtzEOSMixtureBackend(const std::vector<CoolPro
     _phase = iphase_unknown;
 }
 void HelmholtzEOSMixtureBackend::set_components(const std::vector<CoolPropFluid>& components, bool generate_SatL_and_SatV) {
+    component_transport_states.clear();
 
     // Drop the cached ECS transport reference fluids: they are tied to the
     // OLD component's reference-fluid name, so a post-construction component
@@ -482,6 +483,7 @@ void HelmholtzEOSMixtureBackend::set_binary_interaction_string(const std::size_t
 };
 
 void HelmholtzEOSMixtureBackend::calc_change_EOS(const std::size_t i, const std::string& EOS_name) {
+    component_transport_states.clear();
 
     if (i < components.size()) {
         CoolPropFluid& fluid = components[i];
@@ -829,6 +831,29 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity_background(CoolPropDbl et
     return initial_density + residual;
 }
 
+CoolPropDbl HelmholtzEOSMixtureBackend::calc_mixture_transport(parameters property) {
+    component_transport_states.resize(components.size());
+    CoolPropDbl summer = 0;
+    try {
+        for (std::size_t i = 0; i < mole_fractions.size(); ++i) {
+            auto& pure = component_transport_states[i];
+            if (!pure || components_exposed) {
+                pure = std::make_shared<HelmholtzEOSBackend>(components[i]);
+            }
+            // Keep the original pure-fluid update, including phase determination.
+            // Updating every time also clears the pure-fluid property caches.
+            pure->update(DmolarT_INPUTS, _rhomolar, _T);
+            const double value = pure->keyed_output(property);
+            summer += mole_fractions[i] * (property == iviscosity ? log(value) : value);
+        }
+    } catch (...) {
+        // Do not reuse a partially updated saturation or ECS helper after failure.
+        component_transport_states.clear();
+        throw;
+    }
+    return property == iviscosity ? exp(summer) : summer;
+}
+
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity() {
     if (is_pure_or_pseudopure) {
         CoolPropDbl dilute = 0, initial_density = 0, residual = 0, critical = 0;
@@ -836,13 +861,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity() {
         return dilute + initial_density + residual + critical;
     } else {
         set_warning_string("Mixture model for viscosity is highly approximate");
-        CoolPropDbl summer = 0;
-        for (std::size_t i = 0; i < mole_fractions.size(); ++i) {
-            shared_ptr<HelmholtzEOSBackend> HEOS = std::make_shared<HelmholtzEOSBackend>(components[i]);
-            HEOS->update(DmolarT_INPUTS, _rhomolar, _T);
-            summer += mole_fractions[i] * log(HEOS->viscosity());
-        }
-        return exp(summer);
+        return calc_mixture_transport(iviscosity);
     }
 }
 void HelmholtzEOSMixtureBackend::calc_viscosity_contributions(CoolPropDbl& dilute, CoolPropDbl& initial_density, CoolPropDbl& residual,
@@ -1090,13 +1109,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_conductivity() {
         return dilute + initial_density + residual + critical;
     } else {
         set_warning_string("Mixture model for conductivity is highly approximate");
-        CoolPropDbl summer = 0;
-        for (std::size_t i = 0; i < mole_fractions.size(); ++i) {
-            shared_ptr<HelmholtzEOSBackend> HEOS = std::make_shared<HelmholtzEOSBackend>(components[i]);
-            HEOS->update(DmolarT_INPUTS, _rhomolar, _T);
-            summer += mole_fractions[i] * HEOS->conductivity();
-        }
-        return summer;
+        return calc_mixture_transport(iconductivity);
     }
 }
 void HelmholtzEOSMixtureBackend::calc_conformal_state(const std::string& reference_fluid, CoolPropDbl& T, CoolPropDbl& rhomolar) {
@@ -4706,6 +4719,7 @@ void HelmholtzEOSMixtureBackend::calc_build_spinodal() {
 }
 
 void HelmholtzEOSMixtureBackend::set_reference_stateS(const std::string& reference_state) {
+    component_transport_states.clear();
     for (auto& component : components) {
         CoolProp::HelmholtzEOSMixtureBackend HEOS(std::vector<CoolPropFluid>(1, component));
         if (!reference_state.compare("IIR")) {
@@ -4772,6 +4786,7 @@ void HelmholtzEOSMixtureBackend::set_reference_stateS(const std::string& referen
 /// @param hmolar0 Molar enthalpy at reference state [J/mol]
 /// @param smolar0 Molar entropy at reference state [J/mol/K]
 void HelmholtzEOSMixtureBackend::set_reference_stateD(double T, double rhomolar, double hmolar0, double smolar0) {
+    component_transport_states.clear();
     for (auto& component : components) {
         CoolProp::HelmholtzEOSMixtureBackend HEOS(std::vector<CoolPropFluid>(1, component));
 

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -132,6 +132,15 @@ void HelmholtzEOSMixtureBackend::set_components(const std::vector<CoolPropFluid>
         set_mixture_parameters();
     }
 
+    // Linked helpers contain the old component models and matrix dimensions.
+    // Reset both ownership paths so they are rebuilt for the new components.
+    linked_states.clear();
+    SatL.reset();
+    SatV.reset();
+    TPD_state.reset();
+    critical_state.reset();
+    transient_pure_state.reset();
+
     imposed_phase_index = iphase_not_imposed;
 
     // Top-level class can hold copies of the base saturation classes,
@@ -247,7 +256,7 @@ void HelmholtzEOSMixtureBackend::recalculate_singlephase_phase() {
     }
 }
 std::string HelmholtzEOSMixtureBackend::fluid_param_string(const std::string& ParamName) {
-    CoolProp::CoolPropFluid cpfluid = get_components()[0];
+    CoolProp::CoolPropFluid cpfluid = components[0];
     if (!ParamName.compare("name")) {
         return cpfluid.name;
     } else if (!ParamName.compare("aliases")) {
@@ -832,10 +841,13 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_viscosity_background(CoolPropDbl et
 }
 
 CoolPropDbl HelmholtzEOSMixtureBackend::calc_mixture_transport(parameters property) {
-    component_transport_states.resize(components.size());
     CoolPropDbl summer = 0;
     try {
-        for (std::size_t i = 0; i < mole_fractions.size(); ++i) {
+        if (mole_fractions.size() == 0 || mole_fractions.size() != components.size()) {
+            throw ValueError("Mole fractions must be set and match the component count before evaluating mixture transport");
+        }
+        component_transport_states.resize(components.size());
+        for (std::size_t i = 0; i < components.size(); ++i) {
             auto& pure = component_transport_states[i];
             if (!pure || components_exposed) {
                 pure = std::make_shared<HelmholtzEOSBackend>(components[i]);
@@ -2197,9 +2209,9 @@ void HelmholtzEOSMixtureBackend::calc_ssat_max() {
         }
     };
     if (!ssat_max.is_valid() && ssat_max.exists != SsatSimpleState::SSAT_MAX_DOESNT_EXIST) {
-        shared_ptr<CoolProp::HelmholtzEOSMixtureBackend> HEOS_copy = std::make_shared<CoolProp::HelmholtzEOSMixtureBackend>(get_components());
+        shared_ptr<CoolProp::HelmholtzEOSMixtureBackend> HEOS_copy = std::make_shared<CoolProp::HelmholtzEOSMixtureBackend>(components);
         Residual resid(*HEOS_copy);
-        const CoolProp::SimpleState& tripleV = HEOS_copy->get_components()[0].triple_vapor;
+        const CoolProp::SimpleState& tripleV = HEOS_copy->components[0].triple_vapor;
         double v1 = resid.call(hsat_max.T);
         double v2 = resid.call(tripleV.T);
         // If there is a sign change, there is a maxima, otherwise there is no local maxima/minima
@@ -2232,7 +2244,7 @@ void HelmholtzEOSMixtureBackend::calc_hsat_max() {
         }
     };
     if (!hsat_max.is_valid()) {
-        shared_ptr<CoolProp::HelmholtzEOSMixtureBackend> HEOS_copy = std::make_shared<CoolProp::HelmholtzEOSMixtureBackend>(get_components());
+        shared_ptr<CoolProp::HelmholtzEOSMixtureBackend> HEOS_copy = std::make_shared<CoolProp::HelmholtzEOSMixtureBackend>(components);
         Residualhmax residhmax(*HEOS_copy);
         Brent(residhmax, T_critical() - 0.1, HEOS_copy->Ttriple() + 1, DBL_EPSILON, 1e-8, 30);
         hsat_max.T = residhmax.HEOS->T();
@@ -4291,8 +4303,8 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_first_two_phase_deriv_splined(param
         throw ValueError(format("state is not two-phase"));
     }
 
-    shared_ptr<HelmholtzEOSMixtureBackend> Liq = std::make_shared<HelmholtzEOSMixtureBackend>(this->get_components());
-    shared_ptr<HelmholtzEOSMixtureBackend> End = std::make_shared<HelmholtzEOSMixtureBackend>(this->get_components());
+    shared_ptr<HelmholtzEOSMixtureBackend> Liq = std::make_shared<HelmholtzEOSMixtureBackend>(components);
+    shared_ptr<HelmholtzEOSMixtureBackend> End = std::make_shared<HelmholtzEOSMixtureBackend>(components);
 
     Liq->specify_phase(iphase_liquid);
     Liq->_Q = -1;

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.h
@@ -77,6 +77,10 @@ class HelmholtzEOSMixtureBackend : public AbstractState
     /// call (the dominant cost of e.g. SVDSBTL surface builds for ECS fluids).
     shared_ptr<HelmholtzEOSMixtureBackend> viscosity_ecs_reference_state;
     shared_ptr<HelmholtzEOSMixtureBackend> conductivity_ecs_reference_state;
+    /// Pure-component transport backends, independent of the mixture's linked states.
+    std::vector<shared_ptr<HelmholtzEOSMixtureBackend>> component_transport_states;
+    bool components_exposed = false;
+    CoolPropDbl calc_mixture_transport(parameters property);
     /// Update the state class used to calculate the tangent-plane-distance
     virtual void add_TPD_state() {
         if (TPD_state.get() == nullptr) {
@@ -340,6 +344,10 @@ class HelmholtzEOSMixtureBackend : public AbstractState
         return components;
     }
     std::vector<CoolPropFluid>& get_components() {
+        // A retained mutable reference can change the models at any later time.
+        // Such callers keep the fresh-component transport evaluation path.
+        components_exposed = true;
+        component_transport_states.clear();
         return components;
     }
     std::vector<CoolPropDbl>& get_K() {

--- a/src/Backends/Helmholtz/MixtureParameters.cpp
+++ b/src/Backends/Helmholtz/MixtureParameters.cpp
@@ -555,7 +555,7 @@ DepartureFunction* get_departure_function(const std::string& Name) {
 }
 void MixtureParameters::set_mixture_parameters(HelmholtzEOSMixtureBackend& HEOS) {
 
-    std::vector<CoolPropFluid> components = HEOS.get_components();
+    std::vector<CoolPropFluid> components = static_cast<const HelmholtzEOSMixtureBackend&>(HEOS).get_components();
 
     std::size_t N = components.size();
 

--- a/src/Tests/CoolProp-Tests-GERG.cpp
+++ b/src/Tests/CoolProp-Tests-GERG.cpp
@@ -1088,6 +1088,14 @@ TEST_CASE("GERG mixture linked saturation states are GERG-typed", "[GERG]") {
     std::shared_ptr<AbstractState> AS(AbstractState::factory("GERG2008", std::vector<std::string>{"methane", "ethane"}));
     auto* gerg = dynamic_cast<GERGMixtureBackend*>(AS.get());
     REQUIRE(gerg != nullptr);
+    SECTION("fresh construction") {}
+    SECTION("components borrowed from the liquid helper") {
+        // Do not retain shared ownership: replacement destroys the old helper.
+        static_cast<HelmholtzEOSMixtureBackend&>(*gerg).set_components(gerg->get_SatL().get_components());
+    }
+    SECTION("components borrowed from the vapor helper") {
+        static_cast<HelmholtzEOSMixtureBackend&>(*gerg).set_components(gerg->get_SatV().get_components());
+    }
     CHECK(gerg->backend_name() == "GERG2008Backend");
     CHECK(gerg->get_SatL().backend_name() == "GERG2008Backend");
     CHECK(gerg->get_SatV().backend_name() == "GERG2008Backend");

--- a/src/Tests/CoolProp-Tests-MixtureTransport.cpp
+++ b/src/Tests/CoolProp-Tests-MixtureTransport.cpp
@@ -20,6 +20,16 @@ class InspectableMixtureTransport : public HelmholtzEOSMixtureBackend
     const std::vector<shared_ptr<HelmholtzEOSMixtureBackend>>& transport_states() const {
         return component_transport_states;
     }
+
+    const std::vector<shared_ptr<HelmholtzEOSMixtureBackend>>& linked_helpers() const {
+        return linked_states;
+    }
+
+    void create_linked_helpers() {
+        add_TPD_state();
+        add_critical_state();
+        add_transient_pure_state();
+    }
 };
 
 // Preserve the previous implementation as an equivalence reference, not as
@@ -78,6 +88,48 @@ TEST_CASE("Mixture transport agrees with fresh component backends across updates
     }
 }
 
+TEST_CASE("Excess matrices remain square when the component count changes", "[transport][mixture][mixture-transport]") {
+    ExcessTerm excess;
+    for (const std::size_t count : {2, 3, 2, 0, 3}) {
+        CAPTURE(count);
+        excess.resize(count);
+        REQUIRE(excess.N == count);
+        REQUIRE(excess.F.size() == count);
+        REQUIRE(excess.DepartureFunctionMatrix.size() == count);
+        for (std::size_t i = 0; i < count; ++i) {
+            REQUIRE(excess.F[i].size() == count);
+            REQUIRE(excess.DepartureFunctionMatrix[i].size() == count);
+        }
+    }
+}
+
+TEST_CASE("Mixture transport rejects missing or mismatched mole fractions", "[transport][mixture][mixture-transport]") {
+    InspectableMixtureTransport mixture(std::vector<std::string>{"Methane", "Ethane"});
+    SECTION("mole fractions have not been set") {}
+    SECTION("too few mole fractions after replacing components") {
+        check_transport(mixture, {0.6, 0.4}, 100.0, 400.0);
+        const HelmholtzEOSMixtureBackend replacement(std::vector<std::string>{"Methane", "Ethane", "Propane"});
+        mixture.set_components(replacement.get_components());
+    }
+    SECTION("too many mole fractions after replacing components") {
+        const HelmholtzEOSMixtureBackend replacement(std::vector<std::string>{"Methane", "Ethane", "Propane"});
+        mixture.set_components(replacement.get_components());
+        check_transport(mixture, {0.6, 0.3, 0.1}, 100.0, 400.0);
+        const HelmholtzEOSMixtureBackend original(std::vector<std::string>{"Methane", "Ethane"});
+        mixture.set_components(original.get_components());
+    }
+    // Invalidate AbstractState's cached outputs without a flash, which would
+    // itself require valid mole fractions before reaching the transport path.
+    mixture.clear();
+    for (const auto property : {iviscosity, iconductivity}) {
+        CHECK_THROWS_WITH(mixture.keyed_output(property),
+                          "Mole fractions must be set and match the component count before evaluating mixture transport");
+        CHECK(mixture.transport_states().empty());
+    }
+    const auto count = static_cast<const HelmholtzEOSMixtureBackend&>(mixture).get_components().size();
+    check_transport(mixture, std::vector<CoolPropDbl>(count, 1.0 / count), 100.0, 400.0);
+}
+
 TEST_CASE("Mixture transport follows replaced components and EOS", "[transport][mixture][mixture-transport]") {
     InspectableMixtureTransport mixture(std::vector<std::string>{"Methane", "Ethane"});
     check_transport(mixture, {0.6, 0.4}, 100.0, 400.0);
@@ -121,6 +173,61 @@ TEST_CASE("Mixture transport follows replaced components and EOS", "[transport][
     }
 }
 
+TEST_CASE("Component replacement discards old linked helper models", "[transport][mixture][mixture-transport]") {
+    InspectableMixtureTransport mixture(std::vector<std::string>{"Methane", "Ethane"});
+    check_transport(mixture, {0.6, 0.4}, 100.0, 400.0);
+    mixture.create_linked_helpers();
+    const auto old_helpers = mixture.linked_helpers();
+    REQUIRE(old_helpers.size() == 5);
+    const HelmholtzEOSMixtureBackend replacement(std::vector<std::string>{"Methane", "Ethane", "Propane"});
+
+    SECTION("replacement with saturation helpers") {
+        mixture.set_components(replacement.get_components());
+        REQUIRE(mixture.linked_helpers().size() == 2);
+        check_transport(mixture, {0.6, 0.3, 0.1}, 100.0, 400.0);
+        // With an old two-component helper still linked, this write passes
+        // its updated N check but indexes past its unchanged 2x2 matrix.
+        REQUIRE_NOTHROW(mixture.set_binary_interaction_double(0, 2, "Fij", 1.0));
+        CHECK(mixture.SatL->get_binary_interaction_double(0, 2, "Fij") == 1.0);
+        CHECK(mixture.SatV->get_binary_interaction_double(0, 2, "Fij") == 1.0);
+        mixture.create_linked_helpers();
+        REQUIRE(mixture.linked_helpers().size() == 5);
+        for (const auto& helper : mixture.linked_helpers()) {
+            CHECK(static_cast<const HelmholtzEOSMixtureBackend&>(*helper).get_components().size() == 3);
+        }
+    }
+    SECTION("replacement without saturation helpers") {
+        mixture.set_components(replacement.get_components(), false);
+        CHECK(mixture.linked_helpers().empty());
+        CHECK_FALSE(mixture.SatL);
+        CHECK_FALSE(mixture.SatV);
+    }
+    for (const auto& helper : old_helpers) {
+        CHECK(static_cast<const HelmholtzEOSMixtureBackend&>(*helper).get_components().size() == 2);
+        CHECK_THROWS(helper->set_binary_interaction_double(0, 2, "Fij", 1.0));
+    }
+}
+
+TEST_CASE("Invalid mole fractions discard already warmed transport helpers", "[transport][mixture][mixture-transport]") {
+    for (const auto property : {iviscosity, iconductivity}) {
+        for (const std::size_t count : {0, 1, 3}) {
+            CAPTURE(property, count);
+            InspectableMixtureTransport mixture(std::vector<std::string>{"Methane", "Ethane"});
+            check_transport(mixture, {0.6, 0.4}, 100.0, 400.0);
+            const auto old_helpers = mixture.transport_states();
+            REQUIRE(old_helpers.size() == 2);
+            mixture.get_mole_fractions_ref().resize(count);
+            mixture.clear();
+            REQUIRE(mixture.transport_states() == old_helpers);
+            CHECK_THROWS_WITH(mixture.keyed_output(property),
+                              "Mole fractions must be set and match the component count before evaluating mixture transport");
+            CHECK(mixture.transport_states().empty());
+            check_transport(mixture, {0.6, 0.4}, 100.0, 400.0);
+            CHECK(mixture.transport_states() != old_helpers);
+        }
+    }
+}
+
 TEST_CASE("Mixture transport reuses helpers without linking their component counts", "[transport][mixture][mixture-transport]") {
     InspectableMixtureTransport mixture(std::vector<std::string>{"Methane", "Ethane"});
     REQUIRE(mixture.transport_states().empty());
@@ -130,6 +237,8 @@ TEST_CASE("Mixture transport reuses helpers without linking their component coun
     REQUIRE(original[0]);
     REQUIRE(original[1]);
 
+    CHECK(mixture.fluid_param_string("CAS") == "74-82-8");
+    CHECK(mixture.transport_states() == original);
     mixture.clear();
     check_transport(mixture, {0.2, 0.8}, 200.0, 450.0, true);
     CHECK(mixture.transport_states() == original);

--- a/src/Tests/CoolProp-Tests-MixtureTransport.cpp
+++ b/src/Tests/CoolProp-Tests-MixtureTransport.cpp
@@ -1,0 +1,235 @@
+#if defined(ENABLE_CATCH)
+
+#    include <catch2/catch_all.hpp>
+#    include "../Backends/Helmholtz/HelmholtzEOSBackend.h"
+
+#    include <cmath>
+#    include <memory>
+#    include <string>
+#    include <vector>
+
+using namespace CoolProp;
+
+namespace {
+
+class InspectableMixtureTransport : public HelmholtzEOSMixtureBackend
+{
+   public:
+    using HelmholtzEOSMixtureBackend::HelmholtzEOSMixtureBackend;
+
+    const std::vector<shared_ptr<HelmholtzEOSMixtureBackend>>& transport_states() const {
+        return component_transport_states;
+    }
+};
+
+// Preserve the previous implementation as an equivalence reference, not as
+// experimental validation of the approximate mixture transport rules.
+double fresh_component_transport(const HelmholtzEOSMixtureBackend& mixture, const std::vector<CoolPropDbl>& fractions, double rho, double T,
+                                 parameters property) {
+    double sum = 0.0;
+    for (std::size_t i = 0; i < fractions.size(); ++i) {
+        auto pure = std::make_shared<HelmholtzEOSBackend>(mixture.get_components()[i]);
+        pure->update(DmolarT_INPUTS, rho, T);
+        const double value = pure->keyed_output(property);
+        sum += fractions[i] * (property == iviscosity ? std::log(value) : value);
+    }
+    return property == iviscosity ? std::exp(sum) : sum;
+}
+
+void check_transport(HelmholtzEOSMixtureBackend& mixture, const std::vector<CoolPropDbl>& fractions, double rho, double T,
+                     bool conductivity_first = false) {
+    mixture.set_mole_fractions(fractions);
+    mixture.update(DmolarT_INPUTS, rho, T);
+    const auto first = conductivity_first ? iconductivity : iviscosity;
+    const auto second = conductivity_first ? iviscosity : iconductivity;
+    for (const auto property : {first, second}) {
+        CAPTURE(property, rho, T, fractions);
+        const double expected = fresh_component_transport(mixture, fractions, rho, T, property);
+        CHECK(mixture.keyed_output(property) == Catch::Approx(expected).epsilon(1e-12));
+    }
+}
+
+}  // namespace
+
+TEST_CASE("Mixture transport agrees with fresh component backends across updates", "[transport][mixture][mixture-transport]") {
+    struct Mixture
+    {
+        std::vector<std::string> names;
+        std::vector<CoolPropDbl> fractions;
+        double temperature;
+    };
+    for (const auto& entry : {Mixture{{"Nitrogen", "Oxygen", "Argon", "CarbonDioxide", "Water"}, {0.70, 0.08, 0.01, 0.10, 0.11}, 700.0},
+                              Mixture{{"Methane", "Ethane", "Propane"}, {0.7, 0.2, 0.1}, 400.0}, Mixture{{"R125", "R143a"}, {0.5, 0.5}, 400.0},
+                              Mixture{{"Nitrogen", "Oxygen"}, {0.8, 0.2}, 110.0}}) {
+        CAPTURE(entry.names);
+        HelmholtzEOSMixtureBackend mixture(entry.names);
+        for (const double rho : {10.0, 200.0, 1000.0, 10.0}) {
+            check_transport(mixture, entry.fractions, rho, entry.temperature);
+            check_transport(mixture, entry.fractions, rho, entry.temperature + 50.0, true);
+        }
+        auto changed = entry.fractions;
+        changed[0] -= 0.1;
+        changed[1] += 0.1;
+        check_transport(mixture, changed, 20.0, entry.temperature);
+        changed.assign(changed.size(), 0.0);
+        changed[0] = 1.0;
+        check_transport(mixture, changed, 20.0, entry.temperature, true);
+        check_transport(mixture, entry.fractions, 10.0, entry.temperature);
+    }
+}
+
+TEST_CASE("Mixture transport follows replaced components and EOS", "[transport][mixture][mixture-transport]") {
+    InspectableMixtureTransport mixture(std::vector<std::string>{"Methane", "Ethane"});
+    check_transport(mixture, {0.6, 0.4}, 100.0, 400.0);
+
+    SECTION("component replacement with the same count") {
+        const HelmholtzEOSMixtureBackend replacement(std::vector<std::string>{"Nitrogen", "Oxygen"});
+        mixture.set_components(replacement.get_components());
+        check_transport(mixture, {0.6, 0.4}, 100.0, 400.0, true);
+    }
+    SECTION("component replacement with a different count") {
+        const HelmholtzEOSMixtureBackend replacement(std::vector<std::string>{"Methane", "Ethane", "Propane"});
+        mixture.set_components(replacement.get_components());
+        check_transport(mixture, {0.6, 0.3, 0.1}, 100.0, 400.0);
+    }
+    SECTION("component EOS replacement") {
+        mixture.change_EOS(0, "SRK");
+        CHECK(mixture.transport_states().empty());
+        check_transport(mixture, {0.6, 0.4}, 1000.0, 400.0, true);
+    }
+    SECTION("named reference state change") {
+        mixture.set_reference_stateS("NBP");
+        CHECK(mixture.transport_states().empty());
+        check_transport(mixture, {0.6, 0.4}, 100.0, 400.0);
+    }
+    SECTION("custom reference state change") {
+        mixture.set_reference_stateD(400.0, 100.0, 1000.0, 10.0);
+        CHECK(mixture.transport_states().empty());
+        check_transport(mixture, {0.6, 0.4}, 100.0, 400.0);
+    }
+    SECTION("independent backend and get_copy") {
+        HelmholtzEOSMixtureBackend other(std::vector<std::string>{"Methane", "Ethane"});
+        std::unique_ptr<HelmholtzEOSMixtureBackend> copy;
+        {
+            HelmholtzEOSMixtureBackend source(std::vector<std::string>{"Methane", "Ethane"});
+            check_transport(source, {0.6, 0.4}, 100.0, 400.0);
+            copy.reset(source.get_copy());
+        }
+        check_transport(other, {0.2, 0.8}, 200.0, 450.0);
+        check_transport(*copy, {0.4, 0.6}, 400.0, 500.0, true);
+        check_transport(mixture, {0.6, 0.4}, 100.0, 400.0);
+    }
+}
+
+TEST_CASE("Mixture transport reuses helpers without linking their component counts", "[transport][mixture][mixture-transport]") {
+    InspectableMixtureTransport mixture(std::vector<std::string>{"Methane", "Ethane"});
+    REQUIRE(mixture.transport_states().empty());
+    check_transport(mixture, {0.6, 0.4}, 100.0, 400.0);
+    const auto original = mixture.transport_states();
+    REQUIRE(original.size() == 2);
+    REQUIRE(original[0]);
+    REQUIRE(original[1]);
+
+    mixture.clear();
+    check_transport(mixture, {0.2, 0.8}, 200.0, 450.0, true);
+    CHECK(mixture.transport_states() == original);
+    mixture.set_binary_interaction_double(0, 1, "betaT", 1.01);
+    check_transport(mixture, {0.6, 0.4}, 100.0, 400.0);
+    CHECK(mixture.transport_states() == original);
+    for (const auto& pure : original) {
+        CHECK(pure->get_mole_fractions().size() == 1);
+    }
+    InspectableMixtureTransport other(std::vector<std::string>{"Methane", "Ethane"});
+    check_transport(other, {0.6, 0.4}, 100.0, 400.0);
+    CHECK(other.transport_states()[0] != original[0]);
+    CHECK(other.transport_states()[1] != original[1]);
+}
+
+TEST_CASE("Mixture transport handles persistent mutable component aliases", "[transport][mixture][mixture-transport]") {
+    InspectableMixtureTransport mixture(std::vector<std::string>{"Methane", "Ethane"});
+    check_transport(mixture, {0.6, 0.4}, 100.0, 400.0);
+    auto& alias = mixture.get_components();
+    CHECK(mixture.transport_states().empty());
+
+    SECTION("alias retained across repeated evaluations") {
+        check_transport(mixture, {0.6, 0.4}, 100.0, 400.0);
+        const auto previous = mixture.transport_states();
+        check_transport(mixture, {0.6, 0.4}, 100.0, 400.0);
+        CHECK(mixture.transport_states() != previous);
+    }
+    SECTION("vector alias retained across component replacement") {
+        const HelmholtzEOSMixtureBackend replacement(std::vector<std::string>{"Nitrogen", "Oxygen"});
+        mixture.set_components(replacement.get_components());
+        check_transport(mixture, {0.6, 0.4}, 100.0, 400.0);
+    }
+
+    alias[1].transport.viscosity_model_provided = false;
+    mixture.update(DmolarT_INPUTS, 100.0, 400.0);
+    CHECK_THROWS(mixture.viscosity());
+    CHECK(mixture.transport_states().empty());
+    alias[1].transport.viscosity_model_provided = true;
+    check_transport(mixture, {0.6, 0.4}, 100.0, 400.0);
+
+    alias[1].transport.conductivity_model_provided = false;
+    mixture.update(DmolarT_INPUTS, 100.0, 400.0);
+    CHECK_THROWS(mixture.conductivity());
+    alias[1].transport.conductivity_model_provided = true;
+    check_transport(mixture, {0.6, 0.4}, 100.0, 400.0, true);
+}
+
+TEST_CASE("Mixture transport discards helpers after failed evaluation or model mutation", "[transport][mixture][mixture-transport]") {
+    InspectableMixtureTransport mixture(std::vector<std::string>{"Methane", "Ethane"});
+    check_transport(mixture, {0.6, 0.4}, 100.0, 400.0);
+    const auto original = mixture.transport_states();
+    REQUIRE(original.size() == 2);
+
+    SECTION("transport failure after an earlier component succeeds") {
+        original[1]->get_components()[0].transport.viscosity_model_provided = false;
+        mixture.update(DmolarT_INPUTS, 100.0, 400.0);
+        CHECK_THROWS(mixture.viscosity());
+    }
+    SECTION("invalid EOS name") {
+        CHECK_THROWS(mixture.change_EOS(0, "invalid"));
+    }
+    SECTION("invalid reference state") {
+        CHECK_THROWS(mixture.set_reference_stateS("invalid"));
+    }
+    CHECK(mixture.transport_states().empty());
+    check_transport(mixture, {0.6, 0.4}, 100.0, 400.0, true);
+    CHECK(mixture.transport_states() != original);
+}
+
+TEST_CASE("Mixture transport timing", "[mixture-transport][!benchmark]") {
+    const std::vector<CoolPropDbl> fractions{0.70, 0.08, 0.01, 0.10, 0.11};
+    HelmholtzEOSMixtureBackend mixture(std::vector<std::string>{"Nitrogen", "Oxygen", "Argon", "CarbonDioxide", "Water"});
+    mixture.set_mole_fractions(fractions);
+    // Each iteration updates the state, invalidating AbstractState's property
+    // cache. Both paths use identical update calls and the same mixing rules.
+    mixture.update(DmolarT_INPUTS, 20.0, 700.0);
+    const double expected = fresh_component_transport(mixture, fractions, 20.0, 700.0, iviscosity)
+                            + fresh_component_transport(mixture, fractions, 20.0, 700.0, iconductivity);
+    REQUIRE(mixture.viscosity() + mixture.conductivity() == Catch::Approx(expected).epsilon(1e-12));
+
+    BENCHMARK("fresh components: rho,T update + viscosity + conductivity") {
+        mixture.update(DmolarT_INPUTS, 20.0, 700.0);
+        return fresh_component_transport(mixture, fractions, 20.0, 700.0, iviscosity)
+               + fresh_component_transport(mixture, fractions, 20.0, 700.0, iconductivity);
+    };
+    BENCHMARK("reused components: rho,T update + viscosity + conductivity") {
+        mixture.update(DmolarT_INPUTS, 20.0, 700.0);
+        return mixture.viscosity() + mixture.conductivity();
+    };
+    // Also include phase determination/density solving, as in a PT-based caller.
+    mixture.update(PT_INPUTS, 101325.0, 700.0);
+    BENCHMARK("fresh components: p,T update + viscosity + conductivity") {
+        mixture.update(PT_INPUTS, 101325.0, 700.0);
+        return fresh_component_transport(mixture, fractions, mixture.rhomolar(), mixture.T(), iviscosity)
+               + fresh_component_transport(mixture, fractions, mixture.rhomolar(), mixture.T(), iconductivity);
+    };
+    BENCHMARK("reused components: p,T update + viscosity + conductivity") {
+        mixture.update(PT_INPUTS, 101325.0, 700.0);
+        return mixture.viscosity() + mixture.conductivity();
+    };
+}
+
+#endif


### PR DESCRIPTION
## Description of the Change

Reuse backend-owned pure-component states when evaluating HEOS mixture viscosity and thermal conductivity, instead of constructing them for every property evaluation. The mixing rules, summation order, zero-fraction handling, and pure-fluid phase determination are unchanged.

Component states are updated on every evaluation. They are discarded before component/EOS/reference-state changes and after evaluation failures. Calling the mutable `get_components()` accessor permanently retains fresh-object evaluation for that instance, since callers can keep and later modify a reference. Read-only construction and metadata access no longer trigger this fallback.

Review/CI fixes included:
- Reject unset or mismatched mole-fraction counts before indexing, also clearing already-warmed helpers on failure.
- Resize every row of the excess-term matrix when changing the component count. The new replacement test exposed an existing heap-buffer-overflow here under CI AddressSanitizer.
- Discard obsolete linked helpers when replacing components; otherwise later binary-interaction updates can reach matrices belonging to the previous mixture. GERG rebuilds its saturation states from the owned component copy, including when the input came from a discarded helper.
- Build unsigned GUI bundles only for PRs, which cannot access fork signing secrets. Push/release signing remains enabled. This uses Tauri 2.11.0's [documented signing bypass](https://github.com/tauri-apps/tauri/blob/tauri-cli-v2.11.0/crates/tauri-cli/src/bundle.rs#L240); no tests are disabled.

## Benefits

An opt-in Catch2 benchmark compares the previous fresh-component loops with the production path. Both include a state update on every iteration; these are not repeated property-cache hits.

Windows x64, MSVC Release, 50 samples per run. Mole fractions: N2/O2/Ar/CO2/H2O = 0.70/0.08/0.01/0.10/0.11, T = 700 K. Density-input runs use 20 mol/m3; pressure-input runs use 101325 Pa. No phase is imposed.

| Update + viscosity + conductivity | Fresh components | Reused components | Time reduction |
|---|---:|---:|---:|
| rho,T, run 1 | 6.885 ms | 5.315 ms | 22.8% |
| rho,T, run 2 | 7.618 ms | 5.747 ms | 24.6% |
| p,T, run 1 | 9.111 ms | 7.678 ms | 15.7% |
| p,T, run 2 | 9.762 ms | 7.494 ms | 23.2% |

These are local microbenchmark results from the initial implementation, before the review fixes, not an end-to-end application speedup. Timing varies between runs.

## Possible Drawbacks

Each used mixture instance retains a pure-fluid backend, including its saturation helpers, per component. Read-only callers using the mutable component accessor lose the optimization, including some remaining internal saturation/phase-envelope paths. The existing approximate mixture transport models are not made more accurate by this change.

## Verification Process

- Release build completed successfully.
- Nine new regression cases: 344 assertions passed. Coverage includes temperature/density/composition changes, ECS fluids, low temperatures, zero fractions, actual object reuse, component/EOS/reference-state replacement, retained mutable aliases, failure recovery, component-count mismatches, matrix resizing, and linked-helper lifetimes.
- Transport suite including the new cases: 1690 assertions passed in 13 cases.
- Four targeted GERG regression cases: 2019 assertions passed, including component vectors borrowed from a saturation helper without retaining ownership.
- Comparisons against fresh component backends use a relative tolerance of 1e-12. They verify implementation equivalence, not experimental accuracy of the mixing rules.
- clang-format 18.1.8, `git diff --check`, and actionlint 1.7.12 passed (actionlint shellcheck/pyflakes integrations disabled).
- A focused GCC 15.2 AddressSanitizer probe against the actual `ExcessTerm` implementation passed for grow/shrink/empty matrices. This is not a full sanitized Catch2 run; the GitHub ASan job must rerun on the updated commit.
- A separate Codex adversarial review found no remaining blockers after the GERG borrowed-reference fix.
- The broader `[Helmholtz],[REFPROP],[flash],[mixture]` sweep was stopped after exceeding five minutes; it is not reported as passing. The full suite and Win32 build remain unverified locally.
- Preflight was run with `--skip=build,tests,cppcheck,clang-tidy,semgrep`: build/tests were run separately with MSVC; the three static-analysis tools were not run locally. Shared-library symbol and installed-header gates were also skipped with the preflight build.

Reproduce using the configured Catch2 build:

```text
CatchTestRunner "[transport]~[!benchmark]" --reporter compact
CatchTestRunner "[mixture-transport][!benchmark]" --benchmark-samples 50 --benchmark-resamples 1000
```

AI assistance: OpenAI Codex prepared the implementation, tests, benchmark, review fixes, and this description, and executed the checks reported above. These are agent-executed checks, not a claim of independent human validation.

## Applicable Issues

None linked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved mixture viscosity and thermal-conductivity calculations through reusable component transport states.

* **Reliability**
  * Improved consistency after composition, EOS, reference-state, and component updates.
  * Improved recovery after transport-calculation failures.

* **Builds**
  * Pull-request GUI builds no longer require signing; push and release builds continue signing.

* **Tests**
  * Added comprehensive mixture-transport coverage and expanded GERG mixture state validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->