### PR TITLE
Add FluidProps to projects list

### DIFF
--- a/Web/index.rst
+++ b/Web/index.rst
@@ -69,6 +69,7 @@ Projects Using CoolProp
 * `HYRAM+ <https://energy.sandia.gov/programs/sustainable-transportation/hydrogen/hydrogen-safety-codes-and-standards/hyram/>`_ - hydrogen and other alternative fuels risk assessment models
 * `UH2SC <https://github.com/sandialabs/uh2sc>`_ - underground hydrogen salt cavern simulation tool
 * `Calcumber <https://calcumber.app/fluid-properties/>`_ – notebook-style unit-aware web calculator
+* `FluidProps <https://fluidprops.com>`_ - free fluid property calculators and steam tables built on CoolProp
 
 Main Developers
 ---------------


### PR DESCRIPTION
### Description of the Change

Documentation-only change: adds a one-line entry for FluidProps 
(https://fluidprops.com) to the "Projects using CoolProp" list in 
`Web/index.rst`, next to the existing web calculator entries 
(fProperties, CoolPropJavascriptDemo).

FluidProps provides free fluid property calculators and steam tables 
for engineers, with all property calculations powered by CoolProp. 
CoolProp is credited on the site's methodology page: 
https://fluidprops.com/methodology

No code is modified, so no tests are required.

### Benefits

Keeps the "Projects using CoolProp" list up to date and shows users 
another real-world example of CoolProp being used in a free web tool.

### Possible Drawbacks

None — the change only adds one line of documentation and does not 
affect the library or build.

### Verification Process

Verified that the new entry follows the same reStructuredText link 
format as the existing entries in the list. No functional changes 
to verify.

### Applicable Issues

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added FluidProps to the list of projects using CoolProp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->