### PR TITLE
fix(flash): reformulate newton_raphson_twophase in lnK and route interior-Q mixture PQ/QT flash there

### DIFF
--- a/src/Backends/Helmholtz/FlashRoutines.cpp
+++ b/src/Backends/Helmholtz/FlashRoutines.cpp
@@ -21,6 +21,27 @@
 
 namespace CoolProp {
 
+namespace {
+
+/// Record that a mixture flash fell back from its preferred solver to a less accurate one.
+///
+/// These fallbacks are deliberately fail-open -- PQ/QT must not start throwing where they
+/// previously returned an answer -- but a fallback that leaves no trace is indistinguishable
+/// from success to every caller and to CI.  The envelope-guided path was measured falling back
+/// on 42% of interior-Q states on a two-component mixture with nobody able to observe it
+/// (GH #3372).  Route every such fallback through here so it is at least visible via
+/// get_global_param_string("warnstring").
+void record_flash_fallback(const char* attempted, const char* fallback, const char* why) {
+    set_warning_string(format("%s failed (%s); fell back to %s", attempted, why, fallback));
+}
+
+/// Below this distance from Q = 0 or Q = 1 a mixture VLE state is treated as a bubble- or
+/// dew-point rather than an interior two-phase state, and solved with the (cheaper, and there
+/// exact) saturation solver.  Matches the gate in PQ_flash_with_guesses / QT_flash_with_guesses.
+const double Q_saturation_tol = 1e-10;
+
+}  // namespace
+
 void FlashRoutines::PT_flash_mixtures(HelmholtzEOSMixtureBackend& HEOS) {
     // Only use the phase envelope to classify the (T, p) point when the caller has
     // NOT imposed a single homogeneous phase.  A user who called specify_phase(iphase_gas
@@ -1045,10 +1066,16 @@ void FlashRoutines::QT_flash(HelmholtzEOSMixtureBackend& HEOS) {
             try {
                 PT_Q_flash_mixtures(HEOS, iT, HEOS._T);
                 solved_with_envelope = true;
+            } catch (const std::exception& e) {
+                HEOS._T = T_in;
+                HEOS._p = p_in;
+                solved_with_envelope = false;  // fall back to the blind solver below
+                record_flash_fallback("envelope-guided QT flash", "the blind solver", e.what());
             } catch (...) {
                 HEOS._T = T_in;
                 HEOS._p = p_in;
                 solved_with_envelope = false;  // fall back to the blind solver below
+                record_flash_fallback("envelope-guided QT flash", "the blind solver", "unknown exception");
             }
         }
         if (!solved_with_envelope) {
@@ -1070,33 +1097,63 @@ void FlashRoutines::QT_flash(HelmholtzEOSMixtureBackend& HEOS) {
             // Newton-Raphson
             // -----
 
-            SaturationSolvers::newton_raphson_saturation NR;
-            SaturationSolvers::newton_raphson_saturation_options IO;
-
-            IO.bubble_point = (HEOS._Q < 0.5);
-
-            IO.x = options.x;
-            IO.y = options.y;
-            IO.rhomolar_liq = options.rhomolar_liq;
-            IO.rhomolar_vap = options.rhomolar_vap;
-            IO.T = options.T;
-            IO.p = options.p;
-            IO.Nstep_max = 30;
-
-            IO.imposed_variable = SaturationSolvers::newton_raphson_saturation_options::T_IMPOSED;
-
-            if (IO.bubble_point) {
-                // Compositions are z, z_incipient
-                NR.call(HEOS, IO.x, IO.y, IO);
-            } else {
-                // Compositions are z, z_incipient
-                NR.call(HEOS, IO.y, IO.x, IO);
+            // Interior Q goes to the two-phase solver; Q ~ 0 and Q ~ 1 stay on the bubble/dew
+            // solver, which is exact there and cheaper.  See the matching block in PQ_flash for
+            // why the saturation solver cannot answer an interior-Q question (GH #3372).
+            const bool interior_Q = (HEOS._Q > Q_saturation_tol) && (HEOS._Q < 1 - Q_saturation_tol);
+            bool solved_twophase = false;
+            if (interior_Q) {
+                SaturationSolvers::newton_raphson_twophase NR2;
+                SaturationSolvers::newton_raphson_twophase_options IO2;
+                IO2.beta = HEOS._Q;
+                IO2.x = options.x;
+                IO2.y = options.y;
+                IO2.rhomolar_liq = options.rhomolar_liq;
+                IO2.rhomolar_vap = options.rhomolar_vap;
+                IO2.T = options.T;
+                IO2.p = options.p;
+                IO2.z = HEOS.mole_fractions;
+                IO2.Nstep_max = 30;
+                IO2.imposed_variable = SaturationSolvers::newton_raphson_twophase_options::T_IMPOSED;
+                try {
+                    NR2.call(HEOS, IO2);
+                    solved_twophase = true;
+                } catch (const std::exception& e) {
+                    record_flash_fallback("two-phase QT solve", "the bubble/dew solver (no mass balance)", e.what());
+                } catch (...) {
+                    record_flash_fallback("two-phase QT solve", "the bubble/dew solver (no mass balance)", "unknown exception");
+                }
             }
 
-            HEOS._p = IO.p;
-            HEOS._rhomolar = 1 / (HEOS._Q / IO.rhomolar_vap + (1 - HEOS._Q) / IO.rhomolar_liq);
+            if (!solved_twophase) {
+                SaturationSolvers::newton_raphson_saturation NR;
+                SaturationSolvers::newton_raphson_saturation_options IO;
+
+                IO.bubble_point = (HEOS._Q < 0.5);
+
+                IO.x = options.x;
+                IO.y = options.y;
+                IO.rhomolar_liq = options.rhomolar_liq;
+                IO.rhomolar_vap = options.rhomolar_vap;
+                IO.T = options.T;
+                IO.p = options.p;
+                IO.Nstep_max = 30;
+
+                IO.imposed_variable = SaturationSolvers::newton_raphson_saturation_options::T_IMPOSED;
+
+                if (IO.bubble_point) {
+                    // Compositions are z, z_incipient
+                    NR.call(HEOS, IO.x, IO.y, IO);
+                } else {
+                    // Compositions are z, z_incipient
+                    NR.call(HEOS, IO.y, IO.x, IO);
+                }
+            }
         }
-        // Load the outputs
+        // Load the outputs.  (An assignment of _p / _rhomolar from the saturation solver's IO
+        // used to sit here; it was a dead store -- both are overwritten from SatL/SatV
+        // immediately below on every path -- and it referenced a solver-specific local that no
+        // longer spans both branches.)
         HEOS._phase = iphase_twophase;
         HEOS._p = HEOS.SatV->p();
         HEOS._rhomolar = 1 / (HEOS._Q / HEOS.SatV->rhomolar() + (1 - HEOS._Q) / HEOS.SatL->rhomolar());
@@ -1332,10 +1389,16 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend& HEOS) {
             try {
                 PT_Q_flash_mixtures(HEOS, iP, HEOS._p);
                 solved_with_envelope = true;
+            } catch (const std::exception& e) {
+                HEOS._T = T_in;
+                HEOS._p = p_in;
+                solved_with_envelope = false;  // fall back to the blind solver below
+                record_flash_fallback("envelope-guided PQ flash", "the blind solver", e.what());
             } catch (...) {
                 HEOS._T = T_in;
                 HEOS._p = p_in;
                 solved_with_envelope = false;  // fall back to the blind solver below
+                record_flash_fallback("envelope-guided PQ flash", "the blind solver", "unknown exception");
             }
         }
         if (!solved_with_envelope) {
@@ -1391,25 +1454,59 @@ void FlashRoutines::PQ_flash(HelmholtzEOSMixtureBackend& HEOS) {
             // Newton-Raphson
             // -----
 
-            SaturationSolvers::newton_raphson_saturation NR;
-            SaturationSolvers::newton_raphson_saturation_options IO;
+            // For an interior quality, prefer the two-phase solver.  newton_raphson_saturation
+            // is a bubble/dew-point solver: its residual is the N equal-fugacity conditions plus
+            // one specification, and its unknowns are the INCIPIENT phase's composition and
+            // T (or p).  It carries no overall mass-balance condition, so the other phase stays
+            // pinned to whatever successive substitution produced and z = (1-Q)x + Qy is never
+            // enforced.  It is exact at Q = 0 and Q = 1, where the incipient phase is the whole
+            // answer, and only there (GH #3372).
+            const bool interior_Q = (HEOS._Q > Q_saturation_tol) && (HEOS._Q < 1 - Q_saturation_tol);
+            bool solved_twophase = false;
+            if (interior_Q) {
+                SaturationSolvers::newton_raphson_twophase NR2;
+                SaturationSolvers::newton_raphson_twophase_options IO2;
+                IO2.beta = HEOS._Q;
+                IO2.x = io.x;
+                IO2.y = io.y;
+                IO2.rhomolar_liq = io.rhomolar_liq;
+                IO2.rhomolar_vap = io.rhomolar_vap;
+                IO2.T = io.T;
+                IO2.p = io.p;
+                IO2.z = HEOS.mole_fractions;
+                IO2.Nstep_max = 30;
+                IO2.imposed_variable = SaturationSolvers::newton_raphson_twophase_options::P_IMPOSED;
+                try {
+                    NR2.call(HEOS, IO2);
+                    solved_twophase = true;
+                } catch (const std::exception& e) {
+                    record_flash_fallback("two-phase PQ solve", "the bubble/dew solver (no mass balance)", e.what());
+                } catch (...) {
+                    record_flash_fallback("two-phase PQ solve", "the bubble/dew solver (no mass balance)", "unknown exception");
+                }
+            }
 
-            IO.bubble_point = (HEOS._Q < 0.5);
-            IO.x = io.x;
-            IO.y = io.y;
-            IO.rhomolar_liq = io.rhomolar_liq;
-            IO.rhomolar_vap = io.rhomolar_vap;
-            IO.T = io.T;
-            IO.p = io.p;
-            IO.Nstep_max = 30;
-            IO.imposed_variable = SaturationSolvers::newton_raphson_saturation_options::P_IMPOSED;
+            if (!solved_twophase) {
+                SaturationSolvers::newton_raphson_saturation NR;
+                SaturationSolvers::newton_raphson_saturation_options IO;
 
-            if (IO.bubble_point) {
-                // Compositions are z, z_incipient
-                NR.call(HEOS, IO.x, IO.y, IO);
-            } else {
-                // Compositions are z, z_incipient
-                NR.call(HEOS, IO.y, IO.x, IO);
+                IO.bubble_point = (HEOS._Q < 0.5);
+                IO.x = io.x;
+                IO.y = io.y;
+                IO.rhomolar_liq = io.rhomolar_liq;
+                IO.rhomolar_vap = io.rhomolar_vap;
+                IO.T = io.T;
+                IO.p = io.p;
+                IO.Nstep_max = 30;
+                IO.imposed_variable = SaturationSolvers::newton_raphson_saturation_options::P_IMPOSED;
+
+                if (IO.bubble_point) {
+                    // Compositions are z, z_incipient
+                    NR.call(HEOS, IO.x, IO.y, IO);
+                } else {
+                    // Compositions are z, z_incipient
+                    NR.call(HEOS, IO.y, IO.x, IO);
+                }
             }
         }
 

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -1597,19 +1597,41 @@ void SaturationSolvers::newton_raphson_twophase::call(HelmholtzEOSMixtureBackend
     z = IO.z;
     beta = IO.beta;
 
-    // All 2N mole fractions are independent variables, plus the imposed-variable partner
-    // (T or p): 2N+1 unknowns.  Eliminating x[N-1] = 1 - sum(x) instead costs the dependent
-    // component its relative precision -- it is formed by subtracting from 1, so it carries
-    // ~1 ulp of absolute error, and when that component is the SMALLEST (a heavy trace
-    // component in a wide-boiling mixture, y ~ 1e-14) the relative error reaches ~1%.
-    // ln f_{N-1} contains ln y_{N-1}, so that error lands directly in the residual and floors
-    // it above the convergence gate, rejecting an otherwise converged answer (GH #3372).
+    // The unknowns are ln K_i (N of them) and the imposed-variable partner (T or p): N+1.
+    //
+    // The compositions are RECONSTRUCTED from K rather than solved for:
+    //     D_i = (1-beta) + beta K_i,   x_i = z_i / D_i,   y_i = K_i x_i
+    // so (1-beta) x_i + beta y_i = z_i identically at every iterate -- the overall mass balance
+    // is a property of the parameterization, not a residual driven to zero.  That matters
+    // because a mass-balance row cannot determine a trace composition: solving it for y_i
+    // amplifies the relative error in x_i by ((1-beta)/beta)/K_i, which reaches 1.3e13 for a
+    // heavy trace component (Pentane at 91 K, K ~ 7e-13).  Carrying x and y as unknowns
+    // instead -- with or without eliminating one of them -- leaves that amplification in the
+    // system and floors the residual above the convergence gate (GH #3372).
+    //
+    // D_i is a sum of non-negative terms for beta in [0,1] and K_i > 0, so no cancellation is
+    // possible in it: a tiny x_i arrives by division, a tiny y_i by multiplication, and both
+    // keep full relative precision.  Measured against the (x, y) form on
+    // Nitrogen&Methane&Ethane&Butane&Pentane at 3 bar, this drops cond(J) from ~4.5e15 to
+    // ~1e3 and converges in 2-5 iterations at every Q in [0.1, 0.9].
     this->N = z.size();
     x.resize(N);
     y.resize(N);
-    r.resize(2 * N + 1);
-    J.resize(2 * N + 1, 2 * N + 1);
-    err_rel.resize(2 * N + 1);
+    r.resize(N + 1);
+    J.resize(N + 1, N + 1);
+    err_rel.resize(N + 1);
+
+    // Seed ln K from the incoming composition guess.  K is held (not ln K) so the Newton step
+    // applies multiplicatively, K_i *= exp(tau * dw_i), which keeps K_i strictly positive for
+    // any step size -- no damping is needed to preserve feasibility of the compositions.
+    K.resize(N);
+    for (std::size_t i = 0; i < N; ++i) {
+        if (!(x[i] > 0) || !(y[i] > 0)) {
+            throw ValueError(format("newton_raphson_twophase::call needs a strictly positive composition seed (x[%d] = %g, y[%d] = %g)",
+                                    static_cast<int>(i), static_cast<double>(x[i]), static_cast<int>(i), static_cast<double>(y[i])));
+        }
+        K[i] = y[i] / x[i];
+    }
 
     // Hold a pointer to the backend
     this->HEOS = &HEOS;
@@ -1626,46 +1648,43 @@ void SaturationSolvers::newton_raphson_twophase::call(HelmholtzEOSMixtureBackend
             throw ValueError("newton_raphson_twophase::call produced a non-finite residual");
         }
 
-        // Solve for the step; v is the step with the contents
-        // [delta(x_0), delta(x_1), ..., delta(x_{N-2}), delta(spec)]
+        // Solve for the step; v holds [delta(ln K_0) .. delta(ln K_{N-1}), delta(spec)]
         Eigen::VectorXd v = J.colPivHouseholderQr().solve(-r);
 
-        // Damp the Newton step so neither phase composition leaves the open interval (0,1).
-        // An undamped step routinely overshoots (x_i < 0 or y_i > 1); the next fugacity
-        // evaluation then returns NaN and the solve diverges (GH #3192 follow-up).  tau is
-        // the largest fraction of the full step that keeps every stepped mole fraction
-        // inside (0,1), backed off by step_safety so it stays strictly interior.
+        // The compositions cannot leave the simplex regardless of step size -- they are
+        // reconstructed from K, and K_i stays positive under a multiplicative update -- so the
+        // damping here is only about step SIZE, not feasibility.  Cap the ln K step so a wild
+        // early iterate cannot jump many decades in K (which would land the density solve on a
+        // different root), and cap the imposed-variable step in relative terms.
         double tau = 1.0;
-        const double step_safety = 0.8;
-        // Every mole fraction is an independent variable now, so all 2N of them are bounded
-        // by the same rule; there is no dependent component to treat separately.
+        const double max_dlnK = 2.0;      // at most ~e^2 change in K per iteration
+        const double max_rel_spec = 0.2;  // at most 20% change in T (or p) per iteration
         for (std::size_t i = 0; i < N; ++i) {
-            const double dx = v[i], dy = v[i + N];
-            if (x[i] + dx <= 0.0) {
-                tau = std::min(tau, step_safety * (-x[i] / dx));
-            } else if (x[i] + dx >= 1.0) {
-                tau = std::min(tau, step_safety * ((1.0 - x[i]) / dx));
+            const double d = std::abs(v[i]);
+            if (d > max_dlnK) {
+                tau = std::min(tau, max_dlnK / d);
             }
-            if (y[i] + dy <= 0.0) {
-                tau = std::min(tau, step_safety * (-y[i] / dy));
-            } else if (y[i] + dy >= 1.0) {
-                tau = std::min(tau, step_safety * ((1.0 - y[i]) / dy));
+        }
+        {
+            const double spec = (imposed_variable == newton_raphson_twophase_options::P_IMPOSED) ? T : p;
+            const double d = std::abs(v[N]);
+            if (d > max_rel_spec * spec) {
+                tau = std::min(tau, max_rel_spec * spec / d);
             }
         }
 
         for (std::size_t i = 0; i < N; ++i) {
-            err_rel[i] = tau * v[i] / x[i];
-            x[i] += tau * v[i];
-            err_rel[i + N] = tau * v[i + N] / y[i];
-            y[i] += tau * v[i + N];
+            const double dw = tau * v[i];
+            err_rel[i] = dw;  // already a relative change: d(ln K_i) = dK_i / K_i
+            K[i] *= exp(dw);
         }
 
         if (imposed_variable == newton_raphson_twophase_options::P_IMPOSED) {
-            T += tau * v[2 * N];
-            err_rel[2 * N] = tau * v[2 * N] / T;
+            T += tau * v[N];
+            err_rel[N] = tau * v[N] / T;
         } else if (imposed_variable == newton_raphson_twophase_options::T_IMPOSED) {
-            p += tau * v[2 * N];
-            err_rel[2 * N] = tau * v[2 * N] / p;
+            p += tau * v[N];
+            err_rel[N] = tau * v[N] / p;
         } else {
             throw ValueError("invalid imposed_variable");
         }
@@ -1730,7 +1749,16 @@ void SaturationSolvers::newton_raphson_twophase::build_arrays() {
 
     // Step 0:
     // -------
-    // Set mole fractions
+    // Reconstruct both compositions from the current K.  D_i is a sum of non-negative terms
+    // (beta in [0,1], K_i > 0), so this is cancellation-free at both extremes: a tiny x_i comes
+    // out of the division, a tiny y_i out of the product, and (1-beta)x_i + beta*y_i = z_i
+    // holds identically.
+    for (std::size_t i = 0; i < N; ++i) {
+        const CoolPropDbl D = (1 - beta) + beta * K[i];
+        x[i] = z[i] / D;
+        y[i] = K[i] * x[i];
+    }
+
     rSatL.set_mole_fractions(x);
     rSatV.set_mole_fractions(y);
 
@@ -1751,55 +1779,70 @@ void SaturationSolvers::newton_raphson_twophase::build_arrays() {
     // -------
     // Build the residual vector and the Jacobian matrix
 
-    // Every mole fraction is a free variable here, so the composition derivatives must be the
-    // XN_INDEPENDENT ones.  (dln_fugacity_dxj__constT_p_xi honours this flag as of the fix that
-    // precedes this change; before it, the XN_DEPENDENT ideal term was applied unconditionally.)
+    // x and y are reconstructed from K rather than being free variables, but the fugacity
+    // derivatives below are still taken with respect to the individual mole fractions, so they
+    // are the XN_INDEPENDENT ones.  (dln_fugacity_coefficient_dxj__constT_p_xi threads the flag
+    // through; the ideal term that used to ignore it lives in dln_fugacity_dxj, not here.)
     x_N_dependency_flag xN_flag = XN_INDEPENDENT;
 
-    // Residuals, laid out as
-    //   [0 .. N-1]    iso-fugacity        ln f_i^L - ln f_i^V
-    //   [N .. 2N-1]   overall mass balance z_i - (1-beta) x_i - beta y_i
-    //   [2N]          simplex closure      sum(x) - 1
-    // sum(y) = 1 is NOT a separate row: summing the N mass balances with sum(z) = 1 and
-    // sum(x) = 1 already forces it (for beta != 0), so adding it would over-determine the
-    // system.  The mass balance is in linear rather than ratio form because there are now N of
-    // them rather than N-1, and the linear form has no pole at y_i = x_i.
+    // Residuals:
+    //   [0 .. N-1]  iso-fugacity in ln K form   ln K_i - (ln phi_i^L - ln phi_i^V)
+    //   [N]         Rachford-Rice               sum_i z_i (K_i - 1) / D_i   ( = sum y - sum x)
+    // The overall mass balance is absent by construction (see call()).  Rachford-Rice is the
+    // closure condition: combined with (1-beta) sum(x) + beta sum(y) = sum(z) = 1 it forces
+    // sum(x) = sum(y) = 1.  Both blocks are dimensionless and O(1), so error_rms weights them
+    // comparably -- unlike the mass-balance form, where the trace-component rows were O(z_i).
+    std::vector<CoolPropDbl> lnphi_liq(N), lnphi_vap(N);
+    CoolPropDbl rachford_rice = 0;
     for (std::size_t i = 0; i < N; ++i) {
-        CoolPropDbl ln_f_liq = log(MixtureDerivatives::fugacity_i(rSatL, i, xN_flag));
-        CoolPropDbl ln_f_vap = log(MixtureDerivatives::fugacity_i(rSatV, i, xN_flag));
-        r[i] = ln_f_liq - ln_f_vap;
-        r[i + N] = z[i] - (1 - beta) * x[i] - beta * y[i];
+        lnphi_liq[i] = MixtureDerivatives::ln_fugacity_coefficient(rSatL, i, xN_flag);
+        lnphi_vap[i] = MixtureDerivatives::ln_fugacity_coefficient(rSatV, i, xN_flag);
+        r[i] = log(K[i]) - (lnphi_liq[i] - lnphi_vap[i]);
+        const CoolPropDbl D = (1 - beta) + beta * K[i];
+        rachford_rice += z[i] * (K[i] - 1) / D;
     }
-    CoolPropDbl sum_x = std::accumulate(x.begin(), x.end(), static_cast<CoolPropDbl>(0.0));
-    r[2 * N] = sum_x - 1;
+    r[N] = rachford_rice;
 
-    // Iso-fugacity rows: d/dx_j on the liquid, -d/dy_j on the vapor, and the imposed-variable
-    // partner in the last column.
+    // Composition sensitivities to ln K.  D_i depends on K_i alone, so these are diagonal:
+    //   dx_i/dlnK_j = -delta_ij x_i beta K_i / D_i
+    //   dy_i/dlnK_j =  delta_ij y_i (1 - beta K_i / D_i)
+    std::vector<CoolPropDbl> dx_dlnK(N), dy_dlnK(N);
+    for (std::size_t j = 0; j < N; ++j) {
+        const CoolPropDbl D = (1 - beta) + beta * K[j];
+        dx_dlnK[j] = -x[j] * beta * K[j] / D;
+        dy_dlnK[j] = y[j] * (1 - beta * K[j] / D);
+    }
+
+    // Iso-fugacity rows.  d(ln K_i)/d(ln K_j) = delta_ij; the fugacity-coefficient terms pick
+    // up the composition sensitivities above through the chain rule, which stays diagonal in j.
     for (std::size_t i = 0; i < N; ++i) {
         for (std::size_t j = 0; j < N; ++j) {
-            J(i, j) = MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(rSatL, i, j, xN_flag);
-            J(i, j + N) = -MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(rSatV, i, j, xN_flag);
+            const CoolPropDbl dlnphiL = MixtureDerivatives::dln_fugacity_coefficient_dxj__constT_p_xi(rSatL, i, j, xN_flag);
+            const CoolPropDbl dlnphiV = MixtureDerivatives::dln_fugacity_coefficient_dxj__constT_p_xi(rSatV, i, j, xN_flag);
+            J(i, j) = (i == j ? 1.0 : 0.0) - (dlnphiL * dx_dlnK[j] - dlnphiV * dy_dlnK[j]);
         }
 
+        // At fixed composition ln f_i = ln x_i + ln phi_i + ln p, so d(ln f_i)/dT|_{p,n} is
+        // d(ln phi_i)/dT and the existing helper is the right quantity here.
         if (imposed_variable == newton_raphson_twophase_options::P_IMPOSED) {
-            J(i, 2 * N) =
-              MixtureDerivatives::dln_fugacity_i_dT__constp_n(rSatL, i, xN_flag) - MixtureDerivatives::dln_fugacity_i_dT__constp_n(rSatV, i, xN_flag);
+            J(i, N) = -(MixtureDerivatives::dln_fugacity_i_dT__constp_n(rSatL, i, xN_flag)
+                        - MixtureDerivatives::dln_fugacity_i_dT__constp_n(rSatV, i, xN_flag));
         } else if (imposed_variable == newton_raphson_twophase_options::T_IMPOSED) {
-            J(i, 2 * N) =
-              MixtureDerivatives::dln_fugacity_i_dp__constT_n(rSatL, i, xN_flag) - MixtureDerivatives::dln_fugacity_i_dp__constT_n(rSatV, i, xN_flag);
+            J(i, N) = -(MixtureDerivatives::dln_fugacity_i_dp__constT_n(rSatL, i, xN_flag)
+                        - MixtureDerivatives::dln_fugacity_i_dp__constT_n(rSatV, i, xN_flag));
         } else {
             throw ValueError();
         }
     }
-    // Mass-balance rows: two entries each, and no dependence on T or p.
-    for (std::size_t i = 0; i < N; ++i) {
-        J(i + N, i) = -(1 - beta);
-        J(i + N, i + N) = -beta;
-    }
-    // Simplex-closure row.
+
+    // Rachford-Rice row.  d/dlnK_j [ z_j (K_j - 1)/D_j ] = z_j K_j [D_j - beta(K_j - 1)]/D_j^2,
+    // and D_j - beta(K_j - 1) = (1-beta) + beta K_j - beta K_j + beta = 1.  No T/p dependence:
+    // the residual is a function of K, beta and z only.
     for (std::size_t j = 0; j < N; ++j) {
-        J(2 * N, j) = 1.0;
+        const CoolPropDbl D = (1 - beta) + beta * K[j];
+        J(N, j) = z[j] * K[j] / (D * D);
     }
+    J(N, N) = 0.0;
 
     error_rms = r.norm();  // Square-root (The R in RMS)
 }

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -1597,12 +1597,19 @@ void SaturationSolvers::newton_raphson_twophase::call(HelmholtzEOSMixtureBackend
     z = IO.z;
     beta = IO.beta;
 
+    // All 2N mole fractions are independent variables, plus the imposed-variable partner
+    // (T or p): 2N+1 unknowns.  Eliminating x[N-1] = 1 - sum(x) instead costs the dependent
+    // component its relative precision -- it is formed by subtracting from 1, so it carries
+    // ~1 ulp of absolute error, and when that component is the SMALLEST (a heavy trace
+    // component in a wide-boiling mixture, y ~ 1e-14) the relative error reaches ~1%.
+    // ln f_{N-1} contains ln y_{N-1}, so that error lands directly in the residual and floors
+    // it above the convergence gate, rejecting an otherwise converged answer (GH #3372).
     this->N = z.size();
     x.resize(N);
     y.resize(N);
-    r.resize(2 * N - 1);
-    J.resize(2 * N - 1, 2 * N - 1);
-    err_rel.resize(2 * N - 1);
+    r.resize(2 * N + 1);
+    J.resize(2 * N + 1, 2 * N + 1);
+    err_rel.resize(2 * N + 1);
 
     // Hold a pointer to the backend
     this->HEOS = &HEOS;
@@ -1630,15 +1637,10 @@ void SaturationSolvers::newton_raphson_twophase::call(HelmholtzEOSMixtureBackend
         // inside (0,1), backed off by step_safety so it stays strictly interior.
         double tau = 1.0;
         const double step_safety = 0.8;
-        // The dependent mole fractions x[N-1] = 1 - sum(x[0..N-2]) and y[N-1] likewise change by
-        // minus the sum of the independent steps; accumulate those so the dependent component is
-        // bounded to (0,1) too (otherwise it can still overshoot for N>=3 and reintroduce the
-        // non-finite fugacity path this damping is meant to prevent).
-        double dx_last = 0.0, dy_last = 0.0;
-        for (std::size_t i = 0; i < N - 1; ++i) {
-            const double dx = v[i], dy = v[i + (N - 1)];
-            dx_last -= dx;
-            dy_last -= dy;
+        // Every mole fraction is an independent variable now, so all 2N of them are bounded
+        // by the same rule; there is no dependent component to treat separately.
+        for (std::size_t i = 0; i < N; ++i) {
+            const double dx = v[i], dy = v[i + N];
             if (x[i] + dx <= 0.0) {
                 tau = std::min(tau, step_safety * (-x[i] / dx));
             } else if (x[i] + dx >= 1.0) {
@@ -1650,34 +1652,20 @@ void SaturationSolvers::newton_raphson_twophase::call(HelmholtzEOSMixtureBackend
                 tau = std::min(tau, step_safety * ((1.0 - y[i]) / dy));
             }
         }
-        // Bound the dependent (Nth) mole fraction with the same rule.
-        const double x_last = x[N - 1], y_last = y[N - 1];
-        if (x_last + dx_last <= 0.0) {
-            tau = std::min(tau, step_safety * (-x_last / dx_last));
-        } else if (x_last + dx_last >= 1.0) {
-            tau = std::min(tau, step_safety * ((1.0 - x_last) / dx_last));
-        }
-        if (y_last + dy_last <= 0.0) {
-            tau = std::min(tau, step_safety * (-y_last / dy_last));
-        } else if (y_last + dy_last >= 1.0) {
-            tau = std::min(tau, step_safety * ((1.0 - y_last) / dy_last));
-        }
 
-        for (unsigned int i = 0; i < N - 1; ++i) {
+        for (std::size_t i = 0; i < N; ++i) {
             err_rel[i] = tau * v[i] / x[i];
             x[i] += tau * v[i];
-            err_rel[i + (N - 1)] = tau * v[i + (N - 1)] / y[i];
-            y[i] += tau * v[i + (N - 1)];
+            err_rel[i + N] = tau * v[i + N] / y[i];
+            y[i] += tau * v[i + N];
         }
-        x[N - 1] = 1 - std::accumulate(x.begin(), x.end() - 1, 0.0);
-        y[N - 1] = 1 - std::accumulate(y.begin(), y.end() - 1, 0.0);
 
         if (imposed_variable == newton_raphson_twophase_options::P_IMPOSED) {
-            T += tau * v[2 * N - 2];
-            err_rel[2 * N - 2] = tau * v[2 * N - 2] / T;
+            T += tau * v[2 * N];
+            err_rel[2 * N] = tau * v[2 * N] / T;
         } else if (imposed_variable == newton_raphson_twophase_options::T_IMPOSED) {
-            p += tau * v[2 * N - 2];
-            err_rel[2 * N - 2] = tau * v[2 * N - 2] / p;
+            p += tau * v[2 * N];
+            err_rel[2 * N] = tau * v[2 * N] / p;
         } else {
             throw ValueError("invalid imposed_variable");
         }
@@ -1698,6 +1686,22 @@ void SaturationSolvers::newton_raphson_twophase::call(HelmholtzEOSMixtureBackend
     build_arrays();
     if (!ValidNumber(error_rms) || error_rms > 1e-7) {
         throw ValueError(format("newton_raphson_twophase::call did not converge (error_rms = %g)", static_cast<double>(error_rms)));
+    }
+
+    // sum(x) = 1 and sum(y) = 1 are now solved for rather than imposed by construction, so they
+    // hold only to the convergence tolerance.  Callers (and the SatL/SatV states published
+    // above) expect normalized compositions, so close the residual gap explicitly.  Every
+    // component is accurate in a RELATIVE sense here, and dividing by a sum within a few ulp of
+    // 1 preserves that -- which is the whole point of not eliminating one of them.
+    const CoolPropDbl sum_x_final = std::accumulate(x.begin(), x.end(), static_cast<CoolPropDbl>(0.0));
+    const CoolPropDbl sum_y_final = std::accumulate(y.begin(), y.end(), static_cast<CoolPropDbl>(0.0));
+    if (!(sum_x_final > 0) || !(sum_y_final > 0)) {
+        throw ValueError(format("newton_raphson_twophase::call produced a non-positive composition sum (sum_x = %g, sum_y = %g)",
+                                static_cast<double>(sum_x_final), static_cast<double>(sum_y_final)));
+    }
+    for (std::size_t i = 0; i < N; ++i) {
+        x[i] /= sum_x_final;
+        y[i] /= sum_y_final;
     }
 
     IO.Nsteps = iter;
@@ -1747,44 +1751,54 @@ void SaturationSolvers::newton_raphson_twophase::build_arrays() {
     // -------
     // Build the residual vector and the Jacobian matrix
 
-    x_N_dependency_flag xN_flag = XN_DEPENDENT;
+    // Every mole fraction is a free variable here, so the composition derivatives must be the
+    // XN_INDEPENDENT ones.  (dln_fugacity_dxj__constT_p_xi honours this flag as of the fix that
+    // precedes this change; before it, the XN_DEPENDENT ideal term was applied unconditionally.)
+    x_N_dependency_flag xN_flag = XN_INDEPENDENT;
 
-    // Form of residuals do not depend on which variable is imposed
+    // Residuals, laid out as
+    //   [0 .. N-1]    iso-fugacity        ln f_i^L - ln f_i^V
+    //   [N .. 2N-1]   overall mass balance z_i - (1-beta) x_i - beta y_i
+    //   [2N]          simplex closure      sum(x) - 1
+    // sum(y) = 1 is NOT a separate row: summing the N mass balances with sum(z) = 1 and
+    // sum(x) = 1 already forces it (for beta != 0), so adding it would over-determine the
+    // system.  The mass balance is in linear rather than ratio form because there are now N of
+    // them rather than N-1, and the linear form has no pole at y_i = x_i.
     for (std::size_t i = 0; i < N; ++i) {
-        // Equate the liquid and vapor fugacities
         CoolPropDbl ln_f_liq = log(MixtureDerivatives::fugacity_i(rSatL, i, xN_flag));
         CoolPropDbl ln_f_vap = log(MixtureDerivatives::fugacity_i(rSatV, i, xN_flag));
-        r[i] = ln_f_liq - ln_f_vap;  // N of these
-
-        if (i != N - 1) {
-            // Equate the specified vapor mole fraction and that given defined by the ith component
-            r[i + N] = (z[i] - x[i]) / (y[i] - x[i]) - beta;  // N-1 of these
-        }
+        r[i] = ln_f_liq - ln_f_vap;
+        r[i + N] = z[i] - (1 - beta) * x[i] - beta * y[i];
     }
+    CoolPropDbl sum_x = std::accumulate(x.begin(), x.end(), static_cast<CoolPropDbl>(0.0));
+    r[2 * N] = sum_x - 1;
 
-    // First part of derivatives with respect to ln f_i
+    // Iso-fugacity rows: d/dx_j on the liquid, -d/dy_j on the vapor, and the imposed-variable
+    // partner in the last column.
     for (std::size_t i = 0; i < N; ++i) {
-        for (std::size_t j = 0; j < N - 1; ++j) {
+        for (std::size_t j = 0; j < N; ++j) {
             J(i, j) = MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(rSatL, i, j, xN_flag);
-            J(i, j + N - 1) = -MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(rSatV, i, j, xN_flag);
+            J(i, j + N) = -MixtureDerivatives::dln_fugacity_dxj__constT_p_xi(rSatV, i, j, xN_flag);
         }
 
-        // Last derivative with respect to either T or p depending on what is imposed
         if (imposed_variable == newton_raphson_twophase_options::P_IMPOSED) {
-            J(i, 2 * N - 2) =
+            J(i, 2 * N) =
               MixtureDerivatives::dln_fugacity_i_dT__constp_n(rSatL, i, xN_flag) - MixtureDerivatives::dln_fugacity_i_dT__constp_n(rSatV, i, xN_flag);
         } else if (imposed_variable == newton_raphson_twophase_options::T_IMPOSED) {
-            J(i, 2 * N - 2) =
+            J(i, 2 * N) =
               MixtureDerivatives::dln_fugacity_i_dp__constT_n(rSatL, i, xN_flag) - MixtureDerivatives::dln_fugacity_i_dp__constT_n(rSatV, i, xN_flag);
         } else {
             throw ValueError();
         }
     }
-    // Derivatives with respect to the vapor mole fractions residual
-    for (std::size_t i = 0; i < N - 1; ++i) {
-        std::size_t k = i + N;  // N ln f_i residuals
-        J(k, i) = (z[i] - y[i]) / pow(y[i] - x[i], 2);
-        J(k, i + (N - 1)) = -(z[i] - x[i]) / pow(y[i] - x[i], 2);
+    // Mass-balance rows: two entries each, and no dependence on T or p.
+    for (std::size_t i = 0; i < N; ++i) {
+        J(i + N, i) = -(1 - beta);
+        J(i + N, i + N) = -beta;
+    }
+    // Simplex-closure row.
+    for (std::size_t j = 0; j < N; ++j) {
+        J(2 * N, j) = 1.0;
     }
 
     error_rms = r.norm();  // Square-root (The R in RMS)

--- a/src/Backends/Helmholtz/VLERoutines.cpp
+++ b/src/Backends/Helmholtz/VLERoutines.cpp
@@ -1707,11 +1707,34 @@ void SaturationSolvers::newton_raphson_twophase::call(HelmholtzEOSMixtureBackend
         throw ValueError(format("newton_raphson_twophase::call did not converge (error_rms = %g)", static_cast<double>(error_rms)));
     }
 
-    // sum(x) = 1 and sum(y) = 1 are now solved for rather than imposed by construction, so they
-    // hold only to the convergence tolerance.  Callers (and the SatL/SatV states published
-    // above) expect normalized compositions, so close the residual gap explicitly.  Every
-    // component is accurate in a RELATIVE sense here, and dividing by a sum within a few ulp of
-    // 1 preserves that -- which is the whole point of not eliminating one of them.
+    // Reject the trivial solution.  At K_i == 1 the reconstruction gives x == y == z, so both
+    // phases are the SAME state: every iso-fugacity residual is 0 because ln phi^L == ln phi^V,
+    // and Rachford-Rice is 0 because every (K_i - 1) is.  error_rms is therefore 0 and the gate
+    // above passes while SatL and SatV describe one phase.  Nothing else here rules it out --
+    // the last Jacobian column is identically zero at that point and colPivHouseholderQr
+    // silently zeroes the null-space components rather than raising.  A genuine split has at
+    // least one component partitioning measurably.  The threshold is deliberately loose: near a
+    // mixture critical point every K_i legitimately approaches 1, so a tight bound would reject
+    // real splits.  (A rhomolar_liq > rhomolar_vap test is NOT used for the same reason -- the
+    // two roots legitimately converge there.)
+    double max_abs_lnK = 0;
+    for (std::size_t i = 0; i < N; ++i) {
+        max_abs_lnK = std::max(max_abs_lnK, std::abs(log(static_cast<double>(K[i]))));
+    }
+    if (!(max_abs_lnK > 1e-6)) {
+        throw ValueError(
+          format("newton_raphson_twophase::call converged to the trivial solution (max|ln K| = %g, both phases identical)", max_abs_lnK));
+    }
+
+    // sum(x) = 1 and sum(y) = 1 are solved for -- that is what the Rachford-Rice row does --
+    // rather than imposed by construction, so they hold only to the convergence tolerance.
+    // Normalize and then RE-EVALUATE both phases: the compositions this flash publishes are
+    // read from SatL/SatV by calc_mole_fractions_liquid/vapor, not from IO, and the enthalpies
+    // and densities below come from those same backends.  Normalizing IO alone would leave the
+    // published state on the un-normalized composition and the correction invisible.
+    //
+    // This perturbs the (otherwise identical) mass balance by O(|sum(x) - 1|), which the
+    // convergence gate bounds and which measures ~1e-14 in practice.
     const CoolPropDbl sum_x_final = std::accumulate(x.begin(), x.end(), static_cast<CoolPropDbl>(0.0));
     const CoolPropDbl sum_y_final = std::accumulate(y.begin(), y.end(), static_cast<CoolPropDbl>(0.0));
     if (!(sum_x_final > 0) || !(sum_y_final > 0)) {
@@ -1722,6 +1745,12 @@ void SaturationSolvers::newton_raphson_twophase::call(HelmholtzEOSMixtureBackend
         x[i] /= sum_x_final;
         y[i] /= sum_y_final;
     }
+    HEOS.SatL->set_mole_fractions(x);
+    HEOS.SatL->update_TP_guessrho(T, p, rhomolar_liq);
+    rhomolar_liq = HEOS.SatL->rhomolar();
+    HEOS.SatV->set_mole_fractions(y);
+    HEOS.SatV->update_TP_guessrho(T, p, rhomolar_vap);
+    rhomolar_vap = HEOS.SatV->rhomolar();
 
     IO.Nsteps = iter;
     IO.p = p;
@@ -1740,11 +1769,12 @@ void SaturationSolvers::newton_raphson_twophase::build_arrays() {
     // References to the classes for concision
     HelmholtzEOSMixtureBackend &rSatL = *(HEOS->SatL.get()), &rSatV = *(HEOS->SatV.get());
 
-    // Zero the Jacobian first: the beta-constraint rows (k = N .. 2N-2) below only write the
-    // two mole-fraction columns the constraint depends on; the imposed-variable (T/p) column,
-    // and for N>=3 the off-diagonal mole-fraction columns, are left untouched and their true
-    // value is 0.  Eigen::resize() does not zero storage, so without this those entries are
-    // uninitialized memory feeding the Newton solve (GH #3192 follow-up).
+    // Defensive: every one of the (N+1)^2 entries is written explicitly below, so this is
+    // currently redundant.  It is kept because Eigen::resize() does not zero storage, and a
+    // future row or column that is only written conditionally would otherwise read
+    // uninitialized memory straight into the Newton solve -- which is exactly what happened
+    // when the beta-constraint rows left their off-diagonal entries untouched (GH #3192
+    // follow-up).
     J.setZero();
 
     // Step 0:

--- a/src/Backends/Helmholtz/VLERoutines.h
+++ b/src/Backends/Helmholtz/VLERoutines.h
@@ -374,29 +374,37 @@ struct newton_raphson_twophase_options
      *
      * A class is used rather than a function so that it is easier to store iteration histories, additional output values, etc.
      *
-     * As in Gernert, FPE, 2014, except that only one of T and P are known
+     * The independent variables are the \f$N\f$ logarithmic K-factors \f$\ln K_i\f$ and the
+     * non-specified variable in p or T, for a total of \f$N+1\f$ independent variables.  The
+     * compositions are RECONSTRUCTED from K rather than solved for,
      *
-     * The independent variables are \f$N-1\f$ mole fractions in liquid, \f$N-1\f$ mole fractions in vapor, and the non-specified variable in p or T, for a total of \f$2N-1\f$ independent variables
+     * \f$D_i = (1-\beta) + \beta K_i, \quad x_i = z_i/D_i, \quad y_i = K_i x_i\f$
      *
-     * First N residuals are from
+     * so the overall mass balance \f$(1-\beta)x_i + \beta y_i = z_i\f$ holds identically at every
+     * iterate.  \f$D_i\f$ is a sum of non-negative terms for \f$\beta \in [0,1]\f$ and
+     * \f$K_i > 0\f$, so no cancellation is possible in it: a trace \f$x_i\f$ arrives by division
+     * and a trace \f$y_i\f$ by multiplication, both at full relative precision.  Carrying x and y
+     * as unknowns instead -- with or without eliminating one of them -- makes a mass-balance row
+     * determine the trace composition, amplifying the relative error in \f$x_i\f$ by
+     * \f$((1-\beta)/\beta)/K_i\f$, which reaches 1e13 for a heavy trace component (GH #3372).
      *
-     * \f$F_k = \ln f_i(T,p,\mathbf{x}) - \ln f_i(T,p,\mathbf{y})\f$ for \f$i = 1, ... N\f$ and \f$k=i\f$
+     * First N residuals are the iso-fugacity conditions in \f$\ln K\f$ form,
      *
-     * Derivatives are the same as for the saturation solver \ref newton_raphson_saturation
+     * \f$F_i = \ln K_i - (\ln \varphi_i^L - \ln \varphi_i^V)\f$ for \f$i = 0, ... N-1\f$
      *
-     * Second N-1 residuals are from
+     * The last residual is Rachford-Rice, which is the closure condition: combined with
+     * \f$(1-\beta)\sum x + \beta\sum y = \sum z = 1\f$ it forces \f$\sum x = \sum y = 1\f$.
      *
-     * \f$F_k = \dfrac{z_i-x_i}{y_i-x_i} - \beta_{spec}\f$ for \f$ i = 1, ... N-2\f$ and \f$k = i+N\f$
+     * \f$F_N = \sum_i z_i (K_i - 1)/D_i\f$
      *
-     * Gernert eq. 35
+     * The composition sensitivities are diagonal (\f$D_i\f$ depends on \f$K_i\f$ alone),
      *
-     * \f$\dfrac{\partial F_k}{\partial x_i} = \dfrac{z_i-y_i}{(y_i-x_i)^2}\f$
+     * \f$\partial x_i/\partial \ln K_j = -\delta_{ij} x_i \beta K_i / D_i\f$
      *
-     * Gernert eq. 36
+     * \f$\partial y_i/\partial \ln K_j = \delta_{ij} y_i (1 - \beta K_i / D_i)\f$
      *
-     * \f$\dfrac{\partial F_k}{\partial y_i} = -\dfrac{z_i-x_i}{(y_i-x_i)^2}\f$
-     *
-     * \f$\dfrac{\partial F_k}{\partial T} = 0\f$ Because x, y and T are independent by definition of the formulation
+     * \f$\partial F_N/\partial \ln K_j = z_j K_j / D_j^2\f$, and \f$\partial F_N/\partial T = 0\f$
+     * because Rachford-Rice depends only on K, beta and z.
      *
      * \f$\dfrac{\partial F_k}{\partial p} = 0\f$ Because x, y and p are independent by definition of the formulation
      */
@@ -410,9 +418,9 @@ class newton_raphson_twophase
     bool logging;
     int Nsteps;
     Eigen::MatrixXd J;
-    // r and err_rel hold 2N-1 residuals/relative-errors (see class docstring), so they MUST
+    // r and err_rel hold N+1 residuals/relative-errors (see class docstring), so they MUST
     // be dynamically sized.  They were Eigen::Vector2d (fixed size 2), which overflowed for
-    // every mixture (N>=2 -> 2N-1>=3) and hard-crashed via out-of-bounds writes (GH #3192).
+    // every mixture and hard-crashed via out-of-bounds writes (GH #3192).
     Eigen::VectorXd r, err_rel;
     std::vector<CoolPropDbl> K, x, y, z;
     std::vector<SuccessiveSubstitutionStep> step_logger;
@@ -430,8 +438,6 @@ class newton_raphson_twophase
         N(0),
         logging(false),
         Nsteps(0) {};
-
-    void resize(unsigned int N);
 
     // Reset the state of all the internal variables
     void pre_call() {

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -2269,8 +2269,6 @@ TEST_CASE("newton_raphson_twophase converges at interior Q (#3372)", "[michelsen
     }
 }
 
-
-
 // GH #3372: the blind mixture PQ/QT path (no phase envelope) must satisfy the overall mass
 // balance z_i = (1-Q) x_i + Q y_i at an interior quality.  It previously used
 // newton_raphson_saturation, a bubble/dew-point solver with no mass-balance condition, so the
@@ -2334,8 +2332,6 @@ TEST_CASE("Mixture PQ/QT flash satisfies the overall mass balance (#3372)", "[mi
         }
     }
 }
-
-
 
 // GH #3372: interior-Q coverage for the ENVELOPE-guided branch of the mixture PQ/QT dispatch.
 //

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -1928,12 +1928,23 @@ TEST_CASE("PQ flash with built PE: N2/CH4", "[michelsen][flash][PQ_flash][PhaseE
     CAPTURE(npts);
     CHECK(npts > 0);
     CHECK(AS->get_phase_envelope_data().built);
-    // Use a separate (non-PE) object for PQ flash — PQ flash on the same
-    // object that built the PE can crash in the current codebase.
-    auto AS2 = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", "Nitrogen&Methane"));
-    AS2->set_mole_fractions({0.5, 0.5});
-    REQUIRE_NOTHROW(AS2->update(PQ_INPUTS, 1.5e5, 0.5));
-    CHECK(AS2->phase() == iphase_twophase);
+    // Flash on the SAME object that built the envelope.  This used to be done on a separate
+    // envelope-free object, with a comment that flashing on the envelope owner "can crash in
+    // the current codebase" — that crash was the Eigen::Vector2d overflow fixed by #3196, so
+    // the workaround was stale and left the test taking the blind path despite its name
+    // (GH #3372).
+    REQUIRE_NOTHROW(AS->update(PQ_INPUTS, 1.5e5, 0.5));
+    CHECK(AS->phase() == iphase_twophase);
+    CHECK(std::isfinite(AS->T()));
+    // ... and check it actually solved the two-phase specification, not merely that it returned.
+    const std::vector<double> x = AS->mole_fractions_liquid();
+    const std::vector<double> y = AS->mole_fractions_vapor();
+    double mass = 0;
+    for (std::size_t i = 0; i < 2; ++i) {
+        mass = std::max(mass, std::abs(0.5 - 0.5 * x[i] - 0.5 * y[i]));
+    }
+    CAPTURE(mass);
+    CHECK(mass < 1e-10);
 }
 
 TEST_CASE("PQ flash: 6-component no-throw sweep", "[michelsen][flash][PQ_flash]") {
@@ -2322,6 +2333,128 @@ TEST_CASE("Mixture PQ/QT flash satisfies the overall mass balance (#3372)", "[mi
             }
         }
     }
+}
+
+
+
+// GH #3372: interior-Q coverage for the ENVELOPE-guided branch of the mixture PQ/QT dispatch.
+//
+// Before this, four tests built an envelope and then ran a mixture PQ flash, but only two
+// actually reached the envelope branch and both sat at Q = 0.5.  Two guards keep this one
+// honest, because either failing silently would make it vacuous:
+//   * REQUIRE(built) -- without it the dispatch falls straight through to the blind path
+//     (the pattern #3196 established).
+//   * the warning slot must be EMPTY afterwards -- PQ_flash reports every fallback to the
+//     blind solver through set_warning_string, so a non-empty slot means the envelope branch
+//     did not answer and the test would be measuring the blind path again.
+//
+// The mixtures and pressures are chosen because the envelope branch answers at every Q there;
+// it is not yet reliable everywhere (Methane&n-Butane falls back at every Q, for instance),
+// which is tracked separately as the envelope-seed work.
+TEST_CASE("Envelope-branch mixture PQ flash across interior Q (#3372)", "[michelsen][flash][PQ_flash][PhaseEnvelope]") {
+    struct Case
+    {
+        std::string name, fluids;
+        std::vector<double> z;
+        double p;
+    };
+    const std::vector<Case> cases = {
+      {"CH4-C2H6", "Methane&Ethane", {0.5, 0.5}, 1e6},
+      {"N2-CH4", "Nitrogen&Methane", {0.5, 0.5}, 1e6},
+    };
+
+    for (const auto& c : cases) {
+        auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", c.fluids));
+        AS->set_mole_fractions(c.z);
+        AS->build_phase_envelope("");
+        REQUIRE(AS->get_phase_envelope_data().built);
+
+        // Reference on an envelope-free object: same state, forced down the blind path.
+        auto REF = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", c.fluids));
+        REF->set_mole_fractions(c.z);
+
+        for (double Q : {0.05, 0.1, 0.2, 0.3, 0.5, 0.7, 0.8, 0.9, 0.95}) {
+            DYNAMIC_SECTION(c.name << " Q=" << Q) {
+                get_global_param_string("warnstring");  // drain
+                REQUIRE_NOTHROW(AS->update(PQ_INPUTS, c.p, Q));
+                const std::string warn = get_global_param_string("warnstring");
+                CAPTURE(warn);
+                REQUIRE(warn.empty());  // the envelope branch answered, not the fallback
+
+                CHECK(AS->phase() == iphase_twophase);
+                CHECK(std::isfinite(AS->T()));
+                CHECK(AS->T() > 0);
+
+                const std::vector<double> x = AS->mole_fractions_liquid();
+                const std::vector<double> y = AS->mole_fractions_vapor();
+                double mass = 0;
+                for (std::size_t i = 0; i < c.z.size(); ++i) {
+                    mass = std::max(mass, std::abs(c.z[i] - (1 - Q) * x[i] - Q * y[i]));
+                }
+                CAPTURE(mass);
+                CHECK(mass < 1e-10);
+
+                // The two branches must agree: #3192 was the envelope branch silently
+                // publishing a different (and wrong) state than the blind one.
+                REF->update(PQ_INPUTS, c.p, Q);
+                CAPTURE(REF->T());
+                CHECK(AS->T() == Catch::Approx(REF->T()).epsilon(1e-7));
+            }
+        }
+    }
+}
+
+// GH #3372: there was no QT_INPUTS coverage at all after a phase-envelope build.  Take the
+// temperature from a PQ flash and feed it back through QT at the same quality; the pressure
+// must come back, and the split must satisfy the overall mass balance.
+//
+// The QT leg does not assert per-state that the envelope branch answered, because its seed is
+// not yet reliable at every quality -- at the time of writing Q = 0.3 here falls back with a
+// seed pressure of 8.2e7 Pa for a state near 1e6 Pa, which is the envelope-seed defect tracked
+// as item 3 of the issue.  Pinning the exact set of failing qualities would just encode today's
+// bug.  Instead the test requires that SOME quality exercised the QT envelope branch
+// successfully -- enough to catch that path breaking entirely -- while the round-trip and
+// mass-balance checks below hold at every quality regardless of which branch answered.
+TEST_CASE("Envelope-branch mixture QT flash round-trips PQ (#3372)", "[michelsen][flash][QT_flash][PhaseEnvelope]") {
+    auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", "Methane&Ethane"));
+    const std::vector<double> z = {0.5, 0.5};
+    AS->set_mole_fractions(z);
+    AS->build_phase_envelope("");
+    REQUIRE(AS->get_phase_envelope_data().built);
+
+    const double p = 1e6;
+    int qt_via_envelope = 0;
+    for (double Q : {0.1, 0.3, 0.5, 0.7, 0.9}) {
+        CAPTURE(Q);
+
+        get_global_param_string("warnstring");  // drain
+        REQUIRE_NOTHROW(AS->update(PQ_INPUTS, p, Q));
+        REQUIRE(get_global_param_string("warnstring").empty());  // PQ envelope branch answered
+        const double T = AS->T();
+        REQUIRE(std::isfinite(T));
+
+        get_global_param_string("warnstring");
+        REQUIRE_NOTHROW(AS->update(QT_INPUTS, Q, T));
+        if (get_global_param_string("warnstring").empty()) {
+            ++qt_via_envelope;
+        }
+
+        CHECK(AS->phase() == iphase_twophase);
+        CAPTURE(T);
+        CAPTURE(AS->p());
+        CHECK(AS->p() == Catch::Approx(p).epsilon(1e-6));
+
+        const std::vector<double> x = AS->mole_fractions_liquid();
+        const std::vector<double> y = AS->mole_fractions_vapor();
+        double mass = 0;
+        for (std::size_t i = 0; i < z.size(); ++i) {
+            mass = std::max(mass, std::abs(z[i] - (1 - Q) * x[i] - Q * y[i]));
+        }
+        CAPTURE(mass);
+        CHECK(mass < 1e-10);
+    }
+    CAPTURE(qt_via_envelope);
+    CHECK(qt_via_envelope > 0);  // the QT envelope branch is reachable and works somewhere
 }
 
 #endif

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -2247,18 +2247,6 @@ TEST_CASE("newton_raphson_twophase converges at interior Q (#3372)", "[michelsen
                     CHECK(IO.x[i] > 0.0);
                     CHECK(IO.y[i] > 0.0);
                 }
-                // K_i and the mass-balance amplification for each phase, so a failure can be
-                // read against the gain that predicts it.
-                double Kmin = 1e300, Kmax = 0;
-                for (std::size_t i = 0; i < c.z.size(); ++i) {
-                    const double Ki = static_cast<double>(IO.y[i] / IO.x[i]);
-                    Kmin = std::min(Kmin, Ki);
-                    Kmax = std::max(Kmax, Ki);
-                }
-                const double gain_y = ((1 - Q) / Q) / Kmin;   // error in x_i -> y_i, worst for K << 1
-                const double gain_x = (Q / (1 - Q)) * Kmax;   // error in y_i -> x_i, worst for K >> 1
-                printf("  %-10s Q=%-5.2f Kmin=%10.3e Kmax=%10.3e gain_y=%10.3e gain_x=%10.3e mass=%9.2e T=%8.3f\n", c.name.c_str(), Q, Kmin,
-                       Kmax, gain_y, gain_x, mass, static_cast<double>(IO.T));
                 CAPTURE(mass);
                 CAPTURE(IO.T);
                 CHECK(mass < 1e-12);

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -11,10 +11,7 @@
 #    include <vector>
 #    include <catch2/catch_all.hpp>
 #    include "../Backends/Helmholtz/VLERoutines.h"
-#    include "../Backends/Helmholtz/MixtureDerivatives.h"
-#    include <Eigen/Dense>
 #    include "CoolProp/detail/tools.h"
-#    include <numeric>
 #    include "CoolProp/CoolProp.h"
 #    include <cmath>
 
@@ -1936,7 +1933,10 @@ TEST_CASE("PQ flash with built PE: N2/CH4", "[michelsen][flash][PQ_flash][PhaseE
     REQUIRE_NOTHROW(AS->update(PQ_INPUTS, 1.5e5, 0.5));
     CHECK(AS->phase() == iphase_twophase);
     CHECK(std::isfinite(AS->T()));
-    // ... and check it actually solved the two-phase specification, not merely that it returned.
+    // The mass balance below holds by construction for the two-phase solver (x_i = z_i/D_i,
+    // y_i = K_i x_i), so it does not prove convergence -- it proves the dispatch did not fall
+    // back to the bubble/dew solver, which does not satisfy it.  See the #3372 mass-balance
+    // test for the equal-fugacity check that does prove convergence.
     const std::vector<double> x = AS->mole_fractions_liquid();
     const std::vector<double> y = AS->mole_fractions_vapor();
     double mass = 0;
@@ -2303,6 +2303,13 @@ TEST_CASE("Mixture PQ/QT flash satisfies the overall mass balance (#3372)", "[mi
                 REQUIRE(x.size() == c.z.size());
                 REQUIRE(y.size() == c.z.size());
 
+                // ROUTING check, not a convergence check.  Read what it does and does not
+                // prove: the two-phase solver reconstructs x_i = z_i/D_i and y_i = K_i x_i with
+                // D_i = (1-Q) + Q K_i, so (1-Q)x_i + Q y_i = x_i D_i = z_i IDENTICALLY, for any
+                // K, converged or not.  What this catches is the dispatch falling back to
+                // newton_raphson_saturation, which does not construct x and y that way and
+                // whose mass-balance error reached 1.2e-4 in the Q ~ 0.2..0.4 band (GH #3372).
+                // Convergence is asserted separately, below.
                 double mass = 0;
                 for (std::size_t i = 0; i < c.z.size(); ++i) {
                     mass = std::max(mass, std::abs(c.z[i] - (1 - Q) * x[i] - Q * y[i]));
@@ -2311,22 +2318,31 @@ TEST_CASE("Mixture PQ/QT flash satisfies the overall mass balance (#3372)", "[mi
                 CAPTURE(AS->T());
                 CHECK(mass < 1e-10);
 
-                // Independent of the residual the solver minimises: round-trip the reported
-                // (T, p) back through a PT flash and check the vapour fraction comes back.
-                auto RT = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", c.fluids));
-                RT->set_mole_fractions(c.z);
+                // CONVERGENCE check, and the one with teeth: re-solve each published
+                // composition as a single-phase state at the reported (T, p) and require equal
+                // fugacity.  This is computed by a separate code path from the published output,
+                // so unlike the mass balance it cannot be satisfied by construction.
+                const double fug = equilibrium_residual("HEOS", c.fluids, x, y, AS->T(), AS->p());
+                CAPTURE(fug);
+                CHECK(fug < 1e-6);
+
+                // Second independent leg: round-trip the reported (T, p) back through a PT
+                // flash and check the vapour fraction comes back.  The two-phase REQUIRE is
+                // deliberate -- guarding it with `if (RT->phase() == twophase)` would skip the
+                // assertion in exactly the case it exists to detect, a PQ flash returning a bad
+                // T that lands the PT flash outside the two-phase region.
                 if (Q > 0.02 && Q < 0.98) {
+                    auto RT = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", c.fluids));
+                    RT->set_mole_fractions(c.z);
                     REQUIRE_NOTHROW(RT->update(PT_INPUTS, AS->p(), AS->T()));
-                    if (RT->phase() == iphase_twophase) {
-                        CAPTURE(RT->Q());
-                        // Looser below Q = 0.4, and deliberately so: this leg is limited by the
-                        // PT flash, not the PQ flash.  Measured worst |dQ| is 3.9e-6, all of it
-                        // on the wide-boiling 5-component mixture at low Q, where the mass
-                        // balance above is simultaneously 4e-17 -- i.e. the PQ answer satisfies
-                        // its own specification exactly and the disagreement is the PT solve's.
-                        // The ternary and binary stay under 1.4e-10 at every Q.
-                        CHECK(RT->Q() == Catch::Approx(Q).margin(Q < 0.4 ? 1e-5 : 1e-8));
-                    }
+                    REQUIRE(RT->phase() == iphase_twophase);
+                    CAPTURE(RT->Q());
+                    // Looser below Q = 0.4, and deliberately so: this leg is limited by the
+                    // PT flash, not the PQ flash.  Measured worst |dQ| is 3.9e-6, all of it on
+                    // the wide-boiling 5-component mixture at low Q, where the fugacity residual
+                    // above is simultaneously tiny -- i.e. the PQ answer is converged and the
+                    // disagreement is the PT solve's.  Ternary and binary stay under 1.4e-10.
+                    CHECK(RT->Q() == Catch::Approx(Q).margin(Q < 0.4 ? 1e-5 : 1e-8));
                 }
             }
         }
@@ -2388,7 +2404,13 @@ TEST_CASE("Envelope-branch mixture PQ flash across interior Q (#3372)", "[michel
                     mass = std::max(mass, std::abs(c.z[i] - (1 - Q) * x[i] - Q * y[i]));
                 }
                 CAPTURE(mass);
-                CHECK(mass < 1e-10);
+                CHECK(mass < 1e-10);  // routing check -- identical by construction, see above
+
+                // Convergence check: equal fugacity, recomputed from the published state by a
+                // separate code path, so it cannot be satisfied by the parameterization.
+                const double fug = equilibrium_residual("HEOS", c.fluids, x, y, AS->T(), AS->p());
+                CAPTURE(fug);
+                CHECK(fug < 1e-6);
 
                 // The two branches must agree: #3192 was the envelope branch silently
                 // publishing a different (and wrong) state than the blind one.

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -11,6 +11,7 @@
 #    include <vector>
 #    include <catch2/catch_all.hpp>
 #    include "../Backends/Helmholtz/VLERoutines.h"
+#    include <Eigen/Dense>
 #    include "CoolProp/detail/tools.h"
 #    include "CoolProp/CoolProp.h"
 #    include <cmath>
@@ -2199,7 +2200,7 @@ TEST_CASE("HSU_D flash: single-phase N2/O2 HEOS regression", "[michelsen][hsu_d]
 // this threw for every Q <= 0.5 on the 5-component mixture: the dependent component (Pentane)
 // is also the smallest (y ~ 1e-14), and forming it as 1 - sum(...) cost it ~1% relative
 // precision, which ln f_{N-1} carried into the residual and floored it above the gate.
-TEST_CASE("newton_raphson_twophase converges at interior Q (#3372)", "[michelsen][flash][PQ_flash][twophase]") {
+TEST_CASE("newton_raphson_twophase converges at interior Q (#3372)", "[flash][PQ_flash][twophase]") {
     struct Case
     {
         std::string name, fluids;
@@ -2363,7 +2364,7 @@ TEST_CASE("Mixture PQ/QT flash satisfies the overall mass balance (#3372)", "[mi
 // The mixtures and pressures are chosen because the envelope branch answers at every Q there;
 // it is not yet reliable everywhere (Methane&n-Butane falls back at every Q, for instance),
 // which is tracked separately as the envelope-seed work.
-TEST_CASE("Envelope-branch mixture PQ flash across interior Q (#3372)", "[michelsen][flash][PQ_flash][PhaseEnvelope]") {
+TEST_CASE("Envelope-branch mixture PQ flash across interior Q (#3372)", "[flash][PQ_flash][PhaseEnvelope]") {
     struct Case
     {
         std::string name, fluids;
@@ -2433,7 +2434,7 @@ TEST_CASE("Envelope-branch mixture PQ flash across interior Q (#3372)", "[michel
 // bug.  Instead the test requires that SOME quality exercised the QT envelope branch
 // successfully -- enough to catch that path breaking entirely -- while the round-trip and
 // mass-balance checks below hold at every quality regardless of which branch answered.
-TEST_CASE("Envelope-branch mixture QT flash round-trips PQ (#3372)", "[michelsen][flash][QT_flash][PhaseEnvelope]") {
+TEST_CASE("Envelope-branch mixture QT flash round-trips PQ (#3372)", "[flash][QT_flash][PhaseEnvelope]") {
     auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", "Methane&Ethane"));
     const std::vector<double> z = {0.5, 0.5};
     AS->set_mole_fractions(z);
@@ -2473,6 +2474,138 @@ TEST_CASE("Envelope-branch mixture QT flash round-trips PQ (#3372)", "[michelsen
     }
     CAPTURE(qt_via_envelope);
     CHECK(qt_via_envelope > 0);  // the QT envelope branch is reachable and works somewhere
+}
+
+// GH #3372: finite-difference check of newton_raphson_twophase's analytic Jacobian.
+//
+// newton_raphson_saturation has had a check_Jacobian() for a long time; this class never did,
+// and its Jacobian was rewritten wholesale for the ln K formulation.  Each column is checked by
+// central-differencing the residual vector around the converged state.  The ln K columns are
+// perturbed multiplicatively (K *= exp(+-h)), which is exactly a +-h step in w = ln K; the last
+// column perturbs the imposed-variable partner.
+//
+// Every evaluation restores the baseline first, and that is load-bearing: build_arrays() mutates
+// rhomolar_liq/vap (it re-solves both densities using the current values as warm starts) and
+// overwrites p with 0.5*(p_liq + p_vap).  Without the restore the two sides of the difference
+// start from different states, and the check would quietly measure warm-start history instead of
+// a derivative.
+//
+// Errors are scaled by the largest entry in each column.  An entry negligible next to its column
+// cannot be resolved by differencing the whole residual vector, so a per-entry relative error
+// would report a meaningless blow-up on entries the difference simply cannot see.
+TEST_CASE("newton_raphson_twophase Jacobian matches finite differences (#3372)", "[flash][twophase][jacobian]") {
+    struct Case
+    {
+        std::string name, fluids;
+        std::vector<double> z;
+        double p, Q;
+    };
+    const std::vector<Case> cases = {
+      {"binary", "Methane&n-Butane", {0.97, 0.03}, 2e6, 0.5},
+      {"ternary", "Nitrogen&Methane&Ethane", {0.10, 0.85, 0.05}, 5e5, 0.5},
+      {"5comp mid-Q", "Nitrogen&Methane&Ethane&Butane&Pentane", {0.3797, 0.3225, 0.278, 0.0014, 0.0184}, 3e5, 0.5},
+      // Low Q on the wide-boiling mixture: the state the (x, y) formulation could not solve, and
+      // where the trace component's K is ~1e-12.
+      {"5comp low-Q", "Nitrogen&Methane&Ethane&Butane&Pentane", {0.3797, 0.3225, 0.278, 0.0014, 0.0184}, 3e5, 0.1},
+    };
+
+    for (const auto& c : cases) {
+        DYNAMIC_SECTION(c.name) {
+            auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", c.fluids));
+            AS->set_mole_fractions(c.z);
+            auto& HEOS = *static_cast<HelmholtzEOSMixtureBackend*>(AS.get());
+            const std::vector<CoolPropDbl>& zz = HEOS.get_mole_fractions();
+
+            SaturationSolvers::mixture_VLE_IO io;
+            io.sstype = SaturationSolvers::imposed_p;
+            io.Nstep_max = 10;
+            CoolPropDbl Tg = SaturationSolvers::saturation_preconditioner(HEOS, c.p, SaturationSolvers::imposed_p, zz);
+            Tg = SaturationSolvers::saturation_Wilson(HEOS, c.Q, c.p, SaturationSolvers::imposed_p, zz, Tg);
+            std::vector<CoolPropDbl> Kv = HEOS.get_K();
+            REQUIRE_NOTHROW(SaturationSolvers::successive_substitution(HEOS, c.Q, Tg, c.p, zz, Kv, io));
+
+            SaturationSolvers::newton_raphson_twophase NR;
+            SaturationSolvers::newton_raphson_twophase_options IO;
+            IO.beta = c.Q;
+            IO.x = io.x;
+            IO.y = io.y;
+            IO.rhomolar_liq = io.rhomolar_liq;
+            IO.rhomolar_vap = io.rhomolar_vap;
+            IO.T = io.T;
+            IO.p = io.p;
+            IO.z = std::vector<CoolPropDbl>(c.z.begin(), c.z.end());
+            IO.Nstep_max = 30;
+            IO.imposed_variable = SaturationSolvers::newton_raphson_twophase_options::P_IMPOSED;
+            REQUIRE_NOTHROW(NR.call(HEOS, IO));  // land on the converged state
+
+            const std::size_t N = NR.N;
+            const std::vector<CoolPropDbl> K0 = NR.K;
+            const double T0 = NR.T, p0 = NR.p, rhoL0 = NR.rhomolar_liq, rhoV0 = NR.rhomolar_vap;
+
+            auto restore = [&]() {
+                NR.K = K0;
+                NR.T = T0;
+                NR.p = p0;
+                NR.rhomolar_liq = rhoL0;
+                NR.rhomolar_vap = rhoV0;
+            };
+
+            restore();
+            NR.build_arrays();
+            const Eigen::MatrixXd Jan = NR.J;
+
+            for (std::size_t j = 0; j <= N; ++j) {
+                Eigen::VectorXd rp, rm;
+                double step = 0;
+                if (j < N) {
+                    step = 1e-6;  // in w = ln K
+                    restore();
+                    NR.K[j] = K0[j] * std::exp(step);
+                    NR.build_arrays();
+                    rp = NR.r;
+                    restore();
+                    NR.K[j] = K0[j] * std::exp(-step);
+                    NR.build_arrays();
+                    rm = NR.r;
+                } else {
+                    step = 1e-4 * T0;  // imposed-variable partner (T, since p is imposed)
+                    restore();
+                    NR.T = T0 + step;
+                    NR.build_arrays();
+                    rp = NR.r;
+                    restore();
+                    NR.T = T0 - step;
+                    NR.build_arrays();
+                    rm = NR.r;
+                }
+                const Eigen::VectorXd num = (rp - rm) / (2 * step);
+
+                double col_scale = 0;
+                for (std::size_t i = 0; i <= N; ++i) {
+                    col_scale = std::max(col_scale, std::abs(Jan(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j))));
+                }
+                REQUIRE(col_scale > 0);  // a wholly zero column would make the check vacuous
+
+                double worst = 0;
+                std::size_t worst_i = 0;
+                for (std::size_t i = 0; i <= N; ++i) {
+                    const double a = Jan(static_cast<Eigen::Index>(i), static_cast<Eigen::Index>(j));
+                    const double rel = std::abs(num(static_cast<Eigen::Index>(i)) - a) / col_scale;
+                    if (rel > worst) {
+                        worst = rel;
+                        worst_i = i;
+                    }
+                }
+                CAPTURE(j);
+                CAPTURE(worst_i);
+                CAPTURE(col_scale);
+                CAPTURE(num(static_cast<Eigen::Index>(worst_i)));
+                CAPTURE(Jan(static_cast<Eigen::Index>(worst_i), static_cast<Eigen::Index>(j)));
+                CHECK(worst < 1e-4);  // measured worst across these four states is 6.6e-7
+            }
+            restore();
+        }
+    }
 }
 
 #endif

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -2259,4 +2259,69 @@ TEST_CASE("newton_raphson_twophase converges at interior Q (#3372)", "[michelsen
 }
 
 
+
+// GH #3372: the blind mixture PQ/QT path (no phase envelope) must satisfy the overall mass
+// balance z_i = (1-Q) x_i + Q y_i at an interior quality.  It previously used
+// newton_raphson_saturation, a bubble/dew-point solver with no mass-balance condition, so the
+// returned split satisfied equal fugacity but not the specification -- with the error peaking
+// in the Q ~ 0.2..0.4 band (1.2e-4 at p = 3e5 for the mixture below).
+//
+// The metric is the issue's own, computed entirely from the flash's published output.
+TEST_CASE("Mixture PQ/QT flash satisfies the overall mass balance (#3372)", "[michelsen][flash][PQ_flash][massbalance]") {
+    struct Case
+    {
+        std::string name, fluids;
+        std::vector<double> z;
+        double p;
+    };
+    const std::vector<Case> cases = {
+      {"5comp", "Nitrogen&Methane&Ethane&Butane&Pentane", {0.3797, 0.3225, 0.278, 0.0014, 0.0184}, 3e5},
+      {"ternary", "Nitrogen&Methane&Ethane", {0.10, 0.85, 0.05}, 5e5},
+      {"binary", "Methane&n-Butane", {0.97, 0.03}, 2e6},
+    };
+
+    for (const auto& c : cases) {
+        for (double Q : {0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.75, 0.9, 0.95}) {
+            DYNAMIC_SECTION(c.name << " Q=" << Q) {
+                auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", c.fluids));
+                AS->set_mole_fractions(c.z);
+                // No build_phase_envelope() -- this is deliberately the blind path.
+                REQUIRE_NOTHROW(AS->update(PQ_INPUTS, c.p, Q));
+                REQUIRE(AS->phase() == iphase_twophase);
+
+                const std::vector<double> x = AS->mole_fractions_liquid();
+                const std::vector<double> y = AS->mole_fractions_vapor();
+                REQUIRE(x.size() == c.z.size());
+                REQUIRE(y.size() == c.z.size());
+
+                double mass = 0;
+                for (std::size_t i = 0; i < c.z.size(); ++i) {
+                    mass = std::max(mass, std::abs(c.z[i] - (1 - Q) * x[i] - Q * y[i]));
+                }
+                CAPTURE(mass);
+                CAPTURE(AS->T());
+                CHECK(mass < 1e-10);
+
+                // Independent of the residual the solver minimises: round-trip the reported
+                // (T, p) back through a PT flash and check the vapour fraction comes back.
+                auto RT = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", c.fluids));
+                RT->set_mole_fractions(c.z);
+                if (Q > 0.02 && Q < 0.98) {
+                    REQUIRE_NOTHROW(RT->update(PT_INPUTS, AS->p(), AS->T()));
+                    if (RT->phase() == iphase_twophase) {
+                        CAPTURE(RT->Q());
+                        // Looser below Q = 0.4, and deliberately so: this leg is limited by the
+                        // PT flash, not the PQ flash.  Measured worst |dQ| is 3.9e-6, all of it
+                        // on the wide-boiling 5-component mixture at low Q, where the mass
+                        // balance above is simultaneously 4e-17 -- i.e. the PQ answer satisfies
+                        // its own specification exactly and the disagreement is the PT solve's.
+                        // The ternary and binary stay under 1.4e-10 at every Q.
+                        CHECK(RT->Q() == Catch::Approx(Q).margin(Q < 0.4 ? 1e-5 : 1e-8));
+                    }
+                }
+            }
+        }
+    }
+}
+
 #endif

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -10,7 +10,9 @@
 #    include <string>
 #    include <vector>
 #    include <catch2/catch_all.hpp>
+#    include "../Backends/Helmholtz/VLERoutines.h"
 #    include "CoolProp/detail/tools.h"
+#    include <numeric>
 #    include "CoolProp/CoolProp.h"
 #    include <cmath>
 
@@ -2175,6 +2177,77 @@ TEST_CASE("HSU_D flash: single-phase N2/O2 HEOS regression", "[michelsen][hsu_d]
         REQUIRE_NOTHROW(AS2->update(DmolarUmolar_INPUTS, rho, U));
         CHECK(AS2->T() == Catch::Approx(T).epsilon(0.001));
         CHECK(AS2->p() == Catch::Approx(P).epsilon(0.001));
+    }
+}
+
+// GH #3372: newton_raphson_twophase seeded exactly as the blind PQ path seeds itself
+// (saturation_preconditioner -> saturation_Wilson -> successive_substitution), then called
+// directly at an interior quality.  Before all mole fractions were made independent variables,
+// this threw for every Q <= 0.5 on the 5-component mixture: the dependent component (Pentane)
+// is also the smallest (y ~ 1e-14), and forming it as 1 - sum(...) cost it ~1% relative
+// precision, which ln f_{N-1} carried into the residual and floored it above the gate.
+TEST_CASE("newton_raphson_twophase converges at interior Q (#3372)", "[michelsen][flash][PQ_flash][twophase]") {
+    struct Case
+    {
+        std::string name, fluids;
+        std::vector<double> z;
+        double p;
+    };
+    const std::vector<Case> cases = {
+      // Wide-boiling, with the smallest component last -- the case that used to fail.
+      {"5comp", "Nitrogen&Methane&Ethane&Butane&Pentane", {0.3797, 0.3225, 0.278, 0.0014, 0.0184}, 3e5},
+      // Control: converged before this change too, must still converge.
+      {"binary", "Methane&n-Butane", {0.97, 0.03}, 2e6},
+    };
+
+    for (const auto& c : cases) {
+        for (double Q : {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.75, 0.9}) {
+            DYNAMIC_SECTION(c.name << " Q=" << Q) {
+                auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", c.fluids));
+                AS->set_mole_fractions(c.z);
+                auto& HEOS = *static_cast<HelmholtzEOSMixtureBackend*>(AS.get());
+                const std::vector<CoolPropDbl>& zz = HEOS.get_mole_fractions();
+
+                SaturationSolvers::mixture_VLE_IO io;
+                io.sstype = SaturationSolvers::imposed_p;
+                io.Nstep_max = 10;
+                CoolPropDbl Tg = SaturationSolvers::saturation_preconditioner(HEOS, c.p, SaturationSolvers::imposed_p, zz);
+                Tg = SaturationSolvers::saturation_Wilson(HEOS, Q, c.p, SaturationSolvers::imposed_p, zz, Tg);
+                std::vector<CoolPropDbl> K = HEOS.get_K();
+                REQUIRE_NOTHROW(SaturationSolvers::successive_substitution(HEOS, Q, Tg, c.p, zz, K, io));
+
+                SaturationSolvers::newton_raphson_twophase NR;
+                SaturationSolvers::newton_raphson_twophase_options IO;
+                IO.beta = Q;
+                IO.x = io.x;
+                IO.y = io.y;
+                IO.rhomolar_liq = io.rhomolar_liq;
+                IO.rhomolar_vap = io.rhomolar_vap;
+                IO.T = io.T;
+                IO.p = io.p;
+                IO.z = std::vector<CoolPropDbl>(c.z.begin(), c.z.end());
+                IO.Nstep_max = 30;
+                IO.imposed_variable = SaturationSolvers::newton_raphson_twophase_options::P_IMPOSED;
+
+                REQUIRE_NOTHROW(NR.call(HEOS, IO));
+
+                // The point of the change: the overall mass balance must actually hold.
+                double mass = 0, sx = 0, sy = 0;
+                for (std::size_t i = 0; i < c.z.size(); ++i) {
+                    mass = std::max(mass, std::abs(c.z[i] - (1 - Q) * IO.x[i] - Q * IO.y[i]));
+                    sx += IO.x[i];
+                    sy += IO.y[i];
+                    CHECK(IO.x[i] > 0.0);
+                    CHECK(IO.y[i] > 0.0);
+                }
+                CAPTURE(mass);
+                CAPTURE(IO.T);
+                CHECK(mass < 1e-12);
+                CHECK(sx == Catch::Approx(1.0).epsilon(1e-14));
+                CHECK(sy == Catch::Approx(1.0).epsilon(1e-14));
+                CHECK(IO.T > 0);
+            }
+        }
     }
 }
 

--- a/src/Tests/CoolProp-Tests-Michelsen.cpp
+++ b/src/Tests/CoolProp-Tests-Michelsen.cpp
@@ -11,6 +11,8 @@
 #    include <vector>
 #    include <catch2/catch_all.hpp>
 #    include "../Backends/Helmholtz/VLERoutines.h"
+#    include "../Backends/Helmholtz/MixtureDerivatives.h"
+#    include <Eigen/Dense>
 #    include "CoolProp/detail/tools.h"
 #    include <numeric>
 #    include "CoolProp/CoolProp.h"
@@ -2198,10 +2200,15 @@ TEST_CASE("newton_raphson_twophase converges at interior Q (#3372)", "[michelsen
       {"5comp", "Nitrogen&Methane&Ethane&Butane&Pentane", {0.3797, 0.3225, 0.278, 0.0014, 0.0184}, 3e5},
       // Control: converged before this change too, must still converge.
       {"binary", "Methane&n-Butane", {0.97, 0.03}, 2e6},
+      // Mirror of the 5comp case: a LIGHT trace component (K >> 1) rather than a heavy one
+      // (K << 1).  Determining x_i from the mass balance has gain (beta/(1-beta)) * K_i, which
+      // peaks at HIGH beta -- so if the elimination-free form is still mass-balance-limited it
+      // should fail at large Q here, mirroring the 5comp failure at small Q.
+      {"N2-trace", "Nitrogen&n-Propane&n-Butane&n-Pentane", {0.001, 0.40, 0.35, 0.249}, 1e5},
     };
 
     for (const auto& c : cases) {
-        for (double Q : {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.75, 0.9}) {
+        for (double Q : {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.75, 0.9, 0.95, 0.99}) {
             DYNAMIC_SECTION(c.name << " Q=" << Q) {
                 auto AS = std::shared_ptr<AbstractState>(AbstractState::factory("HEOS", c.fluids));
                 AS->set_mole_fractions(c.z);
@@ -2240,6 +2247,18 @@ TEST_CASE("newton_raphson_twophase converges at interior Q (#3372)", "[michelsen
                     CHECK(IO.x[i] > 0.0);
                     CHECK(IO.y[i] > 0.0);
                 }
+                // K_i and the mass-balance amplification for each phase, so a failure can be
+                // read against the gain that predicts it.
+                double Kmin = 1e300, Kmax = 0;
+                for (std::size_t i = 0; i < c.z.size(); ++i) {
+                    const double Ki = static_cast<double>(IO.y[i] / IO.x[i]);
+                    Kmin = std::min(Kmin, Ki);
+                    Kmax = std::max(Kmax, Ki);
+                }
+                const double gain_y = ((1 - Q) / Q) / Kmin;   // error in x_i -> y_i, worst for K << 1
+                const double gain_x = (Q / (1 - Q)) * Kmax;   // error in y_i -> x_i, worst for K >> 1
+                printf("  %-10s Q=%-5.2f Kmin=%10.3e Kmax=%10.3e gain_y=%10.3e gain_x=%10.3e mass=%9.2e T=%8.3f\n", c.name.c_str(), Q, Kmin,
+                       Kmax, gain_y, gain_x, mass, static_cast<double>(IO.T));
                 CAPTURE(mass);
                 CAPTURE(IO.T);
                 CHECK(mass < 1e-12);
@@ -2250,5 +2269,6 @@ TEST_CASE("newton_raphson_twophase converges at interior Q (#3372)", "[michelsen
         }
     }
 }
+
 
 #endif

--- a/src/Tests/CoolProp-Tests.cpp
+++ b/src/Tests/CoolProp-Tests.cpp
@@ -7600,7 +7600,15 @@ TEST_CASE("mole_fractions_liquid/vapor reject single-phase states (#2308)", "[mo
     auto AS = std::shared_ptr<CoolProp::AbstractState>(CoolProp::AbstractState::factory("HEOS", "Nitrogen&Methane&Ethane&Propane"));
     AS->set_mole_fractions({0.10, 0.34, 0.41, 0.15});
 
-    // Build the phase envelope so SatL/SatV pick up some non-trivial state
+    // Build the phase envelope so SatL/SatV pick up some non-trivial state.
+    //
+    // NOTE: for this mixture build_phase_envelope() returns without throwing but leaves
+    // built == 0, so the PQ flash below runs on the BLIND branch.  That is fine here — this
+    // test is about the mole_fractions_liquid/vapor accessors, not about the envelope — but it
+    // means this cannot be counted as envelope-branch coverage, which is what it looks like at
+    // a glance.  Envelope-branch coverage lives in CoolProp-Tests-Michelsen.cpp, guarded by
+    // REQUIRE(get_phase_envelope_data().built) so it cannot silently degrade the same way
+    // (GH #3372).
     AS->build_phase_envelope("");
 
     // Single-phase point: T well above the dew curve at 1.5 bar


### PR DESCRIPTION
### Description of the Change

The blind `PQ_flash` and `QT_flash` solved *every* vapour quality with `newton_raphson_saturation`. That is
a bubble/dew-point solver — its unknowns are the incipient phase's composition and T (or p), and
it carries no overall mass balance condition, so `z = (1−Q)·x + Q·y` is never enforced. It is
exact at Q = 0 and Q = 1 and only there; at an interior Q it returned a state satisfying equal
fugacity but not the vapour fraction specification (measured error up to 1.2e-4 in the Q ≈ 0.2–0.4 band).

The existing two-phase solver carried the vapour fraction constraint but threw for every Q ≤ 0.5
on a wide-boiling mixture, so it could not simply be substituted. The cause is that a
**mass-balance row cannot determine a trace composition**: solving it for `y_i` amplifies the
relative error in `x_i` by `((1−β)/β)/K_i`. This is not a
choice-of-eliminated-variable problem — carrying all 2N mole fractions as unknowns only relocates
the cancellation into the mass balance row.

So `newton_raphson_twophase` is reformulated to *reconstruct* the compositions instead of solving
for them. Unknowns become the N logarithmic K-factors plus the imposed-variable partner — an
(N+1)×(N+1) system, smaller than the 2N−1 it replaces:

```
D_i = (1−β) + β·K_i ,   x_i = z_i/D_i ,   y_i = K_i·x_i
```

`(1−β)x_i + β·y_i = z_i` then holds identically at every iterate, and `D_i` is a sum of
non-negative terms, so no cancellation is possible in it: a trace `x_i` arrives by division, a
trace `y_i` by multiplication, both at full relative precision. The residuals are the N
iso-fugacity conditions in ln K form plus Rachford–Rice, which is the closure condition forcing
`Σx = Σy = 1`. This is the parameterisation `successive_substitution` already uses; the solver it
seeds simply did not share it.

Interior Q in both flashes now routes there; Q within 1e-10 of an endpoint stays on the saturation
solver, where it is exact and cheaper. Both keep a fallback to it so PQ cannot start throwing
where it previously answered — but every fallback now reports through
`get_global_param_string("warnstring")` instead of being silent.

### Benefits

* Interior-Q mixture PQ/QT solves the specification it was given: equal-fugacity residual of the
  published state < 1e-6 across 3 mixtures × 10 qualities, PQ → PT → Q round trip within 1.4e-10
  for the ternary and binary.
* `newton_raphson_twophase` converges at every Q in [0.1, 0.99] on the 5-component mixture in 2–5
  iterations, against 6 failures out of 9 before; cond(J) ≈ 1e3 instead of ≈ 4.5e15.
* Silent degradation becomes visible — on `Methane&Ethane` with a built envelope, 8 of 15 states
  were falling back to a less accurate solver with no signal at all.
* First interior-Q coverage of the envelope branch and first `QT_INPUTS` coverage after an
  envelope build.

### Possible Drawbacks

* **~1.2–1.3× slower** on a full `update(PQ_INPUTS, …)`; the Newton stage itself is 2.2× (365 vs
  165 µs/solve) but seeding dominates the flash. Iteration counts are unchanged, so it is
  per-iteration cost: the new system evaluates composition derivatives for both phases.
* **The acceptance metric proposed in #3372 is now identically zero.** Since
  `(1−Q)x_i + Q·y_i = x_i·D_i = z_i` by construction, `max_i |z_i − ((1−Q)x_i + Q y_i)|` cannot
  fail for this solver, converged or not. It stays useful as a *routing* check, but anyone using
  it to validate future work gets a meaningless pass. The tests label it as such and assert equal
  fugacity for convergence.
* **Fallback visibility is weak**: `warnstring` is a process-global, read-and-cleared slot that
  nothing polls, so a caller gets no exception and no return-value signal.
* **Item 3 of #3372 is not addressed.** The envelope branch's `CubicInterp` seed is untouched and
  that branch still falls back on a substantial fraction of states — visibly now. A prototype fix
  moved fallbacks from 44/63 to 37/63, which did not justify the surface area; the dominant
  remaining failure is `solver_rho_Tp` diverging from a *positive* seed, a separate defect.

### Verification Process

Five new test cases, 933 assertions:

* **Solver, interior Q** (400) — driven from the blind path's own seed, 3 mixtures × Q ∈ [0.1, 0.99],
  including a light-trace (K ≫ 1) mirror of the heavy-trace case.
* **Blind path via the public API** (270) — 3 mixtures × 10 qualities in [0.05, 0.95], with the
  routing check, the equal-fugacity convergence check, and a PQ → PT → Q round trip.
* **Envelope branch, PQ** (180) — 2 mixtures × 9 qualities, guarded by `REQUIRE(built)` **and**
  `REQUIRE(warn.empty())` so it cannot silently measure the blind path instead.
* **Envelope branch, QT** (37) — the `QT_INPUTS` coverage that did not exist. Its PQ leg requires
  the envelope branch per state; its QT leg only requires that *some* quality reached the envelope
  branch (`qt_via_envelope > 0`), because that seed is not reliable at every quality yet — pinning
  which ones fail would encode today's bug. The round-trip and mass-balance checks hold at every
  quality regardless of which branch answered.
* **Jacobian vs. finite differences** (46) — every column central-differenced around the converged
  state on 4 mixture/quality combinations; worst disagreement 6.6e-7, at the FD noise floor.
  `newton_raphson_saturation` has had a `check_Jacobian()` for years, this class never did, and
  its Jacobian was rewritten wholesale here.

Two existing tests were corrected. `PQ flash with built PE: N2/CH4` flashed on a separate
envelope-free object because of a stale comment about a crash that #3196 fixed, so it had been
taking the blind path despite its name. The #2308 accessor test is annotated to record that its
envelope does not build, so its flash runs blind.

`./dev/ci/preflight.sh` and the `[michelsen],[flash],[mixture],[VLE]` scope were run at every step
of the branch. The only failing test is `HSU_P flash: near saturation 5-component N2-HC`, which
fails identically on `master` on this machine (known Windows-only ULP knife-edge from #3326, green
in CI). `clang-format` (pinned 18.1.8) and `semgrep` pass; `cppcheck`, `json-symbols` and
`install-headers` fail environmentally here and `clang-tidy` cannot run under the MSVC generator —
CI covers all four. A scan over 219 blind-path states found 0 fallbacks.

### Applicable Issues

Closes #3372 — items 1, 2 and 4. Item 3 (the envelope `CubicInterp` seed) is deliberately out;
see Possible Drawbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mixture flash calculations for pressure–quality and temperature–quality inputs.
  * Improved handling of interior and boundary two-phase states, with more reliable fallback behavior and clearer warnings when fallback solvers are used.
  * Enhanced convergence for two-phase calculations, including improved mass-balance and phase-equilibrium consistency.
  * Added safeguards to reject trivial or invalid two-phase solutions and ensure returned phase properties are normalized and refreshed.
* **Tests**
  * Expanded coverage for two-phase convergence, envelope-based flashes, mass balance, equal fugacity, round trips, and solver accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->